### PR TITLE
Fix threaded subagent spawn when thread=true is passed

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -68,7 +68,7 @@ export const AgentParamsSchema = Type.Object(
     replyChannel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
     replyAccountId: Type.Optional(Type.String()),
-    threadId: Type.Optional(Type.String()),
+    threadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Boolean()])),
     groupId: Type.Optional(Type.String()),
     groupChannel: Type.Optional(Type.String()),
     groupSpace: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -462,4 +462,72 @@ describe("gateway agent handler", () => {
       }),
     );
   });
+
+  it("normalizes threadId='true' (session-thread selector shorthand)", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+        deliveryContext: { channel: "telegram", to: "group:-1", threadId: 42 },
+      },
+      canonicalKey: "agent:main:telegram:group:-1:topic:42",
+    });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+    mocks.agentCommand.mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 50 } });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        sessionKey: "agent:main:telegram:group:-1:topic:42",
+        threadId: "true",
+        idempotencyKey: "thread-true-string",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "3", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as { threadId?: string | number };
+    expect(callArgs?.threadId).toBeUndefined();
+  });
+
+  it("accepts boolean threadId=true without forwarding literal true", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "existing-session-id",
+        updatedAt: Date.now(),
+        deliveryContext: { channel: "telegram", to: "group:-1", threadId: 77 },
+      },
+      canonicalKey: "agent:main:telegram:group:-1:topic:77",
+    });
+    mocks.updateSessionStore.mockResolvedValue(undefined);
+    mocks.agentCommand.mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 50 } });
+
+    const respond = vi.fn();
+    await agentHandlers.agent({
+      params: {
+        message: "test",
+        sessionKey: "agent:main:telegram:group:-1:topic:77",
+        threadId: true,
+        idempotencyKey: "thread-true-bool",
+      },
+      respond,
+      context: makeContext(),
+      req: { type: "req", id: "4", method: "agent" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as { threadId?: string | number };
+    expect(callArgs?.threadId).toBeUndefined();
+  });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -184,7 +184,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       replyChannel?: string;
       accountId?: string;
       replyAccountId?: string;
-      threadId?: string;
+      threadId?: string | number | boolean;
       groupId?: string;
       groupChannel?: string;
       groupSpace?: string;
@@ -483,10 +483,28 @@ export const agentHandlers: GatewayRequestHandlers = {
         : typeof request.to === "string" && request.to.trim()
           ? request.to.trim()
           : undefined;
-    const explicitThreadId =
-      typeof request.threadId === "string" && request.threadId.trim()
-        ? request.threadId.trim()
-        : undefined;
+    const explicitThreadId = (() => {
+      const raw = request.threadId;
+      if (typeof raw === "boolean") {
+        // `thread=true` is a session-thread selector shorthand: keep existing session thread.
+        return undefined;
+      }
+      if (typeof raw === "number" && Number.isFinite(raw)) {
+        return String(Math.trunc(raw));
+      }
+      if (typeof raw !== "string") {
+        return undefined;
+      }
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      if (trimmed.toLowerCase() === "true") {
+        // CLI/users sometimes pass --thread true to mean "use current session thread".
+        return undefined;
+      }
+      return trimmed;
+    })();
     const turnSourceChannel =
       typeof request.channel === "string" && request.channel.trim()
         ? request.channel.trim()


### PR DESCRIPTION
## Summary\n- accept  as string/number/boolean in gateway  schema\n- normalize  (string or boolean) to session-thread selector behavior instead of treating literal  as topic id\n- keep numeric thread ids supported by normalizing to integer strings\n- add gateway handler tests covering  and \n\n## Why\nSubagent spawn flows in Telegram topic sessions can pass  in mode=session. Previously this could propagate as literal  and break topic routing.\n\n## Validation\n- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/tmp/openclaw-threadfix-294[39m

 [32m✓[39m src/gateway/server-methods/agent.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 61[2mms[22m[39m
 [32m✓[39m src/agents/sessions-spawn-threadid.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 33[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m7 passed[39m[22m[90m (7)[39m
[2m   Start at [22m 16:09:08
[2m   Duration [22m 16.36s[2m (transform 12.62s, setup 12.98s, import 14.49s, tests 93ms, environment 1ms)[22m\n

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `threadId=true` (boolean or string) from subagent spawn flows in Telegram topic sessions was propagated as a literal value, breaking topic routing. The PR:

- Widens the `threadId` field in `AgentParamsSchema` to accept `string | number | boolean`
- Adds normalization logic that maps boolean and string `"true"` to `undefined` (session-thread selector), coerces numeric thread IDs to integer strings, and passes valid string thread IDs through
- Adds two well-structured gateway handler tests covering both string and boolean `true` variants

The change is focused and correct for the described bug. One minor gap: the string `"false"` is not handled the same way as boolean `false` and string `"true"`, which could cause a similar routing issue if CLI parsers produce `--thread false`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real routing bug with well-tested normalization logic and no regressions.
- Score of 4 reflects a clean, focused fix with good test coverage. Deducted 1 point for the missing `"false"` string normalization which is a minor gap in symmetry with the boolean `false` handling.
- `src/gateway/server-methods/agent.ts` — the `explicitThreadId` normalization IIFE should also handle the string `"false"` to match the boolean `false` behavior.

<sub>Last reviewed commit: 8b57b7b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->