### PR TITLE
fix(agents): dereference workspace bridge bootstrap files

### DIFF
--- a/extensions/matrix/src/matrix/client.lazy-import.test.ts
+++ b/extensions/matrix/src/matrix/client.lazy-import.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ createClientModuleLoaded: false }));
+
+vi.mock("./client/create-client.js", () => {
+  state.createClientModuleLoaded = true;
+  throw new Error("create-client module should not load for config-only imports");
+});
+
+describe("matrix client barrel imports", () => {
+  it("does not load create-client when resolving config helpers", async () => {
+    const mod = await import("./client.js");
+    const resolved = mod.resolveMatrixConfig({}, {} as NodeJS.ProcessEnv);
+
+    expect(resolved.encryption).toBe(false);
+    expect(state.createClientModuleLoaded).toBe(false);
+  });
+});

--- a/extensions/matrix/src/matrix/client.ts
+++ b/extensions/matrix/src/matrix/client.ts
@@ -1,3 +1,5 @@
+import type { createMatrixClient as CreateMatrixClientFn } from "./client/create-client.js";
+
 export type { MatrixAuth, MatrixResolvedConfig } from "./client/types.js";
 export { isBunRuntime } from "./client/runtime.js";
 export {
@@ -5,7 +7,14 @@ export {
   resolveMatrixConfigForAccount,
   resolveMatrixAuth,
 } from "./client/config.js";
-export { createMatrixClient } from "./client/create-client.js";
+
+export async function createMatrixClient(
+  ...args: Parameters<CreateMatrixClientFn>
+): ReturnType<CreateMatrixClientFn> {
+  const mod = await import("./client/create-client.js");
+  return mod.createMatrixClient(...args);
+}
+
 export {
   resolveSharedMatrixClient,
   waitForMatrixSync,

--- a/extensions/matrix/src/matrix/client.ts
+++ b/extensions/matrix/src/matrix/client.ts
@@ -1,4 +1,4 @@
-import type { createMatrixClient as CreateMatrixClientFn } from "./client/create-client.js";
+type CreateMatrixClientFn = (typeof import("./client/create-client.js"))["createMatrixClient"];
 
 export type { MatrixAuth, MatrixResolvedConfig } from "./client/types.js";
 export { isBunRuntime } from "./client/runtime.js";

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,11 +1,6 @@
 import fs from "node:fs";
 import type { IStorageProvider, ICryptoStorageProvider } from "@vector-im/matrix-bot-sdk";
-import {
-  LogService,
-  MatrixClient,
-  SimpleFsStorageProvider,
-  RustSdkCryptoStorageProvider,
-} from "@vector-im/matrix-bot-sdk";
+import { LogService, MatrixClient, SimpleFsStorageProvider } from "@vector-im/matrix-bot-sdk";
 import { ensureMatrixSdkLoggingConfigured } from "./logging.js";
 import {
   maybeMigrateLegacyStorage,
@@ -65,7 +60,10 @@ export async function createMatrixClient(params: {
     fs.mkdirSync(storagePaths.cryptoPath, { recursive: true });
 
     try {
-      const { StoreType } = await import("@matrix-org/matrix-sdk-crypto-nodejs");
+      const [{ StoreType }, { RustSdkCryptoStorageProvider }] = await Promise.all([
+        import("@matrix-org/matrix-sdk-crypto-nodejs"),
+        import("@vector-im/matrix-bot-sdk"),
+      ]);
       cryptoStorage = new RustSdkCryptoStorageProvider(storagePaths.cryptoPath, StoreType.Sqlite);
     } catch (err) {
       LogService.warn(

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -3,9 +3,10 @@ import { LogService } from "@vector-im/matrix-bot-sdk";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAuth } from "./config.js";
-import type { createMatrixClient as CreateMatrixClientFn } from "./create-client.js";
 import { DEFAULT_ACCOUNT_KEY } from "./storage.js";
 import type { MatrixAuth } from "./types.js";
+
+type CreateMatrixClientFn = (typeof import("./create-client.js"))["createMatrixClient"];
 
 type SharedMatrixClientState = {
   client: MatrixClient;

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -3,7 +3,7 @@ import { LogService } from "@vector-im/matrix-bot-sdk";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAuth } from "./config.js";
-import { createMatrixClient } from "./create-client.js";
+import type { createMatrixClient as CreateMatrixClientFn } from "./create-client.js";
 import { DEFAULT_ACCOUNT_KEY } from "./storage.js";
 import type { MatrixAuth } from "./types.js";
 
@@ -35,6 +35,8 @@ async function createSharedMatrixClient(params: {
   timeoutMs?: number;
   accountId?: string | null;
 }): Promise<SharedMatrixClientState> {
+  const createMatrixClient: CreateMatrixClientFn = (await import("./create-client.js"))
+    .createMatrixClient;
   const client = await createMatrixClient({
     homeserver: params.auth.homeserver,
     userId: params.auth.userId,

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -142,6 +142,55 @@ describe("loadWorkspaceBootstrapFiles", () => {
     const files = await loadWorkspaceBootstrapFiles(tempDir);
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
+
+  it("dereferences single-line bridge pointers in bootstrap files", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const identityTarget = path.join(tempDir, "identity", "agent.identity.md");
+    await fs.mkdir(path.dirname(identityTarget), { recursive: true });
+    await fs.writeFile(identityTarget, "- Name: Pointer Agent\n", "utf-8");
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: "\u2192 identity/agent.identity.md",
+    });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const identity = files.find((file) => file.name === DEFAULT_IDENTITY_FILENAME);
+    expect(identity?.missing).toBe(false);
+    expect(identity?.content).toBe("- Name: Pointer Agent\n");
+  });
+
+  it("dereferences frontmatter bridge pointers in bootstrap files", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const externalDir = await makeTempWorkspace("openclaw-workspace-bridge-");
+    const sharedPath = path.join(externalDir, "shared-agents.md");
+    await fs.writeFile(sharedPath, "# Shared\n- Rule: Always verify\n", "utf-8");
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_AGENTS_FILENAME,
+      content: `---\ntype: bridge\ntarget: ${sharedPath}\n---\n`,
+    });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+    expect(agents?.missing).toBe(false);
+    expect(agents?.content).toBe("# Shared\n- Rule: Always verify\n");
+  });
+
+  it("keeps original content when bridge target is missing", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const bridgeContent = "---\ntype: bridge\ntarget: ./missing-identity.md\n---\n";
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: bridgeContent,
+    });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const identity = files.find((file) => file.name === DEFAULT_IDENTITY_FILENAME);
+    expect(identity?.missing).toBe(false);
+    expect(identity?.content).toBe(bridgeContent);
+  });
 });
 
 describe("filterBootstrapFilesForSession", () => {

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -270,18 +270,25 @@ describe("doctor config flow", () => {
       expect(cfg.channels.discord.guilds["100"].roles).toEqual(["222"]);
       expect(cfg.channels.discord.guilds["100"].channels.general.users).toEqual(["333"]);
       expect(cfg.channels.discord.guilds["100"].channels.general.roles).toEqual(["444"]);
-      expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["555"]);
-      expect(cfg.channels.discord.accounts.work.dm.allowFrom).toEqual(["666"]);
-      expect(cfg.channels.discord.accounts.work.dm.groupChannels).toEqual(["777"]);
-      expect(cfg.channels.discord.accounts.work.execApprovals.approvers).toEqual(["888"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].users).toEqual(["999"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].roles).toEqual(["1010"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.users).toEqual([
-        "1111",
-      ]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.roles).toEqual([
-        "1212",
-      ]);
+      const workAccount = cfg.channels.discord.accounts.work;
+      expect(workAccount).toBeDefined();
+      if (!workAccount) {
+        throw new Error("expected discord work account to exist after repair");
+      }
+      const workGuild = workAccount.guilds["200"];
+      expect(workGuild).toBeDefined();
+      if (!workGuild) {
+        throw new Error("expected discord work guild 200 to exist after repair");
+      }
+
+      expect(workAccount.allowFrom).toEqual(["555"]);
+      expect(workAccount.dm.allowFrom).toEqual(["666"]);
+      expect(workAccount.dm.groupChannels).toEqual(["777"]);
+      expect(workAccount.execApprovals.approvers).toEqual(["888"]);
+      expect(workGuild.users).toEqual(["999"]);
+      expect(workGuild.roles).toEqual(["1010"]);
+      expect(workGuild.channels.help.users).toEqual(["1111"]);
+      expect(workGuild.channels.help.roles).toEqual(["1212"]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add workspace bootstrap bridge dereferencing so pointer files are resolved before prompt injection.
- Support both `→ <path>` single-line pointers and frontmatter bridges (`type: bridge`, `target: ...`).
- Keep bootstrap loading safe by preventing loops/deep recursion and falling back to original content when a target cannot be read.

## Testing
- pnpm vitest src/agents/workspace.test.ts
- pnpm vitest src/agents/workspace.bootstrap-cache.test.ts src/agents/workspace.load-extra-bootstrap-files.test.ts

Fixes #27351