### PR TITLE
fix(telegram): stop typing indicator after agent run completes

### DIFF
--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { createTypingController } from "./typing.js";
+
+describe("typing persistence bug fix", () => {
+  let onReplyStartSpy: Mock;
+  let onCleanupSpy: Mock;
+  let controller: ReturnType<typeof createTypingController>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onReplyStartSpy = vi.fn();
+    onCleanupSpy = vi.fn();
+
+    controller = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should NOT restart typing after markRunComplete is called", async () => {
+    // Start typing normally
+    await controller.startTypingLoop();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    // Mark run as complete (but not yet dispatch idle)
+    controller.markRunComplete();
+
+    // Advance time to trigger the typing interval (6 seconds)
+    vi.advanceTimersByTime(6000);
+
+    // BUG: The typing loop should NOT call onReplyStart again
+    // because the run is already complete
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+    expect(onReplyStartSpy).not.toHaveBeenCalledTimes(2);
+  });
+
+  it("should stop typing when both runComplete and dispatchIdle are true", async () => {
+    // Start typing
+    await controller.startTypingLoop();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    // Mark run complete
+    controller.markRunComplete();
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    // Mark dispatch idle - should trigger cleanup
+    controller.markDispatchIdle();
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+
+    // After cleanup, typing interval should not restart typing
+    vi.advanceTimersByTime(6000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1); // Still only the initial call
+  });
+
+  it("should prevent typing restart even if cleanup is delayed", async () => {
+    // Start typing
+    await controller.startTypingLoop();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    // Mark run complete (but dispatch not idle yet - simulating cleanup delay)
+    controller.markRunComplete();
+
+    // Multiple typing intervals should NOT restart typing
+    vi.advanceTimersByTime(6000); // First interval
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(6000); // Second interval
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(6000); // Third interval
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    // Eventually dispatch becomes idle and triggers cleanup
+    controller.markDispatchIdle();
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -99,6 +99,10 @@ export function createTypingController(params: {
     if (sealed) {
       return;
     }
+    // Late callbacks after a run completed should never restart typing.
+    if (runComplete) {
+      return;
+    }
     await onReplyStart?.();
   };
 


### PR DESCRIPTION
## Problem

The Telegram typing indicator persists indefinitely after agent responses complete, affecting both `streaming: true` and `streaming: partial` modes. Users see "typing..." forever even though the bot has already responded.

## Impact

Affects **3 open issues**: #27177, #26971, #26761. All Telegram users on v2026.2.24+ are affected. 100% reproducible.

## Root Cause

In `src/auto-reply/reply/typing.ts`, the `triggerTyping()` function only checks `sealed` but not `runComplete`. The 6-second typing keepalive loop calls `triggerTyping()` which calls `onReplyStart`, restarting the typing timer even AFTER the agent run completes.

## Fix

Added `runComplete` guard to `triggerTyping()`:
```typescript
const triggerTyping = async () => {
  if (sealed) return;
  if (runComplete) return; // <-- new guard
  await onReplyStart?.();
};
```

Late callbacks after a completed run can no longer restart the typing loop.

## Testing

- 3 new regression tests in `typing-persistence.test.ts`
- All existing typing tests pass
- All existing Telegram tests pass

Fixes #27177, #26971, #26761