### PR TITLE
fix(auth-profiles): accept mode/apiKey aliases to prevent silent credential loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auth/Auth profiles: normalize `auth-profiles.json` alias fields (`mode -> type`, `apiKey -> key`) before credential validation so entries copied from `openclaw.json` auth examples are no longer silently dropped. (#26950) thanks @byungsker.
 - Cron/Hooks isolated routing: preserve canonical `agent:*` session keys in isolated runs so already-qualified keys are not double-prefixed (for example `agent:main:main` no longer becomes `agent:main:agent:main:main`). Landed from contributor PR #27333 by @MaheshBhushan. (#27289, #27282)
 - iOS/Talk mode: stop injecting the voice directive hint into iOS Talk prompts and remove the Voice Directive Hint setting, reducing model bias toward tool-style TTS directives and keeping relay responses text-first by default. (#27543) thanks @ngutman.
 - Queue/Drain/Cron reliability: harden lane draining with guaranteed `draining` flag reset on synchronous pump failures, reject new queue enqueues during gateway restart drain windows (instead of silently killing accepted tasks), add `/stop` queued-backlog cutoff metadata with stale-message skipping (while avoiding cross-session native-stop cutoff bleed), and raise isolated cron `agentTurn` outer safety timeout to avoid false 10-minute timeout races against longer agent session timeouts. (#27407, #27332, #27427)


### PR DESCRIPTION
## Problem

Users creating `auth-profiles.json` after reading the `openclaw.json` auth-profiles documentation write:
```json
{ "provider": "anthropic", "mode": "api_key", "apiKey": "sk-ant-..." }
```

But the actual `auth-profiles.json` schema is:
```json
{ "provider": "anthropic", "type": "api_key", "key": "sk-ant-..." }
```

The `openclaw.json` `auth.profiles` section uses `mode` (the config reference schema); `auth-profiles.json` uses `type` (the credential store schema). This naming difference is easy to miss.

`coerceAuthStore()` validates entries on `typed.type` and silently skips any entry that lacks a valid `type` value — so every credential written with `mode`/`apiKey` is silently dropped. The user gets `No API key found for provider "anthropic"` with no hint about the mismatch.

## Root Cause

`coerceAuthStore` and `coerceLegacyStore` read raw JSON directly without normalising field names, and the `type` guard immediately discards non-conforming entries.

## Fix

Add `normalizeRawCredentialEntry()` which coerces:
- `mode` → `type` (when `type` is absent)
- `apiKey` → `key` (when `key` is absent)

Both parsers call the normaliser before the type guard so entries written with either spelling are loaded and resolved correctly.

## Tests

New test in `auth-profiles.ensureauthprofilestore.test.ts`: writes an `auth-profiles.json` using the alias spellings and verifies the parsed profile has `type: "api_key"` and the correct `key` value. All 3 ensureAuthProfileStore tests pass.

Fixes #26916

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds field name normalization in `auth-profiles.json` parser to accept both canonical (`type`/`key`) and alias (`mode`/`apiKey`) spellings, preventing silent credential loss when users write credentials using `openclaw.json` format conventions.

- Introduces `normalizeRawCredentialEntry()` function that maps `mode` → `type` and `apiKey` → `key` when canonical fields are absent
- Applied in both `coerceLegacyStore()` and `coerceAuthStore()` parsers before type validation
- Preserves canonical fields when both are present (correct precedence)
- New test validates the fix with real-world scenario described in #26916

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is focused, well-tested, and directly addresses a documented user-facing bug without introducing new risks. The normalization logic correctly handles edge cases (preserving canonical fields when present, type-checking before copying), and the test validates the exact scenario described in the linked issue
- No files require special attention

<sub>Last reviewed commit: e5cd740</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->