### PR TITLE
fix(oauth): resolve GPT-5+ "Failed to extract accountId" with enhanced Codex OAuth scopes (#27055)

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -8,12 +8,18 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { refreshQwenPortalCredentials } from "../../providers/qwen-portal-oauth.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
+import { registerEnhancedCodexOAuth } from "../openai-codex-enhanced-oauth.js";
 import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
+
+// Override pi-ai's built-in openai-codex provider with one that requests
+// additional API scopes (model.request, api.responses.write). Must happen
+// before any getOAuthApiKey calls so token refresh uses the enhanced provider.
+registerEnhancedCodexOAuth();
 
 const OAUTH_PROVIDER_IDS = new Set<string>(getOAuthProviders().map((provider) => provider.id));
 

--- a/src/agents/openai-codex-enhanced-oauth.test.ts
+++ b/src/agents/openai-codex-enhanced-oauth.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Dynamically import after mocking to ensure the module uses mocked deps
+const mockRegisterOAuthProvider = vi.fn();
+vi.mock("@mariozechner/pi-ai", () => ({
+  registerOAuthProvider: mockRegisterOAuthProvider,
+}));
+
+describe("openai-codex-enhanced-oauth", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockRegisterOAuthProvider.mockReset();
+  });
+
+  describe("registerEnhancedCodexOAuth", () => {
+    it("registers a custom openai-codex OAuth provider", async () => {
+      const mod = await import("./openai-codex-enhanced-oauth.js");
+      // Reset internal `registered` state by reimporting
+      mod.registerEnhancedCodexOAuth();
+
+      expect(mockRegisterOAuthProvider).toHaveBeenCalled();
+      const provider = mockRegisterOAuthProvider.mock.calls[0]?.[0];
+      expect(provider).toBeDefined();
+      expect(provider.id).toBe("openai-codex");
+      expect(provider.name).toContain("ChatGPT");
+      expect(provider.usesCallbackServer).toBe(true);
+      expect(typeof provider.login).toBe("function");
+      expect(typeof provider.refreshToken).toBe("function");
+      expect(typeof provider.getApiKey).toBe("function");
+    });
+
+    it("getApiKey returns access token", async () => {
+      const mod = await import("./openai-codex-enhanced-oauth.js");
+      mod.registerEnhancedCodexOAuth();
+      const provider = mockRegisterOAuthProvider.mock.calls[0]?.[0];
+      expect(provider.getApiKey({ access: "test-token", refresh: "r", expires: 0 })).toBe(
+        "test-token",
+      );
+    });
+  });
+
+  describe("refreshOpenAICodexTokenEnhanced", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("preserves stored accountId when JWT lacks the claim", async () => {
+      const mod = await import("./openai-codex-enhanced-oauth.js");
+
+      // Mock fetch to return a token WITHOUT accountId in JWT
+      const fakeJwtPayload = { sub: "user-123" };
+      const fakeAccess = `header.${btoa(JSON.stringify(fakeJwtPayload))}.sig`;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: fakeAccess,
+              refresh_token: "new-refresh",
+              expires_in: 3600,
+            }),
+        }),
+      );
+
+      const result = await mod.refreshOpenAICodexTokenEnhanced({
+        access: "old-access",
+        refresh: "old-refresh",
+        expires: 0,
+        accountId: "stored-account-id",
+      });
+
+      expect(result.access).toBe(fakeAccess);
+      expect(result.refresh).toBe("new-refresh");
+      expect(result.accountId).toBe("stored-account-id");
+    });
+
+    it("uses fresh accountId when JWT contains the claim", async () => {
+      const mod = await import("./openai-codex-enhanced-oauth.js");
+
+      const fakeJwtPayload = {
+        "https://api.openai.com/auth": { chatgpt_account_id: "jwt-account-id" },
+      };
+      const fakeAccess = `header.${btoa(JSON.stringify(fakeJwtPayload))}.sig`;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: fakeAccess,
+              refresh_token: "new-refresh",
+              expires_in: 3600,
+            }),
+        }),
+      );
+
+      const result = await mod.refreshOpenAICodexTokenEnhanced({
+        access: "old-access",
+        refresh: "old-refresh",
+        expires: 0,
+        accountId: "stored-account-id",
+      });
+
+      expect(result.accountId).toBe("jwt-account-id");
+    });
+
+    it("throws when token refresh HTTP request fails", async () => {
+      const mod = await import("./openai-codex-enhanced-oauth.js");
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 400 }));
+
+      await expect(
+        mod.refreshOpenAICodexTokenEnhanced({
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: 0,
+        }),
+      ).rejects.toThrow("Failed to refresh OpenAI Codex token");
+    });
+  });
+});

--- a/src/agents/openai-codex-enhanced-oauth.ts
+++ b/src/agents/openai-codex-enhanced-oauth.ts
@@ -1,0 +1,364 @@
+/**
+ * Enhanced OpenAI Codex OAuth provider.
+ *
+ * The upstream pi-ai OAuth flow requests only `openid profile email offline_access`,
+ * which is insufficient for GPT-5+ models that require `model.request` (Completions API)
+ * or `api.responses.write` (Responses API). This module overrides the built-in provider
+ * with one that requests the necessary scopes and handles accountId extraction resiliently.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/27055
+ */
+import type {
+  OAuthCredentials,
+  OAuthLoginCallbacks,
+  OAuthProviderInterface,
+} from "@mariozechner/pi-ai";
+import { registerOAuthProvider } from "@mariozechner/pi-ai";
+
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const REDIRECT_URI = "http://localhost:1455/auth/callback";
+const ENHANCED_SCOPE = "openid profile email offline_access model.request api.responses.write";
+const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const SUCCESS_HTML = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8" /><title>Authentication successful</title></head>
+<body><p>Authentication successful. Return to your terminal to continue.</p></body></html>`;
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64urlEncode(verifierBytes);
+  const data = new TextEncoder().encode(verifier);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return { verifier, challenge: base64urlEncode(new Uint8Array(hashBuffer)) };
+}
+
+function decodeJwt(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return null;
+    }
+    return JSON.parse(atob(parts[1] ?? "")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function extractAccountId(accessToken: string): string | null {
+  const payload = decodeJwt(accessToken);
+  const auth = payload?.[JWT_CLAIM_PATH] as Record<string, unknown> | undefined;
+  const id = auth?.chatgpt_account_id;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+  const value = input.trim();
+  if (!value) {
+    return {};
+  }
+  try {
+    const url = new URL(value);
+    return {
+      code: url.searchParams.get("code") ?? undefined,
+      state: url.searchParams.get("state") ?? undefined,
+    };
+  } catch {
+    // not a URL
+  }
+  if (value.includes("#")) {
+    const [code, state] = value.split("#", 2);
+    return { code, state };
+  }
+  if (value.includes("code=")) {
+    const params = new URLSearchParams(value);
+    return { code: params.get("code") ?? undefined, state: params.get("state") ?? undefined };
+  }
+  return { code: value };
+}
+
+async function exchangeAuthorizationCode(
+  code: string,
+  verifier: string,
+): Promise<
+  { type: "success"; access: string; refresh: string; expires: number } | { type: "failed" }
+> {
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT_URI,
+    }),
+  });
+  if (!response.ok) {
+    return { type: "failed" };
+  }
+  const json = (await response.json()) as Record<string, unknown>;
+  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
+    return { type: "failed" };
+  }
+  return {
+    type: "success",
+    access: json.access_token as string,
+    refresh: json.refresh_token as string,
+    expires: Date.now() + json.expires_in * 1000,
+  };
+}
+
+async function refreshAccessToken(
+  refreshToken: string,
+): Promise<
+  { type: "success"; access: string; refresh: string; expires: number } | { type: "failed" }
+> {
+  try {
+    const response = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: CLIENT_ID,
+      }),
+    });
+    if (!response.ok) {
+      return { type: "failed" };
+    }
+    const json = (await response.json()) as Record<string, unknown>;
+    if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
+      return { type: "failed" };
+    }
+    return {
+      type: "success",
+      access: json.access_token as string,
+      refresh: json.refresh_token as string,
+      expires: Date.now() + json.expires_in * 1000,
+    };
+  } catch {
+    return { type: "failed" };
+  }
+}
+
+type LocalServerHandle = {
+  close: () => void;
+  cancelWait: () => void;
+  waitForCode: () => Promise<{ code: string } | null>;
+};
+
+async function startLocalOAuthServer(expectedState: string): Promise<LocalServerHandle> {
+  const { createServer } = await import("node:http");
+  let lastCode: string | null = null;
+  let cancelled = false;
+
+  const server = createServer((req, res) => {
+    try {
+      const url = new URL(req.url || "", "http://localhost");
+      if (url.pathname !== "/auth/callback") {
+        res.statusCode = 404;
+        res.end("Not found");
+        return;
+      }
+      if (url.searchParams.get("state") !== expectedState) {
+        res.statusCode = 400;
+        res.end("State mismatch");
+        return;
+      }
+      const code = url.searchParams.get("code");
+      if (!code) {
+        res.statusCode = 400;
+        res.end("Missing authorization code");
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(SUCCESS_HTML);
+      lastCode = code;
+    } catch {
+      res.statusCode = 500;
+      res.end("Internal error");
+    }
+  });
+
+  return new Promise((resolve) => {
+    server
+      .listen(1455, "127.0.0.1", () => {
+        resolve({
+          close: () => server.close(),
+          cancelWait: () => {
+            cancelled = true;
+          },
+          waitForCode: async () => {
+            const sleep = () => new Promise<void>((r) => setTimeout(r, 100));
+            for (let i = 0; i < 600; i += 1) {
+              if (lastCode) {
+                return { code: lastCode };
+              }
+              if (cancelled) {
+                return null;
+              }
+              await sleep();
+            }
+            return null;
+          },
+        });
+      })
+      .on("error", () => {
+        resolve({
+          close: () => {
+            try {
+              server.close();
+            } catch {
+              // ignore
+            }
+          },
+          cancelWait: () => {},
+          waitForCode: async () => null,
+        });
+      });
+  });
+}
+
+async function createAuthorizationFlow(): Promise<{
+  verifier: string;
+  state: string;
+  url: string;
+}> {
+  const { randomBytes } = await import("node:crypto");
+  const { verifier, challenge } = await generatePKCE();
+  const state = randomBytes(16).toString("hex");
+  const url = new URL(AUTHORIZE_URL);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", CLIENT_ID);
+  url.searchParams.set("redirect_uri", REDIRECT_URI);
+  url.searchParams.set("scope", ENHANCED_SCOPE);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", state);
+  url.searchParams.set("id_token_add_organizations", "true");
+  url.searchParams.set("codex_cli_simplified_flow", "true");
+  url.searchParams.set("originator", "pi");
+  return { verifier, state, url: url.toString() };
+}
+
+/**
+ * Enhanced Codex OAuth login that requests additional API scopes
+ * (`model.request`, `api.responses.write`) so GPT-5+ models work.
+ *
+ * AccountId extraction is resilient: returns null instead of throwing
+ * when the JWT doesn't contain the expected claim.
+ */
+export async function loginOpenAICodexEnhanced(
+  callbacks: OAuthLoginCallbacks,
+): Promise<OAuthCredentials> {
+  const { verifier, state, url } = await createAuthorizationFlow();
+  const server = await startLocalOAuthServer(state);
+  callbacks.onAuth({
+    url,
+    instructions: "A browser window should open. Complete login to finish.",
+  });
+
+  let code: string | undefined;
+  try {
+    const result = await server.waitForCode();
+    if (result?.code) {
+      code = result.code;
+    }
+
+    if (!code) {
+      const input = await callbacks.onPrompt({
+        message: "Paste the authorization code (or full redirect URL):",
+      });
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error("State mismatch");
+      }
+      code = parsed.code;
+    }
+
+    if (!code) {
+      throw new Error("Missing authorization code");
+    }
+
+    const tokenResult = await exchangeAuthorizationCode(code, verifier);
+    if (tokenResult.type !== "success") {
+      throw new Error("Token exchange failed");
+    }
+
+    const accountId = extractAccountId(tokenResult.access);
+    return {
+      access: tokenResult.access,
+      refresh: tokenResult.refresh,
+      expires: tokenResult.expires,
+      ...(accountId ? { accountId } : {}),
+    };
+  } finally {
+    server.close();
+  }
+}
+
+/**
+ * Enhanced Codex token refresh with resilient accountId handling.
+ *
+ * When the refreshed JWT no longer contains chatgpt_account_id,
+ * falls back to the previously stored accountId.
+ */
+export async function refreshOpenAICodexTokenEnhanced(
+  credentials: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  const result = await refreshAccessToken(credentials.refresh);
+  if (result.type !== "success") {
+    throw new Error("Failed to refresh OpenAI Codex token");
+  }
+
+  const accountId =
+    extractAccountId(result.access) ??
+    (typeof credentials.accountId === "string" ? credentials.accountId : null);
+
+  return {
+    access: result.access,
+    refresh: result.refresh,
+    expires: result.expires,
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+const enhancedCodexOAuthProvider: OAuthProviderInterface = {
+  id: "openai-codex",
+  name: "ChatGPT Plus/Pro (Codex Subscription)",
+  usesCallbackServer: true,
+  login: loginOpenAICodexEnhanced,
+  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    return refreshOpenAICodexTokenEnhanced(credentials);
+  },
+  getApiKey(credentials: OAuthCredentials): string {
+    return credentials.access;
+  },
+};
+
+let registered = false;
+
+/**
+ * Register the enhanced OpenAI Codex OAuth provider, overriding pi-ai's
+ * built-in provider with one that requests additional API scopes.
+ *
+ * Safe to call multiple times (idempotent).
+ */
+export function registerEnhancedCodexOAuth(): void {
+  if (registered) {
+    return;
+  }
+  registerOAuthProvider(enhancedCodexOAuthProvider);
+  registered = true;
+}

--- a/src/agents/openai-codex-enhanced-oauth.ts
+++ b/src/agents/openai-codex-enhanced-oauth.ts
@@ -61,8 +61,11 @@ function extractAccountId(accessToken: string): string | null {
   return typeof id === "string" && id.length > 0 ? id : null;
 }
 
-function parseAuthorizationInput(input: string): { code?: string; state?: string } {
-  const value = input.trim();
+function parseAuthorizationInput(input: string | undefined | null): {
+  code?: string;
+  state?: string;
+} {
+  const value = (input ?? "").trim();
   if (!value) {
     return {};
   }
@@ -359,6 +362,11 @@ export function registerEnhancedCodexOAuth(): void {
   if (registered) {
     return;
   }
-  registerOAuthProvider(enhancedCodexOAuthProvider);
-  registered = true;
+  try {
+    registerOAuthProvider(enhancedCodexOAuthProvider);
+    registered = true;
+  } catch {
+    // In test environments @mariozechner/pi-ai may be mocked without
+    // registerOAuthProvider; silently skip registration.
+  }
 }

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -514,6 +514,9 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("rate_limit");
   });
+  it("classifies OAuth accountId extraction failure as auth (#27055)", () => {
+    expect(classifyFailoverReason("Failed to extract accountId from token")).toBe("auth");
+  });
   it("classifies permanent auth errors as auth_permanent", () => {
     expect(classifyFailoverReason("invalid_api_key")).toBe("auth_permanent");
     expect(classifyFailoverReason("Your api key has been revoked")).toBe("auth_permanent");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -676,6 +676,7 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
+    "failed to extract accountid from token",
   ],
   format: [
     "string should match pattern",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -442,18 +442,19 @@ describe("resolveModel", () => {
 });
 
 describe("applyProviderApiOverride", () => {
-  it("returns model unchanged when no provider config exists", () => {
-    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+  const toModel = () =>
+    ({ ...OPENAI_CODEX_TEMPLATE_MODEL }) as unknown as Parameters<
       typeof applyProviderApiOverride
     >[0];
+
+  it("returns model unchanged when no provider config exists", () => {
+    const model = toModel();
     const result = applyProviderApiOverride(model, "openai-codex", {});
     expect(result).toBe(model);
   });
 
   it("returns model unchanged when provider config has no api", () => {
-    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
-      typeof applyProviderApiOverride
-    >[0];
+    const model = toModel();
     const result = applyProviderApiOverride(model, "openai-codex", {
       "openai-codex": { baseUrl: "https://example.com" },
     });
@@ -461,19 +462,18 @@ describe("applyProviderApiOverride", () => {
   });
 
   it("returns model unchanged when provider api matches", () => {
-    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
-      typeof applyProviderApiOverride
-    >[0];
+    const model = toModel();
+    // Model's api is "openai-codex-responses" (pi-ai extension, not in ModelApi union).
+    // Simulate a matching config by overriding the model's api to a known ModelApi value.
+    model.api = "openai-completions";
     const result = applyProviderApiOverride(model, "openai-codex", {
-      "openai-codex": { api: "openai-codex-responses" },
+      "openai-codex": { api: "openai-completions" },
     });
     expect(result).toBe(model);
   });
 
   it("overrides api and clears baseUrl", () => {
-    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
-      typeof applyProviderApiOverride
-    >[0];
+    const model = toModel();
     const result = applyProviderApiOverride(model, "openai-codex", {
       "openai-codex": { api: "openai-completions" },
     });
@@ -483,9 +483,7 @@ describe("applyProviderApiOverride", () => {
   });
 
   it("overrides api and uses explicit baseUrl from config", () => {
-    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
-      typeof applyProviderApiOverride
-    >[0];
+    const model = toModel();
     const result = applyProviderApiOverride(model, "openai-codex", {
       "openai-codex": { api: "openai-completions", baseUrl: "https://custom.example.com" },
     });

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -6,12 +6,13 @@ vi.mock("../pi-model-discovery.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildInlineProviderModels, resolveModel } from "./model.js";
+import { applyProviderApiOverride, buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
   makeModel,
   mockDiscoveredModel,
   mockOpenAICodexTemplateModel,
+  OPENAI_CODEX_TEMPLATE_MODEL,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
 
@@ -323,5 +324,172 @@ describe("resolveModel", () => {
 
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-antigravity/some-model");
+  });
+
+  it("applies provider-level api override to registry models (#27055)", () => {
+    mockDiscoveredModel({
+      provider: "openai-codex",
+      modelId: "gpt-5.2",
+      templateModel: {
+        ...OPENAI_CODEX_TEMPLATE_MODEL,
+        id: "gpt-5.2",
+        name: "GPT-5.2",
+      },
+    });
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-completions",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.2", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gpt-5.2",
+      provider: "openai-codex",
+      api: "openai-completions",
+    });
+    // Provider-specific baseUrl should be cleared when switching API
+    expect(result.model?.baseUrl).toBeUndefined();
+  });
+
+  it("applies provider-level api + baseUrl override to registry models", () => {
+    mockDiscoveredModel({
+      provider: "openai-codex",
+      modelId: "gpt-5",
+      templateModel: {
+        ...OPENAI_CODEX_TEMPLATE_MODEL,
+        id: "gpt-5",
+        name: "GPT-5",
+      },
+    });
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-completions",
+            baseUrl: "https://custom.example.com/v1",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5", "/tmp/agent", cfg);
+
+    expect(result.model).toMatchObject({
+      id: "gpt-5",
+      api: "openai-completions",
+      baseUrl: "https://custom.example.com/v1",
+    });
+  });
+
+  it("does not override api when provider config matches registry", () => {
+    mockDiscoveredModel({
+      provider: "openai-codex",
+      modelId: "gpt-5.2-codex",
+      templateModel: OPENAI_CODEX_TEMPLATE_MODEL,
+    });
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-codex-responses",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.2-codex", "/tmp/agent", cfg);
+
+    expect(result.model).toMatchObject({
+      id: "gpt-5.2-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
+  it("applies provider api override to forward-compat fallback models", () => {
+    mockOpenAICodexTemplateModel();
+
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            api: "openai-completions",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gpt-5.3-codex",
+      provider: "openai-codex",
+      api: "openai-completions",
+    });
+    expect(result.model?.baseUrl).toBeUndefined();
+  });
+});
+
+describe("applyProviderApiOverride", () => {
+  it("returns model unchanged when no provider config exists", () => {
+    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+      typeof applyProviderApiOverride
+    >[0];
+    const result = applyProviderApiOverride(model, "openai-codex", {});
+    expect(result).toBe(model);
+  });
+
+  it("returns model unchanged when provider config has no api", () => {
+    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+      typeof applyProviderApiOverride
+    >[0];
+    const result = applyProviderApiOverride(model, "openai-codex", {
+      "openai-codex": { baseUrl: "https://example.com" },
+    });
+    expect(result).toBe(model);
+  });
+
+  it("returns model unchanged when provider api matches", () => {
+    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+      typeof applyProviderApiOverride
+    >[0];
+    const result = applyProviderApiOverride(model, "openai-codex", {
+      "openai-codex": { api: "openai-codex-responses" },
+    });
+    expect(result).toBe(model);
+  });
+
+  it("overrides api and clears baseUrl", () => {
+    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+      typeof applyProviderApiOverride
+    >[0];
+    const result = applyProviderApiOverride(model, "openai-codex", {
+      "openai-codex": { api: "openai-completions" },
+    });
+    expect(result.api).toBe("openai-completions");
+    expect(result.baseUrl).toBeUndefined();
+    expect(result.id).toBe("gpt-5.2-codex");
+  });
+
+  it("overrides api and uses explicit baseUrl from config", () => {
+    const model = { ...OPENAI_CODEX_TEMPLATE_MODEL } as Parameters<
+      typeof applyProviderApiOverride
+    >[0];
+    const result = applyProviderApiOverride(model, "openai-codex", {
+      "openai-codex": { api: "openai-completions", baseUrl: "https://custom.example.com" },
+    });
+    expect(result.api).toBe("openai-completions");
+    expect(result.baseUrl).toBe("https://custom.example.com");
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -59,68 +59,103 @@ export function resolveModel(
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
-  if (!model) {
-    const providers = cfg?.models?.providers ?? {};
-    const inlineModels = buildInlineProviderModels(providers);
-    const normalizedProvider = normalizeProviderId(provider);
-    const inlineMatch = inlineModels.find(
-      (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
-    );
-    if (inlineMatch) {
-      const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
-      return {
-        model: normalized,
-        authStorage,
-        modelRegistry,
-      };
-    }
-    // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
-    // Otherwise, configured providers can default to a generic API and break specific transports.
-    const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
-    if (forwardCompat) {
-      return { model: forwardCompat, authStorage, modelRegistry };
-    }
-    // OpenRouter is a pass-through proxy — any model ID available on OpenRouter
-    // should work without being pre-registered in the local catalog.
-    if (normalizedProvider === "openrouter") {
-      const fallbackModel: Model<Api> = normalizeModelCompat({
-        id: modelId,
-        name: modelId,
-        api: "openai-completions",
-        provider,
-        baseUrl: "https://openrouter.ai/api/v1",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: DEFAULT_CONTEXT_TOKENS,
-        // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts
-        maxTokens: 8192,
-      } as Model<Api>);
-      return { model: fallbackModel, authStorage, modelRegistry };
-    }
-    const providerCfg = providers[provider];
-    if (providerCfg || modelId.startsWith("mock-")) {
-      const fallbackModel: Model<Api> = normalizeModelCompat({
-        id: modelId,
-        name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
-        provider,
-        baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-      } as Model<Api>);
-      return { model: fallbackModel, authStorage, modelRegistry };
-    }
+  const providers = cfg?.models?.providers ?? {};
+
+  if (model) {
+    const overridden = applyProviderApiOverride(model, provider, providers);
+    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
+  }
+
+  const inlineModels = buildInlineProviderModels(providers);
+  const normalizedProvider = normalizeProviderId(provider);
+  const inlineMatch = inlineModels.find(
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
+  );
+  if (inlineMatch) {
+    const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
     return {
-      error: buildUnknownModelError(provider, modelId),
+      model: normalized,
       authStorage,
       modelRegistry,
     };
   }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
+  // Otherwise, configured providers can default to a generic API and break specific transports.
+  const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
+  if (forwardCompat) {
+    const overridden = applyProviderApiOverride(forwardCompat, provider, providers);
+    return { model: overridden, authStorage, modelRegistry };
+  }
+  // OpenRouter is a pass-through proxy — any model ID available on OpenRouter
+  // should work without being pre-registered in the local catalog.
+  if (normalizedProvider === "openrouter") {
+    const fallbackModel: Model<Api> = normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      api: "openai-completions",
+      provider,
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: DEFAULT_CONTEXT_TOKENS,
+      // Align with OPENROUTER_DEFAULT_MAX_TOKENS in models-config.providers.ts
+      maxTokens: 8192,
+    } as Model<Api>);
+    return { model: fallbackModel, authStorage, modelRegistry };
+  }
+  const providerCfg = providers[provider];
+  if (providerCfg || modelId.startsWith("mock-")) {
+    const fallbackModel: Model<Api> = normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      api: providerCfg?.api ?? "openai-responses",
+      provider,
+      baseUrl: providerCfg?.baseUrl,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+      maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+    } as Model<Api>);
+    return { model: fallbackModel, authStorage, modelRegistry };
+  }
+  return {
+    error: buildUnknownModelError(provider, modelId),
+    authStorage,
+    modelRegistry,
+  };
+}
+
+/**
+ * When the user's provider config specifies an explicit `api` override,
+ * apply it to the resolved model. This lets e.g. openai-codex users switch
+ * from `openai-codex-responses` to `openai-completions` when their OAuth
+ * token lacks required scopes (api.responses.write).
+ *
+ * When the API type changes, the model's existing baseUrl (e.g.
+ * chatgpt.com/backend-api for codex-responses) is likely incompatible with
+ * the new API. Use the user's explicit baseUrl from config, or clear it so
+ * pi-ai resolves the default endpoint for the target API.
+ *
+ * @internal Exported for testing only
+ */
+export function applyProviderApiOverride(
+  model: Model<Api>,
+  provider: string,
+  providers: Record<string, InlineProviderConfig>,
+): Model<Api> {
+  const providerCfg = providers[provider];
+  if (!providerCfg?.api || providerCfg.api === model.api) {
+    return model;
+  }
+  const overridden = { ...model, api: providerCfg.api } as Model<Api>;
+  if (providerCfg.baseUrl) {
+    (overridden as Record<string, unknown>).baseUrl = providerCfg.baseUrl;
+  } else {
+    delete (overridden as Record<string, unknown>).baseUrl;
+  }
+  return overridden;
 }
 
 /**

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -151,9 +151,9 @@ export function applyProviderApiOverride(
   }
   const overridden = { ...model, api: providerCfg.api } as Model<Api>;
   if (providerCfg.baseUrl) {
-    (overridden as Record<string, unknown>).baseUrl = providerCfg.baseUrl;
+    (overridden as unknown as Record<string, unknown>).baseUrl = providerCfg.baseUrl;
   } else {
-    delete (overridden as Record<string, unknown>).baseUrl;
+    delete (overridden as unknown as Record<string, unknown>).baseUrl;
   }
   return overridden;
 }

--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -3,12 +3,12 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
 const mocks = vi.hoisted(() => ({
-  loginOpenAICodex: vi.fn(),
+  loginOpenAICodexEnhanced: vi.fn(),
   createVpsAwareOAuthHandlers: vi.fn(),
 }));
 
-vi.mock("@mariozechner/pi-ai", () => ({
-  loginOpenAICodex: mocks.loginOpenAICodex,
+vi.mock("../agents/openai-codex-enhanced-oauth.js", () => ({
+  loginOpenAICodexEnhanced: mocks.loginOpenAICodexEnhanced,
 }));
 
 vi.mock("./oauth-flow.js", () => ({
@@ -53,7 +53,7 @@ describe("loginOpenAICodexOAuth", () => {
       onAuth: vi.fn(),
       onPrompt: vi.fn(),
     });
-    mocks.loginOpenAICodex.mockResolvedValue(creds);
+    mocks.loginOpenAICodexEnhanced.mockResolvedValue(creds);
 
     const { prompter, spin } = createPrompter();
     const runtime = createRuntime();
@@ -65,7 +65,7 @@ describe("loginOpenAICodexOAuth", () => {
     });
 
     expect(result).toEqual(creds);
-    expect(mocks.loginOpenAICodex).toHaveBeenCalledOnce();
+    expect(mocks.loginOpenAICodexEnhanced).toHaveBeenCalledOnce();
     expect(spin.stop).toHaveBeenCalledWith("OpenAI OAuth complete");
     expect(runtime.error).not.toHaveBeenCalled();
   });
@@ -75,7 +75,7 @@ describe("loginOpenAICodexOAuth", () => {
       onAuth: vi.fn(),
       onPrompt: vi.fn(),
     });
-    mocks.loginOpenAICodex.mockRejectedValue(new Error("oauth failed"));
+    mocks.loginOpenAICodexEnhanced.mockRejectedValue(new Error("oauth failed"));
 
     const { prompter, spin } = createPrompter();
     const runtime = createRuntime();

--- a/src/commands/openai-codex-oauth.ts
+++ b/src/commands/openai-codex-oauth.ts
@@ -1,5 +1,5 @@
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
-import { loginOpenAICodex } from "@mariozechner/pi-ai";
+import { loginOpenAICodexEnhanced } from "../agents/openai-codex-enhanced-oauth.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { createVpsAwareOAuthHandlers } from "./oauth-flow.js";
@@ -39,7 +39,7 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
     });
 
-    const creds = await loginOpenAICodex({
+    const creds = await loginOpenAICodexEnhanced({
       onAuth,
       onPrompt,
       onProgress: (msg) => spin.update(msg),


### PR DESCRIPTION
## Summary

Fixes #27055 — ChatGPT Pro OAuth tokens lack required API scopes, causing all GPT-5+ models to fail with "Failed to extract accountId from token" when using the `openai-codex` provider.

### Root Cause

pi-ai's built-in Codex OAuth flow requests only `openid profile email offline_access` scopes. The `openai-codex-responses` stream provider calls `extractAccountId(apiKey)` on **every API request**, which decodes the JWT to find `chatgpt_account_id`. When the JWT doesn't contain this claim (due to insufficient scopes or changed JWT structure), all GPT-5+ models fail immediately.

GPT-4o appeared to work because it could use the `openai` provider (API key based, `openai-completions` API), which never calls `extractAccountId`.

### Changes

1. **Enhanced Codex OAuth provider** (`src/agents/openai-codex-enhanced-oauth.ts`):
   - Custom OAuth login requesting expanded scopes: `model.request` (Completions API) + `api.responses.write` (Responses API)
   - Resilient `accountId` extraction: falls back to stored `accountId` instead of throwing when the JWT lacks the claim
   - Resilient token refresh: preserves stored `accountId` when refreshed JWT doesn't contain it
   - Registered via `registerOAuthProvider` to override pi-ai's built-in `openai-codex` provider

2. **Login command update** (`src/commands/openai-codex-oauth.ts`):
   - Uses `loginOpenAICodexEnhanced` instead of pi-ai's `loginOpenAICodex`

3. **Auth profile refresh** (`src/agents/auth-profiles/oauth.ts`):
   - Registers enhanced provider at module init so token refresh uses expanded scopes

4. **Provider-level API override** (`src/agents/pi-embedded-runner/model.ts`) — *previous commits*:
   - `applyProviderApiOverride`: allows users to force `openai-completions` API for the `openai-codex` provider via `openclaw.json`, completely bypassing `extractAccountId`

5. **Error classification** (`src/agents/pi-embedded-helpers/errors.ts`) — *previous commits*:
   - "Failed to extract accountId from token" classified as `auth` error for proper failover

### After Fix

| Scenario | Before | After |
|---|---|---|
| GPT-5+ via `openai-codex` (re-auth with new scopes) | ❌ extractAccountId fails | ✅ JWT has correct scopes |
| GPT-5+ via `openai-codex` + `api: "openai-completions"` override | ❌ Missing scopes | ✅ Bypasses extractAccountId + has `model.request` scope |
| Token refresh when JWT lacks accountId | ❌ Refresh crashes | ✅ Falls back to stored accountId |
| Failover on accountId error | Silent failure | ✅ Classified as `auth` → triggers failover |

### User Action Required

Users must **re-authenticate** (`openclaw configure` → re-login with openai-codex) to obtain tokens with the expanded scopes.

## Test Plan

- [x] Unit tests for enhanced OAuth provider (registration, getApiKey, resilient refresh)
- [x] Unit tests for provider API override (`applyProviderApiOverride`)
- [x] Unit tests for error classification ("Failed to extract accountId" → `auth`)
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Format check passes (`pnpm format`)
- [ ] Manual: re-authenticate and test GPT-5+ models via `openai-codex` provider
