### PR TITLE
feat(ui): add hide-cron toggle to chat session selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.
 - Cron/Isolated sessions list: persist the intended pre-run model/provider on isolated cron session entries so `sessions_list` reflects payload/session model overrides even when runs fail before post-run telemetry persistence. (#21279) Thanks @altaywtf.
+- Web UI/Chat sessions: add a cron-session visibility toggle in the session selector, fix cron-key detection across `cron:*` and `agent:*:cron:*` formats, and localize the new control labels/tooltips. (#26976) Thanks @ianderrington.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -114,6 +114,9 @@ export const de: TranslationMap = {
     refreshTitle: "Chat-Daten aktualisieren",
     thinkingToggle: "Ausgabe des Assistenten ein-/ausblenden",
     focusToggle: "Fokusmodus ein-/ausschalten (Seitenleiste + Kopfzeile ausblenden)",
+    hideCronSessions: "Cron-Sitzungen ausblenden",
+    showCronSessions: "Cron-Sitzungen anzeigen",
+    showCronSessionsHidden: "Cron-Sitzungen anzeigen ({count} ausgeblendet)",
     onboardingDisabled: "Während der Einrichtung deaktiviert",
   },
   languages: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -111,6 +111,9 @@ export const en: TranslationMap = {
     refreshTitle: "Refresh chat data",
     thinkingToggle: "Toggle assistant thinking/working output",
     focusToggle: "Toggle focus mode (hide sidebar + page header)",
+    hideCronSessions: "Hide cron sessions",
+    showCronSessions: "Show cron sessions",
+    showCronSessionsHidden: "Show cron sessions ({count} hidden)",
     onboardingDisabled: "Disabled during onboarding",
   },
   languages: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -113,6 +113,9 @@ export const pt_BR: TranslationMap = {
     refreshTitle: "Atualizar dados do chat",
     thinkingToggle: "Alternar saída de pensamento/trabalho do assistente",
     focusToggle: "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",
+    hideCronSessions: "Ocultar sessões de cron",
+    showCronSessions: "Mostrar sessões de cron",
+    showCronSessionsHidden: "Mostrar sessões de cron ({count} ocultas)",
     onboardingDisabled: "Desativado durante a integração",
   },
   languages: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -110,6 +110,9 @@ export const zh_CN: TranslationMap = {
     refreshTitle: "刷新聊天数据",
     thinkingToggle: "切换助手思考/工作输出",
     focusToggle: "切换专注模式 (隐藏侧边栏 + 页面页眉)",
+    hideCronSessions: "隐藏定时任务会话",
+    showCronSessions: "显示定时任务会话",
+    showCronSessionsHidden: "显示定时任务会话 (已隐藏 {count} 个)",
     onboardingDisabled: "引导期间禁用",
   },
   languages: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -110,6 +110,9 @@ export const zh_TW: TranslationMap = {
     refreshTitle: "刷新聊天數據",
     thinkingToggle: "切換助手思考/工作輸出",
     focusToggle: "切換專注模式 (隱藏側邊欄 + 頁面頁眉)",
+    hideCronSessions: "隱藏定時任務會話",
+    showCronSessions: "顯示定時任務會話",
+    showCronSessionsHidden: "顯示定時任務會話 (已隱藏 {count} 個)",
     onboardingDisabled: "引導期間禁用",
   },
   languages: {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSessionKey, resolveSessionDisplayName } from "./app-render.helpers.ts";
+import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
@@ -259,5 +259,18 @@ describe("resolveSessionDisplayName", () => {
         row({ key: "agent:main:bluebubbles:direct:+19257864429", label: "Tyler" }),
       ),
     ).toBe("Tyler");
+  });
+});
+
+describe("isCronSessionKey", () => {
+  it("returns true for cron: prefixed keys", () => {
+    expect(isCronSessionKey("cron:abc-123")).toBe(true);
+    expect(isCronSessionKey("cron:weekly-agent-roundtable")).toBe(true);
+  });
+
+  it("returns false for non-cron keys", () => {
+    expect(isCronSessionKey("main")).toBe(false);
+    expect(isCronSessionKey("agent:main:cron:abc-123")).toBe(false);
+    expect(isCronSessionKey("discord:group:eng")).toBe(false);
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./app-render.helpers.ts";
+import {
+  isCronSessionKey,
+  parseSessionKey,
+  resolveSessionDisplayName,
+} from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
@@ -33,6 +37,10 @@ describe("parseSessionKey", () => {
 
   it("identifies cron sessions", () => {
     expect(parseSessionKey("agent:main:cron:daily-briefing-uuid")).toEqual({
+      prefix: "Cron:",
+      fallbackName: "Cron Job:",
+    });
+    expect(parseSessionKey("cron:daily-briefing-uuid")).toEqual({
       prefix: "Cron:",
       fallbackName: "Cron Job:",
     });
@@ -266,11 +274,13 @@ describe("isCronSessionKey", () => {
   it("returns true for cron: prefixed keys", () => {
     expect(isCronSessionKey("cron:abc-123")).toBe(true);
     expect(isCronSessionKey("cron:weekly-agent-roundtable")).toBe(true);
+    expect(isCronSessionKey("agent:main:cron:abc-123")).toBe(true);
+    expect(isCronSessionKey("agent:main:cron:abc-123:run:run-1")).toBe(true);
   });
 
   it("returns false for non-cron keys", () => {
     expect(isCronSessionKey("main")).toBe(false);
-    expect(isCronSessionKey("agent:main:cron:abc-123")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
+    expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -99,8 +99,9 @@ function renderCronFilterIcon(hiddenCount: number) {
         <circle cx="12" cy="12" r="10"></circle>
         <polyline points="12 6 12 12 16 14"></polyline>
       </svg>
-      ${hiddenCount > 0
-        ? html`<span
+      ${
+        hiddenCount > 0
+          ? html`<span
             style="
               position: absolute;
               top: -5px;
@@ -115,7 +116,8 @@ function renderCronFilterIcon(hiddenCount: number) {
             "
           >${hiddenCount}</span
           >`
-        : ""}
+          : ""
+      }
     </span>
   `;
 }
@@ -275,9 +277,13 @@ export function renderChatControls(state: AppViewState) {
           state.sessionsHideCron = !hideCron;
         }}
         aria-pressed=${hideCron}
-        title=${hideCron
-          ? `Show cron sessions${hiddenCronCount > 0 ? ` (${hiddenCronCount} hidden)` : ""}`
-          : "Hide cron sessions"}
+        title=${
+          hideCron
+            ? hiddenCronCount > 0
+              ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
+              : t("chat.showCronSessions")
+            : t("chat.hideCronSessions")
+        }
       >
         ${renderCronFilterIcon(hiddenCronCount)}
       </button>
@@ -336,6 +342,8 @@ function capitalize(s: string): string {
  * fallback display name.  Exported for testing.
  */
 export function parseSessionKey(key: string): SessionKeyInfo {
+  const normalized = key.toLowerCase();
+
   // ── Main session ─────────────────────────────────
   if (key === "main" || key === "agent:main:main") {
     return { prefix: "", fallbackName: "Main Session" };
@@ -347,7 +355,7 @@ export function parseSessionKey(key: string): SessionKeyInfo {
   }
 
   // ── Cron job ─────────────────────────────────────
-  if (key.includes(":cron:")) {
+  if (normalized.startsWith("cron:") || key.includes(":cron:")) {
     return { prefix: "Cron:", fallbackName: "Cron Job:" };
   }
 
@@ -405,7 +413,22 @@ export function resolveSessionDisplayName(
 }
 
 export function isCronSessionKey(key: string): boolean {
-  return key.startsWith("cron:");
+  const normalized = key.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.startsWith("cron:")) {
+    return true;
+  }
+  if (!normalized.startsWith("agent:")) {
+    return false;
+  }
+  const parts = normalized.split(":").filter(Boolean);
+  if (parts.length < 3) {
+    return false;
+  }
+  const rest = parts.slice(2).join(":");
+  return rest.startsWith("cron:");
 }
 
 function resolveSessionOptions(
@@ -456,15 +479,12 @@ function resolveSessionOptions(
 }
 
 /** Count sessions with a cron: key that would be hidden when hideCron=true. */
-function countHiddenCronSessions(
-  sessionKey: string,
-  sessions: SessionsListResult | null,
-): number {
-  if (!sessions?.sessions) return 0;
+function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResult | null): number {
+  if (!sessions?.sessions) {
+    return 0;
+  }
   // Don't count the currently active session even if it's a cron.
-  return sessions.sessions.filter(
-    (s) => isCronSessionKey(s.key) && s.key !== sessionKey,
-  ).length;
+  return sessions.sessions.filter((s) => isCronSessionKey(s.key) && s.key !== sessionKey).length;
 }
 
 const THEME_ORDER: ThemeMode[] = ["system", "light", "dark"];

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -163,6 +163,7 @@ export type AppViewState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionsHideCron: boolean;
   usageLoading: boolean;
   usageResult: SessionsUsageResult | null;
   usageCostSummary: CostUsageSummary | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -245,6 +245,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "120";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
+  @state() sessionsHideCron = true;
 
   @state() usageLoading = false;
   @state() usageResult: import("./types.js").SessionsUsageResult | null = null;


### PR DESCRIPTION
## What

Adds a **clock icon toggle button** in the chat controls bar that filters cron sessions out of the session selector dropdown. Default: **on** (crons hidden).

## Why

Cron sessions (`cron:` key prefix) accumulate fast — a job running every 15 min generates 48 entries/day. They clutter the session picker on small/mobile interfaces (e.g. Rabbit R1 accessing the dashboard).

## How it works

A small clock `⏱` button sits at the end of the existing chat controls row (alongside the Thinking and Focus mode toggles). When active (crons hidden):
- `cron:` sessions are filtered out of the session `<select>` options
- A small badge on the button shows the count of hidden sessions (e.g. `⏱ 14`)
- The button tooltip says "Show cron sessions (14 hidden)"
- The currently active session is **never** filtered out, even if it is a cron

Toggling off restores all sessions to the dropdown.

## Files changed

| File | Change |
|------|--------|
| `app-render.helpers.ts` | `isCronSessionKey()`, `countHiddenCronSessions()`, `renderCronFilterIcon()` helpers; `hideCron` param on `resolveSessionOptions()`; clock toggle button in `renderChatControls()` |
| `app-view-state.ts` | `sessionsHideCron: boolean` added to `AppViewState` |
| `app.ts` | `@state() sessionsHideCron = true` |
| `app-render.helpers.node.test.ts` | Tests for `isCronSessionKey()` |

## UX

```
[Main Session ▾]  [⟳]  |  [🧠]  [⊡]  [⏱ 14]
                                         ↑ new: clock with hidden count badge
                                           active = crons filtered
                                           inactive = all sessions visible
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a toggle button to hide cron sessions from the chat session dropdown, with a badge showing the count of hidden sessions. The UI wiring (`AppViewState` type, `@state()` property, button rendering, option filtering) is clean and follows existing patterns.

- **Critical bug**: The new `isCronSessionKey()` in `app-render.helpers.ts` checks `key.startsWith("cron:")`, but cron session keys returned by the `sessions.list` API use the fully qualified format (e.g. `agent:main:cron:job-1`). The core codebase's own `isCronSessionKey` in `src/sessions/session-key-utils.ts` correctly handles this by parsing the `agent:` prefix first. As a result, the toggle button will render but **never actually filter any cron sessions** from the dropdown.
- The tests encode the same incorrect assumption, asserting that `agent:main:cron:abc-123` returns `false` for the cron check.
- Consider reusing or aligning with the existing `isCronSessionKey` from `src/sessions/session-key-utils.ts` to keep key-matching logic consistent across the codebase.

<h3>Confidence Score: 2/5</h3>

- The PR is safe to merge (no regressions), but the new feature is non-functional due to a key-format mismatch.
- The core logic bug means the cron filter will never match any real session keys, rendering the entire feature inert. While it won't break anything existing, it adds dead UI and misleading controls. The fix is straightforward but required before the feature works as intended.
- Pay close attention to `ui/src/ui/app-render.helpers.ts` — the `isCronSessionKey` function needs to handle the fully qualified `agent:*:cron:*` key format used by the sessions API.

<sub>Last reviewed commit: 367ae8d</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->