### PR TITLE
[Bug fix] Matrix: include sender name in group message envelopes (#27355)

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -498,13 +498,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         storePath,
         sessionKey: route.sessionKey,
       });
-      const body = core.channel.reply.formatAgentEnvelope({
+      const body = core.channel.reply.formatInboundEnvelope({
         channel: "Matrix",
         from: envelopeFrom,
         timestamp: eventTs ?? undefined,
         previousTimestamp,
         envelope: envelopeOptions,
         body: textWithId,
+        chatType: threadRootId ? "thread" : isDirectMessage ? "direct" : "channel",
+        sender: { name: senderName, username: senderId.split(":")[0]?.replace(/^@/, "") },
       });
 
       const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -505,7 +505,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         previousTimestamp,
         envelope: envelopeOptions,
         body: textWithId,
-        chatType: threadRootId ? "thread" : isDirectMessage ? "direct" : "channel",
+        chatType: isDirectMessage ? "direct" : "channel",
         sender: { name: senderName, username: senderId.split(":")[0]?.replace(/^@/, "") },
       });
 


### PR DESCRIPTION
Fixes the bug where the bot resolves "me/I" to the wrong user in Matrix group chats (#27355).

## What changed

In `extensions/matrix/src/matrix/monitor/handler.ts`, the message body passed to the session transcript was built using `formatAgentEnvelope`, which put only the room name in the header — no sender. So the LLM couldn't tell who sent which message in shared group sessions and fell back to whoever had messaged last.

Switched to `formatInboundEnvelope` with `chatType` + `sender` params, which prepends the sender's display name to the body for non-DM messages. This is exactly how Telegram, Discord, and Signal already handle it.

Before:
[Matrix MyRoom 08:25 UTC] show me my recent code commits

After:
[Matrix MyRoom 08:25 UTC] Bu: show me my recent code commits

DMs are unaffected (`chatType: "direct"` skips the sender prefix). Thread messages also correctly get the sender name.

## Testing

- [x] Manually verified with a 2-user Matrix group room (groupPolicy: allowlist, requireMention: true)
- [x] DM behavior unchanged
- [x] `pnpm build && pnpm check && pnpm test` passes
