### PR TITLE
feat: Add Slack thread support - list threads action (#19598)

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -363,10 +363,7 @@ export async function handleSlackAction(
         after: after ?? undefined,
       });
       const threads = result.threads.map((thread) =>
-        withNormalizedTimestamp(
-          thread as Record<string, unknown>,
-          (thread as { ts?: unknown }).ts,
-        ),
+        withNormalizedTimestamp(thread as Record<string, unknown>, (thread as { ts?: unknown }).ts),
       );
       return jsonResult({ ok: true, threads, hasMore: result.hasMore });
     }

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -57,6 +57,7 @@ export type SlackActionConfig = {
   memberInfo?: boolean;
   channelInfo?: boolean;
   emojiList?: boolean;
+  threads?: boolean;
 };
 
 export type SlackSlashCommandConfig = {

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -254,7 +254,7 @@ export async function listSlackThreads(
   } = {},
 ): Promise<{ threads: SlackMessageSummary[]; hasMore: boolean }> {
   const client = await getClient(opts);
-  
+
   // Note: limit applies to the underlying message fetch, not the filtered thread count.
   // The actual number of threads returned may be less than limit since we filter
   // client-side for messages with replies.
@@ -264,15 +264,13 @@ export async function listSlackThreads(
     latest: opts.before,
     oldest: opts.after,
   });
-  
+
   // Filter messages that have replies (thread_ts exists and reply_count > 0)
-  const threads = (result.messages ?? []).filter(
-    (msg) => {
-      const message = msg as SlackMessageSummary;
-      return message.thread_ts && (message.reply_count ?? 0) > 0;
-    }
-  ) as SlackMessageSummary[];
-  
+  const threads = (result.messages ?? []).filter((msg) => {
+    const message = msg as SlackMessageSummary;
+    return message.thread_ts && (message.reply_count ?? 0) > 0;
+  }) as SlackMessageSummary[];
+
   return {
     threads,
     hasMore: Boolean(result.has_more),

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -254,6 +254,10 @@ export async function listSlackThreads(
   } = {},
 ): Promise<{ threads: SlackMessageSummary[]; hasMore: boolean }> {
   const client = await getClient(opts);
+  
+  // Note: limit applies to the underlying message fetch, not the filtered thread count.
+  // The actual number of threads returned may be less than limit since we filter
+  // client-side for messages with replies.
   const result = await client.conversations.history({
     channel: channelId,
     limit: opts.limit,

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -45,7 +45,7 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
     actions.add("emoji-list");
   }
   if (isActionEnabled("threads")) {
-    actions.add("list-threads");
+    actions.add("thread-list");
   }
   return Array.from(actions);
 }

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -44,6 +44,9 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
   if (isActionEnabled("emojiList")) {
     actions.add("emoji-list");
   }
+  if (isActionEnabled("threads")) {
+    actions.add("list-threads");
+  }
   return Array.from(actions);
 }
 


### PR DESCRIPTION
Fixes #19598

This PR implements thread listing functionality for the Slack integration to enable organized conversations as requested in the issue.

The changes add a listSlackThreads function that lists all threads in a channel, implements the listThreads action in the Slack action handler with proper authorization checks, and adds list-threads to the available Slack message actions. It supports pagination with limit, before, and after parameters, and filters messages that have thread_ts and reply_count greater than 0.

Usage example:
{
  action: "listThreads",
  channelId: "C123456",
  limit: 50,
  before: "timestamp",
  after: "timestamp"
}

The limit, before, and after parameters are optional.

Note that thread creation and replies are already supported via sendMessage with the threadTs parameter. This PR adds the missing list functionality that was requested in the issue to help organize conversations better.

I tested the changes locally with the codebase and everything compiles correctly.