### PR TITLE
Feat/sandbox docker volumes strategies

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -96,6 +96,7 @@ export function resolveSandboxDockerConfig(params: {
     : globalDocker?.ulimits;
 
   const binds = [...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
+  const volumes = [...(globalDocker?.volumes ?? []), ...(agentDocker?.volumes ?? [])];
 
   return {
     image: agentDocker?.image ?? globalDocker?.image ?? DEFAULT_SANDBOX_IMAGE,
@@ -121,6 +122,7 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    volumes: volumes.length ? volumes : undefined,
     ...resolveDangerousSandboxDockerBooleans(agentDocker, globalDocker),
   };
 }

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -164,6 +164,7 @@ export function execDockerRaw(
 
 import { formatCliCommand } from "../../cli/command-format.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
+import type { SandboxDockerVolumeSetting } from "../../config/types.sandbox.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
 import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
@@ -314,6 +315,50 @@ function formatUlimitValue(
   return `${name}=${soft}:${hard}`;
 }
 
+function volumeSettingToBindSpec(volume: SandboxDockerVolumeSetting): string | null {
+  if (volume.strategy !== "bind") {
+    return null;
+  }
+  const source = volume.source?.trim();
+  const target = volume.target?.trim();
+  if (!source || !target) {
+    return null;
+  }
+  return `${source}:${target}:${volume.readOnly ? "ro" : "rw"}`;
+}
+
+function appendVolumeMounts(args: string[], cfg: SandboxDockerConfig): void {
+  for (const volume of cfg.volumes ?? []) {
+    const target = volume.target.trim();
+    if (!target) {
+      continue;
+    }
+    if (volume.strategy === "ephemeral") {
+      args.push("--mount", `type=volume,target=${target}${volume.readOnly ? ",readonly" : ""}`);
+      continue;
+    }
+    if (volume.strategy === "named") {
+      const source = volume.source?.trim();
+      if (!source) {
+        continue;
+      }
+      args.push(
+        "--mount",
+        `type=volume,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+      );
+      continue;
+    }
+    const source = volume.source?.trim();
+    if (!source) {
+      continue;
+    }
+    args.push(
+      "--mount",
+      `type=bind,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+    );
+  }
+}
+
 export function buildSandboxCreateArgs(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -329,8 +374,13 @@ export function buildSandboxCreateArgs(params: {
   envSanitizationOptions?: EnvSanitizationOptions;
 }) {
   // Runtime security validation: blocks dangerous bind mounts, network modes, and profiles.
+  const bindSpecsFromVolumes = (params.cfg.volumes ?? [])
+    .map((entry) => volumeSettingToBindSpec(entry))
+    .filter((entry): entry is string => typeof entry === "string");
+
   validateSandboxSecurity({
     ...params.cfg,
+    binds: [...(params.cfg.binds ?? []), ...bindSpecsFromVolumes],
     allowedSourceRoots: params.bindSourceRoots,
     allowSourcesOutsideAllowedRoots:
       params.allowSourcesOutsideAllowedRoots ??
@@ -464,6 +514,7 @@ async function createSandboxContainer(params: {
     workspaceAccess: params.workspaceAccess,
   });
   appendCustomBinds(args, cfg);
+  appendVolumeMounts(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
   await execDocker(args);

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -177,6 +177,60 @@ describe("sandbox docker config", () => {
     });
     expect(res.ok).toBe(false);
   });
+
+  it("accepts sandbox.docker.volumes with mixed strategies", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                { strategy: "ephemeral", target: "/tmp/cache" },
+                { strategy: "named", source: "openclaw-cache", target: "/cache" },
+                {
+                  strategy: "bind",
+                  source: "/home/user/shared",
+                  target: "/shared",
+                  readOnly: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects bind volume strategy without absolute source", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "bind", source: "relative/path", target: "/shared" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects ephemeral volume strategy when source is provided", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "ephemeral", source: "not-allowed", target: "/tmp" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
 });
 
 describe("sandbox browser binds config", () => {

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -1,5 +1,16 @@
 import type { SecretInput } from "./types.secrets.js";
 
+export type SandboxDockerVolumeSetting = {
+  /** Host path (bind), volume name (named), or omitted for ephemeral strategy. */
+  source?: string;
+  /** Container mount target path. */
+  target: string;
+  /** Mount strategy. */
+  strategy: "ephemeral" | "named" | "bind";
+  /** Mount read-only inside container. */
+  readOnly?: boolean;
+};
+
 export type SandboxDockerSettings = {
   /** Docker image to use for sandbox containers. */
   image?: string;
@@ -44,6 +55,8 @@ export type SandboxDockerSettings = {
   extraHosts?: string[];
   /** Additional bind mounts (host:container:mode format, e.g. ["/host/path:/container/path:rw"]). */
   binds?: string[];
+  /** Declarative volume mounts with strategy (ephemeral|named|bind). */
+  volumes?: SandboxDockerVolumeSetting[];
   /**
    * Dangerous override: allow bind mounts that target reserved container paths
    * like /workspace or /agent.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -132,6 +132,18 @@ export const SandboxDockerSchema = z
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
     binds: z.array(z.string()).optional(),
+    volumes: z
+      .array(
+        z
+          .object({
+            source: z.string().optional(),
+            target: z.string(),
+            strategy: z.union([z.literal("ephemeral"), z.literal("named"), z.literal("bind")]),
+            readOnly: z.boolean().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
@@ -158,6 +170,44 @@ export const SandboxDockerSchema = z
             message:
               `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
               "Only absolute POSIX paths are supported for sandbox binds.",
+          });
+        }
+      }
+    }
+    if (data.volumes) {
+      for (let i = 0; i < data.volumes.length; i += 1) {
+        const vol = data.volumes[i];
+        const target = vol?.target?.trim() ?? "";
+        if (!target || !target.startsWith("/")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "target"],
+            message: "Sandbox security: volume target must be an absolute POSIX path.",
+          });
+        }
+        const source = vol?.source?.trim();
+        if (vol.strategy === "bind") {
+          if (!source || !source.startsWith("/")) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                "Sandbox security: bind volume strategy requires an absolute POSIX source path.",
+            });
+          }
+        } else if (vol.strategy === "named") {
+          if (!source) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message: "Sandbox config: named volume strategy requires source (volume name).",
+            });
+          }
+        } else if (source) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "source"],
+            message: "Sandbox config: ephemeral strategy must not set source.",
           });
         }
       }


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: Sandbox mount config is currently bind-string oriented (`sandbox.docker.binds`), which makes Docker-managed volume workflows awkward.
- Why it matters: In containerized environments, forcing host bind semantics adds friction and can require unnecessary host path sharing.
- What changed: Added optional declarative `sandbox.docker.volumes` support with strategies `ephemeral | named | bind`, including validation, config merge support, and Docker `--mount` wiring.
- What did NOT change (scope boundary): Existing `sandbox.docker.binds` behavior/defaults are unchanged; no changes to the separate #9560 fallback bugfix logic in this PR.

## Change Type (select all)
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #9560

## User-visible / Behavior Changes
- New optional config: `sandbox.docker.volumes` (global + agent override paths).
- Supported strategies:
- `ephemeral` → anonymous Docker volume mount
- `named` → named Docker volume mount
- `bind` → declarative bind mount
- Validation rules added:
- `target` must be absolute POSIX
- `bind` requires absolute POSIX `source`
- `named` requires `source`
- `ephemeral` must not set `source`

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`) - **No**
- Secrets/tokens handling changed? (`Yes/No`) - **No**
- New/changed network calls? (`Yes/No`) - **No**
- Command/tool execution surface changed? (`Yes/No`) - **No**
- Data access scope changed? (`Yes/No`) - **No**
- If any `Yes`, explain risk + mitigation:
- N/A

## Repro + Verification
### Environment
- OS: Linux (containerized dev environment)
- Runtime/container: Dockerized OpenClaw workspace
- Model/provider: N/A (runtime/config feature)
- Integration/channel (if any): N/A
- Relevant config (redacted):
- `sandbox.docker.volumes` with mixed strategy entries in tests

### Steps
1. Configure `sandbox.docker.volumes` entries for `ephemeral`, `named`, and `bind`.
2. Run config + sandbox-targeted tests.
3. Run project build.

### Expected
- Valid volume configs pass schema validation.
- Invalid strategy/source combos are rejected.
- Docker sandbox create args include expected `--mount` values.
- Build completes successfully.

### Actual
- Matched expected behavior.
- Targeted tests passed.
- Build passed.

## Evidence
Attach at least one:
- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
What you personally verified (not just CI), and how:
- Verified scenarios:
- Added/ran volume strategy schema tests (valid mixed strategies + invalid cases).
- Confirmed sandbox-related targeted suite passes.
- Confirmed full `pnpm build` passes.
- Edge cases checked:
- `ephemeral` with `source` is rejected.
- `bind` with non-absolute source is rejected.
- Existing `binds` path remains functional (no schema regression).
- What you did **not** verify:
- Full production-like multi-node deployment rollout.

## Compatibility / Migration
- Backward compatible? (`Yes/No`) - **Yes**
- Config/env changes? (`Yes/No`) - **No** (additive optional config only)
- Migration needed? (`Yes/No`) - **No**
- If yes, exact upgrade steps:
- N/A

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly:
- Remove/avoid `sandbox.docker.volumes` config and keep using `sandbox.docker.binds`; or revert this PR commit.
- Files/config to restore:
- `src/config/types.sandbox.ts`
- `src/config/zod-schema.agent-runtime.ts`
- `src/agents/sandbox/config.ts`
- `src/agents/sandbox/docker.ts`
- Known bad symptoms reviewers should watch for:
- Docker create failures due to malformed `--mount` output from invalid config.
- Unexpected schema rejections in existing bind-only setups (should not occur).

## Risks and Mitigations
List only real risks for this PR. Add/remove entries as needed. If none, write `None`.
- Risk: Invalid/malformed volume entries could lead to Docker create failures.
- Mitigation: Strategy-specific schema validation enforces required/forbidden fields and path constraints.
- Risk: Bind-strategy volume entries could bypass bind mount security checks.
- Mitigation: Bind-strategy volumes are routed through existing bind security validation path before container create.