### PR TITLE
usage: include reset archives in session totals + add lifetime/session views

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -128,6 +128,25 @@ describe("gateway-cli coverage", () => {
     expect(runtimeLogs.join("\n")).toContain('"ok": true');
   });
 
+  it("registers usage-sessions and requests sessions + cost", async () => {
+    resetRuntimeCapture();
+    callGateway.mockClear();
+
+    await runGatewayCommand(["gateway", "usage-sessions", "--days", "7", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(callGateway.mock.calls[0]?.[0]).toMatchObject({
+      method: "sessions.usage",
+      params: expect.objectContaining({
+        limit: 200,
+        includeContextWeight: false,
+      }),
+    });
+    expect(callGateway.mock.calls[1]?.[0]).toMatchObject({
+      method: "usage.cost",
+    });
+  });
+
   it("registers gateway probe and routes to gatewayStatusCommand", async () => {
     resetRuntimeCapture();
     gatewayStatusCommand.mockClear();

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -142,10 +142,12 @@ describe("gateway register option collisions", () => {
   });
 
   it("forwards --token to gateway usage-sessions when parent and child option names collide", async () => {
-    await runRegisteredCli({
-      register: registerGatewayCli as (program: Command) => void,
-      argv: ["gateway", "usage-sessions", "--token", "tok_usage", "--json"],
-    });
+    await sharedProgram.parseAsync(
+      ["gateway", "usage-sessions", "--token", "tok_usage", "--json"],
+      {
+        from: "user",
+      },
+    );
 
     expect(callGatewayCli).toHaveBeenNthCalledWith(
       1,

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -141,6 +141,24 @@ describe("gateway register option collisions", () => {
     );
   });
 
+  it("forwards --token to gateway usage-sessions when parent and child option names collide", async () => {
+    await runRegisteredCli({
+      register: registerGatewayCli as (program: Command) => void,
+      argv: ["gateway", "usage-sessions", "--token", "tok_usage", "--json"],
+    });
+
+    expect(callGatewayCli).toHaveBeenNthCalledWith(
+      1,
+      "sessions.usage",
+      expect.objectContaining({
+        token: "tok_usage",
+      }),
+      expect.objectContaining({
+        includeContextWeight: false,
+      }),
+    );
+  });
+
   it("forwards --token to gateway probe when parent and child option names collide", async () => {
     await sharedProgram.parseAsync(["gateway", "probe", "--token", "tok_probe", "--json"], {
       from: "user",

--- a/src/ui-usage-summary-totals.test.ts
+++ b/src/ui-usage-summary-totals.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { __test } from "../ui/src/ui/views/usage.ts";
+
+describe("usage summary totals", () => {
+  it("prefers full daily aggregates for base totals when available", () => {
+    const sessionTotals = {
+      input: 10,
+      output: 20,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 30,
+      totalCost: 1,
+      inputCost: 0.4,
+      outputCost: 0.6,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    };
+
+    const costDaily = [
+      {
+        date: "2026-02-25",
+        input: 100,
+        output: 200,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 300,
+        totalCost: 9,
+        inputCost: 4,
+        outputCost: 5,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 2,
+      },
+    ];
+
+    const totals = __test.resolveBaseTotals({
+      sessionTotals,
+      costDaily,
+    });
+
+    expect(totals?.totalTokens).toBe(300);
+    expect(totals?.totalCost).toBe(9);
+    expect(totals?.missingCostEntries).toBe(2);
+  });
+
+  it("falls back to session totals when daily aggregates are unavailable", () => {
+    const sessionTotals = {
+      input: 11,
+      output: 22,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 33,
+      totalCost: 1.23,
+      inputCost: 0.5,
+      outputCost: 0.73,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 1,
+    };
+
+    const totals = __test.resolveBaseTotals({
+      sessionTotals,
+      costDaily: [],
+    });
+
+    expect(totals).toEqual(sessionTotals);
+  });
+
+  it("resolves lifetime preset to a fixed start date", () => {
+    const range = __test.resolvePresetRange(
+      { lifetime: true },
+      new Date("2026-02-26T12:00:00.000Z"),
+    );
+
+    expect(range).toEqual({
+      startDate: "1970-01-01",
+      endDate: "2026-02-26",
+    });
+  });
+
+  it("resolves rolling presets based on day count", () => {
+    const range = __test.resolvePresetRange({ days: 7 }, new Date("2026-02-26T12:00:00.000Z"));
+
+    expect(range).toEqual({
+      startDate: "2026-02-20",
+      endDate: "2026-02-26",
+    });
+  });
+});

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -260,24 +260,23 @@ export function renderUsage(props: UsageProps) {
 
   // Compute totals from sessions
   const computeSessionTotals = (sessions: UsageSessionEntry[]): UsageTotals => {
-    return sessions.reduce(
-      (acc, s) => {
-        if (!s.usage) return acc;
-        acc.input += s.usage.input;
-        acc.output += s.usage.output;
-        acc.cacheRead += s.usage.cacheRead;
-        acc.cacheWrite += s.usage.cacheWrite;
-        acc.totalTokens += s.usage.totalTokens;
-        acc.totalCost += s.usage.totalCost;
-        acc.inputCost += s.usage.inputCost ?? 0;
-        acc.outputCost += s.usage.outputCost ?? 0;
-        acc.cacheReadCost += s.usage.cacheReadCost ?? 0;
-        acc.cacheWriteCost += s.usage.cacheWriteCost ?? 0;
-        acc.missingCostEntries += s.usage.missingCostEntries ?? 0;
+    return sessions.reduce((acc, s) => {
+      if (!s.usage) {
         return acc;
-      },
-      emptyUsageTotals(),
-    );
+      }
+      acc.input += s.usage.input;
+      acc.output += s.usage.output;
+      acc.cacheRead += s.usage.cacheRead;
+      acc.cacheWrite += s.usage.cacheWrite;
+      acc.totalTokens += s.usage.totalTokens;
+      acc.totalCost += s.usage.totalCost;
+      acc.inputCost += s.usage.inputCost ?? 0;
+      acc.outputCost += s.usage.outputCost ?? 0;
+      acc.cacheReadCost += s.usage.cacheReadCost ?? 0;
+      acc.cacheWriteCost += s.usage.cacheWriteCost ?? 0;
+      acc.missingCostEntries += s.usage.missingCostEntries ?? 0;
+      return acc;
+    }, emptyUsageTotals());
   };
 
   // Compute totals from daily data for selected days (more accurate than session totals)

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -42,51 +42,60 @@ import {
 
 export type { UsageColumnId, SessionLogEntry, SessionLogRole };
 
-function createEmptyUsageTotals(): UsageTotals {
-  return {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    totalCost: 0,
-    inputCost: 0,
-    outputCost: 0,
-    cacheReadCost: 0,
-    cacheWriteCost: 0,
-    missingCostEntries: 0,
-  };
-}
+const emptyUsageTotals = (): UsageTotals => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  inputCost: 0,
+  outputCost: 0,
+  cacheReadCost: 0,
+  cacheWriteCost: 0,
+  missingCostEntries: 0,
+});
 
-function addUsageTotals(
-  acc: UsageTotals,
-  usage: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-    totalTokens: number;
-    totalCost: number;
-    inputCost?: number;
-    outputCost?: number;
-    cacheReadCost?: number;
-    cacheWriteCost?: number;
-    missingCostEntries?: number;
-  },
-): UsageTotals {
-  acc.input += usage.input;
-  acc.output += usage.output;
-  acc.cacheRead += usage.cacheRead;
-  acc.cacheWrite += usage.cacheWrite;
-  acc.totalTokens += usage.totalTokens;
-  acc.totalCost += usage.totalCost;
-  acc.inputCost += usage.inputCost ?? 0;
-  acc.outputCost += usage.outputCost ?? 0;
-  acc.cacheReadCost += usage.cacheReadCost ?? 0;
-  acc.cacheWriteCost += usage.cacheWriteCost ?? 0;
-  acc.missingCostEntries += usage.missingCostEntries ?? 0;
-  return acc;
-}
+const sumDailyTotals = (entries: UsageProps["costDaily"]): UsageTotals =>
+  entries.reduce((acc, entry) => {
+    acc.input += entry.input;
+    acc.output += entry.output;
+    acc.cacheRead += entry.cacheRead;
+    acc.cacheWrite += entry.cacheWrite;
+    acc.totalTokens += entry.totalTokens;
+    acc.totalCost += entry.totalCost;
+    acc.inputCost += entry.inputCost ?? 0;
+    acc.outputCost += entry.outputCost ?? 0;
+    acc.cacheReadCost += entry.cacheReadCost ?? 0;
+    acc.cacheWriteCost += entry.cacheWriteCost ?? 0;
+    acc.missingCostEntries += entry.missingCostEntries ?? 0;
+    return acc;
+  }, emptyUsageTotals());
+
+const resolveBaseTotals = (params: {
+  sessionTotals: UsageTotals | null;
+  costDaily: UsageProps["costDaily"];
+}): UsageTotals | null => {
+  // `usage.cost` is not capped by the session list limit, so prefer it when available.
+  if (params.costDaily.length > 0) {
+    return sumDailyTotals(params.costDaily);
+  }
+  return params.sessionTotals;
+};
+
+const resolvePresetRange = (
+  preset: { days?: number; lifetime?: true },
+  now = new Date(),
+): { startDate: string; endDate: string } => {
+  const endDate = formatIsoDate(now);
+  if (preset.lifetime) {
+    return { startDate: "1970-01-01", endDate };
+  }
+  const start = new Date(now);
+  const days = Math.max(1, preset.days ?? 1);
+  start.setDate(start.getDate() - (days - 1));
+  return { startDate: formatIsoDate(start), endDate };
+};
 
 export function renderUsage(props: UsageProps) {
   // Show loading skeleton if loading and no data yet
@@ -252,21 +261,37 @@ export function renderUsage(props: UsageProps) {
   // Compute totals from sessions
   const computeSessionTotals = (sessions: UsageSessionEntry[]): UsageTotals => {
     return sessions.reduce(
-      (acc, s) => (s.usage ? addUsageTotals(acc, s.usage) : acc),
-      createEmptyUsageTotals(),
+      (acc, s) => {
+        if (!s.usage) return acc;
+        acc.input += s.usage.input;
+        acc.output += s.usage.output;
+        acc.cacheRead += s.usage.cacheRead;
+        acc.cacheWrite += s.usage.cacheWrite;
+        acc.totalTokens += s.usage.totalTokens;
+        acc.totalCost += s.usage.totalCost;
+        acc.inputCost += s.usage.inputCost ?? 0;
+        acc.outputCost += s.usage.outputCost ?? 0;
+        acc.cacheReadCost += s.usage.cacheReadCost ?? 0;
+        acc.cacheWriteCost += s.usage.cacheWriteCost ?? 0;
+        acc.missingCostEntries += s.usage.missingCostEntries ?? 0;
+        return acc;
+      },
+      emptyUsageTotals(),
     );
   };
 
   // Compute totals from daily data for selected days (more accurate than session totals)
-  const computeDailyTotals = (days: string[]): UsageTotals => {
-    const matchingDays = props.costDaily.filter((d) => days.includes(d.date));
-    return matchingDays.reduce((acc, day) => addUsageTotals(acc, day), createEmptyUsageTotals());
-  };
+  const computeDailyTotals = (days: string[]): UsageTotals =>
+    sumDailyTotals(props.costDaily.filter((d) => days.includes(d.date)));
 
   // Compute display totals and count based on filters
   let displayTotals: UsageTotals | null;
   let displaySessionCount: number;
   const totalSessions = sortedSessions.length;
+  const baseTotals = resolveBaseTotals({
+    sessionTotals: props.totals,
+    costDaily: props.costDaily,
+  });
 
   if (props.selectedSessions.length > 0) {
     // Sessions selected - compute totals from selected sessions
@@ -287,7 +312,7 @@ export function renderUsage(props: UsageProps) {
     displaySessionCount = filteredSessions.length;
   } else {
     // No filters - show all
-    displayTotals = props.totals;
+    displayTotals = baseTotals;
     displaySessionCount = totalSessions;
   }
 
@@ -337,13 +362,12 @@ export function renderUsage(props: UsageProps) {
     { label: "Today", days: 1 },
     { label: "7d", days: 7 },
     { label: "30d", days: 30 },
+    { label: "Lifetime", lifetime: true as const },
   ];
-  const applyPreset = (days: number) => {
-    const end = new Date();
-    const start = new Date();
-    start.setDate(start.getDate() - (days - 1));
-    props.onStartDateChange(formatIsoDate(start));
-    props.onEndDateChange(formatIsoDate(end));
+  const applyPreset = (preset: { days?: number; lifetime?: true }) => {
+    const range = resolvePresetRange(preset);
+    props.onStartDateChange(range.startDate);
+    props.onEndDateChange(range.endDate);
   };
   const renderFilterSelect = (key: string, label: string, options: string[]) => {
     if (options.length === 0) {
@@ -572,7 +596,7 @@ export function renderUsage(props: UsageProps) {
           <div class="usage-presets">
             ${datePresets.map(
               (preset) => html`
-                <button class="btn btn-sm" @click=${() => applyPreset(preset.days)}>
+                <button class="btn btn-sm" @click=${() => applyPreset(preset)}>
                   ${preset.label}
                 </button>
               `,
@@ -737,7 +761,8 @@ export function renderUsage(props: UsageProps) {
         props.sessionsLimitReached
           ? html`
               <div class="callout warning" style="margin-top: 12px">
-                Showing first 1,000 sessions. Narrow date range for complete results.
+                Showing first 1,000 sessions in the table. Overview totals still use full daily aggregates for
+                this date range.
               </div>
             `
           : nothing
@@ -834,3 +859,7 @@ export function renderUsage(props: UsageProps) {
 }
 
 // Exposed for Playwright/Vitest browser unit tests.
+export const __test = {
+  resolveBaseTotals,
+  resolvePresetRange,
+};


### PR DESCRIPTION
## Summary
This PR improves usage visibility and correctness when sessions are reset/rotated.

## Problems addressed
- Usage totals and per-session usage could undercount historical spend after session resets because reset transcript archives (`*.jsonl.reset.*`) were not consistently included.
- Usage UI lacked a one-click way to inspect full-history usage.
- CLI lacked a dedicated per-session usage summary command.

## What changed
### 1) Include reset archives in session usage paths
- Added shared transcript filename matcher for `.jsonl` and `.jsonl.reset.*`.
- Updated `discoverAllSessions` to discover sessions by base session ID from reset archives.
- Updated `loadSessionCostSummary` to resolve and aggregate all transcript files for a session (active + reset archives), with canonical path deduping to avoid double counting.

### 2) Web UI usage improvements
- Added `Lifetime` date preset in Usage view (`1970-01-01` to today).
- Kept overview totals sourced from `usage.cost` daily aggregates when available (not capped by session list limit).
- Exposed preset-range helper in view test exports.

### 3) CLI per-session usage command
- Added `openclaw gateway usage-sessions`.
- Supports `--days`, `--start-date`, `--end-date`, `--limit`, `--all`, and `--json`.
- Calls both `sessions.usage` and `usage.cost` for aligned per-session + total usage reporting.

## Tests
Added/updated tests for all behavior changes:
- `src/infra/session-cost-usage.test.ts`
  - includes reset-only session summaries
  - discovers reset archives by base session ID
  - includes reset archives in usage summary
- `src/ui-usage-summary-totals.test.ts`
  - preset range resolution (`Lifetime`, rolling day ranges)
  - base totals resolution from daily aggregates
- `src/cli/gateway-cli.coverage.test.ts`
  - `usage-sessions` command wiring
- `src/cli/gateway-cli/register.option-collisions.test.ts`
  - token forwarding for `usage-sessions`

Validation run locally:
- `vitest run src/infra/session-cost-usage.test.ts src/ui-usage-summary-totals.test.ts src/cli/gateway-cli.coverage.test.ts src/cli/gateway-cli/register.option-collisions.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec oxfmt --check` on changed files

## Notes
This keeps existing APIs backward-compatible and scopes behavior changes to usage read paths + CLI/UI presentation.
