### PR TITLE
fix(appcast): correct sparkle:version for 2026.2.24 to prevent Sparkle downgrade

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.24</title>
             <pubDate>Wed, 25 Feb 2026 02:59:30 +0000</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>14728</sparkle:version>
+            <sparkle:version>202602240</sparkle:version>
             <sparkle:shortVersionString>2026.2.24</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.24</h2>


### PR DESCRIPTION
## Problem

The `appcast.xml` feed has inconsistent `sparkle:version` conventions across entries:

| Release | `sparkle:version` | Convention |
|---------|-------------------|------------|
| 2026.2.14 | `202602140` | Date-based |
| 2026.2.15 | `202602150` | Date-based |
| 2026.2.24 | `14728` | Sequential |

Sparkle compares `sparkle:version` **numerically** to determine the newest release. Since `202602150 > 14728`, Sparkle considers 2.15 newer than 2.24 — offering users on 2.22+ a "downgrade" to 2.15 as an update.

## Fix

Change the 2026.2.24 entry from `14728` → `202602240`, matching the date-based convention used by the earlier entries and restoring the correct ordering:

```
202602140 < 202602150 < 202602240
```

## Change

```diff
- <sparkle:version>14728</sparkle:version>
+ <sparkle:version>202602240</sparkle:version>
```

One-line change in `appcast.xml`.

Fixes #26965