### PR TITLE
fix(status): clamp cache hit rate to 100% in status display

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -336,7 +336,7 @@ const formatCacheLine = (
     (typeof input === "number" ? input : 0);
   const hitRate =
     totalInput > 0 && typeof cacheRead === "number"
-      ? Math.round((cacheRead / totalInput) * 100)
+      ? Math.min(100, Math.round((cacheRead / totalInput) * 100))
       : 0;
 
   return `🗄️ Cache: ${hitRate}% hit · ${cachedLabel} cached, ${newLabel} new`;

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,7 +40,7 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    const hitRate = Math.min(100, Math.round((cacheRead / total) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Summary

- Problem: Cache hit rate percentage in `openclaw status` and `/status` command can exceed 100% (e.g. "1142% cached") because some providers report `cacheRead` tokens separately from (and sometimes exceeding) the total input count.
- Why it matters: Users see nonsensical percentage values in status output, undermining trust in the metrics.
- What changed: Added `Math.min(100, ...)` clamp to the cache hit rate calculation in both the CLI status formatter and the auto-reply `/status` command.
- What did NOT change (scope boundary): Token counting, cost calculation, and all other status fields are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26643
- Related #

## User-visible / Behavior Changes

Cache hit rate in `openclaw status` and `/status` is now clamped to 100%. Previously it could display values like "1142% cached".

## Security Impact (required)

- New permissions/capabilities: None
- Auth/token changes: None
- Data exposure risk: None — display-only change

## Testing

- [x] `npx vitest run src/commands/status.test.ts src/auto-reply/status.test.ts` — 36 tests ✓

## Rollback Plan

Revert the single commit. No migration or data changes involved.
