### PR TITLE
feat: implement dynamic tailnet detection for Headscale/custom ranges

### DIFF
--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { execSync } from "node:child_process";
 import { isIpInCidr } from "../shared/net/ip.js";
 
 export type TailnetAddresses = {
@@ -9,41 +10,92 @@ export type TailnetAddresses = {
 const TAILNET_IPV4_CIDR = "100.64.0.0/10";
 const TAILNET_IPV6_CIDR = "fd7a:115c:a1e0::/48";
 
+/**
+ * Checks if an address is in the official Tailscale range.
+ */
 export function isTailnetIPv4(address: string): boolean {
-  // Tailscale IPv4 range: 100.64.0.0/10
-  // https://tailscale.com/kb/1015/100.x-addresses
-  return isIpInCidr(address, TAILNET_IPV4_CIDR);
+  // Check official range first
+  if (isIpInCidr(address, TAILNET_IPV4_CIDR)) return true;
+  
+  // Check for custom range override via env
+  const customCidr = process.env.OPENCLAW_TAILNET_IPV4_CIDR;
+  if (customCidr && isIpInCidr(address, customCidr)) return true;
+
+  return false;
 }
 
 function isTailnetIPv6(address: string): boolean {
-  // Tailscale IPv6 ULA prefix: fd7a:115c:a1e0::/48
-  // (stable across tailnets; nodes get per-device suffixes)
-  return isIpInCidr(address, TAILNET_IPV6_CIDR);
+  if (isIpInCidr(address, TAILNET_IPV6_CIDR)) return true;
+  const customCidr = process.env.OPENCLAW_TAILNET_IPV6_CIDR;
+  if (customCidr && isIpInCidr(address, customCidr)) return true;
+  return false;
+}
+
+/**
+ * Tries to find the Tailscale binary across common locations.
+ */
+function findTailscaleBin(): string | undefined {
+  const paths = [
+    "tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    "/usr/local/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+  ];
+
+  for (const p of paths) {
+    try {
+      // Use command -v for shell lookup if it's just a name
+      const cmd = p.startsWith("/") ? p : `command -v ${p}`;
+      const resolved = execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+      if (resolved) return resolved;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Attempts to get IPs directly from Tailscale/Headscale CLI if possible.
+ */
+function getAddressesFromCli(): TailnetAddresses | undefined {
+  const bin = findTailscaleBin();
+  if (!bin) return undefined;
+
+  try {
+    // tailscale ip -4 / -6 is fast and returns just the addresses
+    const ipv4 = execSync(`${bin} ip -4`, { timeout: 1000 }).toString().trim().split(/\s+/).filter(Boolean);
+    const ipv6 = execSync(`${bin} ip -6`, { timeout: 1000 }).toString().trim().split(/\s+/).filter(Boolean);
+    if (ipv4.length > 0 || ipv6.length > 0) {
+      return { ipv4, ipv6 };
+    }
+  } catch {
+    // Silently fall back to interface scanning
+  }
+  return undefined;
 }
 
 export function listTailnetAddresses(): TailnetAddresses {
+  // 1. Try CLI first (supports Headscale/custom ranges natively)
+  const fromCli = getAddressesFromCli();
+  if (fromCli) {
+    return fromCli;
+  }
+
+  // 2. Fallback to scanning interfaces with known/custom ranges
   const ipv4: string[] = [];
   const ipv6: string[] = [];
 
   const ifaces = os.networkInterfaces();
   for (const entries of Object.values(ifaces)) {
-    if (!entries) {
-      continue;
-    }
+    if (!entries) continue;
     for (const e of entries) {
-      if (!e || e.internal) {
-        continue;
-      }
+      if (!e || e.internal) continue;
       const address = e.address?.trim();
-      if (!address) {
-        continue;
-      }
-      if (isTailnetIPv4(address)) {
-        ipv4.push(address);
-      }
-      if (isTailnetIPv6(address)) {
-        ipv6.push(address);
-      }
+      if (!address) continue;
+      
+      if (isTailnetIPv4(address)) ipv4.push(address);
+      if (isTailnetIPv6(address)) ipv6.push(address);
     }
   }
 

--- a/src/infra/tailnet.ts
+++ b/src/infra/tailnet.ts
@@ -1,5 +1,5 @@
-import os from "node:os";
 import { execSync } from "node:child_process";
+import os from "node:os";
 import { isIpInCidr } from "../shared/net/ip.js";
 
 export type TailnetAddresses = {
@@ -16,7 +16,7 @@ const TAILNET_IPV6_CIDR = "fd7a:115c:a1e0::/48";
 export function isTailnetIPv4(address: string): boolean {
   // Check official range first
   if (isIpInCidr(address, TAILNET_IPV4_CIDR)) return true;
-  
+
   // Check for custom range override via env
   const customCidr = process.env.OPENCLAW_TAILNET_IPV4_CIDR;
   if (customCidr && isIpInCidr(address, customCidr)) return true;
@@ -46,7 +46,9 @@ function findTailscaleBin(): string | undefined {
     try {
       // Use command -v for shell lookup if it's just a name
       const cmd = p.startsWith("/") ? p : `command -v ${p}`;
-      const resolved = execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+      const resolved = execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .trim();
       if (resolved) return resolved;
     } catch {
       continue;
@@ -112,7 +114,7 @@ export function listTailnetAddresses(): TailnetAddresses {
       if (!e || e.internal) continue;
       const address = e.address?.trim();
       if (!address) continue;
-      
+
       if (isTailnetIPv4(address)) ipv4.push(address);
       if (isTailnetIPv6(address)) ipv6.push(address);
     }


### PR DESCRIPTION
This PR fixes the hardcoded Tailnet IP range issue (#27398).

### Changes
1. **CLI Priority**: Attempts to get IPs directly via `tailscale ip -4/-6`. This is the most reliable way to support Headscale and custom IP ranges.
2. **Binary Discovery**: Added common paths for the Tailscale binary, including the macOS App bundle path (`/Applications/Tailscale.app/Contents/MacOS/Tailscale`).
3. **Environment Overrides**: Added `OPENCLAW_TAILNET_IPV4_CIDR` and `OPENCLAW_TAILNET_IPV6_CIDR` as fallback mechanisms for users who want to manually specify their Tailnet range without using the CLI.
4. **Graceful Fallback**: If the CLI fails or isn't found, it falls back to the original interface scanning logic (which now also respects the new env vars).