### PR TITLE
fix(feishu): pass mediaLocalRoots to loadWebMedia for local file access

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -388,7 +388,8 @@ export async function sendMediaFeishu(params: {
   accountId?: string;
   mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -386,8 +386,9 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, mediaLocalRoots } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +405,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots: mediaLocalRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -26,6 +26,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           mediaUrl,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         });
         return { channel: "feishu", ...result };
       } catch (err) {


### PR DESCRIPTION
## Summary

The Feishu channel adapter fails to send media files (images, documents, etc.) — only the local
file path is sent as a text message instead of the actual media content.

## Root Cause

`sendMedia` in `outbound.ts` does not extract `mediaLocalRoots` from the `ChannelOutboundContext`,
and `sendMediaFeishu` in `media.ts` does not forward it as `localRoots` to `loadWebMedia()`.

Without `localRoots`, `loadWebMedia` can only search OpenClaw's internal default directories and
cannot access files in the agent's workspace — so it fails to read any media file that the agent
generated or received.

All other channel adapters (Discord, Telegram, Slack, Signal, WhatsApp, iMessage, MS Teams)
already pass `mediaLocalRoots` correctly. This is a Feishu-specific omission.

## Changes

| File | Change |
|------|--------|
| `extensions/feishu/src/outbound.ts` | Destructure `mediaLocalRoots` from context; pass it to `sendMediaFeishu` |
| `extensions/feishu/src/media.ts` | Add `mediaLocalRoots` param to `sendMediaFeishu`; pass as `localRoots` to `loadWebMedia` |

## Testing

- Verified the fix follows the same pattern used by Discord, Telegram, Slack, and other adapters
- `pnpm build && pnpm check && pnpm test` passes
