### PR TITLE
fix: log warning when exec-approvals policy is clamped by config defaults

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -5,6 +5,7 @@ import {
   type ExecAsk,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
+import { logWarn } from "../logger.js";
 import { resolveRegisteredExecApprovalDecision } from "./bash-tools.exec-approval-request.js";
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
@@ -29,6 +30,16 @@ export function resolveExecHostApprovalContext(params: {
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
   const hostAsk = maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
+  if (hostSecurity !== params.security) {
+    logWarn(
+      `exec: agent=${params.agentId ?? "default"} security '${params.security}' clamped to '${hostSecurity}' by agent exec approvals for host=${params.host}`,
+    );
+  }
+  if (hostAsk !== params.ask) {
+    logWarn(
+      `exec: agent=${params.agentId ?? "default"} ask '${params.ask}' clamped to '${hostAsk}' by agent exec approvals for host=${params.host}`,
+    );
+  }
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);
   }

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -27,6 +27,7 @@ vi.mock("../infra/exec-obfuscation-detect.js", () => ({
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
 let detectCommandObfuscation: typeof import("../infra/exec-obfuscation-detect.js").detectCommandObfuscation;
+let resolveExecApprovalsPath: typeof import("../infra/exec-approvals.js").resolveExecApprovalsPath;
 
 function buildPreparedSystemRunPayload(rawInvokeParams: unknown) {
   const invoke = (rawInvokeParams ?? {}) as {
@@ -50,6 +51,7 @@ describe("exec approvals", () => {
     ({ callGatewayTool } = await import("./tools/gateway.js"));
     ({ createExecTool } = await import("./bash-tools.exec.js"));
     ({ detectCommandObfuscation } = await import("../infra/exec-obfuscation-detect.js"));
+    ({ resolveExecApprovalsPath } = await import("../infra/exec-approvals.js"));
   });
 
   beforeEach(async () => {
@@ -219,6 +221,118 @@ describe("exec approvals", () => {
     await approvalSeen;
     expect(calls).toContain("exec.approval.request");
     expect(calls).toContain("exec.approval.waitDecision");
+  });
+
+  it("logs when config defaults clamp requested security and ask", async () => {
+    const warnings: string[] = [];
+    vi.spyOn(await import("../logger.js"), "logWarn").mockImplementation((message: string) => {
+      warnings.push(message);
+    });
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "deny" };
+      }
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+        return { payload: { success: true, stdout: "ok" } };
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-clamp-config", {
+      command: "echo ok",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(result.details.status).toBeDefined();
+    expect(
+      warnings.some((message) =>
+        message.includes(
+          "security 'full' clamped to 'allowlist' by config-level tools.exec.security",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      warnings.some((message) =>
+        message.includes("ask 'off' clamped to 'always' by config-level tools.exec.ask"),
+      ),
+    ).toBe(true);
+  });
+
+  it("logs when agent exec approvals clamp node host security and ask", async () => {
+    const warnings: string[] = [];
+    vi.spyOn(await import("../logger.js"), "logWarn").mockImplementation((message: string) => {
+      warnings.push(message);
+    });
+
+    const approvalsFile = {
+      version: 1,
+      defaults: { security: "full", ask: "off", askFallback: "deny" },
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "always",
+        },
+      },
+    };
+    const approvalsPath = resolveExecApprovalsPath();
+    await fs.mkdir(path.dirname(approvalsPath), { recursive: true });
+    await fs.writeFile(approvalsPath, JSON.stringify(approvalsFile), "utf-8");
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: (params as { id?: string })?.id };
+      }
+      if (method === "exec.approval.waitDecision") {
+        return { decision: "deny" };
+      }
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+        return { payload: { success: true, stdout: "ok" } };
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-clamp-approvals", { command: "echo ok" });
+
+    expect(result.details.status).toBeDefined();
+    expect(
+      warnings.some((message) =>
+        message.includes(
+          "security 'full' clamped to 'allowlist' by agent exec approvals for host=node",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      warnings.some((message) =>
+        message.includes("ask 'off' clamped to 'always' by agent exec approvals for host=node"),
+      ),
+    ).toBe(true);
   });
 
   it("waits for approval registration before returning approval-pending", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -7,7 +7,7 @@ import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
-import { logInfo } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
@@ -327,6 +327,16 @@ export function createExecTool(
       const configuredAsk = defaults?.ask ?? "on-miss";
       const requestedAsk = normalizeExecAsk(params.ask);
       let ask = maxAsk(configuredAsk, requestedAsk ?? configuredAsk);
+      if (requestedSecurity && security !== requestedSecurity) {
+        logWarn(
+          `exec: agent=${agentId ?? "default"} security '${requestedSecurity}' clamped to '${security}' by config-level tools.exec.security — set tools.exec.security in your config to allow this`,
+        );
+      }
+      if (requestedAsk && ask !== requestedAsk) {
+        logWarn(
+          `exec: agent=${agentId ?? "default"} ask '${requestedAsk}' clamped to '${ask}' by config-level tools.exec.ask — set tools.exec.ask in your config to allow this`,
+        );
+      }
       const bypassApprovals = elevatedRequested && elevatedMode === "full";
       if (bypassApprovals) {
         ask = "off";


### PR DESCRIPTION
When a user sets `security: "full"` in `exec-approvals.json`, the `minSecurity()` function silently clamps it to the more restrictive config-level `tools.exec.security` default (typically `"allowlist"`). There is zero log output explaining why the user's intended policy was overridden.

This makes debugging exec approval issues extremely frustrating — the config file looks correct, `openclaw approvals get` shows the right values, but commands still get gated with no indication of why.

## Changes

Added `logInfo` calls in all three exec host handlers that log when `minSecurity()` or `maxAsk()` produces a value different from what the user configured in `exec-approvals.json`:

- `src/agents/bash-tools.exec-host-gateway.ts`
- `src/agents/bash-tools.exec-host-node.ts`
- `src/agents/bash-tools.exec.ts`

Example log output:
```
exec: agent security 'full' clamped to 'allowlist' by config-level tools.exec.security
exec: agent ask 'off' clamped to 'on-miss' by config-level tools.exec.ask
```

## Context

This was discovered while debugging why agents with `security: "full"` in `exec-approvals.json` were still hitting the approval gate. The resolution chain `minSecurity("allowlist", "full") = "allowlist"` is correct behavior (defense in depth), but without logging, users have no way to know they also need to set `tools.exec.security: "full"` in the main config.

## Testing

- Build passes (`pnpm build`)
- Format check passes (`pnpm format:check`)
- No new dependencies

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds helpful logging when exec security policies are clamped by config defaults, addressing a real pain point in debugging exec approvals. However, there's a critical logic error in `src/agents/bash-tools.exec.ts` that prevents the warning from appearing in the exact scenario described in the PR (user sets `security: "full"` in exec-approvals.json, but config has `"allowlist"`).

- The implementations in `bash-tools.exec-host-gateway.ts` and `bash-tools.exec-host-node.ts` are correct and will log as intended
- The implementation in `bash-tools.exec.ts` compares against the wrong variable (`configuredSecurity` instead of `requestedSecurity`), causing it to miss the primary use case and log in incorrect scenarios
- The fix is straightforward: compare the final value against the requested value, not the configured value

<h3>Confidence Score: 2/5</h3>

- This PR has a logic error that prevents it from working correctly in the primary use case
- Score reflects a clear logical bug that breaks the main functionality described in the PR. Two of three implementations work correctly, but the third has inverted logic that will cause missed warnings and incorrect warnings.
- `src/agents/bash-tools.exec.ts` requires immediate attention due to incorrect comparison logic

<sub>Last reviewed commit: 8e10b68</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->