### PR TITLE
fix: prevent false-positive silent reply detection for CJK text

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { isSilentReplyText } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  // Should be silent
+  it("matches exact token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  it("matches token with leading whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY")).toBe(true);
+  });
+
+  it("matches token with trailing whitespace", () => {
+    expect(isSilentReplyText("NO_REPLY  ")).toBe(true);
+  });
+
+  it("matches token with trailing period", () => {
+    expect(isSilentReplyText("NO_REPLY.")).toBe(true);
+  });
+
+  it("matches token at end of English sentence", () => {
+    expect(isSilentReplyText("The answer is NO_REPLY.")).toBe(true);
+  });
+
+  it("matches token at end with trailing punctuation", () => {
+    expect(isSilentReplyText("NO_REPLY...")).toBe(true);
+  });
+
+  // Should NOT be silent — CJK content after token
+  it("does not match when CJK text follows the token", () => {
+    expect(isSilentReplyText("其他 agent 输出 NO_REPLY → gateway 不发消息")).toBe(false);
+  });
+
+  it("does not match when Chinese text follows at end", () => {
+    expect(isSilentReplyText("3 个返回了 NO_REPLY 被吞掉了。")).toBe(false);
+  });
+
+  it("does not match when token is mid-sentence in Chinese", () => {
+    expect(
+      isSilentReplyText(
+        "在咱俩的 DM 里，基本不会触发 NO_REPLY，因为你发给我的每条消息我都应该回复。",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match when token appears in explanation with CJK", () => {
+    expect(isSilentReplyText("LLM 返回的内容如果整条只有 NO_REPLY 这几个字")).toBe(false);
+  });
+
+  // Should NOT be silent — content before token at start
+  it("does not match token in middle of English sentence", () => {
+    expect(isSilentReplyText("The system uses NO_REPLY to suppress messages")).toBe(false);
+  });
+
+  // Edge cases
+  it("returns false for empty string", () => {
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+  });
+
+  it("matches token at start followed by newline", () => {
+    expect(isSilentReplyText("NO_REPLY\n")).toBe(true);
+  });
+});

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,11 +11,17 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
+  // Only treat as silent if the token appears at the start (with optional leading whitespace)
+  // followed by end-of-string or ASCII non-word char (not CJK/unicode content).
+  const prefix = new RegExp(`^\\s*${escaped}(?=$|[\\s\\p{P}])`, "u");
   if (prefix.test(text)) {
     return true;
   }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
+  // Only treat as silent if the token appears at the end, followed only by
+  // whitespace or ASCII punctuation — NOT CJK or other unicode content.
+  // Previous regex used \W*$ which incorrectly matched CJK characters as non-word,
+  // causing false positives for messages discussing the token in non-Latin scripts.
+  const suffix = new RegExp(`\\b${escaped}\\b[\\s.!?,;:…]*$`);
   return suffix.test(text);
 }
 


### PR DESCRIPTION
## Problem

`isSilentReplyText` in `src/auto-reply/tokens.ts` uses `\W*$` in the suffix regex to detect trailing characters after the silent reply token. In JavaScript, `\W` matches any character that is not `[a-zA-Z0-9_]`, which means **all CJK characters (Chinese, Japanese, Korean) are treated as non-word characters**.

This causes false positives: any message that *discusses* the silent reply token in a CJK language gets silently suppressed, even though the token is not being used as a directive.

### Example

A message like:
```
3 个返回了 NO_REPLY 被吞掉了。
```
Gets falsely suppressed because `被吞掉了。` (all CJK + punctuation) matches `\W*$`.

### Impact

Any agent responding in Chinese/Japanese/Korean that mentions the silent reply token mid-sentence will have their entire message silently dropped. This was discovered in a real production scenario where an agent was explaining the silent reply mechanism to a user in Chinese.

## Fix

- **Suffix regex**: Replace `\W*$` with `[\s.!?,;:…]*$` — only allow whitespace and common punctuation after the token, not arbitrary Unicode content.
- **Prefix regex**: Use Unicode-aware `\p{P}` for consistency.

## Tests

Added `src/auto-reply/tokens.test.ts` with 14 test cases covering:
- Standard silent reply detection (exact match, leading/trailing whitespace, trailing punctuation)
- CJK false-positive prevention (token embedded in Chinese sentences)
- Edge cases (empty string, undefined, newlines)

All tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical false-positive bug where messages discussing `NO_REPLY` in CJK languages (Chinese/Japanese/Korean) were being silently suppressed. The root cause was the use of `\W` in the regex, which treats all CJK characters as non-word characters, causing any CJK text after the token to match the pattern.

**Key changes:**
- **Prefix regex**: Replaced `\W` with `[\s\p{P}]` using Unicode-aware punctuation matching to properly distinguish between word characters and punctuation across all scripts
- **Suffix regex**: Replaced `\W*$` with `[\s.!?,;:…]*$` to restrict matches to only whitespace and common ASCII punctuation, preventing false positives from CJK content
- **Test coverage**: Added 14 comprehensive test cases covering exact matches, whitespace handling, CJK false-positive prevention, and edge cases

The fix uses an intentional asymmetry: the prefix is more permissive (allows Unicode punctuation) to catch legitimate silent reply directives in various languages, while the suffix is more restrictive (ASCII punctuation only) to avoid false positives when the token appears in explanatory text followed by CJK content.

All test cases appropriately cover the scenarios where CJK text appears around the token with spaces (the common usage pattern), and the fix correctly prevents these from being treated as silent reply directives.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a real production bug with well-tested changes
- Score reflects a targeted bug fix with comprehensive test coverage (14 test cases), clear problem description with real-world examples, minimal surface area of change (2 regex patterns), and proper documentation. The fix addresses a genuine false-positive issue affecting CJK users without introducing regressions. The design trade-offs (asymmetric prefix/suffix patterns) are intentional and reasonable for the use case.
- No files require special attention - both changed files are well-structured with clear test coverage

<sub>Last reviewed commit: 1b06268</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->