### PR TITLE
fix(telegram): use canonical agent-prefixed session key for slash commands

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -585,7 +585,10 @@ export const registerTelegramNativeCommands = ({
             WasMentioned: true,
             CommandAuthorized: commandAuthorized,
             CommandSource: "native" as const,
-            SessionKey: `telegram:slash:${senderId || chatId}`,
+            // Canonical session key: agent:<agentId>:telegram:slash:<userId>.
+            // Using the bare `telegram:slash:<id>` form (without the agent prefix)
+            // created a legacy-format key that openclaw doctor flagged on every run.
+            SessionKey: `agent:${route.agentId}:telegram:slash:${senderId || chatId}`,
             AccountId: route.accountId,
             CommandTargetSessionKey: sessionKey,
             MessageThreadId: threadSpec.id,


### PR DESCRIPTION
## Problem

After running `openclaw doctor --fix` to canonicalize session keys, every subsequent Telegram slash command (`/status`, etc.) immediately creates a new legacy-format session entry:

```
direct | telegramslash214522323     | just now  ← re-created by slash command
direct | agentmaintelegramslash214522323 | 15m ago  ← canonical (doctor-fixed)
```

The doctor fix is required before every slash command interaction, causing perpetual state fragmentation.

## Root Cause

In `bot-native-commands.ts`, the slash command's `SessionKey` is built without the mandatory `agent:<agentId>:` prefix:

```typescript
// Before — legacy format
SessionKey: `telegram:slash:${senderId || chatId}`
```

Every canonical session key must start with `agent:<agentId>:`. Slack slash commands already use the correct form:
```typescript
// Slack — correct
`agent:${route.agentId}:${slashCommand.sessionPrefix}:${command.user_id}`
```

`route.agentId` is already in scope (used on the surrounding lines for `AccountId`, `agentId`, etc.), so no additional plumbing is required.

## Fix

```typescript
// After — canonical format
SessionKey: `agent:${route.agentId}:telegram:slash:${senderId || chatId}`
```

## Tests

All 527 Telegram tests pass with no changes required.

Fixes #26895

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Telegram slash commands to use the canonical `agent:<agentId>:telegram:slash:<userId>` session key format instead of the legacy `telegram:slash:<userId>` format. This prevents the session key fragmentation issue where `openclaw doctor --fix` would canonicalize keys, but every subsequent slash command would recreate legacy-format entries.

- The fix adds the `agent:${route.agentId}:` prefix to the SessionKey, matching the pattern already used by Slack slash commands (src/slack/monitor/slash.ts:592)
- `route.agentId` is already available in scope and used on surrounding lines
- Added clear inline comments explaining the canonical format requirement
- The canonical format is validated by `parseAgentSessionKey()` in src/sessions/session-key-utils.ts which requires the `agent:<agentId>:` prefix
- No other Telegram code paths generate legacy-format session keys

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused one-line fix that adds the required `agent:${route.agentId}:` prefix to match the canonical session key format used throughout the codebase. The fix aligns with the existing Slack implementation, uses variables already in scope, and all 527 Telegram tests pass without modifications. The code includes clear documentation explaining the change.
- No files require special attention

<sub>Last reviewed commit: 174d40f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->