### PR TITLE
fix(routing): Prevent session key doubling in isolated agent runs

### DIFF
--- a/src/cron/isolated-agent.session-key-doubling.test.ts
+++ b/src/cron/isolated-agent.session-key-doubling.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test for session key doubling bug (#27289, #27282).
+ *
+ * When a fully-qualified "agent:main:main" session key was passed to
+ * runCronIsolatedAgentTurn (via hooks or cron jobs), it was incorrectly
+ * double-prefixed to "agent:main:agent:main:main", causing routing failures.
+ */
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import {
+  makeCfg,
+  makeJob,
+  withTempCronHome,
+  writeSessionStore,
+} from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("runCronIsolatedAgentTurn session key doubling regression (#27289)", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks({ fast: true });
+    vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        durationMs: 5,
+        agentMeta: { sessionId: "sid", provider: "anthropic", model: "claude-sonnet-4-5" },
+      },
+    });
+  });
+
+  it("does not double-prefix an already-qualified agent:main:main session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "agent:main:main", // fully-qualified key — must NOT become agent:main:agent:main:main
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:main",
+        }),
+      );
+    });
+  });
+
+  it("does not double-prefix an already-qualified agent:main:hook:uuid session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "agent:main:hook:abc-123", // fully-qualified hook session key
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:hook:abc-123",
+        }),
+      );
+    });
+  });
+
+  it("still correctly qualifies a bare hook session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: "hook:abc-123", // bare key — should become agent:main:hook:abc-123
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:hook:abc-123",
+        }),
+      );
+    });
+  });
+
+  it("correctly qualifies a cron fallback session key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+
+      const cfg = makeCfg(home, storePath);
+      const job = makeJob({ kind: "agentTurn", message: "hello" });
+
+      await runCronIsolatedAgentTurn({
+        cfg,
+        deps: {} as never,
+        job,
+        message: "hello",
+        sessionKey: `cron:${job.id}`, // bare cron key — should become agent:main:cron:job-1
+        lane: "cron",
+      });
+
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: `agent:main:cron:${job.id}`,
+        }),
+      );
+    });
+  });
+});

--- a/src/routing/session-key.doubling-guard.test.ts
+++ b/src/routing/session-key.doubling-guard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the buildAgentMainSessionKey defensive guard against
+ * session key doubling (#27289, #27282).
+ *
+ * buildAgentMainSessionKey now checks whether mainKey is already a
+ * fully-qualified agent session key and returns it as-is to prevent
+ * producing malformed doubled keys like "agent:main:agent:main:main".
+ */
+import { describe, expect, it } from "vitest";
+import { buildAgentMainSessionKey } from "./session-key.js";
+
+describe("buildAgentMainSessionKey doubling guard (#27289)", () => {
+  it("returns an already-qualified agent:main:main key unchanged", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "agent:main:main",
+    });
+    expect(result).toBe("agent:main:main");
+  });
+
+  it("returns an already-qualified agent:main:hook:uuid key unchanged", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "agent:main:hook:abc-123",
+    });
+    expect(result).toBe("agent:main:hook:abc-123");
+  });
+
+  it("returns an already-qualified agent:research:main key unchanged", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "agent:research:main",
+    });
+    expect(result).toBe("agent:research:main");
+  });
+
+  it("still wraps a bare main key correctly", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "main",
+    });
+    expect(result).toBe("agent:main:main");
+  });
+
+  it("still wraps a bare hook key correctly", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "hook:abc-123",
+    });
+    expect(result).toBe("agent:main:hook:abc-123");
+  });
+
+  it("still wraps a bare cron key correctly", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "cron:job-1",
+    });
+    expect(result).toBe("agent:main:cron:job-1");
+  });
+
+  it("uses default main key when mainKey is undefined", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+    });
+    expect(result).toBe("agent:main:main");
+  });
+
+  it("normalizes case for already-qualified keys", () => {
+    const result = buildAgentMainSessionKey({
+      agentId: "main",
+      mainKey: "agent:Main:Main",
+    });
+    // normalizeMainKey lowercases, so parseAgentSessionKey should still match
+    expect(result).toBe("agent:main:main");
+  });
+});

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -108,6 +108,13 @@ export function buildAgentMainSessionKey(params: {
 }): string {
   const agentId = normalizeAgentId(params.agentId);
   const mainKey = normalizeMainKey(params.mainKey);
+  // Guard: if mainKey is already a fully-qualified agent session key,
+  // return it directly to prevent doubling (e.g. passing
+  // "agent:main:main" as mainKey would otherwise produce
+  // "agent:main:agent:main:main").  See #27282 / #27289.
+  if (parseAgentSessionKey(mainKey)) {
+    return mainKey;
+  }
   return `agent:${agentId}:${mainKey}`;
 }
 


### PR DESCRIPTION
This PR resolves an intermittent but critical bug where session keys are incorrectly duplicated, leading to routing and delivery failures, particularly for agent runs triggered by hooks.

### Problem

When a hook dispatches an agent run with a session key that is already fully qualified (e.g., `agent:main:main`), the `runCronIsolatedAgentTurn` function unconditionally wraps it again using `buildAgentMainSessionKey`. This results in a malformed, doubled key such as `agent:main:agent:main:main`.

This behavior was identified as the root cause for issues where hooks would fail intermittently, as the doubled key could not be correctly routed or associated with the intended session.

### Solution

This fix introduces two layers of protection to ensure session keys are never doubled:

1.  **In `src/cron/isolated-agent/run.ts`**: Before building the `agentSessionKey`, the code now checks if the incoming `baseSessionKey` is already a valid agent session key by using `parseAgentSessionKey`. If it is, the key is used directly without modification. Otherwise, the existing wrapping logic is applied. This is the primary fix for the immediate issue.

2.  **In `src/routing/session-key.ts`**: A defensive guard has been added to the `buildAgentMainSessionKey` function itself. It now also checks if the `mainKey` parameter it receives is already a fully-qualified agent session key. If so, it returns the key directly, preventing any future incorrect usage from causing the same bug.

These changes ensure that session keys remain correctly formatted throughout the hook-to-agent execution path, improving the reliability of hooks and other isolated agent runs.

Fixes #27282
Fixes #27289