### PR TITLE
fix: delivery-mirror assistant messages break tool_call pairing on cross-provider replay (#27150)

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -488,3 +488,116 @@ describe("stripToolResultDetails", () => {
     expect(out).toBe(input);
   });
 });
+
+describe("repairToolUseResultPairing — delivery-mirror interleave", () => {
+  it("does not break tool_call pairing when delivery-mirror assistant is interleaved", () => {
+    // Simulates the pattern from #27150: assistant tool_call → delivery-mirror assistant → toolResult
+    // The delivery-mirror assistant (no tool_calls) should NOT sever the scan.
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_01Gp6", name: "message", arguments: {} }],
+        stopReason: "toolUse",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Good morning! Here is your briefing." }],
+        stopReason: "stop",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_01Gp6",
+        toolName: "message",
+        content: [{ type: "text", text: "sent" }],
+        isError: false,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+
+    // The real tool result should be matched, NOT replaced by a synthetic one
+    expect(result.added).toHaveLength(0);
+    // Order: assistant(tool_call) → toolResult → assistant(delivery-mirror)
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("toolu_01Gp6");
+    expect(result.messages[2]?.role).toBe("assistant");
+    expect((result.messages[2] as { model?: string }).model).toBe("delivery-mirror");
+  });
+
+  it("still breaks scan on a real assistant message with tool_calls", () => {
+    // A real assistant message with tool_calls should still break the scan
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+        stopReason: "toolUse",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_2", name: "write", arguments: {} }],
+        stopReason: "toolUse",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "file content" }],
+        isError: false,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+
+    // call_1's real tool result is after the second assistant (which has tool_calls),
+    // so the scan breaks and both get synthetic results
+    expect(result.added).toHaveLength(2);
+    expect(result.added[0]?.toolCallId).toBe("call_1");
+    expect(result.added[1]?.toolCallId).toBe("call_2");
+  });
+
+  it("handles multiple delivery-mirror messages interleaved between tool_call and result", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_a", name: "exec", arguments: {} }],
+        stopReason: "toolUse",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "mirror 1" }],
+        stopReason: "stop",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "mirror 2" }],
+        stopReason: "stop",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_a",
+        toolName: "exec",
+        content: [{ type: "text", text: "done" }],
+        isError: false,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages).toHaveLength(4);
+    // tool result should be right after the tool_call assistant
+    expect(result.messages[0]?.role).toBe("assistant");
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_a");
+  });
+});

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -424,6 +424,20 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
       const nextRole = (next as { role?: unknown }).role;
       if (nextRole === "assistant") {
+        // If this assistant message has no tool calls (e.g. delivery-mirror),
+        // treat it as a non-tool message and defer it to remainder instead of
+        // breaking the scan. This prevents delivery-mirror messages from
+        // severing the tool_call → tool_result pairing, which causes
+        // "tool_call_id not found" errors on cross-provider replay.
+        const nextStopReason = (next as { stopReason?: string }).stopReason;
+        const nextToolCalls =
+          nextStopReason !== "error" && nextStopReason !== "aborted"
+            ? extractToolCallsFromAssistant(next as Extract<AgentMessage, { role: "assistant" }>)
+            : [];
+        if (nextToolCalls.length === 0) {
+          remainder.push(next);
+          continue;
+        }
         break;
       }
 


### PR DESCRIPTION
## Problem

When switching providers mid-session (e.g. Anthropic → Moonshot/Kimi), `[openclaw/delivery-mirror]` assistant messages interleaved between `tool_call` and `tool_result` messages break the OpenAI-compatible API's tool_call pairing:

```
L1: assistant [anthropic]           → toolCall(id=toolu_01Gp6)
L2: assistant [openclaw/delivery-mirror] → text (no tool_calls)
L3: toolResult                      → toolCallId=toolu_01Gp6
```

`repairToolUseResultPairing()` treats any `role: assistant` as a scan boundary (`break`), so the delivery-mirror at L2 severs the scan. The real tool_result at L3 becomes orphaned, and a synthetic error result is inserted instead. On replay to an OpenAI-compatible provider, this produces persistent `400: tool_call_id not found` errors.

## Root Cause

In `session-transcript-repair.ts`, the forward scan loop unconditionally breaks on any `assistant` message:

```typescript
if (nextRole === "assistant") {
  break;  // ← severs scan even for delivery-mirror (no tool_calls)
}
```

## Fix

Only break on assistant messages that carry tool_calls. Tool-call-free assistants (delivery-mirror, text-only) are deferred to `remainder`, preserving the `tool_call → tool_result` pairing:

```typescript
if (nextRole === "assistant") {
  const nextToolCalls = extractToolCallsFromAssistant(next);
  if (nextToolCalls.length === 0) {
    remainder.push(next);  // defer, don't break
    continue;
  }
  break;  // real tool_call assistant still breaks scan
}
```

## Tests

3 new test cases:
- Single delivery-mirror interleaved between tool_call and result → pairing preserved
- Real assistant with tool_calls still breaks scan correctly
- Multiple delivery-mirror messages interleaved → all deferred, pairing preserved

All 16 tests pass.

Closes #27150