### PR TITLE
fix(zai): disable tool_stream default for glm-4.7-flash

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
@@ -50,6 +50,20 @@ describe("extra-params: Z.AI tool_stream support", () => {
     expect(payload.tool_stream).toBe(true);
   });
 
+  it("does not inject tool_stream by default for glm-4.7-flash", () => {
+    const payload = runToolStreamCase({
+      applyProvider: "zai",
+      applyModelId: "glm-4.7-flash",
+      model: {
+        api: "openai-completions",
+        provider: "zai",
+        id: "glm-4.7-flash",
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("tool_stream");
+  });
+
   it("does not inject tool_stream for non-zai providers", () => {
     const payload = runToolStreamCase({
       applyProvider: "openai",
@@ -89,5 +103,32 @@ describe("extra-params: Z.AI tool_stream support", () => {
     });
 
     expect(payload).not.toHaveProperty("tool_stream");
+  });
+
+  it("allows forcing tool_stream=true for glm-4.7-flash via params", () => {
+    const payload = runToolStreamCase({
+      applyProvider: "zai",
+      applyModelId: "glm-4.7-flash",
+      model: {
+        api: "openai-completions",
+        provider: "zai",
+        id: "glm-4.7-flash",
+      } as Model<"openai-completions">,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "zai/glm-4.7-flash": {
+                params: {
+                  tool_stream: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.tool_stream).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #27281

## Summary
- disable automatic `tool_stream` injection for `zai/glm-4.7-flash`
- keep default `tool_stream` behavior unchanged for other Z.AI models
- allow explicit override with `agents.defaults.models["zai/glm-4.7-flash"].params.tool_stream: true`

## Why
`glm-4.7-flash` currently fails in production when `tool_stream` is enabled. This change applies a narrow model-specific default so runs complete normally while preserving explicit opt-in control.

## Validation
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`
- `pnpm vitest src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts`
