### PR TITLE
fix(skill-creator): reject empty name and description in skill valida…

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -115,36 +115,38 @@ def validate_skill(skill_path):
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    if not name:
+        return False, "Name must not be empty"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
     description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    if not description:
+        return False, "Description must not be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -123,36 +123,38 @@ def validate_skill(skill_path):
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    if not name:
+        return False, "Name must not be empty"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
     description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    if not description:
+        return False, "Description must not be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -67,6 +67,50 @@ metadata: |
 
         self.assertTrue(valid, message)
 
+    def test_rejects_empty_name(self):
+        skill_dir = self.temp_dir / "empty-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: ""\ndescription: a valid description\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name must not be empty")
+
+    def test_rejects_whitespace_only_name(self):
+        skill_dir = self.temp_dir / "ws-name-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = "---\nname: '   '\ndescription: a valid description\n---\n# Skill\n"
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Name must not be empty")
+
+    def test_rejects_empty_description(self):
+        skill_dir = self.temp_dir / "empty-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = '---\nname: valid-skill\ndescription: ""\n---\n# Skill\n'
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description must not be empty")
+
+    def test_rejects_whitespace_only_description(self):
+        skill_dir = self.temp_dir / "ws-desc-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = "---\nname: valid-skill\ndescription: '   '\n---\n# Skill\n"
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "Description must not be empty")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

`validate_skill()` in `quick_validate.py` silently accepts empty or whitespace-only `name` and `description` values in SKILL.md frontmatter. The `if name:` guard skips all format checks when the value is an empty string, allowing invalid skill metadata to pass validation.

Since `name` and `description` are the fields OpenClaw reads to decide when a skill gets triggered, accepting blank values violates the documented metadata contract and breaks skill triggering and discovery behavior.

## Changes

**`skills/skill-creator/scripts/quick_validate.py`**
- Replace permissive `if name:` / `if description:` guards with early-return checks that reject empty/whitespace-only values
- Flattens validation logic by removing one level of nesting

**`skills/skill-creator/scripts/test_quick_validate.py`**
- Add 4 regression tests: empty name, whitespace-only name, empty description, whitespace-only description

## Testing

All 7 tests pass (3 existing + 4 new). See **Real behavior proof** section below for the run output.

## Real behavior proof

Behavior addressed: `validate_skill()` in `quick_validate.py` accepts empty or whitespace-only `name` and `description` values in SKILL.md frontmatter, so a skill with `name: ""` or `description: "   "` passes validation and downstream packaging.

Real environment tested: Local `python3 quick_validate.py` against ephemeral SKILL.md fixtures on macOS arm64, comparing `origin/main` (commit 406ae72) against the fix branch. Also ran the colocated `test_quick_validate.py` unittest suite.

Exact steps or command run after this patch:

```
# Before fix (main): empty name silently accepted
$ echo '---
name: ""
description: a valid description
---' > SKILL.md
$ python3 quick_validate.py /path/to/test-skill

# After fix (this branch): four invalid cases
$ python3 quick_validate.py   # name: ""
$ python3 quick_validate.py   # name: "   "
$ python3 quick_validate.py   # description: ""
$ python3 quick_validate.py   # description: "   "

# Unit suite
$ python3 -m unittest skills/skill-creator/scripts/test_quick_validate.py
```

Evidence after fix:

```
# Before fix (main)
$ python3 quick_validate.py /path/to/test-skill
Skill is valid!     <- BUG: should reject empty name

# After fix (this branch)
$ python3 quick_validate.py   # name: ""
Name must not be empty
$ python3 quick_validate.py   # name: "   "
Name must not be empty
$ python3 quick_validate.py   # description: ""
Description must not be empty
$ python3 quick_validate.py   # description: "   "
Description must not be empty

# Unit tests
test_accepts_crlf_frontmatter ... ok
test_fallback_parser_handles_multiline_frontmatter_without_pyyaml ... ok
test_rejects_empty_description ... ok
test_rejects_empty_name ... ok
test_rejects_missing_frontmatter_closing_fence ... ok
test_rejects_whitespace_only_description ... ok
test_rejects_whitespace_only_name ... ok

Ran 7 tests in 0.003s -- OK
```

Observed result after fix: All four empty/whitespace cases produce `Name must not be empty` or `Description must not be empty` and `quick_validate.py` exits non-zero, instead of returning `Skill is valid!`. The four previously-existing tests still pass.

What was not tested: The change was not exercised end-to-end through `package_skill.py`'s real archive build (the validator gate fires before any packaging side effects, so the path is short-circuited deterministically); the regression coverage is at the unit-test layer.
