### PR TITLE
feat: conditional HEARTBEAT.md loading — skip for non-heartbeat messages

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
-import type { WorkspaceBootstrapFile } from "./workspace.js";
+import { DEFAULT_HEARTBEAT_FILENAME, type WorkspaceBootstrapFile } from "./workspace.js";
 
 function registerExtraBootstrapFileHook() {
   registerInternalHook("agent:bootstrap", (event) => {
@@ -62,6 +62,27 @@ describe("resolveBootstrapFilesForRun", () => {
     const files = await resolveBootstrapFilesForRun({ workspaceDir });
 
     expect(files.some((file) => file.path === path.join(workspaceDir, "EXTRA.md"))).toBe(true);
+  });
+
+  it("excludes HEARTBEAT.md when isHeartbeat is false", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir, isHeartbeat: false });
+
+    expect(files.some((file) => file.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(false);
+  });
+
+  it("excludes HEARTBEAT.md when isHeartbeat is omitted", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+
+    expect(files.some((file) => file.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(false);
+  });
+
+  it("includes HEARTBEAT.md when isHeartbeat is true", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const files = await resolveBootstrapFilesForRun({ workspaceDir, isHeartbeat: true });
+
+    expect(files.some((file) => file.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(true);
   });
 
   it("drops malformed hook files with missing/invalid paths", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -360,6 +360,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        isHeartbeat: params.isHeartbeat,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -103,4 +103,6 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  /** When true the current message is a heartbeat poll — include HEARTBEAT.md in context. */
+  isHeartbeat?: boolean;
 };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -185,6 +185,7 @@ export function createFollowupRunner(params: {
               verboseLevel: queued.run.verboseLevel,
               reasoningLevel: queued.run.reasoningLevel,
               suppressToolErrorWarnings: opts?.suppressToolErrorWarnings,
+              isHeartbeat: opts?.isHeartbeat,
               execOverrides: queued.run.execOverrides,
               bashElevated: queued.run.bashElevated,
               timeoutMs: queued.run.timeoutMs,


### PR DESCRIPTION
## Summary

HEARTBEAT.md (300-426 tokens) was injected into every message for every agent, but is only relevant during heartbeat polls. This change makes the injection conditional on the `isHeartbeat` flag.

## Changes

- **`src/agents/bootstrap-files.ts`**: `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun` accept `isHeartbeat?: boolean` — HEARTBEAT.md is excluded when falsy (default)
- **`src/agents/pi-embedded-runner/run/params.ts`**: Added `isHeartbeat?: boolean` to `RunEmbeddedPiAgentParams`
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: Passes `params.isHeartbeat` to `resolveBootstrapContextForRun`
- **`src/auto-reply/reply/followup-runner.ts`**: Threads `opts?.isHeartbeat` to `runEmbeddedPiAgent`
- **`src/agents/bootstrap-files.test.ts`**: 3 new tests covering inclusion/exclusion behavior

## Token savings

~400 tokens saved per non-heartbeat message across all agents.

## Backward compatibility

- Heartbeat behavior unchanged: `heartbeat-runner.ts` already passes `isHeartbeat: true` in opts
- CLI, compaction, and command handlers default to `isHeartbeat: undefined` (falsy) → HEARTBEAT.md excluded (they never needed it)
- The `## Heartbeats` section in the system prompt is unchanged — agents still know how to respond to heartbeat polls

Refs: task-1772060004973-qdsklci2e

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes context token usage by making HEARTBEAT.md loading conditional based on message type. Previously, HEARTBEAT.md (300-426 tokens) was injected into every agent message regardless of whether it was a heartbeat poll.

**Key Changes:**
- Added optional `isHeartbeat?: boolean` parameter to `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun`
- When `isHeartbeat` is falsy or omitted (default), HEARTBEAT.md is filtered out after session filtering but before hook overrides
- Parameter correctly threaded through `RunEmbeddedPiAgentParams` → `attempt.ts` → bootstrap resolution functions
- `followup-runner.ts` passes through `opts?.isHeartbeat` to maintain flexibility for future use

**Backward Compatibility:**
- Heartbeat runners (`src/infra/heartbeat-runner.ts` and `src/web/auto-reply/heartbeat-runner.ts`) already pass `isHeartbeat: true`, so heartbeat behavior is unchanged
- CLI, compaction, and command handlers correctly default to excluding HEARTBEAT.md (they never needed it)
- System prompt "## Heartbeats" section remains unchanged — agents still know how to respond to heartbeat polls

**Test Coverage:**
- Three new tests verify correct inclusion/exclusion behavior for all scenarios (true, false, undefined)

**Impact:**
- Saves approximately 400 context tokens per non-heartbeat message across all agents
- No functional changes to heartbeat behavior or agent capabilities

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — straightforward optimization with no breaking changes
- The implementation is clean, well-tested, and maintains full backward compatibility. The optional parameter defaults to the correct behavior (excluding HEARTBEAT.md), while heartbeat-specific code paths explicitly set `isHeartbeat: true`. Tests comprehensively cover all three scenarios (true/false/undefined). The change only affects context loading and doesn't modify any logic or runtime behavior.
- No files require special attention

<sub>Last reviewed commit: 53aa6e6</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->