### PR TITLE
fix(line): block monitorLineProvider until abort to prevent crash loop

### DIFF
--- a/src/line/monitor.lifecycle.test.ts
+++ b/src/line/monitor.lifecycle.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+// Minimal stub for the LINE bot SDK type used by monitor.ts
+vi.mock("./bot.js", () => ({
+  createLineBot: () => ({
+    account: { accountId: "default", config: {} },
+    handleWebhook: vi.fn(),
+  }),
+}));
+
+vi.mock("../plugins/http-registry.js", () => ({
+  registerPluginHttpRoute: () => vi.fn(), // returns unregister stub
+}));
+
+// Import after mocks are installed
+const { monitorLineProvider } = await import("./monitor.js");
+
+describe("monitorLineProvider lifecycle", () => {
+  it("blocks until abort signal fires instead of resolving immediately", async () => {
+    const abort = new AbortController();
+
+    const task = monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      abortSignal: abort.signal,
+    });
+
+    // Promise must still be pending after a tick
+    let resolved = false;
+    void task.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve(); // flush microtasks
+    expect(resolved).toBe(false);
+
+    // Fire the abort signal — the promise must now resolve
+    abort.abort();
+    await task;
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately when abort signal is already aborted", async () => {
+    const abort = new AbortController();
+    abort.abort();
+
+    // Should not hang
+    await expect(
+      monitorLineProvider({
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        config: {} as OpenClawConfig,
+        runtime: {} as RuntimeEnv,
+        abortSignal: abort.signal,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("resolves (does not block) when no abort signal is provided", async () => {
+    await expect(
+      monitorLineProvider({
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        config: {} as OpenClawConfig,
+        runtime: {} as RuntimeEnv,
+        // no abortSignal
+      }),
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

`monitorLineProvider()` in `src/line/monitor.ts` registers the webhook HTTP handler and returns immediately. The channel manager wraps `startAccount` in:

```ts
Promise.resolve(task).finally(() => {
  setRuntime(channelId, id, { running: false, lastStopAt: Date.now() });
  ...
});
```

Because the promise resolves at once, `.finally()` fires immediately, sets `running: false`, and triggers the exponential-backoff restart loop:

```
[line] [default] starting LINE provider
[line] [default] auto-restart attempt 1/10 in 5s
[line] [default] starting LINE provider
[line] [default] auto-restart attempt 2/10 in 10s
...
[line] [default] giving up after 10 restart attempts
[health-monitor] [line:default] health-monitor: restarting (reason: gave-up)
```

The cycle repeats indefinitely, making the LINE channel completely unusable.

## Fix

Add the abort-signal blocking pattern already used by Telegram's webhook mode (`src/telegram/monitor.ts` lines 173-180): after registering the HTTP route, await a `Promise<void>` that only resolves when the abort signal fires.

```ts
if (abortSignal && !abortSignal.aborted) {
  await new Promise<void>((resolve) => {
    const onAbort = () => {
      abortSignal.removeEventListener('abort', onAbort);
      resolve();
    };
    abortSignal.addEventListener('abort', onAbort, { once: true });
  });
}
```

When no `abortSignal` is provided (e.g. one-shot / test callers), the function returns immediately as before.

## Tests

Added `src/line/monitor.lifecycle.test.ts` with three cases:

- Promise stays pending after a tick (regression guard for the crash-loop bug)  
- Promise resolves once abort fires  
- Promise resolves immediately when no abort signal is provided (no-signal path unchanged)

All 7 LINE monitor tests pass (`monitor.lifecycle`, `monitor.fail-closed`, `monitor.read-body`). Full `pnpm build` and `pnpm check` clean.

Fixes #26978

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes critical infinite restart loop bug in LINE channel by blocking `monitorLineProvider()` until abort signal fires. The issue occurred because the function returned immediately after registering the webhook handler, causing the channel manager to interpret this as an exit and trigger exponential-backoff restarts indefinitely.

The fix adopts the same abort-signal blocking pattern used by Telegram's webhook mode (lines 173-180 in `src/telegram/monitor.ts`). After registering the HTTP route, the function now awaits a Promise that only resolves when the abort signal fires, ensuring the channel manager sees a long-running process.

**Key changes:**
- Added blocking await pattern in `src/line/monitor.ts` (lines 318-326) with clear comments explaining the fix
- Added `src/line/monitor.lifecycle.test.ts` with three test cases covering the regression scenario, already-aborted signals, and backward compatibility for no-signal callers
- All 7 LINE monitor tests pass according to PR description

The implementation is correct, follows established patterns, and includes comprehensive regression guards.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical production issue using a proven pattern
- The fix correctly addresses the root cause by implementing the same abort-signal blocking pattern already proven in Telegram's webhook mode. The implementation is clean, includes clear explanatory comments, and provides comprehensive test coverage for the regression scenario plus edge cases. No logical errors, race conditions, or security issues were found. The change is minimal, focused, and follows repository conventions.
- No files require special attention - both the implementation and tests are straightforward and well-designed

<sub>Last reviewed commit: 36be99e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->