### PR TITLE
fix(web-fetch): include URL and cause in network-level fetch error

### DIFF
--- a/src/agents/tools/web-fetch.network-error.test.ts
+++ b/src/agents/tools/web-fetch.network-error.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../infra/net/ssrf.js";
+
+const lookupMock = vi.fn();
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+async function createWebFetchToolNoFirecrawl() {
+  const { createWebFetchTool } = await import("./web-tools.js");
+  return createWebFetchTool({
+    config: {
+      tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+    },
+  });
+}
+
+describe("web_fetch network-level error enrichment", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("includes the URL and cause in the error when fetch throws a network error", async () => {
+    const cause = new Error("getaddrinfo ENOTFOUND wttr.in");
+    const networkError = new TypeError("fetch failed");
+    (networkError as unknown as { cause: Error }).cause = cause;
+
+    global.fetch = vi.fn().mockRejectedValue(networkError);
+
+    const tool = await createWebFetchToolNoFirecrawl();
+    const url = "https://wttr.in/Kalispell,MT?format=3";
+
+    await expect(tool?.execute?.("call", { url })).rejects.toThrow(
+      /Web fetch failed for .+wttr\.in.+getaddrinfo ENOTFOUND/,
+    );
+  });
+
+  it("falls back to the top-level error message when cause has no message", async () => {
+    const networkError = new TypeError("fetch failed");
+    global.fetch = vi.fn().mockRejectedValue(networkError);
+
+    const tool = await createWebFetchToolNoFirecrawl();
+    const url = "https://example.com/path";
+
+    await expect(tool?.execute?.("call", { url })).rejects.toThrow(
+      /Web fetch failed for .+example\.com/,
+    );
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -561,7 +561,14 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     if (payload) {
       return payload;
     }
-    throw error;
+    const displayUrl = finalUrl || params.url;
+    const reason =
+      (error instanceof Error &&
+        (((error as NodeJS.ErrnoException).cause as Error | undefined)?.message ||
+          (error as NodeJS.ErrnoException).code ||
+          error.message)) ||
+      "unknown error";
+    throw new Error(`Web fetch failed for ${displayUrl}: ${reason}`, { cause: error });
   }
 
   try {


### PR DESCRIPTION
## Problem

When `web_fetch` hits a network-level error (DNS failure, connection refused, timeout), the agent sees only:

```
[tools] web_fetch failed: fetch failed
```

No URL, no reason — completely opaque for debugging or self-correction.

## Root Cause

Node.js's native `fetch()` throws `TypeError("fetch failed")` with the actual reason buried in `error.cause` (e.g. `ENOTFOUND`, `ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`). The bare re-throw in `runWebFetch`'s catch block loses all useful context:

```ts
throw error;  // bare TypeError — no URL, no cause reason
```

## Fix

Wrap the re-throw with a `new Error` that includes the URL and the cause message:

```ts
const reason =
  (error instanceof Error &&
    (((error as NodeJS.ErrnoException).cause as Error | undefined)?.message ||
      (error as NodeJS.ErrnoException).code ||
      error.message)) ||
  "unknown error";
throw new Error(`Web fetch failed for ${displayUrl}: ${reason}`, { cause: error });
```

**Before:** `fetch failed`  
**After:** `Web fetch failed for https://wttr.in/Kalispell,MT?format=3: getaddrinfo ENOTFOUND wttr.in`

## Tests

Added `web-fetch.network-error.test.ts` with two cases:
- Error with a `cause` includes both URL and cause message
- Error without a `cause` falls back to the top-level message but still includes the URL

54/54 web-fetch tests pass. Full `pnpm build` and `pnpm check` clean.

Fixes #27081