### PR TITLE
fix: read tool 返回原始图片内容，修复 #26594

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -8,7 +8,6 @@ import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-import { sanitizeToolResultImages } from "./tool-images.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
 // to normalize payloads and sanitize oversized images before they hit providers.
@@ -688,11 +687,9 @@ export function createOpenClawReadTool(
       const filePath = typeof record?.path === "string" ? String(record.path) : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
-      return sanitizeToolResultImages(
-        normalizedResult,
-        `read:${filePath}`,
-        options?.imageSanitization,
-      );
+      // Skip image sanitization for read tool to preserve original image content
+      // Sanitization (resize) should only happen at delivery time, not at read time
+      return normalizedResult;
     },
   };
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -10,7 +10,7 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
-// to normalize payloads and sanitize oversized images before they hit providers.
+// to normalize payloads (MIME sniffing, adaptive paging) before they hit providers.
 type ToolContentBlock = AgentToolResult<unknown>["content"][number];
 type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;


### PR DESCRIPTION
## 问题
使用 read 工具读取图片时，显示的图片内容与原始图片不符，文件 MD5 不同。

原因：read 工具调用了 `sanitizeToolResultImages`，该函数会调用 `resizeToJpeg` 修改图片内容。

## 修复
- 移除 read 工具中的 `sanitizeToolResultImages` 调用
- read 工具现在返回原始图片内容，不做任何修改
- 图片 sanitization（resize）应该在发送时进行，而不是读取时

## 影响
- ✅ read 工具返回的图片与原始文件一致
- ✅ 转发功能继续使用原始文件流，不受影响
- ⚠️ 超大图片可能会在发送时失败（由发送层的 sanitization 处理）

## 测试
- 读取图片，对比 MD5 与原始文件一致
- 转发图片功能正常

Fixes #26594