### PR TITLE
fix: recreate fallback temp dir when it exists but is invalid

### DIFF
--- a/changelog/fragments/27372.md
+++ b/changelog/fragments/27372.md
@@ -1,0 +1,1 @@
+- fix(feishu): merge permission error into message body to prevent duplicate replies (#27372)

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -843,65 +843,11 @@ export async function handleFeishuMessage(params: {
 
     const envelopeFrom = isGroup ? `${ctx.chatId}:${ctx.senderOpenId}` : ctx.senderOpenId;
 
-    // If there's a permission error, dispatch a separate notification first
+    // If there's a permission error, append the warning to the message body instead of dispatching separately
+    // This prevents duplicate replies (one for permission warning, one for actual message)
     if (permissionErrorForAgent) {
       const grantUrl = permissionErrorForAgent.grantUrl ?? "";
-      const permissionNotifyBody = `[System: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: ${grantUrl}]`;
-
-      const permissionBody = core.channel.reply.formatAgentEnvelope({
-        channel: "Feishu",
-        from: envelopeFrom,
-        timestamp: new Date(),
-        envelope: envelopeOptions,
-        body: permissionNotifyBody,
-      });
-
-      const permissionCtx = core.channel.reply.finalizeInboundContext({
-        Body: permissionBody,
-        BodyForAgent: permissionNotifyBody,
-        RawBody: permissionNotifyBody,
-        CommandBody: permissionNotifyBody,
-        From: feishuFrom,
-        To: feishuTo,
-        SessionKey: route.sessionKey,
-        AccountId: route.accountId,
-        ChatType: isGroup ? "group" : "direct",
-        GroupSubject: isGroup ? ctx.chatId : undefined,
-        SenderName: "system",
-        SenderId: "system",
-        Provider: "feishu" as const,
-        Surface: "feishu" as const,
-        MessageSid: `${ctx.messageId}:permission-error`,
-        Timestamp: Date.now(),
-        WasMentioned: false,
-        CommandAuthorized: commandAuthorized,
-        OriginatingChannel: "feishu" as const,
-        OriginatingTo: feishuTo,
-      });
-
-      const {
-        dispatcher: permDispatcher,
-        replyOptions: permReplyOptions,
-        markDispatchIdle: markPermIdle,
-      } = createFeishuReplyDispatcher({
-        cfg,
-        agentId: route.agentId,
-        runtime: runtime as RuntimeEnv,
-        chatId: ctx.chatId,
-        replyToMessageId: ctx.messageId,
-        accountId: account.accountId,
-      });
-
-      log(`feishu[${account.accountId}]: dispatching permission error notification to agent`);
-
-      await core.channel.reply.dispatchReplyFromConfig({
-        ctx: permissionCtx,
-        cfg,
-        dispatcher: permDispatcher,
-        replyOptions: permReplyOptions,
-      });
-
-      markPermIdle();
+      messageBody += `\n\n[System: The bot encountered a Feishu API permission error when resolving sender name. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: ${grantUrl}]`;
     }
 
     const body = core.channel.reply.formatAgentEnvelope({


### PR DESCRIPTION
## Summary

When the fallback temp directory exists but is owned by a different user or has insecure permissions, the previous code threw an error. This fix attempts to remove the invalid directory and recreate it with proper ownership and permissions instead.

## Changes

- Modified `src/infra/tmp-openclaw-dir.ts`
- When fallback temp dir state is `invalid`, try to `rmSync` and recreate instead of throwing immediately

## Fixes

Fixes #27399