### PR TITLE
fix(telegram): clear stale threadId from session store on topic deletion

### DIFF
--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -88,6 +88,12 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  /**
+   * Callback invoked when a Telegram send succeeds only after falling back
+   * from a stale forum-topic thread id ("message thread not found").
+   * The delivery layer uses this to clear the threadId from the session store.
+   */
+  onThreadIdFallback?: () => void | Promise<void>;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -102,7 +102,9 @@ function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
   };
 }
 
-function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
+export function removeThreadFromDeliveryContext(
+  context?: DeliveryContext,
+): DeliveryContext | undefined {
   if (!context || context.threadId == null) {
     return context;
   }


### PR DESCRIPTION
## Problem

When a Telegram forum topic is deleted, sends to that topic fail with `message thread not found`. The existing `withTelegramThreadFallback()` retries without the thread id and succeeds, but **never updates the persistent session state** — the `deliveryContext.threadId` and `lastThreadId` in `sessions.json` remain stale. This causes every subsequent send to go through the fail→retry cycle unnecessarily.

## Fix

Adds an `onThreadIdFallback` callback that propagates from the Telegram send layer → channel outbound adapter → delivery pipeline. When a thread-not-found fallback succeeds, the callback clears `deliveryContext.threadId` and `lastThreadId` from the session store entry, healing the state so future sends go directly without the stale thread id.

### Changes

- **`src/config/sessions/store.ts`**: Export `removeThreadFromDeliveryContext` (was internal)
- **`src/telegram/send.ts`**: Add `onThreadIdFallback` to `TelegramSendOpts`, `TelegramStickerOpts`, `TelegramPollOpts`; invoke after successful fallback
- **`src/channels/plugins/types.adapters.ts`**: Add `onThreadIdFallback` to `ChannelOutboundContext`
- **`src/channels/plugins/outbound/telegram.ts`**: Wire callback through send context
- **`src/infra/outbound/deliver.ts`**: Build cleanup callback when `sessionKey` is available and channel is telegram; uses lazy imports to avoid circular deps

All cleanup is best-effort — caught errors never block delivery.

## Testing

- TypeScript type-checks pass (`tsc --noEmit`)
- Existing `send.test.ts` thread-not-found tests continue to pass