### PR TITLE
fix(telegram): add exponential backoff for sendChatAction 401 to prevent bot deletion

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -116,8 +116,8 @@ export type BuildTelegramMessageContextParams = {
   resolveGroupActivation: ResolveGroupActivation;
   resolveGroupRequireMention: ResolveGroupRequireMention;
   resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
-  /** Global (per-account) handler for sendChatAction 401 backoff. */
-  sendChatActionHandler?: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
+  /** Global (per-account) handler for sendChatAction 401 backoff (#27092). */
+  sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
 };
 
 async function resolveStickerVisionSupport(params: {
@@ -247,13 +247,11 @@ export const buildTelegramMessageContext = async ({
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
       fn: () =>
-        sendChatActionHandler
-          ? sendChatActionHandler.sendChatAction(
-              chatId,
-              "typing",
-              buildTypingThreadParams(replyThreadId),
-            )
-          : bot.api.sendChatAction(chatId, "typing", buildTypingThreadParams(replyThreadId)),
+        sendChatActionHandler.sendChatAction(
+          chatId,
+          "typing",
+          buildTypingThreadParams(replyThreadId),
+        ),
     });
   };
 
@@ -262,17 +260,11 @@ export const buildTelegramMessageContext = async ({
       await withTelegramApiErrorLogging({
         operation: "sendChatAction",
         fn: () =>
-          sendChatActionHandler
-            ? sendChatActionHandler.sendChatAction(
-                chatId,
-                "record_voice",
-                buildTypingThreadParams(replyThreadId),
-              )
-            : bot.api.sendChatAction(
-                chatId,
-                "record_voice",
-                buildTypingThreadParams(replyThreadId),
-              ),
+          sendChatActionHandler.sendChatAction(
+            chatId,
+            "record_voice",
+            buildTypingThreadParams(replyThreadId),
+          ),
       });
     } catch (err) {
       logVerbose(`telegram record_voice cue failed for chat ${chatId}: ${String(err)}`);

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -158,6 +158,7 @@ export const buildTelegramMessageContext = async ({
   resolveGroupActivation,
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
+  sendChatActionHandler,
 }: BuildTelegramMessageContextParams) => {
   const msg = primaryCtx.message;
   const chatId = msg.chat.id;
@@ -242,7 +243,6 @@ export const buildTelegramMessageContext = async ({
     baseRequireMention,
   );
 
-  const { sendChatActionHandler } = params;
   const sendTyping = async () => {
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -39,6 +39,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     resolveGroupActivation,
     resolveGroupRequireMention,
     resolveTelegramGroupConfig,
+    sendChatActionHandler,
     runtime,
     replyToMode,
     streamMode,
@@ -70,6 +71,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       resolveGroupActivation,
       resolveGroupRequireMention,
       resolveTelegramGroupConfig,
+      sendChatActionHandler,
     });
     if (!context) {
       return;

--- a/src/telegram/sendchataction-401-backoff.test.ts
+++ b/src/telegram/sendchataction-401-backoff.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+
+// Mock the backoff sleep to avoid real delays in tests
+vi.mock("../infra/backoff.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/backoff.js")>();
+  return {
+    ...actual,
+    sleepWithAbort: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("createTelegramSendChatActionHandler", () => {
+  const make401Error = () => new Error("401 Unauthorized");
+  const make500Error = () => new Error("500 Internal Server Error");
+
+  it("calls sendChatActionFn on success", async () => {
+    const fn = vi.fn().mockResolvedValue(true);
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await handler.sendChatAction(123, "typing");
+    expect(fn).toHaveBeenCalledWith(123, "typing", undefined);
+    expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("applies exponential backoff on consecutive 401 errors", async () => {
+    const fn = vi.fn().mockRejectedValue(make401Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 5,
+    });
+
+    // First call fails with 401
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    expect(handler.isSuspended()).toBe(false);
+
+    // Second call should mention backoff in logs
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("backoff"));
+  });
+
+  it("suspends after maxConsecutive401 failures", async () => {
+    const fn = vi.fn().mockRejectedValue(make401Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 3,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+
+    expect(handler.isSuspended()).toBe(true);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("CRITICAL"));
+
+    // Subsequent calls are silently skipped
+    await handler.sendChatAction(123, "typing");
+    expect(fn).toHaveBeenCalledTimes(3); // not called again
+  });
+
+  it("resets failure counter on success", async () => {
+    let callCount = 0;
+    const fn = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        throw make401Error();
+      }
+      return Promise.resolve(true);
+    });
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 5,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    // Third call succeeds
+    await handler.sendChatAction(123, "typing");
+
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("recovered"));
+  });
+
+  it("does not count non-401 errors toward suspension", async () => {
+    const fn = vi.fn().mockRejectedValue(make500Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 2,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
+
+    expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("reset() clears suspension", async () => {
+    const fn = vi.fn().mockRejectedValue(make401Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 1,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+    expect(handler.isSuspended()).toBe(true);
+
+    handler.reset();
+    expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("is shared across multiple chatIds (global handler)", async () => {
+    const fn = vi.fn().mockRejectedValue(make401Error());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutive401: 3,
+    });
+
+    // Different chatIds all contribute to the same failure counter
+    await expect(handler.sendChatAction(111, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(222, "typing")).rejects.toThrow("401");
+    await expect(handler.sendChatAction(333, "typing")).rejects.toThrow("401");
+
+    expect(handler.isSuspended()).toBe(true);
+    // Suspended for all chats
+    await handler.sendChatAction(444, "typing");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/telegram/sendchataction-401-backoff.ts
+++ b/src/telegram/sendchataction-401-backoff.ts
@@ -1,0 +1,133 @@
+import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../infra/backoff.js";
+
+export type TelegramSendChatActionLogger = (message: string) => void;
+
+type ChatAction =
+  | "typing"
+  | "upload_photo"
+  | "record_video"
+  | "upload_video"
+  | "record_voice"
+  | "upload_voice"
+  | "upload_document"
+  | "find_location"
+  | "record_video_note"
+  | "upload_video_note"
+  | "choose_sticker";
+
+type SendChatActionFn = (
+  chatId: number | string,
+  action: ChatAction,
+  threadParams?: unknown,
+) => Promise<unknown>;
+
+export type TelegramSendChatActionHandler = {
+  /**
+   * Send a chat action with automatic 401 backoff and circuit breaker.
+   * Safe to call from multiple concurrent message contexts.
+   */
+  sendChatAction: (
+    chatId: number | string,
+    action: ChatAction,
+    threadParams?: unknown,
+  ) => Promise<void>;
+  isSuspended: () => boolean;
+  reset: () => void;
+};
+
+export type CreateTelegramSendChatActionHandlerParams = {
+  sendChatActionFn: SendChatActionFn;
+  logger: TelegramSendChatActionLogger;
+  maxConsecutive401?: number;
+};
+
+const BACKOFF_POLICY: BackoffPolicy = {
+  initialMs: 1000,
+  maxMs: 300_000, // 5 minutes
+  factor: 2,
+  jitter: 0.1,
+};
+
+function is401Error(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : JSON.stringify(error);
+  return message.includes("401") || message.toLowerCase().includes("unauthorized");
+}
+
+/**
+ * Creates a GLOBAL (per-account) handler for sendChatAction that tracks 401 errors
+ * across all message contexts. This prevents the infinite loop that caused Telegram
+ * to delete bots (issue #27092).
+ *
+ * When a 401 occurs, exponential backoff is applied (1s → 2s → 4s → ... → 5min).
+ * After maxConsecutive401 failures (default 10), all sendChatAction calls are
+ * suspended until reset() is called.
+ */
+export function createTelegramSendChatActionHandler({
+  sendChatActionFn,
+  logger,
+  maxConsecutive401 = 10,
+}: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
+  let consecutive401Failures = 0;
+  let suspended = false;
+
+  const reset = () => {
+    consecutive401Failures = 0;
+    suspended = false;
+  };
+
+  const sendChatAction = async (
+    chatId: number | string,
+    action: ChatAction,
+    threadParams?: unknown,
+  ): Promise<void> => {
+    if (suspended) {
+      return;
+    }
+
+    if (consecutive401Failures > 0) {
+      const backoffMs = computeBackoff(BACKOFF_POLICY, consecutive401Failures);
+      logger(
+        `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
+          `(failure ${consecutive401Failures}/${maxConsecutive401})`,
+      );
+      await sleepWithAbort(backoffMs);
+    }
+
+    try {
+      await sendChatActionFn(chatId, action, threadParams);
+      // Success: reset failure counter
+      if (consecutive401Failures > 0) {
+        logger(`sendChatAction recovered after ${consecutive401Failures} consecutive 401 failures`);
+        consecutive401Failures = 0;
+      }
+    } catch (error) {
+      if (is401Error(error)) {
+        consecutive401Failures++;
+
+        if (consecutive401Failures >= maxConsecutive401) {
+          suspended = true;
+          logger(
+            `CRITICAL: sendChatAction suspended after ${consecutive401Failures} consecutive 401 errors. ` +
+              `Bot token is likely invalid. Telegram may DELETE the bot if requests continue. ` +
+              `Replace the token and restart: openclaw channels restart telegram`,
+          );
+        } else {
+          logger(
+            `sendChatAction 401 error (${consecutive401Failures}/${maxConsecutive401}). ` +
+              `Retrying with exponential backoff.`,
+          );
+        }
+      }
+      throw error;
+    }
+  };
+
+  return {
+    sendChatAction,
+    isSuspended: () => suspended,
+    reset,
+  };
+}


### PR DESCRIPTION
## Problem

When a Telegram bot token becomes invalid (401 Unauthorized), the gateway enters an infinite loop of sendChatAction API calls with no backoff. This results in thousands of rapid-fire 401 errors (~1/sec), causing Telegram to flag the bot as abusive and **permanently delete it**.

## Impact

**CRITICAL** - This bug destroys Telegram bots permanently:
- 15,899 sendChatAction failures in a single day's log
- ~85% error rate (16,788 total 401 errors out of 18,594 log lines)
- Two separate bots destroyed in 48 hours
- Users must create new bots via @BotFather each time
- All existing chat history with users is lost

## Root Cause

The typing keepalive loop calls `sendChatAction` every 6 seconds with no error handling for 401 responses. When the token is invalid, each call fails with 401, but the loop continues indefinitely. Telegram interprets the rapid-fire requests as abuse and deletes the bot.

## Fix

Two-layer defense:
1. **Exponential backoff**: After each consecutive 401, delay increases (1s, 2s, 4s, 8s... up to 5 min)
2. **Circuit breaker**: After 10 consecutive 401 failures, suspend sendChatAction entirely and log a clear warning that the bot token is invalid

## Testing

- New test file `sendchataction-401-backoff.test.ts` with comprehensive coverage
- All existing Telegram tests pass

Fixes #27092