### PR TITLE
fix(telegram): webhook hang - tests and fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/Webhook: pre-initialize webhook bots, switch webhook processing to callback-mode JSON handling, and preserve full near-limit payload reads under delayed handlers to prevent webhook request hangs and dropped updates. (#26156)
 - Agents/Subagents delivery: refactor subagent completion announce dispatch into an explicit queue/direct/fallback state machine, recover outbound channel-plugin resolution in cold/stale plugin-registry states across announce/message/gateway send paths, finalize cleanup bookkeeping when announce flow rejects, and treat Telegram sends without `message_id` as delivery failures (instead of false-success `"unknown"` IDs). (#26867, #25961, #26803, #25069, #26741) Thanks @SmithLabsLLC and @docaohieu2808.
 - Security/SSRF guard: classify IPv6 multicast literals (`ff00::/8`) as blocked/private-internal targets in shared SSRF IP checks, preventing multicast literals from bypassing URL-host preflight and DNS answer validation. This ships in the next npm release (`2026.2.25`). Thanks @zpbrent for reporting.
 - Slack/Session threads: prevent oversized parent-session inheritance from silently bricking new thread sessions, surface embedded context-overflow empty-result failures to users, and add configurable `session.parentForkMaxTokens` (default `100000`, `0` disables). (#26912) Thanks @markshields-tl.

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,3 +1,5 @@
+import type { IncomingMessage } from "node:http";
+import { setTimeout as sleep } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -30,6 +32,74 @@ vi.mock("grammy", async (importOriginal) => {
 vi.mock("./bot.js", () => ({
   createTelegramBot: createTelegramBotSpy,
 }));
+
+async function readRequestBodyWithShortTimeout(
+  req: IncomingMessage,
+  timeoutMs: number,
+): Promise<string | null> {
+  return await new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const cleanup = () => {
+      req.removeListener("data", onData);
+      req.removeListener("end", onEnd);
+      req.removeListener("error", onError);
+      req.removeListener("close", onClose);
+      clearTimeout(timer);
+    };
+
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    };
+
+    const onEnd = () => {
+      finish(Buffer.concat(chunks).toString("utf-8"));
+    };
+
+    const onError = () => {
+      finish(null);
+    };
+
+    const onClose = () => {
+      finish(null);
+    };
+
+    const timer = setTimeout(() => {
+      finish(null);
+    }, timeoutMs);
+
+    req.on("data", onData);
+    req.on("end", onEnd);
+    req.on("error", onError);
+    req.on("close", onClose);
+  });
+}
+
+async function fetchWithTimeout(
+  input: string,
+  init: Omit<RequestInit, "signal">,
+  timeoutMs: number,
+): Promise<Response> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => {
+    abort.abort();
+  }, timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: abort.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 describe("startTelegramWebhook", () => {
   it("starts server, registers webhook, and serves health", async () => {
@@ -112,5 +182,122 @@ describe("startTelegramWebhook", () => {
         token: "tok",
       }),
     ).rejects.toThrow(/requires a non-empty secret token/i);
+  });
+
+  it("keeps webhook payload readable when callback delays body read", async () => {
+    webhookCallbackSpy.mockImplementationOnce(() =>
+      vi.fn(
+        (
+          _req: unknown,
+          res: { writeHead: (status: number) => void; end: (body?: string) => void },
+        ) => {
+          const req = _req as IncomingMessage;
+          // Simulates grammy startup work before it subscribes to req data events.
+          void sleep(50).then(async () => {
+            const raw = await readRequestBodyWithShortTimeout(req, 75);
+            if (raw === null) {
+              res.writeHead(500);
+              res.end("missing-body");
+              return;
+            }
+            res.writeHead(200);
+            res.end(raw);
+          });
+        },
+      ),
+    );
+
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret: "secret",
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+    try {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("no addr");
+      }
+
+      const payload = JSON.stringify({ update_id: 1, message: { text: "hello" } });
+      const res = await fetchWithTimeout(
+        `http://127.0.0.1:${addr.port}/hook`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: payload,
+        },
+        5_000,
+      );
+
+      expect(res.status).toBe(200);
+      await expect(res.text()).resolves.toBe(payload);
+    } finally {
+      abort.abort();
+    }
+  });
+
+  it("keeps webhook payload readable across multiple delayed reads", async () => {
+    const seenPayloads: string[] = [];
+    webhookCallbackSpy.mockImplementationOnce(() =>
+      vi.fn(
+        (
+          _req: unknown,
+          res: { writeHead: (status: number) => void; end: (body?: string) => void },
+        ) => {
+          const req = _req as IncomingMessage;
+          void sleep(50).then(async () => {
+            const raw = await readRequestBodyWithShortTimeout(req, 75);
+            if (raw === null) {
+              res.writeHead(500);
+              res.end("missing-body");
+              return;
+            }
+            seenPayloads.push(raw);
+            res.writeHead(200);
+            res.end("ok");
+          });
+        },
+      ),
+    );
+
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret: "secret",
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+    try {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        throw new Error("no addr");
+      }
+
+      const payloads = [
+        JSON.stringify({ update_id: 1, message: { text: "first" } }),
+        JSON.stringify({ update_id: 2, message: { text: "second" } }),
+      ];
+
+      for (const payload of payloads) {
+        const res = await fetchWithTimeout(
+          `http://127.0.0.1:${addr.port}/hook`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: payload,
+          },
+          5_000,
+        );
+        expect(res.status).toBe(200);
+      }
+
+      expect(seenPayloads).toEqual(payloads);
+    } finally {
+      abort.abort();
+    }
   });
 });

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -1,8 +1,14 @@
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { request } from "node:http";
 import type { IncomingMessage } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { startTelegramWebhook } from "./webhook.js";
 
+const realWebhookCallbackRef = vi.hoisted(() => ({
+  fn: null as null | (typeof import("grammy"))["webhookCallback"],
+}));
 const handlerSpy = vi.hoisted(() =>
   vi.fn(
     (_req: unknown, res: { writeHead: (status: number) => void; end: (body?: string) => void }) => {
@@ -23,6 +29,7 @@ const createTelegramBotSpy = vi.hoisted(() =>
 
 vi.mock("grammy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("grammy")>();
+  realWebhookCallbackRef.fn = actual.webhookCallback;
   return {
     ...actual,
     webhookCallback: webhookCallbackSpy,
@@ -99,6 +106,189 @@ async function fetchWithTimeout(
   } finally {
     clearTimeout(timer);
   }
+}
+
+function installFirstLossThenRealGrammyCallbackOnce() {
+  webhookCallbackSpy.mockImplementationOnce((...args: unknown[]) => {
+    const realWebhookFactory = realWebhookCallbackRef.fn as
+      | ((...factoryArgs: unknown[]) => (...handlerArgs: unknown[]) => unknown)
+      | null;
+    if (!realWebhookFactory) {
+      throw new Error("real webhook callback unavailable");
+    }
+    const realHandler = realWebhookFactory(...args);
+    let requestCount = 0;
+    return vi.fn((...handlerArgs: unknown[]) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        const req = handlerArgs[0] as IncomingMessage;
+        const res = handlerArgs[1] as {
+          writeHead: (status: number) => void;
+          end: (body?: string) => void;
+        };
+        // Mirror startup behavior where body reader attaches too late.
+        void sleep(50).then(async () => {
+          const raw = await readRequestBodyWithShortTimeout(req, 75);
+          if (raw === null) {
+            res.writeHead(500);
+            res.end("missing-body");
+            return;
+          }
+          res.writeHead(200);
+          res.end(raw);
+        });
+        return;
+      }
+      return realHandler(...handlerArgs);
+    });
+  });
+}
+
+function installDelayedBodyCaptureCallbackOnce(capturedBodies: string[]) {
+  webhookCallbackSpy.mockImplementationOnce(() =>
+    vi.fn(
+      (
+        _req: unknown,
+        res: {
+          writeHead: (status: number) => void;
+          end: (body?: string) => void;
+        },
+      ) => {
+        const req = _req as IncomingMessage;
+        void sleep(50).then(async () => {
+          const raw = await readRequestBodyWithShortTimeout(req, 500);
+          if (raw === null) {
+            res.writeHead(500);
+            res.end("missing-body");
+            return;
+          }
+          capturedBodies.push(raw);
+          res.writeHead(200);
+          res.end("ok");
+        });
+      },
+    ),
+  );
+}
+
+function createDeterministicRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 4_294_967_296;
+  };
+}
+
+async function postWebhookPayloadWithChunkPlan(params: {
+  port: number;
+  path: string;
+  payload: string;
+  secret: string;
+  mode: "single" | "random-chunked";
+  timeoutMs?: number;
+}): Promise<{ statusCode: number; body: string }> {
+  const payloadBuffer = Buffer.from(params.payload, "utf-8");
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    const finishResolve = (value: { statusCode: number; body: string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolve(value);
+    };
+    const finishReject = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    };
+
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port: params.port,
+        path: params.path,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(payloadBuffer.length),
+          "x-telegram-bot-api-secret-token": params.secret,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer | string) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          finishResolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          });
+        });
+      },
+    );
+
+    const timeout = setTimeout(() => {
+      finishReject(new Error(`webhook post timed out after ${params.timeoutMs ?? 15_000}ms`));
+      req.destroy();
+    }, params.timeoutMs ?? 15_000);
+
+    req.on("error", (error) => {
+      finishReject(error);
+    });
+
+    const writeAll = async () => {
+      if (params.mode === "single") {
+        req.end(payloadBuffer);
+        return;
+      }
+
+      const rng = createDeterministicRng(26156);
+      let offset = 0;
+      let chunkCount = 0;
+      while (offset < payloadBuffer.length) {
+        const remaining = payloadBuffer.length - offset;
+        const nextSize = Math.max(1, Math.min(remaining, 1 + Math.floor(rng() * 8_192)));
+        const chunk = payloadBuffer.subarray(offset, offset + nextSize);
+        const canContinue = req.write(chunk);
+        offset += nextSize;
+        chunkCount += 1;
+        if (chunkCount % 10 === 0) {
+          await sleep(1 + Math.floor(rng() * 3));
+        }
+        if (!canContinue) {
+          await once(req, "drain");
+        }
+      }
+      req.end();
+    };
+
+    void writeAll().catch((error) => {
+      finishReject(error);
+    });
+  });
+}
+
+function createNearLimitTelegramPayload(): { payload: string; sizeBytes: number } {
+  const maxBytes = 1_024 * 1_024;
+  const targetBytes = maxBytes - 4_096;
+  const shell = { update_id: 77_777, message: { text: "" } };
+  const shellSize = Buffer.byteLength(JSON.stringify(shell), "utf-8");
+  const textLength = Math.max(1, targetBytes - shellSize);
+  const payload = JSON.stringify({
+    update_id: 77_777,
+    message: { text: "x".repeat(textLength) },
+  });
+  return { payload, sizeBytes: Buffer.byteLength(payload, "utf-8") };
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
 }
 
 describe("startTelegramWebhook", () => {
@@ -296,6 +486,182 @@ describe("startTelegramWebhook", () => {
       }
 
       expect(seenPayloads).toEqual(payloads);
+    } finally {
+      abort.abort();
+    }
+  });
+
+  it("processes a second request after first-request delayed-init data loss", async () => {
+    installFirstLossThenRealGrammyCallbackOnce();
+    const seenUpdates: unknown[] = [];
+    createTelegramBotSpy.mockImplementationOnce(() => ({
+      api: { setWebhook: setWebhookSpy },
+      stop: stopSpy,
+      isRunning: () => false,
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: unknown) => {
+        seenUpdates.push(update);
+      }),
+    }));
+
+    const secret = "secret";
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret,
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("no addr");
+      }
+
+      const firstPayload = JSON.stringify({ update_id: 100, message: { text: "first" } });
+      const secondPayload = JSON.stringify({ update_id: 101, message: { text: "second" } });
+      const firstResponse = await postWebhookPayloadWithChunkPlan({
+        port: address.port,
+        path: "/hook",
+        payload: firstPayload,
+        secret,
+        mode: "single",
+        timeoutMs: 8_000,
+      });
+      const secondResponse = await postWebhookPayloadWithChunkPlan({
+        port: address.port,
+        path: "/hook",
+        payload: secondPayload,
+        secret,
+        mode: "single",
+        timeoutMs: 8_000,
+      });
+
+      expect(firstResponse.statusCode).toBe(500);
+      expect(secondResponse.statusCode).toBe(200);
+      expect(seenUpdates).toEqual([JSON.parse(secondPayload)]);
+    } finally {
+      abort.abort();
+    }
+  });
+
+  it("handles near-limit payload with random chunk writes and event-loop yields", async () => {
+    const capturedBodies: string[] = [];
+    installDelayedBodyCaptureCallbackOnce(capturedBodies);
+
+    const { payload, sizeBytes } = createNearLimitTelegramPayload();
+    expect(sizeBytes).toBeLessThan(1_024 * 1_024);
+    expect(sizeBytes).toBeGreaterThan(256 * 1_024);
+
+    const secret = "secret";
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret,
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("no addr");
+      }
+
+      const response = await postWebhookPayloadWithChunkPlan({
+        port: address.port,
+        path: "/hook",
+        payload,
+        secret,
+        mode: "random-chunked",
+        timeoutMs: 8_000,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(capturedBodies).toHaveLength(1);
+      expect(capturedBodies[0]?.length).toBe(payload.length);
+      expect(sha256(capturedBodies[0] ?? "")).toBe(sha256(payload));
+    } finally {
+      abort.abort();
+    }
+  });
+
+  it("handles near-limit payload written in a single request write", async () => {
+    const capturedBodies: string[] = [];
+    installDelayedBodyCaptureCallbackOnce(capturedBodies);
+
+    const { payload, sizeBytes } = createNearLimitTelegramPayload();
+    expect(sizeBytes).toBeLessThan(1_024 * 1_024);
+    expect(sizeBytes).toBeGreaterThan(256 * 1_024);
+
+    const secret = "secret";
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret,
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("no addr");
+      }
+
+      const response = await postWebhookPayloadWithChunkPlan({
+        port: address.port,
+        path: "/hook",
+        payload,
+        secret,
+        mode: "single",
+        timeoutMs: 8_000,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(capturedBodies).toHaveLength(1);
+      expect(capturedBodies[0]?.length).toBe(payload.length);
+      expect(sha256(capturedBodies[0] ?? "")).toBe(sha256(payload));
+    } finally {
+      abort.abort();
+    }
+  });
+
+  it("rejects payloads larger than 1MB before invoking webhook handler", async () => {
+    handlerSpy.mockClear();
+    const abort = new AbortController();
+    const { server } = await startTelegramWebhook({
+      token: "tok",
+      secret: "secret",
+      port: 0,
+      abortSignal: abort.signal,
+      path: "/hook",
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("no addr");
+      }
+
+      const oversizedText = "x".repeat(1_024 * 1_024 + 2_048);
+      const payload = JSON.stringify({ update_id: 999_001, message: { text: oversizedText } });
+      const response = await postWebhookPayloadWithChunkPlan({
+        port: address.port,
+        path: "/hook",
+        payload,
+        secret: "secret",
+        mode: "single",
+        timeoutMs: 8_000,
+      });
+
+      expect(response.statusCode).toBe(413);
+      expect(response.body).toBe("Payload too large");
+      expect(handlerSpy).not.toHaveBeenCalled();
     } finally {
       abort.abort();
     }

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -19,6 +19,8 @@ const createTelegramBotSpy = vi.hoisted(() =>
   })),
 );
 
+const WEBHOOK_POST_TIMEOUT_MS = process.platform === "win32" ? 20_000 : 8_000;
+
 vi.mock("grammy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("grammy")>();
   return {
@@ -432,7 +434,7 @@ describe("startTelegramWebhook", () => {
         payload: firstPayload,
         secret,
         mode: "single",
-        timeoutMs: 8_000,
+        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
       });
       const secondResponse = await postWebhookPayloadWithChunkPlan({
         port: address.port,
@@ -440,7 +442,7 @@ describe("startTelegramWebhook", () => {
         payload: secondPayload,
         secret,
         mode: "single",
-        timeoutMs: 8_000,
+        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
       });
 
       expect(firstResponse.statusCode).toBe(200);
@@ -495,7 +497,7 @@ describe("startTelegramWebhook", () => {
         payload,
         secret,
         mode: "random-chunked",
-        timeoutMs: 8_000,
+        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
       });
 
       expect(response.statusCode).toBe(200);
@@ -552,7 +554,7 @@ describe("startTelegramWebhook", () => {
         payload,
         secret,
         mode: "single",
-        timeoutMs: 8_000,
+        timeoutMs: WEBHOOK_POST_TIMEOUT_MS,
       });
 
       expect(response.statusCode).toBe(200);

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -26,10 +26,11 @@ async function initializeTelegramWebhookBot(params: {
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
 }) {
+  const initSignal = params.abortSignal as Parameters<(typeof params.bot)["init"]>[0];
   await withTelegramApiErrorLogging({
     operation: "getMe",
     runtime: params.runtime,
-    fn: () => params.bot.init(params.abortSignal),
+    fn: () => params.bot.init(initSignal),
   });
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram webhook request bodies could be consumed before Grammy processed them, causing first-request failures, delayed-read failures, and truncation/malformed payload behavior (issue #26156).  Additionally, the top two commits de-register the webhook on gateway restart/config reload so that Telegram will not get an error calling the hook during restart, which then causes a delay in the ability to send messages when the gateway comes back up (~1 minute delay).
- Why it matters: incoming Telegram updates can fail on startup or under delayed/large-body conditions, leading to dropped messages and webhook instability; additionally it appears that the delays would happen at random while using the `webhook` but `polling` was not impacted.
- What changed: switched Telegram webhook handling to `webhookCallback(..., "callback")`, pre-initialized bot startup, read request JSON exactly once via `readJsonBodyWithLimit`, mapped body-read failures to explicit HTTP statuses, and added regression tests for delayed reads, multi-request behavior, near-limit payloads, and >1MB rejection.  The webhook is deregistered during restarts, then re-registered when the gateway comes back up.
- What did NOT change (scope boundary): no webhook path/secret configuration model changes, no increase to max body limit (still 1MB), no protocol changes outside Telegram webhook handling.  The webhook should also be deregistered on SIGTERM graceful shutdown, but that does not appear to be reaching this channel and is out of scope.

**AI Assisted**: Used Codex.  Took many, many, many iterations to zero in on the minimal change.  Lots of manual testing to confirm that the real issue was fixed instead of just causing tests to pass.  This took many hours of work even utilizing Codex.

### Note - Avoiding Bug in `grammy`

`grammy` has a bug in the `http` handler that results in an uncatchable exception and unresolved promise when the webhook contents are discarded by the `guard` calling `end` before the `grammy` reader has read any of the data.  It's not possible to continue to use the `http` handler until that bug is fixed, but it really shouldn't be used even then as consolidating the length check and having only one stream reader is much simpler.  The bug fix PR is here:

https://github.com/grammyjs/grammY/pull/872

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26156
- Related: https://github.com/grammyjs/grammY/pull/872

## User-visible / Behavior Changes

- Telegram webhook body parsing is now deterministic and single-pass before callback dispatch, eliminating first-request/body-read race conditions.
- Invalid/oversized/timeout webhook bodies return explicit status codes (`400`, `408`, `413`) instead of surfacing as generic handler failures.
- Startup now fails fast if bot initialization (`getMe`) fails, instead of deferring initialization side effects to first incoming webhook request.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - `bot.init()`/`getMe` is now executed explicitly during webhook startup. Risk: startup can fail earlier when Telegram API/token is invalid or unreachable. Mitigation: explicit error logging, startup rejection is immediate and observable, and behavior is covered by tests.

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: Node.js v24.13.0, pnpm, Vitest v4.0.18
- Model/provider: N/A
- Integration/channel (if any): Telegram webhook
- Relevant config (redacted): webhook `secret`, webhook `path`, default body limits/timeouts

### Steps

1. Run `pnpm test src/telegram/webhook.test.ts` on a baseline with the body-read race behavior (revert the commits up to the last `test` before the fix
2. Observe failures in delayed-read/body-read scenarios.
3. Apply this branch and rerun `pnpm test src/telegram/webhook.test.ts`.
4. See #26156 for VIDEO of how to reproduce this in a live OpenClaw Gateway with Telegram Webhook

### Expected

- All Telegram webhook regression tests pass, including delayed reads, sequential requests, near-limit payloads, and >1MB rejection.

### Actual

- With this branch, the webhook test suite passes and validates stable body handling across those scenarios.
- With the fix reverted several of the tests fail or emit uncatchable errors

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Video

See #26156 for video of the issue before the fix.  Will attach a video of the fix in action shortly.

### Failing Tests - Gateway Restart WebHook Deregistration

#### After Fix

<img width="797" height="426" alt="image" src="https://github.com/user-attachments/assets/360ea77b-f4a9-4fc3-8f5d-69f27e3aef30" />

#### Fix Reverted

<img width="814" height="639" alt="image" src="https://github.com/user-attachments/assets/d4d01c48-420c-45af-aa5d-b14272c3d45f" />

### Failing Tests - Stream Reading

#### After Fix

<img width="746" height="387" alt="image" src="https://github.com/user-attachments/assets/1d8b6732-0619-4656-9762-16de5f990514" />

#### Fix Reverted

<img width="903" height="730" alt="image" src="https://github.com/user-attachments/assets/71591936-543d-4edd-8e6c-6be972730793" />

<details>
<summary>Failing Logs with Fix Reverted</summary>

```text
pnpm test src/telegram/webhook.test.ts


> openclaw@2026.2.25 test /Users/huntharo/.codex/worktrees/44b6/openclaw
> node scripts/test-parallel.mjs src/telegram/webhook.test.ts


 RUN  v4.0.18 /Users/huntharo/.codex/worktrees/44b6/openclaw

 ✓ src/telegram/webhook.test.ts (9 tests) 256ms
   ✓ startTelegramWebhook (9)
     ✓ starts server, registers webhook, and serves health 13ms
     ✓ invokes webhook handler on matching path 6ms
     ✓ rejects startup when webhook secret is missing 1ms
     ✓ keeps webhook payload readable when callback delays body read 54ms
     ✓ keeps webhook payload readable across multiple delayed reads 105ms
     ✓ processes a second request after first-request delayed-init data loss 3ms
     ✓ handles near-limit payload with random chunk writes and event-loop yields 66ms
     ✓ handles near-limit payload written in a single request write 7ms
     ✓ rejects payloads larger than 1MB before invoking webhook handler 1ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  18:02:10
   Duration  483ms (transform 130ms, setup 106ms, import 64ms, tests 256ms, environment 0ms)


openclaw on  telegram-webhook-hang-tests-and-fix [$⇕] is 📦 v2026.2.25 via  v24.13.0 via 🐍 v3.14.3 
❯ pnpm test src/telegram/webhook.test.ts


> openclaw@2026.2.25 test /Users/huntharo/.codex/worktrees/44b6/openclaw
> node scripts/test-parallel.mjs src/telegram/webhook.test.ts


 RUN  v4.0.18 /Users/huntharo/.codex/worktrees/44b6/openclaw

 ❯ src/telegram/webhook.test.ts (9 tests | 5 failed) 16511ms
   ❯ startTelegramWebhook (9)
     ✓ starts server, registers webhook, and serves health 13ms
     ✓ invokes webhook handler on matching path 4ms
     ✓ rejects startup when webhook secret is missing 1ms
     × keeps webhook payload readable when callback delays body read 134ms
     × keeps webhook payload readable across multiple delayed reads 129ms
     × processes a second request after first-request delayed-init data loss 8133ms
     × handles near-limit payload with random chunk writes and event-loop yields 77ms
     × handles near-limit payload written in a single request write 8007ms
     ✓ rejects payloads larger than 1MB before invoking webhook handler 12ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/telegram/webhook.test.ts > startTelegramWebhook > keeps webhook payload readable when callback delays body read
AssertionError: expected 500 to be 200 // Object.is equality

- Expected
+ Received

- 200
+ 500

 ❯ src/telegram/webhook.test.ts:428:26
    426|       );
    427| 
    428|       expect(res.status).toBe(200);
       |                          ^
    429|       await expect(res.text()).resolves.toBe(payload);
    430|     } finally {

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  src/telegram/webhook.test.ts > startTelegramWebhook > keeps webhook payload readable across multiple delayed reads
AssertionError: expected 500 to be 200 // Object.is equality

- Expected
+ Received

- 200
+ 500

 ❯ src/telegram/webhook.test.ts:488:28
    486|           5_000,
    487|         );
    488|         expect(res.status).toBe(200);
       |                            ^
    489|       }
    490| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  src/telegram/webhook.test.ts > startTelegramWebhook > processes a second request after first-request delayed-init data loss
 FAIL  src/telegram/webhook.test.ts > startTelegramWebhook > handles near-limit payload written in a single request write
Error: webhook post timed out after 8000ms
 ❯ Timeout.<anonymous> src/telegram/webhook.test.ts:237:20
    235| 
    236|     const timeout = setTimeout(() => {
    237|       finishReject(new Error(`webhook post timed out after ${params.timeoutMs ?? 15_000}ms`));
       |                    ^
    238|       req.destroy();
    239|     }, params.timeoutMs ?? 15_000);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  src/telegram/webhook.test.ts > startTelegramWebhook > handles near-limit payload with random chunk writes and event-loop yields
AssertionError: expected 182665 to be 1044480 // Object.is equality

- Expected
+ Received

- 1044480
+ 182665

 ❯ src/telegram/webhook.test.ts:589:41
    587|       expect(response.statusCode).toBe(200);
    588|       expect(capturedBodies).toHaveLength(1);
    589|       expect(capturedBodies[0]?.length).toBe(payload.length);
       |                                         ^
    590|       expect(sha256(capturedBodies[0] ?? "")).toBe(sha256(payload));
    591|     } finally {

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
SyntaxError: Unexpected end of JSON input
 ❯ IncomingMessage.<anonymous> node_modules/.pnpm/grammy@1.40.0/node_modules/grammy/out/convenience/frameworks.js:207:34
 ❯ Object.onceWrapper node:events:622:28
 ❯ IncomingMessage.emit node:events:520:35
 ❯ endReadableNT node:internal/streams/readable:1701:12
 ❯ processTicksAndRejections node:internal/process/task_queues:89:21

This error originated in "src/telegram/webhook.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
The latest test that might've caused the error is "processes a second request after first-request delayed-init data loss". It might mean one of the following:
- The error was thrown, while Vitest was running this test.
- If the error occurred after the test had been completed, this was the last documented test before it was thrown.
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  1 failed (1)
      Tests  5 failed | 4 passed (9)
     Errors  1 error
   Start at  18:03:05
   Duration  16.75s (transform 132ms, setup 113ms, import 64ms, tests 16.51s, environment 0ms)

 ELIFECYCLE  Test failed. See above for more details.
```
</details>


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/telegram/webhook.test.ts`
  - delayed callback read behavior
  - multi-request sequencing after first-request delay
  - near-limit payload handling (chunked + single-write)
  - >1MB payload rejection before handler invocation
  - Manual
     - Restart gateway / immediately able to message on Telegram with no delay using webhook
     - Tested dozens of times
     - See video on linked issue for steps to reproduce before and after this fix
- Edge cases checked:
  - random chunk boundaries + event-loop yields
  - explicit oversize rejection path
- What you did **not** verify:
  - long-running production Telegram traffic under real network jitter/load (in progress, using this for my main gateway)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR
- Files/config to restore:
  - `src/telegram/webhook.ts`
  - `src/telegram/webhook.test.ts` (if test expectations need to be reverted together)
- Known bad symptoms reviewers should watch for:
  - webhook `500` responses on valid payloads
  - first Telegram updates failing after startup
  - delayed-read tests regressing

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: callback-mode integration could drift from Grammy expectations in future updates.
  - Mitigation: regression tests cover delayed reads, sequential requests, near-limit bodies, and oversize rejection.
- Risk: startup now depends on immediate Telegram API reachability.
  - Mitigation: fail-fast startup behavior is explicit, logged, and easier to diagnose than latent first-request failures.