### PR TITLE
Channels: move single-account config into accounts.default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way.
 - Daemon/macOS launchd: forward proxy env vars into supervised service environments, keep LaunchAgent `KeepAlive=true` semantics, and harden restart sequencing to `print -> bootout -> wait old pid exit -> bootstrap -> kickstart`. (#27276) thanks @frankekn.
 - Android/Node invoke: remove native gateway WebSocket `Origin` header to avoid false origin rejections, unify invoke command registry/policy/error parsing paths, and keep command availability checks centralized to reduce dispatcher/advertisement drift. (#27257) Thanks @obviyus.
 - CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way.
+- Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way. (#27334) thanks @gumadeiras.
 - Daemon/macOS launchd: forward proxy env vars into supervised service environments, keep LaunchAgent `KeepAlive=true` semantics, and harden restart sequencing to `print -> bootout -> wait old pid exit -> bootstrap -> kickstart`. (#27276) thanks @frankekn.
 - Android/Node invoke: remove native gateway WebSocket `Origin` header to avoid false origin rejections, unify invoke command registry/policy/error parsing paths, and keep command availability checks centralized to reduce dispatcher/advertisement drift. (#27257) Thanks @obviyus.
 - CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -45,6 +45,16 @@ If you confirm bind now, the wizard asks which agent should own each configured 
 
 You can also manage the same routing rules later with `openclaw agents bindings`, `openclaw agents bind`, and `openclaw agents unbind` (see [agents](/cli/agents)).
 
+When you add a non-default account to a channel that is still using single-account top-level settings (no `channels.<channel>.accounts` entries yet), OpenClaw moves account-scoped single-account top-level values into `channels.<channel>.accounts.default`, then writes the new account. This preserves the original account behavior while moving to the multi-account shape.
+
+Routing behavior stays consistent:
+
+- Existing channel-only bindings (no `accountId`) continue to match the default account.
+- `channels add` does not auto-create or rewrite bindings in non-interactive mode.
+- Interactive setup can optionally add account-scoped bindings.
+
+If your config was already in a mixed state (named accounts present, missing `default`, and top-level single-account values still set), run `openclaw doctor --fix` to move account-scoped values into `accounts.default`.
+
 ## Login / logout (interactive)
 
 ```bash

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -400,6 +400,8 @@ Subcommands:
 - Tip: `channels status` prints warnings with suggested fixes when it can detect common misconfigurations (then points you to `openclaw doctor`).
 - `channels logs`: show recent channel logs from the gateway log file.
 - `channels add`: wizard-style setup when no flags are passed; flags switch to non-interactive mode.
+  - When adding a non-default account to a channel still using single-account top-level config, OpenClaw moves account-scoped values into `channels.<channel>.accounts.default` before writing the new account.
+  - Non-interactive `channels add` does not auto-create/upgrade bindings; channel-only bindings continue to match the default account.
 - `channels remove`: disable by default; pass `--delete` to remove config entries without prompts.
 - `channels login`: interactive channel login (WhatsApp Web only).
 - `channels logout`: log out of a channel session (if supported).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -505,6 +505,9 @@ Run multiple accounts per channel (each with its own `accountId`):
 - Env tokens only apply to the **default** account.
 - Base channel settings apply to all accounts unless overridden per account.
 - Use `bindings[].match.accountId` to route each account to a different agent.
+- If you add a non-default account via `openclaw channels add` (or channel onboarding) while still on a single-account top-level channel config, OpenClaw moves account-scoped top-level single-account values into `channels.<channel>.accounts.default` first so the original account keeps working.
+- Existing channel-only bindings (no `accountId`) keep matching the default account; account-scoped bindings remain optional.
+- `openclaw doctor --fix` also repairs mixed shapes by moving account-scoped top-level single-account values into `accounts.default` when named accounts exist but `default` is missing.
 
 ### Group chat mention gating
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -121,6 +121,7 @@ Current migrations:
 - `routing.agentToAgent` → `tools.agentToAgent`
 - `routing.transcribeAudio` → `tools.media.audio.models`
 - `bindings[].match.accountID` → `bindings[].match.accountId`
+- For channels with named `accounts` but missing `accounts.default`, move account-scoped top-level single-account channel values into `channels.<channel>.accounts.default` when present
 - `identity` → `agents.list[].identity`
 - `agent.*` → `agents.defaults` + `tools.*` (tools/elevated/exec/sandbox/subagents)
 - `agent.model`/`allowedModels`/`modelAliases`/`modelFallbacks`/`imageModelFallbacks`

--- a/src/channels/plugins/onboarding/helpers.test.ts
+++ b/src/channels/plugins/onboarding/helpers.test.ts
@@ -554,6 +554,39 @@ describe("patchChannelConfigForAccount", () => {
     expect(next.channels?.slack?.accounts?.work?.appToken).toBe("new-app");
   });
 
+  it("moves single-account config into default account when patching non-default", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          enabled: true,
+          botToken: "legacy-token",
+          allowFrom: ["100"],
+          groupPolicy: "allowlist",
+          streaming: "partial",
+        },
+      },
+    };
+
+    const next = patchChannelConfigForAccount({
+      cfg,
+      channel: "telegram",
+      accountId: "work",
+      patch: { botToken: "work-token" },
+    });
+
+    expect(next.channels?.telegram?.accounts?.default).toEqual({
+      botToken: "legacy-token",
+      allowFrom: ["100"],
+      groupPolicy: "allowlist",
+      streaming: "partial",
+    });
+    expect(next.channels?.telegram?.botToken).toBeUndefined();
+    expect(next.channels?.telegram?.allowFrom).toBeUndefined();
+    expect(next.channels?.telegram?.groupPolicy).toBeUndefined();
+    expect(next.channels?.telegram?.streaming).toBeUndefined();
+    expect(next.channels?.telegram?.accounts?.work?.botToken).toBe("work-token");
+  });
+
   it("supports imessage/signal account-scoped channel patches", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -119,3 +119,119 @@ export function migrateBaseNameToDefaultAccount(params: {
     },
   } as OpenClawConfig;
 }
+
+type ChannelSectionRecord = Record<string, unknown> & {
+  accounts?: Record<string, Record<string, unknown>>;
+};
+
+const COMMON_SINGLE_ACCOUNT_KEYS_TO_MOVE = new Set([
+  "name",
+  "token",
+  "tokenFile",
+  "botToken",
+  "appToken",
+  "account",
+  "signalNumber",
+  "authDir",
+  "cliPath",
+  "dbPath",
+  "httpUrl",
+  "httpHost",
+  "httpPort",
+  "webhookPath",
+  "webhookUrl",
+  "webhookSecret",
+  "service",
+  "region",
+  "homeserver",
+  "userId",
+  "accessToken",
+  "password",
+  "deviceName",
+  "url",
+  "code",
+  "dmPolicy",
+  "allowFrom",
+  "groupPolicy",
+  "groupAllowFrom",
+  "defaultTo",
+]);
+
+const SINGLE_ACCOUNT_KEYS_TO_MOVE_BY_CHANNEL: Record<string, ReadonlySet<string>> = {
+  telegram: new Set(["streaming"]),
+};
+
+export function shouldMoveSingleAccountChannelKey(params: {
+  channelKey: string;
+  key: string;
+}): boolean {
+  if (COMMON_SINGLE_ACCOUNT_KEYS_TO_MOVE.has(params.key)) {
+    return true;
+  }
+  return SINGLE_ACCOUNT_KEYS_TO_MOVE_BY_CHANNEL[params.channelKey]?.has(params.key) ?? false;
+}
+
+function cloneIfObject<T>(value: T): T {
+  if (value && typeof value === "object") {
+    return structuredClone(value);
+  }
+  return value;
+}
+
+// When promoting a single-account channel config to multi-account,
+// move top-level account settings into accounts.default so the original
+// account keeps working without duplicate account values at channel root.
+export function moveSingleAccountChannelSectionToDefaultAccount(params: {
+  cfg: OpenClawConfig;
+  channelKey: string;
+}): OpenClawConfig {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const baseConfig = channels?.[params.channelKey];
+  const base =
+    typeof baseConfig === "object" && baseConfig ? (baseConfig as ChannelSectionRecord) : undefined;
+  if (!base) {
+    return params.cfg;
+  }
+
+  const accounts = base.accounts ?? {};
+  if (Object.keys(accounts).length > 0) {
+    return params.cfg;
+  }
+
+  const keysToMove = Object.entries(base)
+    .filter(
+      ([key, value]) =>
+        key !== "accounts" &&
+        key !== "enabled" &&
+        value !== undefined &&
+        shouldMoveSingleAccountChannelKey({ channelKey: params.channelKey, key }),
+    )
+    .map(([key]) => key);
+  if (keysToMove.length === 0) {
+    return params.cfg;
+  }
+
+  const defaultAccount: Record<string, unknown> = {};
+  for (const key of keysToMove) {
+    const value = base[key];
+    defaultAccount[key] = cloneIfObject(value);
+  }
+  const nextChannel: ChannelSectionRecord = { ...base };
+  for (const key of keysToMove) {
+    delete nextChannel[key];
+  }
+
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      [params.channelKey]: {
+        ...nextChannel,
+        accounts: {
+          ...accounts,
+          [DEFAULT_ACCOUNT_ID]: defaultAccount,
+        },
+      },
+    },
+  } as OpenClawConfig;
+}

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -207,10 +207,6 @@ export function moveSingleAccountChannelSectionToDefaultAccount(params: {
         shouldMoveSingleAccountChannelKey({ channelKey: params.channelKey, key }),
     )
     .map(([key]) => key);
-  if (keysToMove.length === 0) {
-    return params.cfg;
-  }
-
   const defaultAccount: Record<string, unknown> = {};
   for (const key of keysToMove) {
     const value = base[key];

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -66,6 +66,65 @@ describe("channels command", () => {
     expect(next.channels?.telegram?.accounts?.alerts?.botToken).toBe("123:abc");
   });
 
+  it("moves single-account telegram config into accounts.default when adding non-default", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: "legacy-token",
+            dmPolicy: "allowlist",
+            allowFrom: ["111"],
+            groupPolicy: "allowlist",
+            streaming: "partial",
+          },
+        },
+      },
+    });
+
+    await channelsAddCommand(
+      { channel: "telegram", account: "alerts", token: "alerts-token" },
+      runtime,
+      { hasFlags: true },
+    );
+
+    const next = configMocks.writeConfigFile.mock.calls[0]?.[0] as {
+      channels?: {
+        telegram?: {
+          botToken?: string;
+          dmPolicy?: string;
+          allowFrom?: string[];
+          groupPolicy?: string;
+          streaming?: string;
+          accounts?: Record<
+            string,
+            {
+              botToken?: string;
+              dmPolicy?: string;
+              allowFrom?: string[];
+              groupPolicy?: string;
+              streaming?: string;
+            }
+          >;
+        };
+      };
+    };
+    expect(next.channels?.telegram?.accounts?.default).toEqual({
+      botToken: "legacy-token",
+      dmPolicy: "allowlist",
+      allowFrom: ["111"],
+      groupPolicy: "allowlist",
+      streaming: "partial",
+    });
+    expect(next.channels?.telegram?.botToken).toBeUndefined();
+    expect(next.channels?.telegram?.dmPolicy).toBeUndefined();
+    expect(next.channels?.telegram?.allowFrom).toBeUndefined();
+    expect(next.channels?.telegram?.groupPolicy).toBeUndefined();
+    expect(next.channels?.telegram?.streaming).toBeUndefined();
+    expect(next.channels?.telegram?.accounts?.alerts?.botToken).toBe("alerts-token");
+  });
+
   it("adds a default slack account with tokens", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
     await channelsAddCommand(

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -125,6 +125,37 @@ describe("channels command", () => {
     expect(next.channels?.telegram?.accounts?.alerts?.botToken).toBe("alerts-token");
   });
 
+  it("seeds accounts.default for env-only single-account telegram config when adding non-default", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    await channelsAddCommand(
+      { channel: "telegram", account: "alerts", token: "alerts-token" },
+      runtime,
+      { hasFlags: true },
+    );
+
+    const next = configMocks.writeConfigFile.mock.calls[0]?.[0] as {
+      channels?: {
+        telegram?: {
+          enabled?: boolean;
+          accounts?: Record<string, { botToken?: string }>;
+        };
+      };
+    };
+    expect(next.channels?.telegram?.enabled).toBe(true);
+    expect(next.channels?.telegram?.accounts?.default).toEqual({});
+    expect(next.channels?.telegram?.accounts?.alerts?.botToken).toBe("alerts-token");
+  });
+
   it("adds a default slack account with tokens", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
     await channelsAddCommand(

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,6 +1,7 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listChannelPluginCatalogEntries } from "../../channels/plugins/catalog.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { moveSingleAccountChannelSectionToDefaultAccount } from "../../channels/plugins/setup-helpers.js";
 import type { ChannelId, ChannelSetupInput } from "../../channels/plugins/types.js";
 import { writeConfigFile, type OpenClawConfig } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
@@ -282,6 +283,13 @@ export async function channelsAddCommand(
     channel === "telegram"
       ? resolveTelegramAccount({ cfg: nextConfig, accountId }).token.trim()
       : "";
+
+  if (accountId !== DEFAULT_ACCOUNT_ID) {
+    nextConfig = moveSingleAccountChannelSectionToDefaultAccount({
+      cfg: nextConfig,
+      channelKey: channel,
+    });
+  }
 
   nextConfig = applyChannelAccountConfig({
     cfg: nextConfig,

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { runDoctorConfigWithInput } from "./doctor-config-flow.test-utils.js";
+
+const { noteSpy } = vi.hoisted(() => ({
+  noteSpy: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: noteSpy,
+}));
+
+vi.mock("./doctor-legacy-config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./doctor-legacy-config.js")>();
+  return {
+    ...actual,
+    normalizeLegacyConfigValues: (cfg: unknown) => ({
+      config: cfg,
+      changes: [],
+    }),
+  };
+});
+
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+
+describe("doctor missing default account binding warning", () => {
+  it("emits a doctor warning when named accounts have no valid account-scoped bindings", async () => {
+    await withEnvAsync(
+      {
+        TELEGRAM_BOT_TOKEN: undefined,
+        TELEGRAM_BOT_TOKEN_FILE: undefined,
+      },
+      async () => {
+        await runDoctorConfigWithInput({
+          config: {
+            channels: {
+              telegram: {
+                accounts: {
+                  alerts: {},
+                  work: {},
+                },
+              },
+            },
+            bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
+          },
+          run: loadAndMaybeMigrateDoctorConfig,
+        });
+      },
+    );
+
+    expect(noteSpy).toHaveBeenCalledWith(
+      expect.stringContaining("channels.telegram: accounts.default is missing"),
+      "Doctor warnings",
+    );
+  });
+});

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { collectMissingDefaultAccountBindingWarnings } from "./doctor-config-flow.js";
+
+describe("collectMissingDefaultAccountBindingWarnings", () => {
+  it("warns when named accounts exist without default and no valid binding exists", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            alerts: { botToken: "a" },
+            work: { botToken: "w" },
+          },
+        },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
+    };
+
+    const warnings = collectMissingDefaultAccountBindingWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("channels.telegram");
+    expect(warnings[0]).toContain("alerts, work");
+  });
+
+  it("does not warn when an explicit account binding exists", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            alerts: { botToken: "a" },
+          },
+        },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram", accountId: "alerts" } }],
+    };
+
+    expect(collectMissingDefaultAccountBindingWarnings(cfg)).toEqual([]);
+  });
+
+  it("does not warn when wildcard account binding exists", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            alerts: { botToken: "a" },
+          },
+        },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram", accountId: "*" } }],
+    };
+
+    expect(collectMissingDefaultAccountBindingWarnings(cfg)).toEqual([]);
+  });
+
+  it("does not warn when default account is present", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: { botToken: "d" },
+            alerts: { botToken: "a" },
+          },
+        },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
+    };
+
+    expect(collectMissingDefaultAccountBindingWarnings(cfg)).toEqual([]);
+  });
+});

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.test.ts
@@ -37,6 +37,25 @@ describe("collectMissingDefaultAccountBindingWarnings", () => {
     expect(collectMissingDefaultAccountBindingWarnings(cfg)).toEqual([]);
   });
 
+  it("warns when bindings cover only a subset of configured accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            alerts: { botToken: "a" },
+            work: { botToken: "w" },
+          },
+        },
+      },
+      bindings: [{ agentId: "ops", match: { channel: "telegram", accountId: "alerts" } }],
+    };
+
+    const warnings = collectMissingDefaultAccountBindingWarnings(cfg);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("subset");
+    expect(warnings[0]).toContain("Uncovered accounts: work");
+  });
+
   it("does not warn when wildcard account binding exists", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -1,3 +1,4 @@
+import { shouldMoveSingleAccountChannelKey } from "../channels/plugins/setup-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveDiscordPreviewStreamMode,
@@ -5,6 +6,7 @@ import {
   resolveSlackStreamingMode,
   resolveTelegramPreviewStreamMode,
 } from "../config/discord-preview-streaming.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 export function normalizeLegacyConfigValues(cfg: OpenClawConfig): {
   config: OpenClawConfig;
@@ -289,9 +291,80 @@ export function normalizeLegacyConfigValues(cfg: OpenClawConfig): {
     }
   };
 
+  const seedMissingDefaultAccountsFromSingleAccountBase = () => {
+    const channels = next.channels as Record<string, unknown> | undefined;
+    if (!channels) {
+      return;
+    }
+
+    let channelsChanged = false;
+    const nextChannels = { ...channels };
+    for (const [channelId, rawChannel] of Object.entries(channels)) {
+      if (!isRecord(rawChannel)) {
+        continue;
+      }
+      const rawAccounts = rawChannel.accounts;
+      if (!isRecord(rawAccounts)) {
+        continue;
+      }
+      const accountKeys = Object.keys(rawAccounts);
+      if (accountKeys.length === 0) {
+        continue;
+      }
+      const hasDefault = accountKeys.some((key) => key.trim().toLowerCase() === DEFAULT_ACCOUNT_ID);
+      if (hasDefault) {
+        continue;
+      }
+
+      const keysToMove = Object.entries(rawChannel)
+        .filter(
+          ([key, value]) =>
+            key !== "accounts" &&
+            key !== "enabled" &&
+            value !== undefined &&
+            shouldMoveSingleAccountChannelKey({ channelKey: channelId, key }),
+        )
+        .map(([key]) => key);
+      if (keysToMove.length === 0) {
+        continue;
+      }
+
+      const defaultAccount: Record<string, unknown> = {};
+      for (const key of keysToMove) {
+        const value = rawChannel[key];
+        defaultAccount[key] = value && typeof value === "object" ? structuredClone(value) : value;
+      }
+      const nextChannel: Record<string, unknown> = {
+        ...rawChannel,
+      };
+      for (const key of keysToMove) {
+        delete nextChannel[key];
+      }
+      nextChannel.accounts = {
+        ...rawAccounts,
+        [DEFAULT_ACCOUNT_ID]: defaultAccount,
+      };
+
+      nextChannels[channelId] = nextChannel;
+      channelsChanged = true;
+      changes.push(
+        `Moved channels.${channelId} single-account top-level values into channels.${channelId}.accounts.default.`,
+      );
+    }
+
+    if (!channelsChanged) {
+      return;
+    }
+    next = {
+      ...next,
+      channels: nextChannels as OpenClawConfig["channels"],
+    };
+  };
+
   normalizeProvider("telegram");
   normalizeProvider("slack");
   normalizeProvider("discord");
+  seedMissingDefaultAccountsFromSingleAccountBase();
 
   const normalizeBrowserSsrFPolicyAlias = () => {
     const rawBrowser = next.browser;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw channels add` for a non-default account could leave single-account channel values at top-level while adding `accounts.<new>`, causing split/duplicated account state and breaking the original account path in real configs.
- Why it matters: users upgrading from single-account to multi-account could lose working behavior for the original account and end up with confusing mixed config shape.
- What changed: added shared migration logic to move account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing non-default accounts; wired this into non-interactive `channels add`, onboarding scoped account patching, and `doctor` repair migration.
- What did NOT change (scope boundary): channel-only bindings are not auto-rewritten to explicit `accountId=default`; routing semantics remain the same (channel-only binding still targets default account).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Adding a non-default account now moves account-scoped top-level single-account channel values into `accounts.default` (instead of duplicating/copying).
- Original default-account behavior is preserved after migration.
- `openclaw doctor --fix` repairs already-mixed channel account shapes with the same move behavior.
- Docs updated for channels/CLI/config-reference/doctor.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+ / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram (regression tests), generic plugin/onboarding/doctor paths
- Relevant config (redacted): single-account channel root values + add non-default account

### Steps

1. Start with channel config that has single-account values at `channels.<channel>.*` and no `accounts` object.
2. Run `openclaw channels add --channel telegram --account alerts --token <token>` (non-interactive path), or use onboarding scoped account path.
3. Inspect resulting config.
4. Run `openclaw doctor --fix` on mixed-shape config (`accounts` exists, `default` missing, top-level account values still present).

### Expected

- Top-level account-scoped single-account values are moved into `channels.<channel>.accounts.default`.
- New account is written under `channels.<channel>.accounts.<new>`.
- Channel-only bindings keep matching default account.

### Actual

- Matches expected (verified by targeted tests below).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - non-interactive `channels add` moves single-account channel values into `accounts.default` when adding non-default account.
  - onboarding scoped account patch path performs the same migration.
  - doctor migration repairs mixed shape (`accounts` named entries + missing default + top-level account-scoped values).
- Edge cases checked:
  - migration only moves account-scoped keys, preserving global channel-level values at root.
  - Telegram-specific `streaming` move path covered by tests.
- What you did **not** verify:
  - full cross-channel manual runtime smoke across all integrations; relied on shared-path + targeted regression coverage.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - Restore `src/channels/plugins/setup-helpers.ts`, `src/commands/channels/add.ts`, `src/channels/plugins/onboarding/helpers.ts`, `src/commands/doctor-legacy-config.ts` and rerun tests.
- Known bad symptoms reviewers should watch for:
  - unexpected movement of channel-global keys into `accounts.default`.
  - missing default-account routing after non-default account add.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - moving an unintended key from channel root to `accounts.default` could change provider behavior.
  - Mitigation:
    - migration uses explicit allowlist of account-scoped keys (plus channel-specific exceptions), with regression tests covering Telegram account + doctor paths.
