### PR TITLE
docs(coding-agent): use --body-file to avoid literal \n in PR bodies

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -211,7 +211,14 @@ process action:log sessionId:XXX
 
 # 4. Create PRs after fixes
 cd /tmp/issue-78 && git push -u origin fix/issue-78
-gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body "..."
+cat > /tmp/pr-body.md << 'EOF'
+## Summary
+- what changed
+
+## Testing
+- how it was tested
+EOF
+gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body-file /tmp/pr-body.md
 
 # 5. Cleanup
 git worktree remove /tmp/issue-78
@@ -233,6 +240,18 @@ git worktree remove /tmp/issue-99
 7. **Parallel is OK** - run many Codex processes at once for batch work
 8. **NEVER start Codex in ~/.openclaw/** - it'll read your soul docs and get weird ideas about the org chart!
 9. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
+
+10. **PR bodies must use `--body-file`** - Passing a multiline string to `gh pr create --body "..."` produces literal `\n` characters in the PR body on GitHub. Always write the body to a temp file and use `--body-file`:
+    ```bash
+    cat > /tmp/pr-body.md << 'EOF'
+    ## Summary
+    - what changed and why
+
+    ## Testing
+    - how it was tested
+    EOF
+    gh pr create --title "..." --body-file /tmp/pr-body.md --base dev
+    ```
 
 ---
 


### PR DESCRIPTION
## Problem

When Codex (or any coding agent) runs `gh pr create --body "..."` with a multiline string, the result is literal `\n` characters in the GitHub PR body — not real newlines. The PR body renders as a single unformatted line.

## Fix

Document the correct pattern: write the body to a temp file via heredoc and pass `--body-file` to `gh pr create`. Added as rule 10 in the Rules section, and updated the worktree example to match.

## Testing

Observed directly — every `gh pr create --body "..."` call from Codex produced broken formatting until switched to `--body-file`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents the correct pattern for creating GitHub PR bodies via `gh pr create` to avoid literal `\n` characters in PR descriptions.

- Added rule #10 explaining that `--body "..."` produces broken formatting and `--body-file` with heredoc is required
- Updated the git worktree example to demonstrate the correct pattern
- Aligns with existing project guidelines in CLAUDE.md that mandate proper multiline string handling for GitHub operations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- Documentation-only change that corrects a well-documented problem with clear examples. The heredoc syntax is correct, the solution aligns with project guidelines, and there are no logic or syntax errors.
- No files require special attention

<sub>Last reviewed commit: c2e24e2</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->