### PR TITLE
fix(discord): stop typing indicator on silent/NO_REPLY runs

### DIFF
--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -69,6 +69,8 @@ type ReplyDispatcherWithTypingResult = {
   dispatcher: ReplyDispatcher;
   replyOptions: Pick<GetReplyOptions, "onReplyStart" | "onTypingController" | "onTypingCleanup">;
   markDispatchIdle: () => void;
+  /** Signal that the model run is complete so the typing controller can stop. */
+  markRunComplete: () => void;
 };
 
 export type ReplyDispatcher = {
@@ -236,6 +238,9 @@ export function createReplyDispatcherWithTyping(
     markDispatchIdle: () => {
       typingController?.markDispatchIdle();
       resolvedOnIdle?.();
+    },
+    markRunComplete: () => {
+      typingController?.markRunComplete();
     },
   };
 }

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -100,6 +100,7 @@ vi.mock("../../auto-reply/reply/reply-dispatcher.js", () => ({
       },
       replyOptions: {},
       markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
     }),
   ),
 }));

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -571,64 +571,38 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   // When draft streaming is active, suppress block streaming to avoid double-streaming.
   const disableBlockStreamingForDraft = draftStream ? true : undefined;
 
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    ...prefixOptions,
-    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    typingCallbacks,
-    deliver: async (payload: ReplyPayload, info) => {
-      const isFinal = info.kind === "final";
-      if (payload.isReasoning) {
-        // Reasoning/thinking payloads should not be delivered to Discord.
-        return;
-      }
-      if (draftStream && isFinal) {
-        await flushDraft();
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-        const finalText = payload.text;
-        const previewFinalText = resolvePreviewFinalText(finalText);
-        const previewMessageId = draftStream.messageId();
-
-        // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
-        const canFinalizeViaPreviewEdit =
-          !finalizedViaPreviewMessage &&
-          !hasMedia &&
-          typeof previewFinalText === "string" &&
-          typeof previewMessageId === "string" &&
-          !payload.isError;
-
-        if (canFinalizeViaPreviewEdit) {
-          await draftStream.stop();
-          try {
-            await editMessageDiscord(
-              deliverChannelId,
-              previewMessageId,
-              { content: previewFinalText },
-              { rest: client.rest },
-            );
-            finalizedViaPreviewMessage = true;
-            replyReference.markSent();
-            return;
-          } catch (err) {
-            logVerbose(
-              `discord: preview final edit failed; falling back to standard send (${String(err)})`,
-            );
-          }
+  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
+    createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      deliver: async (payload: ReplyPayload, info) => {
+        const isFinal = info.kind === "final";
+        if (payload.isReasoning) {
+          // Reasoning/thinking payloads should not be delivered to Discord.
+          return;
         }
+        if (draftStream && isFinal) {
+          await flushDraft();
+          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const finalText = payload.text;
+          const previewFinalText = resolvePreviewFinalText(finalText);
+          const previewMessageId = draftStream.messageId();
 
-        // Check if stop() flushed a message we can edit
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.stop();
-          const messageIdAfterStop = draftStream.messageId();
-          if (
-            typeof messageIdAfterStop === "string" &&
-            typeof previewFinalText === "string" &&
+          // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
+          const canFinalizeViaPreviewEdit =
+            !finalizedViaPreviewMessage &&
             !hasMedia &&
-            !payload.isError
-          ) {
+            typeof previewFinalText === "string" &&
+            typeof previewMessageId === "string" &&
+            !payload.isError;
+
+          if (canFinalizeViaPreviewEdit) {
+            await draftStream.stop();
             try {
               await editMessageDiscord(
                 deliverChannelId,
-                messageIdAfterStop,
+                previewMessageId,
                 { content: previewFinalText },
                 { rest: client.rest },
               );
@@ -637,45 +611,72 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               return;
             } catch (err) {
               logVerbose(
-                `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                `discord: preview final edit failed; falling back to standard send (${String(err)})`,
               );
             }
           }
+
+          // Check if stop() flushed a message we can edit
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.stop();
+            const messageIdAfterStop = draftStream.messageId();
+            if (
+              typeof messageIdAfterStop === "string" &&
+              typeof previewFinalText === "string" &&
+              !hasMedia &&
+              !payload.isError
+            ) {
+              try {
+                await editMessageDiscord(
+                  deliverChannelId,
+                  messageIdAfterStop,
+                  { content: previewFinalText },
+                  { rest: client.rest },
+                );
+                finalizedViaPreviewMessage = true;
+                replyReference.markSent();
+                return;
+              } catch (err) {
+                logVerbose(
+                  `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                );
+              }
+            }
+          }
+
+          // Clear the preview and fall through to standard delivery
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.clear();
+          }
         }
 
-        // Clear the preview and fall through to standard delivery
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.clear();
-        }
-      }
-
-      const replyToId = replyReference.use();
-      await deliverDiscordReply({
-        replies: [payload],
-        target: deliverTarget,
-        token,
-        accountId,
-        rest: client.rest,
-        runtime,
-        replyToId,
-        replyToMode,
-        textLimit,
-        maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
-        tableMode,
-        chunkMode,
-        sessionKey: ctxPayload.SessionKey,
-        threadBindings,
-      });
-      replyReference.markSent();
-    },
-    onError: (err, info) => {
-      runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
-    },
-    onReplyStart: async () => {
-      await typingCallbacks.onReplyStart();
-      await statusReactions.setThinking();
-    },
-  });
+        const replyToId = replyReference.use();
+        await deliverDiscordReply({
+          replies: [payload],
+          target: deliverTarget,
+          token,
+          accountId,
+          rest: client.rest,
+          runtime,
+          replyToId,
+          replyToMode,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode,
+          sessionKey: ctxPayload.SessionKey,
+          threadBindings,
+        });
+        replyReference.markSent();
+      },
+      onError: (err, info) => {
+        runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
+      },
+      onReplyStart: async () => {
+        await typingCallbacks.onReplyStart();
+        await statusReactions.setThinking();
+      },
+    });
 
   let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
   let dispatchError = false;
@@ -738,6 +739,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       // Draft cleanup should never keep typing alive.
       logVerbose(`discord: draft cleanup failed: ${String(err)}`);
     } finally {
+      markRunComplete();
       markDispatchIdle();
     }
     if (statusReactionsEnabled) {


### PR DESCRIPTION
## Summary

Fixes #27011 — Discord typing indicator persists indefinitely when the model run produces a silent or NO_REPLY response.

## Root Cause

The typing controller in `src/auto-reply/reply/typing.ts` requires **both** `markRunComplete()` and `markDispatchIdle()` to be called before it triggers `cleanup()` (which clears typing timers and stops the indicator). This is enforced at lines 126-134 in `maybeStopOnIdle()`:

```ts
private maybeStopOnIdle(): void {
  if (this.runComplete && this.dispatchIdle) {
    this.cleanup();
  }
}
```

In `agent-runner.ts`, the agent runner correctly calls `typing.markRunComplete()` in its finally block (line 733). However, `createReplyDispatcherWithTyping` only exposes `markDispatchIdle` — not `markRunComplete` — in its return type. The Discord handler (`message-handler.process.ts`) only calls `markDispatchIdle()` in its finally block (line 724).

When a run produces content (tool results, block replies, or a final reply), this works fine:
1. `agent-runner.ts` calls `typing.markRunComplete()` via the typing controller reference
2. The reply dispatcher's `onIdle` callback calls `typingController.markDispatchIdle()`
3. Both flags are set → `cleanup()` fires

But on silent/NO_REPLY runs where **no replies are enqueued**, the dispatcher's `onIdle` fires via `markComplete()` microtask (line 189-198 in `reply-dispatcher.ts`). The Discord handler's finally block then calls `markDispatchIdle()` again — but `markRunComplete()` was only called internally by the agent runner on its own typing controller reference. If the timing of the `markComplete()` microtask resolution races with the Discord finally block, or if the typing controller reference hasn't been set yet, the `runComplete` flag may never be propagated through the dispatcher's wrapper, leaving the typing indicator stuck.

## Fix

Expose `markRunComplete` alongside `markDispatchIdle` in `createReplyDispatcherWithTyping`'s return type and implementation. Update the Discord handler to call `markRunComplete()` in its finally block before `markDispatchIdle()`, ensuring both flags are always set regardless of whether the agent runner's internal cleanup reached the typing controller.

### Changes

**`src/auto-reply/reply/reply-dispatcher.ts`**
- Added `markRunComplete` to `ReplyDispatcherWithTypingResult` type
- Added `markRunComplete` implementation that delegates to `typingController?.markRunComplete()`

**`src/discord/monitor/message-handler.process.ts`**
- Destructure `markRunComplete` from `createReplyDispatcherWithTyping`
- Call `markRunComplete()` in the finally block before `markDispatchIdle()`

## Test plan

- Deploy with a Discord bot and trigger a silent/NO_REPLY response (e.g., system prompt that instructs NO_REPLY for certain inputs)
- Verify typing indicator stops within a few seconds instead of persisting indefinitely
- Verify normal replies still show typing → response → typing stops as expected