### PR TITLE
fix(telegram): guard reply context text/caption against non-string values

### DIFF
--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -343,7 +343,8 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
 
   const replyLike = reply ?? externalReply;
   if (!body && replyLike) {
-    const replyBody = (replyLike.text ?? replyLike.caption ?? "").trim();
+    const rawText = replyLike.text ?? replyLike.caption ?? "";
+    const replyBody = (typeof rawText === "string" ? rawText : "").trim();
     body = replyBody;
     if (!body) {
       body = resolveTelegramMediaPlaceholder(replyLike) ?? "";


### PR DESCRIPTION
## Summary

- Problem: `describeReplyTarget()` passes a non-string `replyContext` object to template interpolation, producing `[object Object]` in Telegram reply messages.
- Why it matters: Users see garbled `[object Object]` text in bot replies instead of meaningful context.
- What changed: Added a `typeof === "string"` guard in `describeReplyTarget()` so non-string values are treated as empty, preventing object-to-string coercion.
- What did NOT change (scope boundary): Template interpolation logic, reply routing, and all other reply target fields are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27201
- Related #

## User-visible / Behavior Changes

Telegram reply messages no longer contain `[object Object]` when the reply context is a structured object instead of a plain string.

## Security Impact (required)

- New permissions/capabilities: None
- Auth/token changes: None
- Data exposure risk: None — prevents leaking internal object structure into user-visible messages

## Testing

- [x] `npx vitest run src/auto-reply/reply/` — 479 tests ✓

## Rollback Plan

Revert the single commit. No migration or data changes involved.
