### PR TITLE
fix(hooks): reuse sessionId for non-cron hook sessions (#11665)

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,3 +1,7 @@
+import type { CliDeps } from "../../cli/outbound-send-deps.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AgentDefaultsConfig } from "../../config/types.js";
+import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import {
   resolveAgentConfig,
   resolveAgentDir,
@@ -30,14 +34,11 @@ import {
   normalizeVerboseLevel,
   supportsXHighThinking,
 } from "../../auto-reply/thinking.js";
-import type { CliDeps } from "../../cli/outbound-send-deps.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveSessionTranscriptPath,
   setSessionRuntimeModel,
   updateSessionStore,
 } from "../../config/sessions.js";
-import type { AgentDefaultsConfig } from "../../config/types.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../routing/session-key.js";
@@ -48,7 +49,6 @@ import {
   isExternalHookSession,
 } from "../../security/external-content.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
-import type { CronJob, CronRunOutcome, CronRunTelemetry } from "../types.js";
 import {
   dispatchCronDelivery,
   matchesMessagingToolDeliveryTarget,
@@ -222,8 +222,10 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
-    // Isolated cron runs must not carry prior turn context across executions.
-    forceNew: params.job.sessionTarget === "isolated",
+    // Isolated cron runs get a fresh session each execution, but hook sessions
+    // with deterministic keys should reuse their existing session for multi-turn
+    // conversation history (e.g., project management webhooks per card). (#11665)
+    forceNew: params.job.sessionTarget === "isolated" && /(?:^|:)cron:/.test(agentSessionKey),
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")


### PR DESCRIPTION
## Summary

When a webhook hook provides a consistent `sessionKey`, the hook session now reuses the existing `sessionId` instead of always generating a new one. This enables multi-turn conversation history for hook-dispatched sessions (e.g., project management webhooks routing to per-card sessions).

## Problem

Every hook dispatch created a new transcript file, losing all conversation history. The `sessionKey` only preserved metadata (model, thinkingLevel, label) but not the actual conversation. This also caused orphaned `.jsonl` files to accumulate on disk.

For example, a Fizzy project management integration would trigger webhooks for:
- Card created
- Card assigned  
- Comment added
- Comment added (reply)

Each of these would get a separate session with no shared context, even though they all used the same deterministic key like `hook:fizzy:card-461`.

## Solution

The fix changes the `forceNew` derivation in `runCronIsolatedAgentTurn` to only force new sessions for actual cron jobs, not for webhook hooks with deterministic keys:

```ts
// Before: always forceNew for isolated sessions
forceNew: params.job.sessionTarget === "isolated"

// After: only forceNew for cron jobs
forceNew: params.job.sessionTarget === "isolated" && /(?:^|:)cron:/.test(agentSessionKey)
```

## Behavior

- **Cron jobs** (sessionKey containing `:cron:`): Continue to get a fresh `sessionId` on every run (existing behavior preserved)
- **Webhook hooks** with deterministic keys: Reuse existing `sessionId` → same transcript file → threaded history

## Testing

- Added 2 new test cases to `session.test.ts` covering hook session reuse behavior
- All 262 existing cron tests pass

Fixes #11665