### PR TITLE
feat: add Gossip channel extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,6 +25,11 @@
       - any-glob-to-any-file:
           - "extensions/googlechat/**"
           - "docs/channels/googlechat.md"
+"channel: gossip":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/gossip/**"
+          - "docs/channels/gossip.md"
 "channel: imessage":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/channels/gossip.md
+++ b/docs/channels/gossip.md
@@ -1,0 +1,219 @@
+---
+summary: "Gossip decentralized messenger with post-quantum encryption"
+read_when:
+  - You want OpenClaw to use privacy-focused messaging
+  - You want decentralized messaging without a phone number
+  - You need post-quantum encryption
+---
+
+# Gossip
+
+**Status:** Optional plugin (disabled by default).
+
+Gossip is a privacy-focused, decentralized messenger that enables OpenClaw to send and receive encrypted direct messages without requiring a phone number or relying on centralized servers. For more details, see the official Gossip site at [https://usegossip.massa.network/](https://usegossip.massa.network/).
+
+## Why Gossip?
+
+- **Open Source** - Fully auditable codebase; no hidden backdoors.
+- **Privacy Focused** - Post-quantum encryption with deniable plausibility protects your conversations even against future quantum computers.
+- **Decentralized** - No central server owns your data; messages are routed through a distributed network.
+- **No Phone Number Required** - Identity is based on cryptographic keys, not phone numbers or email addresses.
+
+## Install (on demand)
+
+### Onboarding (recommended)
+
+- The onboarding wizard (`openclaw onboard`) and `openclaw channels add` list optional channel plugins.
+- Selecting Gossip prompts you to install the plugin on demand.
+
+Install defaults:
+
+- **Dev channel + git checkout available:** uses the local plugin path.
+- **Stable/Beta:** downloads from npm.
+
+You can always override the choice in the prompt.
+
+### Manual install
+
+```bash
+openclaw plugins install gossip
+```
+
+Or with the full npm spec: `openclaw plugins install @openclaw/gossip`.
+
+Use a local checkout (dev workflows):
+
+```bash
+openclaw plugins install --link <path-to-openclaw>/extensions/gossip
+```
+
+Restart the Gateway after installing or enabling plugins.
+
+## Quick setup
+
+1. Enable the Gossip channel in your config:
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "enabled": true
+    }
+  }
+}
+```
+
+2. Restart the Gateway. On first run, OpenClaw will automatically:
+   - Generate a new BIP39 mnemonic for your account
+   - Create cryptographic keys for encryption
+   - Register with the Gossip network
+
+3. Your Gossip user ID (bech32, e.g. `gossip1...`) is shown at the end of onboarding and is stored in `~/.openclaw/sessions/gossip/<accountId>/session.json` (account ID is usually `default`). Share this ID with users who want to message your bot.
+
+## Configuration reference
+
+| Key           | Type     | Default                         | Description                                                                |
+| ------------- | -------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `enabled`     | boolean  | `false`                         | Enable/disable channel                                                     |
+| `mnemonic`    | string   | auto-generated on first run     | BIP39 mnemonic phrase for account recovery; supports `${VAR}` substitution |
+| `username`    | string   | `openclaw`                      | Username for the Gossip account (used when creating the account)           |
+| `protocolUrl` | string   | `https://api.usegossip.com/api` | Gossip protocol API base URL                                               |
+| `dmPolicy`    | string   | `pairing`                       | DM access policy: `pairing`, `allowlist`, `open`, or `disabled`            |
+| `allowFrom`   | string[] | `[]`                            | Allowed sender Gossip user IDs (e.g. `gossip1...`); use `["*"]` for open   |
+| `name`        | string   | -                               | Optional display name for this account in OpenClaw UI                      |
+
+## Backup your mnemonic
+
+Your mnemonic phrase is the only way to recover your Gossip identity. OpenClaw stores account metadata (mnemonic, user ID, username) at:
+
+```
+~/.openclaw/sessions/gossip/<accountId>/session.json
+```
+
+The default account ID is `default`. The same directory may contain `gossip.db` (SDK persistence for discussions and messages). **Back up the session directory or at least `session.json` securely.** If you lose the mnemonic, you will need to create a new identity.
+
+To use an existing mnemonic (restore an account):
+
+Add this to your main OpenClaw config file (by default `~/.openclaw/config.json5`, or whatever `OPENCLAW_CONFIG_PATH` points to):
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "mnemonic": "${GOSSIP_MNEMONIC}"
+    }
+  }
+}
+```
+
+Then set the environment variable:
+
+```bash
+export GOSSIP_MNEMONIC="word1 word2 word3 ... word12"
+```
+
+You can also restore an existing account via the Gossip channel onboarding flow (`openclaw onboard` or `openclaw channels add`): when asked "Set an existing mnemonic?", choose yes and paste your BIP39 mnemonic.
+
+## Access control
+
+### DM policies
+
+- **pairing** (default): unknown senders get a pairing code.
+- **allowlist**: only user IDs in `allowFrom` can DM.
+- **open**: public inbound DMs (requires `allowFrom: ["*"]`).
+- **disabled**: ignore inbound DMs.
+
+### Contact requests and auto-accept
+
+Gossip uses "discussion requests" when someone tries to DM your bot for the first time. The OpenClaw Gossip plugin **automatically accepts all discussion requests** so you do not need to manually approve each new contact in the Gossip app.
+
+Auto-accepting contacts does **not** bypass OpenClaw's own access control:
+
+- **DM policy still applies**: after a contact is auto-accepted, inbound messages are checked against your configured `dmPolicy` and `allowFrom` list.
+  - With `dmPolicy: "allowlist"`, only user IDs in `allowFrom` are allowed to talk to your agent (a whitelist).
+  - With `dmPolicy: "pairing"`, unknown senders must complete the pairing flow before their messages reach your agent.
+  - With `dmPolicy: "open"` and `allowFrom: ["*"]`, any Gossip user can reach your agent unless they are blocked by higher-level routing rules.
+- **Blocklist-style filtering**: to block specific Gossip user IDs, keep them out of `allowFrom` when using `allowlist`, or add them to your global routing block rules; their messages will be dropped even though the contact may exist in Gossip.
+
+In practice, for a locked-down production bot you will typically:
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["gossip1a23...", "gossip1x89..."]
+    }
+  }
+}
+```
+
+This configuration lets Gossip auto-accept contact requests while still enforcing a strict allowlist for who can actually reach your agent.
+
+### Allowlist example
+
+```json
+{
+  "channels": {
+    "gossip": {
+      "dmPolicy": "allowlist",
+      "allowFrom": ["abc123...", "xyz789..."]
+    }
+  }
+}
+```
+
+## How it works
+
+Gossip uses a unique cryptographic protocol:
+
+1. **Identity**: Your identity is a cryptographic key pair derived from a BIP39 mnemonic.
+2. **Sessions**: When you start a conversation, both parties establish an encrypted session using post-quantum key exchange.
+3. **Messages**: All messages are end-to-end encrypted; only the intended recipient can read them.
+4. **Deniability**: The protocol provides deniable authentication - you can prove a message came from someone, but cannot prove it to a third party.
+
+## Testing
+
+### Manual test
+
+1. Get the bot Gossip user ID from the Gateway logs after start, or from `~/.openclaw/sessions/gossip/default/session.json` (field `userId`).
+2. Open the Gossip app on your phone or computer.
+3. Add the bot as a contact using that user ID (bech32, e.g. `gossip1...`).
+4. Start a conversation and send a message.
+5. Verify the bot responds.
+
+## Troubleshooting
+
+### Not receiving messages
+
+- Verify the channel is enabled (`enabled: true`).
+- Check that the Gateway is running.
+- Confirm the sender has an active session with your bot.
+- Check Gateway logs for connection errors.
+
+### Not sending responses
+
+- Verify outbound network connectivity to `api.usegossip.com` (API path `/api`).
+- Check if the session with the recipient is active.
+- Look for errors in the Gateway logs.
+
+### Session issues
+
+If you see "session broken" or similar errors:
+
+- The SDK automatically attempts to renew broken sessions.
+- Messages are queued and sent when the session becomes active.
+- If problems persist, the other party may need to reinitiate the conversation.
+
+## Security
+
+- **Never share your mnemonic** - it controls your entire identity.
+- Use environment variables for sensitive values.
+- Consider `allowlist` policy for production bots.
+- Protect `~/.openclaw/sessions/gossip/` (session metadata and SDK database); the SDK may use its own persistence in that directory.
+
+## Limitations (initial release)
+
+- Direct messages only (no group chats yet).
+- No media attachments (text only).
+- Single account per OpenClaw instance.

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -30,6 +30,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Nextcloud Talk](/channels/nextcloud-talk) — Self-hosted chat via Nextcloud Talk (plugin, installed separately).
 - [Matrix](/channels/matrix) — Matrix protocol (plugin, installed separately).
 - [Nostr](/channels/nostr) — Decentralized DMs via NIP-04 (plugin, installed separately).
+- [Gossip](/channels/gossip) — Privacy-focused decentralized messenger with post-quantum encryption; no phone number required (plugin, installed separately).
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).
 - [Zalo](/channels/zalo) — Zalo Bot API; Vietnam's popular messenger (plugin, installed separately).

--- a/extensions/gossip/index.ts
+++ b/extensions/gossip/index.ts
@@ -1,0 +1,18 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { gossipPlugin } from "./src/channel.js";
+import { setGossipResolvePath, setGossipRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "gossip",
+  name: "Gossip",
+  description: "Gossip decentralized messenger channel plugin with post-quantum encryption",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setGossipRuntime(api.runtime);
+    setGossipResolvePath(api.resolvePath);
+    api.registerChannel({ plugin: gossipPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/gossip/openclaw.plugin.json
+++ b/extensions/gossip/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "gossip",
+  "channels": ["gossip"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/gossip/package.json
+++ b/extensions/gossip/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@openclaw/gossip",
+  "version": "2026.1.27",
+  "description": "OpenClaw Gossip channel plugin for post-quantum encrypted decentralized messaging",
+  "type": "module",
+  "dependencies": {
+    "@massalabs/gossip-sdk": "0.0.2-dev.20260226131013",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "gossip",
+      "label": "Gossip",
+      "selectionLabel": "Gossip Chat",
+      "docsPath": "/channels/gossip",
+      "docsLabel": "gossip",
+      "blurb": "Privacy-focused decentralized messenger with post-quantum encryption.",
+      "order": 56,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/gossip",
+      "localPath": "extensions/gossip",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/gossip/src/channel.ts
+++ b/extensions/gossip/src/channel.ts
@@ -1,0 +1,440 @@
+import { isValidUserId } from "@massalabs/gossip-sdk";
+import {
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+  type OpenClawConfig,
+  type ReplyPayload,
+} from "openclaw/plugin-sdk";
+import { GossipConfigSchema } from "./config-schema.js";
+
+/** Strip channel-prefixed form so we validate and store raw Gossip user ID only. */
+function stripGossipPrefix(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.toLowerCase().startsWith("gossip:")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+import { startGossipBus, type GossipBusHandle } from "./gossip-bus.js";
+import { gossipOnboardingAdapter } from "./onboarding.js";
+import { getGossipRuntime } from "./runtime.js";
+import { createGossipStorageAdapter } from "./storage.js";
+import {
+  listGossipAccountIds,
+  resolveDefaultGossipAccountId,
+  resolveGossipAccount,
+  type ResolvedGossipAccount,
+} from "./types.js";
+
+// Store active bus handles per account
+const activeBuses = new Map<string, GossipBusHandle>();
+
+function shouldAcceptGossipDiscussionRequest(params: {
+  account: ResolvedGossipAccount;
+  contactUserId: string;
+  log?: { info?(message: string): void };
+}): boolean {
+  const dmPolicy = params.account.config.dmPolicy ?? "pairing";
+  const rawAllowFrom = (params.account.config.allowFrom ?? []).map((entry) => String(entry).trim());
+  const normalizedAllowFrom = rawAllowFrom
+    .filter(Boolean)
+    .map((entry) => (entry === "*" ? "*" : stripGossipPrefix(entry)));
+
+  const senderId = stripGossipPrefix(params.contactUserId);
+
+  if (dmPolicy === "disabled") {
+    params.log?.info?.(
+      `[${params.account.accountId}] Rejecting Gossip discussion from ${senderId} (dmPolicy=disabled)`,
+    );
+    return false;
+  }
+
+  if (dmPolicy === "open" || dmPolicy === "pairing") {
+    return true;
+  }
+
+  // dmPolicy === "allowlist"
+  const allowed =
+    normalizedAllowFrom.includes("*") || normalizedAllowFrom.some((entry) => entry === senderId);
+  if (!allowed) {
+    params.log?.info?.(
+      `[${params.account.accountId}] Rejecting Gossip discussion from ${senderId} (dmPolicy=allowlist, not allowlisted)`,
+    );
+  }
+  return allowed;
+}
+
+export const gossipPlugin: ChannelPlugin<ResolvedGossipAccount> = {
+  id: "gossip",
+  meta: {
+    id: "gossip",
+    label: "Gossip",
+    selectionLabel: "Gossip",
+    docsPath: "/channels/gossip",
+    docsLabel: "gossip",
+    blurb: "Privacy-focused decentralized messenger with post-quantum encryption",
+    order: 100,
+  },
+  capabilities: {
+    chatTypes: ["direct"], // DMs only for now
+    media: false, // No media for initial release
+  },
+  reload: { configPrefixes: ["channels.gossip"] },
+  configSchema: buildChannelConfigSchema(GossipConfigSchema),
+  onboarding: gossipOnboardingAdapter,
+
+  config: {
+    listAccountIds: (cfg) => listGossipAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveGossipAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultGossipAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "gossip",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) => {
+      const storage = createGossipStorageAdapter();
+      storage.deleteSessionData(accountId);
+      return deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "gossip",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "mnemonic",
+          "username",
+          "protocolUrl",
+          "dmPolicy",
+          "allowFrom",
+          "enabled",
+          "markdown",
+        ],
+      });
+    },
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      userId: account.userId,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      (resolveGossipAccount({ cfg, accountId }).config.allowFrom ?? []).map((entry) =>
+        String(entry),
+      ),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => {
+          if (entry === "*") {
+            return "*";
+          }
+          const raw = stripGossipPrefix(entry);
+          if (!isValidUserId(raw)) {
+            console.warn(`Invalid Gossip user ID "${entry}" in allowFrom`);
+          }
+          return raw;
+        })
+        .filter(Boolean),
+  },
+
+  pairing: {
+    idLabel: "gossipUserId",
+    normalizeAllowEntry: (entry) => {
+      const raw = stripGossipPrefix(entry);
+      if (!isValidUserId(raw)) {
+        console.warn(`Invalid Gossip user ID "${entry}" in allowFrom`);
+      }
+      return raw;
+    },
+    notifyApproval: async ({ id }) => {
+      // Get the default account's bus and send approval message
+      const bus = activeBuses.get(DEFAULT_ACCOUNT_ID);
+      if (bus) {
+        await bus.sendDm(id, "Your pairing request has been approved!");
+      }
+    },
+  },
+
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      return {
+        policy: account.config.dmPolicy ?? "pairing",
+        allowFrom: account.config.allowFrom ?? [],
+        policyPath: "channels.gossip.dmPolicy",
+        allowFromPath: "channels.gossip.allowFrom",
+        approveHint: formatPairingApproveHint("gossip"),
+        normalizeEntry: (raw) => {
+          const rawId = stripGossipPrefix(raw);
+          if (!isValidUserId(rawId)) {
+            console.warn(`Invalid Gossip user ID "${raw}"`);
+          }
+          return rawId;
+        },
+      };
+    },
+  },
+
+  messaging: {
+    normalizeTarget: (target) => {
+      const raw = stripGossipPrefix(target);
+      if (!isValidUserId(raw)) {
+        console.warn(`Invalid Gossip user ID "${target}" in target`);
+      }
+      return raw;
+    },
+    targetResolver: {
+      looksLikeId: (input) => {
+        const raw = stripGossipPrefix(input.trim());
+        return isValidUserId(raw);
+      },
+      hint: "<gossip user ID>",
+    },
+  },
+
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 4000,
+    sendText: async ({ to, text, accountId }) => {
+      const core = getGossipRuntime();
+      const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+      const bus = activeBuses.get(aid);
+      if (!bus) {
+        throw new Error(`Gossip bus not running for account ${aid}`);
+      }
+      const tableMode = core.channel.text.resolveMarkdownTableMode({
+        cfg: core.config.loadConfig(),
+        channel: "gossip",
+        accountId: aid,
+      });
+      const message = core.channel.text.convertMarkdownTables(text ?? "", tableMode);
+      const normalizedTo = stripGossipPrefix(to);
+      if (!isValidUserId(normalizedTo)) {
+        console.warn(`Invalid Gossip user ID "${to}" in target`);
+      }
+      await bus.sendDm(normalizedTo, message);
+      return { channel: "gossip", to: normalizedTo, messageId: "" };
+    },
+  },
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((account) => {
+        const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+        if (!lastError) {
+          return [];
+        }
+        return [
+          {
+            channel: "gossip",
+            accountId: account.accountId,
+            kind: "runtime" as const,
+            message: `Channel error: ${lastError}`,
+          },
+        ];
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      userId: ((snapshot.profile as { userId?: string } | undefined)?.userId ?? null) as
+        | string
+        | null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+    }),
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      profile: account.userId ? { userId: account.userId } : undefined,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.setStatus({
+        accountId: account.accountId,
+        profile: account.userId ? { userId: account.userId } : undefined,
+      });
+      ctx.log?.info(`[${account.accountId}] starting Gossip provider`);
+
+      if (!account.configured) {
+        throw new Error("Gossip channel not configured");
+      }
+
+      const runtime = getGossipRuntime();
+
+      const bus = await startGossipBus({
+        accountId: account.accountId,
+        mnemonic: account.mnemonic || undefined,
+        username: account.username,
+        protocolUrl: account.protocolUrl,
+        log: ctx.log,
+        onMessage: async (senderId, text, reply) => {
+          const cfg = runtime.config.loadConfig() as OpenClawConfig;
+
+          // Resolve agent route for this DM
+          const route = runtime.channel.routing.resolveAgentRoute({
+            cfg,
+            channel: "gossip",
+            accountId: account.accountId,
+            peer: { kind: "direct", id: senderId },
+          });
+
+          const rawBody = text;
+          const body = runtime.channel.reply.formatAgentEnvelope({
+            channel: "Gossip",
+            from: senderId,
+            envelope: runtime.channel.reply.resolveEnvelopeFormatOptions(cfg),
+            body: rawBody,
+          });
+
+          // To/OriginatingTo = reply destination (peer), not our identity; session lastTo is used for outbound.
+          const replyTo = `gossip:${senderId}`;
+          const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+            Body: body,
+            RawBody: rawBody,
+            CommandBody: rawBody,
+            From: `gossip:${senderId}`,
+            To: replyTo,
+            SessionKey: route.sessionKey,
+            AccountId: route.accountId,
+            ChatType: "direct",
+            SenderName: senderId,
+            SenderId: senderId,
+            Provider: "gossip",
+            Surface: "gossip",
+            OriginatingChannel: "gossip",
+            OriginatingTo: replyTo,
+          });
+
+          // Record session metadata
+          const storePath = runtime.channel.session.resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          });
+          await runtime.channel.session.recordInboundSession({
+            storePath,
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            ctx: ctxPayload,
+            onRecordError: (err) => {
+              ctx.log?.error(`[${account.accountId}] Failed updating session meta: ${String(err)}`);
+            },
+          });
+
+          const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+            cfg,
+            channel: "gossip",
+            accountId: account.accountId,
+          });
+
+          // Dispatch through the standard reply pipeline
+          await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+            ctx: ctxPayload,
+            cfg,
+            dispatcherOptions: {
+              deliver: async (payload: ReplyPayload) => {
+                if (!payload.text) {
+                  return;
+                }
+                const message = runtime.channel.text.convertMarkdownTables(payload.text, tableMode);
+                await reply(message);
+                ctx.setStatus({ accountId: account.accountId, lastOutboundAt: Date.now() });
+              },
+            },
+          });
+        },
+        onError: (error, context) => {
+          const base = `[${account.accountId}] Gossip error (${context}): ${error.message}`;
+          if (error?.stack) {
+            ctx.log?.error(`${base}\n${error.stack}`);
+          } else {
+            ctx.log?.error(base);
+          }
+        },
+        onReady: (userId) => {
+          ctx.log?.info(`[${account.accountId}] Gossip provider ready, user ID: ${userId}`);
+          const currentProfile =
+            (ctx.getStatus().profile as Record<string, unknown> | undefined) ?? {};
+          ctx.setStatus({
+            accountId: account.accountId,
+            profile: {
+              ...currentProfile,
+              userId,
+            },
+          });
+        },
+        onDiscussionRequest: (discussion, contact) => {
+          ctx.log?.info(
+            `[${account.accountId}] Incoming Gossip discussion request from ${contact.userId}`,
+          );
+        },
+        shouldAcceptDiscussionRequest: (discussion, contact) =>
+          shouldAcceptGossipDiscussionRequest({
+            account,
+            contactUserId: contact.userId,
+            log: ctx.log,
+          }),
+      });
+
+      // Store the bus handle
+      activeBuses.set(account.accountId, bus);
+
+      ctx.log?.info(`[${account.accountId}] Gossip provider started`);
+
+      // Block until the channel manager signals shutdown; without this the
+      // resolved promise is treated as "channel exited" → auto-restart loop.
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+
+      await bus.close();
+      activeBuses.delete(account.accountId);
+      ctx.log?.info(`[${account.accountId}] Gossip provider stopped`);
+    },
+  },
+};
+
+/**
+ * Get an active Gossip bus handle.
+ * Returns undefined if account is not running.
+ */
+export function getGossipBus(accountId: string = DEFAULT_ACCOUNT_ID): GossipBusHandle | undefined {
+  return activeBuses.get(accountId);
+}
+
+/**
+ * Get all active Gossip bus handles.
+ * Useful for debugging and status reporting.
+ */
+export function getActiveGossipBuses(): Map<string, GossipBusHandle> {
+  return new Map(activeBuses);
+}

--- a/extensions/gossip/src/config-schema.ts
+++ b/extensions/gossip/src/config-schema.ts
@@ -1,0 +1,50 @@
+import { MarkdownConfigSchema, buildChannelConfigSchema } from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const allowFromEntry = z.union([z.string(), z.number()]);
+
+/**
+ * Zod schema for channels.gossip.* configuration
+ */
+export const GossipConfigSchema = z.object({
+  /** Account name (optional display name) */
+  name: z.string().optional(),
+
+  /** Whether this channel is enabled */
+  enabled: z.boolean().optional(),
+
+  /** Markdown formatting overrides (tables). */
+  markdown: MarkdownConfigSchema,
+
+  /**
+   * BIP39 mnemonic phrase for account recovery.
+   * If not provided, a new account will be generated on first run.
+   * Supports environment variable substitution (e.g., "${GOSSIP_MNEMONIC}").
+   */
+  mnemonic: z.string().optional(),
+
+  /**
+   * Username for the Gossip account.
+   * Used when creating a new account.
+   */
+  username: z.string().optional(),
+
+  /**
+   * Gossip protocol API base URL.
+   * Defaults to the official Gossip API endpoint.
+   */
+  protocolUrl: z.string().url().optional(),
+
+  /** DM access policy: pairing, allowlist, open, or disabled */
+  dmPolicy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
+
+  /** Allowed sender user IDs (Gossip user ID format) */
+  allowFrom: z.array(allowFromEntry).optional(),
+});
+
+export type GossipConfig = z.infer<typeof GossipConfigSchema>;
+
+/**
+ * JSON Schema for Control UI (converted from Zod)
+ */
+export const gossipChannelConfigSchema = buildChannelConfigSchema(GossipConfigSchema);

--- a/extensions/gossip/src/gossip-bus.ts
+++ b/extensions/gossip/src/gossip-bus.ts
@@ -1,0 +1,344 @@
+/**
+ * Gossip SDK Bus - Wrapper for SDK lifecycle and event handling
+ *
+ * This module provides a clean interface for OpenClaw to interact with the
+ * Gossip SDK, handling initialization, session management, and message routing.
+ */
+
+import {
+  gossipSdk,
+  generateMnemonic,
+  type Message,
+  type Discussion,
+  type Contact,
+  SdkEventType,
+  MessageDirection,
+  MessageStatus,
+  MessageType,
+} from "@massalabs/gossip-sdk";
+import {
+  createGossipStorageAdapter,
+  type GossipSessionData,
+  type GossipStorageAdapter,
+} from "./storage.js";
+
+type GossipEventListeners = {
+  message: (message: Message) => Promise<void>;
+  sessionRequested: (discussion: Discussion, contact: Contact) => void;
+  error: (error: Error, context: string) => void;
+};
+
+let activeListeners: GossipEventListeners | undefined;
+
+function encodeEncryptedSessionBlob(blob: Uint8Array): string {
+  return Buffer.from(blob).toString("base64");
+}
+
+function decodeEncryptedSessionBlob(encoded: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(encoded, "base64"));
+}
+
+function detachGossipEventListeners(): void {
+  if (!activeListeners) {
+    return;
+  }
+  gossipSdk.off(SdkEventType.MESSAGE_RECEIVED, activeListeners.message);
+  gossipSdk.off(SdkEventType.SESSION_REQUESTED, activeListeners.sessionRequested);
+  gossipSdk.off(SdkEventType.ERROR, activeListeners.error);
+  activeListeners = undefined;
+}
+
+export interface GossipBusOptions {
+  /** Account ID for state persistence */
+  accountId: string;
+  /** BIP39 mnemonic phrase (auto-generated if not provided) */
+  mnemonic?: string;
+  /** Username for the account */
+  username: string;
+  /** Gossip protocol API base URL */
+  protocolUrl: string;
+  /** Called when a message is received */
+  onMessage: (
+    senderId: string,
+    text: string,
+    reply: (text: string) => Promise<void>,
+  ) => Promise<void>;
+  /** Called on errors (optional) */
+  onError?: (error: Error, context: string) => void;
+  /** Called when SDK is ready (optional) */
+  onReady?: (userId: string) => void;
+  /** Called on discussion requests (optional) */
+  onDiscussionRequest?: (discussion: Discussion, contact: Contact) => void;
+  /** Decide whether to accept an incoming discussion request (optional; defaults to accept) */
+  shouldAcceptDiscussionRequest?: (
+    discussion: Discussion,
+    contact: Contact,
+  ) => boolean | Promise<boolean>;
+  /** Optional debug logger (e.g. ctx.log from channel gateway) */
+  log?: { debug?(message: string): void };
+}
+
+export interface GossipBusHandle {
+  /** Stop the bus and cleanup */
+  close: () => Promise<void>;
+  /** Get the user's ID (bech32-encoded gossip1… string) */
+  userId: string;
+  /** Send a DM to a user */
+  sendDm: (toUserId: string, text: string) => Promise<void>;
+  /** Get the storage adapter */
+  storage: GossipStorageAdapter;
+  /** Get the mnemonic (for backup purposes) */
+  getMnemonic: () => string;
+}
+
+/**
+ * Start the Gossip bus - initializes SDK and handles message routing
+ */
+export async function startGossipBus(options: GossipBusOptions): Promise<GossipBusHandle> {
+  const {
+    accountId,
+    username,
+    protocolUrl,
+    onMessage,
+    onError,
+    onReady,
+    onDiscussionRequest,
+    shouldAcceptDiscussionRequest,
+    log,
+  } = options;
+
+  const storage = createGossipStorageAdapter(log);
+
+  // Load or create session data
+  const existingSessionData = storage.loadSessionData(accountId);
+  let mutableSessionData: GossipSessionData;
+  let mnemonic = options.mnemonic?.trim();
+
+  if (existingSessionData) {
+    // Restore existing session
+    mnemonic = existingSessionData.mnemonic;
+    mutableSessionData = existingSessionData;
+  } else {
+    // Generate new account if no mnemonic provided
+    if (!mnemonic) {
+      mnemonic = generateMnemonic();
+    }
+    // Save the new session data
+    mutableSessionData = {
+      mnemonic,
+      username,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    storage.saveSessionData(accountId, mutableSessionData);
+  }
+
+  const persistSessionData = (updates: Partial<GossipSessionData>): void => {
+    mutableSessionData = {
+      ...mutableSessionData,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+    storage.saveSessionData(accountId, mutableSessionData);
+  };
+
+  let restoredEncryptedSession: Uint8Array | undefined;
+  if (mutableSessionData.encryptedSession?.trim()) {
+    try {
+      restoredEncryptedSession = decodeEncryptedSessionBlob(mutableSessionData.encryptedSession);
+    } catch (err) {
+      onError?.(
+        err as Error,
+        `decoding persisted encrypted session for account ${accountId}; falling back to mnemonic`,
+      );
+    }
+  }
+
+  const sqlitePath = storage.getSessionDir(accountId);
+  const sqliteFilePath = `${sqlitePath}/gossip.db`;
+
+  const initConfig = {
+    polling: {
+      enabled: false,
+      messagesIntervalMs: 5000,
+      announcementsIntervalMs: 5000,
+      sessionRefreshIntervalMs: 30000,
+    },
+  };
+
+  await gossipSdk.init({
+    protocolBaseUrl: protocolUrl,
+    storage: {
+      type: "node-fs",
+      path: sqliteFilePath,
+    },
+    config: initConfig,
+  });
+
+  // SDK is a singleton; close any existing session (e.g. from onboarding) before opening
+  if (gossipSdk.isSessionOpen) {
+    await gossipSdk.closeSession();
+  }
+
+  // Open session with persistence
+  await gossipSdk.openSession({
+    mnemonic,
+    encryptedSession: restoredEncryptedSession,
+    onPersist: async (encryptedBlob) => {
+      persistSessionData({
+        encryptedSession: encodeEncryptedSessionBlob(encryptedBlob),
+      });
+    },
+  });
+
+  const gossipUserId = gossipSdk.userId;
+  const discussions = await gossipSdk.discussions.list();
+
+  // Persist latest encrypted session snapshot so restarts can restore without re-handshake.
+  persistSessionData({
+    encryptedSession: encodeEncryptedSessionBlob(gossipSdk.getEncryptedSession()),
+  });
+
+  // Update session data with userId
+  if (mutableSessionData.userId !== gossipUserId) {
+    persistSessionData({ userId: gossipUserId });
+  }
+
+  // Set up event handlers. The SDK is a singleton, so always detach any
+  // previous listeners before attaching a new set for this bus instance.
+  detachGossipEventListeners();
+
+  const handleMessage = async (message: Message): Promise<void> => {
+    // Only handle incoming messages
+    if (message.direction !== MessageDirection.INCOMING) {
+      return;
+    }
+
+    const senderId = message.contactUserId;
+    const text = message.content;
+
+    // Create reply function
+    const reply = async (responseText: string): Promise<void> => {
+      await sendMessage(senderId, responseText);
+    };
+
+    try {
+      await onMessage(senderId, text, reply);
+    } catch (err) {
+      onError?.(err as Error, `handling message from ${senderId}`);
+    }
+  };
+
+  const handleSessionRequested = (discussion: Discussion, contact: Contact): void => {
+    // Run policy check before invoking user callbacks or accepting the discussion.
+    (async () => {
+      const shouldAccept = (await shouldAcceptDiscussionRequest?.(discussion, contact)) ?? true;
+      if (!shouldAccept) {
+        return;
+      }
+
+      onDiscussionRequest?.(discussion, contact);
+
+      // Ensure the requester is persisted as a contact before accepting discussion.
+      let existing = await gossipSdk.contacts.get(contact.userId);
+      if (!existing) {
+        const publicKeys = await gossipSdk.auth.fetchPublicKeyByUserId(contact.userId);
+
+        const addResult = await gossipSdk.contacts.add(contact.userId, contact.userId, publicKeys);
+        if (!addResult.success && addResult.error !== "Contact already exists") {
+          throw new Error(
+            `Failed to add contact for discussion request ${contact.userId}: ${addResult.error}`,
+          );
+        }
+
+        existing = await gossipSdk.contacts.get(contact.userId);
+        if (!existing) {
+          throw new Error(`Contact ${contact.userId} is still missing after add attempt`);
+        }
+      }
+
+      // Auto-accept discussion requests for contacts
+      await gossipSdk.discussions.accept(discussion);
+    })().catch((err) => {
+      onError?.(err as Error, `accepting discussion from ${contact.userId}`);
+    });
+  };
+
+  const handleError = (error: Error, context: string): void => {
+    onError?.(error, context);
+  };
+
+  gossipSdk.on(SdkEventType.MESSAGE_RECEIVED, handleMessage);
+  gossipSdk.on(SdkEventType.SESSION_REQUESTED, handleSessionRequested);
+  gossipSdk.on(SdkEventType.ERROR, handleError);
+  activeListeners = {
+    message: handleMessage,
+    sessionRequested: handleSessionRequested,
+    error: handleError,
+  };
+
+  // Notify that SDK is ready
+  onReady?.(gossipUserId);
+
+  // Fetch announcements (discussion requests) before starting polling so that
+  // discussions are established before the first message poll. Without this,
+  // messages can arrive before their discussion exists → "no discussion" error.
+  try {
+    await gossipSdk.announcements.fetch();
+  } catch (err) {
+    onError?.(err as Error, "initial announcements fetch");
+  }
+
+  // Now safe to start polling (discussions are established for known contacts)
+  gossipSdk.polling.start();
+
+  /**
+   * Send a message to a user
+   */
+  async function sendMessage(toUserId: string, text: string): Promise<void> {
+    // Contact must already exist (created when discussion request is accepted).
+    let contact = await gossipSdk.contacts.get(toUserId);
+    if (!contact) {
+      throw new Error(
+        `Contact ${toUserId} is missing. Expected contact to be created while accepting discussion request.`,
+      );
+    }
+
+    // Ensure discussion exists. SDK queues outgoing messages until session is ready.
+    const discussion = await gossipSdk.discussions.get(toUserId);
+    if (!discussion) {
+      const startResult = await gossipSdk.discussions.start(contact);
+      if (!startResult.success) {
+        throw new Error(
+          `Failed to create discussion with ${toUserId}: ${startResult.error.message}`,
+        );
+      }
+    }
+
+    const sendResult = await gossipSdk.messages.send({
+      ownerUserId: gossipUserId,
+      contactUserId: toUserId,
+      content: text,
+      type: MessageType.TEXT,
+      direction: MessageDirection.OUTGOING,
+      status: MessageStatus.WAITING_SESSION,
+      timestamp: new Date(),
+    });
+    if (!sendResult.success) {
+      throw new Error(`Failed to queue gossip message to ${toUserId}: ${sendResult.error}`);
+    }
+  }
+
+  const resolvedMnemonic = mutableSessionData.mnemonic;
+
+  return {
+    close: async () => {
+      detachGossipEventListeners();
+      await gossipSdk.closeSession();
+    },
+    userId: gossipUserId,
+    sendDm: sendMessage,
+    storage,
+    getMnemonic: () => resolvedMnemonic,
+  };
+}

--- a/extensions/gossip/src/onboarding.ts
+++ b/extensions/gossip/src/onboarding.ts
@@ -1,0 +1,363 @@
+import { isValidUserId } from "@massalabs/gossip-sdk";
+import type {
+  ChannelOnboardingAdapter,
+  ChannelOnboardingDmPolicy,
+  DmPolicy,
+  OpenClawConfig,
+  WizardPrompter,
+} from "openclaw/plugin-sdk";
+import {
+  addWildcardAllowFrom,
+  DEFAULT_ACCOUNT_ID,
+  formatDocsLink,
+  normalizeAccountId,
+} from "openclaw/plugin-sdk";
+import { startGossipBus } from "./gossip-bus.js";
+import { getGossipRuntime } from "./runtime.js";
+import { createGossipStorageAdapter, getGossipSessionsBaseDir } from "./storage.js";
+import {
+  listGossipAccountIds,
+  resolveDefaultGossipAccountId,
+  resolveGossipAccount,
+} from "./types.js";
+
+const channel = "gossip" as const;
+
+export const DEFAULT_PROTOCOL_URL = "https://api.usegossip.com/api";
+export const DEFAULT_USERNAME = "openclaw";
+
+function setGossipDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy): OpenClawConfig {
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+  const allowFrom =
+    dmPolicy === "open" ? addWildcardAllowFrom(base?.allowFrom as string[] | undefined) : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip: {
+        ...base,
+        dmPolicy,
+        ...(allowFrom ? { allowFrom } : {}),
+      },
+    } as OpenClawConfig["channels"],
+  };
+}
+
+function setGossipAllowFrom(cfg: OpenClawConfig, allowFrom: string[]): OpenClawConfig {
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip: {
+        ...base,
+        allowFrom,
+      },
+    } as OpenClawConfig["channels"],
+  };
+}
+
+function stripGossipPrefix(id: string): string {
+  const trimmed = id.trim();
+  if (trimmed.toLowerCase().startsWith("gossip:")) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+
+function parseAllowFromInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => (entry === "*" ? "*" : stripGossipPrefix(entry)))
+    .filter((entry) => entry === "*" || isValidUserId(entry));
+}
+
+async function promptGossipAllowFrom(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId?: string;
+}): Promise<OpenClawConfig> {
+  const accountId = params.accountId ?? resolveDefaultGossipAccountId(params.cfg);
+  const resolved = resolveGossipAccount({ cfg: params.cfg, accountId });
+  const existing = (resolved.config.allowFrom ?? []).map(String);
+
+  await params.prompter.note(
+    [
+      "Allowlist DMs by Gossip user ID (e.g. gossip1sw8cvs4vy6k...).",
+      "Leave blank to skip. Multiple IDs: comma-separated.",
+      `Docs: ${formatDocsLink("/channels/gossip", "gossip")}`,
+    ].join("\n"),
+    "Gossip allowlist",
+  );
+
+  const entry = await params.prompter.text({
+    message: "Gossip allowFrom (user IDs)",
+    placeholder: "paste one or more Gossip user IDs",
+    initialValue: existing[0] ?? undefined,
+    validate: (value) => {
+      const raw = String(value ?? "").trim();
+      if (!raw) {
+        return undefined;
+      }
+      const parts = parseAllowFromInput(raw);
+      for (const part of parts) {
+        if (part === "*") {
+          continue;
+        }
+        if (!isValidUserId(part)) {
+          return `Invalid Gossip user ID: ${part}`;
+        }
+      }
+      return undefined;
+    },
+  });
+
+  const parts = parseAllowFromInput(String(entry ?? ""));
+  const normalized = [...new Set(parts)];
+  return setGossipAllowFrom(params.cfg, normalized);
+}
+
+/** Gossip account id prompt with "default" as initial value for new account id. */
+async function promptGossipAccountId(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  currentId?: string;
+  defaultAccountId: string;
+}): Promise<string> {
+  const existingIds = listGossipAccountIds(params.cfg);
+  const initial = params.currentId?.trim() || params.defaultAccountId || DEFAULT_ACCOUNT_ID;
+  const choice = await params.prompter.select({
+    message: "Gossip account",
+    options: [
+      ...existingIds.map((id) => ({
+        value: id,
+        label: id === DEFAULT_ACCOUNT_ID ? "default (primary)" : id,
+      })),
+      { value: "__new__", label: "Add a new account" },
+    ],
+    initialValue: initial,
+  });
+
+  if (choice !== "__new__") {
+    return normalizeAccountId(choice);
+  }
+
+  const entered = await params.prompter.text({
+    message: "New Gossip account id",
+    initialValue: DEFAULT_ACCOUNT_ID,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const normalized = normalizeAccountId(String(entered));
+  if (String(entered).trim() !== normalized) {
+    await params.prompter.note(`Normalized account id to "${normalized}".`, "Gossip account");
+  }
+  return normalized;
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "Gossip",
+  channel,
+  policyKey: "channels.gossip.dmPolicy",
+  allowFromKey: "channels.gossip.allowFrom",
+  getCurrent: (cfg): DmPolicy => {
+    const raw = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+      | Record<string, unknown>
+      | undefined;
+    const p = raw?.dmPolicy;
+    if (p === "pairing" || p === "allowlist" || p === "open" || p === "disabled") {
+      return p;
+    }
+    return "pairing";
+  },
+  setPolicy: (cfg, policy) => setGossipDmPolicy(cfg, policy),
+  promptAllowFrom: promptGossipAllowFrom,
+};
+
+async function noteGossipHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "Gossip uses a mnemonic for identity. Leave mnemonic blank to auto-generate on first run.",
+      "Username is your display name. Protocol URL defaults to the official Gossip API.",
+      `Docs: ${formatDocsLink("/channels/gossip", "gossip")}`,
+    ].join("\n"),
+    "Gossip setup",
+  );
+}
+
+function applyGossipConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: {
+    name?: string;
+    username?: string;
+    protocolUrl?: string;
+    mnemonic?: string;
+  };
+}): OpenClawConfig {
+  const { cfg, input } = params;
+  const base = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | Record<string, unknown>
+    | undefined;
+
+  const gossip = {
+    ...base,
+    enabled: true,
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.username !== undefined ? { username: input.username } : {}),
+    ...(input.protocolUrl !== undefined ? { protocolUrl: input.protocolUrl } : {}),
+    ...(input.mnemonic !== undefined ? { mnemonic: input.mnemonic } : {}),
+  };
+
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gossip,
+    } as OpenClawConfig["channels"],
+  };
+}
+
+export const gossipOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  dmPolicy,
+
+  getStatus: async ({ cfg }) => {
+    const accountIds = listGossipAccountIds(cfg);
+    const configured = accountIds.some(
+      (id) => resolveGossipAccount({ cfg, accountId: id }).configured,
+    );
+
+    return {
+      channel,
+      configured,
+      statusLines: [`Gossip: ${configured ? "configured" : "needs setup"}`],
+      selectionHint: configured ? "configured" : "decentralized messenger",
+      quickstartScore: configured ? 1 : 4,
+    };
+  },
+
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides[channel]?.trim();
+    const defaultAccountId = resolveDefaultGossipAccountId(cfg);
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptGossipAccountId({
+        cfg,
+        prompter,
+        currentId: accountId,
+        defaultAccountId,
+      });
+    }
+
+    const resolved = resolveGossipAccount({ cfg, accountId });
+    await noteGossipHelp(prompter);
+
+    const username = accountId;
+
+    const protocolUrl = await prompter.text({
+      message: "Protocol API URL (blank for default)",
+      placeholder: DEFAULT_PROTOCOL_URL,
+      initialValue:
+        resolved.protocolUrl !== DEFAULT_PROTOCOL_URL ? resolved.protocolUrl : undefined,
+    });
+
+    const wantsMnemonic = await prompter.confirm({
+      message: "Set an existing mnemonic? (no = auto-generate on first run)",
+      initialValue: Boolean(resolved.mnemonic?.trim()),
+    });
+
+    let mnemonic: string | undefined;
+    if (wantsMnemonic) {
+      const raw = await prompter.text({
+        message: "BIP39 mnemonic (12/24 words)",
+        placeholder: "word1 word2 ...",
+        initialValue: resolved.mnemonic || undefined,
+      });
+      mnemonic = raw?.trim() || undefined;
+    }
+
+    const next = applyGossipConfig({
+      cfg,
+      accountId,
+      input: {
+        username,
+        protocolUrl: (protocolUrl?.trim() || DEFAULT_PROTOCOL_URL).trim(),
+        mnemonic,
+      },
+    });
+
+    // Start the bus briefly to obtain and display the Gossip user ID (saved to session.json).
+    const gossipCfg = (next.channels as Record<string, unknown> | undefined)?.gossip as
+      | { mnemonic?: string; username?: string; protocolUrl?: string }
+      | undefined;
+    const busMnemonic = gossipCfg?.mnemonic?.trim() || undefined;
+    const busUsername = (gossipCfg?.username?.trim() || DEFAULT_USERNAME).trim();
+    const busProtocolUrl = (gossipCfg?.protocolUrl?.trim() || DEFAULT_PROTOCOL_URL).trim();
+
+    let onboardingLog: { debug?(message: string): void } | undefined;
+    try {
+      onboardingLog = getGossipRuntime().logging.getChildLogger({
+        module: "gossip-onboarding",
+      });
+    } catch {
+      // Runtime not set (unusual during onboarding)
+    }
+
+    // User chose to generate a new mnemonic: clear any existing session so the bus creates a fresh one.
+    if (!busMnemonic) {
+      const storage = createGossipStorageAdapter(onboardingLog);
+      storage.deleteSessionData(accountId);
+    }
+
+    try {
+      const bus = await startGossipBus({
+        accountId,
+        mnemonic: busMnemonic,
+        username: busUsername,
+        protocolUrl: busProtocolUrl,
+        log: onboardingLog,
+        onMessage: async () => {},
+        onError: () => {},
+      });
+      const userId = bus.userId;
+      const mnemonicForBackup = bus.getMnemonic();
+      await bus.close();
+
+      const sessionPath = `${getGossipSessionsBaseDir()}/${accountId}/session.json`;
+      await prompter.note(
+        [
+          "Gossip onboarding complete.",
+          "",
+          "Share this Gossip ID to start a discussion with your agent:",
+          ``,
+          userId,
+          ``,
+          "Mnemonic backup phrase (save this safely):",
+          ``,
+          mnemonicForBackup,
+          ``,
+          `Both gossipId and mnemonic are saved in: ${sessionPath}`,
+        ].join("\n"),
+        "Gossip account details",
+      );
+    } catch (err) {
+      await prompter.note(
+        [
+          "Could not fetch your Gossip account details now (e.g. network).",
+          "After you start the gateway, your gossipId and mnemonic will be saved in:",
+          `${getGossipSessionsBaseDir()}/${accountId}/session.json`,
+        ].join("\n"),
+        "Gossip account details",
+      );
+    }
+
+    return { cfg: next, accountId };
+  },
+};

--- a/extensions/gossip/src/runtime.ts
+++ b/extensions/gossip/src/runtime.ts
@@ -1,0 +1,32 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: unknown = null;
+let resolvePath: ((input: string) => string) | null = null;
+
+export function setGossipRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function setGossipResolvePath(fn: (input: string) => string): void {
+  resolvePath = fn;
+}
+
+export function getGossipRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Gossip runtime not initialized");
+  }
+  return runtime as PluginRuntime;
+}
+
+/** Resolve user path (e.g. ~/.openclaw). Uses API resolvePath when set; otherwise falls back to process.env.HOME. */
+export function getGossipResolveUserPath(pathInput: string): string {
+  if (resolvePath) {
+    return resolvePath(pathInput);
+  }
+  const trimmed = pathInput.trim();
+  if (trimmed.startsWith("~/") || trimmed === "~") {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    return trimmed === "~" ? home : `${home}${trimmed.slice(1)}`;
+  }
+  return trimmed;
+}

--- a/extensions/gossip/src/storage.test.ts
+++ b/extensions/gossip/src/storage.test.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createGossipStorageAdapter,
+  type GossipSessionData,
+  type GossipStorageAdapter,
+} from "./storage.js";
+
+// Mock the runtime module to control the base directory
+vi.mock("./runtime.js", () => ({
+  getGossipResolveUserPath: (p: string) => p.replace("~", os.tmpdir()),
+}));
+
+describe("storage", () => {
+  let storage: GossipStorageAdapter;
+  let testBaseDir: string;
+  const testAccountId = "test-account-123";
+
+  beforeEach(() => {
+    storage = createGossipStorageAdapter();
+    testBaseDir = path.join(os.tmpdir(), ".openclaw", "sessions", "gossip");
+  });
+
+  afterEach(() => {
+    // Clean up test directories
+    const accountDir = path.join(testBaseDir, testAccountId);
+    if (fs.existsSync(accountDir)) {
+      fs.rmSync(accountDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("getSessionDir", () => {
+    it("creates the session directory if it does not exist", () => {
+      const dir = storage.getSessionDir(testAccountId);
+      expect(fs.existsSync(dir)).toBe(true);
+      expect(dir).toContain(testAccountId);
+    });
+
+    it("returns the same directory on subsequent calls", () => {
+      const dir1 = storage.getSessionDir(testAccountId);
+      const dir2 = storage.getSessionDir(testAccountId);
+      expect(dir1).toBe(dir2);
+    });
+  });
+
+  describe("saveSessionData / loadSessionData", () => {
+    it("saves and loads session data correctly", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
+        userId: "user-123",
+        username: "testuser",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      storage.saveSessionData(testAccountId, sessionData);
+      const loaded = storage.loadSessionData(testAccountId);
+
+      expect(loaded).toEqual(sessionData);
+    });
+
+    it("returns null for non-existent session", () => {
+      const loaded = storage.loadSessionData("non-existent-account");
+      expect(loaded).toBeNull();
+    });
+
+    it("saves session data with correct file permissions", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test mnemonic",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      storage.saveSessionData(testAccountId, sessionData);
+
+      const filePath = path.join(storage.getSessionDir(testAccountId), "session.json");
+      const stats = fs.statSync(filePath);
+      // Check file mode is 0o600 (owner read/write only)
+      const mode = stats.mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  describe("hasSessionData", () => {
+    it("returns false for non-existent session", () => {
+      expect(storage.hasSessionData("non-existent")).toBe(false);
+    });
+
+    it("returns true for existing session", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+
+      expect(storage.hasSessionData(testAccountId)).toBe(true);
+    });
+  });
+
+  describe("deleteSessionData", () => {
+    it("deletes all session files", () => {
+      const sessionData: GossipSessionData = {
+        mnemonic: "test",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      storage.saveSessionData(testAccountId, sessionData);
+
+      expect(storage.hasSessionData(testAccountId)).toBe(true);
+
+      storage.deleteSessionData(testAccountId);
+
+      expect(storage.hasSessionData(testAccountId)).toBe(false);
+      expect(storage.loadSessionData(testAccountId)).toBeNull();
+    });
+
+    it("handles deletion of non-existent session gracefully", () => {
+      // Should not throw
+      expect(() => storage.deleteSessionData("non-existent")).not.toThrow();
+    });
+  });
+});

--- a/extensions/gossip/src/storage.ts
+++ b/extensions/gossip/src/storage.ts
@@ -1,0 +1,107 @@
+/**
+ * File-based metadata storage for Gossip accounts.
+ *
+ * The SDK now manages message/discussion persistence natively.
+ * We keep only stable account metadata (mnemonic, userId, username) on disk.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getGossipResolveUserPath } from "./runtime.js";
+
+export interface GossipSessionData {
+  mnemonic: string;
+  /** Base64-encoded encrypted Gossip session blob */
+  encryptedSession?: string;
+  userId?: string;
+  username?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GossipStorageAdapter {
+  /** Get the session data directory for an account */
+  getSessionDir(accountId: string): string;
+  /** Load session data from disk */
+  loadSessionData(accountId: string): GossipSessionData | null;
+  /** Save session data to disk */
+  saveSessionData(accountId: string, data: GossipSessionData): void;
+  /** Check if session data exists */
+  hasSessionData(accountId: string): boolean;
+  /** Delete session data */
+  deleteSessionData(accountId: string): void;
+}
+
+/**
+ * Get the base directory for Gossip sessions.
+ * Uses ~/.openclaw/sessions/gossip/
+ */
+export function getGossipSessionsBaseDir(): string {
+  const openclawDir = getGossipResolveUserPath("~/.openclaw");
+  return path.join(openclawDir, "sessions", "gossip");
+}
+
+/**
+ * Create a file-based storage adapter for Gossip sessions.
+ */
+export function createGossipStorageAdapter(log?: {
+  debug?(message: string): void;
+}): GossipStorageAdapter {
+  const baseDir = getGossipSessionsBaseDir();
+
+  const ensureDir = (dir: string): void => {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+  };
+
+  const getSessionDir = (accountId: string): string => {
+    const dir = path.join(baseDir, accountId);
+    ensureDir(dir);
+    return dir;
+  };
+
+  const getSessionFilePath = (accountId: string): string => {
+    return path.join(getSessionDir(accountId), "session.json");
+  };
+
+  return {
+    getSessionDir,
+
+    loadSessionData(accountId: string): GossipSessionData | null {
+      const filePath = getSessionFilePath(accountId);
+      const exists = fs.existsSync(filePath);
+      if (!exists) {
+        return null;
+      }
+      try {
+        const raw = fs.readFileSync(filePath, "utf-8");
+        return JSON.parse(raw) as GossipSessionData;
+      } catch {
+        return null;
+      }
+    },
+
+    saveSessionData(accountId: string, data: GossipSessionData): void {
+      ensureDir(getSessionDir(accountId));
+      const filePath = getSessionFilePath(accountId);
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+    },
+
+    hasSessionData(accountId: string): boolean {
+      const filePath = getSessionFilePath(accountId);
+      const exists = fs.existsSync(filePath);
+      return exists;
+    },
+
+    deleteSessionData(accountId: string): void {
+      const sessionDir = path.join(baseDir, accountId);
+      if (fs.existsSync(sessionDir)) {
+        fs.rmSync(sessionDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/extensions/gossip/src/types.ts
+++ b/extensions/gossip/src/types.ts
@@ -1,0 +1,94 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { DEFAULT_PROTOCOL_URL, DEFAULT_USERNAME } from "./onboarding.js";
+
+export interface GossipAccountConfig {
+  enabled?: boolean;
+  name?: string;
+  mnemonic?: string;
+  username?: string;
+  protocolUrl?: string;
+  dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
+  allowFrom?: Array<string | number>;
+}
+
+export interface ResolvedGossipAccount {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  configured: boolean;
+  mnemonic: string;
+  username: string;
+  protocolUrl: string;
+  userId?: string; // Set after session is opened
+  config: GossipAccountConfig;
+}
+/**
+ * List all configured Gossip account IDs
+ */
+export function listGossipAccountIds(cfg: OpenClawConfig): string[] {
+  const gossipCfg = (cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | GossipAccountConfig
+    | undefined;
+
+  // If mnemonic is configured at top level, we have a default account
+  // Also consider configured if no mnemonic (will auto-generate)
+  if (gossipCfg?.enabled !== false) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+
+  return [];
+}
+
+/**
+ * Get the default account ID
+ */
+export function resolveDefaultGossipAccountId(cfg: OpenClawConfig): string {
+  const ids = listGossipAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Resolve a Gossip account from config
+ */
+export function resolveGossipAccount(opts: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedGossipAccount {
+  const accountId = opts.accountId ?? DEFAULT_ACCOUNT_ID;
+  const gossipCfg = (opts.cfg.channels as Record<string, unknown> | undefined)?.gossip as
+    | GossipAccountConfig
+    | undefined;
+
+  const baseEnabled = gossipCfg?.enabled !== false;
+  const mnemonic = gossipCfg?.mnemonic ?? "";
+  const username = gossipCfg?.username ?? DEFAULT_USERNAME;
+  const protocolUrl = gossipCfg?.protocolUrl ?? DEFAULT_PROTOCOL_URL;
+
+  // Account is considered "configured" if enabled.
+  // Mnemonic can be auto-generated if not provided.
+  const configured = baseEnabled;
+
+  return {
+    accountId,
+    name: gossipCfg?.name?.trim() || undefined,
+    enabled: baseEnabled,
+    configured,
+    mnemonic,
+    username,
+    protocolUrl,
+    userId: undefined, // Set when session is opened
+    config: {
+      enabled: gossipCfg?.enabled,
+      name: gossipCfg?.name,
+      mnemonic: gossipCfg?.mnemonic,
+      username: gossipCfg?.username,
+      protocolUrl: gossipCfg?.protocolUrl,
+      dmPolicy: gossipCfg?.dmPolicy,
+      allowFrom: gossipCfg?.allowFrom,
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,9 @@ settings:
 
 overrides:
   hono: 4.11.10
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
@@ -28,13 +28,13 @@ importers:
         version: 3.998.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(hono@4.11.10)(opusscript@0.1.1)(utf-8-validate@6.0.6)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
       '@discordjs/voice':
         specifier: ^0.19.0
-        version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+        version: 0.19.0(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(opusscript@0.1.1)(utf-8-validate@6.0.6)
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.40.0)
@@ -46,7 +46,7 @@ importers:
         version: 1.3.5
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
-        version: 1.59.0
+        version: 1.59.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@line/bot-sdk':
         specifier: ^10.6.0
         version: 10.6.0
@@ -55,13 +55,13 @@ importers:
         version: 1.2.0-beta.3
       '@mariozechner/pi-agent-core':
         specifier: 0.55.1
-        version: 0.55.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.55.1
-        version: 0.55.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.55.1
-        version: 0.55.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.55.1
         version: 0.55.1
@@ -76,7 +76,7 @@ importers:
         version: 0.34.48
       '@slack/bolt':
         specifier: ^4.6.0
-        version: 4.6.0(@types/express@5.0.6)
+        version: 4.6.0(@types/express@5.0.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@slack/web-api':
         specifier: ^7.14.1
         version: 7.14.1
@@ -85,7 +85,7 @@ importers:
         version: 0.1.9
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+        version: 7.0.0-rc.9(audio-decode@2.2.3)(bufferutil@4.1.0)(sharp@0.34.5)(utf-8-validate@6.0.6)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -145,7 +145,7 @@ importers:
         version: 14.1.1
       node-edge-tts:
         specifier: ^1.2.10
-        version: 1.2.10
+        version: 1.2.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       node-llama-cpp:
         specifier: 3.15.1
         version: 3.15.1(typescript@5.9.3)
@@ -181,13 +181,17 @@ importers:
         version: 7.22.0
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.24.0
@@ -218,7 +222,7 @@ importers:
         version: 7.0.0-dev.20260225.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -246,10 +250,6 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
 
   extensions/acpx:
     dependencies:
@@ -303,7 +303,7 @@ importers:
     dependencies:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.59.0
-        version: 1.59.0
+        version: 1.59.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -320,7 +320,20 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(bufferutil@4.1.0)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))(utf-8-validate@6.0.6)
+
+  extensions/gossip:
+    dependencies:
+      '@massalabs/gossip-sdk':
+        specifier: 0.0.2-dev.20260226131013
+        version: 0.0.2-dev.20260226131013(@cloudflare/workers-types@4.20260120.0)(@opentelemetry/api@1.9.0)(bun-types@1.3.9)(postgres@3.4.8)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/imessage: {}
 
@@ -356,7 +369,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(bufferutil@4.1.0)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))(utf-8-validate@6.0.6)
 
   extensions/memory-lancedb:
     dependencies:
@@ -368,7 +381,7 @@ importers:
         version: 0.34.48
       openai:
         specifier: ^6.25.0
-        version: 6.25.0(ws@8.19.0)(zod@4.3.6)
+        version: 6.25.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
 
   extensions/minimax-portal-auth: {}
 
@@ -422,7 +435,7 @@ importers:
         version: 8.0.3
       '@twurple/chat':
         specifier: ^8.0.3
-        version: 8.0.3(@twurple/auth@8.0.3)
+        version: 8.0.3(@twurple/auth@8.0.3)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -434,7 +447,7 @@ importers:
         version: 0.34.48
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -497,7 +510,7 @@ importers:
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
@@ -1406,6 +1419,12 @@ packages:
     resolution: {integrity: sha512-rnqDUp2fm/ySevC0Ltj/ZFRbEc1kZ1A4qHESejj9hA8NVrb/pX9g82XwTE762JOieEGrRWAtmHLNOm7/e4dJMw==}
     engines: {node: '>=20.0.0'}
 
+  '@massalabs/gossip-sdk@0.0.2-dev.20260226131013':
+    resolution: {integrity: sha512-n8P2g1ZJuPjMfv/ju8U/3a+7MX8AgszkeoL+dK8NEyROCkEBPpWYeavWquCp1JFTeoeNf9t4LWIwH9CYZfKoSQ==}
+
+  '@massalabs/massa-web3@5.3.0':
+    resolution: {integrity: sha512-bct2IwjUXN87KaUL3wBc70s6l4N4gVGweIFnVGnxFpp+uJESfwK1oty89yRbrq5Y0LVL3Y6TYZUH5FxJU5QkvA==}
+
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
     resolution: {integrity: sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==}
     engines: {node: '>= 22'}
@@ -1506,8 +1525,15 @@ packages:
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/ed25519@1.7.5':
+    resolution: {integrity: sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==}
+
   '@noble/ed25519@3.0.0':
     resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -3051,8 +3077,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -3242,6 +3268,9 @@ packages:
       bare-abort-controller:
         optional: true
 
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3289,6 +3318,12 @@ packages:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
     engines: {node: 18 || 20 || >=22}
 
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
+  bs58check@4.0.0:
+    resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
+
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
@@ -3297,6 +3332,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
 
   bun-types@1.3.9:
     resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
@@ -3562,9 +3601,105 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
+
+  drizzle-orm@0.45.1:
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
 
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
@@ -3908,6 +4043,9 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3918,6 +4056,9 @@ packages:
   grammy@1.40.0:
     resolution: {integrity: sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==}
     engines: {node: ^12.20.0 || >=14.13.1}
+
+  grpc-web@1.5.0:
+    resolution: {integrity: sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4332,6 +4473,10 @@ packages:
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
 
@@ -4583,6 +4728,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-llama-cpp@3.15.1:
     resolution: {integrity: sha512-/fBNkuLGR2Q8xj2eeV12KXKZ9vCS2+o6aP11lW40pB9H6f0B3wOALi/liFrjhHukAoiH6C9wFTPzv6039+5DRA==}
@@ -5029,7 +5178,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: ^2.34
+      request: npm:@cypress/request@3.0.10
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -5118,6 +5267,9 @@ packages:
 
   sanitize-html@2.17.1:
     resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
+
+  secure-random@1.1.2:
+    resolution: {integrity: sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -5565,6 +5717,10 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5583,6 +5739,9 @@ packages:
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5665,6 +5824,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  wa-sqlite@1.0.0:
+    resolution: {integrity: sha512-Kyybo5/BaJp76z7gDWGk2J6Hthl4NIPsE+swgraEjy3IY6r5zIR02wAs1OJH4XtJp1y3puj3Onp5eMGS0z7nUA==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -6277,17 +6439,17 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(hono@4.11.10)(opusscript@0.1.1)(utf-8-validate@6.0.6)':
     dependencies:
       '@types/node': 25.3.0
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(opusscript@0.1.1)(utf-8-validate@6.0.6)
       '@hono/node-server': 1.19.9(hono@4.11.10)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@discordjs/opus'
       - bufferutil
@@ -6365,15 +6527,15 @@ snapshots:
       '@d-fischer/shared-utils': 3.6.4
       tslib: 2.8.1
 
-  '@d-fischer/connection@9.0.0':
+  '@d-fischer/connection@9.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      '@d-fischer/isomorphic-ws': 7.0.2(ws@8.19.0)
+      '@d-fischer/isomorphic-ws': 7.0.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@d-fischer/logger': 4.2.4
       '@d-fischer/shared-utils': 3.6.4
       '@d-fischer/typed-event-emitter': 3.3.3
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6384,9 +6546,9 @@ snapshots:
 
   '@d-fischer/escape-string-regexp@5.0.0': {}
 
-  '@d-fischer/isomorphic-ws@7.0.2(ws@8.19.0)':
+  '@d-fischer/isomorphic-ws@7.0.2(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@d-fischer/logger@4.2.4':
     dependencies:
@@ -6433,13 +6595,13 @@ snapshots:
       - supports-color
     optional: true
 
-  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)':
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(opusscript@0.1.1)(utf-8-validate@6.0.6)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.40
       prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@discordjs/opus'
       - bufferutil
@@ -6545,12 +6707,12 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
+  '@google/genai@1.42.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6777,7 +6939,7 @@ snapshots:
       '@lancedb/lancedb-win32-arm64-msvc': 0.26.2
       '@lancedb/lancedb-win32-x64-msvc': 0.26.2
 
-  '@larksuiteoapi/node-sdk@1.59.0':
+  '@larksuiteoapi/node-sdk@1.59.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
@@ -6785,7 +6947,7 @@ snapshots:
       lodash.pickby: 4.6.0
       protobufjs: 7.5.4
       qs: 6.14.2
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6890,9 +7052,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6902,9 +7064,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-agent-core@0.55.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6914,17 +7076,17 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.42.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.10.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.22.0
@@ -6938,17 +7100,17 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.42.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.10.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.22.0
@@ -6962,12 +7124,12 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
+      '@mariozechner/pi-agent-core': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -6991,11 +7153,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.55.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7038,6 +7200,60 @@ snapshots:
       koffi: 2.15.1
       marked: 15.0.12
       mime-types: 3.0.2
+
+  '@massalabs/gossip-sdk@0.0.2-dev.20260226131013(@cloudflare/workers-types@4.20260120.0)(@opentelemetry/api@1.9.0)(bun-types@1.3.9)(postgres@3.4.8)':
+    dependencies:
+      '@massalabs/massa-web3': 5.3.0
+      '@scure/base': 2.0.0
+      '@scure/bip39': 2.0.1
+      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260120.0)(@opentelemetry/api@1.9.0)(bun-types@1.3.9)(postgres@3.4.8)
+      wa-sqlite: 1.0.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@cloudflare/workers-types'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - better-sqlite3
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+
+  '@massalabs/massa-web3@5.3.0':
+    dependencies:
+      '@noble/ed25519': 1.7.5
+      '@noble/hashes': 1.8.0
+      bs58check: 4.0.0
+      dotenv: 16.6.1
+      eventemitter3: 5.0.4
+      google-protobuf: 3.21.4
+      grpc-web: 1.5.0
+      lodash.isequal: 4.5.0
+      secure-random: 1.1.2
+      varint: 6.0.0
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
     dependencies:
@@ -7135,7 +7351,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
 
+  '@noble/ed25519@1.7.5': {}
+
   '@noble/ed25519@3.0.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -7906,11 +8126,11 @@ snapshots:
 
   '@sinclair/typebox@0.34.48': {}
 
-  '@slack/bolt@4.6.0(@types/express@5.0.6)':
+  '@slack/bolt@4.6.0(@types/express@5.0.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/oauth': 3.0.4
-      '@slack/socket-mode': 2.0.5
+      '@slack/socket-mode': 2.0.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
@@ -7939,14 +8159,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@slack/socket-mode@2.0.5':
+  '@slack/socket-mode@2.0.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/web-api': 7.14.1
       '@types/node': 25.3.0
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -8392,7 +8612,7 @@ snapshots:
       '@twurple/common': 8.0.3
       tslib: 2.8.1
 
-  '@twurple/chat@8.0.3(@twurple/auth@8.0.3)':
+  '@twurple/chat@8.0.3(@twurple/auth@8.0.3)(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
       '@d-fischer/cache-decorators': 4.0.1
       '@d-fischer/deprecate': 2.0.2
@@ -8402,7 +8622,7 @@ snapshots:
       '@d-fischer/typed-event-emitter': 3.3.3
       '@twurple/auth': 8.0.3
       '@twurple/common': 8.0.3
-      ircv3: 0.33.0
+      ircv3: 0.33.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -8631,9 +8851,9 @@ snapshots:
       - '@cypress/request'
       - supports-color
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
@@ -8644,7 +8864,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
@@ -8654,14 +8874,14 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -8675,7 +8895,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -8739,19 +8959,19 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(bufferutil@4.1.0)(sharp@0.34.5)(utf-8-validate@6.0.6)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
       lru-cache: 11.2.6
       music-metadata: 11.12.1
       p-queue: 9.1.0
       pino: 9.14.0
       protobufjs: 7.5.4
       sharp: 0.34.5
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       audio-decode: 2.2.3
     transitivePeerDependencies:
@@ -8759,7 +8979,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
@@ -8942,6 +9162,8 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  base-x@5.0.1: {}
+
   base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
@@ -9003,11 +9225,25 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
+  bs58check@4.0.0:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 6.0.0
+
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
 
   bun-types@1.3.9:
     dependencies:
@@ -9250,7 +9486,16 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@16.6.1: {}
+
   dotenv@17.3.1: {}
+
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260120.0)(@opentelemetry/api@1.9.0)(bun-types@1.3.9)(postgres@3.4.8):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260120.0
+      '@opentelemetry/api': 1.9.0
+      bun-types: 1.3.9
+      postgres: 3.4.8
 
   dts-resolver@2.1.3: {}
 
@@ -9701,6 +9946,8 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  google-protobuf@3.21.4: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9714,6 +9961,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  grpc-web@1.5.0: {}
 
   has-flag@4.0.0: {}
 
@@ -9880,9 +10129,9 @@ snapshots:
     optionalDependencies:
       '@reflink/reflink': 0.1.19
 
-  ircv3@0.33.0:
+  ircv3@0.33.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      '@d-fischer/connection': 9.0.0
+      '@d-fischer/connection': 9.0.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@d-fischer/escape-string-regexp': 5.0.0
       '@d-fischer/logger': 4.2.4
       '@d-fischer/shared-utils': 3.6.4
@@ -10139,6 +10388,8 @@ snapshots:
 
   lodash.isboolean@3.0.3: {}
 
+  lodash.isequal@4.5.0: {}
+
   lodash.isinteger@4.0.4: {}
 
   lodash.isnumber@3.0.3: {}
@@ -10340,10 +10591,10 @@ snapshots:
 
   node-downloader-helper@2.1.10: {}
 
-  node-edge-tts@1.2.10:
+  node-edge-tts@1.2.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       https-proxy-agent: 7.0.6
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -10359,6 +10610,9 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-llama-cpp@3.15.1(typescript@5.9.3):
     dependencies:
@@ -10503,40 +10757,40 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.10.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.10.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
 
-  openai@6.25.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.25.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.3.6
 
-  openclaw@2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3)):
+  openclaw@2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(bufferutil@4.1.0)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))(utf-8-validate@6.0.6):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.998.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(hono@4.11.10)(opusscript@0.1.1)(utf-8-validate@6.0.6)
       '@clack/prompts': 1.0.1
-      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(bufferutil@4.1.0)(opusscript@0.1.1)(utf-8-validate@6.0.6)
       '@grammyjs/runner': 2.0.3(grammy@1.40.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.40.0)
       '@homebridge/ciao': 1.3.5
-      '@larksuiteoapi/node-sdk': 1.59.0
+      '@larksuiteoapi/node-sdk': 1.59.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.55.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.0
       '@mozilla/readability': 0.6.0
       '@napi-rs/canvas': 0.1.95
       '@sinclair/typebox': 0.34.48
-      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@slack/web-api': 7.14.1
       '@snazzah/davey': 0.1.9
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(bufferutil@4.1.0)(sharp@0.34.5)(utf-8-validate@6.0.6)
       ajv: 8.18.0
       chalk: 5.6.2
       chokidar: 5.0.0
@@ -10556,7 +10810,7 @@ snapshots:
       linkedom: 0.18.12
       long: 5.3.2
       markdown-it: 14.1.1
-      node-edge-tts: 1.2.10
+      node-edge-tts: 1.2.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       node-llama-cpp: 3.15.1(typescript@5.9.3)
       opusscript: 0.1.1
       osc-progress: 0.3.0
@@ -10568,7 +10822,7 @@ snapshots:
       tar: 7.5.9
       tslog: 4.10.2
       undici: 7.22.0
-      ws: 8.19.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yaml: 2.8.2
       zod: 4.3.6
     optionalDependencies:
@@ -11118,6 +11372,8 @@ snapshots:
       parse-srcset: 1.0.2
       postcss: 8.5.6
 
+  secure-random@1.1.2: {}
+
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
@@ -11620,6 +11876,11 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -11629,6 +11890,8 @@ snapshots:
   uuid@8.3.2: {}
 
   validate-npm-package-name@6.0.2: {}
+
+  varint@6.0.0: {}
 
   vary@1.1.2: {}
 
@@ -11679,7 +11942,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@6.0.6)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11692,6 +11955,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  wa-sqlite@1.0.0: {}
 
   web-streams-polyfill@3.3.3: {}
 
@@ -11737,7 +12002,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Adds a new **Gossip** channel extension so OpenClaw can send and receive messages via Gossip alongside the existing channels.

Gossip is a privacy-focused, decentralized messenger that enables users to send and receive encrypted direct messages without requiring a phone number or relying on centralized servers. For more details, see the official Gossip site at https://usegossip.massa.network/.

## Details

- Introduces the `extensions/gossip` plugin with channel wiring and configuration
- Hooks Gossip into the standard routing and channel abstractions including dmPolicy
- Adds user-facing documentation for configuring and using the Gossip channel

## Change Type (select all)

- [x] Feature

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified local setup of the Gossip extension
- Sent and received messages through Gossip to confirm end-to-end behavior

<img width="1476" height="1114" alt="image" src="https://github.com/user-attachments/assets/7afd95a6-d424-4d07-8f05-93ac8a10183e" />