### PR TITLE
fix(msteams): use proactive messaging for replies to avoid revoked turn context

### DIFF
--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -462,19 +462,11 @@ export async function sendMSTeamsMessages(params: {
     return messageIds;
   };
 
-  if (params.replyStyle === "thread") {
-    const ctx = params.context;
-    if (!ctx) {
-      throw new Error("Missing context for replyStyle=thread");
-    }
-    return await sendMessagesInContext(ctx);
-  }
-
   const baseRef = buildConversationReference(params.conversationRef);
-  const proactiveRef: MSTeamsConversationReference = {
-    ...baseRef,
-    activityId: undefined,
-  };
+  const proactiveRef: MSTeamsConversationReference =
+    params.replyStyle === "thread"
+      ? baseRef
+      : { ...baseRef, activityId: undefined };
 
   const messageIds: string[] = [];
   await params.adapter.continueConversation(params.appId, proactiveRef, async (ctx) => {


### PR DESCRIPTION
## Summary

- Problem: MS Teams replies fail with "Cannot perform 'set' on a proxy that has been revoked" because the inbound debouncer delays processing beyond the Bot Framework turn lifecycle, causing the turn context proxy to expire before replies are dispatched.
- Why it matters: The bot appears to read messages but never responds — users see no reply at all.
- What changed: Switched all reply delivery and typing indicators from using the turn context to `adapter.continueConversation()` with the stored conversation reference, which creates a fresh context independent of the original turn.
- What did NOT change (scope boundary): Inbound message handling, conversation reference storage, and the non-thread reply path (which already used proactive messaging) are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27189
- Related #

## User-visible / Behavior Changes

MS Teams replies now deliver reliably regardless of processing delay. The `context` parameter on `createMSTeamsReplyDispatcher` is now optional (backward-compatible).

## Security Impact (required)

- New permissions/capabilities: None — proactive messaging uses the same stored conversation reference and Bot Framework credentials
- Auth/token changes: None
- Data exposure risk: None

## Testing

- [x] `npx vitest run extensions/msteams/` — 213 tests ✓

## Rollback Plan

Revert the single commit. No migration or data changes involved.
