### PR TITLE
Auto-reply: add Tagalog stop triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Android/Chat: improve streaming delivery handling and markdown rendering quality in the native Android chat UI, including better GitHub-flavored markdown behavior. (#26079) Thanks @obviyus.
 - Branding/Docs + Apple surfaces: replace remaining `bot.molt` launchd label, bundle-id, logging subsystem, and command examples with `ai.openclaw` across docs, iOS app surfaces, helper scripts, and CLI test fixtures.
 - Agents/Config: remind agents to call `config.schema` before config edits or config-field questions to avoid guessing. Thanks @thewilloftheshadow.
+- Auto-reply/Abort shortcuts: add Tagalog standalone stop phrases (`tama na`, `tama na yan`) for fast abort detection while preserving strict standalone matching.
 
 ### Fixes
 

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -167,6 +167,8 @@ describe("abort detection", () => {
       "hoer auf",
       "stopp",
       "pare",
+      "tama na",
+      "tama na yan",
     ];
     for (const candidate of positives) {
       expect(isAbortTrigger(candidate)).toBe(true);
@@ -193,6 +195,8 @@ describe("abort detection", () => {
     expect(isAbortRequestText("halt")).toBe(true);
     expect(isAbortRequestText("stopp")).toBe(true);
     expect(isAbortRequestText("pare")).toBe(true);
+    expect(isAbortRequestText("tama na")).toBe(true);
+    expect(isAbortRequestText("tama na yan!!!")).toBe(true);
     expect(isAbortRequestText(" توقف ")).toBe(true);
     expect(isAbortRequestText("/stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
     expect(isAbortRequestText("/Stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
@@ -200,6 +204,7 @@ describe("abort detection", () => {
     expect(isAbortRequestText("/status")).toBe(false);
     expect(isAbortRequestText("do not do that")).toBe(true);
     expect(isAbortRequestText("please do not do that")).toBe(false);
+    expect(isAbortRequestText("uy tama na yan")).toBe(false);
     expect(isAbortRequestText("/abort")).toBe(false);
   });
 

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -66,6 +66,8 @@ const ABORT_TRIGGERS = new Set([
   "do not do that",
   "please stop",
   "stop please",
+  "tama na",
+  "tama na yan",
 ]);
 const ABORT_MEMORY = new Map<string, boolean>();
 const ABORT_MEMORY_MAX = 2000;

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -55,8 +55,11 @@ describe("isChatStopCommandText", () => {
     expect(isChatStopCommandText("halt")).toBe(true);
     expect(isChatStopCommandText("stopp")).toBe(true);
     expect(isChatStopCommandText("pare")).toBe(true);
+    expect(isChatStopCommandText("tama na")).toBe(true);
+    expect(isChatStopCommandText("tama na yan")).toBe(true);
     expect(isChatStopCommandText("/status")).toBe(false);
     expect(isChatStopCommandText("please do not do that")).toBe(false);
+    expect(isChatStopCommandText("uy tama na yan")).toBe(false);
     expect(isChatStopCommandText("keep going")).toBe(false);
   });
 });

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -201,12 +201,22 @@ describe("createTelegramBot", () => {
     ).toBe("telegram:123:control");
     expect(
       getTelegramSequentialKey({
+        message: mockMessage({ chat: mockChat({ id: 123 }), text: "tama na yan" }),
+      }),
+    ).toBe("telegram:123:control");
+    expect(
+      getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort" }),
       }),
     ).toBe("telegram:123");
     expect(
       getTelegramSequentialKey({
         message: mockMessage({ chat: mockChat({ id: 123 }), text: "/abort now" }),
+      }),
+    ).toBe("telegram:123");
+    expect(
+      getTelegramSequentialKey({
+        message: mockMessage({ chat: mockChat({ id: 123 }), text: "uy tama na yan" }),
       }),
     ).toBe("telegram:123");
     expect(


### PR DESCRIPTION
## Summary

- Problem: Fast-abort stop phrase detection did not include Tagalog conversational forms.
- Why it matters: Tagalog users could issue natural stop requests that were not recognized.
- What changed: Added `tama na` and `tama na yan` as standalone abort triggers and expanded gateway/telegram/core abort tests.
- What did NOT change (scope boundary): No matcher semantics changes beyond trigger additions (still strict standalone matching).
- AI-assisted: Yes (Codex; model: gpt-5.3-codex; reasoning: xhigh).
- Testing level: Fully tested (targeted + repo gate).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Tagalog standalone stop phrases now trigger fast abort:
- `tama na`
- `tama na yan`

Strict standalone matching remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk is low: this only broadens stop-trigger recognition for standalone messages.
  - Mitigation: explicit tests include negative phrase coverage (`uy tama na yan`) to preserve strict matching.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway chat + Telegram parsing
- Relevant config (redacted): default test config

### Steps

1. Send a standalone message `tama na` or `tama na yan` in a running session.
2. Observe fast abort handling.
3. Send `uy tama na yan` and verify no abort trigger.

### Expected

- Standalone Tagalog phrases abort current run(s).
- Non-standalone phrase does not trigger abort.

### Actual

- Matches expected in tests and local run.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:
- `pnpm test src/auto-reply/reply/abort.test.ts src/gateway/chat-abort.test.ts src/telegram/bot.create-telegram-bot.test.ts`
- `pnpm build && pnpm check && pnpm test`

Trace excerpts:
- `src/auto-reply/reply/abort.test.ts` passed
- `src/gateway/chat-abort.test.ts` passed
- `src/telegram/bot.create-telegram-bot.test.ts` passed
- Full suite passed (`1312` + `98` test files across the split runs)

## Human Verification (required)

- Verified scenarios:
  - Core abort trigger detection for new Tagalog phrases.
  - Gateway stop command text detection.
  - Telegram control-lane routing for stop text.
- Edge cases checked:
  - Trailing punctuation accepted.
  - Phrase with extra leading word (`uy tama na yan`) does not match.
- What you did **not** verify:
  - Live manual testing on external messaging platforms (relied on tests).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/auto-reply/reply/abort.ts`
  - Related tests under `src/auto-reply/reply`, `src/gateway`, `src/telegram`
- Known bad symptoms reviewers should watch for:
  - Unexpected abort on non-standalone conversational text.

## Risks and Mitigations

- Risk: Added phrases might be over-broad in some contexts.
  - Mitigation: kept additions minimal and added negative coverage for prefixed conversational text.

