### PR TITLE
fix(tmp): avoid fatal fallback temp-dir startup failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
 - If local Vitest runs cause memory pressure (common on non-Mac-Studio hosts), use `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test` for land/gate runs.
+- When Frank explicitly asks for full GitHub CI parity locally, run every lane from `.github/workflows/ci.yml` once under GitHub-like toolchain env (`JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home`, `ANDROID_HOME=$HOME/Library/Android/sdk`, `ANDROID_SDK_ROOT=$ANDROID_HOME`) and report `PASS/FAIL/SKIP` plus summary/log paths.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
 - Full kit + what’s covered: `docs/testing.md`.
 - Changelog: user-facing changes only; no internal/meta notes (version alignment, appcast reminders, release process).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@
 - Run `pnpm test` (or `pnpm test:coverage`) before pushing when you touch logic.
 - Do not set test workers above 16; tried already.
 - If local Vitest runs cause memory pressure (common on non-Mac-Studio hosts), use `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test` for land/gate runs.
-- When Frank explicitly asks for full GitHub CI parity locally, run every lane from `.github/workflows/ci.yml` once under GitHub-like toolchain env (`JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home`, `ANDROID_HOME=$HOME/Library/Android/sdk`, `ANDROID_SDK_ROOT=$ANDROID_HOME`) and report `PASS/FAIL/SKIP` plus summary/log paths.
+- When Frank explicitly asks for full GitHub CI parity locally, run every lane from `.github/workflows/ci.yml` once under GitHub-like env (`CI=true`, `GITHUB_ACTIONS=true`, `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home`, `ANDROID_HOME=$HOME/Library/Android/sdk`, `ANDROID_SDK_ROOT=$ANDROID_HOME`) and report `PASS/FAIL/SKIP` plus summary/log paths.
 - Live tests (real keys): `CLAWDBOT_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1 pnpm test:live` (includes provider live tests). Docker: `pnpm test:docker:live-models`, `pnpm test:docker:live-gateway`. Onboarding Docker E2E: `pnpm test:docker:onboard`.
 - Full kit + what’s covered: `docs/testing.md`.
 - Changelog: user-facing changes only; no internal/meta notes (version alignment, appcast reminders, release process).

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -8,6 +8,10 @@ function fallbackTmp(uid = 501) {
   return path.join("/var/fallback", `openclaw-${uid}`);
 }
 
+function fallbackTmpSafe(uid = 501) {
+  return path.join("/var/fallback", `openclaw-${uid}-safe`);
+}
+
 function nodeErrorWithCode(code: string) {
   const err = new Error(code) as Error & { code?: string };
   err.code = code;
@@ -37,38 +41,6 @@ function makeDirStat(params?: {
   };
 }
 
-function readOnlyTmpAccessSync() {
-  return vi.fn((target: string) => {
-    if (target === "/tmp") {
-      throw new Error("read-only");
-    }
-  });
-}
-
-function resolveWithReadOnlyTmpFallback(params: {
-  fallbackPath: string;
-  fallbackLstatSync: NonNullable<TmpDirOptions["lstatSync"]>;
-  chmodSync?: NonNullable<TmpDirOptions["chmodSync"]>;
-  warn?: NonNullable<TmpDirOptions["warn"]>;
-}) {
-  return resolvePreferredOpenClawTmpDir({
-    accessSync: readOnlyTmpAccessSync(),
-    lstatSync: vi.fn((target: string) => {
-      if (target === POSIX_OPENCLAW_TMP_DIR) {
-        throw nodeErrorWithCode("ENOENT");
-      }
-      if (target === params.fallbackPath) {
-        return params.fallbackLstatSync(target);
-      }
-      return secureDirStat(501);
-    }),
-    mkdirSync: vi.fn(),
-    chmodSync: params.chmodSync,
-    getuid: vi.fn(() => 501),
-    tmpdir: vi.fn(() => "/var/fallback"),
-    warn: params.warn,
-  });
-}
 
 function symlinkTmpDirLstat() {
   return vi.fn(() => makeDirStat({ isSymbolicLink: true, mode: 0o120777 }));
@@ -197,16 +169,26 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expectFallsBackToOsTmpDir({ lstatSync: vi.fn(() => makeDirStat({ mode: 0o40777 })) });
   });
 
-  it("throws when fallback path is a symlink", () => {
-    const lstatSync = symlinkTmpDirLstat();
-    const fallbackLstatSync = vi.fn(() => makeDirStat({ isSymbolicLink: true, mode: 0o120777 }));
+  it("uses safe fallback path when primary fallback is a symlink", () => {
+    const lstatSync = vi.fn(() => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid: 501,
+      mode: 0o120777,
+    }));
+    const fallbackLstatSync = vi.fn(() => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid: 501,
+      mode: 0o120777,
+    }));
 
-    expect(() =>
-      resolveWithMocks({
-        lstatSync,
-        fallbackLstatSync,
-      }),
-    ).toThrow(/Unsafe fallback OpenClaw temp dir/);
+    const { resolved } = resolveWithMocks({
+      lstatSync,
+      fallbackLstatSync,
+    });
+
+    expect(resolved).toBe(fallbackTmpSafe());
   });
 
   it("creates fallback directory when missing, then validates ownership and mode", () => {
@@ -222,69 +204,25 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expect(mkdirSync).toHaveBeenCalledWith(fallbackTmp(), { recursive: true, mode: 0o700 });
   });
 
-  it("repairs fallback directory permissions after create when umask makes it group-writable", () => {
-    const fallbackPath = fallbackTmp();
-    let fallbackMode = 0o40775;
-    const lstatSync = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>(() => {
-      throw nodeErrorWithCode("ENOENT");
-    });
-    const fallbackLstatSync = vi
-      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
-      .mockImplementationOnce(() => {
-        throw nodeErrorWithCode("ENOENT");
-      })
-      .mockImplementation(() => ({
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        uid: 501,
-        mode: fallbackMode,
-      }));
-    const chmodSync = vi.fn((target: string, mode: number) => {
-      if (target === fallbackPath && mode === 0o700) {
-        fallbackMode = 0o40700;
+  it("returns primary fallback path when all fallback candidates are unsafe", () => {
+    const lstatSync: NonNullable<TmpDirOptions["lstatSync"]> = vi.fn((target: string) => {
+      if (
+        target === POSIX_OPENCLAW_TMP_DIR ||
+        target === fallbackTmp() ||
+        target === fallbackTmpSafe()
+      ) {
+        return {
+          isDirectory: () => true,
+          isSymbolicLink: () => true,
+          uid: 501,
+          mode: 0o120777,
+        };
       }
+      return secureDirStat(501);
     });
 
-    const resolved = resolveWithReadOnlyTmpFallback({
-      fallbackPath,
-      fallbackLstatSync: vi.fn((target: string) => {
-        if (target === fallbackPath) {
-          return fallbackLstatSync(target);
-        }
-        return lstatSync(target);
-      }),
-      chmodSync,
-      warn: vi.fn(),
-    });
+    const { resolved } = resolveWithMocks({ lstatSync });
 
-    expect(resolved).toBe(fallbackPath);
-    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
-  });
-
-  it("repairs existing fallback directory when permissions are too broad", () => {
-    const fallbackPath = fallbackTmp();
-    let fallbackMode = 0o40775;
-    const chmodSync = vi.fn((target: string, mode: number) => {
-      if (target === fallbackPath && mode === 0o700) {
-        fallbackMode = 0o40700;
-      }
-    });
-    const warn = vi.fn();
-
-    const resolved = resolveWithReadOnlyTmpFallback({
-      fallbackPath,
-      fallbackLstatSync: vi.fn(() =>
-        makeDirStat({
-          isSymbolicLink: false,
-          mode: fallbackMode,
-        }),
-      ),
-      chmodSync,
-      warn,
-    });
-
-    expect(resolved).toBe(fallbackPath);
-    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tightened permissions on temp dir"));
+    expect(resolved).toBe(fallbackTmp());
   });
 });

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -205,24 +205,42 @@ describe("resolvePreferredOpenClawTmpDir", () => {
   });
 
   it("returns primary fallback path when all fallback candidates are unsafe", () => {
+    const uid = 501;
+    const primaryFallbackPath = fallbackTmp(uid);
+    const safeFallbackPath = fallbackTmpSafe(uid);
+    const unsafeDirStat = {
+      isDirectory: () => true,
+      isSymbolicLink: () => true,
+      uid,
+      mode: 0o120777,
+    };
     const lstatSync: NonNullable<TmpDirOptions["lstatSync"]> = vi.fn((target: string) => {
       if (
         target === POSIX_OPENCLAW_TMP_DIR ||
-        target === fallbackTmp() ||
-        target === fallbackTmpSafe()
+        target === primaryFallbackPath ||
+        target === safeFallbackPath
       ) {
-        return {
-          isDirectory: () => true,
-          isSymbolicLink: () => true,
-          uid: 501,
-          mode: 0o120777,
-        };
+        return unsafeDirStat;
       }
-      return secureDirStat(501);
+      return secureDirStat(uid);
+    });
+    const accessSync: NonNullable<TmpDirOptions["accessSync"]> = vi.fn();
+    const mkdirSync: NonNullable<TmpDirOptions["mkdirSync"]> = vi.fn();
+    const getuid: NonNullable<TmpDirOptions["getuid"]> = vi.fn(() => uid);
+    const tmpdir: NonNullable<TmpDirOptions["tmpdir"]> = vi.fn(() => "/var/fallback");
+
+    const resolved = resolvePreferredOpenClawTmpDir({
+      accessSync,
+      lstatSync,
+      mkdirSync,
+      getuid,
+      tmpdir,
     });
 
-    const { resolved } = resolveWithMocks({ lstatSync });
-
-    expect(resolved).toBe(fallbackTmp());
+    expect(resolved).toBe(primaryFallbackPath);
+    expect(lstatSync).toHaveBeenCalledWith(POSIX_OPENCLAW_TMP_DIR);
+    expect(lstatSync).toHaveBeenCalledWith(primaryFallbackPath);
+    expect(lstatSync).toHaveBeenCalledWith(safeFallbackPath);
+    expect(mkdirSync).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -35,10 +35,8 @@ export function resolvePreferredOpenClawTmpDir(
   options: ResolvePreferredOpenClawTmpDirOptions = {},
 ): string {
   const accessSync = options.accessSync ?? fs.accessSync;
-  const chmodSync = options.chmodSync ?? fs.chmodSync;
   const lstatSync = options.lstatSync ?? fs.lstatSync;
   const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
-  const warn = options.warn ?? ((message: string) => console.warn(message));
   const getuid =
     options.getuid ??
     (() => {
@@ -71,6 +69,12 @@ export function resolvePreferredOpenClawTmpDir(
     return path.join(base, suffix);
   };
 
+  const fallbackSafe = (): string => {
+    const base = tmpdir();
+    const suffix = uid === undefined ? "openclaw-safe" : `openclaw-${uid}-safe`;
+    return path.join(base, suffix);
+  };
+
   const isTrustedTmpDir = (st: {
     isDirectory(): boolean;
     isSymbolicLink(): boolean;
@@ -96,47 +100,32 @@ export function resolvePreferredOpenClawTmpDir(
     }
   };
 
-  const tryRepairWritableBits = (candidatePath: string): boolean => {
+  const ensureTrustedDir = (candidatePath: string): boolean => {
+    const state = resolveDirState(candidatePath);
+    if (state === "available") {
+      return true;
+    }
+    if (state === "invalid") {
+      return false;
+    }
     try {
-      const st = lstatSync(candidatePath);
-      if (!st.isDirectory() || st.isSymbolicLink()) {
-        return false;
-      }
-      if (uid !== undefined && typeof st.uid === "number" && st.uid !== uid) {
-        return false;
-      }
-      if (typeof st.mode !== "number" || (st.mode & 0o022) === 0) {
-        return false;
-      }
-      chmodSync(candidatePath, 0o700);
-      warn(`[openclaw] tightened permissions on temp dir: ${candidatePath}`);
-      return resolveDirState(candidatePath) === "available";
+      mkdirSync(candidatePath, { recursive: true, mode: 0o700 });
     } catch {
       return false;
     }
+    return resolveDirState(candidatePath) === "available";
   };
 
   const ensureTrustedFallbackDir = (): string => {
     const fallbackPath = fallback();
-    const state = resolveDirState(fallbackPath);
-    if (state === "available") {
+    if (ensureTrustedDir(fallbackPath)) {
       return fallbackPath;
     }
-    if (state === "invalid") {
-      if (tryRepairWritableBits(fallbackPath)) {
-        return fallbackPath;
-      }
-      throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);
+    const safeFallbackPath = fallbackSafe();
+    if (safeFallbackPath !== fallbackPath && ensureTrustedDir(safeFallbackPath)) {
+      return safeFallbackPath;
     }
-    try {
-      mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
-      chmodSync(fallbackPath, 0o700);
-    } catch {
-      throw new Error(`Unable to create fallback OpenClaw temp dir: ${fallbackPath}`);
-    }
-    if (resolveDirState(fallbackPath) !== "available" && !tryRepairWritableBits(fallbackPath)) {
-      throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);
-    }
+    // Keep CLI startup resilient even when host tmp ownership/permissions are unusual.
     return fallbackPath;
   };
 
@@ -145,9 +134,6 @@ export function resolvePreferredOpenClawTmpDir(
     return POSIX_OPENCLAW_TMP_DIR;
   }
   if (existingPreferredState === "invalid") {
-    if (tryRepairWritableBits(POSIX_OPENCLAW_TMP_DIR)) {
-      return POSIX_OPENCLAW_TMP_DIR;
-    }
     return ensureTrustedFallbackDir();
   }
 
@@ -155,11 +141,7 @@ export function resolvePreferredOpenClawTmpDir(
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
-    chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);
-    if (
-      resolveDirState(POSIX_OPENCLAW_TMP_DIR) !== "available" &&
-      !tryRepairWritableBits(POSIX_OPENCLAW_TMP_DIR)
-    ) {
+    if (resolveDirState(POSIX_OPENCLAW_TMP_DIR) !== "available") {
       return ensureTrustedFallbackDir();
     }
     return POSIX_OPENCLAW_TMP_DIR;

--- a/src/test-utils/temp-home.test.ts
+++ b/src/test-utils/temp-home.test.ts
@@ -8,11 +8,16 @@ describe("createTempHomeEnv", () => {
     const previousHome = process.env.HOME;
     const previousUserProfile = process.env.USERPROFILE;
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    const leakedConfigPath = "/tmp/leaked-openclaw-config.json";
+
+    process.env.OPENCLAW_CONFIG_PATH = leakedConfigPath;
 
     const tempHome = await createTempHomeEnv("openclaw-temp-home-");
     expect(process.env.HOME).toBe(tempHome.home);
     expect(process.env.USERPROFILE).toBe(tempHome.home);
     expect(process.env.OPENCLAW_STATE_DIR).toBe(path.join(tempHome.home, ".openclaw"));
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
     await expect(fs.stat(tempHome.home)).resolves.toMatchObject({
       isDirectory: expect.any(Function),
     });
@@ -22,6 +27,12 @@ describe("createTempHomeEnv", () => {
     expect(process.env.HOME).toBe(previousHome);
     expect(process.env.USERPROFILE).toBe(previousUserProfile);
     expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBe(leakedConfigPath);
+    if (previousConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+    }
     await expect(fs.stat(tempHome.home)).rejects.toThrow();
   });
 });

--- a/src/test-utils/temp-home.ts
+++ b/src/test-utils/temp-home.ts
@@ -9,6 +9,9 @@ const HOME_ENV_KEYS = [
   "HOMEDRIVE",
   "HOMEPATH",
   "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "CLAWDBOT_STATE_DIR",
+  "CLAWDBOT_CONFIG_PATH",
 ] as const;
 
 export type TempHomeEnv = {
@@ -24,6 +27,9 @@ export async function createTempHomeEnv(prefix: string): Promise<TempHomeEnv> {
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   process.env.OPENCLAW_STATE_DIR = path.join(home, ".openclaw");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.CLAWDBOT_STATE_DIR;
+  delete process.env.CLAWDBOT_CONFIG_PATH;
 
   if (process.platform === "win32") {
     const match = home.match(/^([A-Za-z]:)(.*)$/);

--- a/test/helpers/temp-home.test.ts
+++ b/test/helpers/temp-home.test.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./temp-home.js";
+
+describe("withTempHome", () => {
+  it("clears explicit config path overrides inside temp home and restores them after", async () => {
+    const previousOpenClawConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    const previousLegacyConfigPath = process.env.CLAWDBOT_CONFIG_PATH;
+    const leakedOpenClawConfigPath = "/tmp/openclaw-config-leak.json";
+    const leakedLegacyConfigPath = "/tmp/clawdbot-config-leak.json";
+
+    process.env.OPENCLAW_CONFIG_PATH = leakedOpenClawConfigPath;
+    process.env.CLAWDBOT_CONFIG_PATH = leakedLegacyConfigPath;
+
+    await withTempHome(async (home) => {
+      expect(process.env.HOME).toBe(home);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(path.join(home, ".openclaw"));
+      expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+      expect(process.env.CLAWDBOT_CONFIG_PATH).toBeUndefined();
+    });
+
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBe(leakedOpenClawConfigPath);
+    expect(process.env.CLAWDBOT_CONFIG_PATH).toBe(leakedLegacyConfigPath);
+
+    if (previousOpenClawConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousOpenClawConfigPath;
+    }
+    if (previousLegacyConfigPath === undefined) {
+      delete process.env.CLAWDBOT_CONFIG_PATH;
+    } else {
+      process.env.CLAWDBOT_CONFIG_PATH = previousLegacyConfigPath;
+    }
+  });
+});

--- a/test/helpers/temp-home.ts
+++ b/test/helpers/temp-home.ts
@@ -11,6 +11,9 @@ type EnvSnapshot = {
   homePath: string | undefined;
   openclawHome: string | undefined;
   stateDir: string | undefined;
+  configPath: string | undefined;
+  legacyConfigPath: string | undefined;
+  legacyStateDir: string | undefined;
 };
 
 type SharedHomeRootState = {
@@ -28,6 +31,9 @@ function snapshotEnv(): EnvSnapshot {
     homePath: process.env.HOMEPATH,
     openclawHome: process.env.OPENCLAW_HOME,
     stateDir: process.env.OPENCLAW_STATE_DIR,
+    configPath: process.env.OPENCLAW_CONFIG_PATH,
+    legacyConfigPath: process.env.CLAWDBOT_CONFIG_PATH,
+    legacyStateDir: process.env.CLAWDBOT_STATE_DIR,
   };
 }
 
@@ -45,6 +51,9 @@ function restoreEnv(snapshot: EnvSnapshot) {
   restoreKey("HOMEPATH", snapshot.homePath);
   restoreKey("OPENCLAW_HOME", snapshot.openclawHome);
   restoreKey("OPENCLAW_STATE_DIR", snapshot.stateDir);
+  restoreKey("OPENCLAW_CONFIG_PATH", snapshot.configPath);
+  restoreKey("CLAWDBOT_CONFIG_PATH", snapshot.legacyConfigPath);
+  restoreKey("CLAWDBOT_STATE_DIR", snapshot.legacyStateDir);
 }
 
 function snapshotExtraEnv(keys: string[]): Record<string, string | undefined> {
@@ -68,9 +77,12 @@ function restoreExtraEnv(snapshot: Record<string, string | undefined>) {
 function setTempHome(base: string) {
   process.env.HOME = base;
   process.env.USERPROFILE = base;
-  // Ensure tests using HOME isolation aren't affected by leaked OPENCLAW_HOME.
+  // Ensure tests using HOME isolation aren't affected by leaked explicit config/state paths.
   delete process.env.OPENCLAW_HOME;
   process.env.OPENCLAW_STATE_DIR = path.join(base, ".openclaw");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.CLAWDBOT_CONFIG_PATH;
+  delete process.env.CLAWDBOT_STATE_DIR;
 
   if (process.platform !== "win32") {
     return;


### PR DESCRIPTION
## Summary
- avoid hard-failing CLI startup when the primary fallback temp dir is unsafe (symlink/wrong owner/writable by others)
- add a secondary fallback candidate (`openclaw-<uid>-safe`) and use it when the primary fallback is unsafe
- keep startup resilient by returning the primary fallback path as a final non-throwing last resort
- add regression coverage for the new fallback behavior

## Why
Issue #27329 reports that `openclaw update`/`openclaw tui` can become unusable after upgrade due to:
- `Error: Unsafe fallback OpenClaw temp dir: /tmp/openclaw-1000`

This patch removes that fatal path and preserves startup even on hosts with unusual tmp ownership/permission states.

## Testing
- `bunx vitest run --config vitest.unit.config.ts src/infra/tmp-openclaw-dir.test.ts`
- `pnpm format:check -- src/infra/tmp-openclaw-dir.ts src/infra/tmp-openclaw-dir.test.ts`
