### PR TITLE
fix(signal): harden reaction error handling and require explicit targetAuthor

### DIFF
--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -834,7 +834,7 @@ describe("signalMessageActions", () => {
       channels: { signal: { account: "+15550001111", actions: { reactions: false } } },
     } as OpenClawConfig;
     await expectSignalActionRejected(
-      { to: "+15550001111", messageId: "123", emoji: "✅" },
+      { to: "+15550001111", messageId: "123", emoji: "✅", targetAuthor: "+15550001111" },
       /actions\.reactions/,
       cfg,
     );
@@ -846,8 +846,13 @@ describe("signalMessageActions", () => {
         name: "uses account-level actions when enabled",
         cfg: createSignalAccountOverrideCfg(),
         accountId: "work",
-        params: { to: "+15550001111", messageId: "123", emoji: "👍" },
-        expectedArgs: ["+15550001111", 123, "👍", { accountId: "work" }],
+        params: { to: "+15550001111", messageId: "123", emoji: "👍", targetAuthor: "+15550001111" },
+        expectedArgs: [
+          "+15550001111",
+          123,
+          "👍",
+          { accountId: "work", targetAuthor: "+15550001111", targetAuthorUuid: undefined },
+        ],
       },
       {
         name: "normalizes uuid recipients",
@@ -857,8 +862,14 @@ describe("signalMessageActions", () => {
           recipient: "uuid:123e4567-e89b-12d3-a456-426614174000",
           messageId: "123",
           emoji: "🔥",
+          targetAuthor: "+15550001111",
         },
-        expectedArgs: ["123e4567-e89b-12d3-a456-426614174000", 123, "🔥", { accountId: undefined }],
+        expectedArgs: [
+          "123e4567-e89b-12d3-a456-426614174000",
+          123,
+          "🔥",
+          { accountId: undefined, targetAuthor: "+15550001111", targetAuthorUuid: undefined },
+        ],
       },
       {
         name: "passes groupId and targetAuthor for group reactions",
@@ -921,10 +932,17 @@ describe("signalMessageActions", () => {
     );
   });
 
-  it("requires targetAuthor for group reactions", async () => {
+  it("requires targetAuthor for reactions", async () => {
     const cfg = {
       channels: { signal: { account: "+15550001111" } },
     } as OpenClawConfig;
+    // Direct reaction without targetAuthor
+    await expectSignalActionRejected(
+      { to: "+15550001111", messageId: "123", emoji: "✅" },
+      /targetAuthor/,
+      cfg,
+    );
+    // Group reaction without targetAuthor
     await expectSignalActionRejected(
       { to: "signal:group:group-id", messageId: "123", emoji: "✅" },
       /targetAuthor/,

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -909,7 +909,7 @@ describe("signalMessageActions", () => {
     sendReactionSignal.mockClear();
     await runSignalAction(
       "react",
-      { to: "+15559999999", emoji: "🔥" },
+      { to: "+15559999999", emoji: "🔥", targetAuthor: "+15550001111" },
       { toolContext: { currentMessageId: "1737630212345" } },
     );
     expect(sendReactionSignal).toHaveBeenCalledTimes(1);

--- a/src/channels/plugins/actions/signal.ts
+++ b/src/channels/plugins/actions/signal.ts
@@ -136,8 +136,8 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
       }
       const targetAuthor = readStringParam(params, "targetAuthor");
       const targetAuthorUuid = readStringParam(params, "targetAuthorUuid");
-      if (target.groupId && !targetAuthor && !targetAuthorUuid) {
-        throw new Error("targetAuthor or targetAuthorUuid required for group reactions.");
+      if (!targetAuthor && !targetAuthorUuid) {
+        throw new Error("targetAuthor or targetAuthorUuid required for Signal reactions.");
       }
 
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -55,6 +55,7 @@ describe("registerPluginCommand", () => {
       {
         name: "demo_cmd",
         description: "Demo command",
+        acceptsArgs: false,
       },
     ]);
   });

--- a/src/signal/send-reactions.test.ts
+++ b/src/signal/send-reactions.test.ts
@@ -25,13 +25,19 @@ vi.mock("./client.js", () => ({
   signalRpcRequest: (...args: unknown[]) => rpcMock(...args),
 }));
 
+vi.mock("../infra/channel-activity.js", () => ({
+  recordChannelActivity: () => {},
+}));
+
 describe("sendReactionSignal", () => {
   beforeEach(() => {
-    rpcMock.mockClear().mockResolvedValue({ timestamp: 123 });
+    rpcMock.mockClear().mockResolvedValue({ timestamp: 123, results: [{ type: "SUCCESS" }] });
   });
 
   it("uses recipients array and targetAuthor for uuid dms", async () => {
-    await sendReactionSignal("uuid:123e4567-e89b-12d3-a456-426614174000", 123, "🔥");
+    await sendReactionSignal("uuid:123e4567-e89b-12d3-a456-426614174000", 123, "🔥", {
+      targetAuthor: "uuid:123e4567-e89b-12d3-a456-426614174000",
+    });
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(rpcMock).toHaveBeenCalledWith("sendReaction", expect.any(Object), expect.any(Object));
@@ -54,12 +60,30 @@ describe("sendReactionSignal", () => {
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
   });
 
-  it("defaults targetAuthor to recipient for removals", async () => {
-    await removeReactionSignal("+15551230000", 456, "❌");
+  it("requires explicit targetAuthor for direct reactions", async () => {
+    await expect(removeReactionSignal("+15551230000", 456, "❌")).rejects.toThrow(
+      "targetAuthor is required for direct reaction removal",
+    );
+  });
+
+  it("passes targetAuthor explicitly for removals", async () => {
+    await removeReactionSignal("+15551230000", 456, "❌", {
+      targetAuthor: "+15551230000",
+    });
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(params.recipients).toEqual(["+15551230000"]);
     expect(params.targetAuthor).toBe("+15551230000");
     expect(params.remove).toBe(true);
+  });
+
+  it("throws on per-recipient failure", async () => {
+    rpcMock.mockResolvedValueOnce({
+      timestamp: 789,
+      results: [{ type: "UNREGISTERED_FAILURE", recipientAddress: { number: "+15559999999" } }],
+    });
+    await expect(
+      sendReactionSignal("+15559999999", 100, "👍", { targetAuthor: "+15559999999" }),
+    ).rejects.toThrow("Signal sendReaction failed for recipient result(s):");
   });
 });


### PR DESCRIPTION
## Summary
- Removes the silent fallback that used the recipient as `targetAuthor` for reactions — now requires explicit `targetAuthor` or `targetAuthorUuid` for both group and direct reactions, preventing accidental self-targeting.
- Parses per-recipient result entries from the `sendReaction` RPC response and throws a descriptive error when any recipient fails (e.g. `UNREGISTERED_FAILURE`), instead of silently succeeding.
- Adds `recordChannelActivity` for outbound reaction tracking.
- Splits error messages into `missingGroupTargetAuthor` / `missingDirectTargetAuthor` for clearer diagnostics.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test -- src/signal/send-reactions` passes (5 tests, including new failure detection test)

---
AI-assisted