### PR TITLE
fix(gateway): harden hooks URL parsing for bind hosts

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -208,7 +208,7 @@ export function createHooksRequestHandler(
     logHooks: SubsystemLogger;
   } & HookDispatchers,
 ): HooksRequestHandler {
-  const { getHooksConfig, bindHost, port, logHooks, dispatchAgentHook, dispatchWakeHook } = opts;
+  const { getHooksConfig, logHooks, dispatchAgentHook, dispatchWakeHook } = opts;
   const hookAuthLimiter = createAuthRateLimiter({
     maxAttempts: HOOK_AUTH_FAILURE_LIMIT,
     windowMs: HOOK_AUTH_FAILURE_WINDOW_MS,
@@ -227,7 +227,9 @@ export function createHooksRequestHandler(
     if (!hooksConfig) {
       return false;
     }
-    const url = new URL(req.url ?? "/", `http://${bindHost}:${port}`);
+    // Only pathname/search are used here; keep the base host fixed so bind-host
+    // representation (e.g. IPv6 wildcards) cannot break request parsing.
+    const url = new URL(req.url ?? "/", "http://localhost");
     const basePath = hooksConfig.basePath;
     if (url.pathname !== basePath && !url.pathname.startsWith(`${basePath}/`)) {
       return false;


### PR DESCRIPTION
## Summary
Fixes the hooks request URL parsing to avoid dependence on runtime bind-host representation.

## Root cause
`createHooksRequestHandler` used:

`new URL(req.url ?? "/", `http://${bindHost}:${port}`)`

For unbracketed IPv6 wildcard hosts (for example `::`), that base is invalid URL syntax and can throw during request parsing.

## Changes
- Use fixed parsing base `http://localhost` in hooks handler (only pathname/query are needed).
- Add regression tests proving non-hook request parsing does not throw for:
  - `bindHost="0.0.0.0"`
  - `bindHost="::"`

## Validation
- `pnpm check`
- `pnpm build`
- `pnpm test`

Closes #26864

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes IPv6 wildcard bind host crash in hooks URL parsing by using a fixed `http://localhost` base URL instead of the runtime bind host. The URL object only needs `pathname` and `searchParams`, so the host/port are irrelevant. Includes regression tests for both IPv4 (`0.0.0.0`) and IPv6 (`::`) wildcard hosts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, focused, and well-tested. It solves a concrete crash issue without changing behavior. The URL object is only used for pathname and search parameters, never for host/port, so using a fixed base is safe. Test coverage verifies the fix for both IPv4 and IPv6 wildcard bind hosts.
- No files require special attention

<sub>Last reviewed commit: 8caa054</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->