### PR TITLE
Message error handling: add messages.errorMode and hide raw provider errors by default (issue-#26957)

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2809,6 +2809,7 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
+    public let commandargv: [String]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
     public let host: AnyCodable?
@@ -2823,6 +2824,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public init(
         id: String?,
         command: String,
+        commandargv: [String]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
         host: AnyCodable?,
@@ -2836,6 +2838,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     {
         self.id = id
         self.command = command
+        self.commandargv = commandargv
         self.cwd = cwd
         self.nodeid = nodeid
         self.host = host
@@ -2851,6 +2854,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case command
+        case commandargv = "commandArgv"
         case cwd
         case nodeid = "nodeId"
         case host

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2809,6 +2809,7 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
+    public let commandargv: [String]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
     public let host: AnyCodable?
@@ -2823,6 +2824,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public init(
         id: String?,
         command: String,
+        commandargv: [String]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
         host: AnyCodable?,
@@ -2836,6 +2838,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     {
         self.id = id
         self.command = command
+        self.commandargv = commandargv
         self.cwd = cwd
         self.nodeid = nodeid
         self.host = host
@@ -2851,6 +2854,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id
         case command
+        case commandargv = "commandArgv"
         case cwd
         case nodeid = "nodeId"
         case host

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts
@@ -154,7 +154,7 @@ describe("trigger handling", () => {
         {
           error: "sandbox is not defined.",
           expected:
-            "⚠️ Agent failed before reply: sandbox is not defined.\nLogs: openclaw logs --follow",
+            "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
         },
         {
           error: "Context window exceeded",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -174,7 +174,7 @@ describe("runReplyAgent onAgentRunStart", () => {
 
     expect(onAgentRunStart).not.toHaveBeenCalled();
     expect(result).toMatchObject({
-      text: expect.stringContaining('Something went wrong while processing your request'),
+      text: expect.stringContaining("Something went wrong while processing your request"),
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -174,7 +174,7 @@ describe("runReplyAgent onAgentRunStart", () => {
 
     expect(onAgentRunStart).not.toHaveBeenCalled();
     expect(result).toMatchObject({
-      text: expect.stringContaining('No API key found for provider "anthropic".'),
+      text: expect.stringContaining('Something went wrong while processing your request'),
     });
   });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1300,6 +1300,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
   "messages.suppressToolErrors":
     "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+  "messages.errorMode":
+    'Controls how provider/runtime failures are shown in chat: "silent" sends nothing, "friendly" sends a generic retry hint, and "raw" includes original error details. Default: "friendly".',
+  "messages.suppressErrors":
+    'Deprecated alias for silencing errors. Prefer setting messages.errorMode to "silent".',
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -595,6 +595,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.queue.drop": "Queue Drop Strategy",
   "messages.inbound": "Inbound Debounce",
   "messages.suppressToolErrors": "Suppress Tool Error Warnings",
+  "messages.errorMode": "Message Error Delivery Mode",
+  "messages.suppressErrors": "Suppress Error Messages",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.removeAckAfterReply": "Remove Ack Reaction After Reply",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,6 +82,8 @@ export type StatusReactionsConfig = {
   timing?: StatusReactionsTimingConfig;
 };
 
+export type MessageErrorMode = "silent" | "friendly" | "raw";
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -119,6 +121,16 @@ export type MessagesConfig = {
   statusReactions?: StatusReactionsConfig;
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
+  /**
+   * Controls how provider/runtime errors are delivered to chat users.
+   * - "silent": do not send an error message
+   * - "friendly": send a generic, user-friendly message
+   * - "raw": include the raw provider/runtime error details
+   * Default: "friendly"
+   */
+  errorMode?: MessageErrorMode;
+  /** @deprecated Use `messages.errorMode: "silent"` instead. */
+  suppressErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -183,6 +183,8 @@ export const MessagesSchema = z
       .strict()
       .optional(),
     suppressToolErrors: z.boolean().optional(),
+    errorMode: z.enum(["silent", "friendly", "raw"]).optional(),
+    suppressErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary

- Problem: Raw provider/runtime errors (especially Bedrock toolResult/toolUse mismatch) were forwarded directly to end users in chat channels.
- Why it matters: End users see low-level technical errors, which is confusing and unprofessional.
- What changed: Added `messages.errorMode` (`silent|friendly|raw`) with default `friendly`; added backward-compatible alias `messages.suppressErrors`; routed final error output through mode-based handling; added specific friendly copy for Bedrock toolResult/toolUse mismatch.
- What did NOT change (scope boundary): No changes to model execution flow, tool execution semantics, or session-state core logic; no new permissions/network/execution surfaces.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26957
- Related #N/A

## User-visible / Behavior Changes

- Raw provider/runtime errors are no longer exposed to chat users by default.
- New config: `messages.errorMode`:
  - `friendly` (default): user-friendly fallback message
  - `silent`: no user-visible error message
  - `raw`: keep raw error output (legacy behavior)
- Compatibility alias: `messages.suppressErrors: true` maps to `messages.errorMode: "silent"` (deprecated).
- Bedrock toolResult/toolUse mismatch now returns a targeted friendly recovery hint (`/new`) in `friendly` mode.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: Linux (kernel 4.19)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: Claude Opus via Amazon Bedrock (`bedrock-converse-stream`)
- Integration/channel (if any): Telegram (same class also affects other chat channels)
- Relevant config (redacted):
  - `messages.errorMode: "friendly"` (default)
  - Additional checks with `raw` and `silent`

### Steps

1. Trigger a provider-level failure in chat (e.g., Bedrock toolResult/toolUse mismatch).
2. Observe bot output with default mode (`friendly`).
3. Switch to `messages.errorMode=raw` and `silent`, then repeat and compare behavior.

### Expected

- `friendly`: friendly fallback text, no raw provider details.
- `raw`: raw error output preserved.
- `silent`: no user-visible error message.

### Actual

- Matches expected behavior; added/updated tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional evidence:
- Targeted tests passed:  
  `pnpm test -- src/auto-reply/reply/agent-runner.runreplyagent.test.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.test.ts`
- Result: 2 files passed, 42 tests passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Default `friendly` message is returned for generic provider failures.
  - `messages.errorMode=raw` keeps raw failure output.
  - `messages.errorMode=silent` suppresses user-facing error text.
  - Bedrock toolResult/toolUse mismatch maps to dedicated session-sync guidance.
- Edge cases checked:
  - Existing context-overflow and role-ordering special branches remain unchanged.
  - Backward-compatible alias `messages.suppressErrors` maps to silent mode.
- What you did **not** verify:
  - No full production E2E run on a live long-session Telegram/Bedrock environment.
  - Full repo validation (`pnpm build && pnpm check && pnpm test`) not completed due to local node-llama-cpp/CMake environment constraints.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A (optional config only)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Config rollback: set `messages.errorMode: "raw"` to restore previous raw-output behavior.
  - Code rollback: revert this PR.
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner-execution.ts`
  - `src/config/types.messages.ts`
  - `src/config/zod-schema.session.ts`
  - `src/config/schema.labels.ts`
  - `src/config/schema.help.ts`
- Known bad symptoms reviewers should watch for:
  - In `silent` mode, “no reply” can be mistaken for a stall (expected policy behavior).
  - Misconfigured mode values falling back to default (`friendly`).

## Risks and Mitigations

- Risk: Default behavior changed from raw error exposure to friendly messaging, which may affect debugging habits relying on user-visible raw errors.
  - Mitigation: Explicit rollback path via `messages.errorMode: "raw"`; raw details still available in logs.
  - Risk: `silent` mode can reduce user-visible feedback.
  - Mitigation: Keep `friendly` as default and enable `silent` only when intentionally desired.
 