### PR TITLE
fix(cron): prevent session key doubling when fully-qualified key is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Hook isolated routing: normalize isolated-run session keys via `toAgentStoreSessionKey` so already-qualified keys like `agent:main:main` are not double-prefixed into `agent:main:agent:main:main`, fixing intermittent hook delivery/routing failures. (#27289, #27282)
 - Security/Plugin channel HTTP auth: normalize protected `/api/channels` path checks against canonicalized request paths (case + percent-decoding + slash normalization), and fail closed on malformed `%`-encoded channel prefixes so alternate-path variants cannot bypass gateway auth.
 - Security/Exec approvals forwarding: prefer turn-source channel/account/thread metadata when resolving approval delivery targets so stale session routes do not misroute approval prompts.
 - Auto-reply/Streaming: suppress only exact `NO_REPLY` final replies while still filtering streaming partial sentinel fragments (`NO_`, `NO_RE`, `HEARTBEAT_...`) so substantive replies ending with `NO_REPLY` are delivered and partial silent tokens do not leak during streaming. (#19576) Thanks @aldoeliacim.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let resolvedpath: AnyCodable?
     public let sessionkey: AnyCodable?
+    public let turnsourcechannel: AnyCodable?
+    public let turnsourceto: AnyCodable?
+    public let turnsourceaccountid: AnyCodable?
+    public let turnsourcethreadid: AnyCodable?
     public let timeoutms: Int?
     public let twophase: Bool?
 
@@ -2833,6 +2837,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
+        turnsourcechannel: AnyCodable?,
+        turnsourceto: AnyCodable?,
+        turnsourceaccountid: AnyCodable?,
+        turnsourcethreadid: AnyCodable?,
         timeoutms: Int?,
         twophase: Bool?)
     {
@@ -2847,6 +2855,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.agentid = agentid
         self.resolvedpath = resolvedpath
         self.sessionkey = sessionkey
+        self.turnsourcechannel = turnsourcechannel
+        self.turnsourceto = turnsourceto
+        self.turnsourceaccountid = turnsourceaccountid
+        self.turnsourcethreadid = turnsourcethreadid
         self.timeoutms = timeoutms
         self.twophase = twophase
     }
@@ -2863,6 +2875,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case agentid = "agentId"
         case resolvedpath = "resolvedPath"
         case sessionkey = "sessionKey"
+        case turnsourcechannel = "turnSourceChannel"
+        case turnsourceto = "turnSourceTo"
+        case turnsourceaccountid = "turnSourceAccountId"
+        case turnsourcethreadid = "turnSourceThreadId"
         case timeoutms = "timeoutMs"
         case twophase = "twoPhase"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let resolvedpath: AnyCodable?
     public let sessionkey: AnyCodable?
+    public let turnsourcechannel: AnyCodable?
+    public let turnsourceto: AnyCodable?
+    public let turnsourceaccountid: AnyCodable?
+    public let turnsourcethreadid: AnyCodable?
     public let timeoutms: Int?
     public let twophase: Bool?
 
@@ -2833,6 +2837,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
+        turnsourcechannel: AnyCodable?,
+        turnsourceto: AnyCodable?,
+        turnsourceaccountid: AnyCodable?,
+        turnsourcethreadid: AnyCodable?,
         timeoutms: Int?,
         twophase: Bool?)
     {
@@ -2847,6 +2855,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.agentid = agentid
         self.resolvedpath = resolvedpath
         self.sessionkey = sessionkey
+        self.turnsourcechannel = turnsourcechannel
+        self.turnsourceto = turnsourceto
+        self.turnsourceaccountid = turnsourceaccountid
+        self.turnsourcethreadid = turnsourcethreadid
         self.timeoutms = timeoutms
         self.twophase = twophase
     }
@@ -2863,6 +2875,10 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case agentid = "agentId"
         case resolvedpath = "resolvedPath"
         case sessionkey = "sessionKey"
+        case turnsourcechannel = "turnSourceChannel"
+        case turnsourceto = "turnSourceTo"
+        case turnsourceaccountid = "turnSourceAccountId"
+        case turnsourcethreadid = "turnSourceThreadId"
         case timeoutms = "timeoutMs"
         case twophase = "twoPhase"
     }

--- a/src/cron/isolated-agent.session-key-doubling.test.ts
+++ b/src/cron/isolated-agent.session-key-doubling.test.ts
@@ -125,6 +125,7 @@ describe("runCronIsolatedAgentTurn session key doubling regression (#27289)", ()
         deps: {} as never,
         job,
         message: "hello",
+        sessionKey: " ",
         lane: "cron",
         // no sessionKey — should fall back to "agent:main:cron:job-1"
       });

--- a/src/cron/isolated-agent.session-key-doubling.test.ts
+++ b/src/cron/isolated-agent.session-key-doubling.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test for session key doubling bug (#27289, #27282).
+ *
+ * When a fully-qualified "agent:main:main" session key was passed to
+ * runCronIsolatedAgentTurn (via hooks or cron jobs), it was incorrectly
+ * double-prefixed to "agent:main:agent:main:main", causing routing failures.
+ */
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import {
+  makeCfg,
+  makeJob,
+  withTempCronHome,
+  writeSessionStore,
+} from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("runCronIsolatedAgentTurn session key doubling regression (#27289)", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks({ fast: true });
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        durationMs: 5,
+        agentMeta: { sessionId: "sid", provider: "anthropic", model: "claude-sonnet-4-5" },
+      },
+    });
+  });
+
+  it("does not double-prefix an already-qualified agent:main:main session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "agent:main:main", // fully-qualified key — must NOT become agent:main:agent:main:main
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+        }),
+      );
+    });
+  });
+
+  it("does not double-prefix an already-qualified agent:main:hook:uuid session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "agent:main:hook:abc-123", // fully-qualified hook session key
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:hook:abc-123",
+        }),
+      );
+    });
+  });
+
+  it("still correctly qualifies a bare hook session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "hook:abc-123", // bare key — should become agent:main:hook:abc-123
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:hook:abc-123",
+        }),
+      );
+    });
+  });
+
+  it("uses the job id as fallback when no session key is provided", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        lane: "cron",
+        // no sessionKey — should fall back to "agent:main:cron:job-1"
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: `agent:main:cron:${job.id}`,
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a fully-qualified session key (e.g. `agent:main:main`) was passed to `runCronIsolatedAgentTurn` — which happens when calling `/hooks/agent` with `sessionKey: "agent:main:main"`, or from cron jobs that reference a qualified session key — the key was wrapped a second time by `buildAgentMainSessionKey`:

```typescript
// Before
const baseSessionKey = "agent:main:main";
const agentSessionKey = buildAgentMainSessionKey({
  agentId: "main",
  mainKey: baseSessionKey,  // ← passes the full key as mainKey
});
// Result: "agent:main:agent:main:main"  ← doubled!
```

This caused intermittent routing failures because the doubled key `agent:main:agent:main:main` didn't match any existing session in the store.

Both issues (#27289 and #27282) were reported by the same agents observing 7–26 occurrences of the pattern `session:agent:main:agent:main:main` in their logs.

## Fix

Replace `buildAgentMainSessionKey` with `toAgentStoreSessionKey`, which already guards against this case:

```typescript
// After
const agentSessionKey = toAgentStoreSessionKey({
  agentId,
  requestKey: baseSessionKey,
  mainKey: params.cfg.session?.mainKey,
});
// "agent:main:main" → starts with "agent:" → returned as-is ✅
// "hook:abc-123"    → qualified to "agent:main:hook:abc-123" ✅
// "main"            → qualified to "agent:main:main" ✅
```

## Tests

Added 4 regression tests in `src/cron/isolated-agent.session-key-doubling.test.ts`:
- fully-qualified `agent:main:main` key is not double-prefixed
- fully-qualified `agent:main:hook:uuid` key is not double-prefixed  
- bare `hook:uuid` key is still correctly qualified to `agent:main:hook:uuid`
- missing `sessionKey` still falls back to `agent:main:cron:<jobId>`

Fixes #27289
Fixes #27282