### PR TITLE
fix(config): allow channels.signal.groups in schema

### DIFF
--- a/src/config/config.signal-groups.test.ts
+++ b/src/config/config.signal-groups.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+function expectValidConfig(result: ReturnType<typeof validateConfigObject>) {
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error("expected config to be valid");
+  }
+  return result.config;
+}
+
+describe("config signal groups", () => {
+  it("accepts channels.signal.groups requireMention overrides", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          groups: {
+            "*": { requireMention: false },
+            "group:abc123": { requireMention: true },
+          },
+        },
+      },
+    });
+
+    const config = expectValidConfig(res);
+    expect(config.channels?.signal?.groups?.["*"]?.requireMention).toBe(false);
+    expect(config.channels?.signal?.groups?.["group:abc123"]?.requireMention).toBe(true);
+  });
+
+  it("accepts channels.signal.accounts.*.groups overrides", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          accounts: {
+            personal: {
+              account: "+15550001111",
+              groups: {
+                "*": { requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const config = expectValidConfig(res);
+    expect(config.channels?.signal?.accounts?.personal?.groups?.["*"]?.requireMention).toBe(false);
+  });
+});

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,7 +1,14 @@
 import type { CommonChannelMessagingConfig } from "./types.channel-messaging-common.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
+
+export type SignalGroupConfig = {
+  requireMention?: boolean;
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+};
 
 export type SignalAccountConfig = CommonChannelMessagingConfig & {
   /** Optional explicit E.164 account for signal-cli. */
@@ -41,6 +48,8 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
    * - "extensive": Agent can react liberally
    */
   reactionLevel?: SignalReactionLevel;
+  /** Per-group mention + tool policy overrides. */
+  groups?: Record<string, SignalGroupConfig>;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -750,6 +750,19 @@ export const SignalAccountSchemaBase = z
     defaultTo: z.string().optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            requireMention: z.boolean().optional(),
+            tools: ToolPolicySchema,
+            toolsBySender: ToolPolicyBySenderSchema,
+          })
+          .strict()
+          .optional(),
+      )
+      .optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary
- add groups to SignalAccountSchemaBase so channels.signal.groups and channels.signal.accounts.*.groups pass config validation
- support requireMention, tools, and toolsBySender in Signal group entries (same policy knobs used by other channel configs)
- add Signal types for group overrides
- add config validation tests for top-level and account-scoped Signal groups

## Testing
- pnpm exec vitest run src/config/config.signal-groups.test.ts --config vitest.unit.config.ts

Fixes #20397