### PR TITLE
fix(telegram): allow inline button callbacks in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Channels/Multi-account config: when adding a non-default channel account to a single-account top-level channel setup, move existing account-scoped top-level single-account values into `channels.<channel>.accounts.default` before writing the new account so the original account keeps working without duplicated account values at channel root; `openclaw doctor --fix` now repairs previously mixed channel account shapes the same way. (#27334) thanks @gumadeiras.
+- Telegram/Inline buttons: allow callback-query button handling in groups (including `/models` follow-up buttons) when group policy authorizes the sender, by removing the redundant callback allowlist gate that blocked open-policy groups. (#27343) Thanks @GodsBoy.
 - Daemon/macOS launchd: forward proxy env vars into supervised service environments, keep LaunchAgent `KeepAlive=true` semantics, and harden restart sequencing to `print -> bootout -> wait old pid exit -> bootstrap -> kickstart`. (#27276) thanks @frankekn.
 - Android/Node invoke: remove native gateway WebSocket `Origin` header to avoid false origin rejections, unify invoke command registry/policy/error parsing paths, and keep command availability checks centralized to reduce dispatcher/advertisement drift. (#27257) Thanks @obviyus.
 - CI/Windows: shard the Windows `checks-windows` test lane into two matrix jobs and honor explicit shard index overrides in `scripts/test-parallel.mjs` to reduce CI critical-path wall time. (#27234) Thanks @joshavant.

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -536,7 +536,9 @@ export const registerTelegramHandlers = ({
     },
     "callback-allowlist": {
       enforceDirectAuthorization: true,
-      enforceGroupAllowlistAuthorization: true,
+      // Group auth is already enforced by shouldSkipGroupMessage (group policy + allowlist).
+      // An extra allowlist gate here would block users whose original command was authorized.
+      enforceGroupAllowlistAuthorization: false,
       deniedDmReason: "callback unauthorized by inlineButtonsScope allowlist",
       deniedGroupReason: "callback unauthorized by inlineButtonsScope allowlist",
     },


### PR DESCRIPTION
## Summary

Fixes #27309 — Telegram `/models` inline keyboard buttons silently do nothing in groups (regression in v2026.2.25).

**Root cause:** The `callback-allowlist` authorization mode set `enforceGroupAllowlistAuthorization: true`, which applies a direct allowlist check on callback senders in groups *on top of* the group policy check already performed by `shouldSkipGroupMessage`. When the group policy is "open" or "all", the original `/models` command passes auth and renders inline buttons — but the subsequent button click fails the extra allowlist gate because the user isn't on the explicit allowlist.

**Fix:** Set `enforceGroupAllowlistAuthorization: false` for `callback-allowlist`. The `shouldSkipGroupMessage` call (which runs for all authorization modes) already enforces group policy + allowlist authorization correctly. The extra check was redundant for groups with allowlist policy and overly restrictive for groups with open/all policy.

- DM authorization (`enforceDirectAuthorization: true`) is preserved — unpaired DM users still can't click inline buttons
- Group policy enforcement is preserved via `shouldSkipGroupMessage`
- Added test verifying group callback authorization works when group policy allows the sender

## Test plan

- [x] Existing test "blocks callback_query when inline buttons are allowlist-only and sender not authorized" still passes (DM blocking)
- [x] Existing test "blocks pagination callbacks when allowlist rejects sender" still passes
- [x] New test "allows callback_query in groups when group policy authorizes the sender" passes
- [x] Full telegram bot test suite passes (37/37)
- [x] TypeScript typecheck passes