### PR TITLE
fix(macos): enforce monotonic Sparkle build versions and validate appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.26</title>
             <pubDate>Thu, 26 Feb 2026 23:37:15 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>15221</sparkle:version>
+            <sparkle:version>202602260</sparkle:version>
             <sparkle:shortVersionString>2026.2.26</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.26</h2>

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -38,7 +38,6 @@ Notes:
 # Default is auto-derived from APP_VERSION when omitted.
 BUNDLE_ID=ai.openclaw.mac \
 APP_VERSION=2026.2.27 \
-APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-app.sh
@@ -56,7 +55,6 @@ scripts/create-dmg.sh dist/OpenClaw.app dist/OpenClaw-2026.2.27.dmg
 NOTARIZE=1 NOTARYTOOL_PROFILE=openclaw-notary \
 BUNDLE_ID=ai.openclaw.mac \
 APP_VERSION=2026.2.27 \
-APP_BUILD="$(git rev-list --count HEAD)" \
 BUILD_CONFIG=release \
 SIGN_IDENTITY="Developer ID Application: <Developer Name> (<TEAMID>)" \
 scripts/package-mac-dist.sh

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -27,12 +27,15 @@ This app now ships Sparkle auto-updates. Release builds must be Developer ID–s
 Notes:
 
 - `APP_BUILD` maps to `CFBundleVersion`/`sparkle:version`; keep it numeric + monotonic (no `-beta`), or Sparkle compares it as equal.
+- If `APP_BUILD` is omitted, `scripts/package-mac-app.sh` derives a Sparkle-safe default from `APP_VERSION` (`YYYYMMDD0`) and uses the higher of that value and git commit count.
+- You can still override `APP_BUILD` explicitly when release engineering needs a specific monotonic value.
 - Defaults to the current architecture (`$(uname -m)`). For release/universal builds, set `BUILD_ARCHS="arm64 x86_64"` (or `BUILD_ARCHS=all`).
 - Use `scripts/package-mac-dist.sh` for release artifacts (zip + DMG + notarization). Use `scripts/package-mac-app.sh` for local/dev packaging.
 
 ```bash
 # From repo root; set release IDs so Sparkle feed is enabled.
 # APP_BUILD must be numeric + monotonic for Sparkle compare.
+# Default is auto-derived from APP_VERSION when omitted.
 BUNDLE_ID=ai.openclaw.mac \
 APP_VERSION=2026.2.27 \
 APP_BUILD="$(git rev-list --count HEAD)" \

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -27,7 +27,7 @@ This app now ships Sparkle auto-updates. Release builds must be Developer ID–s
 Notes:
 
 - `APP_BUILD` maps to `CFBundleVersion`/`sparkle:version`; keep it numeric + monotonic (no `-beta`), or Sparkle compares it as equal.
-- If `APP_BUILD` is omitted, `scripts/package-mac-app.sh` derives a Sparkle-safe default from `APP_VERSION` (`YYYYMMDD0`) and uses the higher of that value and git commit count.
+- If `APP_BUILD` is omitted, `scripts/package-mac-app.sh` derives a Sparkle-safe default from `APP_VERSION` (`YYYYMMDDNN`: stable defaults to `90`, prereleases use a suffix-derived lane) and uses the higher of that value and git commit count.
 - You can still override `APP_BUILD` explicitly when release engineering needs a specific monotonic value.
 - Defaults to the current architecture (`$(uname -m)`). For release/universal builds, set `BUILD_ARCHS="arm64 x86_64"` (or `BUILD_ARCHS=all`).
 - Use `scripts/package-mac-dist.sh` for release artifacts (zip + DMG + notarization). Use `scripts/package-mac-app.sh` for local/dev packaging.

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -35,6 +35,8 @@ canonical_build_from_version() {
     local year="${BASH_REMATCH[1]}"
     local month="${BASH_REMATCH[2]}"
     local day="${BASH_REMATCH[3]}"
+    local month_dec=$((10#$month))
+    local day_dec=$((10#$day))
     local suffix="${BASH_REMATCH[4]:-}"
     local lane=90
     # Keep stable releases above same-day prereleases so Sparkle can advance beta -> stable.
@@ -48,7 +50,7 @@ canonical_build_from_version() {
         lane=1
       fi
     fi
-    printf "%d%02d%02d%02d" "$year" "$month" "$day" "$lane"
+    printf "%d%02d%02d%02d" "$year" "$month_dec" "$day_dec" "$lane"
     return 0
   fi
   return 1

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -56,7 +56,7 @@ canonical_build_from_version() {
   return 1
 }
 
-if [[ -z "${APP_BUILD+x}" ]]; then
+if [[ -z "${APP_BUILD:-}" ]]; then
   APP_BUILD="$GIT_BUILD_NUMBER"
   if CANONICAL_BUILD="$(canonical_build_from_version "$APP_VERSION")"; then
     if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -14,7 +14,6 @@ BUILD_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT=$(cd "$ROOT_DIR" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_BUILD_NUMBER=$(cd "$ROOT_DIR" && git rev-list --count HEAD 2>/dev/null || echo "0")
 APP_VERSION="${APP_VERSION:-$PKG_VERSION}"
-APP_BUILD="${APP_BUILD:-$GIT_BUILD_NUMBER}"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
 BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
 if [[ "${BUILD_ARCHS_VALUE}" == "all" ]]; then
@@ -29,6 +28,30 @@ if [[ "$BUNDLE_ID" == *.debug ]]; then
   SPARKLE_FEED_URL=""
   AUTO_CHECKS=false
 fi
+
+canonical_build_from_version() {
+  local version="$1"
+  if [[ "$version" =~ ^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$ ]]; then
+    local year="${BASH_REMATCH[1]}"
+    local month="${BASH_REMATCH[2]}"
+    local day="${BASH_REMATCH[3]}"
+    printf "%d%02d%02d0" "$year" "$month" "$day"
+    return 0
+  fi
+  return 1
+}
+
+if [[ -z "${APP_BUILD+x}" ]]; then
+  APP_BUILD="$GIT_BUILD_NUMBER"
+  if CANONICAL_BUILD="$(canonical_build_from_version "$APP_VERSION")"; then
+    if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then
+      APP_BUILD="$CANONICAL_BUILD"
+    fi
+  fi
+else
+  APP_BUILD="${APP_BUILD}"
+fi
+
 if [[ "$AUTO_CHECKS" == "true" && ! "$APP_BUILD" =~ ^[0-9]+$ ]]; then
   echo "ERROR: APP_BUILD must be numeric for Sparkle compare (CFBundleVersion). Got: $APP_BUILD" >&2
   exit 1

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -14,6 +14,7 @@ BUILD_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT=$(cd "$ROOT_DIR" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_BUILD_NUMBER=$(cd "$ROOT_DIR" && git rev-list --count HEAD 2>/dev/null || echo "0")
 APP_VERSION="${APP_VERSION:-$PKG_VERSION}"
+APP_BUILD="${APP_BUILD:-}"
 BUILD_CONFIG="${BUILD_CONFIG:-debug}"
 BUILD_ARCHS_VALUE="${BUILD_ARCHS:-$(uname -m)}"
 if [[ "${BUILD_ARCHS_VALUE}" == "all" ]]; then
@@ -29,42 +30,17 @@ if [[ "$BUNDLE_ID" == *.debug ]]; then
   AUTO_CHECKS=false
 fi
 
-canonical_build_from_version() {
-  local version="$1"
-  if [[ "$version" =~ ^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$ ]]; then
-    local year="${BASH_REMATCH[1]}"
-    local month="${BASH_REMATCH[2]}"
-    local day="${BASH_REMATCH[3]}"
-    local month_dec=$((10#$month))
-    local day_dec=$((10#$day))
-    local suffix="${BASH_REMATCH[4]:-}"
-    local lane=90
-    # Keep stable releases above same-day prereleases so Sparkle can advance beta -> stable.
-    if [[ -n "$suffix" ]]; then
-      if [[ "$suffix" =~ ([0-9]+)$ ]]; then
-        lane=$((10#${BASH_REMATCH[1]}))
-        if (( lane > 89 )); then
-          lane=89
-        fi
-      else
-        lane=1
-      fi
-    fi
-    printf "%d%02d%02d%02d" "$year" "$month_dec" "$day_dec" "$lane"
-    return 0
-  fi
-  return 1
+sparkle_canonical_build_from_version() {
+  node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1"
 }
 
 if [[ -z "${APP_BUILD:-}" ]]; then
   APP_BUILD="$GIT_BUILD_NUMBER"
-  if CANONICAL_BUILD="$(canonical_build_from_version "$APP_VERSION")"; then
+  if CANONICAL_BUILD="$(sparkle_canonical_build_from_version "$APP_VERSION" 2>/dev/null)"; then
     if [[ "$CANONICAL_BUILD" =~ ^[0-9]+$ ]] && (( CANONICAL_BUILD > APP_BUILD )); then
       APP_BUILD="$CANONICAL_BUILD"
     fi
   fi
-else
-  APP_BUILD="${APP_BUILD}"
 fi
 
 if [[ "$AUTO_CHECKS" == "true" && ! "$APP_BUILD" =~ ^[0-9]+$ ]]; then

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -35,7 +35,20 @@ canonical_build_from_version() {
     local year="${BASH_REMATCH[1]}"
     local month="${BASH_REMATCH[2]}"
     local day="${BASH_REMATCH[3]}"
-    printf "%d%02d%02d0" "$year" "$month" "$day"
+    local suffix="${BASH_REMATCH[4]:-}"
+    local lane=90
+    # Keep stable releases above same-day prereleases so Sparkle can advance beta -> stable.
+    if [[ -n "$suffix" ]]; then
+      if [[ "$suffix" =~ ([0-9]+)$ ]]; then
+        lane=$((10#${BASH_REMATCH[1]}))
+        if (( lane > 89 )); then
+          lane=89
+        fi
+      else
+        lane=1
+      fi
+    fi
+    printf "%d%02d%02d%02d" "$year" "$month" "$day" "$lane"
     return 0
   fi
   return 1

--- a/scripts/sparkle-build.ts
+++ b/scripts/sparkle-build.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S node --import tsx
+
+import { pathToFileURL } from "node:url";
+
+export type SparkleBuildFloors = {
+  dateKey: number;
+  legacyFloor: number;
+  laneFloor: number;
+  lane: number;
+};
+
+const CALVER_REGEX = /^([0-9]{4})\.([0-9]{1,2})\.([0-9]{1,2})([.-].*)?$/;
+
+export function sparkleBuildFloorsFromShortVersion(
+  shortVersion: string,
+): SparkleBuildFloors | null {
+  const match = CALVER_REGEX.exec(shortVersion.trim());
+  if (!match) {
+    return null;
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return null;
+  }
+
+  const dateKey = Number(`${year}${String(month).padStart(2, "0")}${String(day).padStart(2, "0")}`);
+  const legacyFloor = Number(`${dateKey}0`);
+
+  let lane = 90;
+  const suffix = match[4] ?? "";
+  if (suffix.length > 0) {
+    const numericSuffix = /([0-9]+)$/.exec(suffix)?.[1];
+    if (numericSuffix) {
+      lane = Math.min(Number.parseInt(numericSuffix, 10), 89);
+    } else {
+      lane = 1;
+    }
+  }
+
+  const laneFloor = Number(`${dateKey}${String(lane).padStart(2, "0")}`);
+  return { dateKey, legacyFloor, laneFloor, lane };
+}
+
+export function canonicalSparkleBuildFromVersion(shortVersion: string): number | null {
+  return sparkleBuildFloorsFromShortVersion(shortVersion)?.laneFloor ?? null;
+}
+
+function runCli(args: string[]): number {
+  const [command, version] = args;
+  if (command !== "canonical-build" || !version) {
+    return 1;
+  }
+
+  const build = canonicalSparkleBuildFromVersion(version);
+  if (build === null) {
+    return 1;
+  }
+
+  console.log(String(build));
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(runCli(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Summary

- Problem: Sparkle update checks could offer stale/downgrade updates because `sparkle:version` values in `appcast.xml` were inconsistent with calver-based builds.
- Why it matters: Sparkle compares numeric build versions (`CFBundleVersion` / `sparkle:version`), so low or mixed numbering can make older entries appear newer.
- What changed:
  - made default `APP_BUILD` in `scripts/package-mac-app.sh` monotonic by taking `max(git_count, YYYYMMDD0 derived from APP_VERSION)` while still honoring explicit `APP_BUILD`
  - added `appcast.xml` validation to `scripts/release-check.ts` to fail when `sparkle:version` is missing/non-numeric or below the canonical calver floor
  - corrected appcast `sparkle:version` for `2026.2.25` to `202602250`
  - updated mac release docs to document the new default behavior and explicit override support
- What did NOT change (scope boundary): no runtime gateway/channel behavior changes; this is release/update correctness only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #26965
- Related #22954

## User-visible / Behavior Changes

- Mac packaging defaults now generate Sparkle-safe monotonic `CFBundleVersion` when `APP_BUILD` is not explicitly set.
- Release checks now fail fast on invalid/misaligned appcast Sparkle build versions.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo scripts
- Model/provider: n/a
- Integration/channel (if any): Sparkle appcast/update path
- Relevant config (redacted): n/a

### Steps

1. Run `pnpm release:check`.
2. Confirm appcast Sparkle version validation passes with corrected values.
3. Verify `scripts/package-mac-app.sh` now derives monotonic default build number from `APP_VERSION` when `APP_BUILD` is unset.

### Expected

- release check passes.
- default build numbering cannot undercut calver Sparkle build floors.

### Actual

- `pnpm release:check` passes after changes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:
- `release-check: appcast sparkle version validation failed: appcast item '2026.2.25' has sparkle:version 202602240 below canonical floor 202602250`

After:
- `release-check: npm pack contents look OK.`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - ran `pnpm release:check` successfully after fixes
  - confirmed branch synced to latest upstream before implementing
- Edge cases checked:
  - canonical floor parser supports calver suffixes (e.g. beta suffixes)
  - non-calver `shortVersionString` entries are ignored by floor check
- What you did **not** verify:
  - end-to-end Sparkle UI install flow on a signed app build

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR or set explicit `APP_BUILD` in release invocations
- Files/config to restore:
  - `scripts/package-mac-app.sh`
  - `scripts/release-check.ts`
  - `appcast.xml`
- Known bad symptoms reviewers should watch for:
  - release-check false positives on appcast entries
  - non-numeric app builds in release script invocations

## Risks and Mitigations

- Risk:
  - appcast validation could fail on unexpected legacy formatting.
  - Mitigation:
    - validation is narrowly scoped to numeric Sparkle version + calver floor, and skips non-calver short versions.
