### PR TITLE
feat(discord): support appliedTagIds in thread-create for forum posts

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -363,13 +363,11 @@ export async function handleDiscordMessagingAction(
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
           ? autoArchiveMinutesRaw
           : undefined;
+      const appliedTagIds = readStringArrayParam(params, "appliedTagIds");
+      const threadPayload = { name, messageId, autoArchiveMinutes, content, appliedTagIds };
       const thread = accountId
-        ? await createThreadDiscord(
-            channelId,
-            { name, messageId, autoArchiveMinutes, content },
-            { accountId },
-          )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes, content });
+        ? await createThreadDiscord(channelId, threadPayload, { accountId })
+        : await createThreadDiscord(channelId, threadPayload);
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -311,6 +311,13 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTagIds: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Tag IDs to apply when creating a forum/media channel post. " +
+          "Use channel-info to discover available tags.",
+      }),
+    ),
   };
 }
 

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -124,6 +124,9 @@ export async function createThreadDiscord(
   if (isForumLike) {
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
+    if (payload.appliedTagIds?.length) {
+      body.applied_tags = payload.appliedTagIds;
+    }
   }
   // When creating a standalone thread (no messageId) in a non-forum channel,
   // default to public thread (type 11). Discord defaults to private (type 12)

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -74,6 +74,8 @@ export type DiscordThreadCreate = {
   content?: string;
   /** Discord thread type (default: PublicThread for standalone threads). */
   type?: number;
+  /** Tag IDs to apply when creating a post in a forum/media channel. */
+  appliedTagIds?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

Add `appliedTagIds` parameter to the `thread-create` action, allowing AI agents to apply tags when creating posts in forum/media channels.

## Changes

- **`send.types.ts`**: Add `appliedTagIds?: string[]` to `DiscordThreadCreate`
- **`send.messages.ts`**: Pass `applied_tags` in request body for forum/media channels
- **`message-tool.ts`**: Add `appliedTagIds` (string array) to thread schema
- **`discord-actions-messaging.ts`**: Wire `readStringArrayParam` for `appliedTagIds`

## Context

This complements #12070 (forum tag management via `channel-edit`, merged 2/21) by enabling tag application during post creation. Use `channel-info` to discover available tags for a forum channel.

Supersedes #12074 — rebased on latest main with a cleaner, minimal implementation (4 files, +16/-6).