### PR TITLE
feat(session-status): expose lastChannel, lastTo, lastAccountId in tool details

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -527,6 +527,16 @@ export function buildStatusMessage(args: StatusArgs): string {
     .filter(Boolean)
     .join(" • ");
 
+  const deliveryChannel = entry?.lastChannel ?? entry?.channel;
+  const deliveryParts = [
+    deliveryChannel ? `channel: ${deliveryChannel}` : null,
+    entry?.lastAccountId ? `account: ${entry.lastAccountId}` : null,
+    entry?.lastTo ? `to: ${entry.lastTo}` : null,
+    entry?.lastThreadId != null ? `thread: ${entry.lastThreadId}` : null,
+  ].filter(Boolean);
+  const deliveryLine =
+    deliveryParts.length > 0 ? `📬 Delivery: ${deliveryParts.join(" • ")}` : null;
+
   const isGroupSession =
     entry?.chatType === "group" ||
     entry?.chatType === "channel" ||
@@ -676,6 +686,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     mediaLine,
     args.usageLine,
     `🧵 ${sessionLine}`,
+    deliveryLine,
     args.subagentsLine,
     `⚙️ ${optionsLine}`,
     voiceLine,


### PR DESCRIPTION
## Summary

- **Problem:** In cross-session scenarios, if an agent needs to send a message via the `message` tool before a cross-session task completes, it must supply routing parameters (`channel`, `to`, `accountId`, `threadId`). There was no way to obtain these — they exist only in the session store, are absent from the system prompt, and were not surfaced in the `session_status` card.
- **Why it matters:** `session_status` already reads the full `SessionEntry`, so all delivery fields are available at call time — they just weren't rendered for the model, blocking the only viable path for an agent to proactively send messages mid-task.
- **What changed:** Added a `📬 Delivery` line to `buildStatusMessage` exposing `channel`, `account`, `to`, and `thread`. Fields are omitted individually when absent; the entire line is suppressed when none are present.
- **What did NOT change:** Tool `details` structure, session store write logic, and all other status lines are untouched.

## Change Type

- [x] Feature

## Scope

- [x] Skills / tool execution

## User-visible / Behavior Changes

When a session has delivery information, the `/status` output and `session_status` tool response now include an additional line:

```
📬 Delivery: channel: telegram • account: 123456 • to: +8613800138000 • thread: 42
```

Agents can call `session_status` at any point during a task to retrieve the routing parameters needed by the `message` tool — no need to wait for task completion or inject parameters at startup.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — `lastTo` may contain phone numbers or user IDs, but these fields are already accessible to any agent with `message` tool access; this change adds no new capability boundary.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.