### PR TITLE
fix(status): show "externally managed" instead of "not installed" when gateway is reachable

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -293,7 +293,9 @@ export async function statusAllCommand(
         ? {
             Item: "Gateway service",
             Value: !daemon.installed
-              ? `${daemon.label} not installed`
+              ? gatewayReachable
+                ? `${daemon.label} · running (externally managed)`
+                : `${daemon.label} not installed`
               : `${daemon.label} ${daemon.installed ? "installed · " : ""}${daemon.loadedText}${daemon.runtime?.status ? ` · ${daemon.runtime.status}` : ""}${daemon.runtime?.pid ? ` (pid ${daemon.runtime.pid})` : ""}`,
           }
         : { Item: "Gateway service", Value: "unknown" },

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -279,6 +279,13 @@ export async function statusCommand(
   ]);
   const daemonValue = (() => {
     if (daemon.installed === false) {
+      // Gateway is reachable even though no OpenClaw-managed service unit was found.
+      // The user likely started the gateway via their own service manager (e.g. a
+      // hand-written systemd system unit or a container supervisor).  Reporting
+      // "not installed" would be misleading in this case.
+      if (gatewayReachable) {
+        return `${daemon.label} · running (externally managed)`;
+      }
       return `${daemon.label} not installed`;
     }
     const installedPrefix = daemon.installed === true ? "installed · " : "";


### PR DESCRIPTION
## Problem

`openclaw status` and `openclaw status --all` both report **"systemd not installed"** when the gateway is started by a user-managed service (e.g. `/etc/systemd/system/openclaw-gateway.service` or a container supervisor), even though the gateway is healthy and processing messages.

Root cause: `service.isLoaded()` and `service.readCommand()` only look for the OpenClaw-managed **user-level** systemd unit (`~/.config/systemd/user/openclaw-gateway.service`). When the unit is absent, `daemon.installed === false` unconditionally → `"systemd not installed"`.

## Fix

Before emitting the `"not installed"` string, check `gatewayReachable`. If the gateway responds to the probe it is clearly running — just not via the OpenClaw install/uninstall path. In that case display:

```
systemd · running (externally managed)
```

No change when the gateway is unreachable: the existing `"systemd not installed"` hint still appears to guide the user toward `openclaw gateway install`.

## Changed files

| File | Change |
|------|--------|
| `src/commands/status.command.ts` | Add `gatewayReachable` guard in `daemonValue` IIFE |
| `src/commands/status-all.ts` | Same guard in `"Gateway service"` row |

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Gateway started by `openclaw gateway start` | `systemd installed · running` | unchanged |
| Gateway started by custom systemd system unit | ❌ `systemd not installed` | ✅ `systemd · running (externally managed)` |
| Gateway not running, no service installed | `systemd not installed` | unchanged |

Fixes #27267