### PR TITLE
fix(slack): thread agent identity through channel reply path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Identity: thread agent outbound identity (`chat:write.customize` overrides) through the channel reply delivery path so per-agent username, icon URL, and icon emoji are applied to all Slack replies including media messages. (#27134) Thanks @hou-rong.
 - Agents/Subagents delivery: refactor subagent completion announce dispatch into an explicit queue/direct/fallback state machine, recover outbound channel-plugin resolution in cold/stale plugin-registry states across announce/message/gateway send paths, finalize cleanup bookkeeping when announce flow rejects, and treat Telegram sends without `message_id` as delivery failures (instead of false-success `"unknown"` IDs). (#26867, #25961, #26803, #25069, #26741) Thanks @SmithLabsLLC and @docaohieu2808.
 - Telegram/Webhook: pre-initialize webhook bots, switch webhook processing to callback-mode JSON handling, and preserve full near-limit payload reads under delayed handlers to prevent webhook request hangs and dropped updates. (#26156)
 - Slack/Session threads: prevent oversized parent-session inheritance from silently bricking new thread sessions, surface embedded context-overflow empty-result failures to users, and add configurable `session.parentForkMaxTokens` (default `100000`, `0` disables). (#26912) Thanks @markshields-tl.

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -107,7 +107,7 @@ describe("slackPlugin outbound", () => {
 });
 
 describe("slackPlugin config", () => {
-  it("treats HTTP mode accounts with bot token + signing secret as configured", () => {
+  it("treats HTTP mode accounts with bot token + signing secret as configured", async () => {
     const cfg: OpenClawConfig = {
       channels: {
         slack: {
@@ -120,13 +120,17 @@ describe("slackPlugin config", () => {
 
     const account = slackPlugin.config.resolveAccount(cfg, "default");
     const configured = slackPlugin.config.isConfigured?.(account, cfg);
-    const snapshot = slackPlugin.status?.buildAccountSnapshot?.({ account, runtime: undefined });
+    const snapshot = await slackPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: undefined,
+    });
 
     expect(configured).toBe(true);
     expect(snapshot?.configured).toBe(true);
   });
 
-  it("keeps socket mode requiring app token", () => {
+  it("keeps socket mode requiring app token", async () => {
     const cfg: OpenClawConfig = {
       channels: {
         slack: {
@@ -138,7 +142,11 @@ describe("slackPlugin config", () => {
 
     const account = slackPlugin.config.resolveAccount(cfg, "default");
     const configured = slackPlugin.config.isConfigured?.(account, cfg);
-    const snapshot = slackPlugin.status?.buildAccountSnapshot?.({ account, runtime: undefined });
+    const snapshot = await slackPlugin.status?.buildAccountSnapshot?.({
+      account,
+      cfg,
+      runtime: undefined,
+    });
 
     expect(configured).toBe(false);
     expect(snapshot?.configured).toBe(false);

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -1,5 +1,4 @@
 import { resolveHumanDelayConfig } from "../../../agents/identity.js";
-import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
 import { dispatchInboundMessage } from "../../../auto-reply/dispatch.js";
 import { clearHistoryEntriesIfEnabled } from "../../../auto-reply/reply/history.js";
 import { createReplyDispatcherWithTyping } from "../../../auto-reply/reply/reply-dispatcher.js";
@@ -10,6 +9,7 @@ import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
+import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
 import { removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import {

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+vi.mock("../send.js", () => ({
+  sendMessageSlack: (...args: unknown[]) => sendMock(...args),
+}));
+
+import { deliverReplies } from "./replies.js";
+
+function baseParams(overrides?: Record<string, unknown>) {
+  return {
+    replies: [{ text: "hello" }],
+    target: "C123",
+    token: "xoxb-test",
+    runtime: {},
+    textLimit: 4000,
+    replyToMode: "off" as const,
+    ...overrides,
+  };
+}
+
+describe("deliverReplies identity passthrough", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+  });
+  it("passes identity to sendMessageSlack for text replies", async () => {
+    sendMock.mockResolvedValue(undefined);
+    const identity = { username: "Bot", iconEmoji: ":robot:" };
+    await deliverReplies(baseParams({ identity }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).toMatchObject({ identity });
+  });
+
+  it("passes identity to sendMessageSlack for media replies", async () => {
+    sendMock.mockResolvedValue(undefined);
+    const identity = { username: "Bot", iconUrl: "https://example.com/icon.png" };
+    await deliverReplies(
+      baseParams({
+        identity,
+        replies: [{ text: "caption", mediaUrls: ["https://example.com/img.png"] }],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).toMatchObject({ identity });
+  });
+
+  it("omits identity key when not provided", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(baseParams());
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+});

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -12,7 +12,7 @@ function baseParams(overrides?: Record<string, unknown>) {
     replies: [{ text: "hello" }],
     target: "C123",
     token: "xoxb-test",
-    runtime: {},
+    runtime: { log: () => {}, error: () => {}, exit: () => {} },
     textLimit: 4000,
     replyToMode: "off" as const,
     ...overrides,

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -6,7 +6,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
-import { sendMessageSlack } from "../send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -17,6 +17,7 @@ export async function deliverReplies(params: {
   textLimit: number;
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
+  identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
@@ -38,6 +39,7 @@ export async function deliverReplies(params: {
         token: params.token,
         threadTs,
         accountId: params.accountId,
+        ...(params.identity ? { identity: params.identity } : {}),
       });
     } else {
       let first = true;
@@ -49,6 +51,7 @@ export async function deliverReplies(params: {
           mediaUrl,
           threadTs,
           accountId: params.accountId,
+          ...(params.identity ? { identity: params.identity } : {}),
         });
       }
     }


### PR DESCRIPTION
## Summary

Thread agent outbound identity (`chat:write.customize` overrides) through the Slack channel reply delivery path so per-agent username, icon URL, and icon emoji are applied to all Slack replies including media messages.

Fixes #27080

## Problem

When an agent has `outbound.identity` configured (name, avatarUrl, emoji), the Slack monitor reply path (`deliverReplies`) ignores it. All replies appear as the default bot identity, even though `sendMessageSlack` already supports an `identity` parameter via `chat:write.customize`.

## Solution

- Add optional `identity?: SlackSendIdentity` param to `deliverReplies()` in `src/slack/monitor/replies.ts`
- Pass identity through to both text-only and media `sendMessageSlack` calls
- In `dispatch.ts`, resolve the agent's outbound identity via `resolveAgentOutboundIdentity()` and convert to `SlackSendIdentity` format
- Pass the resolved identity to `deliverNormally()` → `deliverReplies()`

## Test plan

- Added `src/slack/monitor/replies.test.ts` with 3 tests:
  - Verifies identity object is passed to `sendMessageSlack` for text replies
  - Verifies identity object is passed to `sendMessageSlack` for media replies
  - Verifies identity key is omitted when no identity is provided
- `pnpm test src/slack/monitor/replies.test.ts` — all 3 tests pass

## Changelog

Added entry under `### Fixes` in CHANGELOG.md.