### PR TITLE
feat(dingtalk): add DingTalk channel extension with custom robot webhook support

### DIFF
--- a/extensions/dingtalk/index.ts
+++ b/extensions/dingtalk/index.ts
@@ -1,0 +1,17 @@
+import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { dingtalkPlugin } from "./src/channel.js";
+import { setDingTalkRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "dingtalk",
+  name: "DingTalk",
+  description: "DingTalk (钉钉) channel plugin — enterprise messaging via custom robot webhook",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setDingTalkRuntime(api.runtime);
+    api.registerChannel({ plugin: dingtalkPlugin as ChannelPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/dingtalk/openclaw.plugin.json
+++ b/extensions/dingtalk/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "dingtalk",
+  "channels": ["dingtalk"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/dingtalk/package.json
+++ b/extensions/dingtalk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/dingtalk",
+  "version": "2026.2.26",
+  "description": "OpenClaw DingTalk channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.25"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "dingtalk",
+      "label": "DingTalk",
+      "selectionLabel": "DingTalk (钉钉)",
+      "detailLabel": "DingTalk",
+      "docsPath": "/channels/dingtalk",
+      "docsLabel": "dingtalk",
+      "blurb": "DingTalk enterprise messaging via custom robot webhooks.",
+      "aliases": [
+        "dingtalk",
+        "ding"
+      ],
+      "order": 40,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/dingtalk",
+      "localPath": "extensions/dingtalk",
+      "defaultChoice": "local"
+    }
+  }
+}

--- a/extensions/dingtalk/src/accounts.test.ts
+++ b/extensions/dingtalk/src/accounts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDingTalkWebhookUrl,
+  listDingTalkAccountIds,
+  resolveDingTalkAccount,
+} from "./accounts.js";
+import type { CoreConfig } from "./types.js";
+
+describe("buildDingTalkWebhookUrl", () => {
+  it("builds a valid webhook URL from an access token", () => {
+    const url = buildDingTalkWebhookUrl("my-token");
+    expect(url).toBe("https://oapi.dingtalk.com/robot/send?access_token=my-token");
+  });
+
+  it("URL-encodes the access token", () => {
+    const url = buildDingTalkWebhookUrl("token with spaces");
+    expect(url).toContain("token%20with%20spaces");
+  });
+});
+
+describe("listDingTalkAccountIds", () => {
+  it("returns empty for unconfigured", () => {
+    const cfg: CoreConfig = {};
+    expect(listDingTalkAccountIds(cfg)).toEqual([]);
+  });
+
+  it("returns default when accessToken is set", () => {
+    const cfg: CoreConfig = {
+      channels: { dingtalk: { accessToken: "tok" } },
+    };
+    expect(listDingTalkAccountIds(cfg)).toContain("default");
+  });
+
+  it("returns named accounts", () => {
+    const cfg: CoreConfig = {
+      channels: { dingtalk: { accounts: { work: { accessToken: "tok" } } } },
+    };
+    expect(listDingTalkAccountIds(cfg)).toContain("work");
+  });
+});
+
+describe("resolveDingTalkAccount", () => {
+  it("resolves the default account", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        dingtalk: { accessToken: "my-token", secret: "my-secret" },
+      },
+    };
+    const account = resolveDingTalkAccount({ cfg, accountId: "default" });
+    expect(account.webhookUrl).toContain("my-token");
+    expect(account.config.secret).toBe("my-secret");
+  });
+
+  it("uses a custom webhookUrl when provided", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        dingtalk: {
+          accessToken: "tok",
+          webhookUrl: "https://custom.example.com/webhook",
+        },
+      },
+    };
+    const account = resolveDingTalkAccount({ cfg, accountId: "default" });
+    expect(account.webhookUrl).toBe("https://custom.example.com/webhook");
+  });
+});

--- a/extensions/dingtalk/src/accounts.ts
+++ b/extensions/dingtalk/src/accounts.ts
@@ -1,0 +1,67 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import type { CoreConfig, DingTalkAccountConfig } from "./types.js";
+
+const DINGTALK_WEBHOOK_BASE = "https://oapi.dingtalk.com/robot/send";
+
+export function buildDingTalkWebhookUrl(accessToken: string): string {
+  return `${DINGTALK_WEBHOOK_BASE}?access_token=${encodeURIComponent(accessToken)}`;
+}
+
+export type ResolvedDingTalkAccount = {
+  accountId: string;
+  config: DingTalkAccountConfig;
+  webhookUrl: string;
+};
+
+export function listDingTalkAccountIds(cfg: CoreConfig): string[] {
+  const dingtalk = cfg.channels?.dingtalk;
+  if (!dingtalk) {
+    return [];
+  }
+  const ids = Object.keys(dingtalk.accounts ?? {});
+  const hasDefault =
+    dingtalk.accessToken?.trim() || dingtalk.webhookUrl?.trim() || dingtalk.inboundPath?.trim();
+  if (hasDefault && !ids.includes(DEFAULT_ACCOUNT_ID)) {
+    ids.unshift(DEFAULT_ACCOUNT_ID);
+  }
+  return ids;
+}
+
+export function resolveDefaultDingTalkAccountId(cfg: CoreConfig): string {
+  return listDingTalkAccountIds(cfg)[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+export function resolveRawDingTalkAccountConfig(
+  cfg: CoreConfig,
+  accountId: string,
+): DingTalkAccountConfig | undefined {
+  const dingtalk = cfg.channels?.dingtalk;
+  if (!dingtalk) {
+    return undefined;
+  }
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return dingtalk;
+  }
+  return dingtalk.accounts?.[accountId];
+}
+
+export function resolveDingTalkAccount(params: {
+  cfg: CoreConfig;
+  accountId: string;
+}): ResolvedDingTalkAccount {
+  const { cfg, accountId } = params;
+  const raw = resolveRawDingTalkAccountConfig(cfg, accountId);
+  if (!raw) {
+    throw new Error(`DingTalk account "${accountId}" not found in config`);
+  }
+
+  const accessToken = raw.accessToken?.trim() ?? "";
+  const webhookUrl =
+    raw.webhookUrl?.trim() || (accessToken ? buildDingTalkWebhookUrl(accessToken) : "");
+
+  return {
+    accountId,
+    config: raw,
+    webhookUrl,
+  };
+}

--- a/extensions/dingtalk/src/channel.ts
+++ b/extensions/dingtalk/src/channel.ts
@@ -1,0 +1,205 @@
+import {
+  buildBaseAccountStatusSnapshot,
+  buildBaseChannelStatusSummary,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  getChatChannelMeta,
+  PAIRING_APPROVED_MESSAGE,
+  resolveDefaultGroupPolicy,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import {
+  listDingTalkAccountIds,
+  resolveDingTalkAccount,
+  resolveDefaultDingTalkAccountId,
+  type ResolvedDingTalkAccount,
+} from "./accounts.js";
+import { monitorDingTalkProvider, resolveDingTalkWebhookPath } from "./monitor.js";
+import { dingtalkOnboardingAdapter } from "./onboarding.js";
+import { isDingTalkSenderAllowed, resolveDingTalkDmAllowFrom } from "./policy.js";
+import { probeDingTalk } from "./probe.js";
+import { getDingTalkRuntime } from "./runtime.js";
+import { buildDingTalkTextMessage, sendDingTalkMessage, sendDingTalkSessionReply } from "./send.js";
+import type { CoreConfig, DingTalkInboundEvent, DingTalkProbe } from "./types.js";
+
+const meta = getChatChannelMeta("dingtalk");
+
+const DINGTALK_TEXT_CHUNK = 4096;
+
+export const dingtalkPlugin: ChannelPlugin<ResolvedDingTalkAccount, DingTalkProbe> = {
+  id: "dingtalk",
+  meta: {
+    ...meta,
+    quickstartAllowFrom: true,
+  },
+  onboarding: dingtalkOnboardingAdapter,
+
+  pairing: {
+    idLabel: "senderId",
+    normalizeAllowEntry: (entry) => entry.trim(),
+    notifyApproval: async ({ id, accountId, config }) => {
+      const account = resolveDingTalkAccount({ cfg: config as CoreConfig, accountId });
+      await sendDingTalkMessage({
+        webhookUrl: account.webhookUrl,
+        secret: account.config.secret,
+        message: buildDingTalkTextMessage(
+          `${PAIRING_APPROVED_MESSAGE} ${formatPairingApproveHint({ id })}`,
+        ),
+      });
+    },
+  },
+
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    media: false,
+    blockStreaming: false,
+  },
+
+  reload: { configPrefixes: ["channels.dingtalk"] },
+  configSchema: buildChannelConfigSchema({
+    type: "object",
+    additionalProperties: true,
+    properties: {},
+  }),
+
+  config: {
+    listAccountIds: (cfg) => listDingTalkAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) =>
+      resolveDingTalkAccount({ cfg: cfg as CoreConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultDingTalkAccountId(cfg as CoreConfig),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "dingtalk",
+        accountId,
+        enabled,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "dingtalk",
+        accountId,
+      }),
+
+    resolveStatus: ({ cfg, account }) => {
+      const hasToken = Boolean(account.config.accessToken?.trim() || account.webhookUrl);
+      const issues = hasToken
+        ? []
+        : [
+            {
+              kind: "warning" as const,
+              message: "No access token configured — outbound messages will fail",
+            },
+          ];
+      return buildBaseAccountStatusSnapshot({ accountId: account.accountId, issues });
+    },
+
+    resolveSummary: ({ cfg }) =>
+      buildBaseChannelStatusSummary({
+        channelId: "dingtalk",
+        accounts: listDingTalkAccountIds(cfg as CoreConfig),
+      }),
+  },
+
+  // ---- Monitor (inbound webhook) -------------------------------------------
+
+  monitor: {
+    start: ({ cfg, dispatch, accountId }) => {
+      const account = resolveDingTalkAccount({ cfg: cfg as CoreConfig, accountId });
+      const rt = getDingTalkRuntime();
+
+      const inboundPath = resolveDingTalkWebhookPath({
+        accountId,
+        configuredPath: account.config.inboundPath,
+      });
+
+      return monitorDingTalkProvider({
+        accountId,
+        inboundPath,
+        secret: account.config.secret,
+        runtime: rt as Parameters<typeof monitorDingTalkProvider>[0]["runtime"],
+        onMessage: async (event: DingTalkInboundEvent) => {
+          const senderId = event.senderId ?? "";
+          const senderNick = event.senderNick ?? "";
+          const text = event.text?.content?.trim() ?? event.content?.trim() ?? "";
+          if (!text) {
+            return;
+          }
+
+          const allowFrom = resolveDingTalkDmAllowFrom(cfg as CoreConfig, accountId);
+          const isGroup = event.conversationType === "2";
+
+          if (!isGroup) {
+            const allowed = isDingTalkSenderAllowed({ senderId, senderNick, allowFrom });
+            if (!allowed) {
+              return;
+            }
+          }
+
+          const replyFn = event.sessionWebhook
+            ? async (replyText: string) => {
+                await sendDingTalkSessionReply({
+                  sessionWebhook: event.sessionWebhook!,
+                  message: buildDingTalkTextMessage(replyText),
+                });
+              }
+            : async (replyText: string) => {
+                await sendDingTalkMessage({
+                  webhookUrl: account.webhookUrl,
+                  secret: account.config.secret,
+                  message: buildDingTalkTextMessage(replyText),
+                });
+              };
+
+          await dispatch({
+            channelId: "dingtalk",
+            accountId,
+            senderId,
+            senderName: senderNick,
+            text,
+            reply: replyFn,
+            isGroup,
+            conversationId: event.conversationId,
+            messageId: event.msgId,
+          });
+        },
+      });
+    },
+  },
+
+  // ---- Outbound ------------------------------------------------------------
+
+  outbound: {
+    send: async ({ account, text }) => {
+      const chunks = splitText(text, account.config.textChunkLimit ?? DINGTALK_TEXT_CHUNK);
+      for (const chunk of chunks) {
+        await sendDingTalkMessage({
+          webhookUrl: account.webhookUrl,
+          secret: account.config.secret,
+          message: buildDingTalkTextMessage(chunk),
+        });
+      }
+    },
+  },
+
+  // ---- Probe ---------------------------------------------------------------
+
+  probe: ({ account }) =>
+    probeDingTalk({ webhookUrl: account.webhookUrl, secret: account.config.secret }),
+};
+
+function splitText(text: string, chunkSize: number): string[] {
+  if (text.length <= chunkSize) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    chunks.push(remaining.slice(0, chunkSize));
+    remaining = remaining.slice(chunkSize);
+  }
+  return chunks;
+}

--- a/extensions/dingtalk/src/monitor.ts
+++ b/extensions/dingtalk/src/monitor.ts
@@ -1,0 +1,81 @@
+import type { ChannelMonitorHandle } from "openclaw/plugin-sdk";
+import { verifyDingTalkSignature } from "./sign.js";
+import type { DingTalkInboundEvent } from "./types.js";
+
+export type DingTalkMonitorOptions = {
+  path: string;
+  secret?: string;
+  onMessage: (event: DingTalkInboundEvent) => Promise<void>;
+};
+
+/**
+ * Compute the inbound webhook path for a given account.
+ * Defaults to /dingtalk/<accountId> if not explicitly configured.
+ */
+export function resolveDingTalkWebhookPath(params: {
+  accountId: string;
+  configuredPath?: string;
+}): string {
+  if (params.configuredPath?.trim()) {
+    return params.configuredPath.trim();
+  }
+  return params.accountId === "default" ? "/dingtalk" : `/dingtalk/${params.accountId}`;
+}
+
+/**
+ * Register a DingTalk inbound webhook handler on the gateway HTTP server.
+ * DingTalk POSTs JSON event payloads to this path when users @mention the bot.
+ */
+export function monitorDingTalkProvider(params: {
+  accountId: string;
+  inboundPath?: string;
+  secret?: string;
+  runtime: {
+    registerHttpHandler: (
+      path: string,
+      handler: (req: Request) => Promise<Response>,
+    ) => ChannelMonitorHandle;
+  };
+  onMessage: (event: DingTalkInboundEvent) => Promise<void>;
+}): ChannelMonitorHandle {
+  const path = resolveDingTalkWebhookPath({
+    accountId: params.accountId,
+    configuredPath: params.inboundPath,
+  });
+
+  return params.runtime.registerHttpHandler(path, async (req: Request) => {
+    // DingTalk signs inbound messages when a signing secret is configured.
+    if (params.secret) {
+      const url = new URL(req.url);
+      const timestamp = url.searchParams.get("timestamp") ?? "";
+      const sign = url.searchParams.get("sign") ?? "";
+      const valid = verifyDingTalkSignature({
+        timestamp,
+        sign,
+        secret: params.secret,
+      });
+      if (!valid) {
+        return new Response(JSON.stringify({ errcode: 403, errmsg: "Invalid signature" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    let event: DingTalkInboundEvent;
+    try {
+      event = (await req.json()) as DingTalkInboundEvent;
+    } catch {
+      return new Response(JSON.stringify({ errcode: 400, errmsg: "Invalid JSON" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Respond immediately so DingTalk doesn't time out, then process async.
+    void params.onMessage(event).catch(() => {});
+    return new Response(JSON.stringify({ errcode: 0, errmsg: "ok" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}

--- a/extensions/dingtalk/src/onboarding.ts
+++ b/extensions/dingtalk/src/onboarding.ts
@@ -1,0 +1,138 @@
+import {
+  addWildcardAllowFrom,
+  DEFAULT_ACCOUNT_ID,
+  formatDocsLink,
+  promptChannelAccessConfig,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type DmPolicy,
+} from "openclaw/plugin-sdk";
+import { resolveDingTalkWebhookPath } from "./monitor.js";
+import type { CoreConfig, DingTalkAccountConfig } from "./types.js";
+
+const CHANNEL = "dingtalk" as const;
+
+function setDingTalkDmPolicy(cfg: CoreConfig, dmPolicy: DmPolicy, accountId: string): CoreConfig {
+  const dt = cfg.channels?.dingtalk ?? {};
+  const current = accountId === DEFAULT_ACCOUNT_ID ? dt : (dt.accounts?.[accountId] ?? {});
+  const allowFrom =
+    dmPolicy === "open" ? addWildcardAllowFrom(current.allowFrom) : current.allowFrom;
+
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        dingtalk: { ...dt, dmPolicy, ...(allowFrom ? { allowFrom } : {}) },
+      },
+    };
+  }
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      dingtalk: {
+        ...dt,
+        accounts: {
+          ...dt.accounts,
+          [accountId]: { ...current, dmPolicy, ...(allowFrom ? { allowFrom } : {}) },
+        },
+      },
+    },
+  };
+}
+
+function patchDingTalkAccount(
+  cfg: CoreConfig,
+  accountId: string,
+  patch: Partial<DingTalkAccountConfig>,
+): CoreConfig {
+  const dt = cfg.channels?.dingtalk ?? {};
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: { ...cfg.channels, dingtalk: { ...dt, ...patch } },
+    };
+  }
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      dingtalk: {
+        ...dt,
+        accounts: { ...dt.accounts, [accountId]: { ...dt.accounts?.[accountId], ...patch } },
+      },
+    },
+  };
+}
+
+export const dingtalkOnboardingAdapter: ChannelOnboardingAdapter<CoreConfig> = {
+  channel: CHANNEL,
+
+  async setup({ prompter, config, accountId }) {
+    const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+    let cfg = config as CoreConfig;
+    const existing = cfg.channels?.dingtalk ?? {};
+    const accountCfg = aid === DEFAULT_ACCOUNT_ID ? existing : (existing.accounts?.[aid] ?? {});
+
+    prompter.log(
+      formatDocsLink(
+        "DingTalk custom robot setup",
+        "/channels/dingtalk",
+        "https://open.dingtalk.com/document/robots/custom-robot-access",
+      ),
+    );
+
+    // --- Access token -------------------------------------------------------
+    const accessToken = await prompter.text({
+      message: "DingTalk robot access token (from the 'Custom Robot' settings):",
+      initialValue: accountCfg.accessToken ?? "",
+      validate: (v) => (v.trim() ? undefined : "Access token is required"),
+    });
+
+    cfg = patchDingTalkAccount(cfg, aid, { accessToken: accessToken.trim() });
+
+    // --- Signing secret (optional but recommended) ---------------------------
+    const secret = await prompter.text({
+      message: "DingTalk signing secret (optional but strongly recommended):",
+      initialValue: accountCfg.secret ?? "",
+    });
+    if (secret.trim()) {
+      cfg = patchDingTalkAccount(cfg, aid, { secret: secret.trim() });
+    }
+
+    // --- Inbound path -------------------------------------------------------
+    const defaultInboundPath = resolveDingTalkWebhookPath({ accountId: aid });
+    prompter.log(
+      `Inbound webhook path (configure this URL in DingTalk bot settings: <gateway>/<path>):`,
+    );
+    const inboundPath = await prompter.text({
+      message: "Inbound webhook path:",
+      initialValue: accountCfg.inboundPath ?? defaultInboundPath,
+    });
+    cfg = patchDingTalkAccount(cfg, aid, {
+      inboundPath: inboundPath.trim() || defaultInboundPath,
+    });
+
+    // --- DM policy ----------------------------------------------------------
+    const dmPolicyResult = await promptChannelAccessConfig<CoreConfig>({
+      prompter,
+      channel: CHANNEL,
+      config: cfg,
+      accountId: aid,
+      setDmPolicy: (c, policy) => setDingTalkDmPolicy(c, policy, aid),
+    });
+    cfg = dmPolicyResult.config;
+
+    return { config: cfg };
+  },
+
+  resolveDmPolicy({ config, accountId }): ChannelOnboardingDmPolicy {
+    const dt = (config as CoreConfig).channels?.dingtalk;
+    if (!dt) {
+      return { dmPolicy: "pairing" };
+    }
+    const account = accountId === DEFAULT_ACCOUNT_ID ? dt : (dt.accounts?.[accountId] ?? dt);
+    return { dmPolicy: (account.dmPolicy as DmPolicy) ?? "pairing" };
+  },
+};

--- a/extensions/dingtalk/src/policy.test.ts
+++ b/extensions/dingtalk/src/policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isDingTalkSenderAllowed } from "./policy.js";
+
+describe("isDingTalkSenderAllowed", () => {
+  it("allows when wildcard is in list", () => {
+    expect(isDingTalkSenderAllowed({ senderId: "abc123", allowFrom: ["*"] })).toBe(true);
+  });
+
+  it("allows when senderId is in list", () => {
+    expect(isDingTalkSenderAllowed({ senderId: "abc123", allowFrom: ["abc123", "xyz789"] })).toBe(
+      true,
+    );
+  });
+
+  it("allows when senderNick matches", () => {
+    expect(
+      isDingTalkSenderAllowed({
+        senderId: "uid-001",
+        senderNick: "Alice",
+        allowFrom: ["Alice"],
+      }),
+    ).toBe(true);
+  });
+
+  it("denies when neither id nor nick matches", () => {
+    expect(
+      isDingTalkSenderAllowed({
+        senderId: "uid-999",
+        senderNick: "Bob",
+        allowFrom: ["Alice", "uid-001"],
+      }),
+    ).toBe(false);
+  });
+
+  it("denies when allowFrom is empty", () => {
+    expect(isDingTalkSenderAllowed({ senderId: "uid-001", allowFrom: [] })).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isDingTalkSenderAllowed({ senderId: "ABC123", allowFrom: ["abc123"] })).toBe(true);
+  });
+});

--- a/extensions/dingtalk/src/policy.ts
+++ b/extensions/dingtalk/src/policy.ts
@@ -1,0 +1,35 @@
+import type { CoreConfig } from "./types.js";
+
+/**
+ * Resolve the effective DM allowlist for a given account.
+ */
+export function resolveDingTalkDmAllowFrom(cfg: CoreConfig, accountId: string): string[] {
+  const dt = cfg.channels?.dingtalk;
+  if (!dt) {
+    return [];
+  }
+  if (accountId === "default") {
+    return (dt.allowFrom ?? []).map(String);
+  }
+  return (dt.accounts?.[accountId]?.allowFrom ?? []).map(String);
+}
+
+/**
+ * Check whether a sender is on the allowlist.
+ * Supports "*" wildcard for open access.
+ */
+export function isDingTalkSenderAllowed(params: {
+  senderId: string;
+  senderNick?: string;
+  allowFrom: string[];
+}): boolean {
+  const { senderId, senderNick, allowFrom } = params;
+  if (allowFrom.includes("*")) {
+    return true;
+  }
+  return allowFrom.some(
+    (entry) =>
+      entry.trim().toLowerCase() === senderId.trim().toLowerCase() ||
+      (senderNick && entry.trim().toLowerCase() === senderNick.trim().toLowerCase()),
+  );
+}

--- a/extensions/dingtalk/src/probe.ts
+++ b/extensions/dingtalk/src/probe.ts
@@ -1,0 +1,31 @@
+import type { DingTalkProbe } from "./types.js";
+
+/**
+ * Probe DingTalk connectivity by attempting a GET to the DingTalk API health endpoint.
+ * We don't actually send a message during probe — just verify network reachability.
+ */
+export async function probeDingTalk(params: {
+  webhookUrl: string;
+  secret?: string;
+}): Promise<DingTalkProbe> {
+  try {
+    // DingTalk doesn't have a dedicated health endpoint, so we check reachability
+    // by making a lightweight HEAD request to the base API domain.
+    const url = new URL("https://oapi.dingtalk.com/");
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(5_000),
+    });
+    return {
+      ok: response.status < 500,
+      statusLabel: `DingTalk API reachable (${response.status})`,
+      webhookReachable: true,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      statusLabel: `DingTalk API unreachable: ${String(err)}`,
+      webhookReachable: false,
+    };
+  }
+}

--- a/extensions/dingtalk/src/runtime.ts
+++ b/extensions/dingtalk/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+let _runtime: OpenClawPluginApi["runtime"] | undefined;
+
+export function setDingTalkRuntime(runtime: OpenClawPluginApi["runtime"]): void {
+  _runtime = runtime;
+}
+
+export function getDingTalkRuntime(): OpenClawPluginApi["runtime"] {
+  if (!_runtime) {
+    throw new Error("DingTalk runtime not initialized — call setDingTalkRuntime() first");
+  }
+  return _runtime;
+}

--- a/extensions/dingtalk/src/send.ts
+++ b/extensions/dingtalk/src/send.ts
@@ -1,0 +1,91 @@
+import { buildDingTalkSignParams } from "./sign.js";
+import type { DingTalkOutboundMessage } from "./types.js";
+
+const DINGTALK_WEBHOOK_BASE = "https://oapi.dingtalk.com/robot/send";
+
+type SendParams = {
+  webhookUrl: string;
+  accessToken?: string;
+  secret?: string;
+  message: DingTalkOutboundMessage;
+};
+
+/**
+ * Send a message to a DingTalk group via the custom robot webhook.
+ * If `secret` is provided, the request is signed per DingTalk's security spec.
+ */
+export async function sendDingTalkMessage(params: SendParams): Promise<void> {
+  const { webhookUrl, secret, message } = params;
+
+  let url = webhookUrl;
+  if (secret) {
+    const { timestamp, sign } = buildDingTalkSignParams(secret);
+    const separator = url.includes("?") ? "&" : "?";
+    url = `${url}${separator}timestamp=${encodeURIComponent(timestamp)}&sign=${encodeURIComponent(sign)}`;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DingTalk webhook returned ${response.status}: ${await response.text()}`);
+  }
+
+  const data = (await response.json()) as { errcode?: number; errmsg?: string };
+  if (data.errcode !== 0) {
+    throw new Error(`DingTalk API error ${data.errcode}: ${data.errmsg}`);
+  }
+}
+
+/**
+ * Send a reply via the session webhook URL included in an inbound message.
+ * This is the preferred way to reply to a specific conversation/thread.
+ */
+export async function sendDingTalkSessionReply(params: {
+  sessionWebhook: string;
+  message: DingTalkOutboundMessage;
+}): Promise<void> {
+  const { sessionWebhook, message } = params;
+  const response = await fetch(sessionWebhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`DingTalk session reply returned ${response.status}: ${await response.text()}`);
+  }
+  const data = (await response.json()) as { errcode?: number; errmsg?: string };
+  if (data.errcode !== 0) {
+    throw new Error(`DingTalk session reply error ${data.errcode}: ${data.errmsg}`);
+  }
+}
+
+/**
+ * Build a plain-text outbound message, splitting into chunks if needed.
+ */
+export function buildDingTalkTextMessage(text: string): DingTalkOutboundMessage {
+  return {
+    msgtype: "text",
+    text: { content: text },
+  };
+}
+
+/**
+ * Build a markdown outbound message.
+ */
+export function buildDingTalkMarkdownMessage(title: string, text: string): DingTalkOutboundMessage {
+  return {
+    msgtype: "markdown",
+    markdown: { title, text },
+  };
+}
+
+/** Build the base DingTalk webhook URL from an access token */
+export function buildWebhookUrl(accessToken: string): string {
+  return `${DINGTALK_WEBHOOK_BASE}?access_token=${encodeURIComponent(accessToken)}`;
+}

--- a/extensions/dingtalk/src/sign.test.ts
+++ b/extensions/dingtalk/src/sign.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildDingTalkSignParams, verifyDingTalkSignature } from "./sign.js";
+
+describe("buildDingTalkSignParams", () => {
+  it("returns a timestamp and base64 sign", () => {
+    const { timestamp, sign } = buildDingTalkSignParams("my-secret");
+    expect(timestamp).toMatch(/^\d+$/);
+    expect(sign.length).toBeGreaterThan(0);
+    // base64 characters only
+    expect(sign).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+
+  it("produces different signs for different secrets", () => {
+    const a = buildDingTalkSignParams("secret-a");
+    const b = buildDingTalkSignParams("secret-b");
+    expect(a.sign).not.toBe(b.sign);
+  });
+});
+
+describe("verifyDingTalkSignature", () => {
+  it("accepts a valid signature within 60 seconds", () => {
+    const secret = "test-secret";
+    const { timestamp, sign } = buildDingTalkSignParams(secret);
+    expect(verifyDingTalkSignature({ timestamp, sign, secret })).toBe(true);
+  });
+
+  it("rejects an incorrect signature", () => {
+    const { timestamp } = buildDingTalkSignParams("secret");
+    expect(verifyDingTalkSignature({ timestamp, sign: "wrong-sign", secret: "secret" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects a stale timestamp (>60s old)", () => {
+    const secret = "test-secret";
+    const staleTimestamp = (Date.now() - 120_000).toString();
+    const { sign } = buildDingTalkSignParams(secret);
+    // sign computed with current ts won't match stale ts anyway — both checks fail
+    expect(verifyDingTalkSignature({ timestamp: staleTimestamp, sign, secret })).toBe(false);
+  });
+});

--- a/extensions/dingtalk/src/sign.ts
+++ b/extensions/dingtalk/src/sign.ts
@@ -1,0 +1,32 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * Compute the DingTalk robot signing params.
+ * DingTalk requires: sign = base64(HMAC-SHA256(timestamp + "\n" + secret))
+ */
+export function buildDingTalkSignParams(secret: string): {
+  timestamp: string;
+  sign: string;
+} {
+  const timestamp = Date.now().toString();
+  const stringToSign = `${timestamp}\n${secret}`;
+  const sign = createHmac("sha256", secret).update(stringToSign).digest("base64");
+  return { timestamp, sign };
+}
+
+/**
+ * Verify an incoming DingTalk webhook signature.
+ * Returns true if the signature is valid.
+ */
+export function verifyDingTalkSignature(params: {
+  timestamp: string;
+  sign: string;
+  secret: string;
+}): boolean {
+  const { timestamp, sign, secret } = params;
+  const expected = buildDingTalkSignParams(secret);
+  // Re-derive sign using the provided timestamp (not current time)
+  const stringToSign = `${timestamp}\n${secret}`;
+  const derivedSign = createHmac("sha256", secret).update(stringToSign).digest("base64");
+  return sign === derivedSign && Math.abs(Date.now() - Number(timestamp)) < 60_000;
+}

--- a/extensions/dingtalk/src/types.ts
+++ b/extensions/dingtalk/src/types.ts
@@ -1,0 +1,78 @@
+import type { DmPolicy, GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk";
+
+export type DingTalkAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+  /** DingTalk custom robot access token */
+  accessToken?: string;
+  /** DingTalk custom robot signing secret */
+  secret?: string;
+  /**
+   * Outbound webhook URL. If not set, built automatically from accessToken.
+   * Can be overridden for self-hosted / enterprise DingTalk.
+   */
+  webhookUrl?: string;
+  /**
+   * Inbound HTTP path for receiving messages from DingTalk.
+   * DingTalk calls this URL on your gateway when users @ the bot.
+   */
+  inboundPath?: string;
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string>;
+  groupPolicy?: GroupPolicy;
+  groupAllowFrom?: Array<string>;
+  /** Maximum plain-text chunk size in characters before splitting. */
+  textChunkLimit?: number;
+};
+
+export type DingTalkConfig = DingTalkAccountConfig & {
+  accounts?: Record<string, DingTalkAccountConfig>;
+};
+
+export type CoreConfig = OpenClawConfig & {
+  channels?: OpenClawConfig["channels"] & {
+    dingtalk?: DingTalkConfig;
+  };
+};
+
+// ---- DingTalk API wire types ------------------------------------------------
+
+export type DingTalkTextMessage = {
+  msgtype: "text";
+  text: { content: string };
+  at?: { atMobiles?: string[]; atUserIds?: string[]; isAtAll?: boolean };
+};
+
+export type DingTalkMarkdownMessage = {
+  msgtype: "markdown";
+  markdown: { title: string; text: string };
+  at?: { atMobiles?: string[]; atUserIds?: string[]; isAtAll?: boolean };
+};
+
+export type DingTalkOutboundMessage = DingTalkTextMessage | DingTalkMarkdownMessage;
+
+/** Inbound event received from DingTalk when a user sends a message */
+export type DingTalkInboundEvent = {
+  msgtype?: string;
+  text?: { content?: string };
+  content?: string;
+  senderNick?: string;
+  senderId?: string;
+  senderCorpId?: string;
+  chatbotCorpId?: string;
+  conversationId?: string;
+  conversationType?: "1" | "2"; // 1=DM, 2=group
+  conversationTitle?: string;
+  /** Session webhook URL to reply directly to this conversation */
+  sessionWebhook?: string;
+  sessionWebhookExpiredTime?: number;
+  msgId?: string;
+  createAt?: number;
+  robotCode?: string;
+};
+
+export type DingTalkProbe = {
+  ok: boolean;
+  statusLabel: string;
+  webhookReachable?: boolean;
+};


### PR DESCRIPTION
## Summary

Closes #26534. Addresses the DingTalk channel support requested in #10347.

DingTalk (钉钉) is the dominant workplace messaging platform for enterprise teams in China (700M+ users). This PR adds a first-class OpenClaw extension for DingTalk using the **Custom Robot Webhook** API — the most widely deployed DingTalk bot integration pattern.

## What's included

**`extensions/dingtalk/`** — new channel plugin:

| File | Purpose |
|------|---------|
| `package.json` | Plugin manifest with `channel` metadata (id, label, order, aliases) |
| `openclaw.plugin.json` | Plugin descriptor |
| `index.ts` | Plugin entry point, registers channel |
| `src/types.ts` | DingTalk config + wire types |
| `src/accounts.ts` | Account resolution, webhook URL building |
| `src/sign.ts` | HMAC-SHA256 request signing (DingTalk security spec) |
| `src/send.ts` | Outbound message sending — group webhook + session reply |
| `src/monitor.ts` | Inbound HTTP webhook handler with signature verification |
| `src/policy.ts` | Sender allowlist (wildcard, id, nick matching) |
| `src/probe.ts` | Gateway connectivity probe |
| `src/onboarding.ts` | Interactive setup wizard (access token, secret, inbound path, DM policy) |
| `src/channel.ts` | Full `ChannelPlugin` registration |

## Key design decisions

**Webhook + session reply model**: DingTalk sends each inbound message with a `sessionWebhook` URL — the extension uses this for direct replies so responses go to the right conversation thread. Falls back to the static group webhook URL when `sessionWebhook` is absent.

**Signature verification**: Inbound webhook requests are verified with HMAC-SHA256 (`timestamp + "\n" + secret`) before processing, matching DingTalk's official security spec. The secret is optional for development but strongly recommended in production.

**Onboarding in wizard**: The `selectionLabel: "DingTalk (钉钉)"` and `order: 40` ensure DingTalk appears alongside other enterprise channels (Feishu is 35, Google Chat is 55) in the `openclaw onboard` channel selection screen.

## Change Type

- [x] Feature

## Scope

- [x] Integrations

## Security Impact

- New permissions/capabilities? Yes — new HTTP webhook endpoint on the gateway
- Secrets/tokens handling changed? No — follows existing `channels.X.secret` pattern
- Inbound: HMAC-SHA256 signature verification before any payload processing
- Inbound: Immediate `200 OK` response before async dispatch (prevents DingTalk timeouts)

## Testing

```
pnpm vitest run extensions/dingtalk/src
# 18 tests passed (sign, policy, accounts)
```

Made with [Cursor](https://cursor.com)