### PR TITLE
fix: add openclaw symlink to /usr/local/bin for kubectl exec usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docker/Image health checks: add Dockerfile `HEALTHCHECK` that probes gateway `GET /healthz` so container runtimes can mark unhealthy instances without requiring auth credentials in the probe command. (#11478) Thanks @U-C4N and @vincentkoc.
+- Docker/Kubernetes CLI exec: expose `openclaw` on `$PATH` inside the Docker image via `/usr/local/bin/openclaw` so `kubectl exec ... -- openclaw ...` works without invoking `node /app/openclaw.mjs`. (#27202) Thanks @thepagent.
 - Android/Nodes reliability: reject `facing=both` when `deviceId` is set to avoid mislabeled duplicate captures, allow notification `open`/`reply` on non-clearable entries while still gating dismiss, trigger listener rebind before notification actions, and scale invoke-result ack timeout to invoke budget for large clip payloads. (#28260) Thanks @obviyus.
 - Windows/Plugin install: avoid `spawn EINVAL` on Windows npm/npx invocations by resolving to `node` + npm CLI scripts instead of spawning `.cmd` directly. Landed from contributor PR #31147 by @codertony. Thanks @codertony.
 - LINE/Voice transcription: classify M4A voice media as `audio/mp4` (not `video/mp4`) by checking the MPEG-4 `ftyp` major brand (`M4A ` / `M4B `), restoring voice transcription for LINE voice messages. Landed from contributor PR #31151 by @scoootscooob. Thanks @scoootscooob.

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,6 @@ ENV NODE_ENV=production
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
-USER root
-# Add openclaw to PATH so `openclaw <command>` works inside the container
-RUN ln -s /app/openclaw.mjs /usr/local/bin/openclaw
-
 USER node
 
 # Start gateway server with default config.

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,10 @@ ENV NODE_ENV=production
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
+USER root
+# Add openclaw to PATH so `openclaw <command>` works inside the container
+RUN ln -s /app/openclaw.mjs /usr/local/bin/openclaw
+
 USER node
 
 # Start gateway server with default config.


### PR DESCRIPTION
## Problem

When running OpenClaw in Kubernetes, `openclaw` is not available in `$PATH` inside the container. The CLI entry point exists at `/app/openclaw.mjs` but has no symlink, so users must call `node /app/openclaw.mjs` explicitly when using `kubectl exec`.

This was raised in the Helm chart repo: https://github.com/serhanekicii/openclaw-helm/issues/14

## Fix

Add a symlink from `/app/openclaw.mjs` to `/usr/local/bin/openclaw` in the Dockerfile so the `openclaw` command works directly inside the container:

```bash
kubectl exec -n openclaw deployment/openclaw -- openclaw message send --channel telegram --target 123456 --message "hello"
```

## Change

One line added to `Dockerfile`:
```dockerfile
RUN ln -s /app/openclaw.mjs /usr/local/bin/openclaw
```