### PR TITLE
fix(restart-sentinel): suppress doctorHint on successful restart/update/config

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -3,11 +3,7 @@ import { isRestartEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
-import {
-  formatDoctorNonInteractiveHint,
-  type RestartSentinelPayload,
-  writeRestartSentinel,
-} from "../../infra/restart-sentinel.js";
+import { type RestartSentinelPayload, writeRestartSentinel } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { stringEnum } from "../schema/typebox.js";
@@ -108,7 +104,7 @@ export function createGatewayTool(opts?: {
           deliveryContext,
           threadId,
           message: note ?? reason ?? null,
-          doctorHint: formatDoctorNonInteractiveHint(),
+          doctorHint: null,
           stats: {
             mode: "gateway.restart",
             reason,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -20,11 +20,7 @@ import {
 import { buildConfigSchema, type ConfigSchemaResponse } from "../../config/schema.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  formatDoctorNonInteractiveHint,
-  type RestartSentinelPayload,
-  writeRestartSentinel,
-} from "../../infra/restart-sentinel.js";
+import { type RestartSentinelPayload, writeRestartSentinel } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
 import { diffConfigPaths } from "../config-reload.js";
@@ -190,7 +186,7 @@ function buildConfigRestartSentinelPayload(params: {
     deliveryContext: params.deliveryContext,
     threadId: params.threadId,
     message: params.note ?? null,
-    doctorHint: formatDoctorNonInteractiveHint(),
+    doctorHint: null,
     stats: {
       mode: params.mode,
       root: CONFIG_PATH,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -63,7 +63,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       message: note ?? null,
-      doctorHint: formatDoctorNonInteractiveHint(),
+      doctorHint: result.status === "error" ? formatDoctorNonInteractiveHint() : null,
       stats: {
         mode: result.mode,
         root: result.root ?? undefined,


### PR DESCRIPTION
## Problem

After every successful restart, config change, or update, the gateway sends this message to the user:

```
Run: openclaw doctor --non-interactive
```

This bare hint is confusing — it implies something went wrong when usually everything is fine. Users don't know whether this is routine advice or an indication of a real issue.

## Fix

Make the `doctorHint` conditional on whether something actually needs attention:

- **`update.ts`**: Only include the hint when `result.status === "error"`. Failed updates can leave the installation in a broken state where `doctor` helps recover; successful/skipped updates need no hint.
- **`config.ts`**: Set `doctorHint: null`. Config apply/patch operations complete atomically — if they succeed, nothing is broken.
- **`gateway-tool.ts`**: Set `doctorHint: null`. Plain gateway restarts don't change installation state; `doctor` is not needed.

## Before / After

**Before (always shown):**
```
Gateway restart update ok
Run: openclaw doctor --non-interactive
```

**After (only on error):**
```
Gateway restart update ok
```
or on failure:
```
Gateway restart update error
Run: openclaw doctor --non-interactive
```

Fixes #27280