### PR TITLE
fix(line): use resolved authorization for inline directives

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -252,7 +252,9 @@ export async function resolveReplyDirectives(params: {
       }
     }
   }
-  let directives = commandAuthorized
+  // Use command.isAuthorizedSender (resolved authorization) instead of raw commandAuthorized
+  // to ensure inline directives work when commands.allowFrom grants access (e.g., LINE).
+  let directives = command.isAuthorizedSender
     ? parsedDirectives
     : {
         ...parsedDirectives,


### PR DESCRIPTION
Fixes #27240

Use command.isAuthorizedSender (from resolveCommandAuthorization) instead of raw commandAuthorized when determining whether to process inline directives like /model, /think, /verbose.

This ensures inline directives work on LINE when commands.allowFrom grants access, even though LINE doesn't set CommandAuthorized in the inbound context.