### PR TITLE
feat: conditional HEARTBEAT.md loading — skip injection for non-heartbeat messages

### DIFF
--- a/src/agents/bootstrap-files-heartbeat.test.ts
+++ b/src/agents/bootstrap-files-heartbeat.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
+import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
+import { DEFAULT_HEARTBEAT_FILENAME } from "./workspace.js";
+
+describe("HEARTBEAT.md conditional loading", () => {
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    clearInternalHooks();
+    workspaceDir = await makeTempWorkspace("openclaw-heartbeat-");
+    // Ensure HEARTBEAT.md exists in the workspace
+    await fs.writeFile(
+      path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME),
+      "# HEARTBEAT.md\n\n## Priority Order\n1. Check active tasks\n2. Post status updates\n",
+    );
+  });
+
+  afterEach(() => clearInternalHooks());
+
+  it("excludes HEARTBEAT.md when isHeartbeat is false", async () => {
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      isHeartbeat: false,
+    });
+    expect(files.some((f) => f.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(false);
+  });
+
+  it("excludes HEARTBEAT.md when isHeartbeat is undefined (default)", async () => {
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+    });
+    expect(files.some((f) => f.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(false);
+  });
+
+  it("includes HEARTBEAT.md when isHeartbeat is true", async () => {
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      isHeartbeat: true,
+    });
+    expect(files.some((f) => f.name === DEFAULT_HEARTBEAT_FILENAME)).toBe(true);
+  });
+
+  it("preserves all non-HEARTBEAT files regardless of isHeartbeat flag", async () => {
+    const withHeartbeat = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      isHeartbeat: true,
+    });
+    const withoutHeartbeat = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      isHeartbeat: false,
+    });
+
+    const nonHeartbeatNames = withHeartbeat
+      .filter((f) => f.name !== DEFAULT_HEARTBEAT_FILENAME)
+      .map((f) => f.name)
+      .sort();
+    const withoutNames = withoutHeartbeat.map((f) => f.name).sort();
+
+    expect(nonHeartbeatNames).toEqual(withoutNames);
+  });
+
+  it("contextFiles exclude HEARTBEAT.md for non-heartbeat messages", async () => {
+    const { contextFiles } = await resolveBootstrapContextForRun({
+      workspaceDir,
+      isHeartbeat: false,
+    });
+    expect(
+      contextFiles.some(
+        (f) => f.path === DEFAULT_HEARTBEAT_FILENAME || f.path.includes("HEARTBEAT"),
+      ),
+    ).toBe(false);
+  });
+
+  it("contextFiles include HEARTBEAT.md for heartbeat messages", async () => {
+    const { contextFiles } = await resolveBootstrapContextForRun({
+      workspaceDir,
+      isHeartbeat: true,
+    });
+    expect(
+      contextFiles.some(
+        (f) => f.path === DEFAULT_HEARTBEAT_FILENAME || f.path.includes("HEARTBEAT"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -384,6 +384,7 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            isHeartbeat: params.isHeartbeat,
           });
 
           const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -193,6 +193,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        isHeartbeat: params.isHeartbeat,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -102,4 +102,6 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  /** When true, include HEARTBEAT.md in the system prompt bootstrap files. */
+  isHeartbeat?: boolean;
 };

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -89,6 +89,8 @@ export type EmbeddedRunAttemptParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  /** When true, include HEARTBEAT.md in bootstrap files. */
+  isHeartbeat?: boolean;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -434,6 +434,7 @@ export async function runAgentTurnWithFallback(params: {
                     await blockReplyPipeline.flush({ force: true });
                   }
                 : undefined,
+            isHeartbeat: params.isHeartbeat,
             shouldEmitToolResult: params.shouldEmitToolResult,
             shouldEmitToolOutput: params.shouldEmitToolOutput,
             onToolResult: onToolResult


### PR DESCRIPTION
## Summary

HEARTBEAT.md (~300-400 tokens) was injected into every agent message's system prompt, but is only relevant during heartbeat polls. This PR skips it for non-heartbeat messages.

## Changes

- **bootstrap-files.ts**: Added `isHeartbeat?: boolean` param to `resolveBootstrapFilesForRun` and `resolveBootstrapContextForRun`. Filters out HEARTBEAT.md when `!isHeartbeat`.
- **run/params.ts & run/types.ts**: Added `isHeartbeat?` to `RunEmbeddedPiAgentParams` and `EmbeddedRunAttemptParams`.
- **run.ts**: Threads `isHeartbeat` from `runEmbeddedPiAgent` → `runEmbeddedAttempt`.
- **attempt.ts**: Passes `isHeartbeat` to `resolveBootstrapContextForRun`.
- **agent-runner-execution.ts**: Passes `isHeartbeat` from the reply pipeline to `runEmbeddedPiAgent`.

## Impact

~300-400 tokens saved per non-heartbeat message across all agents. Heartbeat behavior unchanged — HEARTBEAT.md is still injected during heartbeat polls. System prompt heartbeat instructions (HEARTBEAT_OK ack) remain always-on (they're tiny).

## Tests

6 new integration tests in `bootstrap-files-heartbeat.test.ts` covering:
- HEARTBEAT.md excluded when `isHeartbeat=false`
- HEARTBEAT.md excluded when `isHeartbeat=undefined` (default)
- HEARTBEAT.md included when `isHeartbeat=true`
- Non-heartbeat files preserved in all cases
- Context files properly reflect the filtering

Task: task-1772060004973-qdsklci2e

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Optimized token usage by conditionally loading HEARTBEAT.md only during heartbeat polls, saving ~300-400 tokens per non-heartbeat agent message.

**Implementation:**
- Added `isHeartbeat?: boolean` parameter threaded through bootstrap file resolution (`bootstrap-files.ts` → `attempt.ts` → `run.ts` → `agent-runner-execution.ts`)
- HEARTBEAT.md excluded by default (when `isHeartbeat` is `false` or `undefined`)
- HEARTBEAT.md included only when `isHeartbeat: true` (heartbeat polls via `heartbeat-runner.ts:621`)
- System prompt heartbeat instructions (HEARTBEAT_OK acknowledgment) remain always-on as intended

**Testing:**
- 6 comprehensive integration tests covering all scenarios (exclude when false/undefined, include when true, preserve non-heartbeat files, context file filtering)

**Impact:**
- Backward compatible optimization - existing non-heartbeat flows correctly exclude HEARTBEAT.md
- Heartbeat polls continue to receive HEARTBEAT.md as expected
- No changes required to other callers (cli-runner, compaction, context reports)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean implementation with comprehensive test coverage (6 new tests), proper parameter threading through all layers, clear documentation, and correct default behavior. The optimization is well-isolated and doesn't introduce regressions.
- No files require special attention

<sub>Last reviewed commit: eddd60b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->