### PR TITLE
fix(typing): prevent keepalive restart after cleanup during in-flight onReplyStart

### DIFF
--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -174,6 +174,40 @@ describe("createTypingCallbacks", () => {
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
+  it("does not restart keepalive when fireStop races with in-flight onReplyStart", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveStart!: () => void;
+      const start = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, stop, onStartError });
+
+      // Begin onReplyStart — it will await the pending start()
+      const replyPromise = callbacks.onReplyStart();
+
+      // While start() is in-flight, fire cleanup (simulates markRunComplete + markDispatchIdle)
+      callbacks.onCleanup?.();
+
+      // Now let start() resolve
+      resolveStart();
+      await replyPromise;
+
+      // The keepalive loop must NOT have been restarted after cleanup
+      await vi.advanceTimersByTimeAsync(9_000);
+      // start was called once (the initial fireStart inside onReplyStart), not again by keepalive
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not restart keepalive after idle cleanup", async () => {
     await withFakeTimers(async () => {
       const { start, stop, callbacks } = createTypingHarness();

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -77,6 +77,9 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     keepaliveLoop.stop();
     clearTtlTimer();
     await fireStart();
+    if (closed) {
+      return;
+    }
     if (startGuard.isTripped()) {
       return;
     }


### PR DESCRIPTION
## Problem

When `fireStop()` is called while `onReplyStart()` is awaiting `fireStart()`, the keepalive loop gets restarted after the await completes. The `closed` flag is only checked at the top of `onReplyStart`, not after the async gap.

This causes the typing indicator to persist **indefinitely** on Discord (and other channels without a cancel-typing API) because the inner keepalive loop keeps sending `triggerTyping()` every 3 seconds with no mechanism to stop it.

## Race condition timeline

1. `onReplyStart()` checks `closed` → `false`, proceeds
2. `keepaliveLoop.stop()`
3. `await fireStart()` — HTTP request in flight
4. `fireStop()` called (via `markRunComplete` + `markDispatchIdle`) → `closed = true`, `keepaliveLoop.stop()` (no-op, already stopped in step 2)
5. `fireStart()` resolves
6. `keepaliveLoop.start()` — **loop leaked**, sends typing forever

## Fix

Add a post-await `closed` check before `keepaliveLoop.start()` — one line change.

## Testing

- Added a test that reproduces the exact race condition (pending `start()` + concurrent `onCleanup()`)
- All 7 typing tests pass
- Verified fix on a live Discord instance — typing indicator now clears immediately after reply

## AI Disclosure

- [x] AI-assisted (OpenClaw agent + Claude Opus)
- [x] Fully tested locally on live Discord
- [x] I understand what the code does

## Related

- Builds on prior work in `a0fa283` (`fix(discord): prevent stuck typing indicator`) and `97eb554` (`fix(typing): guard fireStart against post-close invocation`) which added the `closed` flag but missed this specific race window