### PR TITLE
fix(web-fetch): include URL in error message for network failures

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -561,7 +561,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     if (payload) {
       return payload;
     }
-    throw error;
+    // Enhance error with URL context before rethrowing
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`web_fetch failed for ${finalUrl}: ${errorMessage}`, { cause: error });
   }
 
   try {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -467,4 +467,40 @@ describe("web_fetch extraction fallbacks", () => {
     expect(message).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
     expect(message).toContain("blocked");
   });
+
+  it("includes URL in error message when fetch fails with network error", async () => {
+    installMockFetch(() => {
+      return Promise.reject(new TypeError("fetch failed: Connection refused"));
+    });
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+
+    const message = await captureToolErrorMessage({
+      tool,
+      url: "https://example.com/network-fail",
+    });
+
+    expect(message).toContain("web_fetch failed for https://example.com/network-fail");
+    expect(message).toContain("Connection refused");
+  });
+
+  it("includes URL in error when both fetch and firecrawl fail", async () => {
+    installMockFetch((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.includes("api.firecrawl.dev")) {
+        return Promise.reject(new Error("Firecrawl service unavailable"));
+      }
+      return Promise.reject(new TypeError("fetch failed: DNS lookup failed"));
+    });
+
+    const tool = createFetchTool({ firecrawl: { apiKey: "firecrawl-test" } });
+
+    const message = await captureToolErrorMessage({
+      tool,
+      url: "https://example.com/both-fail",
+    });
+
+    expect(message).toContain("web_fetch failed for https://example.com/both-fail");
+    expect(message).toContain("DNS lookup failed");
+  });
 });


### PR DESCRIPTION
## Summary

When web_fetch encounters a network-level error, the error now includes the URL and error message instead of just 'fetch failed'.

**Before:** fetch failed
**After:** web_fetch failed for https://example.com: Connection refused

## Changes

- Modified error handling in runWebFetch to wrap network errors with URL context
- Added tests for new functionality

Fixes #27081