### PR TITLE
fix(telegram): add type guard for reply context text/caption

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -344,6 +344,46 @@ describe("describeReplyTarget", () => {
     expect(result?.forwardedFrom?.fromId).toBe("123");
     expect(result?.forwardedFrom?.date).toBe(700);
   });
+
+  it("handles non-string text gracefully instead of producing [object Object]", () => {
+    const result = describeReplyTarget({
+      message_id: 10,
+      date: 2000,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 9,
+        date: 1900,
+        chat: { id: 1, type: "private" },
+        // Simulate an edge case where text is an object instead of a string
+        text: { entities: [] } as unknown as string,
+        from: { id: 50, first_name: "Charlie", is_bot: false },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    // Should return null because the non-string text is treated as empty,
+    // NOT produce a body containing "[object Object]".
+    expect(result).toBeNull();
+  });
+
+  it("handles non-string caption gracefully", () => {
+    const result = describeReplyTarget({
+      message_id: 11,
+      date: 2100,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 10,
+        date: 2000,
+        chat: { id: 1, type: "private" },
+        caption: { raw: "some data" } as unknown as string,
+        photo: [{ file_id: "abc", file_unique_id: "u1", width: 100, height: 100 }],
+        from: { id: 51, first_name: "Diana", is_bot: false },
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+    // Should fall through to media placeholder instead of [object Object]
+    expect(result).not.toBeNull();
+    expect(result?.body).not.toContain("[object Object]");
+  });
 });
 
 describe("expandTextLinks", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -369,7 +369,8 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
 
   const replyLike = reply ?? externalReply;
   if (!body && replyLike) {
-    const replyBody = (replyLike.text ?? replyLike.caption ?? "").trim();
+    const rawReplyText = replyLike.text ?? replyLike.caption ?? "";
+    const replyBody = (typeof rawReplyText === "string" ? rawReplyText : "").trim();
     body = replyBody;
     if (!body) {
       body = resolveTelegramMediaPlaceholder(replyLike) ?? "";

--- a/src/telegram/sequential-key.ts
+++ b/src/telegram/sequential-key.ts
@@ -33,7 +33,8 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     ctx.update?.edited_channel_post ??
     ctx.update?.callback_query?.message;
   const chatId = msg?.chat?.id ?? ctx.chat?.id;
-  const rawText = msg?.text ?? msg?.caption;
+  const rawTextValue = msg?.text ?? msg?.caption;
+  const rawText = typeof rawTextValue === "string" ? rawTextValue : undefined;
   const botUsername = ctx.me?.username;
   if (isAbortRequestText(rawText, botUsername ? { botUsername } : undefined)) {
     if (typeof chatId === "number") {


### PR DESCRIPTION
Fixes #27201

## Summary

When processing a Telegram reply context, `describeReplyTarget()` in `src/telegram/bot/helpers.ts` did not check if `replyLike.text` or `replyLike.caption` were strings before using them. In edge cases where the Telegram API returns a non-string value (e.g., an object), JavaScript's string coercion results in `[object Object]` appearing in the delivered message content.

This commit fixes the issue by adding a `typeof rawReplyText === "string"` guard to ensure that only string values are used. This prevents the `[object Object]` bug and aligns the reply context logic with existing safe patterns in the codebase.

## Changes

| File | What changed |
|---|---|
| `src/telegram/bot/helpers.ts` | Added a `typeof` check for `replyLike.text ?? replyLike.caption` in `describeReplyTarget()`. |
| `src/telegram/bot.ts` | Added a similar defensive `typeof` guard in `getTelegramSequentialKey()` for `msg.text ?? msg.caption`. |
| `src/telegram/bot/helpers.test.ts` | Added two new test cases to verify that non-string `text` and `caption` values are handled gracefully and do not produce `[object Object]`. |


