### PR TITLE
feat: add sessions.archives API and archive support for chat.history

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1026,6 +1026,24 @@ public struct PushTestResult: Codable, Sendable {
     }
 }
 
+public struct SessionsArchivesParams: Codable, Sendable {
+    public let agentid: String?
+    public let limit: Int?
+
+    public init(
+        agentid: String?,
+        limit: Int?)
+    {
+        self.agentid = agentid
+        self.limit = limit
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case limit
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?
@@ -3063,19 +3081,27 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
 }
 
 public struct ChatHistoryParams: Codable, Sendable {
-    public let sessionkey: String
+    public let sessionkey: String?
+    public let archivefile: String?
+    public let agentid: String?
     public let limit: Int?
 
     public init(
-        sessionkey: String,
+        sessionkey: String?,
+        archivefile: String?,
+        agentid: String?,
         limit: Int?)
     {
         self.sessionkey = sessionkey
+        self.archivefile = archivefile
+        self.agentid = agentid
         self.limit = limit
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
+        case archivefile = "archiveFile"
+        case agentid = "agentId"
         case limit
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1026,6 +1026,24 @@ public struct PushTestResult: Codable, Sendable {
     }
 }
 
+public struct SessionsArchivesParams: Codable, Sendable {
+    public let agentid: String?
+    public let limit: Int?
+
+    public init(
+        agentid: String?,
+        limit: Int?)
+    {
+        self.agentid = agentid
+        self.limit = limit
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case limit
+    }
+}
+
 public struct SessionsListParams: Codable, Sendable {
     public let limit: Int?
     public let activeminutes: Int?
@@ -3063,19 +3081,27 @@ public struct DevicePairResolvedEvent: Codable, Sendable {
 }
 
 public struct ChatHistoryParams: Codable, Sendable {
-    public let sessionkey: String
+    public let sessionkey: String?
+    public let archivefile: String?
+    public let agentid: String?
     public let limit: Int?
 
     public init(
-        sessionkey: String,
+        sessionkey: String?,
+        archivefile: String?,
+        agentid: String?,
         limit: Int?)
     {
         self.sessionkey = sessionkey
+        self.archivefile = archivefile
+        self.agentid = agentid
         self.limit = limit
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
+        case archivefile = "archiveFile"
+        case agentid = "agentId"
         case limit
     }
 }

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -58,6 +58,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "skills.status",
     "voicewake.get",
     "sessions.list",
+    "sessions.archives",
     "sessions.preview",
     "sessions.resolve",
     "sessions.usage",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -168,6 +168,8 @@ import {
   type ResponseFrame,
   ResponseFrameSchema,
   SendParamsSchema,
+  type SessionsArchivesParams,
+  SessionsArchivesParamsSchema,
   type SessionsCompactParams,
   SessionsCompactParamsSchema,
   type SessionsDeleteParams,
@@ -284,6 +286,9 @@ export const validateNodeInvokeResultParams = ajv.compile<NodeInvokeResultParams
 );
 export const validateNodeEventParams = ajv.compile<NodeEventParams>(NodeEventParamsSchema);
 export const validatePushTestParams = ajv.compile<PushTestParams>(PushTestParamsSchema);
+export const validateSessionsArchivesParams = ajv.compile<SessionsArchivesParams>(
+  SessionsArchivesParamsSchema,
+);
 export const validateSessionsListParams = ajv.compile<SessionsListParams>(SessionsListParamsSchema);
 export const validateSessionsPreviewParams = ajv.compile<SessionsPreviewParams>(
   SessionsPreviewParamsSchema,
@@ -445,6 +450,7 @@ export {
   NodePairVerifyParamsSchema,
   NodeListParamsSchema,
   NodeInvokeParamsSchema,
+  SessionsArchivesParamsSchema,
   SessionsListParamsSchema,
   SessionsPreviewParamsSchema,
   SessionsPatchParamsSchema,
@@ -592,6 +598,7 @@ export type {
   NodeInvokeParams,
   NodeInvokeResultParams,
   NodeEventParams,
+  SessionsArchivesParams,
   SessionsListParams,
   SessionsPreviewParams,
   SessionsResolveParams,

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -25,7 +25,11 @@ export const LogsTailResultSchema = Type.Object(
 // WebChat/WebSocket-native chat methods
 export const ChatHistoryParamsSchema = Type.Object(
   {
-    sessionKey: NonEmptyString,
+    sessionKey: Type.Optional(NonEmptyString),
+    /** Archived transcript filename (from sessions.archives response). Mutually exclusive with sessionKey. */
+    archiveFile: Type.Optional(NonEmptyString),
+    /** Agent that owns the archive (default "main"). Only used with archiveFile. */
+    agentId: Type.Optional(NonEmptyString),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
   },
   { additionalProperties: false },

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -125,6 +125,7 @@ import {
 } from "./nodes.js";
 import { PushTestParamsSchema, PushTestResultSchema } from "./push.js";
 import {
+  SessionsArchivesParamsSchema,
   SessionsCompactParamsSchema,
   SessionsDeleteParamsSchema,
   SessionsListParamsSchema,
@@ -179,6 +180,7 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   NodeInvokeRequestEvent: NodeInvokeRequestEventSchema,
   PushTestParams: PushTestParamsSchema,
   PushTestResult: PushTestResultSchema,
+  SessionsArchivesParams: SessionsArchivesParamsSchema,
   SessionsListParams: SessionsListParamsSchema,
   SessionsPreviewParams: SessionsPreviewParamsSchema,
   SessionsResolveParams: SessionsResolveParamsSchema,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -108,6 +108,14 @@ export const SessionsCompactParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SessionsArchivesParamsSchema = Type.Object(
+  {
+    agentId: Type.Optional(NonEmptyString),
+    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
+  },
+  { additionalProperties: false },
+);
+
 export const SessionsUsageParamsSchema = Type.Object(
   {
     /** Specific session key to analyze; if omitted returns all sessions. */

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -118,6 +118,7 @@ import type {
 } from "./nodes.js";
 import type { PushTestParamsSchema, PushTestResultSchema } from "./push.js";
 import type {
+  SessionsArchivesParamsSchema,
   SessionsCompactParamsSchema,
   SessionsDeleteParamsSchema,
   SessionsListParamsSchema,
@@ -168,6 +169,7 @@ export type NodeInvokeResultParams = Static<typeof NodeInvokeResultParamsSchema>
 export type NodeEventParams = Static<typeof NodeEventParamsSchema>;
 export type PushTestParams = Static<typeof PushTestParamsSchema>;
 export type PushTestResult = Static<typeof PushTestResultSchema>;
+export type SessionsArchivesParams = Static<typeof SessionsArchivesParamsSchema>;
 export type SessionsListParams = Static<typeof SessionsListParamsSchema>;
 export type SessionsPreviewParams = Static<typeof SessionsPreviewParamsSchema>;
 export type SessionsResolveParams = Static<typeof SessionsResolveParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -51,6 +51,7 @@ const BASE_METHODS = [
   "voicewake.get",
   "voicewake.set",
   "sessions.list",
+  "sessions.archives",
   "sessions.preview",
   "sessions.patch",
   "sessions.reset",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -20,6 +20,7 @@ import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
 import { pushHandlers } from "./server-methods/push.js";
 import { sendHandlers } from "./server-methods/send.js";
+import { sessionsArchivesHandlers } from "./server-methods/sessions-archives.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
 import { systemHandlers } from "./server-methods/system.js";
@@ -82,6 +83,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...toolsCatalogHandlers,
   ...ttsHandlers,
   ...skillsHandlers,
+  ...sessionsArchivesHandlers,
   ...sessionsHandlers,
   ...systemHandlers,
   ...updateHandlers,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -614,7 +614,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         respond(true, { archiveFile, messages: [] });
         return;
       }
-      if (!realFile.startsWith(realSessions + path.sep) && realFile !== realSessions) {
+      if (!realFile.startsWith(realSessions + path.sep)) {
         respond(
           false,
           undefined,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,14 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveDefaultAgentId, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
-import { resolveSessionFilePath } from "../../config/sessions.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionTranscriptsDirForAgent,
+} from "../../config/sessions.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import {
   stripInlineDirectiveTagsForDisplay,
@@ -542,11 +547,129 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit } = params as {
-      sessionKey: string;
+    const {
+      sessionKey,
+      archiveFile,
+      agentId: rawAgentId,
+      limit,
+    } = params as {
+      sessionKey?: string;
+      archiveFile?: string;
+      agentId?: string;
       limit?: number;
     };
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+
+    // Require exactly one of sessionKey or archiveFile.
+    if (!sessionKey && !archiveFile) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "one of sessionKey or archiveFile is required"),
+      );
+      return;
+    }
+    if (sessionKey && archiveFile) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "sessionKey and archiveFile are mutually exclusive"),
+      );
+      return;
+    }
+
+    // Archive file path: read directly from the sessions directory.
+    if (archiveFile) {
+      const cfg = loadConfig();
+      const agentId = normalizeAgentId(rawAgentId ?? resolveDefaultAgentId(cfg));
+      let sessionsDir: string;
+      try {
+        sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+      } catch {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "unable to resolve sessions directory"),
+        );
+        return;
+      }
+
+      // Security: validate filename doesn't contain path traversal.
+      const baseName = path.basename(archiveFile);
+      if (baseName !== archiveFile || archiveFile.includes("..") || archiveFile.includes("/")) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid archiveFile name"),
+        );
+        return;
+      }
+
+      const filePath = path.join(sessionsDir, baseName);
+      // Double-check resolved path is within sessions directory.
+      const realSessions = fs.realpathSync(sessionsDir);
+      let realFile: string;
+      try {
+        realFile = fs.realpathSync(filePath);
+      } catch {
+        respond(true, { archiveFile, messages: [] });
+        return;
+      }
+      if (!realFile.startsWith(realSessions + path.sep) && realFile !== realSessions) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid archiveFile path"),
+        );
+        return;
+      }
+
+      // Read the transcript directly.
+      let rawMessages: unknown[];
+      try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        rawMessages = [];
+        for (const line of content.split("\n")) {
+          if (!line.trim()) {
+            continue;
+          }
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed?.message) {
+              rawMessages.push(parsed.message);
+            }
+          } catch {
+            // ignore bad lines
+          }
+        }
+      } catch {
+        respond(true, { archiveFile, messages: [] });
+        return;
+      }
+
+      const hardMax = 1000;
+      const defaultLimit = 200;
+      const requested = typeof limit === "number" ? limit : defaultLimit;
+      const max = Math.min(hardMax, requested);
+      const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
+      const sanitized = stripEnvelopeFromMessages(sliced);
+      const normalized = sanitizeChatHistoryMessages(sanitized);
+      const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
+      const perMessageHardCap = Math.min(CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES, maxHistoryBytes);
+      const replaced = replaceOversizedChatHistoryMessages({
+        messages: normalized,
+        maxSingleMessageBytes: perMessageHardCap,
+      });
+      const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
+      const bounded = enforceChatHistoryFinalBudget({
+        messages: capped,
+        maxBytes: maxHistoryBytes,
+      });
+      respond(true, { archiveFile, messages: bounded.messages });
+      return;
+    }
+
+    // Existing sessionKey path.
+    const { cfg, storePath, entry } = loadSessionEntry(sessionKey!);
     const sessionId = entry?.sessionId;
     const rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
@@ -578,7 +701,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       if (configured) {
         thinkingLevel = configured;
       } else {
-        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+        const sessionAgentId = resolveSessionAgentId({ sessionKey: sessionKey!, config: cfg });
         const { provider, model } = resolveSessionModelRef(cfg, entry, sessionAgentId);
         const catalog = await context.loadGatewayModelCatalog();
         thinkingLevel = resolveThinkingDefault({

--- a/src/gateway/server-methods/sessions-archives.test.ts
+++ b/src/gateway/server-methods/sessions-archives.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { formatSessionArchiveTimestamp } from "../../config/sessions/artifacts.js";
+
+// --- Mocks ---
+
+let tmpDir = "";
+const mockStore: Record<string, { sessionId?: string; sessionFile?: string }> = {};
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ session: {} })),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("../../config/sessions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
+    "../../config/sessions.js",
+  );
+  return {
+    ...actual,
+    resolveSessionTranscriptsDirForAgent: vi.fn(() => tmpDir),
+    resolveStorePath: vi.fn(() => path.join(tmpDir, "sessions.json")),
+    loadSessionStore: vi.fn(() => ({ ...mockStore })),
+  };
+});
+
+// --- Helpers ---
+
+function writeJsonlFile(dir: string, fileName: string, lines: unknown[]): string {
+  const filePath = path.join(dir, fileName);
+  fs.writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+  return filePath;
+}
+
+type RespondArgs = [ok: boolean, payload?: unknown, error?: unknown];
+
+function createRespond(): { calls: RespondArgs[]; fn: (...args: RespondArgs) => void } {
+  const calls: RespondArgs[] = [];
+  return {
+    calls,
+    fn: (...args: RespondArgs) => {
+      calls.push(args);
+    },
+  };
+}
+
+// --- Tests ---
+
+describe("sessions.archives handler", () => {
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-archives-handler-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    // Clear files and store between tests.
+    for (const f of fs.readdirSync(tmpDir)) {
+      fs.unlinkSync(path.join(tmpDir, f));
+    }
+    for (const key of Object.keys(mockStore)) {
+      delete mockStore[key];
+    }
+  });
+
+  // Import handler after mocks are set up.
+  async function getHandler() {
+    const { sessionsArchivesHandlers } = await import("./sessions-archives.js");
+    return sessionsArchivesHandlers["sessions.archives"];
+  }
+
+  function callHandler(handler: Function, params: Record<string, unknown> = {}) {
+    const respond = createRespond();
+    const promise = handler({
+      params,
+      respond: respond.fn,
+      context: {},
+    });
+    return { respond, promise };
+  }
+
+  test("returns archived files with .reset suffix", async () => {
+    const ts = formatSessionArchiveTimestamp();
+    writeJsonlFile(tmpDir, `sess-a.jsonl.reset.${ts}`, [
+      { id: "sess-a", timestamp: "2026-02-26T00:00:00.000Z", type: "header" },
+      { message: { role: "user", content: "hello" } },
+      { message: { role: "assistant", content: "hi" } },
+    ]);
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler);
+    await promise;
+
+    expect(respond.calls).toHaveLength(1);
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: unknown[]; total: number };
+    expect(result.total).toBe(1);
+    expect(result.archives).toHaveLength(1);
+    const entry = result.archives[0] as Record<string, unknown>;
+    expect(entry.sessionId).toBe("sess-a");
+    expect(entry.archiveReason).toBe("reset");
+    expect(entry.messageCount).toBe(2);
+  });
+
+  test("returns archived files with .deleted and .bak suffixes", async () => {
+    const ts = formatSessionArchiveTimestamp();
+    writeJsonlFile(tmpDir, `sess-d.jsonl.deleted.${ts}`, [
+      { id: "sess-d", timestamp: "2026-02-25T00:00:00.000Z", type: "header" },
+      { message: { role: "user", content: "test" } },
+    ]);
+    writeJsonlFile(tmpDir, `sess-b.jsonl.bak.${ts}`, [
+      { id: "sess-b", timestamp: "2026-02-24T00:00:00.000Z", type: "header" },
+    ]);
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler);
+    await promise;
+
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: Array<Record<string, unknown>>; total: number };
+    expect(result.total).toBe(2);
+    const reasons = result.archives.map((a) => a.archiveReason);
+    expect(reasons).toContain("deleted");
+    expect(reasons).toContain("bak");
+  });
+
+  test("excludes active sessions referenced in store", async () => {
+    // Active session in store.
+    mockStore["my-key"] = { sessionId: "active-sess" };
+    writeJsonlFile(tmpDir, "active-sess.jsonl", [
+      { id: "active-sess", timestamp: "2026-02-26T10:00:00.000Z", type: "header" },
+      { message: { role: "user", content: "active" } },
+    ]);
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler);
+    await promise;
+
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: unknown[]; total: number };
+    expect(result.total).toBe(0);
+  });
+
+  test("returns orphaned .jsonl files not in store", async () => {
+    // No store entry for this session.
+    writeJsonlFile(tmpDir, "orphan-sess.jsonl", [
+      { id: "orphan-sess", timestamp: "2026-02-20T00:00:00.000Z", type: "header" },
+      { message: { role: "user", content: "orphan" } },
+    ]);
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler);
+    await promise;
+
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: Array<Record<string, unknown>>; total: number };
+    expect(result.total).toBe(1);
+    expect(result.archives[0].archiveReason).toBe("orphaned");
+    expect(result.archives[0].sessionId).toBe("orphan-sess");
+  });
+
+  test("respects limit param", async () => {
+    const ts = formatSessionArchiveTimestamp();
+    for (let i = 0; i < 5; i++) {
+      writeJsonlFile(tmpDir, `s${i}.jsonl.reset.${ts}`, [
+        { id: `s${i}`, timestamp: "2026-02-26T00:00:00.000Z", type: "header" },
+      ]);
+    }
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler, { limit: 2 });
+    await promise;
+
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: unknown[]; total: number };
+    expect(result.total).toBe(5);
+    expect(result.archives).toHaveLength(2);
+  });
+
+  test("rejects invalid params", async () => {
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler, { limit: -1 });
+    await promise;
+
+    const [ok] = respond.calls[0];
+    expect(ok).toBe(false);
+  });
+
+  test("returns empty for nonexistent sessions directory", async () => {
+    const { resolveSessionTranscriptsDirForAgent } = await import("../../config/sessions.js");
+    (resolveSessionTranscriptsDirForAgent as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      "/nonexistent/path/that/does/not/exist",
+    );
+
+    const handler = await getHandler();
+    const { respond, promise } = callHandler(handler);
+    await promise;
+
+    const [ok, payload] = respond.calls[0];
+    expect(ok).toBe(true);
+    const result = payload as { archives: unknown[]; total: number };
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("chat.history archiveFile path traversal", () => {
+  test("basename check rejects path traversal attempts", () => {
+    const badNames = ["../etc/passwd", "foo/../../bar.jsonl", "/absolute/path.jsonl"];
+    for (const name of badNames) {
+      const baseName = path.basename(name);
+      expect(baseName === name && !name.includes("..") && !name.includes("/")).toBe(false);
+    }
+  });
+
+  test("basename check accepts valid archive filenames", () => {
+    const goodNames = [
+      "fa84d053-xxx.jsonl",
+      "test.jsonl.reset.2026-02-26T01-06-04.374Z",
+      "abc-123.jsonl.deleted.2026-01-01T00-00-00.000Z",
+    ];
+    for (const name of goodNames) {
+      const baseName = path.basename(name);
+      expect(baseName).toBe(name);
+      expect(name.includes("..")).toBe(false);
+      expect(name.includes("/")).toBe(false);
+    }
+  });
+});

--- a/src/gateway/server-methods/sessions-archives.ts
+++ b/src/gateway/server-methods/sessions-archives.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  isSessionArchiveArtifactName,
+  isPrimarySessionTranscriptFileName,
+  loadSessionStore,
+  parseSessionArchiveTimestamp,
+  resolveSessionTranscriptsDirForAgent,
+  resolveStorePath,
+  type SessionArchiveReason,
+} from "../../config/sessions.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { validateSessionsArchivesParams } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+export interface SessionArchiveEntry {
+  sessionId: string;
+  fileName: string;
+  archiveReason?: string;
+  archivedAt?: string;
+  createdAt?: string;
+  sizeBytes: number;
+  messageCount?: number;
+}
+
+const ARCHIVE_REASONS: SessionArchiveReason[] = ["reset", "deleted", "bak"];
+const MAX_FILE_SIZE_FOR_COUNT = 10 * 1024 * 1024; // 10MB
+
+/**
+ * Detect the archive reason from a filename suffix.
+ * Returns "reset", "deleted", or "bak" if the file has that suffix,
+ * or "orphaned" if it's a plain .jsonl that isn't referenced by an active session.
+ */
+function detectArchiveReason(fileName: string, isOrphan: boolean): string | undefined {
+  for (const reason of ARCHIVE_REASONS) {
+    if (parseSessionArchiveTimestamp(fileName, reason) !== null) {
+      return reason;
+    }
+  }
+  if (isOrphan) {
+    return "orphaned";
+  }
+  return undefined;
+}
+
+/**
+ * Extract the archivedAt timestamp from archive suffix, or fall back to file mtime.
+ */
+function resolveArchivedAt(fileName: string, mtimeMs: number): string | undefined {
+  for (const reason of ARCHIVE_REASONS) {
+    const ts = parseSessionArchiveTimestamp(fileName, reason);
+    if (ts !== null) {
+      return new Date(ts).toISOString();
+    }
+  }
+  // For orphaned files, use file modification time.
+  return new Date(mtimeMs).toISOString();
+}
+
+/**
+ * Read the first JSONL line header to extract sessionId and timestamp.
+ */
+function readJsonlHeader(filePath: string): { id?: string; timestamp?: string } {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const buf = Buffer.alloc(4096);
+    const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+    if (bytesRead === 0) {
+      return {};
+    }
+    const chunk = buf.toString("utf-8", 0, bytesRead);
+    const newlineIdx = chunk.indexOf("\n");
+    const firstLine = newlineIdx >= 0 ? chunk.slice(0, newlineIdx) : chunk;
+    if (!firstLine.trim()) {
+      return {};
+    }
+    const parsed = JSON.parse(firstLine);
+    return {
+      id: typeof parsed?.id === "string" ? parsed.id : undefined,
+      timestamp: typeof parsed?.timestamp === "string" ? parsed.timestamp : undefined,
+    };
+  } catch {
+    return {};
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+/**
+ * Count message lines in a JSONL file (lines containing `"message":`).
+ * Only for files under the size threshold.
+ */
+function countMessages(filePath: string, sizeBytes: number): number | undefined {
+  if (sizeBytes > MAX_FILE_SIZE_FOR_COUNT) {
+    return undefined;
+  }
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    let count = 0;
+    for (const line of content.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.message) {
+          count++;
+        }
+      } catch {
+        // ignore bad lines
+      }
+    }
+    return count;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Derive sessionId from filename by stripping .jsonl and any archive suffix.
+ * E.g. "fa84d053-xxx.jsonl.reset.2026-02-26T01-06-04.374Z" -> "fa84d053-xxx"
+ */
+function sessionIdFromFileName(fileName: string): string {
+  // Strip archive suffixes first: .reset.TIMESTAMP, .deleted.TIMESTAMP, .bak.TIMESTAMP
+  let base = fileName;
+  for (const reason of ARCHIVE_REASONS) {
+    const marker = `.${reason}.`;
+    const idx = base.lastIndexOf(marker);
+    if (idx >= 0) {
+      base = base.slice(0, idx);
+      break;
+    }
+  }
+  // Strip .jsonl extension
+  if (base.endsWith(".jsonl")) {
+    base = base.slice(0, -6);
+  }
+  return base;
+}
+
+export const sessionsArchivesHandlers: GatewayRequestHandlers = {
+  "sessions.archives": async ({ params, respond }) => {
+    if (!assertValidParams(params, validateSessionsArchivesParams, "sessions.archives", respond)) {
+      return;
+    }
+
+    const cfg = loadConfig();
+    const rawAgentId = params.agentId ?? resolveDefaultAgentId(cfg);
+    const agentId = normalizeAgentId(rawAgentId);
+    const limit = Math.min(params.limit ?? 50, 200);
+
+    // Resolve the sessions directory for this agent.
+    let sessionsDir: string;
+    try {
+      sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+    } catch {
+      respond(true, { archives: [], total: 0 });
+      return;
+    }
+
+    if (!fs.existsSync(sessionsDir)) {
+      respond(true, { archives: [], total: 0 });
+      return;
+    }
+
+    // Load the set of referenced session IDs from the store.
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    let referencedSessionIds: Set<string>;
+    let referencedFiles: Set<string>;
+    try {
+      const store = loadSessionStore(storePath);
+      referencedSessionIds = new Set<string>();
+      referencedFiles = new Set<string>();
+      for (const entry of Object.values(store)) {
+        if (entry.sessionId) {
+          referencedSessionIds.add(entry.sessionId);
+        }
+        if (entry.sessionFile) {
+          referencedFiles.add(entry.sessionFile);
+        }
+      }
+    } catch {
+      referencedSessionIds = new Set();
+      referencedFiles = new Set();
+    }
+
+    // Scan the directory for JSONL files.
+    let dirEntries: fs.Dirent[];
+    try {
+      dirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+    } catch {
+      respond(true, { archives: [], total: 0 });
+      return;
+    }
+
+    const archives: SessionArchiveEntry[] = [];
+
+    for (const dirent of dirEntries) {
+      if (!dirent.isFile()) {
+        continue;
+      }
+      const fileName = dirent.name;
+
+      // Skip non-JSONL files.
+      if (!fileName.includes(".jsonl")) {
+        continue;
+      }
+      // Skip sessions.json, lock files, etc.
+      if (fileName === "sessions.json" || fileName.endsWith(".lock")) {
+        continue;
+      }
+
+      const isArchiveArtifact = isSessionArchiveArtifactName(fileName);
+      const isPrimary = isPrimarySessionTranscriptFileName(fileName);
+
+      if (!isArchiveArtifact && !isPrimary) {
+        continue;
+      }
+
+      const filePath = path.join(sessionsDir, fileName);
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(filePath);
+      } catch {
+        continue;
+      }
+
+      // Determine sessionId from header or filename.
+      const derivedSessionId = sessionIdFromFileName(fileName);
+      const header = readJsonlHeader(filePath);
+      const sessionId = header.id || derivedSessionId;
+
+      // Check if this is an active (referenced) session transcript.
+      if (isPrimary && !isArchiveArtifact) {
+        // It's a plain .jsonl file; check if it's orphaned.
+        const isReferenced =
+          referencedSessionIds.has(sessionId) ||
+          referencedSessionIds.has(derivedSessionId) ||
+          referencedFiles.has(fileName);
+        if (isReferenced) {
+          continue; // Active session, skip.
+        }
+      }
+
+      const archiveReason = detectArchiveReason(fileName, isPrimary && !isArchiveArtifact);
+      const archivedAt = resolveArchivedAt(fileName, stat.mtimeMs);
+      const messageCount = countMessages(filePath, stat.size);
+
+      archives.push({
+        sessionId,
+        fileName,
+        archiveReason,
+        archivedAt,
+        createdAt: header.timestamp,
+        sizeBytes: stat.size,
+        messageCount,
+      });
+    }
+
+    // Sort by archivedAt descending (most recent first).
+    archives.sort((a, b) => {
+      const ta = a.archivedAt ? new Date(a.archivedAt).getTime() : 0;
+      const tb = b.archivedAt ? new Date(b.archivedAt).getTime() : 0;
+      return tb - ta;
+    });
+
+    const total = archives.length;
+    const sliced = archives.slice(0, limit);
+
+    respond(true, { archives: sliced, total });
+  },
+};

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -54,7 +54,12 @@ import {
 import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
-import { deleteSessionAndRefresh, loadSessions, patchSession } from "./controllers/sessions.ts";
+import {
+  deleteSessionAndRefresh,
+  loadArchives,
+  loadSessions,
+  patchSession,
+} from "./controllers/sessions.ts";
 import {
   installSkill,
   loadSkills,
@@ -420,6 +425,10 @@ export function renderApp(state: AppViewState) {
                 includeGlobal: state.sessionsIncludeGlobal,
                 includeUnknown: state.sessionsIncludeUnknown,
                 basePath: state.basePath,
+                archivesExpanded: state.archivesExpanded,
+                archivesLoading: state.archivesLoading,
+                archivesResult: state.archivesResult,
+                archivesError: state.archivesError,
                 onFiltersChange: (next) => {
                   state.sessionsFilterActive = next.activeMinutes;
                   state.sessionsFilterLimit = next.limit;
@@ -429,6 +438,13 @@ export function renderApp(state: AppViewState) {
                 onRefresh: () => loadSessions(state),
                 onPatch: (key, patch) => patchSession(state, key, patch),
                 onDelete: (key) => deleteSessionAndRefresh(state, key),
+                onToggleArchives: () => {
+                  state.archivesExpanded = !state.archivesExpanded;
+                  if (state.archivesExpanded && !state.archivesResult) {
+                    void loadArchives(state);
+                  }
+                },
+                onRefreshArchives: () => void loadArchives(state),
               })
             : nothing
         }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -163,6 +163,10 @@ export type AppViewState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  archivesExpanded: boolean;
+  archivesLoading: boolean;
+  archivesResult: import("./controllers/sessions.ts").SessionsArchivesResult | null;
+  archivesError: string | null;
   usageLoading: boolean;
   usageResult: SessionsUsageResult | null;
   usageCostSummary: CostUsageSummary | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -245,6 +245,10 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "120";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
+  @state() archivesExpanded = false;
+  @state() archivesLoading = false;
+  @state() archivesResult: import("./controllers/sessions.ts").SessionsArchivesResult | null = null;
+  @state() archivesError: string | null = null;
 
   @state() usageLoading = false;
   @state() usageResult: import("./types.js").SessionsUsageResult | null = null;

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -14,6 +14,10 @@ function createState(request: RequestFn, overrides: Partial<SessionsState> = {})
     sessionsFilterLimit: "0",
     sessionsIncludeGlobal: true,
     sessionsIncludeUnknown: true,
+    archivesExpanded: false,
+    archivesLoading: false,
+    archivesResult: null,
+    archivesError: null,
     ...overrides,
   };
 }

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -23,10 +23,16 @@ function buildProps(result: SessionsListResult): SessionsProps {
     includeGlobal: false,
     includeUnknown: false,
     basePath: "",
+    archivesExpanded: false,
+    archivesLoading: false,
+    archivesResult: null,
+    archivesError: null,
     onFiltersChange: () => undefined,
     onRefresh: () => undefined,
     onPatch: () => undefined,
     onDelete: () => undefined,
+    onToggleArchives: () => undefined,
+    onRefreshArchives: () => undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Add ability to discover and read archived/orphaned session transcripts via two Gateway API changes.

## Changes

### New Gateway method: `sessions.archives`

Scans the sessions directory for archived and orphaned JSONL transcript files:

- **Archived files**: `.jsonl.reset.*`, `.jsonl.deleted.*`, `.jsonl.bak.*` suffixes
- **Orphaned files**: plain `.jsonl` files not referenced by any active session in `sessions.json`

Returns metadata for each archive: `sessionId`, `fileName`, `archiveReason`, `archivedAt`, `createdAt`, `sizeBytes`, `messageCount`.

### Extended `chat.history` with `archiveFile` parameter

- Accepts `archiveFile` (filename from `sessions.archives` response) as alternative to `sessionKey`
- Path traversal protection: `basename` check + `realpath` validation
- Same sanitization, truncation, and size caps as regular `chat.history`
- Archived sessions are read-only (no `chat.send` support)

### Gateway Dashboard

- Collapsible "Archived Sessions" section at bottom of Sessions page
- Lazy-loaded on expand, shows archive metadata table

### Protocol

- New `SessionsArchivesParams` schema (`agentId?`, `limit?`)
- `ChatHistoryParams.sessionKey` changed to optional (mutually exclusive with `archiveFile`)
- Runtime validation ensures exactly one of `sessionKey` or `archiveFile` is provided

## Testing

- Unit tests for archive scanning (`.reset`, `.deleted`, `.bak`, orphaned files)
- Active session exclusion, limit enforcement, path traversal rejection
- All existing tests pass, `tsc --noEmit` clean