### PR TITLE
fix(auto-reply): use resolved authorization for inline directive gating

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -252,7 +252,8 @@ export async function resolveReplyDirectives(params: {
       }
     }
   }
-  let directives = commandAuthorized
+  const effectiveAuthorized = commandAuthorized || command.isAuthorizedSender;
+  let directives = effectiveAuthorized
     ? parsedDirectives
     : {
         ...parsedDirectives,


### PR DESCRIPTION
## Summary

- Problem: Inline directives (`/model`, `/think`, `/verbose`, etc.) are silently stripped on LINE because the raw `CommandAuthorized` flag is never set by the LINE channel, defaulting to `false`.
- Why it matters: LINE users who are authorized via `commands.allowFrom` cannot use any inline directives, even though control commands work fine.
- What changed: Used the resolved `command.isAuthorizedSender` (which accounts for `commands.allowFrom`) as a fallback for inline directive authorization: `commandAuthorized || command.isAuthorizedSender`.
- What did NOT change (scope boundary): Control command authorization, the `commands.allowFrom` resolution logic, and channels that already set `CommandAuthorized` are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27240
- Related #

## User-visible / Behavior Changes

LINE users authorized via `commands.allowFrom` can now use inline directives (`/model`, `/think`, `/verbose`, `/status`, `/queue`). Previously these were silently stripped.

## Security Impact (required)

- New permissions/capabilities: None — strictly additive; uses the same `isAuthorizedSender` already used for control commands
- Auth/token changes: Inline directive authorization now respects `commands.allowFrom` in addition to the raw `CommandAuthorized` flag
- Data exposure risk: None — if neither flag is true, directives remain stripped (same as before)

## Testing

- [x] `npx vitest run src/auto-reply/reply/` — 479 tests ✓
- [x] `npx vitest run src/auto-reply/command-control` — 24 tests ✓

## Rollback Plan

Revert the single commit. No migration or data changes involved.
