### PR TITLE
ci: add architecture-specific latest tags to Docker releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,6 +58,9 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-amd64")
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
+              tags+=("${IMAGE}:latest-amd64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No amd64 tags resolved for ref ${GITHUB_REF}"
@@ -117,6 +120,9 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             version="${GITHUB_REF#refs/tags/v}"
             tags+=("${IMAGE}:${version}-arm64")
+            if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$ ]]; then
+              tags+=("${IMAGE}:latest-arm64")
+            fi
           fi
           if [[ ${#tags[@]} -eq 0 ]]; then
             echo "::error::No arm64 tags resolved for ref ${GITHUB_REF}"


### PR DESCRIPTION
## Summary

- **Problem:** Docker images built from stable release tags only get $arch-latest tags. There are no `latest-amd64` / `latest-arm64` tags, so users who need to pull a single-architecture image cannot use a stable `latest-<arch>` reference — they must know the exact version.
- **Why it matters:** Architecture-specific latest tags (`latest-amd64`, `latest-arm64`) let users pin to a specific architecture while still tracking the most recent stable release. This is useful for CI pipelines, constrained environments, and deployments where multi-arch manifest resolution is not desired or supported. The multi-platform `latest` manifest tag was already fixed upstream.
- **What changed:** The `docker-release.yml` workflow now additionally tags stable (non-beta) release images with `latest-amd64` and `latest-arm64` for the per-architecture builds. The regex `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$` gates this to stable releases only — beta/prerelease tags (e.g. `v2026.2.25-beta.1`) are excluded.
- **What did NOT change (scope boundary):** `main` branch builds are unaffected (still tagged `main` / `main-amd64` / `main-arm64`). The version-specific tags (e.g. `2026.2.25-amd64`) are unchanged. No other workflows were modified.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [X] CI/CD / infra

## Linked Issue/PR

- Related #24607
- https://github.com/openclaw/openclaw/pull/27140

## User-visible / Behavior Changes

- `ghcr.io/openclaw/openclaw:latest-amd64` and `ghcr.io/openclaw/openclaw:latest-arm64` will now point to the most recent stable release for each architecture.
- Beta/prerelease tags will not update these tags.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- CI workflow (GitHub Actions)

### Steps

1. Push a stable release tag (e.g. `v2026.2.25`) to the repository.
2. Wait for the Docker Release workflow to complete.
3. Verify the `latest-amd64` and `latest-arm64` tags exist in GHCR alongside the version-specific tags.

### Expected

- `ghcr.io/openclaw/openclaw:latest-amd64` and `latest-arm64` resolve to the newly built per-architecture images.
- Version-specific tags (e.g. `2026.2.25-amd64`) also exist as before.

### Actual

- Before this change, only version-specific arch tags were pushed; no `latest-<arch>` tags existed.

## Evidence

- Verified by reading the workflow diff: the `latest-<arch>` tagging logic is gated behind a regex that matches stable version formats only, correctly excluding beta tags since they contain non-numeric suffixes after the hyphen.
- Tested tag resolution logic with a local shell script covering stable, beta, rc, alpha, legacy patch, and main branch scenarios (24 cases, 0 failures). Test script: https://gist.github.com/ipl31/61f4ba62d0bbd6eb773cafa40adc0509

## Human Verification (required)

- Verified scenarios: Reviewed workflow logic for stable tags, beta tags, and main branch pushes.
- Edge cases checked: Beta tags with `-beta.N` suffix are correctly excluded. Legacy patch tags (e.g. `v2026.2.6-1`) are correctly included. Main branch pushes are unaffected.
- What you did **not** verify: End-to-end run of the workflow (requires pushing a release tag to trigger CI).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two added `if` blocks in `docker-release.yml`, or delete the `latest-<arch>` tags from GHCR.
- Files/config to restore: `.github/workflows/docker-release.yml`
- Known bad symptoms reviewers should watch for: `latest-<arch>` pointing to a beta release (would indicate the regex guard failed).

## Risks and Mitigations

- Risk: Users pinned to `latest-amd64`/`latest-arm64` receive unexpected upgrades when a new stable release is pushed.
  - Mitigation: This is standard Docker `latest` tag behavior and the expected user intent. Users who want stability should pin to a specific version tag.
