### PR TITLE
fix(daemon): stabilize LaunchAgent restart and proxy env passthrough

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,20 @@
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
 - Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
 
+### Local full-CI one-shot record (2026-02-25)
+
+- Ran local parity sweep for GitHub CI workflows (`workflow-sanity.yml`, `ci.yml`, `install-smoke.yml`, `sandbox-common-smoke.yml`) via `/tmp/run-openclaw-local-ci.sh`.
+- Artifacts: `/tmp/openclaw-local-ci-20260225-221535.summary`, `/tmp/openclaw-local-ci-20260225-221535.log`.
+- Result: `PASS=15`, `FAIL=15`, `SKIP=1` (`ci:secrets-zizmor` skipped because no workflow-file diff vs `origin/main`).
+- `ci.yml` jobs with `if: false` (`deadcode`, `ios`) are disabled in GitHub CI and were not executed.
+- Main local blockers seen in this run:
+  - `ci:check`: formatting failure in `src/daemon/launchd.ts`.
+  - `ci:checks-node-test` and `ci:macos-ts-tests`: test failures plus Node OOM during full `pnpm test`.
+  - `ci:skills-python-*` / `ci:secrets-*`: Homebrew Python PEP668 (`externally-managed-environment`) and missing `pre-commit`/`detect-secrets`.
+  - `ci:macos-swift*`: missing `swiftlint`/`swiftformat` and Swift `6.2.0` required vs local `6.1.0`.
+  - `ci:android-*`: Android SDK not configured (`ANDROID_HOME` / `apps/android/local.properties`).
+  - `sandbox-common-smoke:common-image`: passed after running the workflow command directly (temp script had unescaped `$u` with `set -u`).
+
 ## Commit & Pull Request Guidelines
 
 **Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see `.agents/skills/PR_WORKFLOW.md`. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to PR_WORKFLOW.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,20 +102,6 @@
 - Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior or the user asks for one.
 - Mobile: before using a simulator, check for connected real devices (iOS + Android) and prefer them when available.
 
-### Local full-CI one-shot record (2026-02-25)
-
-- Ran local parity sweep for GitHub CI workflows (`workflow-sanity.yml`, `ci.yml`, `install-smoke.yml`, `sandbox-common-smoke.yml`) via `/tmp/run-openclaw-local-ci.sh`.
-- Artifacts: `/tmp/openclaw-local-ci-20260225-221535.summary`, `/tmp/openclaw-local-ci-20260225-221535.log`.
-- Result: `PASS=15`, `FAIL=15`, `SKIP=1` (`ci:secrets-zizmor` skipped because no workflow-file diff vs `origin/main`).
-- `ci.yml` jobs with `if: false` (`deadcode`, `ios`) are disabled in GitHub CI and were not executed.
-- Main local blockers seen in this run:
-  - `ci:check`: formatting failure in `src/daemon/launchd.ts`.
-  - `ci:checks-node-test` and `ci:macos-ts-tests`: test failures plus Node OOM during full `pnpm test`.
-  - `ci:skills-python-*` / `ci:secrets-*`: Homebrew Python PEP668 (`externally-managed-environment`) and missing `pre-commit`/`detect-secrets`.
-  - `ci:macos-swift*`: missing `swiftlint`/`swiftformat` and Swift `6.2.0` required vs local `6.1.0`.
-  - `ci:android-*`: Android SDK not configured (`ANDROID_HOME` / `apps/android/local.properties`).
-  - `sandbox-common-smoke:common-image`: passed after running the workflow command directly (temp script had unescaped `$u` with `set -u`).
-
 ## Commit & Pull Request Guidelines
 
 **Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see `.agents/skills/PR_WORKFLOW.md`. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to PR_WORKFLOW.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Daemon/macOS launchd: forward proxy env vars into supervised service environments, switch LaunchAgent keepalive policy to crash-only with throttling, and harden restart sequencing to `print -> bootout -> wait old pid exit -> bootstrap -> kickstart`. (#27276) thanks @frankekn.
 - Android/Node invoke: remove native gateway WebSocket `Origin` header to avoid false origin rejections, unify invoke command registry/policy/error parsing paths, and keep command availability checks centralized to reduce dispatcher/advertisement drift. (#27257) Thanks @obviyus.
 - CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.
 

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 
+const LAUNCHD_THROTTLE_INTERVAL_SECONDS = 5;
+
 const plistEscape = (value: string): string =>
   value
     .replaceAll("&", "&amp;")
@@ -106,5 +108,5 @@ export function buildLaunchAgentPlist({
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <dict>\n      <key>SuccessfulExit</key>\n      <false/>\n    </dict>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCHD_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.integration.test.ts
+++ b/src/daemon/launchd.integration.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  installLaunchAgent,
+  readLaunchAgentRuntime,
+  restartLaunchAgent,
+  resolveLaunchAgentPlistPath,
+  uninstallLaunchAgent,
+} from "./launchd.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const WAIT_INTERVAL_MS = 200;
+const WAIT_TIMEOUT_MS = 15_000;
+
+function canRunLaunchdIntegration(): boolean {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+  if (typeof process.getuid !== "function") {
+    return false;
+  }
+  const domain = `gui/${process.getuid()}`;
+  const probe = spawnSync("launchctl", ["print", domain], { encoding: "utf8" });
+  if (probe.error) {
+    return false;
+  }
+  return probe.status === 0;
+}
+
+const describeLaunchdIntegration = canRunLaunchdIntegration() ? describe : describe.skip;
+
+async function waitForRunningRuntime(params: {
+  env: GatewayServiceEnv;
+  pidNot?: number;
+  timeoutMs?: number;
+}): Promise<{ pid: number }> {
+  const timeoutMs = params.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  let lastPid: number | undefined;
+  while (Date.now() < deadline) {
+    const runtime = await readLaunchAgentRuntime(params.env);
+    lastStatus = runtime.status;
+    lastPid = runtime.pid;
+    if (
+      runtime.status === "running" &&
+      typeof runtime.pid === "number" &&
+      runtime.pid > 1 &&
+      (params.pidNot === undefined || runtime.pid !== params.pidNot)
+    ) {
+      return { pid: runtime.pid };
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, WAIT_INTERVAL_MS);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for launchd runtime (status=${lastStatus}, pid=${lastPid ?? "none"})`,
+  );
+}
+
+describeLaunchdIntegration("launchd integration", () => {
+  let env: GatewayServiceEnv | undefined;
+  let homeDir = "";
+  const stdout = new PassThrough();
+
+  beforeAll(async () => {
+    const testId = randomUUID().slice(0, 8);
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-launchd-int-${testId}-`));
+    env = {
+      HOME: homeDir,
+      OPENCLAW_LAUNCHD_LABEL: `ai.openclaw.launchd-int-${testId}`,
+      OPENCLAW_LOG_PREFIX: `gateway-launchd-int-${testId}`,
+    };
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+    });
+    await waitForRunningRuntime({ env });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (env) {
+      try {
+        await uninstallLaunchAgent({ env, stdout });
+      } catch {
+        // Best-effort cleanup in case launchctl state already changed.
+      }
+    }
+    if (homeDir) {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("restarts launchd service and keeps it running with a new pid", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const before = await waitForRunningRuntime({ env });
+    await restartLaunchAgent({ env, stdout });
+    const after = await waitForRunningRuntime({ env, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(env));
+  }, 30_000);
+});

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -309,6 +309,26 @@ describe("buildServiceEnvironment", () => {
       expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
     }
   });
+
+  it("forwards proxy environment variables for launchd/systemd runtime", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        HTTP_PROXY: " http://proxy.local:7890 ",
+        HTTPS_PROXY: "https://proxy.local:7890",
+        NO_PROXY: "localhost,127.0.0.1",
+        http_proxy: "http://proxy.local:7890",
+        all_proxy: "socks5://proxy.local:1080",
+      },
+      port: 18789,
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://proxy.local:7890");
+    expect(env.HTTPS_PROXY).toBe("https://proxy.local:7890");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.http_proxy).toBe("http://proxy.local:7890");
+    expect(env.all_proxy).toBe("socks5://proxy.local:1080");
+  });
 });
 
 describe("buildNodeServiceEnvironment", () => {
@@ -317,6 +337,19 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.HOME).toBe("/home/user");
+  });
+
+  it("forwards proxy environment variables for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        HTTPS_PROXY: " https://proxy.local:7890 ",
+        no_proxy: "localhost,127.0.0.1",
+      },
+    });
+
+    expect(env.HTTPS_PROXY).toBe("https://proxy.local:7890");
+    expect(env.no_proxy).toBe("localhost,127.0.0.1");
   });
 
   it("forwards TMPDIR for node services", () => {


### PR DESCRIPTION
## Summary
- forward proxy-related env vars into service environments (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`/`ALL_PROXY` + lowercase forms)
- change LaunchAgent plist keepalive policy to crash-only with `ThrottleInterval=5`
- harden launchd restart flow to `print -> bootout -> wait old pid exit -> bootstrap -> kickstart`
- add regression coverage for proxy env passthrough, LaunchAgent plist policy, and restart command ordering

## Testing
- `bunx vitest run --config vitest.unit.config.ts src/daemon/service-env.test.ts src/daemon/launchd.test.ts`
- `pnpm check`
