### PR TITLE
logging: add structured file log format (prefix + original JSON)

### DIFF
--- a/src/logging/parse-log-line.test.ts
+++ b/src/logging/parse-log-line.test.ts
@@ -42,4 +42,33 @@ describe("parseLogLine", () => {
   it("returns null for invalid JSON", () => {
     expect(parseLogLine("not-json")).toBeNull();
   });
+
+  it("parses structured prefix + short message", () => {
+    const line = "[2026-02-23 15:42:38.123] [12345] [gateway] info: hello world";
+    const parsed = parseLogLine(line);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.time).toBe("2026-02-23 15:42:38.123");
+    expect(parsed?.level).toBe("info");
+    expect(parsed?.subsystem).toBe("gateway");
+    expect(parsed?.message).toBe("hello world");
+    expect(parsed?.raw).toBe(line);
+  });
+
+  it("parses structured prefix + JSON payload (full line)", () => {
+    const jsonPayload = JSON.stringify({
+      time: "2026-02-23T07:42:38.123Z",
+      0: '{"subsystem":"gateway/channels/whatsapp"}',
+      1: "connected",
+      _meta: { name: '{"subsystem":"gateway/channels/whatsapp"}', logLevelName: "INFO" },
+    });
+    const line =
+      "[2026-02-23 15:42:38.123] [12345] [gateway/channels/whatsapp] info: " + jsonPayload;
+    const parsed = parseLogLine(line);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.time).toBe("2026-02-23 15:42:38.123");
+    expect(parsed?.level).toBe("info");
+    expect(parsed?.subsystem).toBe("gateway/channels/whatsapp");
+    expect(parsed?.message).toBe(jsonPayload);
+    expect(parsed?.raw).toBe(line);
+  });
 });


### PR DESCRIPTION
## Summary

- **Problem:** File logs were one JSON object per line with no leading structure; hard to grep by time/pid/subsystem without parsing JSON.
- **Why it matters:** Operators often `tail`/`grep` log files; a structured prefix (time, pid, subsystem, level) at the start of each line makes filtering and scanning easier while keeping full payload for tools that need it.
- **What changed:** (1) File log lines are now written as `[YYYY-MM-DD HH:mm:ss.SSS] [pid] [subsystem] level: <original JSON line>`. The content after the prefix is the same as before (one full JSON object per line). (2) `parseLogLine()` accepts both this structured format (regex) and legacy plain-JSON lines for backward compatibility.
- **What did NOT change:** Console output; log level/config; CLI `logs` command behavior (still parses and displays); default log path or rotation. No change to what data is logged—only a prefix is added.

## Format change: before vs after

<!-- markdownlint-disable MD060 -->

| Item                    | Before                                                    | After                                                                               |
| ----------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| **Line format**         | Single-line JSON (NDJSON)                                 | Structured prefix + same single-line JSON: `[time] [pid] [subsystem] level: <json>` |
| **Time**                | ISO 8601 or `_meta.date`, e.g. `2026-01-09T01:38:41.523Z` | Prefix: local `YYYY-MM-DD HH:mm:ss.SSS`; payload still has `time` in JSON           |
| **Pid/subsystem/level** | In `_meta`, numeric keys; requires JSON parsing           | In prefix: `[pid]`, `[subsystem]`, `level:`; payload unchanged                      |
| **Payload**             | Full log object as JSON                                   | Same full log object as JSON after the prefix                                       |
| **Readability**         | Needed `jq` or parser to see time/subsystem               | `tail`/`grep` can match on prefix; full payload still in line                       |

<!-- markdownlint-enable MD060 -->

**Before (one line):**

```json
{
  "time": "2026-01-09T01:38:41.523Z",
  "0": "{\"subsystem\":\"gateway/channels/whatsapp\"}",
  "1": "connected",
  "_meta": { "name": "{\"subsystem\":\"gateway/channels/whatsapp\"}", "logLevelName": "INFO" }
}
```

**After (one line):**

```
[2026-02-23 15:42:38.123] [12345] [gateway/channels/whatsapp] info: {"time":"2026-02-23T07:42:38.123Z","0":"{\"subsystem\":\"gateway/channels/whatsapp\"}","1":"connected","_meta":{...}}
```

**Parse compatibility:** `parseLogLine()` tries the structured format first (regex: prefix + rest as message), then falls back to legacy JSON. So existing plain-JSON log files and new structured lines are both readable by the CLI and Control UI.

## Benefits and value

| Benefit                 | How it shows up                                                                    |
| ----------------------- | ---------------------------------------------------------------------------------- |
| **Easier to grep**      | Prefix gives time, pid, subsystem, level at a glance without parsing JSON.         |
| **Standard tooling**    | `tail -f`, `grep '\[web-outbound\]'`, `grep 'error:'` work on the prefix.          |
| **Full payload**        | Original JSON preserved after prefix; no loss of fields or backward compatibility. |
| **Backward compatible** | Parser accepts both structured lines and legacy JSON lines; mixed files work.      |

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] API / contracts (log file format is a contract for tail/CLI/Control UI)
- [ ] Gateway / orchestration
- [ ] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- **File log format:** Each line is now `[YYYY-MM-DD HH:mm:ss.SSS] [pid] [subsystem] level: <original JSON>`. Same data as before; only a structured prefix is prepended. Existing JSON-line log files remain parseable; new writes use the prefixed format.
- **Docs:** Update [Logging](https://docs.openclaw.ai/logging) “File logs” section to describe the new format if not already done in this PR.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

- Run gateway with file logging enabled; `tail -f` the log file and confirm each line starts with `[date time] [pid] [subsystem] level: ` followed by JSON.
- Run `openclaw logs --follow` (and Control UI Logs tab) and confirm entries display correctly for both new-format and old JSON-line files.

## Compatibility / Migration

- **Backward compatible?** Yes. Parser accepts both the new structured lines and legacy JSON lines.
- **Config/env changes?** No.
- **Migration needed?** No. Old log files remain readable; new writes use the prefixed format.

## Risks and Mitigations

- **Risk:** Tools that assume each line is _only_ JSON (no prefix) may need to strip the prefix or use the parser.
  - **Mitigation:** Document the format; `parseLogLine()` supports both; legacy JSON-only lines still parse.
