### PR TITLE
fix(message): honor agent-bound account defaults for message routing

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -326,7 +326,9 @@ describe("initSessionState thread forking", () => {
     expect(result.sessionEntry.forkedFromParent).toBe(true);
     expect(result.sessionEntry.sessionFile).toBeTruthy();
     const forkedContent = await fs.readFile(result.sessionEntry.sessionFile ?? "", "utf-8");
-    expect(forkedContent).toContain(parentSessionFile);
+    // In JSONL, backslashes are escaped, so use JSON.stringify slice to match
+    const needle = JSON.stringify(parentSessionFile).slice(1, -1);
+    expect(forkedContent).toContain(needle);
   });
 
   it("records topic-specific session files when MessageThreadId is present", async () => {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1021,4 +1021,37 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.accountId).toBe("ops");
     expect(ctx.params.accountId).toBe("ops");
   });
+
+  it("falls back to the current agent's bound account when accountId is omitted", async () => {
+    await runMessageAction({
+      cfg: {
+        bindings: [
+          {
+            agentId: "agent-b",
+            match: { channel: "discord", accountId: "account-b" },
+          },
+        ],
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "discord",
+        target: "channel:123",
+        message: "hi",
+      },
+      agentId: "agent-b",
+    });
+
+    expect(handleAction).toHaveBeenCalled();
+    const ctx = (handleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+      | {
+          accountId?: string | null;
+          params: Record<string, unknown>;
+        }
+      | undefined;
+    if (!ctx) {
+      throw new Error("expected action context");
+    }
+    expect(ctx.accountId).toBe("account-b");
+    expect(ctx.params.accountId).toBe("account-b");
+  });
 });


### PR DESCRIPTION
Closes #26975

Problem
Multi-agent message tool sends could route to the wrong Telegram bot when `channel=telegram` and `accountId` was omitted. In coordinator/sub-agent flows, the send path could skip the current agent's channel binding and fall back to a global/default account.

Root Cause
`runMessageAction()` only resolved `accountId` from explicit params or `defaultAccountId`. When neither was present, it did not consult agent/channel bindings even though the runner already knew the resolved agent identity.

Fix
Add a binding-based fallback in `runMessageAction()` after channel resolution: if no explicit/default `accountId` is present, look up the resolved agent's bound account for that channel and inject it into params before dispatch. This preserves precedence: explicit `accountId` > tool default > agent binding > plugin default. Also added a regression test covering agent-bound fallback behavior.

Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run src/infra/outbound/message-action-runner.test.ts --config vitest.unit.config.ts` (33 passed)
