### PR TITLE
fix(ci): restore latest Docker tag on stable releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -172,7 +172,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}")
-            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
               tags+=("${IMAGE}:latest")
             fi
           fi

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -172,6 +172,9 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}")
+            if [[ "$version" != *-* ]]; then
+              tags+=("${IMAGE}:latest")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No manifest tags resolved for ref ${GITHUB_REF}"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -172,7 +172,7 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}")
-            if [[ "$version" != *-* ]]; then
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               tags+=("${IMAGE}:latest")
             fi
           fi


### PR DESCRIPTION
## Summary
- restore `latest` tagging in Docker release workflow for stable and legacy stable tag formats
- allow `latest` for exact stable tags (`vYYYY.M.D`) and legacy patch tags (`vYYYY.M.D-<n>`)
- keep beta/prerelease tags from overwriting `latest`

## Examples
- `v2026.2.26` -> `:2026.2.26` and `:latest`
- `v2026.2.6-3` -> `:2026.2.6-3` and `:latest`
- `v2026.2.26-beta.1` -> `:2026.2.26-beta.1` only
- `v2026.2.6.beta.1` -> `:2026.2.6.beta.1` only
- `main` branch push -> `:main`
