### PR TITLE
fix(discord): isolate status reaction lifecycle

### DIFF
--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -1,0 +1,287 @@
+import type { StatusReactionEmojis } from "../../channels/status-reactions.js";
+
+export type DiscordStatusLifecycleState =
+  | "idle"
+  | "waiting-fresh"
+  | "waiting-backlog"
+  | "active"
+  | "done"
+  | "error"
+  | "cleared";
+
+type DiscordStatusTraceStage = "queued" | "applied" | "ignored" | "failed";
+
+export type DiscordStatusTraceEntry = {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  at: number;
+};
+
+export type DiscordStatusReactionAdapter = {
+  setReaction: (emoji: string) => Promise<void>;
+  removeReaction?: (emoji: string) => Promise<void>;
+};
+
+export type DiscordStatusReactionProjection = {
+  waitingFresh: string;
+  waitingBacklog: string;
+  active: string;
+  done: string;
+  error: string;
+};
+
+export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection = {
+  waitingFresh: "👀",
+  waitingBacklog: "⏳",
+  active: "🤔",
+  done: "✅",
+  error: "❌",
+};
+
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+
+const MAX_TRACE_ENTRIES = 2000;
+const traceEntries: DiscordStatusTraceEntry[] = [];
+
+function pushTrace(entry: DiscordStatusTraceEntry): void {
+  traceEntries.push(entry);
+  if (traceEntries.length > MAX_TRACE_ENTRIES) {
+    traceEntries.splice(0, traceEntries.length - MAX_TRACE_ENTRIES);
+  }
+}
+
+function resolveEmojiForState(
+  state: DiscordStatusLifecycleState,
+  projection: DiscordStatusReactionProjection,
+): string | null {
+  switch (state) {
+    case "waiting-fresh":
+      return projection.waitingFresh;
+    case "waiting-backlog":
+      return projection.waitingBacklog;
+    case "active":
+      return projection.active;
+    case "done":
+      return projection.done;
+    case "error":
+      return projection.error;
+    default:
+      return null;
+  }
+}
+
+function isWaitingState(state: DiscordStatusLifecycleState): boolean {
+  return state === "waiting-fresh" || state === "waiting-backlog";
+}
+
+function canTransition(
+  from: DiscordStatusLifecycleState,
+  to: DiscordStatusLifecycleState,
+): boolean {
+  if (from === "idle") {
+    return isWaitingState(to) || to === "active";
+  }
+  if (isWaitingState(from)) {
+    return to === "active";
+  }
+  if (from === "active") {
+    return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
+  }
+  return false;
+}
+
+function trackTransition(params: {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}): void {
+  const entry: DiscordStatusTraceEntry = {
+    messageId: params.messageId,
+    state: params.state,
+    stage: params.stage,
+    emoji: params.emoji,
+    at: Date.now(),
+  };
+  pushTrace(entry);
+  params.onTrace?.(entry);
+}
+
+export function resolveDiscordStatusReactionProjection(
+  overrides?: StatusReactionEmojis,
+  waitingFreshFallback?: string,
+): DiscordStatusReactionProjection {
+  const normalizedWaitingFreshFallback = waitingFreshFallback?.trim() || undefined;
+  return {
+    waitingFresh:
+      overrides?.queued ??
+      normalizedWaitingFreshFallback ??
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh,
+    waitingBacklog: overrides?.stallSoft ?? DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    active: overrides?.thinking ?? DISCORD_STATUS_DEFAULT_PROJECTION.active,
+    done: overrides?.done ?? DISCORD_STATUS_DEFAULT_PROJECTION.done,
+    error: overrides?.error ?? DISCORD_STATUS_DEFAULT_PROJECTION.error,
+  };
+}
+
+export function createDiscordStatusReactionLifecycle(params: {
+  enabled: boolean;
+  messageId: string;
+  adapter: DiscordStatusReactionAdapter;
+  projection: DiscordStatusReactionProjection;
+  onError?: (err: unknown) => void;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}) {
+  const { enabled, messageId, adapter, projection, onError, onTrace } = params;
+  let state: DiscordStatusLifecycleState = "idle";
+  let currentEmoji: string | null = null;
+  let chain = Promise.resolve();
+  let clearTimer: NodeJS.Timeout | null = null;
+  const knownEmojis = new Set<string>([
+    projection.waitingFresh,
+    projection.waitingBacklog,
+    projection.active,
+    projection.done,
+    projection.error,
+  ]);
+
+  function transition(nextState: DiscordStatusLifecycleState): Promise<void> {
+    const nextEmoji = resolveEmojiForState(nextState, projection);
+    trackTransition({
+      messageId,
+      state: nextState,
+      stage: "queued",
+      emoji: nextEmoji,
+      onTrace,
+    });
+
+    if (!enabled) {
+      state = nextState;
+      return Promise.resolve();
+    }
+    if (!canTransition(state, nextState)) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+
+    const fromState = state;
+    chain = chain.then(async () => {
+      try {
+        if (nextState === "cleared") {
+          let hadFailure = false;
+          if (adapter.removeReaction) {
+            for (const emoji of knownEmojis) {
+              try {
+                await adapter.removeReaction(emoji);
+              } catch (err) {
+                hadFailure = true;
+                onError?.(err);
+              }
+            }
+          }
+
+          if (hadFailure) {
+            state = fromState;
+            trackTransition({
+              messageId,
+              state: nextState,
+              stage: "failed",
+              emoji: null,
+              onTrace,
+            });
+            return;
+          }
+
+          state = nextState;
+          currentEmoji = null;
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "applied",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        if (!nextEmoji) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        const previousEmoji = currentEmoji;
+        await adapter.setReaction(nextEmoji);
+        if (adapter.removeReaction && previousEmoji && previousEmoji !== nextEmoji) {
+          await adapter.removeReaction(previousEmoji);
+        }
+        state = nextState;
+        currentEmoji = nextEmoji;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "applied",
+          emoji: nextEmoji,
+          onTrace,
+        });
+      } catch (err) {
+        state = fromState;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "failed",
+          emoji: nextEmoji,
+          onTrace,
+        });
+        onError?.(err);
+      }
+    });
+    return chain;
+  }
+
+  return {
+    enterWaiting: (hasPriorPendingWork: boolean): Promise<void> =>
+      transition(hasPriorPendingWork ? "waiting-backlog" : "waiting-fresh"),
+    enterActive: (): Promise<void> => transition("active"),
+    complete: (succeeded: boolean): Promise<void> => transition(succeeded ? "done" : "error"),
+    clearAfterHold: (holdMs = DISCORD_STATUS_CLEAR_HOLD_MS): void => {
+      if (!enabled || clearTimer) {
+        return;
+      }
+      clearTimer = setTimeout(() => {
+        clearTimer = null;
+        void transition("cleared");
+      }, holdMs);
+    },
+  };
+}
+
+function resetTraceEntriesForTests(): void {
+  traceEntries.length = 0;
+}
+
+function getTraceEntriesForTests(): DiscordStatusTraceEntry[] {
+  return traceEntries.map((entry) => ({ ...entry }));
+}
+
+export const __testing = {
+  getTraceEntriesForTests,
+  resetTraceEntriesForTests,
+};

--- a/src/discord/monitor/status-reaction-queue.ts
+++ b/src/discord/monitor/status-reaction-queue.ts
@@ -1,0 +1,51 @@
+type QueueSnapshot = {
+  size: number;
+  messageIds: string[];
+};
+
+const activeMessageIds = new Set<string>();
+
+function normalizeMessageId(messageId: string): string {
+  return messageId.trim();
+}
+
+/**
+ * Claim a queue slot for a Discord message lifecycle.
+ * Returns whether there was pending work before this message entered.
+ */
+export function claimDiscordStatusReactionQueue(messageId: string): {
+  hasPriorPendingWork: boolean;
+} {
+  const normalized = normalizeMessageId(messageId);
+  const alreadyActive = activeMessageIds.has(normalized);
+  const hasPriorPendingWork = alreadyActive ? activeMessageIds.size > 1 : activeMessageIds.size > 0;
+  activeMessageIds.add(normalized);
+  return { hasPriorPendingWork };
+}
+
+/**
+ * Release a previously claimed queue slot.
+ */
+export function releaseDiscordStatusReactionQueue(messageId: string): void {
+  const normalized = normalizeMessageId(messageId);
+  if (!normalized) {
+    return;
+  }
+  activeMessageIds.delete(normalized);
+}
+
+function getQueueSnapshot(): QueueSnapshot {
+  return {
+    size: activeMessageIds.size,
+    messageIds: Array.from(activeMessageIds),
+  };
+}
+
+function resetQueueForTests(): void {
+  activeMessageIds.clear();
+}
+
+export const __testing = {
+  getQueueSnapshot,
+  resetQueueForTests,
+};


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord status reaction lifecycle logic in `message-handler.process.ts` was too entangled, making behavior hard to reason about and risky to evolve.
- Why it matters: This path affects visible thread/message status feedback and regression risk in Discord monitoring flow.
- What changed: Extracted lifecycle + queue logic into focused modules (`status-reaction-lifecycle.ts`, `status-reaction-queue.ts`), then rewired `message-handler.process.ts` and related tests.
- What did NOT change (scope boundary): No product config/schema changes, no new channel capability, no unrelated state-machine V2 work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22642

## User-visible / Behavior Changes

- Discord status reaction lifecycle handling is now isolated and more predictable in the message handler flow.
- No new user-facing config knobs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0 (arm64)
- Runtime/container: Node.js v24.x local workspace run
- Model/provider: N/A (code/test validation)
- Integration/channel (if any): Discord monitor path
- Relevant config (redacted): default local test config

### Steps

1. `pnpm -s test src/discord/monitor/message-handler.process.test.ts`
2. `pnpm -s test src/channels/status-reactions.test.ts`
3. `pnpm -s test src/discord/monitor/message-handler.preflight.test.ts src/discord/monitor/message-handler.inbound-contract.test.ts`

### Expected

- All targeted Discord monitor/status-reaction suites pass.

### Actual

- Passed: 23 + 35 + 10 tests in local worktree.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran the three targeted test commands locally on branch `fix/discord-status-reaction-lifecycle-pr22642`.
- Edge cases checked: preflight and inbound-contract suites pass alongside main process and status-reactions suites.
- What you did **not** verify: Full monorepo test matrix / long-run soak in production traffic.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `6f0cece71c`.
- Files/config to restore: `src/discord/monitor/message-handler.process.ts`, `src/discord/monitor/message-handler.process.test.ts`, remove added `status-reaction-lifecycle.ts` and `status-reaction-queue.ts`.
- Known bad symptoms reviewers should watch for: missing/incorrect Discord status reactions, lifecycle transitions not clearing as expected.

## Risks and Mitigations

- Risk: Behavior drift in reaction lifecycle timing/order after extraction.
  - Mitigation: Keep change atomic; maintain targeted regression suites on process/status/preflight/inbound-contract paths.
