### PR TITLE
fix(memory): enable FTS-only mode indexing when no embedding provider configured

### DIFF
--- a/src/memory/embedding-chunk-limits.ts
+++ b/src/memory/embedding-chunk-limits.ts
@@ -4,7 +4,7 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { hashText, type MemoryChunk } from "./internal.js";
 
 export function enforceEmbeddingMaxInputTokens(
-  provider: EmbeddingProvider,
+  provider: EmbeddingProvider | null | undefined,
   chunks: MemoryChunk[],
   hardMaxInputTokens?: number,
 ): MemoryChunk[] {

--- a/src/memory/embedding-model-limits.ts
+++ b/src/memory/embedding-model-limits.ts
@@ -13,7 +13,12 @@ const KNOWN_EMBEDDING_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage:voyage-code-3": 32000,
 };
 
-export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): number {
+export function resolveEmbeddingMaxInputTokens(
+  provider: EmbeddingProvider | null | undefined,
+): number {
+  if (!provider) {
+    return DEFAULT_EMBEDDING_MAX_INPUT_TOKENS;
+  }
   if (typeof provider.maxInputTokens === "number") {
     return provider.maxInputTokens;
   }


### PR DESCRIPTION
## Summary

- Problem: When no embedding provider (OpenAI/Google/Voyage) is configured, memory indexing was completely skipped, leaving the FTS table empty even though FTS search was available.
- Why it matters: Users in FTS-only mode couldn't search memory content via keyword search, defeating the purpose of the fallback mode.
- What changed: Removed early returns that skipped all indexing when no provider was present; made `this.provider.model` access null-safe with fallback to `'fts-only'`; `embedChunksInBatches` returns empty embeddings when no provider exists; `enforceEmbeddingMaxInputTokens` and `resolveEmbeddingMaxInputTokens` accept nullable provider.
- What did NOT change: Embedding/vector search behavior when a provider IS configured remains unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #26792
- Split from #26908

## User-visible / Behavior Changes

FTS-only mode now indexes memory files into the FTS table, enabling keyword search without requiring an embedding provider.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: FTS-only mode indexing with no provider configured
- Edge cases checked: Null provider access throughout the pipeline
- What you did **not** verify: Full integration test with all embedding providers

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Known bad symptoms reviewers should watch for: Errors during memory sync when no embedding provider is configured

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables FTS (full-text search) indexing when no embedding provider is configured, fixing a bug where memory content was completely unsearchable in FTS-only mode.

**Key changes:**
- Removed early returns in `syncMemoryFiles` and `syncSessionFiles` that skipped all indexing when `this.provider` was null
- Made provider access null-safe throughout the indexing pipeline using optional chaining (`this.provider?.model ?? 'fts-only'`)
- `embedChunksInBatches` now returns empty embeddings array when no provider exists, allowing FTS indexing to proceed
- Updated `enforceEmbeddingMaxInputTokens` and `resolveEmbeddingMaxInputTokens` to accept nullable provider

**How it works:**
- When no provider is configured, chunks are indexed into the FTS table with `model = 'fts-only'` and empty embeddings (`[]`)
- The vector table remains empty (no vector search available)
- FTS keyword search works normally and can find indexed content
- Switching between having/not having a provider triggers a full reindex (verified via `meta.providerKey` comparison)

**Code quality:**
- Null safety is properly handled throughout with guards and optional chaining
- Existing guards in `embedBatchWithRetry` and `embedQueryWithTimeout` prevent accidental embedding calls in FTS-only mode
- The `searchKeyword` function already handles `undefined` providerModel by searching all models, which will correctly find `'fts-only'` entries

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a clear bug without introducing new issues
- The fix is well-implemented with proper null-safety throughout. All code paths that access `this.provider` are protected by guards or use optional chaining. The reindexing logic correctly handles transitions between having/not having a provider. Empty embeddings are handled safely, and existing tests confirm that null providers are an expected scenario. No breaking changes to existing functionality when a provider IS configured.
- No files require special attention - all changes follow consistent patterns and are properly guarded

<sub>Last reviewed commit: c6bea1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->