### PR TITLE
discord: pass SSRF policy to attachment downloads

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -104,11 +104,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     discordRestFetch,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
+  const ssrfPolicy = cfg.browser?.ssrfPolicy;
+  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch, ssrfPolicy);
   const forwardedMediaList = await resolveForwardedMediaList(
     message,
     mediaMaxBytes,
     discordRestFetch,
+    ssrfPolicy,
   );
   mediaList.push(...forwardedMediaList);
   const text = messageText;

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -507,6 +507,9 @@ describe("agents.files.list", () => {
 });
 
 describe("agents.files.get/set symlink safety", () => {
+  // These tests need to be platform-agnostic (Windows uses backslashes).
+  const norm = (p: string) => p.replace(/\\/g, "/");
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.loadConfigReturn = {};
@@ -517,17 +520,17 @@ describe("agents.files.get/set symlink safety", () => {
     const workspace = "/workspace/test-agent";
     const candidate = `${workspace}/AGENTS.md`;
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      if (norm(p) === norm(workspace)) {
         return workspace;
       }
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return "/outside/secret.txt";
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return makeSymlinkStat();
       }
       throw createEnoentError();
@@ -550,17 +553,17 @@ describe("agents.files.get/set symlink safety", () => {
     const workspace = "/workspace/test-agent";
     const candidate = `${workspace}/AGENTS.md`;
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      if (norm(p) === norm(workspace)) {
         return workspace;
       }
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return "/outside/secret.txt";
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return makeSymlinkStat();
       }
       throw createEnoentError();
@@ -588,27 +591,27 @@ describe("agents.files.get/set symlink safety", () => {
     const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
 
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
+      if (norm(p) === norm(workspace)) {
         return workspace;
       }
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return target;
       }
       return p;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === candidate) {
+      if (norm(p) === norm(candidate)) {
         return makeSymlinkStat({ dev: 9, ino: 41 });
       }
-      if (p === target) {
+      if (norm(p) === norm(target)) {
         return targetStat;
       }
       throw createEnoentError();
     });
     mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === target) {
+      if (norm(p) === norm(target)) {
         return targetStat;
       }
       throw createEnoentError();


### PR DESCRIPTION
### Problem
OpenClaw blocks Discord attachment downloads when the attachment host resolves to a private/internal/special-use IP (SSRF guard). This is correct behavior, but in some environments (e.g. local proxy/TUN/DNS pinning) public hosts like cdn.discordapp.com may incorrectly resolve to special-use ranges, which prevents any image attachments from being downloaded and therefore disables vision for Discord messages.

### Proposed change
Pass configured SSRF policy to Discord attachment downloads so users can add explicit hostname exceptions via existing config keys:
- browser.ssrfPolicy.allowedHostnames
- browser.ssrfPolicy.hostnameAllowlist

### Implementation
- In Discord message processing, read SSRF policy from config (cfg.browser.ssrfPolicy)
- Thread this policy through resolveMediaList / resolveForwardedMediaList into fetchRemoteMedia() calls

### Notes
- Reuses existing SSRF policy plumbing rather than adding new config surface.
- Default behavior remains unchanged when ssrfPolicy is not configured.

### Test
pnpm -w vitest src/discord/monitor/message-utils.test.ts
