### PR TITLE
fix: suppress SUBAGENT_SPAWN_ACCEPTED_NOTE for cron isolated sessions

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -523,13 +523,23 @@ export async function spawnSubagentDirect(
     }
   }
 
+  // Check if we're in a cron isolated session - don't add "do not poll" note
+  // because cron sessions end immediately after the agent produces a response,
+  // so the agent needs to wait for subagent results to keep the turn alive.
+  const isCronSession = ctx.agentSessionKey?.startsWith("cron:");
+  const note =
+    spawnMode === "session"
+      ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE
+      : isCronSession
+        ? undefined
+        : SUBAGENT_SPAWN_ACCEPTED_NOTE;
+
   return {
     status: "accepted",
     childSessionKey,
     runId: childRunId,
     mode: spawnMode,
-    note:
-      spawnMode === "session" ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE : SUBAGENT_SPAWN_ACCEPTED_NOTE,
+    note,
     modelApplied: resolvedModel ? modelApplied : undefined,
   };
 }


### PR DESCRIPTION
## Summary

Fixes issue #27308 - Cron isolated sessions break with sessions_spawn because the 'do not poll/sleep' note causes premature turn completion.

## Root Cause

When the agent sees the SUBAGENT_SPAWN_ACCEPTED_NOTE ("auto-announces on completion, do not poll/sleep"), it immediately responds with "Waiting for sub-agents..." and the turn completes. In cron isolated sessions, the turn ending means the cron job finalizes, so subagent results are never collected.

## Fix

Detect cron sessions by checking if  starts with "cron:" and suppress the note in that case. This allows the agent to wait naturally for subagent results, keeping the turn alive until subagents complete.

## Testing

- [x] TypeScript compiles without errors
- [ ] Need to test with actual cron job with sessions_spawn

## Related

- #27308
- #26867 (parent issue, closed as fixed but Bug 1 remained)