### PR TITLE
feat(gateway): support multimodal input from gateway clients

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -324,4 +324,17 @@ describe("resolveModel", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-antigravity/some-model");
   });
+
+  it("creates openrouter fallback with image input support for unknown model ids", () => {
+    const result = resolveModel("openrouter", "anthropic/claude-opus-4.6", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "anthropic/claude-opus-4.6",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+      input: expect.arrayContaining(["text", "image"]),
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -78,6 +78,8 @@ export function resolveModel(
     }
     // OpenRouter is a pass-through proxy — any model ID available on OpenRouter
     // should work without being pre-registered in the local catalog.
+    // Most OpenRouter models support vision; default to image-capable so
+    // gateway clients can send multimodal input without silent drops.
     if (normalizedProvider === "openrouter") {
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
@@ -86,7 +88,7 @@ export function resolveModel(
         provider,
         baseUrl: "https://openrouter.ai/api/v1",
         reasoning: false,
-        input: ["text"],
+        input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: DEFAULT_CONTEXT_TOKENS,
         // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts

--- a/src/agents/pi-embedded-runner/run/gateway-multimodal.integration.test.ts
+++ b/src/agents/pi-embedded-runner/run/gateway-multimodal.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test: Gateway multimodal input pipeline.
+ *
+ * Simulates the full path from a gateway client sending base64 image
+ * attachments via `chat.send` RPC, through model resolution, to the
+ * image array that gets passed to the model prompt.
+ *
+ * Covers the fix for: OpenRouter fallback models dropping images because
+ * `input` was `["text"]` instead of `["text", "image"]`, and
+ * `detectAndLoadPromptImages` discarding explicitly-provided images
+ * when the model doesn't advertise native vision support.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseMessageWithAttachments } from "../../../gateway/chat-attachments.js";
+import { normalizeRpcAttachmentsToChatAttachments } from "../../../gateway/server-methods/attachment-normalize.js";
+import { detectAndLoadPromptImages, modelSupportsImages } from "./images.js";
+
+vi.mock("../../pi-model-discovery.js", () => ({
+  discoverAuthStorage: vi.fn(() => ({ mocked: true })),
+  discoverModels: vi.fn(() => ({ find: vi.fn(() => null) })),
+}));
+
+import { resolveModel } from "../model.js";
+import { resetMockDiscoverModels } from "../model.test-harness.js";
+
+beforeEach(() => {
+  resetMockDiscoverModels();
+});
+
+const PNG_1x1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+
+describe("gateway multimodal input: full pipeline integration", () => {
+  it("OpenRouter model resolution includes image capability for unknown model IDs", () => {
+    const { model } = resolveModel("openrouter", "anthropic/claude-opus-4.6", "/tmp/agent");
+
+    expect(model).toBeDefined();
+    expect(model!.input).toContain("image");
+    expect(model!.input).toContain("text");
+    expect(model!.api).toBe("openai-completions");
+    expect(model!.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(modelSupportsImages(model!)).toBe(true);
+  });
+
+  it("full pipeline: RPC attachment → parse → model resolve → image injection (OpenRouter)", async () => {
+    // Step 1: Simulate gateway client (e.g. ClawX) sending RPC with base64 attachment
+    const rpcAttachments = [
+      {
+        type: "image",
+        mimeType: "image/png",
+        fileName: "chrome-logo.png",
+        content: PNG_1x1_BASE64,
+      },
+    ];
+
+    // Step 2: Gateway normalizes RPC attachments
+    const normalized = normalizeRpcAttachmentsToChatAttachments(rpcAttachments);
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0].content).toBe(PNG_1x1_BASE64);
+
+    // Step 3: Gateway parses message with attachments
+    const parsed = await parseMessageWithAttachments("What is this logo?", normalized, {
+      log: { warn: () => {} },
+    });
+    expect(parsed.message).toBe("What is this logo?");
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.images[0].type).toBe("image");
+    expect(parsed.images[0].mimeType).toBe("image/png");
+    expect(parsed.images[0].data).toBe(PNG_1x1_BASE64);
+
+    // Step 4: Model resolution for OpenRouter
+    const { model } = resolveModel("openrouter", "anthropic/claude-opus-4.6", "/tmp/agent");
+    expect(model).toBeDefined();
+    expect(modelSupportsImages(model!)).toBe(true);
+
+    // Step 5: detectAndLoadPromptImages (embedded runner)
+    const imageResult = await detectAndLoadPromptImages({
+      prompt: "What is this logo?",
+      workspaceDir: "/tmp",
+      model: model!,
+      existingImages: parsed.images,
+    });
+
+    // VERIFY: images reach the model
+    expect(imageResult.images).toHaveLength(1);
+    expect(imageResult.images[0].type).toBe("image");
+    expect(imageResult.images[0].data).toBe(PNG_1x1_BASE64);
+    expect(imageResult.images[0].mimeType).toBe("image/png");
+  });
+
+  it("full pipeline: existingImages survive even for text-only model definition", async () => {
+    // Simulate a model that doesn't advertise image support
+    const textOnlyModel = { input: ["text"] };
+
+    // Gateway parsed images (from RPC attachments)
+    const gatewayImages = [{ type: "image" as const, data: PNG_1x1_BASE64, mimeType: "image/png" }];
+
+    // detectAndLoadPromptImages should STILL pass through existingImages
+    const imageResult = await detectAndLoadPromptImages({
+      prompt: "What is this logo?",
+      workspaceDir: "/tmp",
+      model: textOnlyModel,
+      existingImages: gatewayImages,
+    });
+
+    expect(imageResult.images).toHaveLength(1);
+    expect(imageResult.images[0].data).toBe(PNG_1x1_BASE64);
+  });
+
+  it("multiple images from gateway client all reach the model", async () => {
+    const rpcAttachments = [
+      { type: "image", mimeType: "image/png", fileName: "img1.png", content: PNG_1x1_BASE64 },
+      { type: "image", mimeType: "image/png", fileName: "img2.png", content: PNG_1x1_BASE64 },
+    ];
+
+    const normalized = normalizeRpcAttachmentsToChatAttachments(rpcAttachments);
+    const parsed = await parseMessageWithAttachments("Compare these images", normalized, {
+      log: { warn: () => {} },
+    });
+    expect(parsed.images).toHaveLength(2);
+
+    const { model } = resolveModel("openrouter", "anthropic/claude-opus-4.6", "/tmp/agent");
+    const imageResult = await detectAndLoadPromptImages({
+      prompt: "Compare these images",
+      workspaceDir: "/tmp",
+      model: model!,
+      existingImages: parsed.images,
+    });
+
+    expect(imageResult.images).toHaveLength(2);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -254,12 +254,39 @@ describe("loadImageFromRef", () => {
 });
 
 describe("detectAndLoadPromptImages", () => {
-  it("returns no images for non-vision models even when existing images are provided", async () => {
+  it("passes through existing images for non-vision models (gateway multimodal input)", async () => {
+    const existing = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
     const result = await detectAndLoadPromptImages({
       prompt: "ignore",
       workspaceDir: "/tmp",
       model: { input: ["text"] },
-      existingImages: [{ type: "image", data: "abc", mimeType: "image/png" }],
+      existingImages: existing,
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]).toEqual(existing[0]);
+    expect(result.detectedRefs).toHaveLength(0);
+  });
+
+  it("skips file detection for non-vision models but keeps existing images", async () => {
+    const existing = [{ type: "image" as const, data: "abc", mimeType: "image/png" }];
+    const result = await detectAndLoadPromptImages({
+      prompt: "check /tmp/test.png",
+      workspaceDir: "/tmp",
+      model: { input: ["text"] },
+      existingImages: existing,
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.detectedRefs).toHaveLength(0);
+    expect(result.loadedCount).toBe(0);
+  });
+
+  it("returns empty images for non-vision models when no existing images are provided", async () => {
+    const result = await detectAndLoadPromptImages({
+      prompt: "ignore",
+      workspaceDir: "/tmp",
+      model: { input: ["text"] },
     });
 
     expect(result.images).toHaveLength(0);

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -296,10 +296,13 @@ export async function detectAndLoadPromptImages(params: {
   loadedCount: number;
   skippedCount: number;
 }> {
-  // If model doesn't support images, return empty results
+  // When model doesn't advertise image input, skip file-path detection but
+  // still pass through explicitly provided images (e.g. base64 attachments
+  // from gateway clients). Silently dropping user-provided images is worse
+  // than letting the upstream API reject them with a clear error.
   if (!modelSupportsImages(params.model)) {
     return {
-      images: [],
+      images: params.existingImages ?? [],
       detectedRefs: [],
       loadedCount: 0,
       skippedCount: 0,


### PR DESCRIPTION
Two root-cause fixes for images being silently dropped when sent via gateway RPC (e.g. chat.send with base64 attachments):

1. OpenRouter fallback model: change input from ["text"] to ["text", "image"]. When a model ID is not in the local catalog (e.g. anthropic/claude-opus-4.6 via openrouter), the fallback model was missing image capability, causing modelSupportsImages() to return false and all images to be silently dropped.

2. detectAndLoadPromptImages: always pass through existingImages (explicitly provided via gateway RPC) even when the model does not advertise native image support. File-path detection is still gated by model capabilities, but user-provided base64 images are never silently discarded.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

Note: Previously-dropped image payloads now reach the upstream model API
via the existing prompt path. This increases request body size for
multimodal messages (expected behavior), but does not introduce any new
network surface or destination.

## Repro + Verification

## Environment  
- **OS**: Linux 6.1.147 x86_64 (Cloud Agent) / macOS  
- **Runtime/Container**: Node v22.21.1, pnpm 10.23.0  
- **Model/Provider**: anthropic/claude-opus-4.6 via OpenRouter (API: openai-completions)  
- **Integration/Channel**: ClawX desktop app → OpenClaw gateway (chat.send RPC with attachments)  
- **Relevant Configuration**: OpenRouter provider with API key; model set to anthropic/claude-opus-4.6 (not pre-registered in local catalog, defaults to OpenRouter fallback)  

## Steps  
1. The Gateway client sends a `chat.send` RPC request, including a base64-encoded PNG image in the attachments array.  
2. Gateway normalizes and parses the attachments into `ChatImageContent[]` (functioning as expected).  
3. The model is resolved via `resolveModel("openrouter", "anthropic/claude-opus-4.6")`, following the fallback path.  
4. `detectAndLoadPromptImages` is invoked with `existingImages` containing the parsed images.  

## Expected Outcome  
- The model receives inline image content blocks and accurately describes the image.  
- `imageResult.images.length` is expected to be ≥ 1, ensuring the images are delivered.  

## Actual Outcome  

### Before Fix (4/4 Tests Failed):  
- **Test Results**:  
  1. OpenRouter model resolution did not include image capability (expected `["text", "image"]`, but only `["text"]` was present).  
  2. The full pipeline (RPC attachment → parsing → model resolution → image injection) failed as the model did not support images (`modelSupportsImages(model!)` returned `false`).  
  3. Existing images were not retained for text-only model definitions (expected 1 image, but got 0).  
  4. Multiple images sent from the gateway client were not delivered to the model (expected 2 images, but got 0).  

- **Pipeline Trace (Before Fix)**:  
  - **Model ID**: anthropic/claude-opus-4.6  
  - **Model Input**: `["text"]` (missing "image")  
  - **Has Vision Capability**: `false`  
  - **Existing Images Provided**: 1  
  - **Images Passed to Model**: 0 (all images were dropped)  
  - **Model Input**: Text body only, with no image content  
  - **Estimated Input Tokens**: ~493 (text only, no image data)  

### After Fix (4/4 Tests Passed):  
- **Test Results**:  
  1. OpenRouter model resolution now includes image capability (`["text", "image"]`).  
  2. The full pipeline (RPC attachment → parsing → model resolution → image injection) successfully delivers images to the model.  
  3. Existing images are preserved even for text-only model definitions (1 image retained).  
  4. Multiple images sent from the gateway client are successfully delivered to the model (2 images retained).  

- **Pipeline Trace (After Fix)**:  
  - **Model ID**: anthropic/claude-opus-4.6  
  - **Model Input**: `["text", "image"]` (now includes "image")  
  - **Has Vision Capability**: `true`  
  - **Existing Images Provided**: 1  
  - **Images Passed to Model**: 1 (images successfully delivered)  
  - **Model Input**: Image content blocks included:  
    - [0] `type=image`, `mimeType=image/png`, `base64Len=92`  

### Defense-in-Depth Validation:  
- Even when the model is defined as text-only (`["text"]`), explicit images are no longer silently dropped.  
- **Model Input**: `["text"]`  
- **Existing Images Provided**: 1  
- **Images Passed to Model**: 1 (explicit images are retained).

Attach at least one:

- [x] Failing test/log before + passing after
Full test suite: 22 test files, 181 tests all pass (including integration test):
 Test Files  22 passed (22)
  Tests  181 passed (181)

- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
