### PR TITLE
fix(gateway-lock): detect any running gateway process to prevent duplicates

### DIFF
--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -1,9 +1,9 @@
+import { execSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 
@@ -148,7 +148,11 @@ async function isAnyGatewayProcessRunning(): Promise<boolean> {
       encoding: "utf8",
       timeout: 2000,
     });
-    const pids = output.trim().split("\n").filter(Boolean).map((p) => parseInt(p, 10));
+    const pids = output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((p) => parseInt(p, 10));
     // Filter out current process
     const otherPids = pids.filter((pid) => pid !== process.pid);
     return otherPids.length > 0;


### PR DESCRIPTION
## Summary
Before: Lock only checked if configured port was in use.
After: Check if any openclaw-gateway process is running (via pgrep).

This fixes the issue where gateways start on different ports (e.g., env OPENCLAW_GATEWAY_PORT vs config) and bypass lock detection.

## Root Cause
When gateway is started via env var (OPENCLAW_GATEWAY_PORT=8787) vs config (port 18789), two gateways could run on different ports, bypassing the port-based lock check.

## Fix
Added `isAnyGatewayProcessRunning()` that uses `pgrep -f openclaw-gateway` to detect any running gateway process regardless of port.