### PR TITLE
docs(subagents): fix workspace bootstrap injection list

### DIFF
--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -34,6 +34,7 @@ Security trust model:
 
 - By default, OpenClaw is a personal agent: one trusted operator boundary.
 - Shared/multi-user setups require lock-down (split trust boundaries, keep tool access minimal, and follow [Security](/gateway/security)).
+
 </Step>
 <Step title="Local vs Remote">
 <Frame>

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -275,6 +275,8 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context only injects a minimal workspace bootstrap by default:
++  - Included: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
++  - Not included: `HEARTBEAT.md`, `BOOTSTRAP.md`, and the rest of the workspace
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -276,9 +276,8 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
 - Sub-agent context only injects a minimal workspace bootstrap by default:
-
-* - Included: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
-* - Not included: `HEARTBEAT.md`, `BOOTSTRAP.md`, and the rest of the workspace
+  - Included: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
+  - Not included: `HEARTBEAT.md`, `BOOTSTRAP.md`, and the rest of the workspace
 
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -276,7 +276,9 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
 - Sub-agent context only injects a minimal workspace bootstrap by default:
-+  - Included: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
-+  - Not included: `HEARTBEAT.md`, `BOOTSTRAP.md`, and the rest of the workspace
+
+* - Included: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
+* - Not included: `HEARTBEAT.md`, `BOOTSTRAP.md`, and the rest of the workspace
+
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -164,4 +164,6 @@ x-i18n:
 - 子智能体通告是**尽力而为**的。如果 Gateway 网关重启，待处理的"通告回复"工作会丢失。
 - 子智能体仍然共享相同的 Gateway 网关进程资源；将 `maxConcurrent` 视为安全阀。
 - `sessions_spawn` 始终是非阻塞的：它立即返回 `{ status: "accepted", runId, childSessionKey }`。
-- 子智能体上下文仅注入 `AGENTS.md` + `TOOLS.md`（无 `SOUL.md`、`IDENTITY.md`、`USER.md`、`HEARTBEAT.md` 或 `BOOTSTRAP.md`）。
+- 默认情况下，子智能体上下文仅注入最小化的工作区引导文件：
++  - 包含：`AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md`、`USER.md`
++  - 不包含：`HEARTBEAT.md`、`BOOTSTRAP.md` 以及工作区中的其它文件

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -165,5 +165,6 @@ x-i18n:
 - 子智能体仍然共享相同的 Gateway 网关进程资源；将 `maxConcurrent` 视为安全阀。
 - `sessions_spawn` 始终是非阻塞的：它立即返回 `{ status: "accepted", runId, childSessionKey }`。
 - 默认情况下，子智能体上下文仅注入最小化的工作区引导文件：
-+  - 包含：`AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md`、`USER.md`
-+  - 不包含：`HEARTBEAT.md`、`BOOTSTRAP.md` 以及工作区中的其它文件
+
+* - 包含：`AGENTS.md`、`TOOLS.md`、`SOUL.md`、`IDENTITY.md`、`USER.md`
+* - 不包含：`HEARTBEAT.md`、`BOOTSTRAP.md` 以及工作区中的其它文件


### PR DESCRIPTION
Fixes #27038\n\nDocs said sub-agent context only injects AGENTS.md + TOOLS.md, but runtime currently minimal-injects , , and  as well. This updates EN + zh-CN docs to match the current behavior.