### PR TITLE
Skills: refresh stale session snapshots after watcher init

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const watchMock = vi.fn(() => ({
   on: vi.fn(),
@@ -14,6 +14,21 @@ vi.mock("chokidar", () => {
 });
 
 describe("ensureSkillsWatcher", () => {
+  beforeEach(() => {
+    watchMock.mockClear();
+  });
+
+  it("bumps the workspace snapshot version when a watcher is created", async () => {
+    const mod = await import("./refresh.js");
+    const workspaceDir = `/tmp/workspace-${Date.now()}`;
+
+    expect(mod.getSkillsSnapshotVersion(workspaceDir)).toBe(0);
+    mod.ensureSkillsWatcher({ workspaceDir });
+
+    expect(watchMock).toHaveBeenCalled();
+    expect(mod.getSkillsSnapshotVersion(workspaceDir)).toBeGreaterThan(0);
+  });
+
   it("ignores node_modules, dist, .git, and Python venvs by default", async () => {
     const mod = await import("./refresh.js");
     mod.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -204,4 +204,8 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   });
 
   watchers.set(workspaceDir, state);
+  // Invalidate persisted per-session skill snapshots when a watcher is first created (or
+  // replaced after process restart/config change). Without this, long-lived sessions can keep a
+  // stale snapshot until an actual filesystem event occurs.
+  bumpSkillsSnapshotVersion({ workspaceDir, reason: "manual" });
 }

--- a/src/auto-reply/reply/session-updates.skills-refresh-regression.test.ts
+++ b/src/auto-reply/reply/session-updates.skills-refresh-regression.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const watchMock = vi.fn(() => ({
+  on: vi.fn(),
+  close: vi.fn(async () => undefined),
+}));
+
+const updateSessionStoreMock = vi.fn(async () => undefined);
+
+vi.mock("chokidar", () => ({
+  default: { watch: watchMock },
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    updateSessionStore: updateSessionStoreMock,
+  };
+});
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => undefined,
+}));
+
+describe("ensureSkillSnapshot stale snapshot refresh regression (#27125)", () => {
+  const originalFastFlag = process.env.OPENCLAW_TEST_FAST;
+
+  beforeEach(() => {
+    watchMock.mockClear();
+    updateSessionStoreMock.mockClear();
+    vi.resetModules();
+    delete process.env.OPENCLAW_TEST_FAST;
+  });
+
+  afterEach(() => {
+    if (originalFastFlag === undefined) {
+      delete process.env.OPENCLAW_TEST_FAST;
+    } else {
+      process.env.OPENCLAW_TEST_FAST = originalFastFlag;
+    }
+  });
+
+  it("rebuilds a stale persisted snapshot on first turn after watcher initialization", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-27125-"));
+    const workspaceDir = path.join(root, "workspace");
+    const skillDir = path.join(workspaceDir, "skills", "demo-refresh-check");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: demo-refresh-check",
+        "description: Verifies stale snapshot refresh path",
+        "---",
+        "",
+        "# demo-refresh-check",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { ensureSkillSnapshot } = await import("./session-updates.js");
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId: "s1",
+        updatedAt: Date.now() - 1_000,
+        systemSent: true,
+        skillsSnapshot: {
+          version: 0,
+          prompt: "stale",
+          skills: [],
+          resolvedSkills: [],
+        },
+      },
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      sessionKey,
+      sessionId: "s1",
+      isFirstTurnInSession: false,
+      workspaceDir,
+      cfg: {} as never,
+    });
+
+    const resolvedNames = (result.skillsSnapshot?.resolvedSkills ?? []).map((s) => s.name);
+    expect(watchMock).toHaveBeenCalled();
+    expect(result.skillsSnapshot?.version).toBeGreaterThan(0);
+    expect(resolvedNames).toContain("demo-refresh-check");
+    expect(sessionStore[sessionKey]?.skillsSnapshot?.version).toBeGreaterThan(0);
+  });
+});

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const watchMock = vi.fn(() => ({
+  on: vi.fn(),
+  close: vi.fn(async () => undefined),
+}));
+
+const buildWorkspaceSkillSnapshotMock = vi.fn(
+  (_workspaceDir: string, opts?: { snapshotVersion?: number }) => ({
+    version: opts?.snapshotVersion ?? 0,
+    prompt: "",
+    skills: [],
+    resolvedSkills: [],
+  }),
+);
+
+const updateSessionStoreMock = vi.fn(async () => undefined);
+
+vi.mock("chokidar", () => ({
+  default: { watch: watchMock },
+}));
+
+vi.mock("../../agents/skills.js", () => ({
+  buildWorkspaceSkillSnapshot: buildWorkspaceSkillSnapshotMock,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: updateSessionStoreMock,
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => undefined,
+}));
+
+describe("ensureSkillSnapshot", () => {
+  const originalFastFlag = process.env.OPENCLAW_TEST_FAST;
+
+  beforeEach(() => {
+    watchMock.mockClear();
+    buildWorkspaceSkillSnapshotMock.mockClear();
+    updateSessionStoreMock.mockClear();
+    vi.resetModules();
+    delete process.env.OPENCLAW_TEST_FAST;
+  });
+
+  afterEach(() => {
+    if (originalFastFlag === undefined) {
+      delete process.env.OPENCLAW_TEST_FAST;
+    } else {
+      process.env.OPENCLAW_TEST_FAST = originalFastFlag;
+    }
+  });
+
+  it("refreshes stale persisted snapshots after watcher initialization", async () => {
+    const mod = await import("./session-updates.js");
+    const workspaceDir = `/tmp/skills-refresh-${Date.now()}`;
+    const sessionKey = "agent:main:telegram:123";
+    const staleSnapshot = {
+      version: 0,
+      prompt: "old",
+      skills: [],
+      resolvedSkills: [],
+    };
+    const sessionStore = {
+      [sessionKey]: {
+        sessionId: "s1",
+        updatedAt: 1,
+        skillsSnapshot: staleSnapshot,
+      },
+    };
+
+    const result = await mod.ensureSkillSnapshot({
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      sessionKey,
+      sessionId: "s1",
+      isFirstTurnInSession: false,
+      workspaceDir,
+      cfg: {} as never,
+    });
+
+    expect(watchMock).toHaveBeenCalled();
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalled();
+    expect(result.skillsSnapshot?.version).toBeGreaterThan(0);
+    expect(sessionStore[sessionKey]?.skillsSnapshot?.version).toBeGreaterThan(0);
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -152,8 +152,8 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
-  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const shouldRefreshSnapshot =
     snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
 

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 /* ------------------------------------------------------------------ */
@@ -514,8 +515,8 @@ describe("agents.files.get/set symlink safety", () => {
   });
 
   it("rejects agents.files.get when allowlisted file symlink escapes workspace", async () => {
-    const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
+    const workspace = path.resolve("/workspace/test-agent");
+    const candidate = path.join(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
       if (p === workspace) {
         return workspace;
@@ -547,8 +548,8 @@ describe("agents.files.get/set symlink safety", () => {
   });
 
   it("rejects agents.files.set when allowlisted file symlink escapes workspace", async () => {
-    const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
+    const workspace = path.resolve("/workspace/test-agent");
+    const candidate = path.join(workspace, "AGENTS.md");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
       if (p === workspace) {
         return workspace;
@@ -582,9 +583,9 @@ describe("agents.files.get/set symlink safety", () => {
   });
 
   it("allows in-workspace symlink targets for get/set", async () => {
-    const workspace = "/workspace/test-agent";
-    const candidate = `${workspace}/AGENTS.md`;
-    const target = `${workspace}/policies/AGENTS.md`;
+    const workspace = path.resolve("/workspace/test-agent");
+    const candidate = path.join(workspace, "AGENTS.md");
+    const target = path.join(workspace, "policies", "AGENTS.md");
     const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
 
     mocks.fsRealpath.mockImplementation(async (p: string) => {


### PR DESCRIPTION
## Summary

Fixes stale per-session skills snapshots so long-lived sessions (commonly Telegram chats) refresh skills after watcher initialization instead of keeping an old cached snapshot until a filesystem change event occurs.

Closes #27125.

## Root Cause

`ensureSkillSnapshot()` read the skills snapshot version before starting the skills watcher. After a process restart, an existing session could carry a persisted `skillsSnapshot.version=0`, and the first message would not refresh because no watcher event had occurred yet.

This showed up as channel asymmetry in practice: a long-lived Telegram session reused the stale snapshot, while a new Web UI session built a fresh snapshot and saw the skill.

## Fix

- Start the skills watcher before reading `getSkillsSnapshotVersion(...)` in `ensureSkillSnapshot()`.
- Bump the workspace skills snapshot version once when a watcher is created/replaced to invalidate persisted stale snapshots immediately after startup/reconfiguration.

## Tests

Ran locally:

- `pnpm test -- src/agents/skills/refresh.test.ts src/auto-reply/reply/session-updates.test.ts src/auto-reply/reply/session-updates.skills-refresh-regression.test.ts`
- `pnpm test -- src/commands/agent.test.ts`

Added/updated regression coverage:

- watcher initialization bumps workspace snapshot version
- stale persisted snapshot refreshes after watcher init
- real `SKILL.md` reproduction verifies refreshed snapshot includes the skill
