### PR TITLE
feat(rocketchat): add Rocket.Chat channel extension with webhook and REST API support

### DIFF
--- a/extensions/rocketchat/index.ts
+++ b/extensions/rocketchat/index.ts
@@ -1,0 +1,17 @@
+import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { rocketchatPlugin } from "./src/channel.js";
+import { setRocketChatRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "rocketchat",
+  name: "Rocket.Chat",
+  description: "Rocket.Chat open-source team messaging — webhooks and REST API",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setRocketChatRuntime(api.runtime);
+    api.registerChannel({ plugin: rocketchatPlugin as ChannelPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/rocketchat/openclaw.plugin.json
+++ b/extensions/rocketchat/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "rocketchat",
+  "channels": ["rocketchat"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/rocketchat/package.json
+++ b/extensions/rocketchat/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/rocketchat",
+  "version": "2026.2.26",
+  "description": "OpenClaw Rocket.Chat channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.2.25"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "rocketchat",
+      "label": "Rocket.Chat",
+      "selectionLabel": "Rocket.Chat (self-hosted or cloud)",
+      "detailLabel": "Rocket.Chat",
+      "docsPath": "/channels/rocketchat",
+      "docsLabel": "rocketchat",
+      "blurb": "Rocket.Chat open-source team messaging via webhooks or REST API.",
+      "aliases": [
+        "rocket",
+        "rc"
+      ],
+      "order": 45,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/rocketchat",
+      "localPath": "extensions/rocketchat",
+      "defaultChoice": "local"
+    }
+  }
+}

--- a/extensions/rocketchat/src/accounts.test.ts
+++ b/extensions/rocketchat/src/accounts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { listRocketChatAccountIds, resolveRocketChatAccount } from "./accounts.js";
+import type { CoreConfig } from "./types.js";
+
+describe("listRocketChatAccountIds", () => {
+  it("returns empty for unconfigured", () => {
+    const cfg: CoreConfig = {};
+    expect(listRocketChatAccountIds(cfg)).toEqual([]);
+  });
+
+  it("returns default when serverUrl is set", () => {
+    const cfg: CoreConfig = {
+      channels: { rocketchat: { serverUrl: "https://chat.example.com" } },
+    };
+    expect(listRocketChatAccountIds(cfg)).toContain("default");
+  });
+
+  it("returns named accounts", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        rocketchat: {
+          accounts: {
+            work: { serverUrl: "https://work.rocket.chat" },
+            personal: { serverUrl: "https://open.rocket.chat" },
+          },
+        },
+      },
+    };
+    const ids = listRocketChatAccountIds(cfg);
+    expect(ids).toContain("work");
+    expect(ids).toContain("personal");
+  });
+});
+
+describe("resolveRocketChatAccount", () => {
+  it("resolves mode from webhookUrl when mode not set", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        rocketchat: {
+          serverUrl: "https://chat.example.com",
+          webhookUrl: "https://chat.example.com/hooks/tok123",
+        },
+      },
+    };
+    const account = resolveRocketChatAccount({ cfg, accountId: "default" });
+    expect(account.mode).toBe("webhook");
+  });
+
+  it("resolves mode from authToken when mode not set", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        rocketchat: {
+          serverUrl: "https://chat.example.com",
+          authToken: "tok",
+          userId: "uid",
+        },
+      },
+    };
+    const account = resolveRocketChatAccount({ cfg, accountId: "default" });
+    expect(account.mode).toBe("api");
+  });
+
+  it("strips trailing slashes from serverUrl", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        rocketchat: { serverUrl: "https://chat.example.com///" },
+      },
+    };
+    const account = resolveRocketChatAccount({ cfg, accountId: "default" });
+    expect(account.serverUrl).toBe("https://chat.example.com");
+  });
+});

--- a/extensions/rocketchat/src/accounts.ts
+++ b/extensions/rocketchat/src/accounts.ts
@@ -1,0 +1,53 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import type { CoreConfig, RocketChatAccountConfig } from "./types.js";
+
+export type ResolvedRocketChatAccount = {
+  accountId: string;
+  config: RocketChatAccountConfig;
+  serverUrl: string;
+  mode: "webhook" | "api";
+};
+
+export function listRocketChatAccountIds(cfg: CoreConfig): string[] {
+  const rc = cfg.channels?.rocketchat;
+  if (!rc) {
+    return [];
+  }
+  const ids = Object.keys(rc.accounts ?? {});
+  const hasDefault = rc.serverUrl?.trim() || rc.webhookUrl?.trim();
+  if (hasDefault && !ids.includes(DEFAULT_ACCOUNT_ID)) {
+    ids.unshift(DEFAULT_ACCOUNT_ID);
+  }
+  return ids;
+}
+
+export function resolveDefaultRocketChatAccountId(cfg: CoreConfig): string {
+  return listRocketChatAccountIds(cfg)[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+export function resolveRawRocketChatAccountConfig(
+  cfg: CoreConfig,
+  accountId: string,
+): RocketChatAccountConfig | undefined {
+  const rc = cfg.channels?.rocketchat;
+  if (!rc) {
+    return undefined;
+  }
+  return accountId === DEFAULT_ACCOUNT_ID ? rc : rc.accounts?.[accountId];
+}
+
+export function resolveRocketChatAccount(params: {
+  cfg: CoreConfig;
+  accountId: string;
+}): ResolvedRocketChatAccount {
+  const { cfg, accountId } = params;
+  const raw = resolveRawRocketChatAccountConfig(cfg, accountId);
+  if (!raw) {
+    throw new Error(`Rocket.Chat account "${accountId}" not found in config`);
+  }
+
+  const serverUrl = (raw.serverUrl ?? "").replace(/\/+$/, "");
+  const mode = raw.mode ?? (raw.webhookUrl ? "webhook" : raw.authToken ? "api" : "webhook");
+
+  return { accountId, config: raw, serverUrl, mode };
+}

--- a/extensions/rocketchat/src/channel.ts
+++ b/extensions/rocketchat/src/channel.ts
@@ -1,0 +1,206 @@
+import {
+  buildBaseAccountStatusSnapshot,
+  buildBaseChannelStatusSummary,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  getChatChannelMeta,
+  PAIRING_APPROVED_MESSAGE,
+  resolveDefaultGroupPolicy,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import {
+  listRocketChatAccountIds,
+  resolveDefaultRocketChatAccountId,
+  resolveRocketChatAccount,
+  type ResolvedRocketChatAccount,
+} from "./accounts.js";
+import { monitorRocketChatProvider, resolveRocketChatWebhookPath } from "./monitor.js";
+import { rocketchatOnboardingAdapter } from "./onboarding.js";
+import { isRocketChatSenderAllowed, resolveRocketChatDmAllowFrom } from "./policy.js";
+import { probeRocketChat } from "./probe.js";
+import { getRocketChatRuntime } from "./runtime.js";
+import { sendRocketChatApi, sendRocketChatWebhook, splitText } from "./send.js";
+import type { CoreConfig, RocketChatOutgoingWebhookEvent, RocketChatProbe } from "./types.js";
+
+const meta = getChatChannelMeta("rocketchat");
+
+const DEFAULT_ALIAS = "OpenClaw";
+const DEFAULT_EMOJI = ":robot:";
+
+export const rocketchatPlugin: ChannelPlugin<ResolvedRocketChatAccount, RocketChatProbe> = {
+  id: "rocketchat",
+  meta: {
+    ...meta,
+    quickstartAllowFrom: true,
+  },
+  onboarding: rocketchatOnboardingAdapter,
+
+  pairing: {
+    idLabel: "userId",
+    normalizeAllowEntry: (entry) => entry.trim(),
+    notifyApproval: async ({ id, accountId, config }) => {
+      const account = resolveRocketChatAccount({ cfg: config as CoreConfig, accountId });
+      const text = `${PAIRING_APPROVED_MESSAGE} ${formatPairingApproveHint({ id })}`;
+      await sendOutbound(account, account.config.defaultRoom ?? "#general", text);
+    },
+  },
+
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    media: false,
+    blockStreaming: false,
+  },
+
+  reload: { configPrefixes: ["channels.rocketchat"] },
+  configSchema: buildChannelConfigSchema({
+    type: "object",
+    additionalProperties: true,
+    properties: {},
+  }),
+
+  config: {
+    listAccountIds: (cfg) => listRocketChatAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) =>
+      resolveRocketChatAccount({ cfg: cfg as CoreConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultRocketChatAccountId(cfg as CoreConfig),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "rocketchat",
+        accountId,
+        enabled,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "rocketchat",
+        accountId,
+      }),
+
+    resolveStatus: ({ account }) => {
+      const hasOutbound =
+        account.mode === "api"
+          ? Boolean(account.config.authToken?.trim() && account.config.userId?.trim())
+          : Boolean(account.config.webhookUrl?.trim());
+      const issues = hasOutbound
+        ? []
+        : [
+            {
+              kind: "warning" as const,
+              message:
+                account.mode === "api"
+                  ? "No auth token or userId configured — messages will fail"
+                  : "No incoming webhook URL configured — messages will fail",
+            },
+          ];
+      return buildBaseAccountStatusSnapshot({ accountId: account.accountId, issues });
+    },
+
+    resolveSummary: ({ cfg }) =>
+      buildBaseChannelStatusSummary({
+        channelId: "rocketchat",
+        accounts: listRocketChatAccountIds(cfg as CoreConfig),
+      }),
+  },
+
+  // ---- Monitor (inbound outgoing-webhook) ----------------------------------
+
+  monitor: {
+    start: ({ cfg, dispatch, accountId }) => {
+      const account = resolveRocketChatAccount({ cfg: cfg as CoreConfig, accountId });
+      const rt = getRocketChatRuntime();
+      const inboundPath = resolveRocketChatWebhookPath({
+        accountId,
+        configuredPath: account.config.inboundPath,
+      });
+
+      return monitorRocketChatProvider({
+        accountId,
+        inboundPath,
+        outgoingToken: account.config.outgoingToken,
+        runtime: rt as Parameters<typeof monitorRocketChatProvider>[0]["runtime"],
+        onMessage: async (event: RocketChatOutgoingWebhookEvent) => {
+          const userId = event.user_id ?? "";
+          const userName = event.user_name ?? "";
+          const text = (event.text ?? "").trim();
+          if (!text) return;
+
+          const allowFrom = resolveRocketChatDmAllowFrom(cfg as CoreConfig, accountId);
+          const isGroup = Boolean(event.channel_name && !event.channel_name.startsWith("@"));
+
+          if (!isGroup) {
+            const allowed = isRocketChatSenderAllowed({ userId, userName, allowFrom });
+            if (!allowed) return;
+          }
+
+          const roomId = event.room_id ?? event.channel_id ?? account.config.defaultRoom ?? "";
+
+          await dispatch({
+            channelId: "rocketchat",
+            accountId,
+            senderId: userId,
+            senderName: userName,
+            text,
+            reply: async (replyText: string) => {
+              for (const chunk of splitText(replyText, account.config.textChunkLimit)) {
+                await sendOutbound(account, roomId, chunk);
+              }
+            },
+            isGroup,
+            conversationId: event.room_id,
+            messageId: event.message_id,
+          });
+        },
+      });
+    },
+  },
+
+  // ---- Outbound ------------------------------------------------------------
+
+  outbound: {
+    send: async ({ account, text }) => {
+      const room = account.config.defaultRoom ?? "#general";
+      for (const chunk of splitText(text, account.config.textChunkLimit)) {
+        await sendOutbound(account, room, chunk);
+      }
+    },
+  },
+
+  // ---- Probe ---------------------------------------------------------------
+
+  probe: ({ account }) => probeRocketChat({ serverUrl: account.serverUrl }),
+};
+
+async function sendOutbound(
+  account: ResolvedRocketChatAccount,
+  room: string,
+  text: string,
+): Promise<void> {
+  const alias = account.config.alias ?? DEFAULT_ALIAS;
+  const emoji = account.config.emoji ?? DEFAULT_EMOJI;
+
+  if (account.mode === "api") {
+    const authToken = account.config.authToken?.trim() ?? "";
+    const userId = account.config.userId?.trim() ?? "";
+    await sendRocketChatApi({
+      serverUrl: account.serverUrl,
+      authToken,
+      userId,
+      message: {
+        channel: room,
+        text,
+        alias,
+        emoji,
+      },
+    });
+  } else {
+    const webhookUrl = account.config.webhookUrl?.trim() ?? "";
+    await sendRocketChatWebhook({
+      webhookUrl,
+      message: { text, alias, emoji, channel: room },
+    });
+  }
+}

--- a/extensions/rocketchat/src/monitor.ts
+++ b/extensions/rocketchat/src/monitor.ts
@@ -1,0 +1,72 @@
+import type { ChannelMonitorHandle } from "openclaw/plugin-sdk";
+import type { RocketChatOutgoingWebhookEvent } from "./types.js";
+
+export function resolveRocketChatWebhookPath(params: {
+  accountId: string;
+  configuredPath?: string;
+}): string {
+  if (params.configuredPath?.trim()) {
+    return params.configuredPath.trim();
+  }
+  return params.accountId === "default" ? "/rocketchat" : `/rocketchat/${params.accountId}`;
+}
+
+/**
+ * Register an HTTP handler that receives Rocket.Chat outgoing webhook events.
+ * Rocket.Chat POSTs here when a user sends a message matching the configured trigger word.
+ */
+export function monitorRocketChatProvider(params: {
+  accountId: string;
+  inboundPath?: string;
+  outgoingToken?: string;
+  runtime: {
+    registerHttpHandler: (
+      path: string,
+      handler: (req: Request) => Promise<Response>,
+    ) => ChannelMonitorHandle;
+  };
+  onMessage: (event: RocketChatOutgoingWebhookEvent) => Promise<void>;
+}): ChannelMonitorHandle {
+  const path = resolveRocketChatWebhookPath({
+    accountId: params.accountId,
+    configuredPath: params.inboundPath,
+  });
+
+  return params.runtime.registerHttpHandler(path, async (req: Request) => {
+    let event: RocketChatOutgoingWebhookEvent;
+    try {
+      const contentType = req.headers.get("content-type") ?? "";
+      if (contentType.includes("application/x-www-form-urlencoded")) {
+        const text = await req.text();
+        const form = new URLSearchParams(text);
+        const payload = form.get("payload");
+        if (payload) {
+          event = JSON.parse(payload) as RocketChatOutgoingWebhookEvent;
+        } else {
+          event = Object.fromEntries(form.entries()) as RocketChatOutgoingWebhookEvent;
+        }
+      } else {
+        event = (await req.json()) as RocketChatOutgoingWebhookEvent;
+      }
+    } catch {
+      return new Response(JSON.stringify({ success: false, error: "Invalid request body" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Verify outgoing webhook token if configured
+    if (params.outgoingToken && event.token !== params.outgoingToken) {
+      return new Response(JSON.stringify({ success: false, error: "Invalid token" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    void params.onMessage(event).catch(() => {});
+    // Rocket.Chat displays the `text` from this response in the chat
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}

--- a/extensions/rocketchat/src/onboarding.ts
+++ b/extensions/rocketchat/src/onboarding.ts
@@ -1,0 +1,157 @@
+import {
+  addWildcardAllowFrom,
+  DEFAULT_ACCOUNT_ID,
+  formatDocsLink,
+  promptChannelAccessConfig,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type DmPolicy,
+} from "openclaw/plugin-sdk";
+import { resolveRocketChatWebhookPath } from "./monitor.js";
+import type { CoreConfig, RocketChatAccountConfig, RocketChatMode } from "./types.js";
+
+const CHANNEL = "rocketchat" as const;
+
+function patchAccount(
+  cfg: CoreConfig,
+  accountId: string,
+  patch: Partial<RocketChatAccountConfig>,
+): CoreConfig {
+  const rc = cfg.channels?.rocketchat ?? {};
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return { ...cfg, channels: { ...cfg.channels, rocketchat: { ...rc, ...patch } } };
+  }
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      rocketchat: {
+        ...rc,
+        accounts: { ...rc.accounts, [accountId]: { ...rc.accounts?.[accountId], ...patch } },
+      },
+    },
+  };
+}
+
+function setDmPolicy(cfg: CoreConfig, dmPolicy: DmPolicy, accountId: string): CoreConfig {
+  const rc = cfg.channels?.rocketchat ?? {};
+  const current = accountId === DEFAULT_ACCOUNT_ID ? rc : (rc.accounts?.[accountId] ?? {});
+  const allowFrom =
+    dmPolicy === "open" ? addWildcardAllowFrom(current.allowFrom) : current.allowFrom;
+  return patchAccount(cfg, accountId, { dmPolicy, ...(allowFrom ? { allowFrom } : {}) });
+}
+
+export const rocketchatOnboardingAdapter: ChannelOnboardingAdapter<CoreConfig> = {
+  channel: CHANNEL,
+
+  async setup({ prompter, config, accountId }) {
+    const aid = accountId ?? DEFAULT_ACCOUNT_ID;
+    let cfg = config as CoreConfig;
+    const rc = cfg.channels?.rocketchat ?? {};
+    const current = aid === DEFAULT_ACCOUNT_ID ? rc : (rc.accounts?.[aid] ?? {});
+
+    prompter.log(
+      formatDocsLink(
+        "Rocket.Chat integration setup",
+        "/channels/rocketchat",
+        "https://developer.rocket.chat/docs/webhooks",
+      ),
+    );
+
+    // --- Server URL ---------------------------------------------------------
+    const serverUrl = await prompter.text({
+      message: "Rocket.Chat server URL (e.g. https://my.rocket.chat):",
+      initialValue: current.serverUrl ?? "",
+      validate: (v) => (v.trim() ? undefined : "Server URL is required"),
+    });
+    cfg = patchAccount(cfg, aid, { serverUrl: serverUrl.trim().replace(/\/+$/, "") });
+
+    // --- Mode ---------------------------------------------------------------
+    const mode = (await prompter.select<RocketChatMode>({
+      message: "Connection mode:",
+      options: [
+        {
+          value: "webhook",
+          label: "Incoming webhook (simple, group bots)",
+          hint: "Requires an incoming webhook URL from Rocket.Chat Admin",
+        },
+        {
+          value: "api",
+          label: "REST API (full DM support)",
+          hint: "Requires an auth token and userId from your profile",
+        },
+      ],
+      initialValue: current.mode ?? "webhook",
+    })) as RocketChatMode;
+    cfg = patchAccount(cfg, aid, { mode });
+
+    if (mode === "webhook") {
+      const webhookUrl = await prompter.text({
+        message: "Incoming webhook URL (from Rocket.Chat Admin > Integrations):",
+        initialValue: current.webhookUrl ?? "",
+        validate: (v) => (v.trim() ? undefined : "Webhook URL is required"),
+      });
+      cfg = patchAccount(cfg, aid, { webhookUrl: webhookUrl.trim() });
+    } else {
+      const authToken = await prompter.text({
+        message: "Auth token (from your Rocket.Chat profile > Personal Access Tokens):",
+        initialValue: current.authToken ?? "",
+        validate: (v) => (v.trim() ? undefined : "Auth token is required"),
+      });
+      const userId = await prompter.text({
+        message: "User ID (shown next to auth token):",
+        initialValue: current.userId ?? "",
+        validate: (v) => (v.trim() ? undefined : "User ID is required"),
+      });
+      cfg = patchAccount(cfg, aid, { authToken: authToken.trim(), userId: userId.trim() });
+    }
+
+    // --- Outgoing token (for verification of inbound events) ----------------
+    const outgoingToken = await prompter.text({
+      message:
+        "Outgoing webhook token (optional — set in Rocket.Chat Admin > Integrations > Outgoing):",
+      initialValue: current.outgoingToken ?? "",
+    });
+    if (outgoingToken.trim()) {
+      cfg = patchAccount(cfg, aid, { outgoingToken: outgoingToken.trim() });
+    }
+
+    // --- Inbound path -------------------------------------------------------
+    const defaultPath = resolveRocketChatWebhookPath({ accountId: aid });
+    const inboundPath = await prompter.text({
+      message: "Inbound webhook path (configure in Rocket.Chat Admin > Outgoing webhook URL):",
+      initialValue: current.inboundPath ?? defaultPath,
+    });
+    cfg = patchAccount(cfg, aid, {
+      inboundPath: inboundPath.trim() || defaultPath,
+    });
+
+    // --- Default room -------------------------------------------------------
+    const defaultRoom = await prompter.text({
+      message: "Default room to post to (e.g. #general) — used when no session context exists:",
+      initialValue: current.defaultRoom ?? "#general",
+    });
+    if (defaultRoom.trim()) {
+      cfg = patchAccount(cfg, aid, { defaultRoom: defaultRoom.trim() });
+    }
+
+    // --- DM policy ----------------------------------------------------------
+    const dmPolicyResult = await promptChannelAccessConfig<CoreConfig>({
+      prompter,
+      channel: CHANNEL,
+      config: cfg,
+      accountId: aid,
+      setDmPolicy: (c, policy) => setDmPolicy(c, policy, aid),
+    });
+    cfg = dmPolicyResult.config;
+
+    return { config: cfg };
+  },
+
+  resolveDmPolicy({ config, accountId }): ChannelOnboardingDmPolicy {
+    const rc = (config as CoreConfig).channels?.rocketchat;
+    if (!rc) return { dmPolicy: "pairing" };
+    const account = accountId === DEFAULT_ACCOUNT_ID ? rc : (rc.accounts?.[accountId] ?? rc);
+    return { dmPolicy: (account.dmPolicy as DmPolicy) ?? "pairing" };
+  },
+};

--- a/extensions/rocketchat/src/policy.test.ts
+++ b/extensions/rocketchat/src/policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isRocketChatSenderAllowed } from "./policy.js";
+
+describe("isRocketChatSenderAllowed", () => {
+  it("allows wildcard", () => {
+    expect(isRocketChatSenderAllowed({ userId: "u1", allowFrom: ["*"] })).toBe(true);
+  });
+
+  it("allows matching userId", () => {
+    expect(isRocketChatSenderAllowed({ userId: "u1", allowFrom: ["u1", "u2"] })).toBe(true);
+  });
+
+  it("allows matching userName", () => {
+    expect(
+      isRocketChatSenderAllowed({ userId: "uid-x", userName: "alice", allowFrom: ["alice"] }),
+    ).toBe(true);
+  });
+
+  it("denies unrecognized sender", () => {
+    expect(isRocketChatSenderAllowed({ userId: "uid-x", allowFrom: ["uid-y"] })).toBe(false);
+  });
+
+  it("denies empty allowFrom", () => {
+    expect(isRocketChatSenderAllowed({ userId: "uid-x", allowFrom: [] })).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isRocketChatSenderAllowed({ userId: "UID-X", allowFrom: ["uid-x"] })).toBe(true);
+  });
+});

--- a/extensions/rocketchat/src/policy.ts
+++ b/extensions/rocketchat/src/policy.ts
@@ -1,0 +1,22 @@
+import type { CoreConfig } from "./types.js";
+
+export function resolveRocketChatDmAllowFrom(cfg: CoreConfig, accountId: string): string[] {
+  const rc = cfg.channels?.rocketchat;
+  if (!rc) return [];
+  const account = accountId === "default" ? rc : (rc.accounts?.[accountId] ?? rc);
+  return (account.allowFrom ?? []).map(String);
+}
+
+export function isRocketChatSenderAllowed(params: {
+  userId: string;
+  userName?: string;
+  allowFrom: string[];
+}): boolean {
+  const { userId, userName, allowFrom } = params;
+  if (allowFrom.includes("*")) return true;
+  return allowFrom.some(
+    (entry) =>
+      entry.trim().toLowerCase() === userId.trim().toLowerCase() ||
+      (userName && entry.trim().toLowerCase() === userName.trim().toLowerCase()),
+  );
+}

--- a/extensions/rocketchat/src/probe.ts
+++ b/extensions/rocketchat/src/probe.ts
@@ -1,0 +1,35 @@
+import type { RocketChatProbe } from "./types.js";
+
+/** Probe Rocket.Chat server by fetching the /api/info endpoint */
+export async function probeRocketChat(params: { serverUrl: string }): Promise<RocketChatProbe> {
+  const { serverUrl } = params;
+  if (!serverUrl) {
+    return { ok: false, statusLabel: "No server URL configured" };
+  }
+  try {
+    const url = `${serverUrl}/api/info`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        statusLabel: `Rocket.Chat server returned ${response.status}`,
+        serverReachable: true,
+      };
+    }
+    const data = (await response.json()) as { version?: string };
+    return {
+      ok: true,
+      statusLabel: `Rocket.Chat ${data.version ?? "unknown version"} reachable`,
+      serverReachable: true,
+      version: data.version,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      statusLabel: `Rocket.Chat server unreachable: ${String(err)}`,
+      serverReachable: false,
+    };
+  }
+}

--- a/extensions/rocketchat/src/runtime.ts
+++ b/extensions/rocketchat/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+let _runtime: OpenClawPluginApi["runtime"] | undefined;
+
+export function setRocketChatRuntime(runtime: OpenClawPluginApi["runtime"]): void {
+  _runtime = runtime;
+}
+
+export function getRocketChatRuntime(): OpenClawPluginApi["runtime"] {
+  if (!_runtime) {
+    throw new Error("Rocket.Chat runtime not initialized — call setRocketChatRuntime() first");
+  }
+  return _runtime;
+}

--- a/extensions/rocketchat/src/send.test.ts
+++ b/extensions/rocketchat/src/send.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { splitText } from "./send.js";
+
+describe("splitText", () => {
+  it("returns single chunk for short text", () => {
+    expect(splitText("hello", 100)).toEqual(["hello"]);
+  });
+
+  it("splits text at chunk boundary", () => {
+    const text = "a".repeat(10);
+    const chunks = splitText(text, 3);
+    expect(chunks).toEqual(["aaa", "aaa", "aaa", "a"]);
+  });
+
+  it("uses default chunk size of 4000", () => {
+    const text = "x".repeat(4001);
+    const chunks = splitText(text);
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(4000);
+    expect(chunks[1].length).toBe(1);
+  });
+});

--- a/extensions/rocketchat/src/send.ts
+++ b/extensions/rocketchat/src/send.ts
@@ -1,0 +1,62 @@
+import type { RocketChatApiMessage, RocketChatIncomingMessage } from "./types.js";
+
+const ROCKETCHAT_TEXT_CHUNK = 4000;
+
+/** Send via incoming webhook URL */
+export async function sendRocketChatWebhook(params: {
+  webhookUrl: string;
+  message: RocketChatIncomingMessage;
+}): Promise<void> {
+  const { webhookUrl, message } = params;
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Rocket.Chat webhook returned ${response.status}: ${await response.text()}`);
+  }
+}
+
+/** Send via REST API (chat.postMessage) */
+export async function sendRocketChatApi(params: {
+  serverUrl: string;
+  authToken: string;
+  userId: string;
+  message: RocketChatApiMessage;
+}): Promise<void> {
+  const { serverUrl, authToken, userId, message } = params;
+  const url = `${serverUrl}/api/v1/chat.postMessage`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth-Token": authToken,
+      "X-User-Id": userId,
+    },
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Rocket.Chat API returned ${response.status}: ${await response.text()}`);
+  }
+  const data = (await response.json()) as { success?: boolean; error?: string };
+  if (data.success === false) {
+    throw new Error(`Rocket.Chat API error: ${data.error}`);
+  }
+}
+
+/** Split long text into chunks for Rocket.Chat's message size limit */
+export function splitText(text: string, chunkSize: number = ROCKETCHAT_TEXT_CHUNK): string[] {
+  if (text.length <= chunkSize) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    chunks.push(remaining.slice(0, chunkSize));
+    remaining = remaining.slice(chunkSize);
+  }
+  return chunks;
+}

--- a/extensions/rocketchat/src/types.ts
+++ b/extensions/rocketchat/src/types.ts
@@ -1,0 +1,116 @@
+import type { DmPolicy, GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk";
+
+/**
+ * How outbound messages are sent:
+ * - "webhook": POST to an incoming webhook URL (simple, token-only)
+ * - "api": Rocket.Chat REST API with user auth token + userId (full DM support)
+ */
+export type RocketChatMode = "webhook" | "api";
+
+export type RocketChatAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+  /**
+   * Rocket.Chat server URL, e.g. "https://my.rocket.chat"
+   */
+  serverUrl?: string;
+  /**
+   * Mode: "webhook" (default) or "api".
+   */
+  mode?: RocketChatMode;
+  /**
+   * Incoming webhook URL (mode=webhook). Created in Rocket.Chat Admin > Integrations.
+   */
+  webhookUrl?: string;
+  /**
+   * Outgoing webhook token sent by Rocket.Chat for verification.
+   */
+  outgoingToken?: string;
+  /**
+   * REST API auth token (mode=api). From user profile / Admin.
+   */
+  authToken?: string;
+  /**
+   * REST API userId (mode=api).
+   */
+  userId?: string;
+  /**
+   * Default room to post to when no session context is available.
+   */
+  defaultRoom?: string;
+  /**
+   * HTTP path for receiving outgoing webhook events from Rocket.Chat.
+   */
+  inboundPath?: string;
+  /**
+   * Bot alias shown as sender name in Rocket.Chat.
+   */
+  alias?: string;
+  /**
+   * Bot emoji shown as avatar.
+   */
+  emoji?: string;
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string>;
+  groupPolicy?: GroupPolicy;
+  groupAllowFrom?: Array<string>;
+  textChunkLimit?: number;
+};
+
+export type RocketChatConfig = RocketChatAccountConfig & {
+  accounts?: Record<string, RocketChatAccountConfig>;
+};
+
+export type CoreConfig = OpenClawConfig & {
+  channels?: OpenClawConfig["channels"] & {
+    rocketchat?: RocketChatConfig;
+  };
+};
+
+// ---- Wire types ------------------------------------------------------------
+
+/** Inbound outgoing-webhook payload from Rocket.Chat */
+export type RocketChatOutgoingWebhookEvent = {
+  token?: string;
+  channel_id?: string;
+  channel_name?: string;
+  timestamp?: string;
+  user_id?: string;
+  user_name?: string;
+  text?: string;
+  trigger_word?: string;
+  message_id?: string;
+  room_id?: string;
+  room_name?: string;
+  /** Reply-to channel info for threaded response */
+  bot?: {
+    i?: string;
+  };
+};
+
+/** Outbound incoming-webhook body for Rocket.Chat */
+export type RocketChatIncomingMessage = {
+  text: string;
+  alias?: string;
+  emoji?: string;
+  avatar?: string;
+  roomId?: string;
+  channel?: string;
+  attachments?: Array<{ text: string; color?: string }>;
+};
+
+/** REST API request body for chat.postMessage */
+export type RocketChatApiMessage = {
+  roomId?: string;
+  channel?: string;
+  text: string;
+  alias?: string;
+  emoji?: string;
+};
+
+export type RocketChatProbe = {
+  ok: boolean;
+  statusLabel: string;
+  serverReachable?: boolean;
+  version?: string;
+};


### PR DESCRIPTION
## Summary

Closes #7520.

Adds a first-class OpenClaw extension for Rocket.Chat — the leading open-source team messaging platform. Works like the existing Telegram integration (issue's ask), supporting both self-hosted and cloud Rocket.Chat instances.

## What's included

**`extensions/rocketchat/`** — new channel plugin:

| File | Purpose |
|------|---------|
| `package.json` | Plugin manifest with `channel` metadata (label, order, aliases) |
| `openclaw.plugin.json` | Plugin descriptor |
| `index.ts` | Plugin entry point |
| `src/types.ts` | Config + wire types (webhook and API modes) |
| `src/accounts.ts` | Account resolution and mode detection |
| `src/send.ts` | Outbound via incoming webhook or REST API (`chat.postMessage`) |
| `src/monitor.ts` | Inbound outgoing-webhook handler with token verification |
| `src/policy.ts` | Sender allowlist (wildcard, userId, userName) |
| `src/probe.ts` | Server reachability probe via `/api/info` |
| `src/onboarding.ts` | Setup wizard (server URL, mode selection, token/auth config, DM policy) |
| `src/channel.ts` | Full `ChannelPlugin` registration |

## Two integration modes

**Webhook mode** (default — simplest for group bots):
- Configure an "Incoming Webhook" in Rocket.Chat Admin → Integrations
- OpenClaw posts to the webhook URL
- Rocket.Chat fires an "Outgoing Webhook" to OpenClaw's inbound path when trigger words match

**REST API mode** (full DM support):
- Authenticate with a Rocket.Chat Personal Access Token + userId
- OpenClaw calls `POST /api/v1/chat.postMessage` for any room or DM
- Same inbound outgoing-webhook for receiving messages

## Onboarding

DM policy, pairing, and allowFrom work exactly like Telegram/Discord: users run `openclaw onboard`, select "Rocket.Chat", and are guided through the setup. `order: 45` puts it between DingTalk (40) and Google Chat (55).

## Change Type

- [x] Feature

## Scope

- [x] Integrations

## Security Impact

- New permissions/capabilities? Yes — new HTTP endpoint on the gateway
- Secrets/tokens handling changed? No — follows existing `channels.X.outgoingToken` pattern  
- Inbound: outgoing webhook token verification before payload processing

## Testing

```
pnpm vitest run extensions/rocketchat/src
# 15 tests passed (accounts, policy, send)
```

Made with [Cursor](https://cursor.com)