### PR TITLE
fix(memory/qmd): throw QmdScopeDeniedError instead of silently returning empty results

### DIFF
--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -94,13 +94,8 @@ const DEFAULT_QMD_MCPORTER: ResolvedQmdMcporterConfig = {
 };
 
 const DEFAULT_QMD_SCOPE: SessionSendPolicyConfig = {
-  default: "deny",
-  rules: [
-    {
-      action: "allow",
-      match: { chatType: "direct" },
-    },
-  ],
+  default: "allow",
+  rules: [],
 };
 
 function sanitizeName(input: string): string {

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -94,8 +94,13 @@ const DEFAULT_QMD_MCPORTER: ResolvedQmdMcporterConfig = {
 };
 
 const DEFAULT_QMD_SCOPE: SessionSendPolicyConfig = {
-  default: "allow",
-  rules: [],
+  default: "deny",
+  rules: [
+    {
+      action: "allow",
+      match: { chatType: "direct" },
+    },
+  ],
 };
 
 function sanitizeName(input: string): string {

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1761,7 +1761,7 @@ describe("QmdMemoryManager", () => {
     }
   });
 
-  it("allows all chat types when no scope is configured (default allow)", async () => {
+  it("denies group/channel chats and allows direct when no scope is configured (secure default)", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1770,7 +1770,7 @@ describe("QmdMemoryManager", () => {
           includeDefaultMemory: false,
           update: { interval: "0s", debounceMs: 60_000, onBoot: false },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
-          // no scope configured → should default to allow
+          // no scope configured → default scope allows direct only
         },
       },
     } as OpenClawConfig;
@@ -1779,11 +1779,35 @@ describe("QmdMemoryManager", () => {
     const isAllowed = (key?: string) =>
       (manager as unknown as { isScopeAllowed: (key?: string) => boolean }).isScopeAllowed(key);
 
-    // all chat types and no session key should be allowed by default
-    expect(isAllowed(undefined)).toBe(true);
     expect(isAllowed("agent:main:telegram:direct:u123")).toBe(true);
-    expect(isAllowed("agent:main:telegram:group:g123")).toBe(true);
-    expect(isAllowed("agent:main:discord:channel:c123")).toBe(true);
+    expect(isAllowed("agent:main:telegram:group:g123")).toBe(false);
+    expect(isAllowed("agent:main:discord:channel:c123")).toBe(false);
+    expect(isAllowed(undefined)).toBe(false); // no session key → no chat type → deny
+
+    await manager.close();
+  });
+
+  it("throws QmdScopeDeniedError on scope-denied search", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          scope: {
+            default: "deny",
+            rules: [{ action: "allow", match: { chatType: "direct" } }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { manager } = await createManager();
+
+    await expect(
+      manager.search("anything", { sessionKey: "agent:main:telegram:group:g123" }),
+    ).rejects.toThrow("memory search is not available");
 
     await manager.close();
   });
@@ -1839,7 +1863,7 @@ describe("QmdMemoryManager", () => {
     const beforeCalls = spawnMock.mock.calls.length;
     await expect(
       manager.search("blocked", { sessionKey: "agent:main:discord:channel:c123" }),
-    ).resolves.toEqual([]);
+    ).rejects.toThrow("memory search is not available");
 
     expect(spawnMock.mock.calls.length).toBe(beforeCalls);
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("qmd search denied by scope"));

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1761,6 +1761,33 @@ describe("QmdMemoryManager", () => {
     }
   });
 
+  it("allows all chat types when no scope is configured (default allow)", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          // no scope configured → should default to allow
+        },
+      },
+    } as OpenClawConfig;
+    const { manager } = await createManager();
+
+    const isAllowed = (key?: string) =>
+      (manager as unknown as { isScopeAllowed: (key?: string) => boolean }).isScopeAllowed(key);
+
+    // all chat types and no session key should be allowed by default
+    expect(isAllowed(undefined)).toBe(true);
+    expect(isAllowed("agent:main:telegram:direct:u123")).toBe(true);
+    expect(isAllowed("agent:main:telegram:group:g123")).toBe(true);
+    expect(isAllowed("agent:main:discord:channel:c123")).toBe(true);
+
+    await manager.close();
+  });
+
   it("scopes by channel for agent-prefixed session keys", async () => {
     cfg = {
       ...cfg,


### PR DESCRIPTION
## Problem

When the QMD scope policy denies a search (e.g. in group/channel chats, which the default scope excludes), `manager.search()` returned `[]` with only a `warn` log. The agent received empty results, indistinguishable from a genuine "no matches", and reported "nothing found" — no hint that memory search was disabled for that context.

## Root cause

`DEFAULT_QMD_SCOPE` correctly denies group/channel chats by default to avoid leaking personal memory (home address, private notes, etc.) into chats where other participants can read the responses. The security intent was right. The bug was the silent failure mode.

## Fix

- Introduce `QmdScopeDeniedError`, thrown by `QmdMemoryManager.search()` when the session's chat context is outside the configured scope
- `memory-tool` catches `QmdScopeDeniedError` and returns a structured `{disabled: true, scopeDenied: true, action: <reason>}` response — the same pattern already used for other unavailable-memory states — so the agent surfaces a meaningful explanation instead of silently returning nothing
- `DEFAULT_QMD_SCOPE` is restored to its original deny-except-direct shape; the security default is correct

## To enable memory search in group chats

Users can opt in by configuring `memory.qmd.scope` in `openclaw.json`:

```json
"memory": {
  "qmd": {
    "scope": {
      "default": "allow"
    }
  }
}
```

## Tests

- Updated the scope-denial test: now asserts `rejects.toThrow` instead of `resolves.toEqual([])`
- Added a test asserting default scope allows direct, denies group and channel, and denies undefined session keys