### PR TITLE
fix: status no longer reports systemd as not installed when service is running

### DIFF
--- a/src/commands/status.daemon.test.ts
+++ b/src/commands/status.daemon.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  gatewayService: {
+    label: "systemd",
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    isLoaded: vi.fn(),
+    readCommand: vi.fn(),
+    readRuntime: vi.fn(),
+  },
+  nodeService: {
+    label: "systemd",
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    isLoaded: vi.fn(),
+    readCommand: vi.fn(),
+    readRuntime: vi.fn(),
+  },
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => mocks.gatewayService,
+}));
+
+vi.mock("../daemon/node-service.js", () => ({
+  resolveNodeService: () => mocks.nodeService,
+}));
+
+import { getDaemonStatusSummary } from "./status.daemon.js";
+
+describe("getDaemonStatusSummary", () => {
+  beforeEach(() => {
+    mocks.gatewayService.isLoaded.mockReset();
+    mocks.gatewayService.readRuntime.mockReset();
+    mocks.gatewayService.readCommand.mockReset();
+  });
+
+  it("treats a running service as installed even when command config cannot be read", async () => {
+    mocks.gatewayService.isLoaded.mockResolvedValue(false);
+    mocks.gatewayService.readCommand.mockResolvedValue(null);
+    mocks.gatewayService.readRuntime.mockResolvedValue({ status: "running", pid: 1234 });
+
+    const summary = await getDaemonStatusSummary();
+
+    expect(summary.installed).toBe(true);
+    expect(summary.label).toBe("systemd");
+  });
+
+  it("keeps missing services as not installed", async () => {
+    mocks.gatewayService.isLoaded.mockResolvedValue(false);
+    mocks.gatewayService.readCommand.mockResolvedValue(null);
+    mocks.gatewayService.readRuntime.mockResolvedValue({
+      status: "stopped",
+      missingUnit: true,
+    });
+
+    const summary = await getDaemonStatusSummary();
+
+    expect(summary.installed).toBe(false);
+  });
+});

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -20,7 +20,7 @@ async function buildDaemonStatusSummary(
       service.readRuntime(process.env).catch(() => undefined),
       service.readCommand(process.env).catch(() => null),
     ]);
-    const installed = command != null;
+    const installed = command != null || loaded || runtime?.status === "running";
     const loadedText = loaded ? service.loadedText : service.notLoadedText;
     const runtimeShort = formatDaemonRuntimeShort(runtime);
     return { label: service.label, installed, loadedText, runtimeShort };


### PR DESCRIPTION
Closes #27267

Problem
`openclaw status` could report `systemd not installed` even when the gateway was already running under systemd, because install detection relied on reading the service command/unit file only.

Root Cause
`src/commands/status.daemon.ts` treated `readCommand() == null` as `installed=false`. In some systemd-managed setups the service can still be running (or loaded) while the command config cannot be read from the expected path.

Fix
Treat a service as installed when any of these are true: command config is readable, the service is loaded, or runtime status reports `running`. This preserves existing missing-unit behavior while avoiding the false negative for active systemd services.

Testing
- `pnpm vitest run src/commands/status.daemon.test.ts --config vitest.unit.config.ts`
- `pnpm vitest run src/commands/status.test.ts --config vitest.unit.config.ts`
