### PR TITLE
fix(line): download file message content

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
LINE inbound handler downloaded media only for image/video/audio. This change also downloads media when message.type === "file" so document uploads are available to the agent.