### PR TITLE
[FEAT] Expose requestHeartbeatNow in Plugin SDK

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -103,6 +103,7 @@ function createMockRuntime(): PluginRuntime {
     system: {
       enqueueSystemEvent:
         mockEnqueueSystemEvent as unknown as PluginRuntime["system"]["enqueueSystemEvent"],
+      requestHeartbeatNow: vi.fn() as unknown as PluginRuntime["system"]["requestHeartbeatNow"],
       runCommandWithTimeout: vi.fn() as unknown as PluginRuntime["system"]["runCommandWithTimeout"],
       formatNativeDependencyHint: vi.fn(
         () => "",

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -75,6 +75,7 @@ describe("handleFeishuMessage command authorization", () => {
     setFeishuRuntime({
       system: {
         enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
       },
       channel: {
         routing: {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -8,6 +8,13 @@ vi.mock("../../process/exec.js", () => ({
 
 import { createPluginRuntime } from "./index.js";
 
+describe("plugin runtime system surface", () => {
+  it("exposes requestHeartbeatNow on system", () => {
+    const runtime = createPluginRuntime();
+    expect(typeof runtime.system.requestHeartbeatNow).toBe("function");
+  });
+});
+
 describe("plugin runtime command execution", () => {
   beforeEach(() => {
     runCommandWithTimeoutMock.mockClear();

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -71,6 +71,7 @@ import { monitorIMessageProvider } from "../../imessage/monitor.js";
 import { probeIMessage } from "../../imessage/probe.js";
 import { sendMessageIMessage } from "../../imessage/send.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   listLineAccountIds,
@@ -260,6 +261,7 @@ function createRuntimeConfig(): PluginRuntime["config"] {
 function createRuntimeSystem(): PluginRuntime["system"] {
   return {
     enqueueSystemEvent,
+    requestHeartbeatNow,
     runCommandWithTimeout,
     formatNativeDependencyHint,
   };

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -73,6 +73,7 @@ type WriteConfigFile = typeof import("../../config/config.js").writeConfigFile;
 type RecordChannelActivity = typeof import("../../infra/channel-activity.js").recordChannelActivity;
 type GetChannelActivity = typeof import("../../infra/channel-activity.js").getChannelActivity;
 type EnqueueSystemEvent = typeof import("../../infra/system-events.js").enqueueSystemEvent;
+type RequestHeartbeatNow = typeof import("../../infra/heartbeat-wake.js").requestHeartbeatNow;
 type RunCommandWithTimeout = typeof import("../../process/exec.js").runCommandWithTimeout;
 type FormatNativeDependencyHint = typeof import("./native-deps.js").formatNativeDependencyHint;
 type LoadWebMedia = typeof import("../../web/media.js").loadWebMedia;
@@ -184,6 +185,7 @@ export type PluginRuntime = {
   };
   system: {
     enqueueSystemEvent: EnqueueSystemEvent;
+    requestHeartbeatNow: RequestHeartbeatNow;
     runCommandWithTimeout: RunCommandWithTimeout;
     formatNativeDependencyHint: FormatNativeDependencyHint;
   };


### PR DESCRIPTION
## Summary
- Add `requestHeartbeatNow` to `PluginRuntime.system`, enabling plugins
  and extensions to wake idle agent sessions on external events
- This matches the pattern already used internally by the Cron service

## Motivation
Webhook-based integrations (e.g. project boards, CI notifications) currently
have no way to wake an idle session. `enqueueSystemEvent` only queues —
events sit undelivered until the next heartbeat interval or inbound message.

## Test plan
- [x] `npx vitest run src/plugins/runtime` passes (3 tests)
- [x] `pnpm build` has no TS errors
- [x] `pnpm check` (format + tsgo + lint) passes