### PR TITLE
fix: recreate fallback temp dir when it exists but is invalid

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -98,9 +98,15 @@ export function resolvePreferredOpenClawTmpDir(
     if (state === "available") {
       return fallbackPath;
     }
+    // If fallback exists but is invalid (wrong owner/permissions), try to remove and recreate
     if (state === "invalid") {
-      throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);
+      try {
+        fs.rmSync(fallbackPath, { recursive: true, force: true });
+      } catch {
+        // Failed to remove, will try to create below
+      }
     }
+    // state is "missing" or we just removed invalid dir - try to create it
     try {
       mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
     } catch {


### PR DESCRIPTION
When the fallback temp directory (e.g., /tmp/openclaw-1002) exists but does not meet security requirements (wrong owner or permissions), the previous code would throw an error. This fix attempts to remove and recreate the directory instead of failing.

Fixes #27399