### PR TITLE
fix(agents): inject num_ctx for Ollama OpenAI-compat API to prevent 4096 token cap

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -109,8 +109,14 @@ export function resolveModel(
         reasoning: false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+        contextWindow:
+          providerCfg?.models?.find((m) => m.id === modelId)?.contextWindow ??
+          providerCfg?.models?.[0]?.contextWindow ??
+          DEFAULT_CONTEXT_TOKENS,
+        maxTokens:
+          providerCfg?.models?.find((m) => m.id === modelId)?.maxTokens ??
+          providerCfg?.models?.[0]?.maxTokens ??
+          DEFAULT_CONTEXT_TOKENS,
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }


### PR DESCRIPTION
## Summary

- Problem: Ollama models always cap input at 4096 tokens when configured with `api: "openai-completions"`, causing conversation history to be lost after a few messages. The native `api: "ollama"` path sends `num_ctx` but the OpenAI-compat path does not.
- Why it matters: Users lose all conversation context — the model forgets everything said earlier in the same conversation.
- What changed: (1) Detect Ollama providers using the OpenAI-compat API (by provider name or baseUrl pattern) and inject `num_ctx` into the request payload via `onPayload`. (2) Fix fallback model resolution to match by model ID instead of blindly using `models[0]`.
- What did NOT change (scope boundary): The native `api: "ollama"` path, non-Ollama providers, and the model registry lookup are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27278
- Related #

## User-visible / Behavior Changes

Ollama models configured with `api: "openai-completions"` now respect the configured `contextWindow` value. Conversation history is maintained up to the configured limit instead of being silently truncated at 4096 tokens.

## Security Impact (required)

- New permissions/capabilities: None — only adds a parameter to the existing HTTP request body
- Auth/token changes: None
- Data exposure risk: None

## Testing

- [x] `npx vitest run src/agents/pi-embedded-runner/run/attempt` — 9 tests ✓
- [x] `npx vitest run src/agents/pi-embedded-runner/model` — 20 tests ✓

## Rollback Plan

Revert the single commit. Non-Ollama providers are unaffected. Ollama reverts to the 4096 default.
