### PR TITLE
fix: stop Telegram typing heartbeat ticks after run completion

### DIFF
--- a/src/auto-reply/reply/typing.test.ts
+++ b/src/auto-reply/reply/typing.test.ts
@@ -25,11 +25,11 @@ describe("typing controller", () => {
 
     typing.markRunComplete();
     vi.advanceTimersByTime(1_000);
-    expect(onReplyStart).toHaveBeenCalledTimes(4);
+    expect(onReplyStart).toHaveBeenCalledTimes(3);
 
     typing.markDispatchIdle();
     vi.advanceTimersByTime(2_000);
-    expect(onReplyStart).toHaveBeenCalledTimes(4);
+    expect(onReplyStart).toHaveBeenCalledTimes(3);
   });
 
   it("keeps typing until both idle and run completion are set", async () => {

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -102,6 +102,9 @@ export function createTypingController(params: {
     if (sealed) {
       return;
     }
+    if (runComplete) {
+      return;
+    }
     await onReplyStart?.();
   };
 


### PR DESCRIPTION
Closes #27177

## Problem
Telegram typing can persist indefinitely after an agent run finishes because the typing heartbeat may fire during the run-complete/dispatch-idle boundary and re-trigger channel typing callbacks.

## Root Cause
`createTypingController()` blocked late restarts in `ensureStart()`, but the interval callback path (`triggerTyping()`) only checked `sealed` and could still call `onReplyStart` after `markRunComplete()`.

## Fix
Guard `triggerTyping()` with `runComplete` so heartbeat interval ticks cannot invoke channel typing callbacks once the run is finished. Updated the typing controller test to assert no extra typing signals after run completion before dispatcher idle.

## Testing
- `pnpm exec vitest run src/auto-reply/reply/typing.test.ts` (17 tests passed)
