### PR TITLE
fix(hooks): deduplicate after_tool_call hook in embedded runs [AI-assisted]

### DIFF
--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Integration test: after_tool_call fires exactly once when both the adapter
+ * (toToolDefinitions) and the subscription handler (handleToolExecutionEnd)
+ * are active — the production scenario for embedded runs.
+ *
+ * Regression guard for the double-fire bug fixed by removing the adapter-side
+ * after_tool_call invocation (see PR #15012 → dedup in this fix).
+ */
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => true),
+    runAfterToolCall: vi.fn(async () => {}),
+    runBeforeToolCall: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+}));
+
+vi.mock("./pi-tools.before-tool-call.js", () => ({
+  consumeAdjustedParamsForToolCall: vi.fn((_: string) => undefined),
+  isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
+  runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
+    blocked: false,
+    params,
+  })),
+}));
+
+function createTestTool(name: string) {
+  return {
+    name,
+    label: name,
+    description: `test tool: ${name}`,
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: { ok: true },
+    })),
+  } satisfies AgentTool;
+}
+
+function createFailingTool(name: string) {
+  return {
+    name,
+    label: name,
+    description: `failing tool: ${name}`,
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => {
+      throw new Error("tool failed");
+    }),
+  } satisfies AgentTool;
+}
+
+function createToolHandlerCtx() {
+  return {
+    params: {
+      runId: "integration-test",
+      session: { messages: [] },
+    },
+    hookRunner: hookMocks.runner,
+    state: {
+      toolMetaById: new Map<string, unknown>(),
+      toolMetas: [] as Array<{ toolName?: string; meta?: string }>,
+      toolSummaryById: new Set<string>(),
+      lastToolError: undefined,
+      pendingMessagingTexts: new Map<string, string>(),
+      pendingMessagingTargets: new Map<string, unknown>(),
+      pendingMessagingMediaUrls: new Map<string, string[]>(),
+      messagingToolSentTexts: [] as string[],
+      messagingToolSentTextsNormalized: [] as string[],
+      messagingToolSentMediaUrls: [] as string[],
+      messagingToolSentTargets: [] as unknown[],
+      blockBuffer: "",
+      successfulCronAdds: 0,
+    },
+    log: { debug: vi.fn(), warn: vi.fn() },
+    flushBlockReplyBuffer: vi.fn(),
+    shouldEmitToolResult: () => false,
+    shouldEmitToolOutput: () => false,
+    emitToolSummary: vi.fn(),
+    emitToolOutput: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+  };
+}
+
+let toToolDefinitions: typeof import("./pi-tool-definition-adapter.js").toToolDefinitions;
+let handleToolExecutionStart: typeof import("./pi-embedded-subscribe.handlers.tools.js").handleToolExecutionStart;
+let handleToolExecutionEnd: typeof import("./pi-embedded-subscribe.handlers.tools.js").handleToolExecutionEnd;
+
+describe("after_tool_call fires exactly once in embedded runs", () => {
+  beforeAll(async () => {
+    ({ toToolDefinitions } = await import("./pi-tool-definition-adapter.js"));
+    ({ handleToolExecutionStart, handleToolExecutionEnd } =
+      await import("./pi-embedded-subscribe.handlers.tools.js"));
+  });
+
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockClear();
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    hookMocks.runner.runAfterToolCall.mockClear();
+    hookMocks.runner.runAfterToolCall.mockResolvedValue(undefined);
+    hookMocks.runner.runBeforeToolCall.mockClear();
+    hookMocks.runner.runBeforeToolCall.mockResolvedValue(undefined);
+  });
+
+  it("fires after_tool_call exactly once on success when both adapter and handler are active", async () => {
+    const tool = createTestTool("read");
+    const defs = toToolDefinitions([tool]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    const toolCallId = "integration-call-1";
+    const args = { path: "/tmp/test.txt" };
+    const ctx = createToolHandlerCtx();
+
+    // Step 1: Simulate tool_execution_start event (SDK emits this)
+    await handleToolExecutionStart(
+      ctx as never,
+      { type: "tool_execution_start", toolName: "read", toolCallId, args } as never,
+    );
+
+    // Step 2: Execute tool through the adapter wrapper (SDK calls this)
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+    await def.execute(toolCallId, args, undefined, undefined, extensionContext);
+
+    // Step 3: Simulate tool_execution_end event (SDK emits this after execute returns)
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "read",
+        toolCallId,
+        isError: false,
+        result: { content: [{ type: "text", text: "ok" }] },
+      } as never,
+    );
+
+    // The hook must fire exactly once — not zero, not two.
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires after_tool_call exactly once on error when both adapter and handler are active", async () => {
+    const tool = createFailingTool("exec");
+    const defs = toToolDefinitions([tool]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    const toolCallId = "integration-call-err";
+    const args = { command: "fail" };
+    const ctx = createToolHandlerCtx();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      { type: "tool_execution_start", toolName: "exec", toolCallId, args } as never,
+    );
+
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+    await def.execute(toolCallId, args, undefined, undefined, extensionContext);
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId,
+        isError: true,
+        result: { status: "error", error: "tool failed" },
+      } as never,
+    );
+
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+
+    const call = (hookMocks.runner.runAfterToolCall as ReturnType<typeof vi.fn>).mock.calls[0];
+    const event = call?.[0] as { error?: unknown } | undefined;
+    expect(event?.error).toBeDefined();
+  });
+
+  it("fires after_tool_call exactly once per tool across multiple sequential tool calls", async () => {
+    const tool = createTestTool("write");
+    const defs = toToolDefinitions([tool]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    const ctx = createToolHandlerCtx();
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    for (let i = 0; i < 3; i++) {
+      const toolCallId = `sequential-call-${i}`;
+      const args = { path: `/tmp/file-${i}.txt`, content: "data" };
+
+      await handleToolExecutionStart(
+        ctx as never,
+        { type: "tool_execution_start", toolName: "write", toolCallId, args } as never,
+      );
+
+      await def.execute(toolCallId, args, undefined, undefined, extensionContext);
+
+      await handleToolExecutionEnd(
+        ctx as never,
+        {
+          type: "tool_execution_end",
+          toolName: "write",
+          toolCallId,
+          isError: false,
+          result: { content: [{ type: "text", text: "written" }] },
+        } as never,
+      );
+    }
+
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
@@ -5,7 +5,7 @@ import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
 
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn((_: string) => false),
+    hasHooks: vi.fn((_: string) => true),
     runAfterToolCall: vi.fn(async () => {}),
   },
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
@@ -39,31 +39,6 @@ function createReadTool() {
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
 
-function enableAfterToolCallHook() {
-  hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
-}
-
-async function executeReadTool(callId: string) {
-  const defs = toToolDefinitions([createReadTool()]);
-  const def = defs[0];
-  if (!def) {
-    throw new Error("missing tool definition");
-  }
-  const execute = (...args: Parameters<(typeof defs)[0]["execute"]>) => def.execute(...args);
-  return await execute(callId, { path: "/tmp/file" }, undefined, undefined, extensionContext);
-}
-
-function expectReadAfterToolCallPayload(result: Awaited<ReturnType<typeof executeReadTool>>) {
-  expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
-    {
-      toolName: "read",
-      params: { mode: "safe" },
-      result,
-    },
-    { toolName: "read" },
-  );
-}
-
 describe("pi tool definition adapter after_tool_call", () => {
   beforeEach(() => {
     hookMocks.runner.hasHooks.mockClear();
@@ -80,32 +55,21 @@ describe("pi tool definition adapter after_tool_call", () => {
     }));
   });
 
-  it("dispatches after_tool_call once on successful adapter execution", async () => {
-    enableAfterToolCallHook();
-    hookMocks.runBeforeToolCallHook.mockResolvedValue({
-      blocked: false,
-      params: { mode: "safe" },
-    });
-    const result = await executeReadTool("call-ok");
+  // Regression guard: after_tool_call is handled exclusively by
+  // handleToolExecutionEnd in the subscription handler to prevent
+  // duplicate invocations in embedded runs.
+  it("does not fire after_tool_call from the adapter (handled by subscription handler)", async () => {
+    const defs = toToolDefinitions([createReadTool()]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+    await def.execute("call-ok", { path: "/tmp/file" }, undefined, undefined, extensionContext);
 
-    expect(result.details).toMatchObject({ ok: true });
-    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
-    expectReadAfterToolCallPayload(result);
+    expect(hookMocks.runner.runAfterToolCall).not.toHaveBeenCalled();
   });
 
-  it("uses wrapped-tool adjusted params for after_tool_call payload", async () => {
-    enableAfterToolCallHook();
-    hookMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(true);
-    hookMocks.consumeAdjustedParamsForToolCall.mockReturnValue({ mode: "safe" } as unknown);
-    const result = await executeReadTool("call-ok-wrapped");
-
-    expect(result.details).toMatchObject({ ok: true });
-    expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
-    expectReadAfterToolCallPayload(result);
-  });
-
-  it("dispatches after_tool_call once on adapter error with normalized tool name", async () => {
-    enableAfterToolCallHook();
+  it("does not fire after_tool_call from the adapter on error", async () => {
     const tool = {
       name: "bash",
       label: "Bash",
@@ -121,31 +85,27 @@ describe("pi tool definition adapter after_tool_call", () => {
     if (!def) {
       throw new Error("missing tool definition");
     }
-    const execute = (...args: Parameters<(typeof defs)[0]["execute"]>) => def.execute(...args);
-    const result = await execute("call-err", { cmd: "ls" }, undefined, undefined, extensionContext);
+    await def.execute("call-err", { cmd: "ls" }, undefined, undefined, extensionContext);
 
-    expect(result.details).toMatchObject({
-      status: "error",
-      tool: "exec",
-      error: "boom",
-    });
-    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
-    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
-      {
-        toolName: "exec",
-        params: { cmd: "ls" },
-        error: "boom",
-      },
-      { toolName: "exec" },
-    );
+    expect(hookMocks.runner.runAfterToolCall).not.toHaveBeenCalled();
   });
 
-  it("does not break execution when after_tool_call hook throws", async () => {
-    enableAfterToolCallHook();
-    hookMocks.runner.runAfterToolCall.mockRejectedValue(new Error("hook failed"));
-    const result = await executeReadTool("call-ok2");
+  it("consumes adjusted params for wrapped tools to avoid leaks", async () => {
+    hookMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(true);
+    const defs = toToolDefinitions([createReadTool()]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+    await def.execute(
+      "call-wrapped",
+      { path: "/tmp/file" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
 
-    expect(result.details).toMatchObject({ ok: true });
-    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+    expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
+    expect(hookMocks.consumeAdjustedParamsForToolCall).toHaveBeenCalledWith("call-wrapped");
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** The `after_tool_call` plugin hook fires twice per tool execution in embedded agent runs. Two independent code paths both dispatch the hook: `pi-tool-definition-adapter.ts` (the tool adapter wrapper) and `handleToolExecutionEnd` in `pi-embedded-subscribe.handlers.tools.ts` (the subscription event handler).
- **Why it matters:** Plugin authors observing `after_tool_call` see duplicate events for every tool call, forcing them to implement client-side deduplication workarounds (windowed hash maps, etc.). This is a correctness bug in the hook lifecycle.
- **What changed:** Removed the `after_tool_call` dispatch from `pi-tool-definition-adapter.ts`. The subscription handler (`handleToolExecutionEnd`) is now the single source of truth — it already has richer context (duration, sanitized result, session info). Added regression tests and an integration test that verifies the hook fires exactly once.
- **What did NOT change (scope boundary):** `before_tool_call` behavior is untouched (it was already deduplicated in PR #15635). The subscription handler dispatch logic is unchanged. `consumeAdjustedParamsForToolCall` cleanup remains in the adapter to prevent memory leaks from `before_tool_call` parameter tracking.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #15012 (PR that introduced hooks in both paths)
- Related: #15635 (PR that deduplicated `before_tool_call` — this PR applies the same fix to `after_tool_call`)

## User-visible / Behavior Changes

Plugins listening on `after_tool_call` will now receive exactly one event per tool execution instead of two. Plugins with deduplication workarounds will continue to work but the workarounds become unnecessary.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15 (darwin 24.6.0)
- Runtime/container: Node 22+, Bun
- Model/provider: Any (hook fires regardless of model)
- Integration/channel (if any): Any plugin using `after_tool_call`

### Steps

1. Install a plugin that logs `after_tool_call` events
2. Run an embedded agent session (e.g. `openclaw agent`)
3. Trigger any tool execution (e.g. Read, Bash)

### Expected

- Plugin receives exactly 1 `after_tool_call` event per tool execution

### Actual (on `main`)

- Plugin receives 2 `after_tool_call` events per tool execution — one from the adapter wrapper, one from the subscription handler

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**New integration test** (`pi-tool-definition-adapter.after-tool-call.fires-once.test.ts`): simulates the full embedded runtime flow (adapter execute + subscription handler event) and asserts `toHaveBeenCalledTimes(1)`. This test was verified to fail with `toHaveBeenCalledTimes(2)` when the bug is reintroduced.

**Regression guard test** (`pi-tool-definition-adapter.after-tool-call.test.ts`): updated to assert the adapter does NOT call `runAfterToolCall`, confirming the hook dispatch was removed from the adapter.

**Full test suite:** 1417 test files, 11613 tests — all passing (`pnpm build && pnpm check && pnpm test`).

## Human Verification (required)

- **Verified scenarios:**
  - Ran full test suite (11613 tests pass)
  - Ran the gateway on `main` with a plugin observing `after_tool_call` — confirmed 2 events fire per tool call
  - Ran the gateway on this branch with the same plugin — confirmed exactly 1 event fires per tool call
  - Verified the integration test correctly detects the bug: reverting the fix causes the test to fail with count=2
- **Edge cases checked:**
  - Tool execution errors (hook still fires once with error info via subscription handler)
  - Sequential tool calls (each fires exactly once, no cross-contamination)
  - `consumeAdjustedParamsForToolCall` cleanup still runs in the adapter to prevent leaks from `before_tool_call` parameter tracking
- **What you did not verify:**
  - Non-embedded (standalone CLI) runs — `after_tool_call` dispatch paths differ there and are not affected by this change

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `c129a1a74` — it re-adds the `after_tool_call` dispatch block to `pi-tool-definition-adapter.ts`
- Files/config to restore: `src/agents/pi-tool-definition-adapter.ts`
- Known bad symptoms reviewers should watch for: If `after_tool_call` stops firing entirely (zero times), it means the subscription handler path is not being reached — but that would also break `before_tool_call` which uses the same handler pattern

## Risks and Mitigations

- Risk: The adapter was dispatching `after_tool_call` with the raw (unsanitized) tool result, while the subscription handler dispatches with the sanitized result. Plugins that depended on seeing the raw result will now only see the sanitized version.
  - Mitigation: The sanitized result is the correct one for plugins to consume (it strips sensitive/internal data). The raw result exposure was unintentional.

---

**AI Disclosure:** This PR was built with AI assistance (Cursor + Claude).
- **Degree of testing:** Fully tested — full test suite (11613 tests), new regression + integration tests, and manual end-to-end verification on both `main` (bug present) and fix branch (bug resolved).
- **Code understanding confirmed:** Yes. The root cause was traced through git history to PR #15012 which added hooks to both tool execution paths. The `before_tool_call` half was already deduplicated in PR #15635; this PR completes the same fix for `after_tool_call`.

Made with [Cursor](https://cursor.com)