### PR TITLE
fix(gateway): use loopback for CLI status probe when bind=lan

### DIFF
--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -73,7 +73,10 @@ export function pickProbeHostForBind(
     return tailnetIPv4 ?? "127.0.0.1";
   }
   if (bindMode === "lan") {
-    return pickPrimaryLanIPv4() ?? "127.0.0.1";
+    // Same as call.ts: self-connections should always target loopback.
+    // bind=lan controls which interfaces the server listens on (0.0.0.0),
+    // but co-located CLI probes should connect via 127.0.0.1.
+    return "127.0.0.1";
   }
   return "127.0.0.1";
 }


### PR DESCRIPTION
Commit 47f397975 fixed `buildGatewayConnectionDetails()` in call.ts to always use 127.0.0.1 for local self-connections, but the same fix was not applied to `pickProbeHostForBind()` in shared.ts.

This causes `openclaw gateway status` to construct the RPC probe URL using the LAN IP (e.g. ws://192.168.2.7:18789) instead of loopback, which then fails the plaintext-ws security check — even though the gateway is running and healthy on the same host.

The bind mode controls which interfaces the *server* listens on; it should not affect which address the co-located *client* uses. 0.0.0.0 always accepts loopback connections.

Fixes the remaining case from #19004.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `pickProbeHostForBind()` to always use loopback (127.0.0.1) for CLI status probes, matching the security fix previously applied to `buildGatewayConnectionDetails()` in call.ts. The bug caused `openclaw gateway status` to construct probe URLs using the LAN IP (e.g., ws://192.168.2.7:18789) when `bind=lan`, which then failed the plaintext-ws security check even though the gateway was running locally.

Key changes:
- Replaced `pickPrimaryLanIPv4() ?? "127.0.0.1"` with `"127.0.0.1"` for `bind=lan` mode
- Added clear comment explaining that self-connections should always target loopback, regardless of bind mode
- The bind mode controls which interfaces the server listens on (0.0.0.0), but co-located clients should always connect via 127.0.0.1

This fix is correct because loopback connections are always accepted by 0.0.0.0 listeners, and the security policy (from commit 9edec67a1) blocks plaintext ws:// connections to non-loopback addresses to prevent credential and chat data exposure (CWE-319).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security bugfix that makes the code consistent.
- The fix is straightforward, well-commented, and correctly addresses a security check failure. It makes `pickProbeHostForBind()` consistent with the parallel fix in `buildGatewayConnectionDetails()`, which has comprehensive test coverage demonstrating that loopback should always be used for self-connections. The change is minimal (3 lines changed to 1 return statement with explanatory comment), follows established patterns in the codebase, and fixes a clear bug where CLI status probes were incorrectly using LAN IPs instead of loopback.
- No files require special attention

<sub>Last reviewed commit: ecebf06</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->