### PR TITLE
Fix cron delivery.announce docs note (#27018)

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -202,7 +202,7 @@ Behavior details:
 - If the isolated run already sent a message to the same target via the message tool, delivery is
   skipped to avoid duplicates.
 - Missing or invalid delivery targets fail the job unless `delivery.bestEffort = true`.
-- A short summary is posted to the main session only when `delivery.mode = "announce"`.
+- A short summary is posted to the main session only when `delivery.mode = "announce"` and delivery did not already happen.
 - The main-session summary respects `wakeMode`: `now` triggers an immediate heartbeat and
   `next-heartbeat` waits for the next scheduled heartbeat.
 


### PR DESCRIPTION
Clarifies that the main-session summary is only posted when announce delivery was requested *and* the isolated run did not already deliver.

Fixes #27018}