### PR TITLE
fix(skills): expand glob patterns before passing to chokidar v5

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -153,7 +153,7 @@ export async function ensureSkillSnapshot(params: {
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
-  ensureSkillsWatcher({ workspaceDir, config: cfg });
+  await ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =
     snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
 


### PR DESCRIPTION
## Summary

chokidar v5+ 不再直接支持 glob 模式。此修复使用 glob 库将模式展开为实际文件路径，然后再传递给 chokidar.watch()。同时监听父目录以检测新的 SKILL.md 文件（add/unlink 事件）。

## Changes

- 使用  库展开 glob 模式为实际文件路径
- 监听父目录以检测新的 SKILL.md 文件
- 更新  为异步函数

Fixes #27404