### PR TITLE
fix(failover): trigger fallback for stop reason error

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -33,12 +33,17 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ code: "ECONNRESET" })).toBe("timeout");
   });
 
-  it("infers timeout from abort stop-reason messages", () => {
+  it("infers timeout from abort/error stop-reason messages", () => {
     expect(resolveFailoverReasonFromError({ message: "Unhandled stop reason: abort" })).toBe(
       "timeout",
     );
     expect(resolveFailoverReasonFromError({ message: "stop reason: abort" })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ message: "reason: abort" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ message: "Unhandled stop reason: error" })).toBe(
+      "timeout",
+    );
+    expect(resolveFailoverReasonFromError({ message: "stop reason: error" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ message: "reason: error" })).toBe("timeout");
   });
 
   it("treats AbortError reason=abort as timeout", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -5,7 +5,7 @@ import {
 } from "./pi-embedded-helpers.js";
 
 const TIMEOUT_HINT_RE =
-  /timeout|timed out|deadline exceeded|context deadline exceeded|stop reason:\s*abort|reason:\s*abort|unhandled stop reason:\s*abort/i;
+  /timeout|timed out|deadline exceeded|context deadline exceeded|stop reason:\s*(?:abort|error)|reason:\s*(?:abort|error)|unhandled stop reason:\s*(?:abort|error)/i;
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
 export class FailoverError extends Error {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -422,8 +422,15 @@ describe("isFailoverErrorMessage", () => {
     }
   });
 
-  it("matches abort stop-reason timeout variants", () => {
-    const samples = ["Unhandled stop reason: abort", "stop reason: abort", "reason: abort"];
+  it("matches abort/error stop-reason timeout variants", () => {
+    const samples = [
+      "Unhandled stop reason: abort",
+      "stop reason: abort",
+      "reason: abort",
+      "Unhandled stop reason: error",
+      "stop reason: error",
+      "reason: error",
+    ];
     for (const sample of samples) {
       expect(isTimeoutErrorMessage(sample)).toBe(true);
       expect(classifyFailoverReason(sample)).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -637,9 +637,9 @@ const ERROR_PATTERNS = {
     "deadline exceeded",
     "context deadline exceeded",
     /without sending (?:any )?chunks?/i,
-    /\bstop reason:\s*abort\b/i,
-    /\breason:\s*abort\b/i,
-    /\bunhandled stop reason:\s*abort\b/i,
+    /\bstop reason:\s*(?:abort|error)\b/i,
+    /\breason:\s*(?:abort|error)\b/i,
+    /\bunhandled stop reason:\s*(?:abort|error)\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
Fixes #26970

## Summary
- treat `stop reason: error` variants as timeout-class failover signals
- keep existing `abort` handling unchanged
- add regression coverage for `Unhandled stop reason: error`, `stop reason: error`, and `reason: error`

## Validation
- `pnpm exec vitest run src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`