### PR TITLE
feat: add Android notifications.list support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/Routing CLI: add `openclaw agents bindings`, `openclaw agents bind`, and `openclaw agents unbind` for account-scoped route management, including channel-only to account-scoped binding upgrades, role-aware binding identity handling, plugin-resolved binding account IDs, and optional account-binding prompts in `openclaw channels add`. (#27195) thanks @gumadeiras.
+- Android/Nodes: add `notifications.list` support on Android nodes and expose `nodes notifications_list` in agent tooling for listing active device notifications. (#27344) thanks @obviyus.
 
 ### Fixes
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,15 @@
             android:name=".NodeForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync|microphone|mediaProjection" />
+        <service
+            android:name=".node.DeviceNotificationListenerService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -92,6 +92,10 @@ class NodeRuntime(context: Context) {
     locationPreciseEnabled = { locationPreciseEnabled.value },
   )
 
+  private val notificationsHandler: NotificationsHandler = NotificationsHandler(
+    appContext = appContext,
+  )
+
   private val screenHandler: ScreenHandler = ScreenHandler(
     screenRecorder = screenRecorder,
     setScreenRecordActive = { _screenRecordActive.value = it },
@@ -123,6 +127,7 @@ class NodeRuntime(context: Context) {
     canvas = canvas,
     cameraHandler = cameraHandler,
     locationHandler = locationHandler,
+    notificationsHandler = notificationsHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,
     a2uiHandler = a2uiHandler,

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceNotificationListenerService.kt
@@ -1,0 +1,171 @@
+package ai.openclaw.android.node
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+
+private const val MAX_NOTIFICATION_TEXT_CHARS = 512
+
+data class DeviceNotificationEntry(
+  val key: String,
+  val packageName: String,
+  val title: String?,
+  val text: String?,
+  val subText: String?,
+  val category: String?,
+  val channelId: String?,
+  val postTimeMs: Long,
+  val isOngoing: Boolean,
+  val isClearable: Boolean,
+)
+
+data class DeviceNotificationSnapshot(
+  val enabled: Boolean,
+  val connected: Boolean,
+  val notifications: List<DeviceNotificationEntry>,
+)
+
+private object DeviceNotificationStore {
+  private val lock = Any()
+  private var connected = false
+  private val byKey = LinkedHashMap<String, DeviceNotificationEntry>()
+
+  fun replace(entries: List<DeviceNotificationEntry>) {
+    synchronized(lock) {
+      byKey.clear()
+      for (entry in entries) {
+        byKey[entry.key] = entry
+      }
+    }
+  }
+
+  fun upsert(entry: DeviceNotificationEntry) {
+    synchronized(lock) {
+      byKey[entry.key] = entry
+    }
+  }
+
+  fun remove(key: String) {
+    synchronized(lock) {
+      byKey.remove(key)
+    }
+  }
+
+  fun setConnected(value: Boolean) {
+    synchronized(lock) {
+      connected = value
+      if (!value) {
+        byKey.clear()
+      }
+    }
+  }
+
+  fun snapshot(enabled: Boolean): DeviceNotificationSnapshot {
+    val (isConnected, entries) =
+      synchronized(lock) {
+        connected to byKey.values.sortedByDescending { it.postTimeMs }
+      }
+    return DeviceNotificationSnapshot(
+      enabled = enabled,
+      connected = isConnected,
+      notifications = entries,
+    )
+  }
+}
+
+class DeviceNotificationListenerService : NotificationListenerService() {
+  override fun onListenerConnected() {
+    super.onListenerConnected()
+    DeviceNotificationStore.setConnected(true)
+    refreshActiveNotifications()
+  }
+
+  override fun onListenerDisconnected() {
+    DeviceNotificationStore.setConnected(false)
+    super.onListenerDisconnected()
+  }
+
+  override fun onNotificationPosted(sbn: StatusBarNotification?) {
+    super.onNotificationPosted(sbn)
+    val entry = sbn?.toEntry() ?: return
+    DeviceNotificationStore.upsert(entry)
+  }
+
+  override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+    super.onNotificationRemoved(sbn)
+    val key = sbn?.key ?: return
+    DeviceNotificationStore.remove(key)
+  }
+
+  private fun refreshActiveNotifications() {
+    val entries =
+      runCatching {
+        activeNotifications
+          ?.mapNotNull { it.toEntry() }
+          ?: emptyList()
+      }.getOrElse { emptyList() }
+    DeviceNotificationStore.replace(entries)
+  }
+
+  private fun StatusBarNotification.toEntry(): DeviceNotificationEntry {
+    val extras = notification.extras
+    val keyValue = key.takeIf { it.isNotBlank() } ?: "$packageName:$id:$postTime"
+    val title = sanitizeText(extras?.getCharSequence(Notification.EXTRA_TITLE))
+    val body =
+      sanitizeText(extras?.getCharSequence(Notification.EXTRA_BIG_TEXT))
+        ?: sanitizeText(extras?.getCharSequence(Notification.EXTRA_TEXT))
+    val subText = sanitizeText(extras?.getCharSequence(Notification.EXTRA_SUB_TEXT))
+    return DeviceNotificationEntry(
+      key = keyValue,
+      packageName = packageName,
+      title = title,
+      text = body,
+      subText = subText,
+      category = notification.category?.trim()?.ifEmpty { null },
+      channelId = notification.channelId?.trim()?.ifEmpty { null },
+      postTimeMs = postTime,
+      isOngoing = isOngoing,
+      isClearable = isClearable,
+    )
+  }
+
+  private fun sanitizeText(value: CharSequence?): String? {
+    val normalized = value?.toString()?.trim().orEmpty()
+    if (normalized.isEmpty()) {
+      return null
+    }
+    return if (normalized.length <= MAX_NOTIFICATION_TEXT_CHARS) {
+      normalized
+    } else {
+      normalized.take(MAX_NOTIFICATION_TEXT_CHARS)
+    }
+  }
+
+  companion object {
+    private fun serviceComponent(context: Context): ComponentName {
+      return ComponentName(context, DeviceNotificationListenerService::class.java)
+    }
+
+    fun isAccessEnabled(context: Context): Boolean {
+      val manager = context.getSystemService(NotificationManager::class.java) ?: return false
+      return manager.isNotificationListenerAccessGranted(serviceComponent(context))
+    }
+
+    fun snapshot(context: Context): DeviceNotificationSnapshot {
+      return DeviceNotificationStore.snapshot(enabled = isAccessEnabled(context))
+    }
+
+    fun requestServiceRebind(context: Context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        return
+      }
+      runCatching {
+        NotificationListenerService.requestRebind(serviceComponent(context))
+      }
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
@@ -4,6 +4,7 @@ import ai.openclaw.android.protocol.OpenClawCanvasA2UICommand
 import ai.openclaw.android.protocol.OpenClawCanvasCommand
 import ai.openclaw.android.protocol.OpenClawCameraCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
+import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawScreenCommand
 import ai.openclaw.android.protocol.OpenClawSmsCommand
 
@@ -73,6 +74,9 @@ object InvokeCommandRegistry {
       InvokeCommandSpec(
         name = OpenClawLocationCommand.Get.rawValue,
         availability = InvokeCommandAvailability.LocationEnabled,
+      ),
+      InvokeCommandSpec(
+        name = OpenClawNotificationsCommand.List.rawValue,
       ),
       InvokeCommandSpec(
         name = OpenClawSmsCommand.Send.rawValue,

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -5,6 +5,7 @@ import ai.openclaw.android.protocol.OpenClawCanvasA2UICommand
 import ai.openclaw.android.protocol.OpenClawCanvasCommand
 import ai.openclaw.android.protocol.OpenClawCameraCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
+import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawScreenCommand
 import ai.openclaw.android.protocol.OpenClawSmsCommand
 
@@ -12,6 +13,7 @@ class InvokeDispatcher(
   private val canvas: CanvasController,
   private val cameraHandler: CameraHandler,
   private val locationHandler: LocationHandler,
+  private val notificationsHandler: NotificationsHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
   private val a2uiHandler: A2UIHandler,
@@ -113,6 +115,9 @@ class InvokeDispatcher(
 
       // Location command
       OpenClawLocationCommand.Get.rawValue -> locationHandler.handleLocationGet(paramsJson)
+
+      // Notifications command
+      OpenClawNotificationsCommand.List.rawValue -> notificationsHandler.handleNotificationsList(paramsJson)
 
       // Screen command
       OpenClawScreenCommand.Record.rawValue -> screenHandler.handleScreenRecord(paramsJson)

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationsHandler.kt
@@ -1,0 +1,57 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class NotificationsHandler(
+  private val appContext: Context,
+) {
+  suspend fun handleNotificationsList(_paramsJson: String?): GatewaySession.InvokeResult {
+    if (!DeviceNotificationListenerService.isAccessEnabled(appContext)) {
+      return GatewaySession.InvokeResult.error(
+        code = "NOTIFICATION_LISTENER_DISABLED",
+        message =
+          "NOTIFICATION_LISTENER_DISABLED: enable Notification Access for OpenClaw in system settings",
+      )
+    }
+    val snapshot = DeviceNotificationListenerService.snapshot(appContext)
+    if (!snapshot.connected) {
+      DeviceNotificationListenerService.requestServiceRebind(appContext)
+      return GatewaySession.InvokeResult.error(
+        code = "NOTIFICATION_LISTENER_UNAVAILABLE",
+        message = "NOTIFICATION_LISTENER_UNAVAILABLE: listener is reconnecting; retry shortly",
+      )
+    }
+
+    val payload =
+      buildJsonObject {
+        put("enabled", JsonPrimitive(snapshot.enabled))
+        put("connected", JsonPrimitive(snapshot.connected))
+        put("count", JsonPrimitive(snapshot.notifications.size))
+        put(
+          "notifications",
+          JsonArray(
+            snapshot.notifications.map { entry ->
+              buildJsonObject {
+                put("key", JsonPrimitive(entry.key))
+                put("packageName", JsonPrimitive(entry.packageName))
+                put("postTimeMs", JsonPrimitive(entry.postTimeMs))
+                put("isOngoing", JsonPrimitive(entry.isOngoing))
+                put("isClearable", JsonPrimitive(entry.isClearable))
+                entry.title?.let { put("title", JsonPrimitive(it)) }
+                entry.text?.let { put("text", JsonPrimitive(it)) }
+                entry.subText?.let { put("subText", JsonPrimitive(it)) }
+                entry.category?.let { put("category", JsonPrimitive(it)) }
+                entry.channelId?.let { put("channelId", JsonPrimitive(it)) }
+              }
+            },
+          ),
+        )
+      }
+    return GatewaySession.InvokeResult.ok(payload.toString())
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/NotificationsHandler.kt
@@ -7,51 +7,75 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-class NotificationsHandler(
-  private val appContext: Context,
-) {
-  suspend fun handleNotificationsList(_paramsJson: String?): GatewaySession.InvokeResult {
-    if (!DeviceNotificationListenerService.isAccessEnabled(appContext)) {
-      return GatewaySession.InvokeResult.error(
-        code = "NOTIFICATION_LISTENER_DISABLED",
-        message =
-          "NOTIFICATION_LISTENER_DISABLED: enable Notification Access for OpenClaw in system settings",
-      )
-    }
-    val snapshot = DeviceNotificationListenerService.snapshot(appContext)
-    if (!snapshot.connected) {
-      DeviceNotificationListenerService.requestServiceRebind(appContext)
-      return GatewaySession.InvokeResult.error(
-        code = "NOTIFICATION_LISTENER_UNAVAILABLE",
-        message = "NOTIFICATION_LISTENER_UNAVAILABLE: listener is reconnecting; retry shortly",
-      )
-    }
+internal interface NotificationsStateProvider {
+  fun readSnapshot(context: Context): DeviceNotificationSnapshot
 
-    val payload =
-      buildJsonObject {
-        put("enabled", JsonPrimitive(snapshot.enabled))
-        put("connected", JsonPrimitive(snapshot.connected))
-        put("count", JsonPrimitive(snapshot.notifications.size))
-        put(
-          "notifications",
-          JsonArray(
-            snapshot.notifications.map { entry ->
-              buildJsonObject {
-                put("key", JsonPrimitive(entry.key))
-                put("packageName", JsonPrimitive(entry.packageName))
-                put("postTimeMs", JsonPrimitive(entry.postTimeMs))
-                put("isOngoing", JsonPrimitive(entry.isOngoing))
-                put("isClearable", JsonPrimitive(entry.isClearable))
-                entry.title?.let { put("title", JsonPrimitive(it)) }
-                entry.text?.let { put("text", JsonPrimitive(it)) }
-                entry.subText?.let { put("subText", JsonPrimitive(it)) }
-                entry.category?.let { put("category", JsonPrimitive(it)) }
-                entry.channelId?.let { put("channelId", JsonPrimitive(it)) }
-              }
-            },
-          ),
-        )
-      }
-    return GatewaySession.InvokeResult.ok(payload.toString())
+  fun requestServiceRebind(context: Context)
+}
+
+private object SystemNotificationsStateProvider : NotificationsStateProvider {
+  override fun readSnapshot(context: Context): DeviceNotificationSnapshot {
+    val enabled = DeviceNotificationListenerService.isAccessEnabled(context)
+    if (!enabled) {
+      return DeviceNotificationSnapshot(
+        enabled = false,
+        connected = false,
+        notifications = emptyList(),
+      )
+    }
+    return DeviceNotificationListenerService.snapshot(context, enabled = true)
+  }
+
+  override fun requestServiceRebind(context: Context) {
+    DeviceNotificationListenerService.requestServiceRebind(context)
+  }
+}
+
+class NotificationsHandler private constructor(
+  private val appContext: Context,
+  private val stateProvider: NotificationsStateProvider,
+) {
+  constructor(appContext: Context) : this(appContext = appContext, stateProvider = SystemNotificationsStateProvider)
+
+  suspend fun handleNotificationsList(_paramsJson: String?): GatewaySession.InvokeResult {
+    val snapshot = stateProvider.readSnapshot(appContext)
+    if (snapshot.enabled && !snapshot.connected) {
+      stateProvider.requestServiceRebind(appContext)
+    }
+    return GatewaySession.InvokeResult.ok(snapshotPayloadJson(snapshot))
+  }
+
+  private fun snapshotPayloadJson(snapshot: DeviceNotificationSnapshot): String {
+    return buildJsonObject {
+      put("enabled", JsonPrimitive(snapshot.enabled))
+      put("connected", JsonPrimitive(snapshot.connected))
+      put("count", JsonPrimitive(snapshot.notifications.size))
+      put(
+        "notifications",
+        JsonArray(
+          snapshot.notifications.map { entry ->
+            buildJsonObject {
+              put("key", JsonPrimitive(entry.key))
+              put("packageName", JsonPrimitive(entry.packageName))
+              put("postTimeMs", JsonPrimitive(entry.postTimeMs))
+              put("isOngoing", JsonPrimitive(entry.isOngoing))
+              put("isClearable", JsonPrimitive(entry.isClearable))
+              entry.title?.let { put("title", JsonPrimitive(it)) }
+              entry.text?.let { put("text", JsonPrimitive(it)) }
+              entry.subText?.let { put("subText", JsonPrimitive(it)) }
+              entry.category?.let { put("category", JsonPrimitive(it)) }
+              entry.channelId?.let { put("channelId", JsonPrimitive(it)) }
+            }
+          },
+        ),
+      )
+    }.toString()
+  }
+
+  companion object {
+    internal fun forTesting(
+      appContext: Context,
+      stateProvider: NotificationsStateProvider,
+    ): NotificationsHandler = NotificationsHandler(appContext = appContext, stateProvider = stateProvider)
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
@@ -69,3 +69,12 @@ enum class OpenClawLocationCommand(val rawValue: String) {
     const val NamespacePrefix: String = "location."
   }
 }
+
+enum class OpenClawNotificationsCommand(val rawValue: String) {
+  List("notifications.list"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "notifications."
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.android.node
 
 import ai.openclaw.android.protocol.OpenClawCameraCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
+import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawSmsCommand
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -21,6 +22,7 @@ class InvokeCommandRegistryTest {
     assertFalse(commands.contains(OpenClawCameraCommand.Snap.rawValue))
     assertFalse(commands.contains(OpenClawCameraCommand.Clip.rawValue))
     assertFalse(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(OpenClawNotificationsCommand.List.rawValue))
     assertFalse(commands.contains(OpenClawSmsCommand.Send.rawValue))
     assertFalse(commands.contains("debug.logs"))
     assertFalse(commands.contains("debug.ed25519"))
@@ -40,6 +42,7 @@ class InvokeCommandRegistryTest {
     assertTrue(commands.contains(OpenClawCameraCommand.Snap.rawValue))
     assertTrue(commands.contains(OpenClawCameraCommand.Clip.rawValue))
     assertTrue(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(OpenClawNotificationsCommand.List.rawValue))
     assertTrue(commands.contains(OpenClawSmsCommand.Send.rawValue))
     assertTrue(commands.contains("debug.logs"))
     assertTrue(commands.contains("debug.ed25519"))

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/NotificationsHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/NotificationsHandlerTest.kt
@@ -1,0 +1,146 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import ai.openclaw.android.gateway.GatewaySession
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationsHandlerTest {
+  @Test
+  fun notificationsListReturnsStatusPayloadWhenDisabled() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = false,
+            connected = false,
+            notifications = emptyList(),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertFalse(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertFalse(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(0, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(0, payload.getValue("notifications").jsonArray.size)
+      assertEquals(0, provider.rebindRequests)
+    }
+
+  @Test
+  fun notificationsListRequestsRebindWhenEnabledButDisconnected() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = true,
+            connected = false,
+            notifications = listOf(sampleEntry("n1")),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertTrue(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertFalse(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(1, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(1, payload.getValue("notifications").jsonArray.size)
+      assertEquals(1, provider.rebindRequests)
+    }
+
+  @Test
+  fun notificationsListDoesNotRequestRebindWhenConnected() =
+    runTest {
+      val provider =
+        FakeNotificationsStateProvider(
+          DeviceNotificationSnapshot(
+            enabled = true,
+            connected = true,
+            notifications = listOf(sampleEntry("n2")),
+          ),
+        )
+      val handler = NotificationsHandler.forTesting(appContext = appContext(), stateProvider = provider)
+
+      val result = handler.handleNotificationsList(null)
+
+      assertTrue(result.ok)
+      assertNull(result.error)
+      val payload = parsePayload(result)
+      assertTrue(payload.getValue("enabled").jsonPrimitive.boolean)
+      assertTrue(payload.getValue("connected").jsonPrimitive.boolean)
+      assertEquals(1, payload.getValue("count").jsonPrimitive.int)
+      assertEquals(0, provider.rebindRequests)
+    }
+
+  @Test
+  fun sanitizeNotificationTextReturnsNullForBlankInput() {
+    assertNull(sanitizeNotificationText(null))
+    assertNull(sanitizeNotificationText("    "))
+  }
+
+  @Test
+  fun sanitizeNotificationTextTrimsAndTruncates() {
+    val value = "  ${"x".repeat(600)}  "
+    val sanitized = sanitizeNotificationText(value)
+
+    assertEquals(512, sanitized?.length)
+    assertTrue((sanitized ?: "").all { it == 'x' })
+  }
+
+  private fun parsePayload(result: GatewaySession.InvokeResult): JsonObject {
+    val payloadJson = result.payloadJson ?: error("expected payload")
+    return Json.parseToJsonElement(payloadJson).jsonObject
+  }
+
+  private fun appContext(): Context = RuntimeEnvironment.getApplication()
+
+  private fun sampleEntry(key: String): DeviceNotificationEntry =
+    DeviceNotificationEntry(
+      key = key,
+      packageName = "com.example.app",
+      title = "Title",
+      text = "Text",
+      subText = null,
+      category = null,
+      channelId = null,
+      postTimeMs = 123L,
+      isOngoing = false,
+      isClearable = true,
+    )
+}
+
+private class FakeNotificationsStateProvider(
+  private val snapshot: DeviceNotificationSnapshot,
+) : NotificationsStateProvider {
+  var rebindRequests: Int = 0
+    private set
+
+  override fun readSnapshot(context: Context): DeviceNotificationSnapshot = snapshot
+
+  override fun requestServiceRebind(context: Context) {
+    rebindRequests += 1
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/protocol/OpenClawProtocolConstantsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/protocol/OpenClawProtocolConstantsTest.kt
@@ -32,4 +32,9 @@ class OpenClawProtocolConstantsTest {
   fun screenCommandsUseStableStrings() {
     assertEquals("screen.record", OpenClawScreenCommand.Record.rawValue)
   }
+
+  @Test
+  fun notificationsCommandsUseStableStrings() {
+    assertEquals("notifications.list", OpenClawNotificationsCommand.List.rawValue)
+  }
 }

--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -138,6 +138,42 @@ describe("nodes camera_snap", () => {
   });
 });
 
+describe("nodes notifications_list", () => {
+  it("invokes notifications.list and returns payload", async () => {
+    callGateway.mockImplementation(async ({ method, params }) => {
+      if (method === "node.list") {
+        return mockNodeList(["notifications.list"]);
+      }
+      if (method === "node.invoke") {
+        expect(params).toMatchObject({
+          nodeId: NODE_ID,
+          command: "notifications.list",
+          params: {},
+        });
+        return {
+          payload: {
+            enabled: true,
+            connected: true,
+            count: 1,
+            notifications: [{ key: "n1", packageName: "com.example.app" }],
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    const result = await executeNodes({
+      action: "notifications_list",
+      node: NODE_ID,
+    });
+
+    expect(result.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining('"notifications"'),
+    });
+  });
+});
+
 describe("nodes run", () => {
   it("passes invoke and command timeouts", async () => {
     callGateway.mockImplementation(async ({ method, params }) => {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -40,6 +40,7 @@ const NODES_TOOL_ACTIONS = [
   "camera_clip",
   "screen_record",
   "location_get",
+  "notifications_list",
   "run",
   "invoke",
 ] as const;
@@ -122,7 +123,7 @@ export function createNodesTool(options?: {
     label: "Nodes",
     name: "nodes",
     description:
-      "Discover and control paired nodes (status/describe/pairing/notify/camera/screen/location/run/invoke).",
+      "Discover and control paired nodes (status/describe/pairing/notify/camera/screen/location/notifications/run/invoke).",
     parameters: NodesToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -402,6 +403,17 @@ export function createNodesTool(options?: {
                 desiredAccuracy,
                 timeoutMs: locationTimeoutMs,
               },
+              idempotencyKey: crypto.randomUUID(),
+            });
+            return jsonResult(raw?.payload ?? {});
+          }
+          case "notifications_list": {
+            const node = readStringParam(params, "node", { required: true });
+            const nodeId = await resolveNodeId(gatewayOpts, node);
+            const raw = await callGatewayTool<{ payload: unknown }>("node.invoke", gatewayOpts, {
+              nodeId,
+              command: "notifications.list",
+              params: {},
               idempotencyKey: crypto.randomUUID(),
             });
             return jsonResult(raw?.payload ?? {});

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -334,6 +334,19 @@ describe("resolveNodeCommandAllowlist", () => {
     }
   });
 
+  it("includes Android notifications.list by default", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {},
+      {
+        platform: "android 16",
+        deviceFamily: "Android",
+      },
+    );
+
+    expect(allow.has("notifications.list")).toBe(true);
+    expect(allow.has("system.notify")).toBe(false);
+  });
+
   it("can explicitly allow dangerous commands via allowCommands", () => {
     const allow = resolveNodeCommandAllowlist(
       {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -18,6 +18,7 @@ const CAMERA_DANGEROUS_COMMANDS = ["camera.snap", "camera.clip"];
 const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 
 const LOCATION_COMMANDS = ["location.get"];
+const NOTIFICATION_COMMANDS = ["notifications.list"];
 
 const DEVICE_COMMANDS = ["device.info", "device.status"];
 
@@ -69,6 +70,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...CANVAS_COMMANDS,
     ...CAMERA_COMMANDS,
     ...LOCATION_COMMANDS,
+    ...NOTIFICATION_COMMANDS,
     ...DEVICE_COMMANDS,
     ...CONTACTS_COMMANDS,
     ...CALENDAR_COMMANDS,


### PR DESCRIPTION
## Summary
- add Android notification listener support and `notifications.list` invoke handler
- register `notifications.list` in Android node command registry/dispatcher/protocol constants
- expose `nodes` tool action `notifications_list` and route it to `node.invoke`
- include `notifications.list` in the default Android gateway node allowlist

## Validation
- Android emulator manual check: `openclaw nodes invoke --node <android-node-id> --command notifications.list --params '{}'`
- Telegram manual check: model-triggered `nodes` action `notifications_list` returns current device notifications
- updated Android protocol/registry tests, gateway allowlist test, and nodes tool test
