### PR TITLE
fix(gateway): reject new lane enqueues during drain to prevent silent task kill

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -9,6 +9,7 @@ const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
 const getActiveTaskCount = vi.fn(() => 0);
+const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
@@ -37,6 +38,7 @@ vi.mock("../../infra/process-respawn.js", () => ({
 
 vi.mock("../../process/command-queue.js", () => ({
   getActiveTaskCount: () => getActiveTaskCount(),
+  markGatewayDraining: () => markGatewayDraining(),
   waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
 }));

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -274,15 +274,15 @@ describe("doctor config flow", () => {
       expect(cfg.channels.discord.guilds["100"].channels.general.users).toEqual(["333"]);
       expect(cfg.channels.discord.guilds["100"].channels.general.roles).toEqual(["444"]);
       expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["555"]);
-      expect(cfg.channels.discord.accounts.work.dm.allowFrom).toEqual(["666"]);
-      expect(cfg.channels.discord.accounts.work.dm.groupChannels).toEqual(["777"]);
-      expect(cfg.channels.discord.accounts.work.execApprovals.approvers).toEqual(["888"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].users).toEqual(["999"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].roles).toEqual(["1010"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.users).toEqual([
+      expect(cfg.channels.discord.accounts.work.dm!.allowFrom).toEqual(["666"]);
+      expect(cfg.channels.discord.accounts.work.dm!.groupChannels).toEqual(["777"]);
+      expect(cfg.channels.discord.accounts.work.execApprovals!.approvers).toEqual(["888"]);
+      expect(cfg.channels.discord.accounts.work.guilds!["200"].users).toEqual(["999"]);
+      expect(cfg.channels.discord.accounts.work.guilds!["200"].roles).toEqual(["1010"]);
+      expect(cfg.channels.discord.accounts.work.guilds!["200"].channels.help.users).toEqual([
         "1111",
       ]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.roles).toEqual([
+      expect(cfg.channels.discord.accounts.work.guilds!["200"].channels.help.roles).toEqual([
         "1212",
       ]);
     });


### PR DESCRIPTION
## Summary

- **Problem:** During a gateway restart, the drain period (`waitForActiveTasks`) only waits for task IDs active *at drain-start*. The WebSocket server remained fully open throughout the 30 s window, so newly connecting clients could enqueue work that was silently killed when the process exited — leaving the session frozen with no error.
- **Why it matters:** Any user or agent session that submits a request within the drain window loses that work invisibly. The client has no way to distinguish a crash from a hang, and may stall indefinitely waiting for a response that will never arrive.
- **What changed:** Added `markGatewayDraining()` to `command-queue.ts`. When called, `enqueueCommandInLane` immediately rejects new tasks with `GatewayDrainingError` rather than queueing them. `run-loop.ts` calls `markGatewayDraining()` before `waitForActiveTasks()`. `resetAllLanes()` clears the flag on in-process restart.
- **What did NOT change (scope boundary):** No changes to the drain timeout, the server close handler, the WebSocket accept logic, or any other subsystem. In-flight tasks complete normally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

- Sessions that connect during a gateway restart drain window now receive an immediate `GatewayDrainingError` instead of being silently killed. The session can surface a clean "gateway is restarting" error to the user rather than appearing frozen.
- No change in behavior for sessions already active when the restart begins — they continue to completion as before.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.0 (arm64)
- Runtime/container: Node.js v25.6.1, openclaw gateway (LaunchAgent)
- Model/provider: anthropic/claude-opus-4-6
- Integration/channel: webchat (WebSocket), Discord DM
- Relevant config: default

### Steps

1. Have a gateway running with at least one active agent session (Discord DM or webchat).
2. Trigger a `gateway.restart` tool call (e.g. from an agent responding to a timeout condition).
3. While the drain countdown is active (up to 30 s), submit a new message from a second client session.

### Expected

- The new session receives a `GatewayDrainingError` immediately.
- The client can show "gateway is restarting, please retry" instead of silently hanging.

### Actual (before fix)

- The new session's task was accepted into the lane queue.
- The process exited at drain-end, killing the in-flight task with no error delivered to the client.
- The client session appeared frozen/deadlocked.

## Evidence

- [x] Trace/log snippets

Observed in production logs (`/tmp/openclaw/openclaw-2026-02-26.log`):

```
# Drain triggered at 09:23:46 (2 active tasks)
09:23:46Z  gateway: draining 2 active task(s) before restart (timeout 30000ms)

# New session connected DURING drain and started an embedded run
09:23:54Z  lane enqueue: lane=session:agent:main:76767 queueSize=1
09:23:54Z  embedded run start: runId=85545df4 sessionId=63a96bba provider=anthropic

# Tool calls made progress…
09:24:03Z  embedded run tool start: tool=exec
09:24:13Z  embedded run tool end: tool=exec

# …then the process exited — no "embedded run done" for 85545df4
09:24:16Z  gateway: restart mode: full process restart (spawned pid 84243)

# Client reconnected; new run also hit errors (isError=true)
09:24:45Z  embedded run start: runId=8bb77b11 sessionId=63a96bba
09:25:15Z  embedded run agent end: runId=8bb77b11 isError=true
```

The session (76767) was frozen from 09:24:16 until 09:25:15 — nearly a full minute — due to the silent kill and subsequent error on reconnect.

## Human Verification (required)

- Verified scenarios: unit tests for `markGatewayDraining()` cover (1) new enqueue rejected with `GatewayDrainingError`, (2) in-flight task completes normally, (3) `resetAllLanes()` clears the flag and restores normal enqueue behavior.
- Edge cases checked: in-process restart path (`resetAllLanes` called by `createRestartIterationHook`) correctly clears the flag so work is accepted again after the in-process restart.
- What you did **not** verify: end-to-end test with a real WebSocket client receiving the error message (no E2E harness available locally for the drain scenario).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the 3-line addition in `enqueueCommandInLane` and the `markGatewayDraining()` call in `run-loop.ts`.
- Files/config to restore: `src/process/command-queue.ts`, `src/cli/gateway-cli/run-loop.ts`
- Known bad symptoms reviewers should watch for: if the flag is somehow set and never cleared, all new enqueues will be permanently rejected. The only code path that sets it is `markGatewayDraining()` (called once, on restart signal) and it is cleared by `resetAllLanes()` on in-process restart; the full-process restart path exits and spawns a fresh process, so the flag is naturally reset.

## Risks and Mitigations

- Risk: callers of `enqueueCommandInLane` that do not handle `GatewayDrainingError` may produce unhandled-rejection noise in logs.
  - Mitigation: the error is a named subclass (`GatewayDrainingError`) so catch blocks can identify and suppress it with a log line if desired. The existing behavior (silent process kill) is strictly worse — at least now there is a traceable error.