### PR TITLE
fix(session): preserve lastAccountId on session reset

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -511,6 +511,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         label: entry?.label,
         origin: snapshotSessionOrigin(entry),
         lastChannel: entry?.lastChannel,
+        lastAccountId: entry?.lastAccountId,
         lastTo: entry?.lastTo,
         skillsSnapshot: entry?.skillsSnapshot,
         // Reset token counts to 0 on session reset (#1523)


### PR DESCRIPTION
## Summary

- **Problem:** Session reset path in `sessions.ts` did not carry over `lastAccountId` when constructing `nextEntry`.
- **Why it matters:** `lastAccountId` is used by routing and `inbound_meta` to populate the `account_id` field. Losing it after a reset causes the next conversation to see an empty `account_id`, breaking isolated cron delivery targets and inbound metadata.
- **What changed:** Added `lastAccountId: entry?.lastAccountId` to the reset path in `sessions.ts`, consistent with `lastChannel` and `lastTo` which were already preserved.
- **What did NOT change:** Write logic for `lastAccountId`, inbound-meta template, routing rules, or any other field.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Related: `feat(inbound-meta): add account_id to trusted metadata` (d90873390)

## User-visible / Behavior Changes

After a session reset, `account_id` in the `inbound_meta` system prompt block is now correctly carried over from the previous session, consistent with `chat_id` and `channel`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+ / Bun
- Integration/channel: Any channel that sets `lastAccountId` (e.g. WhatsApp multi-account)

### Steps

1. Start a session on a channel that sets `lastAccountId`.
2. Trigger a session reset.
3. Send a new message and inspect the `inbound_meta` block in the system prompt.

### Expected

- `account_id` matches the pre-reset session's account.

### Actual (before fix)

- `account_id` is empty after reset.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets

## Human Verification (required)

- Verified scenarios: code review against the `lastChannel`/`lastTo` pattern in the same block
- Edge cases checked: `entry` is `undefined` — optional chaining `entry?.lastAccountId` handles it gracefully
- What you did **not** verify: live multi-account WhatsApp reset flow end-to-end

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: revert the single-line addition in `sessions.ts`
- Known bad symptoms: `account_id` empty in `inbound_meta` after session reset

## Risks and Mitigations

- None
