### PR TITLE
fix(cron): remove hardcoded relay instructions from cron prompts

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -2,15 +2,23 @@ import { describe, expect, it } from "vitest";
 import { buildCronEventPrompt, buildExecEventPrompt } from "./heartbeat-events-filter.js";
 
 describe("heartbeat event prompts", () => {
-  it("builds user-relay cron prompt by default", () => {
+  it("builds cron prompt without relay instruction by default", () => {
     const prompt = buildCronEventPrompt(["Cron: rotate logs"]);
-    expect(prompt).toContain("Please relay this reminder to the user");
+    expect(prompt).toContain("A scheduled reminder has been triggered");
+    expect(prompt).toContain("Cron: rotate logs");
+    expect(prompt).not.toContain("Please relay this reminder to the user");
   });
 
   it("builds internal-only cron prompt when delivery is disabled", () => {
     const prompt = buildCronEventPrompt(["Cron: rotate logs"], { deliverToUser: false });
     expect(prompt).toContain("Handle this reminder internally");
     expect(prompt).not.toContain("Please relay this reminder to the user");
+  });
+
+  it("builds exec prompt without relay instruction by default", () => {
+    const prompt = buildExecEventPrompt();
+    expect(prompt).toContain("An async command you ran earlier has completed");
+    expect(prompt).not.toContain("Please relay the command output to the user");
   });
 
   it("builds internal-only exec prompt when delivery is disabled", () => {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -30,11 +30,9 @@ export function buildCronEventPrompt(
       "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested."
     );
   }
-  return (
-    "A scheduled reminder has been triggered. The reminder content is:\n\n" +
-    eventText +
-    "\n\nPlease relay this reminder to the user in a helpful and friendly way."
-  );
+  // deliverToUser=true: just show the reminder content
+  // Users can add relay instructions in their message text if needed
+  return "A scheduled reminder has been triggered. The reminder content is:\n\n" + eventText;
 }
 
 export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
@@ -45,11 +43,9 @@ export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string
       "Handle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
-  return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
-  );
+  // deliverToUser=true: just notify about completion
+  // Users can add relay instructions in their message text if needed
+  return "An async command you ran earlier has completed. The result is shown in the system messages above.";
 }
 
 const HEARTBEAT_OK_PREFIX = HEARTBEAT_TOKEN.toLowerCase();


### PR DESCRIPTION
## Summary

Removes hardcoded "Please relay this reminder to the user" and "Please relay the command output" instructions from cron and exec prompts.

## Motivation

The hardcoded relay instruction caused confusion:
- Agents interpreted diary/reminder crons as messages to relay to users
- Unnecessary configuration complexity (`relayPrompt` field in #27324)

## Solution

Just remove the hardcoded suffix. Users control relay instructions via their message text:

```json
{
  "text": "🦞 Good morning! Write your diary. Handle internally, do not relay to user."
}
```

vs previous complex approach:
```json
{
  "text": "🦞 Good morning!",
  "relayPrompt": null
}
```

## Changes

- Remove "Please relay this reminder to the user in a helpful and friendly way." from cron prompts
- Remove "Please relay the command output..." from exec prompts
- Users add relay instructions in their message text if needed

## Testing

All 260 cron tests pass. Build succeeds.

Closes #27324 (superseded by simpler approach)