### PR TITLE
feat(cron): add --session-key option to cron add/edit CLI

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -71,6 +71,7 @@ export function registerCronAddCommand(cron: Command) {
       .option("--keep-after-run", "Keep one-shot job after it succeeds", false)
       .option("--agent <id>", "Agent id for this job")
       .option("--session <target>", "Session target (main|isolated)")
+      .option("--session-key <key>", "Session key for job routing (e.g. agent:my-agent:my-session)")
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)", "now")
       .option("--at <when>", "Run once at time (ISO) or +duration (e.g. 20m)")
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
@@ -240,12 +241,18 @@ export function registerCronAddCommand(cron: Command) {
               ? opts.description.trim()
               : undefined;
 
+          const sessionKey =
+            typeof opts.sessionKey === "string" && opts.sessionKey.trim()
+              ? opts.sessionKey.trim()
+              : undefined;
+
           const params = {
             name,
             description,
             enabled: !opts.disabled,
             deleteAfterRun: opts.deleteAfterRun ? true : opts.keepAfterRun ? false : undefined,
             agentId,
+            sessionKey,
             schedule,
             sessionTarget,
             wakeMode,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -37,6 +37,8 @@ export function registerCronEditCommand(cron: Command) {
       .option("--session <target>", "Session target (main|isolated)")
       .option("--agent <id>", "Set agent id")
       .option("--clear-agent", "Unset agent and use default", false)
+      .option("--session-key <key>", "Set session key for job routing")
+      .option("--clear-session-key", "Unset session key", false)
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
@@ -132,6 +134,15 @@ export function registerCronEditCommand(cron: Command) {
           }
           if (opts.clearAgent) {
             patch.agentId = null;
+          }
+          if (opts.sessionKey && opts.clearSessionKey) {
+            throw new Error("Use --session-key or --clear-session-key, not both");
+          }
+          if (typeof opts.sessionKey === "string" && opts.sessionKey.trim()) {
+            patch.sessionKey = opts.sessionKey.trim();
+          }
+          if (opts.clearSessionKey) {
+            patch.sessionKey = null;
           }
 
           const scheduleChosen = [opts.at, opts.every, opts.cron].filter(Boolean).length;


### PR DESCRIPTION
## Summary

- Add `--session-key <key>` option to `cron add` for setting session key at creation time
- Add `--session-key <key>` and `--clear-session-key` options to `cron edit` for updating/removing session key on existing jobs
- Enables targeting cron jobs at specific named sessions (e.g. `agent:project-lead:project-name`) directly from the CLI

## Motivation

The `CronJob` type already has a `sessionKey` field, and the entire backend chain supports it (`createJob()` -> `applyJobPatch()` -> `executeJobCore()` -> `runCronIsolatedAgentTurn()`). However, the CLI commands never exposed this field, forcing users to use shell scripts + system crontab as a workaround for per-session heartbeats in multi-agent setups.

This is a pure CLI surface addition - no backend changes needed.

## Usage

```bash
# Create a cron job targeting a specific named session
openclaw cron add \
  --name "calculator-heartbeat" \
  --every 5m \
  --session-key "agent:project-lead:calculator" \
  --message "Check for pending calculations" \
  --agent project-lead

# Edit an existing job to target a different session
openclaw cron edit <job-id> --session-key "agent:project-lead:dashboard"

# Clear session key (revert to default routing)
openclaw cron edit <job-id> --clear-session-key
```

## Test plan

- [ ] `openclaw cron add --session-key <key> ...` creates job with sessionKey persisted
- [ ] `openclaw cron edit <id> --session-key <key>` updates sessionKey on existing job
- [ ] `openclaw cron edit <id> --clear-session-key` removes sessionKey from job
- [ ] `--session-key` and `--clear-session-key` together on edit throws error
- [ ] Omitting `--session-key` preserves existing behavior (no regression)
- [ ] Job with sessionKey routes execution to the correct named session

Closes #27158

🤖 Generated with [Claude Code](https://claude.com/claude-code)