### PR TITLE
test(gateway): add hooks bind-host hardening coverage

### DIFF
--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, test, vi } from "vitest";
+import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { createGatewayHttpServer } from "./server-http.js";
+import type { HooksConfigResolved } from "./hooks.js";
+import { createGatewayHttpServer, createHooksRequestHandler } from "./server-http.js";
 import { withTempConfig } from "./test-temp-config.js";
 
 function createRequest(params: {
@@ -63,6 +65,25 @@ async function dispatchRequest(
 ): Promise<void> {
   server.emit("request", req, res);
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createHooksConfig(): HooksConfigResolved {
+  return {
+    basePath: "/hooks",
+    token: "hook-secret",
+    maxBodyBytes: 1024,
+    mappings: [],
+    agentPolicy: {
+      defaultAgentId: "main",
+      knownAgentIds: new Set(["main"]),
+      allowedAgentIds: undefined,
+    },
+    sessionPolicy: {
+      allowRequestSessionKey: false,
+      defaultSessionKey: undefined,
+      allowedSessionKeyPrefixes: undefined,
+    },
+  };
 }
 
 describe("gateway plugin HTTP auth boundary", () => {
@@ -217,6 +238,103 @@ describe("gateway plugin HTTP auth boundary", () => {
         expect(unauthenticatedPublic.getBody()).toContain('"route":"public"');
 
         expect(handlePluginRequest).toHaveBeenCalledTimes(2);
+      },
+    });
+  });
+
+  test.each(["0.0.0.0", "::"])(
+    "returns 404 (not 500) for non-hook routes with hooks enabled and bindHost=%s",
+    async (bindHost) => {
+      const resolvedAuth: ResolvedGatewayAuth = {
+        mode: "none",
+        token: undefined,
+        password: undefined,
+        allowTailscale: false,
+      };
+
+      await withTempConfig({
+        cfg: { gateway: { trustedProxies: [] } },
+        prefix: "openclaw-plugin-http-hooks-bindhost-",
+        run: async () => {
+          const handleHooksRequest = createHooksRequestHandler({
+            getHooksConfig: () => createHooksConfig(),
+            bindHost,
+            port: 18789,
+            logHooks: {
+              warn: vi.fn(),
+              debug: vi.fn(),
+              info: vi.fn(),
+              error: vi.fn(),
+            } as unknown as ReturnType<typeof createSubsystemLogger>,
+            dispatchWakeHook: () => {},
+            dispatchAgentHook: () => "run-1",
+          });
+          const server = createGatewayHttpServer({
+            canvasHost: null,
+            clients: new Set(),
+            controlUiEnabled: false,
+            controlUiBasePath: "/__control__",
+            openAiChatCompletionsEnabled: false,
+            openResponsesEnabled: false,
+            handleHooksRequest,
+            resolvedAuth,
+          });
+
+          const response = createResponse();
+          await dispatchRequest(server, createRequest({ path: "/" }), response.res);
+
+          expect(response.res.statusCode).toBe(404);
+          expect(response.getBody()).toBe("Not Found");
+        },
+      });
+    },
+  );
+
+  test("rejects query-token hooks requests with bindHost=::", async () => {
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    };
+
+    await withTempConfig({
+      cfg: { gateway: { trustedProxies: [] } },
+      prefix: "openclaw-plugin-http-hooks-query-token-",
+      run: async () => {
+        const handleHooksRequest = createHooksRequestHandler({
+          getHooksConfig: () => createHooksConfig(),
+          bindHost: "::",
+          port: 18789,
+          logHooks: {
+            warn: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+          } as unknown as ReturnType<typeof createSubsystemLogger>,
+          dispatchWakeHook: () => {},
+          dispatchAgentHook: () => "run-1",
+        });
+        const server = createGatewayHttpServer({
+          canvasHost: null,
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest,
+          resolvedAuth,
+        });
+
+        const response = createResponse();
+        await dispatchRequest(
+          server,
+          createRequest({ path: "/hooks/wake?token=bad" }),
+          response.res,
+        );
+
+        expect(response.res.statusCode).toBe(400);
+        expect(response.getBody()).toContain("Hook token must be provided");
       },
     });
   });


### PR DESCRIPTION
## Summary
Adds integration-level coverage for the hooks bind-host hardening path.

## Added tests
- Non-hook request path with hooks enabled returns `404` (not catch-all `500`) when bindHost is:
  - `0.0.0.0`
  - `::`
- Hook route with query token under bindHost `::` still parses and returns `400` as expected.

## Validation
- `pnpm vitest run src/gateway/server.plugin-http-auth.test.ts src/gateway/server-http.hooks-request-timeout.test.ts`
- `pnpm check`

Refs #26864

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds integration-level test coverage for the hooks bind-host hardening introduced in #26864. The tests verify that URL parsing works correctly when using wildcard bind addresses (`0.0.0.0` and `::`), ensuring non-hook requests return `404` instead of crashing with `500`, and that hook routes with query tokens are properly rejected with `400`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Test-only change that adds coverage for existing hardening logic. The tests follow established patterns, use proper mocking, and have clear assertions. No functional code changes means zero risk of runtime regressions.
- No files require special attention

<sub>Last reviewed commit: d67928a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->