### PR TITLE
fix(models): agent-level models.json apiKey overrides main config (#27243)

### DIFF
--- a/src/agents/models-config.agent-level-overrides-provider-config.test.ts
+++ b/src/agents/models-config.agent-level-overrides-provider-config.test.ts
@@ -8,6 +8,7 @@ import {
   withModelsTempHome as withTempHome,
 } from "./models-config.e2e-harness.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
+import { makeModel } from "./pi-embedded-runner/model.test-harness.js";
 
 installModelsConfigTestHooks();
 
@@ -29,7 +30,7 @@ describe("models-config", () => {
                 baseUrl: "https://custom-api.example.com/",
                 apiKey: "agent_specific_key_12345",
                 api: "openai-completions",
-                models: [{ id: "claude-4-sonnet", name: "Claude 4 Sonnet" }],
+                models: [makeModel("claude-4-sonnet")],
               },
             },
           },
@@ -47,7 +48,7 @@ describe("models-config", () => {
               baseUrl: "https://main-api.example.com/",
               apiKey: "main_config_key_67890",
               api: "openai-completions",
-              models: [{ id: "claude-4-sonnet", name: "Claude 4 Sonnet" }],
+              models: [makeModel("claude-4-sonnet")],
             },
           },
         },

--- a/src/agents/models-config.agent-level-overrides-provider-config.test.ts
+++ b/src/agents/models-config.agent-level-overrides-provider-config.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+installModelsConfigTestHooks();
+
+describe("models-config", () => {
+  it("allows agent-level models.json provider.apiKey/baseUrl to override main config", async () => {
+    await withTempHome(async () => {
+      const agentDir = resolveOpenClawAgentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+
+      // Simulate an agent-level models.json already present on disk.
+      // NOTE: we must set models.mode="merge" so ensureOpenClawModelsJson reads and merges
+      // the on-disk models.json file.
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify(
+          {
+            providers: {
+              "user-custom": {
+                baseUrl: "https://custom-api.example.com/",
+                apiKey: "agent_specific_key_12345",
+                api: "openai-completions",
+                models: [{ id: "claude-4-sonnet", name: "Claude 4 Sonnet" }],
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+
+      const cfg: OpenClawConfig = {
+        models: {
+          mode: "merge",
+          providers: {
+            "user-custom": {
+              baseUrl: "https://main-api.example.com/",
+              apiKey: "main_config_key_67890",
+              api: "openai-completions",
+              models: [{ id: "claude-4-sonnet", name: "Claude 4 Sonnet" }],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
+      const parsed = JSON.parse(raw) as {
+        providers: Record<string, { baseUrl?: string; apiKey?: string }>;
+      };
+
+      expect(parsed.providers["user-custom"]?.baseUrl).toBe("https://custom-api.example.com/");
+      expect(parsed.providers["user-custom"]?.apiKey).toBe("agent_specific_key_12345");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #27243

Summary:
- Fix merge precedence so agent-level provider fields (apiKey/baseUrl) override main config when merging provider models.
- Ensure on-disk agent  overrides main config providers in merge mode.
- Add regression test covering agent-level overrides.

Verification:
- Added unit test: src/agents/models-config.agent-level-overrides-provider-config.test.ts
- Ran targeted tests + oxfmt check.