### PR TITLE
fix(ssrf): stop forcing autoSelectFamily in pinned dispatcher

### DIFF
--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -13,7 +13,7 @@ vi.mock("undici", () => ({
 import { createPinnedDispatcher, type PinnedHostname } from "./ssrf.js";
 
 describe("createPinnedDispatcher", () => {
-  it("enables network family auto-selection for pinned lookups", () => {
+  it("uses pinned lookup without overriding global family policy", () => {
     const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const pinned: PinnedHostname = {
       hostname: "api.telegram.org",
@@ -27,9 +27,11 @@ describe("createPinnedDispatcher", () => {
     expect(agentCtor).toHaveBeenCalledWith({
       connect: {
         lookup,
-        autoSelectFamily: true,
-        autoSelectFamilyAttemptTimeout: 300,
       },
     });
+    const firstCallArg = agentCtor.mock.calls[0]?.[0] as
+      | { connect?: Record<string, unknown> }
+      | undefined;
+    expect(firstCallArg?.connect?.autoSelectFamily).toBeUndefined();
   });
 });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -333,8 +333,6 @@ export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
   return new Agent({
     connect: {
       lookup: pinned.lookup,
-      autoSelectFamily: true,
-      autoSelectFamilyAttemptTimeout: 300,
     },
   });
 }


### PR DESCRIPTION
## Summary
- remove hardcoded `autoSelectFamily` settings from SSRF pinned dispatcher
- let pinned fetches follow the same process/global network family policy as other Telegram requests
- update dispatcher unit test to assert no forced `autoSelectFamily`

## Why
Pinned media downloads used a separate undici Agent path with forced `autoSelectFamily: true`, which could bypass WSL2 IPv4-only settings and fail Telegram media downloads.

## Testing
- `pnpm test src/infra/net/ssrf.dispatcher.test.ts`
- `pnpm test src/telegram/bot/delivery.resolve-media-retry.test.ts`
