### PR TITLE
fix(cron): stop falsely marking announce delivery as confirmed

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -33,6 +33,15 @@ function expectDeliveredOk(result: Awaited<ReturnType<typeof runCronIsolatedAgen
   expect(result.delivered).toBe(true);
 }
 
+function expectAnnounceDispatchedOk(
+  result: Awaited<ReturnType<typeof runCronIsolatedAgentTurn>>,
+): void {
+  expect(result.status).toBe("ok");
+  // Announce delivery cannot confirm channel-level send; delivered is
+  // undefined ("unknown") rather than true when bestEffort is off.
+  expect(result.delivered).toBeUndefined();
+}
+
 async function expectBestEffortTelegramNotDelivered(
   payload: Record<string, unknown>,
 ): Promise<void> {
@@ -76,7 +85,7 @@ async function expectExplicitTelegramTargetAnnounce(params: {
       deps,
     });
 
-    expectDeliveredOk(res);
+    expectAnnounceDispatchedOk(res);
     expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
     const announceArgs = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as
       | {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -116,7 +116,7 @@ type DispatchCronDeliveryParams = {
 
 export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
-  delivered: boolean;
+  delivered?: boolean;
   deliveryAttempted: boolean;
   summary?: string;
   outputText?: string;
@@ -133,8 +133,9 @@ export async function dispatchCronDelivery(
   let deliveryPayloads = params.deliveryPayloads;
 
   // `true` means we confirmed at least one outbound send reached the target.
+  // `undefined` means delivery was attempted but channel confirmation is unavailable.
   // Keep this strict so timer fallback can safely decide whether to wake main.
-  let delivered = params.skipMessagingToolDelivery;
+  let delivered: boolean | undefined = params.skipMessagingToolDelivery ? true : false;
   let deliveryAttempted = params.skipMessagingToolDelivery;
   const failDeliveryTarget = (error: string) =>
     params.withRunSession({
@@ -314,7 +315,13 @@ export async function dispatchCronDelivery(
         signal: params.abortSignal,
       });
       if (didAnnounce) {
-        delivered = true;
+        // The announce flow dispatches via queue/steer/gateway-agent, which
+        // confirms the message was *accepted* but NOT that the outbound channel
+        // (e.g. Telegram) successfully sent it.  Mark delivery as confirmed
+        // only for best-effort mode; otherwise leave it undefined so
+        // resolveDeliveryStatus reports "unknown" instead of a false positive
+        // "delivered" (#27069).
+        delivered = params.deliveryBestEffort ? true : undefined;
       } else {
         const message = "cron announce delivery failed";
         if (!params.deliveryBestEffort) {


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs with `delivery.announce` mark messages as `delivered: true` even when the Telegram API fails to actually send the message. This is because the announce flow confirms message *acceptance* (queued/steered/dispatched) but not *channel-level delivery*.
- **Why it matters:** Users miss critical reminders. Cron state shows "delivered" while the user received nothing. No visibility into delivery failures.
- **What changed:**
  - `src/cron/isolated-agent/delivery-dispatch.ts` — When `bestEffortDeliver` is `false` (truthful delivery status required), set `delivered` to `undefined` instead of `true` after successful announce dispatch. `resolveDeliveryStatus` maps `undefined` to `"unknown"` rather than `"delivered"`.
  - Changed `DispatchCronDeliveryState.delivered` from `boolean` to `boolean | undefined` to support the "unknown" state.
- **What did NOT change:** Announce flow internals, queue/steer behavior, direct delivery path, best-effort delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27069

## User-visible / Behavior Changes

- Cron jobs using `delivery.announce` now show `deliveryStatus: "unknown"` instead of `deliveryStatus: "delivered"` when channel-level delivery confirmation is unavailable
- Direct delivery path (structured payloads, thread targets) still shows `"delivered"` / `"not-delivered"` as before
- Best-effort delivery mode is unchanged

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22
- Integration/channel: Telegram

### Steps

1. Create a cron job with `delivery.announce` to a Telegram channel
2. Trigger network issues or Telegram API failures
3. Check cron run logs

### Expected

- `deliveryStatus: "unknown"` when channel delivery cannot be confirmed

### Actual

- Before fix: `deliveryStatus: "delivered"` even when Telegram API failed
- After fix: `deliveryStatus: "unknown"` for announce path with `bestEffort: false`

## Evidence

```
Tests: 260 passed (260) — src/cron/ (37 test files)
All existing tests pass with updated expectations for announce path.
```

## Human Verification (required)

- Verified scenarios: Announce success with bestEffort=false returns undefined, announce failure returns error, bestEffort=true preserves existing behavior, direct delivery path unchanged
- Edge cases checked: skipMessagingToolDelivery=true (delivered stays true), structured payload routing unchanged
- What I did **not** verify: Live cron job with Telegram API failure

## Compatibility / Migration

- Backward compatible? `Partially` — cron state will show "unknown" instead of "delivered" for announce delivery. This is intentionally more conservative.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; announce delivery will return to marking `delivered: true`
- Files/config to restore: `src/cron/isolated-agent/delivery-dispatch.ts`

## Risks and Mitigations

- Risk: Users may see more "unknown" delivery statuses and be confused. Mitigation: "unknown" is more accurate than a false "delivered"; users can check gateway logs for actual delivery status.
- Risk: Timer fallback logic may behave differently with `delivered: undefined`. Mitigation: `resolveDeliveryStatus` already handles undefined correctly (returns "unknown"), and downstream consumers handle this case.
