### PR TITLE
Use agent bindings for message account defaults

### DIFF
--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1263,6 +1263,42 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.params.accountId).toBe("codeagent");
   });
 
+  it("resolves agent-bound account from sessionKey when agentId is omitted", async () => {
+    await runMessageAction({
+      cfg: {
+        bindings: [
+          {
+            agentId: "codeagent",
+            match: {
+              channel: "discord",
+              accountId: "codeagent",
+            },
+          },
+        ],
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "discord",
+        target: "channel:123",
+        message: "hi",
+      },
+      sessionKey: "agent:codeagent:main",
+      defaultAccountId: "main",
+    });
+
+    const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+      | {
+          accountId?: string | null;
+          params: Record<string, unknown>;
+        }
+      | undefined;
+    if (!ctx) {
+      throw new Error("expected action context");
+    }
+    expect(ctx.accountId).toBe("codeagent");
+    expect(ctx.params.accountId).toBe("codeagent");
+  });
+
   it("keeps explicit accountId even when an agent binding exists", async () => {
     await runMessageAction({
       cfg: {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1227,10 +1227,18 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.params.accountId).toBe("ops");
   });
 
-  it("falls back to the agent's bound account when accountId is omitted", async () => {
+  it("prefers agent-bound account over inherited defaultAccountId", async () => {
     await runMessageAction({
       cfg: {
-        bindings: [{ agentId: "agent-b", match: { channel: "discord", accountId: "account-b" } }],
+        bindings: [
+          {
+            agentId: "codeagent",
+            match: {
+              channel: "discord",
+              accountId: "codeagent",
+            },
+          },
+        ],
       } as OpenClawConfig,
       action: "send",
       params: {
@@ -1238,10 +1246,10 @@ describe("runMessageAction accountId defaults", () => {
         target: "channel:123",
         message: "hi",
       },
-      agentId: "agent-b",
+      agentId: "codeagent",
+      defaultAccountId: "main",
     });
 
-    expect(handleAction).toHaveBeenCalled();
     const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
       | {
           accountId?: string | null;
@@ -1251,7 +1259,44 @@ describe("runMessageAction accountId defaults", () => {
     if (!ctx) {
       throw new Error("expected action context");
     }
-    expect(ctx.accountId).toBe("account-b");
-    expect(ctx.params.accountId).toBe("account-b");
+    expect(ctx.accountId).toBe("codeagent");
+    expect(ctx.params.accountId).toBe("codeagent");
+  });
+
+  it("keeps explicit accountId even when an agent binding exists", async () => {
+    await runMessageAction({
+      cfg: {
+        bindings: [
+          {
+            agentId: "codeagent",
+            match: {
+              channel: "discord",
+              accountId: "codeagent",
+            },
+          },
+        ],
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "discord",
+        target: "channel:123",
+        message: "hi",
+        accountId: "ops",
+      },
+      agentId: "codeagent",
+      defaultAccountId: "main",
+    });
+
+    const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+      | {
+          accountId?: string | null;
+          params: Record<string, unknown>;
+        }
+      | undefined;
+    if (!ctx) {
+      throw new Error("expected action context");
+    }
+    expect(ctx.accountId).toBe("ops");
+    expect(ctx.params.accountId).toBe("ops");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,11 +14,13 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "../../poll-params.js";
-import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
-import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
+import {
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+  type GatewayClientMode,
+  type GatewayClientName,
+} from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import {
   listConfiguredMessageChannels,
@@ -227,6 +229,19 @@ async function resolveChannel(
     params.channel = selection.channel;
   }
   return selection.channel;
+}
+
+function resolveAgentBoundAccountId(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  agentId?: string;
+}): string | undefined {
+  const agentId = params.agentId?.trim();
+  if (!agentId) {
+    return undefined;
+  }
+  const byAgent = buildChannelAccountBindings(params.cfg).get(params.channel);
+  return byAgent?.get(agentId)?.[0];
 }
 
 async function resolveActionTarget(params: {
@@ -726,6 +741,42 @@ export async function runMessageAction(
       accountId = boundAccountIds[0];
     }
   }
+  if (!explicitTarget && actionRequiresTarget(action) && hasLegacyTarget) {
+    const legacyTo = typeof params.to === "string" ? params.to.trim() : "";
+    const legacyChannelId = typeof params.channelId === "string" ? params.channelId.trim() : "";
+    const legacyTarget = legacyTo || legacyChannelId;
+    if (legacyTarget) {
+      params.target = legacyTarget;
+      delete params.to;
+      delete params.channelId;
+    }
+  }
+  const explicitChannel = typeof params.channel === "string" ? params.channel.trim() : "";
+  if (!explicitChannel) {
+    const inferredChannel = normalizeMessageChannel(input.toolContext?.currentChannelProvider);
+    if (inferredChannel && isDeliverableMessageChannel(inferredChannel)) {
+      params.channel = inferredChannel;
+    }
+  }
+
+  applyTargetToParams({ action, args: params });
+  if (actionRequiresTarget(action)) {
+    if (!actionHasTarget(action, params)) {
+      throw new Error(`Action ${action} requires a target.`);
+    }
+  }
+
+  const channel = await resolveChannel(cfg, params);
+  const explicitAccountId = readStringParam(params, "accountId");
+  const agentBoundAccountId =
+    !explicitAccountId && resolvedAgentId
+      ? resolveAgentBoundAccountId({
+          cfg,
+          channel,
+          agentId: resolvedAgentId,
+        })
+      : undefined;
+  const accountId = explicitAccountId ?? agentBoundAccountId ?? input.defaultAccountId;
   if (accountId) {
     params.accountId = accountId;
   }


### PR DESCRIPTION
## Summary
- prefer channel/agent binding account IDs when the message action omits accountId
- keep explicit accountId values as highest priority
- add tests for binding precedence and explicit override behavior

## Why
Sub-agents can inherit the requester account context, which caused outbound messages to route through the wrong bot in multi-account setups. This change makes account selection align with routing bindings for the active agent.

## Testing
- bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /Users/newdldewdl/.openclaw/workspace/memory/openclaw-contrib/worktrees/issue-26975

AI-assisted: yes

Fixes #26975

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds agent-bound account ID resolution to the message action runner, ensuring sub-agents use their configured account bindings instead of inheriting the requester's account context.

- Introduced `resolveAgentBoundAccountId` helper that looks up agent-specific account bindings from channel configuration
- Modified account resolution to use three-tier precedence: explicit `accountId` param → agent binding → `defaultAccountId`
- Added comprehensive test coverage for binding precedence and explicit override behavior

The implementation correctly prevents wrong-bot routing in multi-account setups by respecting agent-to-account bindings defined in the configuration.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The changes are well-structured, thoroughly tested, and maintain backward compatibility. The new account resolution logic correctly implements the stated precedence (explicit > agent-bound > default) and all edge cases are properly handled with optional chaining and type safety.
- No files require special attention

<sub>Last reviewed commit: 5acd1d6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->