### PR TITLE
fix(discord): bypass Carbon FormData interception for voice upload-url (#16103)

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -523,6 +523,7 @@ export async function sendVoiceMessageDiscord(
       opts.replyTo,
       request,
       opts.silent,
+      token,
     );
 
     recordChannelActivity({

--- a/src/discord/voice-message.upload-url.test.ts
+++ b/src/discord/voice-message.upload-url.test.ts
@@ -1,0 +1,130 @@
+import { DiscordError, RateLimitError } from "@buape/carbon";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { VoiceMessageMetadata } from "./voice-message.js";
+import { sendDiscordVoiceMessage } from "./voice-message.js";
+
+describe("sendDiscordVoiceMessage upload-url step (#16103)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses raw fetch for upload-url to bypass Carbon FormData interception", async () => {
+    let fetchCallIndex = 0;
+    const fetchCalls: Array<{ init: RequestInit }> = [];
+
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls.push({ init: init ?? {} });
+      const idx = fetchCallIndex++;
+
+      // Step 1: upload-url response
+      if (idx === 0) {
+        return new Response(
+          JSON.stringify({
+            attachments: [
+              {
+                upload_url: "https://cdn.discordapp.com/upload/test",
+                upload_filename: "attachments/0/voice-message.ogg",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      // Step 2: CDN upload response
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    const mockRest = {
+      post: vi.fn().mockResolvedValue({ id: "msg123", channel_id: "ch456" }),
+    };
+
+    const metadata: VoiceMessageMetadata = {
+      durationSecs: 5.0,
+      waveform: "AAAA",
+    };
+
+    const request = async (fn: () => Promise<unknown>) => fn();
+
+    await sendDiscordVoiceMessage(
+      mockRest as never,
+      "channel123",
+      Buffer.from("fake-ogg-data"),
+      metadata,
+      undefined,
+      request as never,
+      false,
+      "test-bot-token",
+    );
+
+    // Step 1 used raw fetch with JSON body (not Carbon's rest.post)
+    expect(fetchCalls).toHaveLength(2);
+    const step1Headers = fetchCalls[0].init.headers as Record<string, string>;
+    expect(step1Headers["Content-Type"]).toBe("application/json");
+    expect(step1Headers.Authorization).toBe("Bot test-bot-token");
+    const step1Body = JSON.parse(fetchCalls[0].init.body as string);
+    expect(step1Body.files[0].filename).toBe("voice-message.ogg");
+
+    // Step 3 used rest.post (Carbon is fine for non-files bodies)
+    expect(mockRest.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws DiscordError with structured payload on upload-url failure", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({ message: "Missing Access", code: 50001 }), {
+        status: 403,
+      });
+    }) as typeof fetch;
+
+    const mockRest = { post: vi.fn() };
+    const metadata: VoiceMessageMetadata = { durationSecs: 3.0, waveform: "BBBB" };
+    const request = async (fn: () => Promise<unknown>) => fn();
+
+    await expect(
+      sendDiscordVoiceMessage(
+        mockRest as never,
+        "channel123",
+        Buffer.from("fake-ogg-data"),
+        metadata,
+        undefined,
+        request as never,
+        false,
+        "test-bot-token",
+      ),
+    ).rejects.toThrow(DiscordError);
+  });
+
+  it("throws RateLimitError on 429 so retry runner can back off", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({ message: "You are being rate limited.", retry_after: 1.5, global: false }),
+        {
+          status: 429,
+          headers: {
+            "X-RateLimit-Scope": "user",
+            "X-RateLimit-Bucket": "abc123",
+          },
+        },
+      );
+    }) as typeof fetch;
+
+    const mockRest = { post: vi.fn() };
+    const metadata: VoiceMessageMetadata = { durationSecs: 2.0, waveform: "CCCC" };
+    const request = async (fn: () => Promise<unknown>) => fn();
+
+    await expect(
+      sendDiscordVoiceMessage(
+        mockRest as never,
+        "channel123",
+        Buffer.from("fake-ogg-data"),
+        metadata,
+        undefined,
+        request as never,
+        false,
+        "test-bot-token",
+      ),
+    ).rejects.toThrow(RateLimitError);
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord voice messages (`asVoice: true`) always fail with a bare `"Error"` — no API status code, no stack trace, no indication of which step failed.
- Why it matters: Any Discord bot user sending voice messages gets an opaque failure with no actionable diagnostic; the feature is effectively broken.
- What changed: `sendDiscordVoiceMessage()` now uses a raw `fetch` call (with `Authorization: Bot <token>` header) for the upload-URL step only. On non-2xx it throws `DiscordError` or `RateLimitError` (matching Carbon semantics) so the retry runner and `buildDiscordSendError()` can classify errors correctly.
- What did NOT change (scope boundary): Steps 2 (CDN PUT) and 3 (message POST) still use Carbon's `rest.post`. No other Discord send paths are affected; the token is threaded through only to this one call site.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #16103
- Related #19668

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Discord voice messages (`asVoice: true`) now succeed instead of failing silently. When an error does occur, the error message contains the Discord API status code and error body (e.g. "Missing Access", code 50001) rather than a bare `"Error"`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: The bot token is now passed into `sendDiscordVoiceMessage()` and used in a single raw `fetch` `Authorization` header for the upload-URL step. The token was already available at the call site and already sent to Discord via Carbon for every other request — this change does not expand scope. The raw fetch call is scoped to a single internal step, not exposed to user-controlled input.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord bot token + channel with `AttachFiles` + `SendMessages` permissions

### Steps

1. Configure a Discord bot account in OpenClaw.
2. Call the `message` tool with `asVoice: true` and a valid audio file path targeting a Discord channel.
3. Observe the result.

### Expected

- Voice message is delivered to the Discord channel as a native voice message (blue waveform player).

### Actual

- Tool returns `{"status": "error", "error": "Error"}` with no additional context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/discord/voice-message.upload-url.test.ts` (130 lines, 3 cases):
1. Confirms step 1 uses raw `fetch` with `Content-Type: application/json` and `Authorization: Bot <token>` headers (not Carbon's `rest.post`).
2. Confirms non-2xx throws `DiscordError` with structured Discord API body so `buildDiscordSendError` can classify it.
3. Confirms 429 throws `RateLimitError` so the retry runner can back off correctly.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Unit tests pass; build and lint are clean; root cause confirmed by reading Carbon's `RequestClient.executeRequest` source.
- Edge cases checked: 403 (missing permissions), 429 (rate limit), successful round-trip through all three voice message steps.
- What you did **not** verify: End-to-end delivery on a live Discord bot (no live bot available in this environment).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `c2996c6be`; the only production files changed are `src/discord/voice-message.ts` and `src/discord/send.outbound.ts`.
- Files/config to restore: `src/discord/voice-message.ts`, `src/discord/send.outbound.ts`
- Known bad symptoms reviewers should watch for: If `token` is undefined at the call site, the raw fetch will be sent without an `Authorization` header and receive a 401. The `DiscordError` throw path will surface this clearly rather than silently.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Raw `fetch` bypasses any future Carbon middleware (retry hooks, request logging) added to `rest.post`.
  - Mitigation: The retry runner (`request()`) still wraps the entire step; only the innermost HTTP call is raw. Carbon middleware for the other two steps is untouched.
- Risk: If a new call site calls `sendDiscordVoiceMessage()` without passing `token`, the upload-URL request will fail with a 401.
  - Mitigation: `token` is optional (`token?: string`); the function throws a clear `DiscordError` on 401 rather than a bare `Error`. The existing call site already has the token available and passes it correctly.
