### PR TITLE
CI: shard Windows test lane for faster CI critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,12 +418,23 @@ jobs:
         include:
           - runtime: node
             task: lint
+            shard_index: 0
+            shard_count: 1
             command: pnpm lint
           - runtime: node
             task: test
+            shard_index: 1
+            shard_count: 2
+            command: pnpm canvas:a2ui:bundle && pnpm test
+          - runtime: node
+            task: test
+            shard_index: 2
+            shard_count: 2
             command: pnpm canvas:a2ui:bundle && pnpm test
           - runtime: node
             task: protocol
+            shard_index: 0
+            shard_count: 1
             command: pnpm protocol:check
     steps:
       - name: Checkout
@@ -495,6 +506,12 @@ jobs:
           pnpm -v
           pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
+      - name: Configure test shard (Windows)
+        if: matrix.task == 'test'
+        run: |
+          echo "OPENCLAW_TEST_SHARDS=${{ matrix.shard_count }}" >> "$GITHUB_ENV"
+          echo "OPENCLAW_TEST_SHARD_INDEX=${{ matrix.shard_index }}" >> "$GITHUB_ENV"
+
       - name: Configure vitest JSON reports
         if: matrix.task == 'test'
         run: echo "OPENCLAW_VITEST_REPORT_DIR=$RUNNER_TEMP/vitest-reports" >> "$GITHUB_ENV"
@@ -512,7 +529,7 @@ jobs:
         if: matrix.task == 'test'
         uses: actions/upload-artifact@v4
         with:
-          name: vitest-reports-${{ runner.os }}-${{ matrix.runtime }}
+          name: vitest-reports-${{ runner.os }}-${{ matrix.runtime }}-shard${{ matrix.shard_index }}of${{ matrix.shard_count }}
           path: |
             ${{ env.OPENCLAW_VITEST_REPORT_DIR }}
             ${{ runner.temp }}/vitest-slowest.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.2.25
+## 2026.2.25 (Unreleased)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.
 - Docker/GCP onboarding: reduce first-build OOM risk by capping Node heap during `pnpm install`, reuse existing gateway token during `docker-setup.sh` reruns so `.env` stays aligned with config, auto-bootstrap Control UI allowed origins for non-loopback Docker binds, and add GCP docs guidance for tokenized dashboard links + pairing recovery commands. (#26253) Thanks @pandego.
 - Agents/Subagents delivery: refactor subagent completion announce dispatch into an explicit queue/direct/fallback state machine, recover outbound channel-plugin resolution in cold/stale plugin-registry states across announce/message/gateway send paths, finalize cleanup bookkeeping when announce flow rejects, and treat Telegram sends without `message_id` as delivery failures (instead of false-success `"unknown"` IDs). (#26867, #25961, #26803, #25069, #26741) Thanks @SmithLabsLLC and @docaohieu2808.
 - Telegram/Webhook: pre-initialize webhook bots, switch webhook processing to callback-mode JSON handling, and preserve full near-limit payload reads under delayed handlers to prevent webhook request hangs and dropped updates. (#26156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.2.25 (Unreleased)
+## 2026.2.26 (Unreleased)
+
+### Fixes
+
+- CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.
+
+## 2026.2.25
 
 ### Changes
 
@@ -22,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.
 - Docker/GCP onboarding: reduce first-build OOM risk by capping Node heap during `pnpm install`, reuse existing gateway token during `docker-setup.sh` reruns so `.env` stays aligned with config, auto-bootstrap Control UI allowed origins for non-loopback Docker binds, and add GCP docs guidance for tokenized dashboard links + pairing recovery commands. (#26253) Thanks @pandego.
 - Agents/Subagents delivery: refactor subagent completion announce dispatch into an explicit queue/direct/fallback state machine, recover outbound channel-plugin resolution in cold/stale plugin-registry states across announce/message/gateway send paths, finalize cleanup bookkeeping when announce flow rejects, and treat Telegram sends without `message_id` as delivery failures (instead of false-success `"unknown"` IDs). (#26867, #25961, #26803, #25069, #26741) Thanks @SmithLabsLLC and @docaohieu2808.
 - Telegram/Webhook: pre-initialize webhook bots, switch webhook processing to callback-mode JSON handling, and preserve full near-limit payload reads under delayed handlers to prevent webhook request hangs and dropped updates. (#26156)


### PR DESCRIPTION
## Summary
- split the `checks-windows` test lane into two matrix shards (`shard_index: 1/2`, `shard_index: 2/2`) so Windows test work runs in parallel jobs instead of one sequential job
- wire shard env vars in workflow (`OPENCLAW_TEST_SHARDS`, `OPENCLAW_TEST_SHARD_INDEX`) and keep shard-specific vitest report artifact names
- update `scripts/test-parallel.mjs` so shard behavior can be controlled explicitly via env overrides on any platform and validates invalid shard/index combinations early

## Why
Windows CI test runtime is the main bottleneck. Sharding reduces the critical path to the slower of two shard jobs.

## Benchmark (UTM Windows 11 Home)
- baseline full run (`pnpm canvas:a2ui:bundle && pnpm test` with sequential internal shards): `1913.04s`
- shard 1 (`OPENCLAW_TEST_SHARDS=2`, `OPENCLAW_TEST_SHARD_INDEX=1`): `1328.71s`
- shard 2 (`OPENCLAW_TEST_SHARDS=2`, `OPENCLAW_TEST_SHARD_INDEX=2`): `1276.37s`
- projected critical path reduction vs baseline: `~30.5%` (`1913.04s -> 1328.71s`)
- using recent GitHub Windows lane average (`~12.83m`), projected new lane: `~8.91m` (about `3.92m` faster)

## Validation
- `node --check scripts/test-parallel.mjs`
- workflow YAML parse check passed

## Notes
- the benchmark runs include existing Windows test failures already present in this branch/repo; the timing delta is still representative for CI critical-path estimation
