### PR TITLE
fix(bonjour): suppress ciao IPv4 address-change assertion crash

### DIFF
--- a/src/infra/bonjour-ciao.test.ts
+++ b/src/infra/bonjour-ciao.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: mocks.logWarn,
+  logDebug: mocks.logDebug,
+}));
+
+const { ignoreCiaoCancellationRejection } = await import("./bonjour-ciao.js");
+
+describe("ignoreCiaoCancellationRejection", () => {
+  it("suppresses ciao announcement cancellation", () => {
+    const err = new Error("ciao announcement cancelled");
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logDebug).toHaveBeenCalled();
+  });
+
+  it("suppresses IPv4 address change from defined to undefined assertion", () => {
+    const err = new assert.AssertionError({
+      message: "Reached illegal state! IPV4 address change from defined to undefined!",
+    });
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed ciao network-change assertion"),
+    );
+  });
+
+  it("suppresses IPv4 address changed from undefined to defined assertion", () => {
+    const err = new assert.AssertionError({
+      message: "Reached illegal state! IPv4 address changed from undefined to defined!",
+    });
+    expect(ignoreCiaoCancellationRejection(err)).toBe(true);
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed ciao network-change assertion"),
+    );
+  });
+
+  it("does not suppress unrelated errors", () => {
+    expect(ignoreCiaoCancellationRejection(new Error("something else"))).toBe(false);
+    expect(ignoreCiaoCancellationRejection(new TypeError("boom"))).toBe(false);
+    expect(ignoreCiaoCancellationRejection("random string")).toBe(false);
+  });
+});

--- a/src/infra/bonjour-ciao.ts
+++ b/src/infra/bonjour-ciao.ts
@@ -1,11 +1,27 @@
-import { logDebug } from "../logger.js";
+import { logDebug, logWarn } from "../logger.js";
 import { formatBonjourError } from "./bonjour-errors.js";
+
+// ciao's MDNSServer.handleUpdatedNetworkInterfaces fires assert.fail when an
+// interface's IPv4 address transitions between defined⇄undefined (e.g. WiFi
+// drop, VPN toggle, sleep/wake).  These are transient network events, not bugs
+// in OpenClaw — swallow them so the gateway stays alive.
+const CIAO_TRANSIENT_PATTERNS = [
+  "CIAO ANNOUNCEMENT CANCELLED",
+  "REACHED ILLEGAL STATE! IPV4 ADDRESS CHANGE",
+  "REACHED ILLEGAL STATE! IPV4 ADDRESS CHANGED",
+];
 
 export function ignoreCiaoCancellationRejection(reason: unknown): boolean {
   const message = formatBonjourError(reason).toUpperCase();
-  if (!message.includes("CIAO ANNOUNCEMENT CANCELLED")) {
+  const matched = CIAO_TRANSIENT_PATTERNS.some((pattern) => message.includes(pattern));
+  if (!matched) {
     return false;
   }
-  logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatBonjourError(reason)}`);
+  const formatted = formatBonjourError(reason);
+  if (message.includes("REACHED ILLEGAL STATE")) {
+    logWarn(`bonjour: suppressed ciao network-change assertion (non-fatal): ${formatted}`);
+  } else {
+    logDebug(`bonjour: ignoring unhandled ciao rejection: ${formatted}`);
+  }
   return true;
 }


### PR DESCRIPTION
## Summary

- Problem: `@homebridge/ciao` fires `assert.fail()` inside `MDNSServer.handleUpdatedNetworkInterfaces` when a network interface's IPv4 address transitions between defined↔undefined (WiFi drop, VPN toggle, sleep/wake).
- Why it matters: The assertion becomes an unhandled promise rejection that falls through to `process.exit(1)`, crashing the gateway.
- What changed: Extended `ignoreCiaoCancellationRejection` in `src/infra/bonjour-ciao.ts` to also match ciao's IPv4 address-change assertions, logging them as non-fatal warnings instead of letting them crash the process.
- What did NOT change (scope boundary): No changes to the `@homebridge/ciao` dependency itself or other unhandled rejection logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: `@homebridge/ciao` upstream bug in `MDNSServer.handleUpdatedNetworkInterfaces`

## User-visible / Behavior Changes

Gateway no longer crashes when network interfaces change (WiFi disconnect/reconnect, VPN toggle, sleep/wake). A warning is logged instead.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): mDNS/Bonjour discovery
- Relevant config (redacted): N/A

### Steps

1. Start OpenClaw gateway with Bonjour advertising enabled
2. Toggle WiFi off or disconnect VPN while gateway is running
3. Observe gateway behavior

### Expected

- Gateway logs a warning and continues running

### Actual (before fix)

- Gateway crashes with `AssertionError [ERR_ASSERTION]: Reached illegal state! IPV4 address change from defined to undefined!`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Error trace before fix:
```
[openclaw] Unhandled promise rejection: AssertionError [ERR_ASSERTION]: Reached illegal state! IPV4 address change from defined to undefined!
    at MDNSServer.handleUpdatedNetworkInterfaces (.../@homebridge/ciao/src/MDNSServer.ts:695:18)
    at NetworkManager.checkForNewInterfaces (.../@homebridge/ciao/src/NetworkManager.ts:345:12)
```

New tests added in `src/infra/bonjour-ciao.test.ts` covering both assertion variants and unrelated error passthrough.

## Human Verification (required)

- Verified scenarios: All 11 bonjour tests pass (4 new + 7 existing)
- Edge cases checked: Both IPv4 assertion variants (defined→undefined, undefined→defined), unrelated errors still propagate
- What you did **not** verify: Live reproduction on hardware network toggle (error observed in production logs)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit on `src/infra/bonjour-ciao.ts`
- Files/config to restore: `src/infra/bonjour-ciao.ts`
- Known bad symptoms reviewers should watch for: Gateway crashing on network changes (regression to current behavior)

## Risks and Mitigations

- Risk: Suppressing a ciao assertion that indicates a real bug could mask mDNS state corruption
  - Mitigation: The assertion is logged as a warning (`logWarn`), and the bonjour watchdog (60s interval) will attempt re-advertisement if the service falls out of `announced` state
