### PR TITLE
fix(config): add missing enabled field to WhatsAppConfigSchema

### DIFF
--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -113,6 +113,7 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
 }).strict();
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({
+  enabled: z.boolean().optional(),
   accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
   mediaMaxMb: z.number().int().positive().optional().default(50),
   actions: z


### PR DESCRIPTION
## Summary

- `WhatsAppConfigSchema` uses `.strict()` but lacks the `enabled: z.boolean().optional()` field that all other channel config schemas include (Telegram, Discord, Slack, Signal, IRC, iMessage, Google Chat, MS Teams all have it)
- `WhatsAppAccountSchema` already has this field — only the top-level schema was missing it
- This causes `applyPluginAutoEnable` to fail with `Config validation failed: channels.whatsapp: Unrecognized key: "enabled"` when it writes `channels.whatsapp.enabled = true` via `registerPluginEntry`, preventing the config from being persisted

## Test plan

- [ ] Verify `pnpm tsgo` passes
- [ ] Verify config validation accepts `channels.whatsapp.enabled: true`
- [ ] Verify `applyPluginAutoEnable` no longer warns about WhatsApp config