### PR TITLE
fix(onboard): increase verification timeout and reduce max_tokens for custom provider probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/WS: close repeated post-handshake `unauthorized role:*` request floods per connection and sample duplicate rejection logs, preventing a single misbehaving client from degrading gateway responsiveness. (#20168) Thanks @acy103, @vibecodooor, and @vincentkoc.
 - Gateway/Auth: improve device-auth v2 migration diagnostics so operators get clearer guidance when legacy clients connect. (#28305) Thanks @vincentkoc.
 - CLI/Install: add an npm-link fallback to fix CLI startup `Permission denied` failures (`exit 127`) on affected installs. (#17151) Thanks @sskyu and @vincentkoc.
+- Onboarding/Custom providers: improve verification reliability for slower local endpoints (for example Ollama) during setup. (#27380) Thanks @Sid-Qin.
 - Agents/Ollama: demote empty-discovery logging from `warn` to `debug` to reduce noisy warnings in normal edge-case discovery flows. (#26379) Thanks @byungsker.
 - Install/npm: fix npm global install deprecation warnings. (#28318) Thanks @vincentkoc.
 - Slack/Native commands: register Slack native status as `/agentstatus` (Slack-reserved `/status`) so manifest slash command registration stays valid while text `/status` still works. Landed from contributor PR #29032 by @maloqab. Thanks @maloqab.

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -128,7 +128,7 @@ describe("promptCustomApiConfig", () => {
 
     const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
     expect(firstCall?.body).toBeDefined();
-    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1024 });
+    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
 
   it("uses expanded max_tokens for anthropic verification probes", async () => {
@@ -143,7 +143,7 @@ describe("promptCustomApiConfig", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const secondCall = fetchMock.mock.calls[1]?.[1] as { body?: string } | undefined;
     expect(secondCall?.body).toBeDefined();
-    expect(JSON.parse(secondCall?.body ?? "{}")).toMatchObject({ max_tokens: 1024 });
+    expect(JSON.parse(secondCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
 
   it("re-prompts base url when unknown detection fails", async () => {
@@ -220,7 +220,7 @@ describe("promptCustomApiConfig", () => {
 
     const promise = runPromptCustomApi(prompter);
 
-    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(30_000);
     await promise;
 
     expect(prompter.text).toHaveBeenCalledTimes(6);

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,7 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 10000;
+const VERIFY_TIMEOUT_MS = 30_000;
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.
@@ -317,7 +317,8 @@ async function requestOpenAiVerification(params: {
     body: {
       model: params.modelId,
       messages: [{ role: "user", content: "Hi" }],
-      max_tokens: 1024,
+      max_tokens: 1,
+      stream: false,
     },
   });
 }
@@ -343,8 +344,9 @@ async function requestAnthropicVerification(params: {
     headers: buildAnthropicHeaders(params.apiKey),
     body: {
       model: params.modelId,
-      max_tokens: 1024,
+      max_tokens: 1,
       messages: [{ role: "user", content: "Hi" }],
+      stream: false,
     },
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** Onboard wizard fails to verify local llama.cpp servers (Custom Provider) — the verification request times out after 10 seconds because the server needs to load a large model and generate up to 1024 tokens.
- **Why it matters:** Users with local LLM servers (llama.cpp, vLLM, etc.) cannot complete the onboard wizard, even though their API is fully functional.
- **What changed:** `src/commands/onboard-custom.ts` — raised `VERIFY_TIMEOUT_MS` from 10s to 30s, reduced `max_tokens` from 1024 to 1 (verification only needs a single token), added explicit `stream: false` to both OpenAI and Anthropic probes.
- **What did NOT change:** The verification flow logic, error handling, retry prompts, or any other onboard wizard behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27346

## User-visible / Behavior Changes

- Custom provider verification during onboard now tolerates slower local LLM servers (up to 30s instead of 10s).
- Verification requests generate only 1 token instead of 1024, making the probe much faster.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\` (same endpoints, just different timeout and body params)
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Docker)
- Runtime: Node 22+
- Integration/channel: CLI onboard wizard

### Steps

1. Run llama-server with a large model (e.g. Qwen3.5-27B) on host
2. Run \`openclaw\` onboard wizard in Docker
3. Select Custom Provider → Base URL: \`http://172.17.0.1:8080/v1\` → Model ID: \`Qwen3.5-27B-UD-Q8_K_XL.gguf\`

### Expected

- Verification succeeds (model responds with 1 token within 30s)

### Actual

- Before fix: "Verification failed: This operation was aborted" after 10s
- After fix: Verification succeeds because max_tokens=1 completes quickly and timeout is 30s

## Evidence

Root cause:
- \`VERIFY_TIMEOUT_MS\` was 10s — too short for large local models that need to load into GPU memory
- \`max_tokens: 1024\` forced the server to generate a full response, adding unnecessary latency
- The verification only needs to confirm the API is reachable and the model ID is valid — 1 token suffices

```typescript
// Before
const VERIFY_TIMEOUT_MS = 10000;
// body: { max_tokens: 1024 }

// After
const VERIFY_TIMEOUT_MS = 30_000;
// body: { max_tokens: 1, stream: false }
```

All 14 tests pass after updating test expectations.

## Human Verification (required)

- Verified scenarios: All 14 unit tests pass, including timeout test updated to 30s
- Edge cases checked: OpenAI probe, Anthropic probe, timeout abort, retry flow
- What I did **not** verify: Live testing with actual llama.cpp server (no GPU available)

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert changes in \`onboard-custom.ts\`
- Files/config to restore: \`src/commands/onboard-custom.ts\`, \`src/commands/onboard-custom.test.ts\`
- Known bad symptoms: If reverted, large local models will continue to fail verification

## Risks and Mitigations

- Risk: 30s timeout means users wait longer if the server is truly unreachable. Mitigated by max_tokens=1 making successful probes much faster than before.
