### PR TITLE
feat(macos): add hide cron sessions toggle to menu bar sessions list

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuSessionsHeaderView: View {
     let count: Int
     let statusText: String?
+    var hiddenCronCount: Int = 0
 
     private let paddingTop: CGFloat = 8
     private let paddingBottom: CGFloat = 6
@@ -16,9 +17,16 @@ struct MenuSessionsHeaderView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 10)
-                Text(self.subtitle)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    if self.hiddenCronCount > 0 {
+                        Text("\(self.hiddenCronCount) cron hidden")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
+                    Text(self.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             if let statusText, !statusText.isEmpty {

--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -103,10 +103,11 @@ struct SessionRow: Identifiable {
 }
 
 enum SessionKind {
-    case direct, group, global, unknown
+    case direct, group, global, unknown, cron
 
     static func from(key: String) -> SessionKind {
         if key == "global" { return .global }
+        if key.hasPrefix("cron:") { return .cron }
         if key.hasPrefix("group:") { return .group }
         if key.contains(":group:") { return .group }
         if key.contains(":channel:") { return .group }
@@ -120,6 +121,7 @@ enum SessionKind {
         case .group: "Group"
         case .global: "Global"
         case .unknown: "Unknown"
+        case .cron: "Cron"
         }
     }
 
@@ -129,6 +131,7 @@ enum SessionKind {
         case .group: .orange
         case .global: .purple
         case .unknown: .gray
+        case .cron: Color(nsColor: .systemTeal)
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/SessionDataTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SessionDataTests.swift
@@ -9,6 +9,8 @@ struct SessionDataTests {
         #expect(SessionKind.from(key: "discord:group:engineering") == .group)
         #expect(SessionKind.from(key: "unknown") == .unknown)
         #expect(SessionKind.from(key: "user@example.com") == .direct)
+        #expect(SessionKind.from(key: "cron:abc123-def") == .cron)
+        #expect(SessionKind.from(key: "cron:weekly-agent-roundtable") == .cron)
     }
 
     @Test func sessionTokenStatsFormatKTokensRoundsAsExpected() {


### PR DESCRIPTION
## What

Adds a **Hide Cron Sessions** toggle at the bottom of the macOS menu bar sessions list.

Cron sessions (key prefix `cron:`) currently show up in the sessions list even when they produce no output and have `delivery.mode = "none"`. For users with many cron jobs running frequently (e.g. every 15 minutes), this pollutes the sessions list with dozens of low-signal entries.

## Changes

### `SessionData.swift`
- Add `.cron` case to `SessionKind` enum, detected by `cron:` key prefix
- Teal tint color, "Cron" label

### `MenuSessionsHeaderView.swift`
- Shows **"N cron hidden"** hint text in the header when crons are filtered

### `MenuSessionsInjector.swift`
- Add `hideCronSessions: Bool` backed by `UserDefaults` (key: `openclaw.menu.hideCronSessions`, **default: true**)
- Filter cron rows from the session list when enabled
- Inject a checkmarked toggle item at the bottom of the session list: **Hide Cron Sessions** / **Show Cron Sessions**
- Toggling re-injects immediately without closing/reopening the menu
- Empty state message: "No active sessions (cron hidden)" when crons are filtered and nothing else is active

### Tests
- 2 new `MenuSessionsInjectorTests` covering `hideCron=true` and `hideCron=false`
- 2 new `SessionKind` detection assertions for `cron:` keys

## UX

```
╭─────────────────────────────────────────╮
│ Context      2 cron hidden · 3 sessions │
│                                         │
│  main                        just now   │
│  discord:group:eng             2h ago   │
│  user@example.com              5h ago   │
│                                         │
│ ✓  Hide Cron Sessions                   │  ← bottom of list
╰─────────────────────────────────────────╯
```

Toggle flips to **Show Cron Sessions** when disabled. State persists across menu opens via UserDefaults.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a clean toggle to hide cron sessions from the macOS menu bar sessions list, addressing session list pollution from frequent cron jobs.

- Added `.cron` case to `SessionKind` enum with `cron:` prefix detection and teal color styling
- Header now shows "N cron hidden" hint when crons are filtered
- Toggle persists via `UserDefaults` with `openclaw.menu.hideCronSessions` key (default: `true`)
- Toggle menu item appears at bottom of session list with checkmark state indicator
- Empty state message updates to "No active sessions (cron hidden)" when applicable
- Comprehensive test coverage for both enabled/disabled states

The implementation follows existing patterns in the codebase and provides immediate visual feedback when toggling without requiring menu close/reopen.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing codebase patterns. The changes are isolated to session display logic with no impact on core functionality. Tests verify both enabled and disabled states, and the feature uses standard UserDefaults for persistence.
- No files require special attention

<sub>Last reviewed commit: d6f96e2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->