### PR TITLE
fix(line): detect office files from zip and preserve extensions

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
Improves LINE media downloads by detecting ZIP-based Office formats (xlsx/docx/pptx) and mapping them to correct MIME types + extensions instead of defaulting to .bin.

Note: This pairs well with #27117 which enables downloading message.type="file".