### PR TITLE
feat(browser): make --disable-blink-features=AutomationControlled configurable per profile

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -215,7 +215,10 @@ export async function launchOpenClawChrome(
     }
 
     // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
+    // Only enable if profile.stealth is not explicitly false
+    if (profile.stealth) {
+      args.push("--disable-blink-features=AutomationControlled");
+    }
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -44,6 +44,7 @@ export type ResolvedBrowserProfile = {
   cdpIsLoopback: boolean;
   color: string;
   driver: "openclaw" | "extension";
+  stealth: boolean;
 };
 
 function normalizeHexColor(raw: string | undefined) {
@@ -302,6 +303,7 @@ export function resolveProfile(
     cdpIsLoopback: isLoopbackHost(cdpHost),
     color: profile.color,
     driver,
+    stealth: profile.stealth !== false,
   };
 }
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -7,6 +7,8 @@ export type BrowserProfileConfig = {
   driver?: "openclaw" | "extension";
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
+  /** If false, disable the AutomationControlled stealth flag. Default: true */
+  stealth?: boolean;
 };
 export type BrowserSnapshotDefaults = {
   /** Default snapshot mode (applies when mode is not provided). */


### PR DESCRIPTION
## Summary

- Add `stealth` option to `BrowserProfileConfig` (default: `true`)
- Add `stealth` to `ResolvedBrowserProfile`
- Make the flag conditional in chrome.ts: only added if `profile.stealth !== false`

## Usage

```json
{
  "browser": {
    "profiles": {
      "personal": {
        "stealth": false
      }
    }
  }
}
```

Fixes #26897