### PR TITLE
fix(models): redirect deprecated Google model IDs to their successors

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -365,12 +365,30 @@ function resolveApiKeyFromProfiles(params: {
   return undefined;
 }
 
+const DEPRECATED_GOOGLE_MODEL_REDIRECTS: Record<string, string> = {
+  "gemini-1.5-flash": "gemini-2.5-flash",
+  "gemini-1.5-flash-latest": "gemini-2.5-flash",
+  "gemini-1.5-flash-8b": "gemini-2.5-flash",
+  "gemini-1.5-pro": "gemini-2.5-pro",
+  "gemini-1.5-pro-latest": "gemini-2.5-pro",
+  "gemini-2.0-flash": "gemini-2.5-flash",
+  "gemini-2.0-flash-lite": "gemini-2.5-flash",
+};
+
 export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-pro") {
     return "gemini-3-pro-preview";
   }
   if (id === "gemini-3-flash") {
     return "gemini-3-flash-preview";
+  }
+  const redirect = DEPRECATED_GOOGLE_MODEL_REDIRECTS[id];
+  if (redirect) {
+    log.warn(
+      `Google model "${id}" has been deprecated; automatically redirecting to "${redirect}". ` +
+        `Update your config to use "${redirect}" directly.`,
+    );
+    return redirect;
   }
   return id;
 }


### PR DESCRIPTION
## Summary

- **Problem:** Users referencing deprecated Google model IDs (`gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-2.0-flash`, etc.) in their config get HTTP 404 from the Google API (`models/gemini-1.5-flash is not found for API version v1beta`). Google removed these models from the `v1beta` endpoint.
- **Why it matters:** Users cannot use their existing config without manually researching successor model names. The error message from Google is opaque and doesn't suggest what to use instead.
- **What changed:** `src/agents/models-config.providers.ts` — Added a `DEPRECATED_GOOGLE_MODEL_REDIRECTS` lookup table in `normalizeGoogleModelId()` that transparently maps deprecated model IDs to their current successors with a warning log.
- **What did NOT change:** No changes to the API version (`v1beta`), provider configuration schema, or model registry. Users with current model IDs are unaffected.

### Redirect table

| Deprecated ID | Redirected to |
|---|---|
| `gemini-1.5-flash` | `gemini-2.5-flash` |
| `gemini-1.5-flash-latest` | `gemini-2.5-flash` |
| `gemini-1.5-flash-8b` | `gemini-2.5-flash` |
| `gemini-1.5-pro` | `gemini-2.5-pro` |
| `gemini-1.5-pro-latest` | `gemini-2.5-pro` |
| `gemini-2.0-flash` | `gemini-2.5-flash` |
| `gemini-2.0-flash-lite` | `gemini-2.5-flash` |

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26911

## User-visible / Behavior Changes

- Deprecated Google model IDs now auto-redirect to successors instead of failing with HTTP 404
- A warning log is emitted prompting users to update their config

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Akamai/Linode)
- Runtime: Node.js
- Integration/channel: Any

### Steps

1. Set `agents.defaults.model.primary` to `google/gemini-1.5-flash`
2. Send a message

### Expected

- Model resolves and generates a response (redirected to `gemini-2.5-flash`)

### Actual

- Before fix: HTTP 404 "models/gemini-1.5-flash is not found for API version v1beta"
- After fix: Transparent redirect to `gemini-2.5-flash` with warning log

## Evidence

- `models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts`: 1 test passes
- `model-selection.test.ts`: 24 tests pass

## Human Verification (required)

- Verified scenarios: Deprecated model IDs map to correct successors
- Edge cases checked: Non-deprecated IDs pass through unchanged, `gemini-3-*` normalization still works
- What I did **not** verify: Live Google API call with redirected model

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (existing deprecated IDs auto-redirect)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; users must manually update model IDs
- Files/config to restore: `src/agents/models-config.providers.ts`
- Known bad symptoms: None — the redirect only fires for IDs that already fail

## Risks and Mitigations

- If Google re-introduces the deprecated model IDs with different capabilities, the redirect could be surprising. Mitigation: the warning log clearly instructs users to update their config.
