### PR TITLE
fix(daemon): correct systemd status detection for externally managed services

### DIFF
--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -130,7 +130,7 @@ export async function statusAllCommand(
           service.readRuntime(process.env).catch(() => undefined),
           service.readCommand(process.env).catch(() => null),
         ]);
-        const installed = command != null;
+        const installed = command != null || loaded || runtimeInfo?.status === "running";
         return {
           label: service.label,
           installed,

--- a/src/commands/status.daemon.test.ts
+++ b/src/commands/status.daemon.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  gatewayService: {
+    label: "systemd",
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    isLoaded: vi.fn(),
+    readCommand: vi.fn(),
+    readRuntime: vi.fn(),
+  },
+  nodeService: {
+    label: "systemd",
+    loadedText: "enabled",
+    notLoadedText: "disabled",
+    install: vi.fn(),
+    uninstall: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    isLoaded: vi.fn(),
+    readCommand: vi.fn(),
+    readRuntime: vi.fn(),
+  },
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => mocks.gatewayService,
+}));
+
+vi.mock("../daemon/node-service.js", () => ({
+  resolveNodeService: () => mocks.nodeService,
+}));
+
+import { getDaemonStatusSummary } from "./status.daemon.js";
+
+describe("getDaemonStatusSummary", () => {
+  beforeEach(() => {
+    mocks.gatewayService.isLoaded.mockReset();
+    mocks.gatewayService.readRuntime.mockReset();
+    mocks.gatewayService.readCommand.mockReset();
+  });
+
+  it("treats a running service as installed even when command config cannot be read", async () => {
+    mocks.gatewayService.isLoaded.mockResolvedValue(false);
+    mocks.gatewayService.readCommand.mockResolvedValue(null);
+    mocks.gatewayService.readRuntime.mockResolvedValue({ status: "running", pid: 1234 });
+
+    const summary = await getDaemonStatusSummary();
+
+    expect(summary.installed).toBe(true);
+    expect(summary.label).toBe("systemd");
+  });
+
+  it("treats a loaded service as installed even when command config cannot be read", async () => {
+    mocks.gatewayService.isLoaded.mockResolvedValue(true);
+    mocks.gatewayService.readCommand.mockResolvedValue(null);
+    mocks.gatewayService.readRuntime.mockResolvedValue({ status: "stopped" });
+
+    const summary = await getDaemonStatusSummary();
+
+    expect(summary.installed).toBe(true);
+    expect(summary.label).toBe("systemd");
+  });
+
+  it("keeps missing services as not installed", async () => {
+    mocks.gatewayService.isLoaded.mockResolvedValue(false);
+    mocks.gatewayService.readCommand.mockResolvedValue(null);
+    mocks.gatewayService.readRuntime.mockResolvedValue({
+      status: "stopped",
+      missingUnit: true,
+    });
+
+    const summary = await getDaemonStatusSummary();
+
+    expect(summary.installed).toBe(false);
+  });
+});

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -20,7 +20,7 @@ async function buildDaemonStatusSummary(
       service.readRuntime(process.env).catch(() => undefined),
       service.readCommand(process.env).catch(() => null),
     ]);
-    const installed = command != null;
+    const installed = command != null || loaded || runtime?.status === "running";
     const loadedText = loaded ? service.loadedText : service.notLoadedText;
     const runtimeShort = formatDaemonRuntimeShort(runtime);
     return { label: service.label, installed, loadedText, runtimeShort };

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -40,6 +40,19 @@ describe("systemd availability", () => {
     });
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
   });
+
+  it("returns true when systemctl exits non-zero without a known unavailable indicator", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("exit status 1") as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr = "";
+      err.code = 1;
+      cb(err, "Failed to get D-Bus connection: No such unit", "");
+    });
+    await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -166,7 +166,9 @@ export async function isSystemdUserServiceAvailable(): Promise<boolean> {
   if (detail.includes("not supported")) {
     return false;
   }
-  return false;
+  // Non-zero exit without a known "unavailable" indicator means systemd is
+  // present but returned a non-fatal status (e.g. no default target unit).
+  return true;
 }
 
 async function assertSystemdAvailable() {


### PR DESCRIPTION
This fixes an issue where `openclaw status` incorrectly reports "systemd not installed" when the gateway is running under a systemd service that was not created by OpenClaw (e.g., a system-level unit at `/etc/systemd/system/`).

Fixes  #27267

### Problem

The status detection logic had two main flaws:

1.  `isSystemdUserServiceAvailable()` in `src/daemon/systemd.ts` would incorrectly return `false` if `systemctl --user status` exited with a non-zero code, even if the reason was not that systemd was unavailable (e.g., no user units found).
2.  The `installed` flag in `status.daemon.ts` and `status-all.ts` was solely determined by whether a unit file's command could be read (`command != null`). This fails for system-level services or other externally managed setups where OpenClaw doesn't manage the unit file directly.

### Solution

This PR implements a more robust fix than existing proposals by addressing the root causes:

1.  **Corrected `isSystemdUserServiceAvailable`**: The function now correctly returns `true` if `systemctl` exits non-zero without a known "unavailable" error message, accurately reflecting that the systemd user instance is available.

2.  **Improved "installed" logic**: The `installed` status in both `status.daemon.ts` and `status-all.ts` is now determined by a more comprehensive check: `command != null || loaded || runtime?.status === "running"`. This ensures that if a service is loaded or actively running, it is considered "installed" for status purposes, regardless of whether OpenClaw can read its unit file.

3.  **Added Tests**: New unit tests have been added to `systemd.test.ts` and a new test file `status.daemon.test.ts` is created to cover these cases and prevent regressions.

This provides a more accurate and reliable status report for users managing the gateway with systemd in various configurations.