### PR TITLE
web-search: change default provider from Brave to Perplexity via OpenRouter

### DIFF
--- a/docs/brave-search.md
+++ b/docs/brave-search.md
@@ -8,7 +8,7 @@ title: "Brave Search"
 
 # Brave Search API
 
-OpenClaw uses Brave Search as the default provider for `web_search`.
+OpenClaw supports Brave Search as an alternative provider for `web_search`.
 
 ## Get an API key
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1576,7 +1576,10 @@ Settings can be defined globally in `tools.loopDetection` and overridden per-age
     web: {
       search: {
         enabled: true,
-        apiKey: "brave_api_key", // or BRAVE_API_KEY env
+        provider: "perplexity", // default provider
+        perplexity: {
+          apiKey: "openrouter_or_perplexity_key", // or OPENROUTER_API_KEY / PERPLEXITY_API_KEY env
+        },
         maxResults: 5,
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1422,10 +1422,11 @@ The Gateway watches the config and supports hot-reload:
 
 ### How do I enable web search and web fetch
 
-`web_fetch` works without an API key. `web_search` requires a Brave Search API
-key. **Recommended:** run `openclaw configure --section web` to store it in
-`tools.web.search.apiKey`. Environment alternative: set `BRAVE_API_KEY` for the
-Gateway process.
+`web_fetch` works without an API key. `web_search` defaults to Perplexity and
+requires either a Perplexity/OpenRouter key or another provider key (such as Brave).
+**Recommended:** run `openclaw configure --section web` to store it in
+`tools.web.search.perplexity.apiKey`. Environment alternative: set
+`PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` for the Gateway process.
 
 ```json5
 {
@@ -1433,7 +1434,10 @@ Gateway process.
     web: {
       search: {
         enabled: true,
-        apiKey: "BRAVE_API_KEY_HERE",
+        provider: "perplexity",
+        perplexity: {
+          apiKey: "OPENROUTER_OR_PERPLEXITY_KEY_HERE",
+        },
         maxResults: 5,
       },
       fetch: {

--- a/docs/perplexity.md
+++ b/docs/perplexity.md
@@ -8,8 +8,8 @@ title: "Perplexity Sonar"
 
 # Perplexity Sonar
 
-OpenClaw can use Perplexity Sonar for the `web_search` tool. You can connect
-through Perplexity’s direct API or via OpenRouter.
+OpenClaw uses Perplexity Sonar as the default provider for the `web_search`
+tool. You can connect through Perplexity’s direct API or via OpenRouter.
 
 ## API options
 

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -74,12 +74,12 @@ You can keep it local with `memorySearch.provider = "local"` (no API usage).
 
 See [Memory](/concepts/memory).
 
-### 4) Web search tool (Brave / Perplexity via OpenRouter)
+### 4) Web search tool (Perplexity via OpenRouter / Brave alternative)
 
 `web_search` uses API keys and may incur usage charges:
 
-- **Brave Search API**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
 - **Perplexity** (via OpenRouter): `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY`
+- **Brave Search API** (alternative): `BRAVE_API_KEY` or `tools.web.search.apiKey`
 
 **Brave free tier (generous):**
 

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -35,9 +35,9 @@ openclaw agents add <name>
 </Note>
 
 <Tip>
-Recommended: set up a Brave Search API key so the agent can use `web_search`
+Recommended: set up Perplexity via OpenRouter so the agent can use `web_search`
 (`web_fetch` works without a key). Easiest path: `openclaw configure --section web`
-which stores `tools.web.search.apiKey`. Docs: [Web tools](/tools/web).
+which stores `tools.web.search.perplexity.apiKey` (Brave is still supported as an alternative). Docs: [Web tools](/tools/web).
 </Tip>
 
 ## QuickStart vs Advanced

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -255,7 +255,7 @@ Enable with `tools.loopDetection.enabled: true` (default is `false`).
 
 ### `web_search`
 
-Search the web using Brave Search API.
+Search the web using Perplexity Sonar (default), with Brave as an alternative provider.
 
 Core parameters:
 
@@ -264,7 +264,7 @@ Core parameters:
 
 Notes:
 
-- Requires a Brave API key (recommended: `openclaw configure --section web`, or set `BRAVE_API_KEY`).
+- Requires a provider API key (recommended: `openclaw configure --section web`; Perplexity via `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` is the default path, Brave is also supported via `BRAVE_API_KEY`).
 - Enable via `tools.web.search.enabled`.
 - Responses are cached (default 15 min).
 - See [Web tools](/tools/web) for setup.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,9 +1,9 @@
 ---
-summary: "Web search + fetch tools (Brave Search API, Perplexity direct/OpenRouter, Gemini Google Search grounding)"
+summary: "Web search + fetch tools (Perplexity via OpenRouter/default, Brave alternative, Gemini Google Search grounding)"
 read_when:
   - You want to enable web_search or web_fetch
-  - You need Brave Search API key setup
-  - You want to use Perplexity Sonar for web search
+  - You want to use Perplexity Sonar (default) for web search
+  - You need Brave Search API key setup as an alternative
   - You want to use Gemini with Google Search grounding
 title: "Web Tools"
 ---
@@ -12,7 +12,7 @@ title: "Web Tools"
 
 OpenClaw ships two lightweight web tools:
 
-- `web_search` — Search the web via Brave Search API (default), Perplexity Sonar, or Gemini with Google Search grounding.
+- `web_search` — Search the web via Perplexity Sonar (default), Brave Search API, or Gemini with Google Search grounding.
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -21,8 +21,8 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 ## How it works
 
 - `web_search` calls your configured provider and returns results.
-  - **Brave** (default): returns structured results (title, URL, snippet).
-  - **Perplexity**: returns AI-synthesized answers with citations from real-time web search.
+  - **Perplexity** (default): returns AI-synthesized answers with citations from real-time web search.
+  - **Brave**: returns structured results (title, URL, snippet).
   - **Gemini**: returns AI-synthesized answers grounded in Google Search with citations.
 - Results are cached by query for 15 minutes (configurable).
 - `web_fetch` does a plain HTTP GET and extracts readable content
@@ -33,8 +33,8 @@ These are **not** browser automation. For JS-heavy sites or logins, use the
 
 | Provider            | Pros                                         | Cons                                     | API Key                                      |
 | ------------------- | -------------------------------------------- | ---------------------------------------- | -------------------------------------------- |
-| **Brave** (default) | Fast, structured results, free tier          | Traditional search results               | `BRAVE_API_KEY`                              |
-| **Perplexity**      | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **Perplexity** (default) | AI-synthesized answers, citations, real-time | Requires Perplexity or OpenRouter access | `OPENROUTER_API_KEY` or `PERPLEXITY_API_KEY` |
+| **Brave**               | Fast, structured results, free tier          | Traditional search results               | `BRAVE_API_KEY`                              |
 | **Gemini**          | Google Search grounding, AI-synthesized      | Requires Gemini API key                  | `GEMINI_API_KEY`                             |
 
 See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for provider-specific details.
@@ -43,12 +43,13 @@ See [Brave Search setup](/brave-search) and [Perplexity Sonar](/perplexity) for 
 
 If no `provider` is explicitly set, OpenClaw auto-detects which provider to use based on available API keys, checking in this order:
 
-1. **Brave** — `BRAVE_API_KEY` env var or `search.apiKey` config
+1. **Perplexity** — `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` env var or `search.perplexity.apiKey` config
 2. **Gemini** — `GEMINI_API_KEY` env var or `search.gemini.apiKey` config
-3. **Perplexity** — `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` env var or `search.perplexity.apiKey` config
-4. **Grok** — `XAI_API_KEY` env var or `search.grok.apiKey` config
+3. **Kimi** — `KIMI_API_KEY` / `MOONSHOT_API_KEY` env var or `search.kimi.apiKey` config
+4. **Brave** — `BRAVE_API_KEY` env var or `search.apiKey` config
+5. **Grok** — `XAI_API_KEY` env var or `search.grok.apiKey` config
 
-If no keys are found, it falls back to Brave (you'll get a missing-key error prompting you to configure one).
+If no keys are found, it falls back to Perplexity (you'll get a missing-key error prompting you to configure one).
 
 ### Explicit provider
 
@@ -59,49 +60,27 @@ Set the provider in config:
   tools: {
     web: {
       search: {
-        provider: "brave", // or "perplexity" or "gemini"
+        provider: "perplexity", // or "brave" or "gemini"
       },
     },
   },
 }
 ```
 
-Example: switch to Perplexity Sonar (direct API):
+Example: switch to Brave Search:
 
 ```json5
 {
   tools: {
     web: {
       search: {
-        provider: "perplexity",
-        perplexity: {
-          apiKey: "pplx-...",
-          baseUrl: "https://api.perplexity.ai",
-          model: "perplexity/sonar-pro",
-        },
+        provider: "brave",
+        apiKey: "BRAVE_API_KEY_HERE",
       },
     },
   },
 }
 ```
-
-## Getting a Brave API key
-
-1. Create a Brave Search API account at [https://brave.com/search/api/](https://brave.com/search/api/)
-2. In the dashboard, choose the **Data for Search** plan (not “Data for AI”) and generate an API key.
-3. Run `openclaw configure --section web` to store the key in config (recommended), or set `BRAVE_API_KEY` in your environment.
-
-Brave provides a free tier plus paid plans; check the Brave API portal for the
-current limits and pricing.
-
-### Where to set the key (recommended)
-
-**Recommended:** run `openclaw configure --section web`. It stores the key in
-`~/.openclaw/openclaw.json` under `tools.web.search.apiKey`.
-
-**Environment alternative:** set `BRAVE_API_KEY` in the Gateway process
-environment. For a gateway install, put it in `~/.openclaw/.env` (or your
-service environment). See [Env vars](/help/faq#how-does-openclaw-load-environment-variables).
 
 ## Using Perplexity (direct or via OpenRouter)
 
@@ -155,6 +134,21 @@ If no base URL is set, OpenClaw chooses a default based on the API key source:
 | `perplexity/sonar-pro` (default) | Multi-step reasoning with web search | Complex questions |
 | `perplexity/sonar-reasoning-pro` | Chain-of-thought analysis            | Deep research     |
 
+## Getting a Brave API key (alternative provider)
+
+1. Create a Brave Search API account at [https://brave.com/search/api/](https://brave.com/search/api/)
+2. In the dashboard, choose the **Data for Search** plan (not “Data for AI”) and generate an API key.
+3. Run `openclaw configure --section web` to store the key in config, or set `BRAVE_API_KEY` in your environment.
+
+Brave provides a free tier plus paid plans; check the Brave API portal for the
+current limits and pricing.
+
+### Where to set the key
+
+Set `tools.web.search.apiKey` in config, or set `BRAVE_API_KEY` in the Gateway process
+environment. For a gateway install, put it in `~/.openclaw/.env` (or your
+service environment). See [Env vars](/help/faq#how-does-openclaw-load-environment-variables).
+
 ## Using Gemini (Google Search grounding)
 
 Gemini models support built-in [Google Search grounding](https://ai.google.dev/gemini-api/docs/grounding),
@@ -206,8 +200,8 @@ Search the web using your configured provider.
 
 - `tools.web.search.enabled` must not be `false` (default: enabled)
 - API key for your chosen provider:
-  - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Perplexity**: `OPENROUTER_API_KEY`, `PERPLEXITY_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
 
 ### Config
 
@@ -217,7 +211,10 @@ Search the web using your configured provider.
     web: {
       search: {
         enabled: true,
-        apiKey: "BRAVE_API_KEY_HERE", // optional if BRAVE_API_KEY is set
+        provider: "perplexity",
+        perplexity: {
+          apiKey: "OPENROUTER_OR_PERPLEXITY_KEY_HERE", // optional if OPENROUTER_API_KEY or PERPLEXITY_API_KEY is set
+        },
         maxResults: 5,
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,
@@ -321,4 +318,4 @@ Notes:
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
-- If the Brave key is missing, `web_search` returns a short setup hint with a docs link.
+- If the configured provider key is missing, `web_search` returns a short setup hint with a docs link.

--- a/docs/zh-CN/brave-search.md
+++ b/docs/zh-CN/brave-search.md
@@ -15,7 +15,7 @@ x-i18n:
 
 # Brave Search API
 
-OpenClaw 使用 Brave Search 作为 `web_search` 的默认提供商。
+OpenClaw 支持将 Brave Search 作为 `web_search` 的替代提供商。
 
 ## 获取 API 密钥
 

--- a/docs/zh-CN/gateway/configuration.md
+++ b/docs/zh-CN/gateway/configuration.md
@@ -2000,7 +2000,9 @@ Z.AI 模型可通过 `zai/<model>` 使用（例如 `zai/glm-4.7`），需要环�
 `tools.web` 配置 Web 搜索 + 获取工具：
 
 - `tools.web.search.enabled`（默认：有密钥时为 true）
-- `tools.web.search.apiKey`（推荐：通过 `openclaw configure --section web` 设置，或使用 `BRAVE_API_KEY` 环境变量）
+- `tools.web.search.provider`（默认 `perplexity`；可选 `brave`、`gemini`、`grok`、`kimi`）
+- `tools.web.search.perplexity.apiKey`（推荐：通过 `openclaw configure --section web` 设置，或使用 `OPENROUTER_API_KEY`/`PERPLEXITY_API_KEY` 环境变量）
+- `tools.web.search.apiKey`（Brave 替代提供商密钥；或使用 `BRAVE_API_KEY` 环境变量）
 - `tools.web.search.maxResults`（1–10，默认 5）
 - `tools.web.search.timeoutSeconds`（默认 30）
 - `tools.web.search.cacheTtlMinutes`（默认 15）

--- a/docs/zh-CN/help/faq.md
+++ b/docs/zh-CN/help/faq.md
@@ -1266,7 +1266,7 @@ Gateway 网关监视配置文件并支持热重载：
 
 ### 如何启用网络搜索（和网页抓取）
 
-`web_fetch` 无需 API 密钥即可工作。`web_search` 需要 Brave Search API 密钥。**推荐：** 运行 `openclaw configure --section web` 将其存储在 `tools.web.search.apiKey` 中。环境变量替代方案：为 Gateway 网关进程设置 `BRAVE_API_KEY`。
+`web_fetch` 无需 API 密钥即可工作。`web_search` 默认使用 Perplexity，需要 Perplexity/OpenRouter 密钥（或其他提供商密钥，如 Brave）。**推荐：** 运行 `openclaw configure --section web` 将其存储在 `tools.web.search.perplexity.apiKey` 中。环境变量替代方案：为 Gateway 网关进程设置 `PERPLEXITY_API_KEY` 或 `OPENROUTER_API_KEY`。
 
 ```json5
 {
@@ -1274,7 +1274,10 @@ Gateway 网关监视配置文件并支持热重载：
     web: {
       search: {
         enabled: true,
-        apiKey: "BRAVE_API_KEY_HERE",
+        provider: "perplexity",
+        perplexity: {
+          apiKey: "OPENROUTER_OR_PERPLEXITY_KEY_HERE",
+        },
         maxResults: 5,
       },
       fetch: {

--- a/docs/zh-CN/reference/api-usage-costs.md
+++ b/docs/zh-CN/reference/api-usage-costs.md
@@ -75,12 +75,12 @@ OpenClaw 可以从以下来源获取凭据：
 
 请参阅[记忆](/concepts/memory)。
 
-### 4）网页搜索工具（Brave / 通过 OpenRouter 使用 Perplexity）
+### 4）网页搜索工具（通过 OpenRouter 使用 Perplexity / Brave 替代）
 
 `web_search` 使用 API 密钥，可能产生使用费用：
 
-- **Brave Search API**：`BRAVE_API_KEY` 或 `tools.web.search.apiKey`
 - **Perplexity**（通过 OpenRouter）：`PERPLEXITY_API_KEY` 或 `OPENROUTER_API_KEY`
+- **Brave Search API**（替代）：`BRAVE_API_KEY` 或 `tools.web.search.apiKey`
 
 **Brave 免费套餐（额度充裕）：**
 

--- a/docs/zh-CN/tools/index.md
+++ b/docs/zh-CN/tools/index.md
@@ -232,7 +232,7 @@ OpenClaw 为 browser、canvas、nodes 和 cron 暴露**一流的智能体工具*
 
 ### `web_search`
 
-使用 Brave Search API 搜索网络。
+使用 Perplexity Sonar（默认）搜索网络，Brave 作为替代提供商。
 
 核心参数：
 
@@ -241,7 +241,7 @@ OpenClaw 为 browser、canvas、nodes 和 cron 暴露**一流的智能体工具*
 
 注意：
 
-- 需要 Brave API 密钥（推荐：`openclaw configure --section web`，或设置 `BRAVE_API_KEY`）。
+- 需要提供商 API 密钥（推荐：`openclaw configure --section web`；默认可用 `OPENROUTER_API_KEY` 或 `PERPLEXITY_API_KEY`，Brave 仍支持 `BRAVE_API_KEY`）。
 - 通过 `tools.web.search.enabled` 启用。
 - 响应被缓存（默认 15 分钟）。
 - 参见 [Web 工具](/tools/web) 了解设置。

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -355,12 +355,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
 
   // Auto-detect provider from available API keys (priority order)
   if (raw === "") {
-    // 1. Brave
-    if (resolveSearchApiKey(search)) {
+    // 1. Perplexity
+    const perplexityConfig = resolvePerplexityConfig(search);
+    const { apiKey: perplexityKey } = resolvePerplexityApiKey(perplexityConfig);
+    if (perplexityKey) {
       logVerbose(
-        'web_search: no provider configured, auto-detected "brave" from available API keys',
+        'web_search: no provider configured, auto-detected "perplexity" from available API keys',
       );
-      return "brave";
+      return "perplexity";
     }
     // 2. Gemini
     const geminiConfig = resolveGeminiConfig(search);
@@ -378,14 +380,12 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "kimi";
     }
-    // 4. Perplexity
-    const perplexityConfig = resolvePerplexityConfig(search);
-    const { apiKey: perplexityKey } = resolvePerplexityApiKey(perplexityConfig);
-    if (perplexityKey) {
+    // 4. Brave
+    if (resolveSearchApiKey(search)) {
       logVerbose(
-        'web_search: no provider configured, auto-detected "perplexity" from available API keys',
+        'web_search: no provider configured, auto-detected "brave" from available API keys',
       );
-      return "perplexity";
+      return "brave";
     }
     // 5. Grok
     const grokConfig = resolveGrokConfig(search);
@@ -397,7 +397,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
     }
   }
 
-  return "brave";
+  return "perplexity";
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -72,8 +72,8 @@ describe("web search provider auto-detection", () => {
     vi.restoreAllMocks();
   });
 
-  it("falls back to brave when no keys available", () => {
-    expect(resolveSearchProvider({})).toBe("brave");
+  it("falls back to perplexity when no keys available", () => {
+    expect(resolveSearchProvider({})).toBe("perplexity");
   });
 
   it("auto-detects brave when only BRAVE_API_KEY is set", () => {
@@ -111,16 +111,19 @@ describe("web search provider auto-detection", () => {
     expect(resolveSearchProvider({})).toBe("kimi");
   });
 
-  it("follows priority order — brave wins when multiple keys available", () => {
+  it("follows priority order — perplexity wins when multiple keys available", () => {
+    process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
     process.env.BRAVE_API_KEY = "test-brave-key";
     process.env.GEMINI_API_KEY = "test-gemini-key";
     process.env.XAI_API_KEY = "test-xai-key";
-    expect(resolveSearchProvider({})).toBe("brave");
+    expect(resolveSearchProvider({})).toBe("perplexity");
   });
 
-  it("gemini wins over perplexity and grok when brave unavailable", () => {
+  it("gemini wins over kimi, brave, and grok when perplexity unavailable", () => {
     process.env.GEMINI_API_KEY = "test-gemini-key";
-    process.env.PERPLEXITY_API_KEY = "test-perplexity-key";
+    process.env.KIMI_API_KEY = "test-kimi-key";
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    process.env.XAI_API_KEY = "test-xai-key";
     expect(resolveSearchProvider({})).toBe("gemini");
   });
 

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,9 +430,9 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
+      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"; default: "perplexity"). */
       provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
-      /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
+      /** Brave Search API key (optional alternative provider; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
       maxResults?: number;


### PR DESCRIPTION
## Summary

Changes the default web_search provider from Brave Search to Perplexity Sonar (via OpenRouter).

### Source code changes
- **Auto-detection priority reordered:** Perplexity → Gemini → Kimi → Brave → Grok (was Brave first)
- **Final fallback** when no provider is configured: `perplexity` (was `brave`)
- Updated JSDoc comments in `types.tools.ts`

### Docs (EN + ZH — 14 files)
- `docs/tools/web.md`: Perplexity listed as default, Brave demoted to alternative
- `docs/brave-search.md`: "alternative provider" (was "default provider")
- `docs/perplexity.md`: "default provider" (was "can use")
- `docs/start/wizard.md`: recommend Perplexity/OpenRouter setup
- `docs/help/faq.md`: updated web search setup instructions
- `docs/tools/index.md`: updated web_search description
- `docs/reference/api-usage-costs.md`: Perplexity listed first
- `docs/gateway/configuration-reference.md`: config example uses perplexity
- All `docs/zh-CN/` mirrors updated to match

### Tests
- Updated provider auto-detection and fallback test expectations
- Priority order tests now verify Perplexity wins when multiple keys are available

### What stays the same
- Brave Search still fully supported as an alternative provider
- All Brave-related code (endpoint, API key resolution, etc.) preserved
- Existing users with `provider: "brave"` configured explicitly are unaffected