### PR TITLE
feat(diagnostics): trace context propagation + log transport isolation fix

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -12,6 +12,10 @@ import {
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  createChildContext,
+  diagnosticTraceStore,
+} from "../../../infra/diagnostic-trace-context.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -306,859 +310,1008 @@ function summarizeSessionContext(messages: AgentMessage[]): {
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  const resolvedWorkspace = resolveUserPath(params.workspaceDir);
-  const prevCwd = process.cwd();
-  const runAbortController = new AbortController();
+  // Establish child trace context for this LLM attempt, inheriting the parent
+  // trace from dispatchReplyFromConfig's root context via AsyncLocalStorage.
+  const childCtx = createChildContext();
+  return diagnosticTraceStore.run(childCtx, async () => {
+    const resolvedWorkspace = resolveUserPath(params.workspaceDir);
+    const prevCwd = process.cwd();
+    const runAbortController = new AbortController();
 
-  log.debug(
-    `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
-  );
+    log.debug(
+      `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
+    );
 
-  await fs.mkdir(resolvedWorkspace, { recursive: true });
+    await fs.mkdir(resolvedWorkspace, { recursive: true });
 
-  const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
-  const sandbox = await resolveSandboxContext({
-    config: params.config,
-    sessionKey: sandboxSessionKey,
-    workspaceDir: resolvedWorkspace,
-  });
-  const effectiveWorkspace = sandbox?.enabled
-    ? sandbox.workspaceAccess === "rw"
-      ? resolvedWorkspace
-      : sandbox.workspaceDir
-    : resolvedWorkspace;
-  await fs.mkdir(effectiveWorkspace, { recursive: true });
-
-  let restoreSkillEnv: (() => void) | undefined;
-  process.chdir(effectiveWorkspace);
-  try {
-    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
-    const skillEntries = shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(effectiveWorkspace)
-      : [];
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
-
-    const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+    const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
+    const sandbox = await resolveSandboxContext({
       config: params.config,
-      workspaceDir: effectiveWorkspace,
+      sessionKey: sandboxSessionKey,
+      workspaceDir: resolvedWorkspace,
     });
+    const effectiveWorkspace = sandbox?.enabled
+      ? sandbox.workspaceAccess === "rw"
+        ? resolvedWorkspace
+        : sandbox.workspaceDir
+      : resolvedWorkspace;
+    await fs.mkdir(effectiveWorkspace, { recursive: true });
 
-    const sessionLabel = params.sessionKey ?? params.sessionId;
-    const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
-      await resolveBootstrapContextForRun({
-        workspaceDir: effectiveWorkspace,
+    let restoreSkillEnv: (() => void) | undefined;
+    process.chdir(effectiveWorkspace);
+    try {
+      const shouldLoadSkillEntries =
+        !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+      const skillEntries = shouldLoadSkillEntries
+        ? loadWorkspaceSkillEntries(effectiveWorkspace)
+        : [];
+      restoreSkillEnv = params.skillsSnapshot
+        ? applySkillEnvOverridesFromSnapshot({
+            snapshot: params.skillsSnapshot,
+            config: params.config,
+          })
+        : applySkillEnvOverrides({
+            skills: skillEntries ?? [],
+            config: params.config,
+          });
+
+      const skillsPrompt = resolveSkillsPromptForRun({
+        skillsSnapshot: params.skillsSnapshot,
+        entries: shouldLoadSkillEntries ? skillEntries : undefined,
         config: params.config,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+        workspaceDir: effectiveWorkspace,
       });
-    const workspaceNotes = hookAdjustedBootstrapFiles.some(
-      (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
-    )
-      ? ["Reminder: commit your changes in this workspace after edits."]
-      : undefined;
 
-    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-
-    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-      agentId: params.agentId,
-    });
-    const effectiveFsWorkspaceOnly = resolveAttemptFsWorkspaceOnly({
-      config: params.config,
-      sessionAgentId,
-    });
-    // Check if the model supports native image input
-    const modelHasVision = params.model.input?.includes("image") ?? false;
-    const toolsRaw = params.disableTools
-      ? []
-      : createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          sessionKey: params.sessionKey ?? params.sessionId,
-          agentDir,
+      const sessionLabel = params.sessionKey ?? params.sessionId;
+      const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
+        await resolveBootstrapContextForRun({
           workspaceDir: effectiveWorkspace,
           config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-        });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
-    const allowedToolNames = collectAllowedToolNames({
-      tools,
-      clientTools: params.clientTools,
-    });
-    logToolSchemasForGoogle({ tools, provider: params.provider });
-
-    const machineName = await getMachineDisplayName();
-    const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
-    let runtimeCapabilities = runtimeChannel
-      ? (resolveChannelCapabilities({
-          cfg: params.config,
-          channel: runtimeChannel,
-          accountId: params.agentAccountId,
-        }) ?? [])
-      : undefined;
-    if (runtimeChannel === "telegram" && params.config) {
-      const inlineButtonsScope = resolveTelegramInlineButtonsScope({
-        cfg: params.config,
-        accountId: params.agentAccountId ?? undefined,
-      });
-      if (inlineButtonsScope !== "off") {
-        if (!runtimeCapabilities) {
-          runtimeCapabilities = [];
-        }
-        if (
-          !runtimeCapabilities.some((cap) => String(cap).trim().toLowerCase() === "inlinebuttons")
-        ) {
-          runtimeCapabilities.push("inlineButtons");
-        }
-      }
-    }
-    const reactionGuidance =
-      runtimeChannel && params.config
-        ? (() => {
-            if (runtimeChannel === "telegram") {
-              const resolved = resolveTelegramReactionLevel({
-                cfg: params.config,
-                accountId: params.agentAccountId ?? undefined,
-              });
-              const level = resolved.agentReactionGuidance;
-              return level ? { level, channel: "Telegram" } : undefined;
-            }
-            if (runtimeChannel === "signal") {
-              const resolved = resolveSignalReactionLevel({
-                cfg: params.config,
-                accountId: params.agentAccountId ?? undefined,
-              });
-              const level = resolved.agentReactionGuidance;
-              return level ? { level, channel: "Signal" } : undefined;
-            }
-            return undefined;
-          })()
-        : undefined;
-    const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
-    const reasoningTagHint = isReasoningTagProvider(params.provider);
-    // Resolve channel-specific message actions for system prompt
-    const channelActions = runtimeChannel
-      ? listChannelSupportedActions({
-          cfg: params.config,
-          channel: runtimeChannel,
-        })
-      : undefined;
-    const messageToolHints = runtimeChannel
-      ? resolveChannelMessageToolHints({
-          cfg: params.config,
-          channel: runtimeChannel,
-          accountId: params.agentAccountId,
-        })
-      : undefined;
-
-    const defaultModelRef = resolveDefaultModelForAgent({
-      cfg: params.config ?? {},
-      agentId: sessionAgentId,
-    });
-    const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-    const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
-      config: params.config,
-      agentId: sessionAgentId,
-      workspaceDir: effectiveWorkspace,
-      cwd: process.cwd(),
-      runtime: {
-        host: machineName,
-        os: `${os.type()} ${os.release()}`,
-        arch: os.arch(),
-        node: process.version,
-        model: `${params.provider}/${params.modelId}`,
-        defaultModel: defaultModelLabel,
-        shell: detectRuntimeShell(),
-        channel: runtimeChannel,
-        capabilities: runtimeCapabilities,
-        channelActions,
-      },
-    });
-    const isDefaultAgent = sessionAgentId === defaultAgentId;
-    const promptMode = resolvePromptModeForSession(params.sessionKey);
-    const docsPath = await resolveOpenClawDocsPath({
-      workspaceDir: effectiveWorkspace,
-      argv1: process.argv[1],
-      cwd: process.cwd(),
-      moduleUrl: import.meta.url,
-    });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
-    const ownerDisplay = resolveOwnerDisplaySetting(params.config);
-
-    const appendPrompt = buildEmbeddedSystemPrompt({
-      workspaceDir: effectiveWorkspace,
-      defaultThinkLevel: params.thinkLevel,
-      reasoningLevel: params.reasoningLevel ?? "off",
-      extraSystemPrompt: params.extraSystemPrompt,
-      ownerNumbers: params.ownerNumbers,
-      ownerDisplay: ownerDisplay.ownerDisplay,
-      ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
-      reasoningTagHint,
-      heartbeatPrompt: isDefaultAgent
-        ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
-        : undefined,
-      skillsPrompt,
-      docsPath: docsPath ?? undefined,
-      ttsHint,
-      workspaceNotes,
-      reactionGuidance,
-      promptMode,
-      runtimeInfo,
-      messageToolHints,
-      sandboxInfo,
-      tools,
-      modelAliasLines: buildModelAliasLines(params.config),
-      userTimezone,
-      userTime,
-      userTimeFormat,
-      contextFiles,
-      memoryCitationsMode: params.config?.memory?.citations,
-    });
-    const systemPromptReport = buildSystemPromptReport({
-      source: "run",
-      generatedAt: Date.now(),
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      provider: params.provider,
-      model: params.modelId,
-      workspaceDir: effectiveWorkspace,
-      bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
-      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
-      sandbox: (() => {
-        const runtime = resolveSandboxRuntimeStatus({
-          cfg: params.config,
-          sessionKey: params.sessionKey ?? params.sessionId,
-        });
-        return { mode: runtime.mode, sandboxed: runtime.sandboxed };
-      })(),
-      systemPrompt: appendPrompt,
-      bootstrapFiles: hookAdjustedBootstrapFiles,
-      injectedFiles: contextFiles,
-      skillsPrompt,
-      tools,
-    });
-    const systemPromptOverride = createSystemPromptOverride(appendPrompt);
-    let systemPromptText = systemPromptOverride();
-
-    const sessionLock = await acquireSessionWriteLock({
-      sessionFile: params.sessionFile,
-      maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
-        timeoutMs: params.timeoutMs,
-      }),
-    });
-
-    let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
-    let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
-    let removeToolResultContextGuard: (() => void) | undefined;
-    try {
-      await repairSessionFileIfNeeded({
-        sessionFile: params.sessionFile,
-        warn: (message) => log.warn(message),
-      });
-      const hadSessionFile = await fs
-        .stat(params.sessionFile)
-        .then(() => true)
-        .catch(() => false);
-
-      const transcriptPolicy = resolveTranscriptPolicy({
-        modelApi: params.model?.api,
-        provider: params.provider,
-        modelId: params.modelId,
-      });
-
-      await prewarmSessionFile(params.sessionFile);
-      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
-        agentId: sessionAgentId,
-        sessionKey: params.sessionKey,
-        inputProvenance: params.inputProvenance,
-        allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
-        allowedToolNames,
-      });
-      trackSessionManagerAccess(params.sessionFile);
-
-      await prepareSessionManagerForRun({
-        sessionManager,
-        sessionFile: params.sessionFile,
-        hadSessionFile,
-        sessionId: params.sessionId,
-        cwd: effectiveWorkspace,
-      });
-
-      const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
-      applyPiCompactionSettingsFromConfig({
-        settingsManager,
-        cfg: params.config,
-      });
-
-      // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
-      const extensionFactories = buildEmbeddedExtensionFactories({
-        cfg: params.config,
-        sessionManager,
-        provider: params.provider,
-        modelId: params.modelId,
-        model: params.model,
-      });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
-      }
-
-      // Get hook runner early so it's available when creating tools
-      const hookRunner = getGlobalHookRunner();
-
-      const { builtInTools, customTools } = splitSdkTools({
-        tools,
-        sandboxEnabled: !!sandbox?.enabled,
-      });
-
-      // Add client tools (OpenResponses hosted tools) to customTools
-      let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
-      const clientToolLoopDetection = resolveToolLoopDetectionConfig({
-        cfg: params.config,
-        agentId: sessionAgentId,
-      });
-      const clientToolDefs = params.clientTools
-        ? toClientToolDefinitions(
-            params.clientTools,
-            (toolName, toolParams) => {
-              clientToolCallDetected = { name: toolName, params: toolParams };
-            },
-            {
-              agentId: sessionAgentId,
-              sessionKey: params.sessionKey,
-              loopDetection: clientToolLoopDetection,
-            },
-          )
-        : [];
-
-      const allCustomTools = [...customTools, ...clientToolDefs];
-
-      ({ session } = await createAgentSession({
-        cwd: resolvedWorkspace,
-        agentDir,
-        authStorage: params.authStorage,
-        modelRegistry: params.modelRegistry,
-        model: params.model,
-        thinkingLevel: mapThinkingLevel(params.thinkLevel),
-        tools: builtInTools,
-        customTools: allCustomTools,
-        sessionManager,
-        settingsManager,
-        resourceLoader,
-      }));
-      applySystemPromptOverrideToSession(session, systemPromptText);
-      if (!session) {
-        throw new Error("Embedded agent session missing");
-      }
-      const activeSession = session;
-      removeToolResultContextGuard = installToolResultContextGuard({
-        agent: activeSession.agent,
-        contextWindowTokens: Math.max(
-          1,
-          Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-          ),
-        ),
-      });
-      const cacheTrace = createCacheTrace({
-        cfg: params.config,
-        env: process.env,
-        runId: params.runId,
-        sessionId: activeSession.sessionId,
-        sessionKey: params.sessionKey,
-        provider: params.provider,
-        modelId: params.modelId,
-        modelApi: params.model.api,
-        workspaceDir: params.workspaceDir,
-      });
-      const anthropicPayloadLogger = createAnthropicPayloadLogger({
-        env: process.env,
-        runId: params.runId,
-        sessionId: activeSession.sessionId,
-        sessionKey: params.sessionKey,
-        provider: params.provider,
-        modelId: params.modelId,
-        modelApi: params.model.api,
-        workspaceDir: params.workspaceDir,
-      });
-
-      // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
-      // for reliable streaming + tool calling support (#11828).
-      if (params.model.api === "ollama") {
-        // Use the resolved model baseUrl first so custom provider aliases work.
-        const providerConfig = params.config?.models?.providers?.[params.model.provider];
-        const modelBaseUrl =
-          typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : "";
-        const providerBaseUrl =
-          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
-        const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
-        activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
-      } else {
-        // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
-        activeSession.agent.streamFn = streamSimple;
-      }
-
-      applyExtraParamsToAgent(
-        activeSession.agent,
-        params.config,
-        params.provider,
-        params.modelId,
-        params.streamParams,
-        params.thinkLevel,
-        sessionAgentId,
-      );
-
-      if (cacheTrace) {
-        cacheTrace.recordStage("session:loaded", {
-          messages: activeSession.messages,
-          system: systemPromptText,
-          note: "after session create",
-        });
-        activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
-      }
-
-      // Copilot/Claude can reject persisted `thinking` blocks (e.g. thinkingSignature:"reasoning_text")
-      // on *any* follow-up provider call (including tool continuations). Wrap the stream function
-      // so every outbound request sees sanitized messages.
-      if (transcriptPolicy.dropThinkingBlocks) {
-        const inner = activeSession.agent.streamFn;
-        activeSession.agent.streamFn = (model, context, options) => {
-          const ctx = context as unknown as { messages?: unknown };
-          const messages = ctx?.messages;
-          if (!Array.isArray(messages)) {
-            return inner(model, context, options);
-          }
-          const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[]) as unknown;
-          if (sanitized === messages) {
-            return inner(model, context, options);
-          }
-          const nextContext = {
-            ...(context as unknown as Record<string, unknown>),
-            messages: sanitized,
-          } as unknown;
-          return inner(model, nextContext as typeof context, options);
-        };
-      }
-
-      // Mistral (and other strict providers) reject tool call IDs that don't match their
-      // format requirements (e.g. [a-zA-Z0-9]{9}). sanitizeSessionHistory only processes
-      // historical messages at attempt start, but the agent loop's internal tool call →
-      // tool result cycles bypass that path. Wrap streamFn so every outbound request
-      // sees sanitized tool call IDs.
-      if (transcriptPolicy.sanitizeToolCallIds && transcriptPolicy.toolCallIdMode) {
-        const inner = activeSession.agent.streamFn;
-        const mode = transcriptPolicy.toolCallIdMode;
-        activeSession.agent.streamFn = (model, context, options) => {
-          const ctx = context as unknown as { messages?: unknown };
-          const messages = ctx?.messages;
-          if (!Array.isArray(messages)) {
-            return inner(model, context, options);
-          }
-          const sanitized = sanitizeToolCallIdsForCloudCodeAssist(messages as AgentMessage[], mode);
-          if (sanitized === messages) {
-            return inner(model, context, options);
-          }
-          const nextContext = {
-            ...(context as unknown as Record<string, unknown>),
-            messages: sanitized,
-          } as unknown;
-          return inner(model, nextContext as typeof context, options);
-        };
-      }
-
-      if (anthropicPayloadLogger) {
-        activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(
-          activeSession.agent.streamFn,
-        );
-      }
-
-      try {
-        const prior = await sanitizeSessionHistory({
-          messages: activeSession.messages,
-          modelApi: params.model.api,
-          modelId: params.modelId,
-          provider: params.provider,
-          allowedToolNames,
-          config: params.config,
-          sessionManager,
+          sessionKey: params.sessionKey,
           sessionId: params.sessionId,
-          policy: transcriptPolicy,
+          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
         });
-        cacheTrace?.recordStage("session:sanitized", { messages: prior });
-        const validatedGemini = transcriptPolicy.validateGeminiTurns
-          ? validateGeminiTurns(prior)
-          : prior;
-        const validated = transcriptPolicy.validateAnthropicTurns
-          ? validateAnthropicTurns(validatedGemini)
-          : validatedGemini;
-        const truncated = limitHistoryTurns(
-          validated,
-          getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
-        );
-        // Re-run tool_use/tool_result pairing repair after truncation, since
-        // limitHistoryTurns can orphan tool_result blocks by removing the
-        // assistant message that contained the matching tool_use.
-        const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
-          : truncated;
-        cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0) {
-          activeSession.agent.replaceMessages(limited);
-        }
-      } catch (err) {
-        await flushPendingToolResultsAfterIdle({
-          agent: activeSession?.agent,
-          sessionManager,
-        });
-        activeSession.dispose();
-        throw err;
-      }
+      const workspaceNotes = hookAdjustedBootstrapFiles.some(
+        (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
+      )
+        ? ["Reminder: commit your changes in this workspace after edits."]
+        : undefined;
 
-      let aborted = Boolean(params.abortSignal?.aborted);
-      let timedOut = false;
-      let timedOutDuringCompaction = false;
-      const getAbortReason = (signal: AbortSignal): unknown =>
-        "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
-      const makeTimeoutAbortReason = (): Error => {
-        const err = new Error("request timed out");
-        err.name = "TimeoutError";
-        return err;
-      };
-      const makeAbortError = (signal: AbortSignal): Error => {
-        const reason = getAbortReason(signal);
-        const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
-        err.name = "AbortError";
-        return err;
-      };
-      const abortRun = (isTimeout = false, reason?: unknown) => {
-        aborted = true;
-        if (isTimeout) {
-          timedOut = true;
-        }
-        if (isTimeout) {
-          runAbortController.abort(reason ?? makeTimeoutAbortReason());
-        } else {
-          runAbortController.abort(reason);
-        }
-        void activeSession.abort();
-      };
-      const abortable = <T>(promise: Promise<T>): Promise<T> => {
-        const signal = runAbortController.signal;
-        if (signal.aborted) {
-          return Promise.reject(makeAbortError(signal));
-        }
-        return new Promise<T>((resolve, reject) => {
-          const onAbort = () => {
-            signal.removeEventListener("abort", onAbort);
-            reject(makeAbortError(signal));
-          };
-          signal.addEventListener("abort", onAbort, { once: true });
-          promise.then(
-            (value) => {
-              signal.removeEventListener("abort", onAbort);
-              resolve(value);
-            },
-            (err) => {
-              signal.removeEventListener("abort", onAbort);
-              reject(err);
-            },
-          );
-        });
-      };
+      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 
-      const subscription = subscribeEmbeddedPiSession({
-        session: activeSession,
-        runId: params.runId,
-        hookRunner: getGlobalHookRunner() ?? undefined,
-        verboseLevel: params.verboseLevel,
-        reasoningMode: params.reasoningLevel ?? "off",
-        toolResultFormat: params.toolResultFormat,
-        shouldEmitToolResult: params.shouldEmitToolResult,
-        shouldEmitToolOutput: params.shouldEmitToolOutput,
-        onToolResult: params.onToolResult,
-        onReasoningStream: params.onReasoningStream,
-        onReasoningEnd: params.onReasoningEnd,
-        onBlockReply: params.onBlockReply,
-        onBlockReplyFlush: params.onBlockReplyFlush,
-        blockReplyBreak: params.blockReplyBreak,
-        blockReplyChunking: params.blockReplyChunking,
-        onPartialReply: params.onPartialReply,
-        onAssistantMessageStart: params.onAssistantMessageStart,
-        onAgentEvent: params.onAgentEvent,
-        enforceFinalTag: params.enforceFinalTag,
+      const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+        sessionKey: params.sessionKey,
         config: params.config,
-        sessionKey: params.sessionKey ?? params.sessionId,
+        agentId: params.agentId,
       });
+      const effectiveFsWorkspaceOnly = resolveAttemptFsWorkspaceOnly({
+        config: params.config,
+        sessionAgentId,
+      });
+      // Check if the model supports native image input
+      const modelHasVision = params.model.input?.includes("image") ?? false;
+      const toolsRaw = params.disableTools
+        ? []
+        : createOpenClawCodingTools({
+            agentId: sessionAgentId,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
+            sandbox,
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            sessionKey: params.sessionKey ?? params.sessionId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+          });
+      const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
+      const allowedToolNames = collectAllowedToolNames({
+        tools,
+        clientTools: params.clientTools,
+      });
+      logToolSchemasForGoogle({ tools, provider: params.provider });
 
-      const {
-        assistantTexts,
-        toolMetas,
-        unsubscribe,
-        waitForCompactionRetry,
-        getMessagingToolSentTexts,
-        getMessagingToolSentMediaUrls,
-        getMessagingToolSentTargets,
-        getSuccessfulCronAdds,
-        didSendViaMessagingTool,
-        getLastToolError,
-        getUsageTotals,
-        getCompactionCount,
-      } = subscription;
-
-      const queueHandle: EmbeddedPiQueueHandle = {
-        queueMessage: async (text: string) => {
-          await activeSession.steer(text);
-        },
-        isStreaming: () => activeSession.isStreaming,
-        isCompacting: () => subscription.isCompacting(),
-        abort: abortRun,
-      };
-      setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
-
-      let abortWarnTimer: NodeJS.Timeout | undefined;
-      const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
-      const abortTimer = setTimeout(
-        () => {
-          if (!isProbeSession) {
-            log.warn(
-              `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
-            );
+      const machineName = await getMachineDisplayName();
+      const runtimeChannel = normalizeMessageChannel(
+        params.messageChannel ?? params.messageProvider,
+      );
+      let runtimeCapabilities = runtimeChannel
+        ? (resolveChannelCapabilities({
+            cfg: params.config,
+            channel: runtimeChannel,
+            accountId: params.agentAccountId,
+          }) ?? [])
+        : undefined;
+      if (runtimeChannel === "telegram" && params.config) {
+        const inlineButtonsScope = resolveTelegramInlineButtonsScope({
+          cfg: params.config,
+          accountId: params.agentAccountId ?? undefined,
+        });
+        if (inlineButtonsScope !== "off") {
+          if (!runtimeCapabilities) {
+            runtimeCapabilities = [];
           }
           if (
+            !runtimeCapabilities.some((cap) => String(cap).trim().toLowerCase() === "inlinebuttons")
+          ) {
+            runtimeCapabilities.push("inlineButtons");
+          }
+        }
+      }
+      const reactionGuidance =
+        runtimeChannel && params.config
+          ? (() => {
+              if (runtimeChannel === "telegram") {
+                const resolved = resolveTelegramReactionLevel({
+                  cfg: params.config,
+                  accountId: params.agentAccountId ?? undefined,
+                });
+                const level = resolved.agentReactionGuidance;
+                return level ? { level, channel: "Telegram" } : undefined;
+              }
+              if (runtimeChannel === "signal") {
+                const resolved = resolveSignalReactionLevel({
+                  cfg: params.config,
+                  accountId: params.agentAccountId ?? undefined,
+                });
+                const level = resolved.agentReactionGuidance;
+                return level ? { level, channel: "Signal" } : undefined;
+              }
+              return undefined;
+            })()
+          : undefined;
+      const sandboxInfo = buildEmbeddedSandboxInfo(sandbox, params.bashElevated);
+      const reasoningTagHint = isReasoningTagProvider(params.provider);
+      // Resolve channel-specific message actions for system prompt
+      const channelActions = runtimeChannel
+        ? listChannelSupportedActions({
+            cfg: params.config,
+            channel: runtimeChannel,
+          })
+        : undefined;
+      const messageToolHints = runtimeChannel
+        ? resolveChannelMessageToolHints({
+            cfg: params.config,
+            channel: runtimeChannel,
+            accountId: params.agentAccountId,
+          })
+        : undefined;
+
+      const defaultModelRef = resolveDefaultModelForAgent({
+        cfg: params.config ?? {},
+        agentId: sessionAgentId,
+      });
+      const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
+      const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
+        config: params.config,
+        agentId: sessionAgentId,
+        workspaceDir: effectiveWorkspace,
+        cwd: process.cwd(),
+        runtime: {
+          host: machineName,
+          os: `${os.type()} ${os.release()}`,
+          arch: os.arch(),
+          node: process.version,
+          model: `${params.provider}/${params.modelId}`,
+          defaultModel: defaultModelLabel,
+          shell: detectRuntimeShell(),
+          channel: runtimeChannel,
+          capabilities: runtimeCapabilities,
+          channelActions,
+        },
+      });
+      const isDefaultAgent = sessionAgentId === defaultAgentId;
+      const promptMode = resolvePromptModeForSession(params.sessionKey);
+      const docsPath = await resolveOpenClawDocsPath({
+        workspaceDir: effectiveWorkspace,
+        argv1: process.argv[1],
+        cwd: process.cwd(),
+        moduleUrl: import.meta.url,
+      });
+      const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+      const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+
+      const appendPrompt = buildEmbeddedSystemPrompt({
+        workspaceDir: effectiveWorkspace,
+        defaultThinkLevel: params.thinkLevel,
+        reasoningLevel: params.reasoningLevel ?? "off",
+        extraSystemPrompt: params.extraSystemPrompt,
+        ownerNumbers: params.ownerNumbers,
+        ownerDisplay: ownerDisplay.ownerDisplay,
+        ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
+        reasoningTagHint,
+        heartbeatPrompt: isDefaultAgent
+          ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
+          : undefined,
+        skillsPrompt,
+        docsPath: docsPath ?? undefined,
+        ttsHint,
+        workspaceNotes,
+        reactionGuidance,
+        promptMode,
+        runtimeInfo,
+        messageToolHints,
+        sandboxInfo,
+        tools,
+        modelAliasLines: buildModelAliasLines(params.config),
+        userTimezone,
+        userTime,
+        userTimeFormat,
+        contextFiles,
+        memoryCitationsMode: params.config?.memory?.citations,
+      });
+      const systemPromptReport = buildSystemPromptReport({
+        source: "run",
+        generatedAt: Date.now(),
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        provider: params.provider,
+        model: params.modelId,
+        workspaceDir: effectiveWorkspace,
+        bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+        bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+        sandbox: (() => {
+          const runtime = resolveSandboxRuntimeStatus({
+            cfg: params.config,
+            sessionKey: params.sessionKey ?? params.sessionId,
+          });
+          return { mode: runtime.mode, sandboxed: runtime.sandboxed };
+        })(),
+        systemPrompt: appendPrompt,
+        bootstrapFiles: hookAdjustedBootstrapFiles,
+        injectedFiles: contextFiles,
+        skillsPrompt,
+        tools,
+      });
+      const systemPromptOverride = createSystemPromptOverride(appendPrompt);
+      let systemPromptText = systemPromptOverride();
+
+      const sessionLock = await acquireSessionWriteLock({
+        sessionFile: params.sessionFile,
+        maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
+          timeoutMs: params.timeoutMs,
+        }),
+      });
+
+      let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
+      let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+      let removeToolResultContextGuard: (() => void) | undefined;
+      try {
+        await repairSessionFileIfNeeded({
+          sessionFile: params.sessionFile,
+          warn: (message) => log.warn(message),
+        });
+        const hadSessionFile = await fs
+          .stat(params.sessionFile)
+          .then(() => true)
+          .catch(() => false);
+
+        const transcriptPolicy = resolveTranscriptPolicy({
+          modelApi: params.model?.api,
+          provider: params.provider,
+          modelId: params.modelId,
+        });
+
+        await prewarmSessionFile(params.sessionFile);
+        sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          inputProvenance: params.inputProvenance,
+          allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+          allowedToolNames,
+        });
+        trackSessionManagerAccess(params.sessionFile);
+
+        await prepareSessionManagerForRun({
+          sessionManager,
+          sessionFile: params.sessionFile,
+          hadSessionFile,
+          sessionId: params.sessionId,
+          cwd: effectiveWorkspace,
+        });
+
+        const settingsManager = SettingsManager.create(effectiveWorkspace, agentDir);
+        applyPiCompactionSettingsFromConfig({
+          settingsManager,
+          cfg: params.config,
+        });
+
+        // Sets compaction/pruning runtime state and returns extension factories
+        // that must be passed to the resource loader for the safeguard to be active.
+        const extensionFactories = buildEmbeddedExtensionFactories({
+          cfg: params.config,
+          sessionManager,
+          provider: params.provider,
+          modelId: params.modelId,
+          model: params.model,
+        });
+        // Only create an explicit resource loader when there are extension factories
+        // to register; otherwise let createAgentSession use its built-in default.
+        let resourceLoader: DefaultResourceLoader | undefined;
+        if (extensionFactories.length > 0) {
+          resourceLoader = new DefaultResourceLoader({
+            cwd: resolvedWorkspace,
+            agentDir,
+            settingsManager,
+            extensionFactories,
+          });
+          await resourceLoader.reload();
+        }
+
+        // Get hook runner early so it's available when creating tools
+        const hookRunner = getGlobalHookRunner();
+
+        const { builtInTools, customTools } = splitSdkTools({
+          tools,
+          sandboxEnabled: !!sandbox?.enabled,
+        });
+
+        // Add client tools (OpenResponses hosted tools) to customTools
+        let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
+        const clientToolLoopDetection = resolveToolLoopDetectionConfig({
+          cfg: params.config,
+          agentId: sessionAgentId,
+        });
+        const clientToolDefs = params.clientTools
+          ? toClientToolDefinitions(
+              params.clientTools,
+              (toolName, toolParams) => {
+                clientToolCallDetected = { name: toolName, params: toolParams };
+              },
+              {
+                agentId: sessionAgentId,
+                sessionKey: params.sessionKey,
+                loopDetection: clientToolLoopDetection,
+              },
+            )
+          : [];
+
+        const allCustomTools = [...customTools, ...clientToolDefs];
+
+        ({ session } = await createAgentSession({
+          cwd: resolvedWorkspace,
+          agentDir,
+          authStorage: params.authStorage,
+          modelRegistry: params.modelRegistry,
+          model: params.model,
+          thinkingLevel: mapThinkingLevel(params.thinkLevel),
+          tools: builtInTools,
+          customTools: allCustomTools,
+          sessionManager,
+          settingsManager,
+          resourceLoader,
+        }));
+        applySystemPromptOverrideToSession(session, systemPromptText);
+        if (!session) {
+          throw new Error("Embedded agent session missing");
+        }
+        const activeSession = session;
+        removeToolResultContextGuard = installToolResultContextGuard({
+          agent: activeSession.agent,
+          contextWindowTokens: Math.max(
+            1,
+            Math.floor(
+              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            ),
+          ),
+        });
+        const cacheTrace = createCacheTrace({
+          cfg: params.config,
+          env: process.env,
+          runId: params.runId,
+          sessionId: activeSession.sessionId,
+          sessionKey: params.sessionKey,
+          provider: params.provider,
+          modelId: params.modelId,
+          modelApi: params.model.api,
+          workspaceDir: params.workspaceDir,
+        });
+        const anthropicPayloadLogger = createAnthropicPayloadLogger({
+          env: process.env,
+          runId: params.runId,
+          sessionId: activeSession.sessionId,
+          sessionKey: params.sessionKey,
+          provider: params.provider,
+          modelId: params.modelId,
+          modelApi: params.model.api,
+          workspaceDir: params.workspaceDir,
+        });
+
+        // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
+        // for reliable streaming + tool calling support (#11828).
+        if (params.model.api === "ollama") {
+          // Use the resolved model baseUrl first so custom provider aliases work.
+          const providerConfig = params.config?.models?.providers?.[params.model.provider];
+          const modelBaseUrl =
+            typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : "";
+          const providerBaseUrl =
+            typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
+          const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
+          activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
+        } else {
+          // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
+          activeSession.agent.streamFn = streamSimple;
+        }
+
+        applyExtraParamsToAgent(
+          activeSession.agent,
+          params.config,
+          params.provider,
+          params.modelId,
+          params.streamParams,
+          params.thinkLevel,
+          sessionAgentId,
+        );
+
+        if (cacheTrace) {
+          cacheTrace.recordStage("session:loaded", {
+            messages: activeSession.messages,
+            system: systemPromptText,
+            note: "after session create",
+          });
+          activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
+        }
+
+        // Copilot/Claude can reject persisted `thinking` blocks (e.g. thinkingSignature:"reasoning_text")
+        // on *any* follow-up provider call (including tool continuations). Wrap the stream function
+        // so every outbound request sees sanitized messages.
+        if (transcriptPolicy.dropThinkingBlocks) {
+          const inner = activeSession.agent.streamFn;
+          activeSession.agent.streamFn = (model, context, options) => {
+            const ctx = context as unknown as { messages?: unknown };
+            const messages = ctx?.messages;
+            if (!Array.isArray(messages)) {
+              return inner(model, context, options);
+            }
+            const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[]) as unknown;
+            if (sanitized === messages) {
+              return inner(model, context, options);
+            }
+            const nextContext = {
+              ...(context as unknown as Record<string, unknown>),
+              messages: sanitized,
+            } as unknown;
+            return inner(model, nextContext as typeof context, options);
+          };
+        }
+
+        // Mistral (and other strict providers) reject tool call IDs that don't match their
+        // format requirements (e.g. [a-zA-Z0-9]{9}). sanitizeSessionHistory only processes
+        // historical messages at attempt start, but the agent loop's internal tool call →
+        // tool result cycles bypass that path. Wrap streamFn so every outbound request
+        // sees sanitized tool call IDs.
+        if (transcriptPolicy.sanitizeToolCallIds && transcriptPolicy.toolCallIdMode) {
+          const inner = activeSession.agent.streamFn;
+          const mode = transcriptPolicy.toolCallIdMode;
+          activeSession.agent.streamFn = (model, context, options) => {
+            const ctx = context as unknown as { messages?: unknown };
+            const messages = ctx?.messages;
+            if (!Array.isArray(messages)) {
+              return inner(model, context, options);
+            }
+            const sanitized = sanitizeToolCallIdsForCloudCodeAssist(
+              messages as AgentMessage[],
+              mode,
+            );
+            if (sanitized === messages) {
+              return inner(model, context, options);
+            }
+            const nextContext = {
+              ...(context as unknown as Record<string, unknown>),
+              messages: sanitized,
+            } as unknown;
+            return inner(model, nextContext as typeof context, options);
+          };
+        }
+
+        if (anthropicPayloadLogger) {
+          activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(
+            activeSession.agent.streamFn,
+          );
+        }
+
+        try {
+          const prior = await sanitizeSessionHistory({
+            messages: activeSession.messages,
+            modelApi: params.model.api,
+            modelId: params.modelId,
+            provider: params.provider,
+            allowedToolNames,
+            config: params.config,
+            sessionManager,
+            sessionId: params.sessionId,
+            policy: transcriptPolicy,
+          });
+          cacheTrace?.recordStage("session:sanitized", { messages: prior });
+          const validatedGemini = transcriptPolicy.validateGeminiTurns
+            ? validateGeminiTurns(prior)
+            : prior;
+          const validated = transcriptPolicy.validateAnthropicTurns
+            ? validateAnthropicTurns(validatedGemini)
+            : validatedGemini;
+          const truncated = limitHistoryTurns(
+            validated,
+            getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
+          );
+          // Re-run tool_use/tool_result pairing repair after truncation, since
+          // limitHistoryTurns can orphan tool_result blocks by removing the
+          // assistant message that contained the matching tool_use.
+          const limited = transcriptPolicy.repairToolUseResultPairing
+            ? sanitizeToolUseResultPairing(truncated)
+            : truncated;
+          cacheTrace?.recordStage("session:limited", { messages: limited });
+          if (limited.length > 0) {
+            activeSession.agent.replaceMessages(limited);
+          }
+        } catch (err) {
+          await flushPendingToolResultsAfterIdle({
+            agent: activeSession?.agent,
+            sessionManager,
+          });
+          activeSession.dispose();
+          throw err;
+        }
+
+        let aborted = Boolean(params.abortSignal?.aborted);
+        let timedOut = false;
+        let timedOutDuringCompaction = false;
+        const getAbortReason = (signal: AbortSignal): unknown =>
+          "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+        const makeTimeoutAbortReason = (): Error => {
+          const err = new Error("request timed out");
+          err.name = "TimeoutError";
+          return err;
+        };
+        const makeAbortError = (signal: AbortSignal): Error => {
+          const reason = getAbortReason(signal);
+          const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
+          err.name = "AbortError";
+          return err;
+        };
+        const abortRun = (isTimeout = false, reason?: unknown) => {
+          aborted = true;
+          if (isTimeout) {
+            timedOut = true;
+          }
+          if (isTimeout) {
+            runAbortController.abort(reason ?? makeTimeoutAbortReason());
+          } else {
+            runAbortController.abort(reason);
+          }
+          void activeSession.abort();
+        };
+        const abortable = <T>(promise: Promise<T>): Promise<T> => {
+          const signal = runAbortController.signal;
+          if (signal.aborted) {
+            return Promise.reject(makeAbortError(signal));
+          }
+          return new Promise<T>((resolve, reject) => {
+            const onAbort = () => {
+              signal.removeEventListener("abort", onAbort);
+              reject(makeAbortError(signal));
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            promise.then(
+              (value) => {
+                signal.removeEventListener("abort", onAbort);
+                resolve(value);
+              },
+              (err) => {
+                signal.removeEventListener("abort", onAbort);
+                reject(err);
+              },
+            );
+          });
+        };
+
+        const subscription = subscribeEmbeddedPiSession({
+          session: activeSession,
+          runId: params.runId,
+          hookRunner: getGlobalHookRunner() ?? undefined,
+          verboseLevel: params.verboseLevel,
+          reasoningMode: params.reasoningLevel ?? "off",
+          toolResultFormat: params.toolResultFormat,
+          shouldEmitToolResult: params.shouldEmitToolResult,
+          shouldEmitToolOutput: params.shouldEmitToolOutput,
+          onToolResult: params.onToolResult,
+          onReasoningStream: params.onReasoningStream,
+          onReasoningEnd: params.onReasoningEnd,
+          onBlockReply: params.onBlockReply,
+          onBlockReplyFlush: params.onBlockReplyFlush,
+          blockReplyBreak: params.blockReplyBreak,
+          blockReplyChunking: params.blockReplyChunking,
+          onPartialReply: params.onPartialReply,
+          onAssistantMessageStart: params.onAssistantMessageStart,
+          onAgentEvent: params.onAgentEvent,
+          enforceFinalTag: params.enforceFinalTag,
+          config: params.config,
+          sessionKey: params.sessionKey ?? params.sessionId,
+        });
+
+        const {
+          assistantTexts,
+          toolMetas,
+          unsubscribe,
+          waitForCompactionRetry,
+          getMessagingToolSentTexts,
+          getMessagingToolSentMediaUrls,
+          getMessagingToolSentTargets,
+          getSuccessfulCronAdds,
+          didSendViaMessagingTool,
+          getLastToolError,
+          getUsageTotals,
+          getCompactionCount,
+        } = subscription;
+
+        const queueHandle: EmbeddedPiQueueHandle = {
+          queueMessage: async (text: string) => {
+            await activeSession.steer(text);
+          },
+          isStreaming: () => activeSession.isStreaming,
+          isCompacting: () => subscription.isCompacting(),
+          abort: abortRun,
+        };
+        setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+
+        let abortWarnTimer: NodeJS.Timeout | undefined;
+        const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
+        const abortTimer = setTimeout(
+          () => {
+            if (!isProbeSession) {
+              log.warn(
+                `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
+              );
+            }
+            if (
+              shouldFlagCompactionTimeout({
+                isTimeout: true,
+                isCompactionPendingOrRetrying: subscription.isCompacting(),
+                isCompactionInFlight: activeSession.isCompacting,
+              })
+            ) {
+              timedOutDuringCompaction = true;
+            }
+            abortRun(true);
+            if (!abortWarnTimer) {
+              abortWarnTimer = setTimeout(() => {
+                if (!activeSession.isStreaming) {
+                  return;
+                }
+                if (!isProbeSession) {
+                  log.warn(
+                    `embedded run abort still streaming: runId=${params.runId} sessionId=${params.sessionId}`,
+                  );
+                }
+              }, 10_000);
+            }
+          },
+          Math.max(1, params.timeoutMs),
+        );
+
+        let messagesSnapshot: AgentMessage[] = [];
+        let sessionIdUsed = activeSession.sessionId;
+        const onAbort = () => {
+          const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
+          const timeout = reason ? isTimeoutError(reason) : false;
+          if (
             shouldFlagCompactionTimeout({
-              isTimeout: true,
+              isTimeout: timeout,
               isCompactionPendingOrRetrying: subscription.isCompacting(),
               isCompactionInFlight: activeSession.isCompacting,
             })
           ) {
             timedOutDuringCompaction = true;
           }
-          abortRun(true);
-          if (!abortWarnTimer) {
-            abortWarnTimer = setTimeout(() => {
-              if (!activeSession.isStreaming) {
-                return;
-              }
-              if (!isProbeSession) {
-                log.warn(
-                  `embedded run abort still streaming: runId=${params.runId} sessionId=${params.sessionId}`,
-                );
-              }
-            }, 10_000);
-          }
-        },
-        Math.max(1, params.timeoutMs),
-      );
-
-      let messagesSnapshot: AgentMessage[] = [];
-      let sessionIdUsed = activeSession.sessionId;
-      const onAbort = () => {
-        const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
-        const timeout = reason ? isTimeoutError(reason) : false;
-        if (
-          shouldFlagCompactionTimeout({
-            isTimeout: timeout,
-            isCompactionPendingOrRetrying: subscription.isCompacting(),
-            isCompactionInFlight: activeSession.isCompacting,
-          })
-        ) {
-          timedOutDuringCompaction = true;
-        }
-        abortRun(timeout, reason);
-      };
-      if (params.abortSignal) {
-        if (params.abortSignal.aborted) {
-          onAbort();
-        } else {
-          params.abortSignal.addEventListener("abort", onAbort, {
-            once: true,
-          });
-        }
-      }
-
-      // Hook runner was already obtained earlier before tool creation
-      const hookAgentId = sessionAgentId;
-
-      let promptError: unknown = null;
-      let promptErrorSource: "prompt" | "compaction" | null = null;
-      try {
-        const promptStartedAt = Date.now();
-
-        // Run before_prompt_build hooks to allow plugins to inject prompt context.
-        // Legacy compatibility: before_agent_start is also checked for context fields.
-        let effectivePrompt = params.prompt;
-        const hookCtx = {
-          agentId: hookAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageProvider ?? undefined,
+          abortRun(timeout, reason);
         };
-        const hookResult = await resolvePromptBuildHookResult({
-          prompt: params.prompt,
-          messages: activeSession.messages,
-          hookCtx,
-          hookRunner,
-          legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
-        });
-        {
-          if (hookResult?.prependContext) {
-            effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
-            log.debug(
-              `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
-            );
-          }
-          const legacySystemPrompt =
-            typeof hookResult?.systemPrompt === "string" ? hookResult.systemPrompt.trim() : "";
-          if (legacySystemPrompt) {
-            applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
-            systemPromptText = legacySystemPrompt;
-            log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
-          }
-        }
-
-        log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
-        cacheTrace?.recordStage("prompt:before", {
-          prompt: effectivePrompt,
-          messages: activeSession.messages,
-        });
-
-        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
-          if (leafEntry.parentId) {
-            sessionManager.branch(leafEntry.parentId);
+        if (params.abortSignal) {
+          if (params.abortSignal.aborted) {
+            onAbort();
           } else {
-            sessionManager.resetLeaf();
+            params.abortSignal.addEventListener("abort", onAbort, {
+              once: true,
+            });
           }
-          const sessionContext = sessionManager.buildSessionContext();
-          activeSession.agent.replaceMessages(sessionContext.messages);
-          log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
-              `runId=${params.runId} sessionId=${params.sessionId}`,
-          );
         }
 
-        try {
-          // Detect and load images referenced in the prompt for vision-capable models.
-          // This eliminates the need for an explicit "view" tool call by injecting
-          // images directly into the prompt when the model supports it.
-          // Also scans conversation history to enable follow-up questions about earlier images.
-          const imageResult = await detectAndLoadPromptImages({
-            prompt: effectivePrompt,
-            workspaceDir: effectiveWorkspace,
-            model: params.model,
-            existingImages: params.images,
-            historyMessages: activeSession.messages,
-            maxBytes: MAX_IMAGE_BYTES,
-            maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
-            workspaceOnly: effectiveFsWorkspaceOnly,
-            // Enforce sandbox path restrictions when sandbox is enabled
-            sandbox:
-              sandbox?.enabled && sandbox?.fsBridge
-                ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                : undefined,
-          });
+        // Hook runner was already obtained earlier before tool creation
+        const hookAgentId = sessionAgentId;
 
-          // Inject history images into their original message positions.
-          // This ensures the model sees images in context (e.g., "compare to the first image").
-          const didMutate = injectHistoryImagesIntoMessages(
-            activeSession.messages,
-            imageResult.historyImagesByIndex,
-          );
-          if (didMutate) {
-            // Persist message mutations (e.g., injected history images) so we don't re-scan/reload.
-            activeSession.agent.replaceMessages(activeSession.messages);
+        let promptError: unknown = null;
+        let promptErrorSource: "prompt" | "compaction" | null = null;
+        try {
+          const promptStartedAt = Date.now();
+
+          // Run before_prompt_build hooks to allow plugins to inject prompt context.
+          // Legacy compatibility: before_agent_start is also checked for context fields.
+          let effectivePrompt = params.prompt;
+          const hookCtx = {
+            agentId: hookAgentId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: params.workspaceDir,
+            messageProvider: params.messageProvider ?? undefined,
+          };
+          const hookResult = await resolvePromptBuildHookResult({
+            prompt: params.prompt,
+            messages: activeSession.messages,
+            hookCtx,
+            hookRunner,
+            legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
+          });
+          {
+            if (hookResult?.prependContext) {
+              effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
+              log.debug(
+                `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
+              );
+            }
+            const legacySystemPrompt =
+              typeof hookResult?.systemPrompt === "string" ? hookResult.systemPrompt.trim() : "";
+            if (legacySystemPrompt) {
+              applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
+              systemPromptText = legacySystemPrompt;
+              log.debug(
+                `hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`,
+              );
+            }
           }
 
-          cacheTrace?.recordStage("prompt:images", {
+          log.debug(
+            `embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`,
+          );
+          cacheTrace?.recordStage("prompt:before", {
             prompt: effectivePrompt,
             messages: activeSession.messages,
-            note: `images: prompt=${imageResult.images.length} history=${imageResult.historyImagesByIndex.size}`,
           });
 
-          // Diagnostic: log context sizes before prompt to help debug early overflow errors.
-          if (log.isEnabled("debug")) {
-            const msgCount = activeSession.messages.length;
-            const systemLen = systemPromptText?.length ?? 0;
-            const promptLen = effectivePrompt.length;
-            const sessionSummary = summarizeSessionContext(activeSession.messages);
-            log.debug(
-              `[context-diag] pre-prompt: sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `messages=${msgCount} roleCounts=${sessionSummary.roleCounts} ` +
-                `historyTextChars=${sessionSummary.totalTextChars} ` +
-                `maxMessageTextChars=${sessionSummary.maxMessageTextChars} ` +
-                `historyImageBlocks=${sessionSummary.totalImageBlocks} ` +
-                `systemPromptChars=${systemLen} promptChars=${promptLen} ` +
-                `promptImages=${imageResult.images.length} ` +
-                `historyImageMessages=${imageResult.historyImagesByIndex.size} ` +
-                `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
+          // Repair orphaned trailing user messages so new prompts don't violate role ordering.
+          const leafEntry = sessionManager.getLeafEntry();
+          if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
+            if (leafEntry.parentId) {
+              sessionManager.branch(leafEntry.parentId);
+            } else {
+              sessionManager.resetLeaf();
+            }
+            const sessionContext = sessionManager.buildSessionContext();
+            activeSession.agent.replaceMessages(sessionContext.messages);
+            log.warn(
+              `Removed orphaned user message to prevent consecutive user turns. ` +
+                `runId=${params.runId} sessionId=${params.sessionId}`,
             );
           }
 
-          if (hookRunner?.hasHooks("llm_input")) {
+          try {
+            // Detect and load images referenced in the prompt for vision-capable models.
+            // This eliminates the need for an explicit "view" tool call by injecting
+            // images directly into the prompt when the model supports it.
+            // Also scans conversation history to enable follow-up questions about earlier images.
+            const imageResult = await detectAndLoadPromptImages({
+              prompt: effectivePrompt,
+              workspaceDir: effectiveWorkspace,
+              model: params.model,
+              existingImages: params.images,
+              historyMessages: activeSession.messages,
+              maxBytes: MAX_IMAGE_BYTES,
+              maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
+              workspaceOnly: effectiveFsWorkspaceOnly,
+              // Enforce sandbox path restrictions when sandbox is enabled
+              sandbox:
+                sandbox?.enabled && sandbox?.fsBridge
+                  ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
+                  : undefined,
+            });
+
+            // Inject history images into their original message positions.
+            // This ensures the model sees images in context (e.g., "compare to the first image").
+            const didMutate = injectHistoryImagesIntoMessages(
+              activeSession.messages,
+              imageResult.historyImagesByIndex,
+            );
+            if (didMutate) {
+              // Persist message mutations (e.g., injected history images) so we don't re-scan/reload.
+              activeSession.agent.replaceMessages(activeSession.messages);
+            }
+
+            cacheTrace?.recordStage("prompt:images", {
+              prompt: effectivePrompt,
+              messages: activeSession.messages,
+              note: `images: prompt=${imageResult.images.length} history=${imageResult.historyImagesByIndex.size}`,
+            });
+
+            // Diagnostic: log context sizes before prompt to help debug early overflow errors.
+            if (log.isEnabled("debug")) {
+              const msgCount = activeSession.messages.length;
+              const systemLen = systemPromptText?.length ?? 0;
+              const promptLen = effectivePrompt.length;
+              const sessionSummary = summarizeSessionContext(activeSession.messages);
+              log.debug(
+                `[context-diag] pre-prompt: sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `messages=${msgCount} roleCounts=${sessionSummary.roleCounts} ` +
+                  `historyTextChars=${sessionSummary.totalTextChars} ` +
+                  `maxMessageTextChars=${sessionSummary.maxMessageTextChars} ` +
+                  `historyImageBlocks=${sessionSummary.totalImageBlocks} ` +
+                  `systemPromptChars=${systemLen} promptChars=${promptLen} ` +
+                  `promptImages=${imageResult.images.length} ` +
+                  `historyImageMessages=${imageResult.historyImagesByIndex.size} ` +
+                  `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
+              );
+            }
+
+            if (hookRunner?.hasHooks("llm_input")) {
+              hookRunner
+                .runLlmInput(
+                  {
+                    runId: params.runId,
+                    sessionId: params.sessionId,
+                    provider: params.provider,
+                    model: params.modelId,
+                    systemPrompt: systemPromptText,
+                    prompt: effectivePrompt,
+                    historyMessages: activeSession.messages,
+                    imagesCount: imageResult.images.length,
+                  },
+                  {
+                    agentId: hookAgentId,
+                    sessionKey: params.sessionKey,
+                    sessionId: params.sessionId,
+                    workspaceDir: params.workspaceDir,
+                    messageProvider: params.messageProvider ?? undefined,
+                  },
+                )
+                .catch((err) => {
+                  log.warn(`llm_input hook failed: ${String(err)}`);
+                });
+            }
+
+            // Only pass images option if there are actually images to pass
+            // This avoids potential issues with models that don't expect the images parameter
+            if (imageResult.images.length > 0) {
+              await abortable(
+                activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+              );
+            } else {
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
+          } catch (err) {
+            promptError = err;
+            promptErrorSource = "prompt";
+          } finally {
+            log.debug(
+              `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
+            );
+          }
+
+          // Capture snapshot before compaction wait so we have complete messages if timeout occurs
+          // Check compaction state before and after to avoid race condition where compaction starts during capture
+          // Use session state (not subscription) for snapshot decisions - need instantaneous compaction status
+          const wasCompactingBefore = activeSession.isCompacting;
+          const snapshot = activeSession.messages.slice();
+          const wasCompactingAfter = activeSession.isCompacting;
+          // Only trust snapshot if compaction wasn't running before or after capture
+          const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
+          const preCompactionSessionId = activeSession.sessionId;
+
+          try {
+            await abortable(waitForCompactionRetry());
+          } catch (err) {
+            if (isRunnerAbortError(err)) {
+              if (!promptError) {
+                promptError = err;
+                promptErrorSource = "compaction";
+              }
+              if (!isProbeSession) {
+                log.debug(
+                  `compaction wait aborted: runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              }
+            } else {
+              throw err;
+            }
+          }
+
+          // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
+          // Previously this was before the prompt, which caused a custom entry to be
+          // inserted between compaction and the next prompt — breaking the
+          // prepareCompaction() guard that checks the last entry type, leading to
+          // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
+          // Skip when timed out during compaction — session state may be inconsistent.
+          if (!timedOutDuringCompaction) {
+            const shouldTrackCacheTtl =
+              params.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl" &&
+              isCacheTtlEligibleProvider(params.provider, params.modelId);
+            if (shouldTrackCacheTtl) {
+              appendCacheTtlTimestamp(sessionManager, {
+                timestamp: Date.now(),
+                provider: params.provider,
+                modelId: params.modelId,
+              });
+            }
+          }
+
+          // If timeout occurred during compaction, use pre-compaction snapshot when available
+          // (compaction restructures messages but does not add user/assistant turns).
+          const snapshotSelection = selectCompactionTimeoutSnapshot({
+            timedOutDuringCompaction,
+            preCompactionSnapshot,
+            preCompactionSessionId,
+            currentSnapshot: activeSession.messages.slice(),
+            currentSessionId: activeSession.sessionId,
+          });
+          if (timedOutDuringCompaction) {
+            if (!isProbeSession) {
+              log.warn(
+                `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+            }
+          }
+          messagesSnapshot = snapshotSelection.messagesSnapshot;
+          sessionIdUsed = snapshotSelection.sessionIdUsed;
+
+          if (promptError && promptErrorSource === "prompt") {
+            try {
+              sessionManager.appendCustomEntry("openclaw:prompt-error", {
+                timestamp: Date.now(),
+                runId: params.runId,
+                sessionId: params.sessionId,
+                provider: params.provider,
+                model: params.modelId,
+                api: params.model.api,
+                error: describeUnknownError(promptError),
+              });
+            } catch (entryErr) {
+              log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            }
+          }
+
+          cacheTrace?.recordStage("session:after", {
+            messages: messagesSnapshot,
+            note: timedOutDuringCompaction
+              ? "compaction timeout"
+              : promptError
+                ? "prompt error"
+                : undefined,
+          });
+          anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
+
+          // Run agent_end hooks to allow plugins to analyze the conversation
+          // This is fire-and-forget, so we don't await
+          // Run even on compaction timeout so plugins can log/cleanup
+          if (hookRunner?.hasHooks("agent_end")) {
             hookRunner
-              .runLlmInput(
+              .runAgentEnd(
                 {
-                  runId: params.runId,
-                  sessionId: params.sessionId,
-                  provider: params.provider,
-                  model: params.modelId,
-                  systemPrompt: systemPromptText,
-                  prompt: effectivePrompt,
-                  historyMessages: activeSession.messages,
-                  imagesCount: imageResult.images.length,
+                  messages: messagesSnapshot,
+                  success: !aborted && !promptError,
+                  error: promptError ? describeUnknownError(promptError) : undefined,
+                  durationMs: Date.now() - promptStartedAt,
                 },
                 {
                   agentId: hookAgentId,
@@ -1169,129 +1322,56 @@ export async function runEmbeddedAttempt(
                 },
               )
               .catch((err) => {
-                log.warn(`llm_input hook failed: ${String(err)}`);
+                log.warn(`agent_end hook failed: ${err}`);
               });
           }
-
-          // Only pass images option if there are actually images to pass
-          // This avoids potential issues with models that don't expect the images parameter
-          if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
-          } else {
-            await abortable(activeSession.prompt(effectivePrompt));
-          }
-        } catch (err) {
-          promptError = err;
-          promptErrorSource = "prompt";
         } finally {
-          log.debug(
-            `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
-          );
-        }
-
-        // Capture snapshot before compaction wait so we have complete messages if timeout occurs
-        // Check compaction state before and after to avoid race condition where compaction starts during capture
-        // Use session state (not subscription) for snapshot decisions - need instantaneous compaction status
-        const wasCompactingBefore = activeSession.isCompacting;
-        const snapshot = activeSession.messages.slice();
-        const wasCompactingAfter = activeSession.isCompacting;
-        // Only trust snapshot if compaction wasn't running before or after capture
-        const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
-        const preCompactionSessionId = activeSession.sessionId;
-
-        try {
-          await abortable(waitForCompactionRetry());
-        } catch (err) {
-          if (isRunnerAbortError(err)) {
-            if (!promptError) {
-              promptError = err;
-              promptErrorSource = "compaction";
-            }
-            if (!isProbeSession) {
-              log.debug(
-                `compaction wait aborted: runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-            }
-          } else {
-            throw err;
+          clearTimeout(abortTimer);
+          if (abortWarnTimer) {
+            clearTimeout(abortWarnTimer);
           }
-        }
-
-        // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
-        // Previously this was before the prompt, which caused a custom entry to be
-        // inserted between compaction and the next prompt — breaking the
-        // prepareCompaction() guard that checks the last entry type, leading to
-        // double-compaction. See: https://github.com/openclaw/openclaw/issues/9282
-        // Skip when timed out during compaction — session state may be inconsistent.
-        if (!timedOutDuringCompaction) {
-          const shouldTrackCacheTtl =
-            params.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl" &&
-            isCacheTtlEligibleProvider(params.provider, params.modelId);
-          if (shouldTrackCacheTtl) {
-            appendCacheTtlTimestamp(sessionManager, {
-              timestamp: Date.now(),
-              provider: params.provider,
-              modelId: params.modelId,
-            });
-          }
-        }
-
-        // If timeout occurred during compaction, use pre-compaction snapshot when available
-        // (compaction restructures messages but does not add user/assistant turns).
-        const snapshotSelection = selectCompactionTimeoutSnapshot({
-          timedOutDuringCompaction,
-          preCompactionSnapshot,
-          preCompactionSessionId,
-          currentSnapshot: activeSession.messages.slice(),
-          currentSessionId: activeSession.sessionId,
-        });
-        if (timedOutDuringCompaction) {
-          if (!isProbeSession) {
-            log.warn(
-              `using ${snapshotSelection.source} snapshot: timed out during compaction runId=${params.runId} sessionId=${params.sessionId}`,
+          if (!isProbeSession && (aborted || timedOut) && !timedOutDuringCompaction) {
+            log.debug(
+              `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
             );
           }
-        }
-        messagesSnapshot = snapshotSelection.messagesSnapshot;
-        sessionIdUsed = snapshotSelection.sessionIdUsed;
-
-        if (promptError && promptErrorSource === "prompt") {
           try {
-            sessionManager.appendCustomEntry("openclaw:prompt-error", {
-              timestamp: Date.now(),
-              runId: params.runId,
-              sessionId: params.sessionId,
-              provider: params.provider,
-              model: params.modelId,
-              api: params.model.api,
-              error: describeUnknownError(promptError),
-            });
-          } catch (entryErr) {
-            log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
+            unsubscribe();
+          } catch (err) {
+            // unsubscribe() should never throw; if it does, it indicates a serious bug.
+            // Log at error level to ensure visibility, but don't rethrow in finally block
+            // as it would mask any exception from the try block above.
+            log.error(
+              `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
+            );
           }
+          clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+          params.abortSignal?.removeEventListener?.("abort", onAbort);
         }
 
-        cacheTrace?.recordStage("session:after", {
-          messages: messagesSnapshot,
-          note: timedOutDuringCompaction
-            ? "compaction timeout"
-            : promptError
-              ? "prompt error"
-              : undefined,
-        });
-        anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
+        const lastAssistant = messagesSnapshot
+          .slice()
+          .toReversed()
+          .find((m) => m.role === "assistant");
 
-        // Run agent_end hooks to allow plugins to analyze the conversation
-        // This is fire-and-forget, so we don't await
-        // Run even on compaction timeout so plugins can log/cleanup
-        if (hookRunner?.hasHooks("agent_end")) {
+        const toolMetasNormalized = toolMetas
+          .filter(
+            (entry): entry is { toolName: string; meta?: string } =>
+              typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
+          )
+          .map((entry) => ({ toolName: entry.toolName, meta: entry.meta }));
+
+        if (hookRunner?.hasHooks("llm_output")) {
           hookRunner
-            .runAgentEnd(
+            .runLlmOutput(
               {
-                messages: messagesSnapshot,
-                success: !aborted && !promptError,
-                error: promptError ? describeUnknownError(promptError) : undefined,
-                durationMs: Date.now() - promptStartedAt,
+                runId: params.runId,
+                sessionId: params.sessionId,
+                provider: params.provider,
+                model: params.modelId,
+                assistantTexts,
+                lastAssistant,
+                usage: getUsageTotals(),
               },
               {
                 agentId: hookAgentId,
@@ -1302,114 +1382,55 @@ export async function runEmbeddedAttempt(
               },
             )
             .catch((err) => {
-              log.warn(`agent_end hook failed: ${err}`);
+              log.warn(`llm_output hook failed: ${String(err)}`);
             });
         }
+
+        return {
+          aborted,
+          timedOut,
+          timedOutDuringCompaction,
+          promptError,
+          sessionIdUsed,
+          systemPromptReport,
+          messagesSnapshot,
+          assistantTexts,
+          toolMetas: toolMetasNormalized,
+          lastAssistant,
+          lastToolError: getLastToolError?.(),
+          didSendViaMessagingTool: didSendViaMessagingTool(),
+          messagingToolSentTexts: getMessagingToolSentTexts(),
+          messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+          messagingToolSentTargets: getMessagingToolSentTargets(),
+          successfulCronAdds: getSuccessfulCronAdds(),
+          cloudCodeAssistFormatError: Boolean(
+            lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
+          ),
+          attemptUsage: getUsageTotals(),
+          compactionCount: getCompactionCount(),
+          // Client tool call detected (OpenResponses hosted tools)
+          clientToolCall: clientToolCallDetected ?? undefined,
+        };
       } finally {
-        clearTimeout(abortTimer);
-        if (abortWarnTimer) {
-          clearTimeout(abortWarnTimer);
-        }
-        if (!isProbeSession && (aborted || timedOut) && !timedOutDuringCompaction) {
-          log.debug(
-            `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
-          );
-        }
-        try {
-          unsubscribe();
-        } catch (err) {
-          // unsubscribe() should never throw; if it does, it indicates a serious bug.
-          // Log at error level to ensure visibility, but don't rethrow in finally block
-          // as it would mask any exception from the try block above.
-          log.error(
-            `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
-          );
-        }
-        clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
-        params.abortSignal?.removeEventListener?.("abort", onAbort);
+        // Always tear down the session (and release the lock) before we leave this attempt.
+        //
+        // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
+        // pi-agent-core's auto-retry resolves waitForRetry() on assistant message receipt,
+        // *before* tool execution completes in the retried agent loop. Without this wait,
+        // flushPendingToolResults() fires while tools are still executing, inserting
+        // synthetic "missing tool result" errors and causing silent agent failures.
+        // See: https://github.com/openclaw/openclaw/issues/8643
+        removeToolResultContextGuard?.();
+        await flushPendingToolResultsAfterIdle({
+          agent: session?.agent,
+          sessionManager,
+        });
+        session?.dispose();
+        await sessionLock.release();
       }
-
-      const lastAssistant = messagesSnapshot
-        .slice()
-        .toReversed()
-        .find((m) => m.role === "assistant");
-
-      const toolMetasNormalized = toolMetas
-        .filter(
-          (entry): entry is { toolName: string; meta?: string } =>
-            typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
-        )
-        .map((entry) => ({ toolName: entry.toolName, meta: entry.meta }));
-
-      if (hookRunner?.hasHooks("llm_output")) {
-        hookRunner
-          .runLlmOutput(
-            {
-              runId: params.runId,
-              sessionId: params.sessionId,
-              provider: params.provider,
-              model: params.modelId,
-              assistantTexts,
-              lastAssistant,
-              usage: getUsageTotals(),
-            },
-            {
-              agentId: hookAgentId,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              workspaceDir: params.workspaceDir,
-              messageProvider: params.messageProvider ?? undefined,
-            },
-          )
-          .catch((err) => {
-            log.warn(`llm_output hook failed: ${String(err)}`);
-          });
-      }
-
-      return {
-        aborted,
-        timedOut,
-        timedOutDuringCompaction,
-        promptError,
-        sessionIdUsed,
-        systemPromptReport,
-        messagesSnapshot,
-        assistantTexts,
-        toolMetas: toolMetasNormalized,
-        lastAssistant,
-        lastToolError: getLastToolError?.(),
-        didSendViaMessagingTool: didSendViaMessagingTool(),
-        messagingToolSentTexts: getMessagingToolSentTexts(),
-        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
-        messagingToolSentTargets: getMessagingToolSentTargets(),
-        successfulCronAdds: getSuccessfulCronAdds(),
-        cloudCodeAssistFormatError: Boolean(
-          lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
-        ),
-        attemptUsage: getUsageTotals(),
-        compactionCount: getCompactionCount(),
-        // Client tool call detected (OpenResponses hosted tools)
-        clientToolCall: clientToolCallDetected ?? undefined,
-      };
     } finally {
-      // Always tear down the session (and release the lock) before we leave this attempt.
-      //
-      // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
-      // pi-agent-core's auto-retry resolves waitForRetry() on assistant message receipt,
-      // *before* tool execution completes in the retried agent loop. Without this wait,
-      // flushPendingToolResults() fires while tools are still executing, inserting
-      // synthetic "missing tool result" errors and causing silent agent failures.
-      // See: https://github.com/openclaw/openclaw/issues/8643
-      removeToolResultContextGuard?.();
-      await flushPendingToolResultsAfterIdle({
-        agent: session?.agent,
-        sessionManager,
-      });
-      session?.dispose();
-      await sessionLock.release();
+      restoreSkillEnv?.();
+      process.chdir(prevCwd);
     }
-  } finally {
-    restoreSkillEnv?.();
-    process.chdir(prevCwd);
-  }
+  }); // end diagnosticTraceStore.run
 }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -4,6 +4,7 @@ import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { createTraceContext, diagnosticTraceStore } from "../../infra/diagnostic-trace-context.js";
 import {
   logMessageProcessed,
   logMessageQueued,
@@ -88,101 +89,143 @@ export async function dispatchReplyFromConfig(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof getReplyFromConfig;
 }): Promise<DispatchFromConfigResult> {
-  const { ctx, cfg, dispatcher } = params;
-  const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
-  const channel = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
-  const chatId = ctx.To ?? ctx.From;
-  const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const sessionKey = ctx.SessionKey;
-  const startTime = diagnosticsEnabled ? Date.now() : 0;
-  const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
+  // Establish root trace context for the full message dispatch lifecycle.
+  // All nested async operations (agent runs, LLM calls) inherit this context
+  // via AsyncLocalStorage so diagnostic events carry correlated trace IDs.
+  const traceCtx = createTraceContext();
+  return diagnosticTraceStore.run(traceCtx, async () => {
+    const { ctx, cfg, dispatcher } = params;
+    const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
+    const channel = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
+    const chatId = ctx.To ?? ctx.From;
+    const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+    const sessionKey = ctx.SessionKey;
+    const startTime = diagnosticsEnabled ? Date.now() : 0;
+    const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
 
-  const recordProcessed = (
-    outcome: "completed" | "skipped" | "error",
-    opts?: {
-      reason?: string;
-      error?: string;
-    },
-  ) => {
-    if (!diagnosticsEnabled) {
-      return;
+    const recordProcessed = (
+      outcome: "completed" | "skipped" | "error",
+      opts?: {
+        reason?: string;
+        error?: string;
+      },
+    ) => {
+      if (!diagnosticsEnabled) {
+        return;
+      }
+      logMessageProcessed({
+        channel,
+        chatId,
+        messageId,
+        sessionKey,
+        durationMs: Date.now() - startTime,
+        outcome,
+        reason: opts?.reason,
+        error: opts?.error,
+      });
+    };
+
+    const markProcessing = () => {
+      if (!canTrackSession || !sessionKey) {
+        return;
+      }
+      logMessageQueued({ sessionKey, channel, source: "dispatch" });
+      logSessionStateChange({
+        sessionKey,
+        state: "processing",
+        reason: "message_start",
+      });
+    };
+
+    const markIdle = (reason: string) => {
+      if (!canTrackSession || !sessionKey) {
+        return;
+      }
+      logSessionStateChange({
+        sessionKey,
+        state: "idle",
+        reason,
+      });
+    };
+
+    if (shouldSkipDuplicateInbound(ctx)) {
+      recordProcessed("skipped", { reason: "duplicate" });
+      return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
     }
-    logMessageProcessed({
-      channel,
-      chatId,
-      messageId,
-      sessionKey,
-      durationMs: Date.now() - startTime,
-      outcome,
-      reason: opts?.reason,
-      error: opts?.error,
-    });
-  };
 
-  const markProcessing = () => {
-    if (!canTrackSession || !sessionKey) {
-      return;
+    const inboundAudio = isInboundAudioContext(ctx);
+    const sessionTtsAuto = resolveSessionTtsAuto(ctx, cfg);
+    const hookRunner = getGlobalHookRunner();
+
+    // Extract message context for hooks (plugin and internal)
+    const timestamp =
+      typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp)
+        ? ctx.Timestamp
+        : undefined;
+    const messageIdForHook =
+      ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+    const content =
+      typeof ctx.BodyForCommands === "string"
+        ? ctx.BodyForCommands
+        : typeof ctx.RawBody === "string"
+          ? ctx.RawBody
+          : typeof ctx.Body === "string"
+            ? ctx.Body
+            : "";
+    const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+    const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+
+    // Trigger plugin hooks (fire-and-forget)
+    if (hookRunner?.hasHooks("message_received")) {
+      void hookRunner
+        .runMessageReceived(
+          {
+            from: ctx.From ?? "",
+            content,
+            timestamp,
+            metadata: {
+              to: ctx.To,
+              provider: ctx.Provider,
+              surface: ctx.Surface,
+              threadId: ctx.MessageThreadId,
+              originatingChannel: ctx.OriginatingChannel,
+              originatingTo: ctx.OriginatingTo,
+              messageId: messageIdForHook,
+              senderId: ctx.SenderId,
+              senderName: ctx.SenderName,
+              senderUsername: ctx.SenderUsername,
+              senderE164: ctx.SenderE164,
+              guildId: ctx.GroupSpace,
+              channelName: ctx.GroupChannel,
+            },
+          },
+          {
+            channelId,
+            accountId: ctx.AccountId,
+            conversationId,
+          },
+        )
+        .catch((err) => {
+          logVerbose(`dispatch-from-config: message_received plugin hook failed: ${String(err)}`);
+        });
     }
-    logMessageQueued({ sessionKey, channel, source: "dispatch" });
-    logSessionStateChange({
-      sessionKey,
-      state: "processing",
-      reason: "message_start",
-    });
-  };
 
-  const markIdle = (reason: string) => {
-    if (!canTrackSession || !sessionKey) {
-      return;
-    }
-    logSessionStateChange({
-      sessionKey,
-      state: "idle",
-      reason,
-    });
-  };
-
-  if (shouldSkipDuplicateInbound(ctx)) {
-    recordProcessed("skipped", { reason: "duplicate" });
-    return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-  }
-
-  const inboundAudio = isInboundAudioContext(ctx);
-  const sessionTtsAuto = resolveSessionTtsAuto(ctx, cfg);
-  const hookRunner = getGlobalHookRunner();
-
-  // Extract message context for hooks (plugin and internal)
-  const timestamp =
-    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
-  const messageIdForHook =
-    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const content =
-    typeof ctx.BodyForCommands === "string"
-      ? ctx.BodyForCommands
-      : typeof ctx.RawBody === "string"
-        ? ctx.RawBody
-        : typeof ctx.Body === "string"
-          ? ctx.Body
-          : "";
-  const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
-  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
-
-  // Trigger plugin hooks (fire-and-forget)
-  if (hookRunner?.hasHooks("message_received")) {
-    void hookRunner
-      .runMessageReceived(
-        {
+    // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
+    if (sessionKey) {
+      void triggerInternalHook(
+        createInternalHookEvent("message", "received", sessionKey, {
           from: ctx.From ?? "",
           content,
           timestamp,
+          channelId,
+          accountId: ctx.AccountId,
+          conversationId,
+          messageId: messageIdForHook,
           metadata: {
             to: ctx.To,
             provider: ctx.Provider,
             surface: ctx.Surface,
             threadId: ctx.MessageThreadId,
-            originatingChannel: ctx.OriginatingChannel,
-            originatingTo: ctx.OriginatingTo,
-            messageId: messageIdForHook,
             senderId: ctx.SenderId,
             senderName: ctx.SenderName,
             senderUsername: ctx.SenderUsername,
@@ -190,326 +233,294 @@ export async function dispatchReplyFromConfig(params: {
             guildId: ctx.GroupSpace,
             channelName: ctx.GroupChannel,
           },
-        },
-        {
-          channelId,
-          accountId: ctx.AccountId,
-          conversationId,
-        },
-      )
-      .catch((err) => {
-        logVerbose(`dispatch-from-config: message_received plugin hook failed: ${String(err)}`);
+        }),
+      ).catch((err) => {
+        logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
       });
-  }
+    }
 
-  // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
-  if (sessionKey) {
-    void triggerInternalHook(
-      createInternalHookEvent("message", "received", sessionKey, {
-        from: ctx.From ?? "",
-        content,
-        timestamp,
-        channelId,
+    // Check if we should route replies to originating channel instead of dispatcher.
+    // Only route when the originating channel is DIFFERENT from the current surface.
+    // This handles cross-provider routing (e.g., message from Telegram being processed
+    // by a shared session that's currently on Slack) while preserving normal dispatcher
+    // flow when the provider handles its own messages.
+    //
+    // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
+    const originatingChannel = ctx.OriginatingChannel;
+    const originatingTo = ctx.OriginatingTo;
+    const currentSurface = (ctx.Surface ?? ctx.Provider)?.toLowerCase();
+    const shouldRouteToOriginating =
+      isRoutableChannel(originatingChannel) &&
+      originatingTo &&
+      originatingChannel !== currentSurface;
+    const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
+
+    /**
+     * Helper to send a payload via route-reply (async).
+     * Only used when actually routing to a different provider.
+     * Note: Only called when shouldRouteToOriginating is true, so
+     * originatingChannel and originatingTo are guaranteed to be defined.
+     */
+    const sendPayloadAsync = async (
+      payload: ReplyPayload,
+      abortSignal?: AbortSignal,
+      mirror?: boolean,
+    ): Promise<void> => {
+      // TypeScript doesn't narrow these from the shouldRouteToOriginating check,
+      // but they're guaranteed non-null when this function is called.
+      if (!originatingChannel || !originatingTo) {
+        return;
+      }
+      if (abortSignal?.aborted) {
+        return;
+      }
+      const result = await routeReply({
+        payload,
+        channel: originatingChannel,
+        to: originatingTo,
+        sessionKey: ctx.SessionKey,
         accountId: ctx.AccountId,
-        conversationId,
-        messageId: messageIdForHook,
-        metadata: {
-          to: ctx.To,
-          provider: ctx.Provider,
-          surface: ctx.Surface,
-          threadId: ctx.MessageThreadId,
-          senderId: ctx.SenderId,
-          senderName: ctx.SenderName,
-          senderUsername: ctx.SenderUsername,
-          senderE164: ctx.SenderE164,
-          guildId: ctx.GroupSpace,
-          channelName: ctx.GroupChannel,
-        },
-      }),
-    ).catch((err) => {
-      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
-    });
-  }
-
-  // Check if we should route replies to originating channel instead of dispatcher.
-  // Only route when the originating channel is DIFFERENT from the current surface.
-  // This handles cross-provider routing (e.g., message from Telegram being processed
-  // by a shared session that's currently on Slack) while preserving normal dispatcher
-  // flow when the provider handles its own messages.
-  //
-  // Debug: `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
-  const originatingChannel = ctx.OriginatingChannel;
-  const originatingTo = ctx.OriginatingTo;
-  const currentSurface = (ctx.Surface ?? ctx.Provider)?.toLowerCase();
-  const shouldRouteToOriginating =
-    isRoutableChannel(originatingChannel) && originatingTo && originatingChannel !== currentSurface;
-  const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
-
-  /**
-   * Helper to send a payload via route-reply (async).
-   * Only used when actually routing to a different provider.
-   * Note: Only called when shouldRouteToOriginating is true, so
-   * originatingChannel and originatingTo are guaranteed to be defined.
-   */
-  const sendPayloadAsync = async (
-    payload: ReplyPayload,
-    abortSignal?: AbortSignal,
-    mirror?: boolean,
-  ): Promise<void> => {
-    // TypeScript doesn't narrow these from the shouldRouteToOriginating check,
-    // but they're guaranteed non-null when this function is called.
-    if (!originatingChannel || !originatingTo) {
-      return;
-    }
-    if (abortSignal?.aborted) {
-      return;
-    }
-    const result = await routeReply({
-      payload,
-      channel: originatingChannel,
-      to: originatingTo,
-      sessionKey: ctx.SessionKey,
-      accountId: ctx.AccountId,
-      threadId: ctx.MessageThreadId,
-      cfg,
-      abortSignal,
-      mirror,
-    });
-    if (!result.ok) {
-      logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
-    }
-  };
-
-  markProcessing();
-
-  try {
-    const fastAbort = await tryFastAbortFromMessage({ ctx, cfg });
-    if (fastAbort.handled) {
-      const payload = {
-        text: formatAbortReplyText(fastAbort.stoppedSubagents),
-      } satisfies ReplyPayload;
-      let queuedFinal = false;
-      let routedFinalCount = 0;
-      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-        const result = await routeReply({
-          payload,
-          channel: originatingChannel,
-          to: originatingTo,
-          sessionKey: ctx.SessionKey,
-          accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
-          cfg,
-        });
-        queuedFinal = result.ok;
-        if (result.ok) {
-          routedFinalCount += 1;
-        }
-        if (!result.ok) {
-          logVerbose(
-            `dispatch-from-config: route-reply (abort) failed: ${result.error ?? "unknown error"}`,
-          );
-        }
-      } else {
-        queuedFinal = dispatcher.sendFinalReply(payload);
+        threadId: ctx.MessageThreadId,
+        cfg,
+        abortSignal,
+        mirror,
+      });
+      if (!result.ok) {
+        logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
       }
-      const counts = dispatcher.getQueuedCounts();
-      counts.final += routedFinalCount;
-      recordProcessed("completed", { reason: "fast_abort" });
-      markIdle("message_completed");
-      return { queuedFinal, counts };
-    }
-
-    // Track accumulated block text for TTS generation after streaming completes.
-    // When block streaming succeeds, there's no final reply, so we need to generate
-    // TTS audio separately from the accumulated block content.
-    let accumulatedBlockText = "";
-    let blockCount = 0;
-
-    const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
-
-    const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
-      if (shouldSendToolSummaries) {
-        return payload;
-      }
-      // Group/native flows intentionally suppress tool summary text, but media-only
-      // tool results (for example TTS audio) must still be delivered.
-      const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-      if (!hasMedia) {
-        return null;
-      }
-      return { ...payload, text: undefined };
     };
 
-    const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
-      ctx,
-      {
-        ...params.replyOptions,
-        onToolResult: (payload: ReplyPayload) => {
-          const run = async () => {
-            const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
-              cfg,
-              channel: ttsChannel,
-              kind: "tool",
-              inboundAudio,
-              ttsAuto: sessionTtsAuto,
-            });
-            const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
-            if (!deliveryPayload) {
-              return;
-            }
-            if (shouldRouteToOriginating) {
-              await sendPayloadAsync(deliveryPayload, undefined, false);
-            } else {
-              dispatcher.sendToolResult(deliveryPayload);
-            }
-          };
-          return run();
-        },
-        onBlockReply: (payload: ReplyPayload, context) => {
-          const run = async () => {
-            // Suppress reasoning payloads — channels using this generic dispatch
-            // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-            // Telegram has its own dispatch path that handles reasoning splitting.
-            if (shouldSuppressReasoningPayload(payload)) {
-              return;
-            }
-            // Accumulate block text for TTS generation after streaming
-            if (payload.text) {
-              if (accumulatedBlockText.length > 0) {
-                accumulatedBlockText += "\n";
+    markProcessing();
+
+    try {
+      const fastAbort = await tryFastAbortFromMessage({ ctx, cfg });
+      if (fastAbort.handled) {
+        const payload = {
+          text: formatAbortReplyText(fastAbort.stoppedSubagents),
+        } satisfies ReplyPayload;
+        let queuedFinal = false;
+        let routedFinalCount = 0;
+        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+          const result = await routeReply({
+            payload,
+            channel: originatingChannel,
+            to: originatingTo,
+            sessionKey: ctx.SessionKey,
+            accountId: ctx.AccountId,
+            threadId: ctx.MessageThreadId,
+            cfg,
+          });
+          queuedFinal = result.ok;
+          if (result.ok) {
+            routedFinalCount += 1;
+          }
+          if (!result.ok) {
+            logVerbose(
+              `dispatch-from-config: route-reply (abort) failed: ${result.error ?? "unknown error"}`,
+            );
+          }
+        } else {
+          queuedFinal = dispatcher.sendFinalReply(payload);
+        }
+        const counts = dispatcher.getQueuedCounts();
+        counts.final += routedFinalCount;
+        recordProcessed("completed", { reason: "fast_abort" });
+        markIdle("message_completed");
+        return { queuedFinal, counts };
+      }
+
+      // Track accumulated block text for TTS generation after streaming completes.
+      // When block streaming succeeds, there's no final reply, so we need to generate
+      // TTS audio separately from the accumulated block content.
+      let accumulatedBlockText = "";
+      let blockCount = 0;
+
+      const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
+
+      const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
+        if (shouldSendToolSummaries) {
+          return payload;
+        }
+        // Group/native flows intentionally suppress tool summary text, but media-only
+        // tool results (for example TTS audio) must still be delivered.
+        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+        if (!hasMedia) {
+          return null;
+        }
+        return { ...payload, text: undefined };
+      };
+
+      const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
+        ctx,
+        {
+          ...params.replyOptions,
+          onToolResult: (payload: ReplyPayload) => {
+            const run = async () => {
+              const ttsPayload = await maybeApplyTtsToPayload({
+                payload,
+                cfg,
+                channel: ttsChannel,
+                kind: "tool",
+                inboundAudio,
+                ttsAuto: sessionTtsAuto,
+              });
+              const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
+              if (!deliveryPayload) {
+                return;
               }
-              accumulatedBlockText += payload.text;
-              blockCount++;
-            }
-            const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
-              cfg,
-              channel: ttsChannel,
-              kind: "block",
-              inboundAudio,
-              ttsAuto: sessionTtsAuto,
-            });
-            if (shouldRouteToOriginating) {
-              await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
-            } else {
-              dispatcher.sendBlockReply(ttsPayload);
-            }
-          };
-          return run();
+              if (shouldRouteToOriginating) {
+                await sendPayloadAsync(deliveryPayload, undefined, false);
+              } else {
+                dispatcher.sendToolResult(deliveryPayload);
+              }
+            };
+            return run();
+          },
+          onBlockReply: (payload: ReplyPayload, context) => {
+            const run = async () => {
+              // Suppress reasoning payloads — channels using this generic dispatch
+              // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
+              // Telegram has its own dispatch path that handles reasoning splitting.
+              if (shouldSuppressReasoningPayload(payload)) {
+                return;
+              }
+              // Accumulate block text for TTS generation after streaming
+              if (payload.text) {
+                if (accumulatedBlockText.length > 0) {
+                  accumulatedBlockText += "\n";
+                }
+                accumulatedBlockText += payload.text;
+                blockCount++;
+              }
+              const ttsPayload = await maybeApplyTtsToPayload({
+                payload,
+                cfg,
+                channel: ttsChannel,
+                kind: "block",
+                inboundAudio,
+                ttsAuto: sessionTtsAuto,
+              });
+              if (shouldRouteToOriginating) {
+                await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
+              } else {
+                dispatcher.sendBlockReply(ttsPayload);
+              }
+            };
+            return run();
+          },
         },
-      },
-      cfg,
-    );
-
-    const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
-
-    let queuedFinal = false;
-    let routedFinalCount = 0;
-    for (const reply of replies) {
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (shouldSuppressReasoningPayload(reply)) {
-        continue;
-      }
-      const ttsReply = await maybeApplyTtsToPayload({
-        payload: reply,
         cfg,
-        channel: ttsChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-      });
-      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-        // Route final reply to originating channel.
-        const result = await routeReply({
-          payload: ttsReply,
-          channel: originatingChannel,
-          to: originatingTo,
-          sessionKey: ctx.SessionKey,
-          accountId: ctx.AccountId,
-          threadId: ctx.MessageThreadId,
-          cfg,
-        });
-        if (!result.ok) {
-          logVerbose(
-            `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
-          );
-        }
-        queuedFinal = result.ok || queuedFinal;
-        if (result.ok) {
-          routedFinalCount += 1;
-        }
-      } else {
-        queuedFinal = dispatcher.sendFinalReply(ttsReply) || queuedFinal;
-      }
-    }
+      );
 
-    const ttsMode = resolveTtsConfig(cfg).mode ?? "final";
-    // Generate TTS-only reply after block streaming completes (when there's no final reply).
-    // This handles the case where block streaming succeeds and drops final payloads,
-    // but we still want TTS audio to be generated from the accumulated block content.
-    if (
-      ttsMode === "final" &&
-      replies.length === 0 &&
-      blockCount > 0 &&
-      accumulatedBlockText.trim()
-    ) {
-      try {
-        const ttsSyntheticReply = await maybeApplyTtsToPayload({
-          payload: { text: accumulatedBlockText },
+      const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+
+      let queuedFinal = false;
+      let routedFinalCount = 0;
+      for (const reply of replies) {
+        // Suppress reasoning payloads from channel delivery — channels using this
+        // generic dispatch path do not have a dedicated reasoning lane.
+        if (shouldSuppressReasoningPayload(reply)) {
+          continue;
+        }
+        const ttsReply = await maybeApplyTtsToPayload({
+          payload: reply,
           cfg,
           channel: ttsChannel,
           kind: "final",
           inboundAudio,
           ttsAuto: sessionTtsAuto,
         });
-        // Only send if TTS was actually applied (mediaUrl exists)
-        if (ttsSyntheticReply.mediaUrl) {
-          // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
-          const ttsOnlyPayload: ReplyPayload = {
-            mediaUrl: ttsSyntheticReply.mediaUrl,
-            audioAsVoice: ttsSyntheticReply.audioAsVoice,
-          };
-          if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-            const result = await routeReply({
-              payload: ttsOnlyPayload,
-              channel: originatingChannel,
-              to: originatingTo,
-              sessionKey: ctx.SessionKey,
-              accountId: ctx.AccountId,
-              threadId: ctx.MessageThreadId,
-              cfg,
-            });
-            queuedFinal = result.ok || queuedFinal;
-            if (result.ok) {
-              routedFinalCount += 1;
-            }
-            if (!result.ok) {
-              logVerbose(
-                `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
-              );
-            }
-          } else {
-            const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
-            queuedFinal = didQueue || queuedFinal;
+        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+          // Route final reply to originating channel.
+          const result = await routeReply({
+            payload: ttsReply,
+            channel: originatingChannel,
+            to: originatingTo,
+            sessionKey: ctx.SessionKey,
+            accountId: ctx.AccountId,
+            threadId: ctx.MessageThreadId,
+            cfg,
+          });
+          if (!result.ok) {
+            logVerbose(
+              `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
+            );
           }
+          queuedFinal = result.ok || queuedFinal;
+          if (result.ok) {
+            routedFinalCount += 1;
+          }
+        } else {
+          queuedFinal = dispatcher.sendFinalReply(ttsReply) || queuedFinal;
         }
-      } catch (err) {
-        logVerbose(
-          `dispatch-from-config: accumulated block TTS failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
       }
-    }
 
-    const counts = dispatcher.getQueuedCounts();
-    counts.final += routedFinalCount;
-    recordProcessed("completed");
-    markIdle("message_completed");
-    return { queuedFinal, counts };
-  } catch (err) {
-    recordProcessed("error", { error: String(err) });
-    markIdle("message_error");
-    throw err;
-  }
+      const ttsMode = resolveTtsConfig(cfg).mode ?? "final";
+      // Generate TTS-only reply after block streaming completes (when there's no final reply).
+      // This handles the case where block streaming succeeds and drops final payloads,
+      // but we still want TTS audio to be generated from the accumulated block content.
+      if (
+        ttsMode === "final" &&
+        replies.length === 0 &&
+        blockCount > 0 &&
+        accumulatedBlockText.trim()
+      ) {
+        try {
+          const ttsSyntheticReply = await maybeApplyTtsToPayload({
+            payload: { text: accumulatedBlockText },
+            cfg,
+            channel: ttsChannel,
+            kind: "final",
+            inboundAudio,
+            ttsAuto: sessionTtsAuto,
+          });
+          // Only send if TTS was actually applied (mediaUrl exists)
+          if (ttsSyntheticReply.mediaUrl) {
+            // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
+            const ttsOnlyPayload: ReplyPayload = {
+              mediaUrl: ttsSyntheticReply.mediaUrl,
+              audioAsVoice: ttsSyntheticReply.audioAsVoice,
+            };
+            if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+              const result = await routeReply({
+                payload: ttsOnlyPayload,
+                channel: originatingChannel,
+                to: originatingTo,
+                sessionKey: ctx.SessionKey,
+                accountId: ctx.AccountId,
+                threadId: ctx.MessageThreadId,
+                cfg,
+              });
+              queuedFinal = result.ok || queuedFinal;
+              if (result.ok) {
+                routedFinalCount += 1;
+              }
+              if (!result.ok) {
+                logVerbose(
+                  `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
+                );
+              }
+            } else {
+              const didQueue = dispatcher.sendFinalReply(ttsOnlyPayload);
+              queuedFinal = didQueue || queuedFinal;
+            }
+          }
+        } catch (err) {
+          logVerbose(
+            `dispatch-from-config: accumulated block TTS failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      const counts = dispatcher.getQueuedCounts();
+      counts.final += routedFinalCount;
+      recordProcessed("completed");
+      markIdle("message_completed");
+      return { queuedFinal, counts };
+    } catch (err) {
+      recordProcessed("error", { error: String(err) });
+      markIdle("message_error");
+      throw err;
+    }
+  }); // end diagnosticTraceStore.run
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -2,9 +2,20 @@ import type { OpenClawConfig } from "../config/config.js";
 
 export type DiagnosticSessionState = "idle" | "processing" | "waiting";
 
+/** Lightweight trace context carried on diagnostic events for span correlation. */
+export type DiagnosticTraceContext = {
+  /** 32 hex chars, same across one message lifecycle. */
+  traceId: string;
+  /** 16 hex chars, unique per operation. */
+  spanId: string;
+  /** 16 hex chars, links child to parent. */
+  parentSpanId?: string;
+};
+
 type DiagnosticBaseEvent = {
   ts: number;
   seq: number;
+  traceCtx?: DiagnosticTraceContext;
 };
 
 export type DiagnosticUsageEvent = DiagnosticBaseEvent & {

--- a/src/infra/diagnostic-trace-context.test.ts
+++ b/src/infra/diagnostic-trace-context.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  createChildContext,
+  createTraceContext,
+  currentTraceContext,
+  diagnosticTraceStore,
+} from "./diagnostic-trace-context.js";
+
+describe("diagnostic-trace-context", () => {
+  describe("createTraceContext", () => {
+    it("produces a valid root context with 32-char traceId and 16-char spanId", () => {
+      const ctx = createTraceContext();
+      expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(ctx.parentSpanId).toBeUndefined();
+    });
+
+    it("generates unique IDs across calls", () => {
+      const a = createTraceContext();
+      const b = createTraceContext();
+      expect(a.traceId).not.toBe(b.traceId);
+      expect(a.spanId).not.toBe(b.spanId);
+    });
+  });
+
+  describe("createChildContext", () => {
+    it("preserves parent traceId and sets parentSpanId", () => {
+      const parent = createTraceContext();
+      const child = createChildContext(parent);
+      expect(child.traceId).toBe(parent.traceId);
+      expect(child.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(child.spanId).not.toBe(parent.spanId);
+      expect(child.parentSpanId).toBe(parent.spanId);
+    });
+
+    it("reads parent from AsyncLocalStorage when no explicit parent given", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        const child = createChildContext();
+        expect(child.traceId).toBe(root.traceId);
+        expect(child.parentSpanId).toBe(root.spanId);
+      });
+    });
+
+    it("creates a new root context when no parent exists anywhere", () => {
+      // Outside any diagnosticTraceStore.run(), with no explicit parent
+      const ctx = createChildContext();
+      expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(ctx.parentSpanId).toBeUndefined();
+    });
+  });
+
+  describe("currentTraceContext", () => {
+    it("returns undefined outside of a store run", () => {
+      expect(currentTraceContext()).toBeUndefined();
+    });
+
+    it("returns the active context inside a store run", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        expect(currentTraceContext()).toBe(root);
+      });
+    });
+
+    it("returns nested child context after re-wrapping", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        expect(currentTraceContext()).toBe(root);
+        const child = createChildContext();
+        await diagnosticTraceStore.run(child, async () => {
+          expect(currentTraceContext()).toBe(child);
+          expect(currentTraceContext()?.traceId).toBe(root.traceId);
+          expect(currentTraceContext()?.parentSpanId).toBe(root.spanId);
+        });
+        // After child run completes, parent context is restored
+        expect(currentTraceContext()).toBe(root);
+      });
+    });
+  });
+
+  describe("async propagation", () => {
+    it("propagates trace context across async boundaries", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        expect(currentTraceContext()).toBe(root);
+
+        // Simulate nested async work
+        const result = await Promise.resolve().then(() => {
+          return currentTraceContext();
+        });
+        expect(result).toBe(root);
+      });
+    });
+  });
+});

--- a/src/infra/diagnostic-trace-context.ts
+++ b/src/infra/diagnostic-trace-context.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+import type { DiagnosticTraceContext } from "./diagnostic-events.js";
+
+/**
+ * AsyncLocalStorage-based trace context for diagnostic events.
+ *
+ * Wrap hot-path entry points with `diagnosticTraceStore.run(ctx, fn)` to
+ * establish a trace context that nested code can read via `currentTraceContext()`.
+ * This avoids threading a `traceCtx` parameter through every function signature.
+ */
+export const diagnosticTraceStore = new AsyncLocalStorage<DiagnosticTraceContext>();
+
+/** Create a new root trace context (new traceId + spanId). */
+export function createTraceContext(): DiagnosticTraceContext {
+  return {
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+  };
+}
+
+/**
+ * Create a child trace context that shares the parent's traceId.
+ * If no parent is provided, reads from AsyncLocalStorage.
+ * If no context exists at all, creates a new root context.
+ */
+export function createChildContext(parent?: DiagnosticTraceContext): DiagnosticTraceContext {
+  const p = parent ?? diagnosticTraceStore.getStore();
+  return {
+    traceId: p?.traceId ?? randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    parentSpanId: p?.spanId,
+  };
+}
+
+/** Get the current trace context from AsyncLocalStorage, or undefined if none. */
+export function currentTraceContext(): DiagnosticTraceContext | undefined {
+  return diagnosticTraceStore.getStore();
+}


### PR DESCRIPTION
## Summary

- **Problem:** The `diagnostics-otel` extension produces only disconnected point
  spans with no parent-child hierarchy. Operators cannot see the end-to-end flow
  of a message through routing, agent execution, and LLM calls. Additionally,
  the log transport registry in `logger.ts` has the same module-isolation bug
  that PR #12897 fixed for the diagnostic event bus -- `externalTransports` is
  module-scoped and may not survive jiti/bundler splitting.
- **Why it matters:** Without trace hierarchy, OTel traces in Jaeger/Fiddler/etc.
  are a flat list of unrelated spans. This makes latency debugging and cost
  attribution impossible. The log transport bug means OTel log export may
  silently fail depending on how the bundler resolves modules.
- **What changed:** (1) Log transport registry now uses a `globalThis` singleton
  matching the pattern PR #12897 established for the event bus. (2) New
  `DiagnosticTraceContext` type on all diagnostic events. (3) New
  `AsyncLocalStorage`-based trace context store with factory functions. (4) Hot
  path entry points (`dispatchReplyFromConfig`, `runEmbeddedAttempt`) wrapped
  with trace context so all nested async operations inherit correlated trace/span
  IDs.
- **What did NOT change:** No new dependencies, no config schema changes, no new
  diagnostic event types emitted yet. The OTel plugin is not modified in this PR
  -- it will consume the trace context in a follow-up PR. This is a pure
  foundation PR.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #8249 (Enhanced OTel trace context for tool call correlation)
- Related #13608 (Add metrics and observability support)
- Builds on #12897 (globalThis event bus fix -- same pattern applied to log transport)
- Supersedes #12475 (log transport Symbol.for fix -- same intent, different pattern)

## User-visible / Behavior Changes

No user-visible changes in this PR. This is infrastructure that enables
hierarchical OTel traces in a follow-up PR. The log transport fix may resolve
silent OTel log export failures for users who had the module isolation issue.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node v22+
- Test framework: Vitest 4.0.18

### Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm build` (verify compilation)
3. `pnpm test -- --run src/infra/diagnostic-trace-context.test.ts src/logging/`
   (verify 54/54 tests pass)
4. `pnpm lint` (verify 0 warnings, 0 errors)

### Expected

All tests pass. Build succeeds. No lint errors.

### Actual

All tests pass. Build succeeds. No lint errors.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Test output (9 new tests, all passing):

```
 ✓ src/infra/diagnostic-trace-context.test.ts (9 tests) 6ms
   ✓ createTraceContext > produces a valid root context with 32-char traceId and 16-char spanId
   ✓ createTraceContext > generates unique IDs across calls
   ✓ createChildContext > preserves parent traceId and sets parentSpanId
   ✓ createChildContext > reads parent from AsyncLocalStorage when no explicit parent given
   ✓ createChildContext > creates a new root context when no parent exists anywhere
   ✓ currentTraceContext > returns undefined outside of a store run
   ✓ currentTraceContext > returns the active context inside a store run
   ✓ currentTraceContext > returns nested child context after re-wrapping
   ✓ async propagation > propagates trace context across async boundaries
```

Full targeted test run (54/54 passing, including all logging tests to verify
the globalThis change is safe):

```
 Test Files  11 passed (11)
       Tests  54 passed (54)
```

## Human Verification (required)

- Verified scenarios: Trace context factory produces valid hex IDs with correct
  lengths (32-char traceId, 16-char spanId). Child contexts correctly inherit
  parent traceId and link via parentSpanId. AsyncLocalStorage propagates context
  across async boundaries including `setTimeout`, `Promise.resolve().then()`.
  Nested `diagnosticTraceStore.run()` calls correctly scope and restore context.
- Edge cases checked: `createChildContext()` without any parent (outside ALS)
  creates a new root. `currentTraceContext()` returns undefined outside any run.
  All existing logging tests continue to pass after the globalThis migration.
- What I did **not** verify: Live OTel collector integration (no new spans are
  emitted by this PR -- that is the follow-up). Multi-process globalThis
  isolation (Vitest workers are isolated by default).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

The `traceCtx` field on `DiagnosticBaseEvent` is optional. Existing diagnostic
event listeners (including the OTel plugin) will receive events with
`traceCtx: undefined` until Phase 2 adds emission. No existing behavior changes.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two commits. The
  `globalThis` singleton degrades gracefully -- if removed, log transport
  returns to module-scoped behavior. The AsyncLocalStorage wrapping is inert
  (the trace context is created but not yet consumed by any event emission).
- Files/config to restore: `src/logging/logger.ts`,
  `src/infra/diagnostic-events.ts`,
  `src/auto-reply/reply/dispatch-from-config.ts`,
  `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: If `AsyncLocalStorage` context
  is lost across a specific async boundary (rare in Node 22+), child contexts
  would fall back to creating new root traces. This would manifest as
  disconnected spans once the OTel plugin consumes the context -- not a crash.

## Risks and Mitigations

- Risk: `globalThis` log transport state could cause test interference if tests
  share the same Vitest worker process.
  - Mitigation: The existing `resetLogger()` test helper clears cached state.
    The globalThis Set is shared but `registerLogTransport()` returns an
    unsubscribe function, and `attachExternalTransport` checks membership before
    dispatching. Existing logging tests (11 files, 45 tests) all pass.

- Risk: `AsyncLocalStorage` overhead on the hot path.
  - Mitigation: `getStore()` is ~50ns per call (Node.js core, zero-allocation
    read). Negligible vs. seconds of LLM latency. No measurable impact.

---

**AI disclosure:** This PR was developed with AI assistance (Claude). All
changes were manually reviewed and verified with the test suite.