### PR TITLE
fix(memory): pass agent session key in memory search

### DIFF
--- a/src/cli/memory-cli.test.ts
+++ b/src/cli/memory-cli.test.ts
@@ -377,6 +377,7 @@ describe("memory cli", () => {
     expect(search).toHaveBeenCalledWith("hello", {
       maxResults: undefined,
       minScore: undefined,
+      sessionKey: "agent:main:main",
     });
     expect(log).toHaveBeenCalledWith("No matches.");
     expect(close).toHaveBeenCalled();
@@ -393,6 +394,7 @@ describe("memory cli", () => {
     expect(search).toHaveBeenCalledWith("deployment notes", {
       maxResults: undefined,
       minScore: undefined,
+      sessionKey: "agent:main:main",
     });
     expect(log).toHaveBeenCalledWith("No matches.");
     expect(close).toHaveBeenCalled();
@@ -410,6 +412,7 @@ describe("memory cli", () => {
     expect(search).toHaveBeenCalledWith("flagged", {
       maxResults: undefined,
       minScore: undefined,
+      sessionKey: "agent:main:main",
     });
     expect(close).toHaveBeenCalled();
   });

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -6,6 +6,7 @@ import type { Command } from "commander";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import { resolveAgentMainSessionKey } from "../config/sessions.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { setVerbose } from "../globals.js";
 import { getMemorySearchManager, type MemorySearchManagerResult } from "../memory/index.js";
@@ -733,9 +734,11 @@ export function registerMemoryCli(program: Command) {
           run: async (manager) => {
             let results: Awaited<ReturnType<typeof manager.search>>;
             try {
+              const sessionKey = resolveAgentMainSessionKey({ cfg, agentId });
               results = await manager.search(query, {
                 maxResults: opts.maxResults,
                 minScore: opts.minScore,
+                sessionKey,
               });
             } catch (err) {
               const message = formatErrorMessage(err);


### PR DESCRIPTION
## Summary
- resolve agent-scoped memory search context mismatch by passing `sessionKey` into `manager.search`
- derive key from config via `resolveAgentMainSessionKey({ cfg, agentId })`
- update memory CLI tests to assert session key forwarding

## Validation
- `pnpm test src/cli/memory-cli.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly passes the agent session context to memory search operations in the CLI, resolving agent-scoped memory context mismatches.

- Added `resolveAgentMainSessionKey` import from the config sessions module
- Derives the session context from config and agent ID before calling memory search
- Updated all three memory CLI tests to assert the session context parameter is forwarded

The change aligns with existing patterns in the agent tools (memory-tool.ts) which already includes session context in searches. The session context parameter is optional in the MemorySearchManager interface, making this a safe, backward-compatible addition.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (6 lines), follows existing patterns in the codebase, and includes proper test coverage. The sessionKey parameter is optional, ensuring backward compatibility. The implementation correctly uses the `resolveAgentMainSessionKey` function which is already widely used across the codebase.
- No files require special attention

<sub>Last reviewed commit: 2c143d1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->