### PR TITLE
fix(line): save downloaded media under preferred OpenClaw tmp dir

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
Fixes LINE file/image/audio/video downloads being written to OS tmp (e.g. /tmp) which may not be in the default local media allowlist, causing errors like: "Local media path is not under an allowed directory".

Change: in src/line/download.ts, write downloaded media to resolvePreferredOpenClawTmpDir() and pass it to buildRandomTempFilePath({ tmpDir }).

Test: npx vitest run src/line/download.test.ts