### PR TITLE
fix/test a2ui bundle preflight

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +6,26 @@ import path from "node:path";
 // On Windows, `.cmd` launchers can fail with `spawn EINVAL` when invoked without a shell
 // (especially under GitHub Actions + Git Bash). Use `shell: true` and let the shell resolve pnpm.
 const pnpm = "pnpm";
+const a2uiBundlePath = path.join("src", "canvas-host", "a2ui", "a2ui.bundle.js");
+
+function ensureA2uiBundle() {
+  if (fs.existsSync(a2uiBundlePath)) {
+    return;
+  }
+  console.log(`[test-parallel] Missing ${a2uiBundlePath}; running "pnpm canvas:a2ui:bundle"...`);
+  const result = spawnSync(pnpm, ["canvas:a2ui:bundle"], {
+    stdio: "inherit",
+    env: process.env,
+    shell: isWindows,
+  });
+  if (result.status !== 0) {
+    const exitCode = result.status ?? 1;
+    console.error(
+      `[test-parallel] Failed to generate A2UI bundle (exit ${exitCode}). Run "pnpm canvas:a2ui:bundle" and retry.`,
+    );
+    process.exit(exitCode);
+  }
+}
 
 const unitIsolatedFilesRaw = [
   "src/plugins/loader.test.ts",
@@ -432,6 +452,8 @@ const shutdown = (signal) => {
 
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+ensureA2uiBundle();
 
 if (passthroughArgs.length > 0) {
   const maxWorkers = maxWorkersForRun("unit");


### PR DESCRIPTION
## Summary

- Problem: On fresh clones, `pnpm test` can fail in canvas auth tests when
`src/canvas-host/a2ui/a2ui.bundle.js` is missing (`503` from A2UI handler).
- Why it matters: New contributors hit a confusing failure before touching
code.
- What changed: `scripts/test-parallel.mjs` now preflights A2UI assets and
runs `pnpm canvas:a2ui:bundle` when the bundle is missing.
- What did NOT change: No gateway/runtime behavior changes; test bootstrap
only.

## Change Type

- [x] Bug fix
- [x] CI/CD / infra

## User-visible / Behavior Changes

- `pnpm test` now auto-generates missing A2UI bundle before running tests.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps (before)
1. Fresh clone with missing `src/canvas-host/a2ui/a2ui.bundle.js`
2. Run `pnpm test`
3. `src/gateway/server.canvas-auth.test.ts` can fail with `503` vs expected
`200`

### Steps (after)
1. Run `pnpm test`
2. Test launcher generates missing A2UI bundle
3. Test suite passes

## Risks and Mitigations

- Risk: Slight extra startup work when bundle is missing.
- Mitigation: Preflight only runs bundling when file is absent.
