### PR TITLE
fix(sessions): add bootId/pidStartTime to lock files to prevent PID recycling issues

### DIFF
--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -1,6 +1,6 @@
 import fsSync from "node:fs";
 import { describe, expect, it, vi } from "vitest";
-import { isPidAlive } from "./pid-alive.js";
+import { getBootId, getProcessStartTime, isPidAlive } from "./pid-alive.js";
 
 describe("isPidAlive", () => {
   it("returns true for the current running process", () => {
@@ -49,5 +49,39 @@ describe("isPidAlive", () => {
       Object.defineProperty(process, "platform", originalPlatformDescriptor);
       vi.restoreAllMocks();
     }
+  });
+});
+
+describe("getBootId", () => {
+  it("returns a non-empty string on Linux", () => {
+    if (process.platform !== "linux") {
+      expect(getBootId()).toBeUndefined();
+      return;
+    }
+    const bootId = getBootId();
+    expect(typeof bootId).toBe("string");
+    expect(bootId!.length).toBeGreaterThan(0);
+  });
+
+  it("returns the same value on subsequent calls (cached)", () => {
+    const first = getBootId();
+    const second = getBootId();
+    expect(first).toBe(second);
+  });
+});
+
+describe("getProcessStartTime", () => {
+  it("returns a string for the current process on Linux", () => {
+    if (process.platform !== "linux") {
+      expect(getProcessStartTime(process.pid)).toBeUndefined();
+      return;
+    }
+    const startTime = getProcessStartTime(process.pid);
+    expect(typeof startTime).toBe("string");
+    expect(startTime!.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined for a non-existent PID", () => {
+    expect(getProcessStartTime(2 ** 30)).toBeUndefined();
   });
 });

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -17,6 +17,53 @@ function isZombieProcess(pid: number): boolean {
   }
 }
 
+let cachedBootId: string | null | undefined;
+
+/**
+ * Read the Linux boot ID from /proc/sys/kernel/random/boot_id.
+ * This value changes on every system/container restart, making it useful
+ * for detecting stale lock files left by a previous container instance
+ * whose PIDs may have been recycled in the new PID namespace.
+ *
+ * Returns `undefined` on non-Linux platforms or when the file is unreadable.
+ * The result is cached for the lifetime of the process.
+ */
+export function getBootId(): string | undefined {
+  if (cachedBootId !== undefined) {
+    return cachedBootId ?? undefined;
+  }
+  try {
+    cachedBootId = fsSync.readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+  } catch {
+    cachedBootId = null;
+  }
+  return cachedBootId ?? undefined;
+}
+
+/**
+ * Read the start time of a process from /proc/<pid>/stat.
+ * The start time (field 22) is measured in clock ticks since boot and is
+ * unique per PID lifecycle — if a PID is recycled, its start time will differ.
+ *
+ * Returns `undefined` on non-Linux platforms or when the file is unreadable.
+ */
+export function getProcessStartTime(pid: number): string | undefined {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  try {
+    const stat = fsSync.readFileSync(`/proc/${pid}/stat`, "utf8");
+    // Field 22 (1-indexed) is starttime. The comm field (2) may contain
+    // spaces and parentheses, so we split after the closing paren.
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 2);
+    const fields = afterComm.split(" ");
+    // fields[0] = state (field 3), so starttime is fields[19] (field 22 - 3)
+    return fields[19];
+  } catch {
+    return undefined;
+  }
+}
+
 export function isPidAlive(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) {
     return false;


### PR DESCRIPTION
Fixes #27252

## Summary

In containerized environments, PIDs can be recycled across container restarts. A lock file from a previous container instance could contain a PID that happens to be alive (but belongs to a different process) in the new container, causing the gateway to honor a stale lock and fail to start. The existing `isPidAlive` check is insufficient to detect this scenario.

This commit makes the session lock mechanism more robust by adding two fields to the lock file payload, making it resilient to PID namespace recycling:

- **`bootId`**: Read from `/proc/sys/kernel/random/boot_id`, this value changes on every container restart. A boot ID mismatch is a definitive sign of a stale lock from a previous container instance.

- **`pidStartTime`**: Read from `/proc/<pid>/stat`, this value is unique to a PID's lifecycle. If the boot ID matches but the PID's start time differs, it means the PID was recycled within the same boot (a rare but possible edge case), which is also a sign of a stale lock.

The lock acquisition logic in `acquireSessionWriteLock` now checks for these mismatches and reclaims the lock if either is detected, preventing deadlocks on startup after a container redeployment.

## Changes

| File | What changed |
|---|---|
| `src/shared/pid-alive.ts` | Added `getBootId()` and `getProcessStartTime()` helpers to read Linux procfs data. |
| `src/agents/session-write-lock.ts` | `LockFilePayload` now includes `bootId` and `pidStartTime`. `acquireSessionWriteLock` now writes these fields. `inspectLockPayload` now checks for `boot-id-mismatch` and `pid-start-time-mismatch` and marks the lock as stale if detected. `readLockPayload` now reads the new fields. |
| `src/shared/pid-alive.test.ts` | Added unit tests for `getBootId()` and `getProcessStartTime()`. |
| `src/agents/session-write-lock.test.ts` | Added a new test case to verify that a lock file with a mismatched `bootId` is correctly reclaimed, simulating a container restart scenario. |

## How to test

1.  The new unit tests cover the core logic.
2.  To manually test:
    1.  Run OpenClaw in a Docker container with a persistent `/data` volume.
    2.  Start a session with an agent.
    3.  Restart the Docker container (`docker restart <container_id>`).
    4.  The gateway should now start successfully without timing out on a stale session lock.

