### PR TITLE
fix(bluebubbles): honor explicit chat_guid targets

### DIFF
--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -75,4 +75,33 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroups).not.toHaveBeenCalled();
     expect(mocks.listGroupsLive).not.toHaveBeenCalled();
   });
+
+  it("preserves explicit chat_guid targets for bluebubbles", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      messaging: {
+        normalizeTarget: () => "+13239092441",
+        targetResolver: {
+          looksLikeId: () => true,
+        },
+      },
+      directory: {
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+    });
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "bluebubbles",
+      input: "chat_guid:SMS;-;+13239092441",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.source).toBe("normalized");
+      expect(result.target.to).toBe("chat_guid:SMS;-;+13239092441");
+    }
+    expect(mocks.listGroups).not.toHaveBeenCalled();
+    expect(mocks.listGroupsLive).not.toHaveBeenCalled();
+  });
 });

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -130,10 +130,23 @@ export function formatTargetDisplay(params: {
 }
 
 function preserveTargetCase(channel: ChannelId, raw: string, normalized: string): string {
+  const trimmed = raw.trim();
+
+  // For iMessage-style channels, explicit chat_* prefixes must be preserved as-is.
+  // Normalization can collapse chat_guid DM targets down to handles, which breaks
+  // callers that intentionally provide a concrete chat GUID (e.g. SMS vs iMessage).
+  if (
+    (channel === "bluebubbles" || channel === "imessage") &&
+    /^(chat_id:|chatid:|chat:|chat_guid:|chatguid:|guid:|chat_identifier:|chatidentifier:|chatident:)/i.test(
+      trimmed,
+    )
+  ) {
+    return trimmed;
+  }
+
   if (channel !== "slack") {
     return normalized;
   }
-  const trimmed = raw.trim();
   if (/^channel:/i.test(trimmed) || /^user:/i.test(trimmed)) {
     return trimmed;
   }


### PR DESCRIPTION
## Summary
- Problem: explicit `chat_guid:` BlueBubbles targets could be rewritten during resolver normalization.
- Why it matters: `chat_guid:SMS;-;+...` could degrade to a generic handle and route via the wrong service (iMessage), failing for SMS-only contacts.
- What changed: preserve explicit `chat_id:` / `chat_guid:` / `chat_identifier:` targets as-is for `bluebubbles` and `imessage` in outbound target resolution.
- What did NOT change: non-explicit handle/phone resolution and directory lookup behavior.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations
- [x] API / contracts

## Linked Issue/PR
- Closes #26868

## User-visible / Behavior Changes
- Explicit `chat_guid:` targets now stay intact end-to-end instead of being rewritten.

## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification
### Environment
- OS: Linux (dev)
- Runtime/container: Node 22 + pnpm

### Steps
1. Resolve a BlueBubbles target using `chat_guid:SMS;-;+13239092441`.
2. Verify resolver output target string.

### Expected
- Resolver returns the explicit `chat_guid:SMS;-;+13239092441` target unchanged.

### Actual
- Confirmed via unit test in `src/infra/outbound/target-resolver.test.ts`.

## Evidence
- [x] Behavioral coverage via unit test for explicit chat_guid preservation

## Human Verification
- Verified scenarios:
  - `pnpm test -- --run src/infra/outbound/target-resolver.test.ts`
  - `pnpm check`
  - `pnpm check:docs`
  - `pnpm protocol:check`
- Edge cases checked:
  - Explicit `chat_guid:` preservation for BlueBubbles path with custom normalize output.
- What was not verified:
  - Live BlueBubbles server delivery on macOS.

## Compatibility / Migration
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery
- Revert commit `bc4d42188`.

## Risks and Mitigations
- Risk: Preserving explicit chat targets might bypass normalization that some callers relied on.
  - Mitigation: change is narrowly scoped to explicit `chat_*` prefixes on iMessage-style channels; direct-id intent is preserved and covered by test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes explicit BlueBubbles `chat_guid:` targets being collapsed to bare handles during resolution, which could cause SMS-only messages to incorrectly route via iMessage.

**Key Changes:**
- Modified `preserveTargetCase` in `src/infra/outbound/target-resolver.ts` to detect and preserve explicit chat_* prefixes (`chat_guid:`, `chat_id:`, `chatguid:`, `guid:`, etc.) for bluebubbles/imessage channels
- Added bypass logic before normalization to prevent `chat_guid:SMS;-;+phone` from degrading to just `+phone`
- Added unit test verifying explicit chat_guid targets are preserved end-to-end

**Impact:**
- Callers can now provide explicit chat GUIDs (e.g., `chat_guid:SMS;-;+13239092441`) and have them preserved through the resolution pipeline
- Prevents service-specific routing failures for SMS-only contacts
- Backward compatible: only affects explicit chat_* prefix inputs; normal handle/phone resolution unchanged

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean, focused bug fix with excellent test coverage. The change is narrowly scoped to bluebubbles/imessage channels with explicit chat_* prefixes, doesn't modify any critical logic paths, and includes a comprehensive unit test that verifies the fix works as intended. The regex pattern matches all documented BlueBubbles prefix variations.
- No files require special attention

<sub>Last reviewed commit: bc4d421</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->