### PR TITLE
fix: prevent session key double-prefixing for hook isolated runs

### DIFF
--- a/src/cron/isolated-agent/run.session-key.test.ts
+++ b/src/cron/isolated-agent/run.session-key.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronAgentSessionKey } from "./run.js";
+
+describe("resolveCronAgentSessionKey", () => {
+  it("builds an agent-scoped key for legacy aliases", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "main", agentId: "main" })).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("preserves canonical agent keys instead of prefixing twice", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "agent:main:main", agentId: "main" })).toBe(
+      "agent:main:main",
+    );
+  });
+
+  it("keeps hook keys scoped under the target agent", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "hook:webhook:42", agentId: "main" })).toBe(
+      "agent:main:hook:webhook:42",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- preserve canonical `agent:*` session keys in isolated cron runs instead of wrapping them again
- add regression coverage for alias keys, canonical keys, and hook-derived keys routed through isolated runs
- fix intermittent routing failures reported in #27289 where `agent:main:main` became `agent:main:agent:main:main`