### PR TITLE
fix(providers): guard against missing usage in Anthropic message_start event

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,9 @@
   "packageManager": "pnpm@10.23.0",
   "pnpm": {
     "minimumReleaseAge": 2880,
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.55.1": "patches/@mariozechner__pi-ai@0.55.1.patch"
+    },
     "overrides": {
       "hono": "4.11.10",
       "fast-xml-parser": "5.3.6",

--- a/patches/@mariozechner__pi-ai@0.55.1.patch
+++ b/patches/@mariozechner__pi-ai@0.55.1.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index 1234567..abcdefg 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -152,10 +152,11 @@ function streamAnthropic(model, context, options) {
+                 if (event.type === "message_start") {
+                     // Capture initial token usage from message_start event
+                     // This ensures we have input token counts even if the stream is aborted early
+-                    output.usage.input = event.message.usage.input_tokens || 0;
+-                    output.usage.output = event.message.usage.output_tokens || 0;
+-                    output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;
+-                    output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;
++                    const msgUsage = event.message?.usage;
++                    output.usage.input = msgUsage?.input_tokens || 0;
++                    output.usage.output = msgUsage?.output_tokens || 0;
++                    output.usage.cacheRead = msgUsage?.cache_read_input_tokens || 0;
++                    output.usage.cacheWrite = msgUsage?.cache_creation_input_tokens || 0;
+                     // Anthropic doesn't provide total_tokens, compute from components
+                     output.usage.totalTokens =
+                         output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,20 @@ settings:
 
 overrides:
   hono: 4.11.10
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
   '@sinclair/typebox': 0.34.48
   tar: 7.5.9
   tough-cookie: 4.1.3
+
+patchedDependencies:
+  '@mariozechner/pi-ai@0.55.1':
+    hash: 87451938d219e1b57885a3dc385ab4ccf1a21233749a4608d6f82fcae92aa79f
+    path: patches/@mariozechner__pi-ai@0.55.1.patch
 
 importers:
 
@@ -58,7 +63,7 @@ importers:
         version: 0.55.1(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.55.1
-        version: 0.55.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.1(patch_hash=87451938d219e1b57885a3dc385ab4ccf1a21233749a4608d6f82fcae92aa79f)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.55.1
         version: 0.55.1(ws@8.19.0)(zod@4.3.6)
@@ -6853,7 +6858,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(patch_hash=87451938d219e1b57885a3dc385ab4ccf1a21233749a4608d6f82fcae92aa79f)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6887,7 +6892,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.1(patch_hash=87451938d219e1b57885a3dc385ab4ccf1a21233749a4608d6f82fcae92aa79f)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
@@ -6944,7 +6949,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(patch_hash=87451938d219e1b57885a3dc385ab4ccf1a21233749a4608d6f82fcae92aa79f)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2


### PR DESCRIPTION
## Summary

Guard against missing `usage` field in the Anthropic `message_start` SSE event. Third-party Claude API relays may omit `usage` from the event payload, causing a crash: `Cannot read properties of undefined (reading 'input_tokens')`.

Applied as a `pnpm patch` against `@mariozechner/pi-ai@0.54.1` — adds optional chaining (`event.message?.usage?.input_tokens`) so missing usage data defaults to zero instead of throwing.

## Change Type

Bug fix

## Scope

- `patches/@mariozechner__pi-ai@0.54.1.patch` — SDK patch
- `package.json` — `patchedDependencies` entry

## Linked Issue

Closes #27331

## Security Impact

None — only adds null guards to usage field access.

## Repro + Verification

1. Configure a third-party Claude API relay that omits `usage` from `message_start` events
2. Send any message via the relay
3. **Before fix**: Crash with `Cannot read properties of undefined (reading 'input_tokens')`
4. **After fix**: Usage defaults to zero; message processes successfully

\`\`\`bash
npx vitest run src/agents/pi-embedded-runner/run/attempt
# 9 tests pass ✓
\`\`\`

## Human Verification

- [x] `message_delta` path (line 286+) already has null guards — this fix makes `message_start` consistent
- [x] `output.usage` is pre-initialized with zeros (line 124-131), so missing `message_start` usage just keeps the defaults
- [x] Official Anthropic API always includes `usage` — this only affects third-party relays

## Compatibility

Fully backward-compatible. When `usage` is present (official API), optional chaining is a no-op.

## Risks

None. The patch is minimal (4 lines changed) and only adds defensive null checks.
