### PR TITLE
test(doctor): guard optional nested account assertions in config-flow test

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -274,15 +274,15 @@ describe("doctor config flow", () => {
       expect(cfg.channels.discord.guilds["100"].channels.general.users).toEqual(["333"]);
       expect(cfg.channels.discord.guilds["100"].channels.general.roles).toEqual(["444"]);
       expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["555"]);
-      expect(cfg.channels.discord.accounts.work.dm.allowFrom).toEqual(["666"]);
-      expect(cfg.channels.discord.accounts.work.dm.groupChannels).toEqual(["777"]);
-      expect(cfg.channels.discord.accounts.work.execApprovals.approvers).toEqual(["888"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].users).toEqual(["999"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].roles).toEqual(["1010"]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.users).toEqual([
+      expect(cfg.channels.discord.accounts.work.dm?.allowFrom).toEqual(["666"]);
+      expect(cfg.channels.discord.accounts.work.dm?.groupChannels).toEqual(["777"]);
+      expect(cfg.channels.discord.accounts.work.execApprovals?.approvers).toEqual(["888"]);
+      expect(cfg.channels.discord.accounts.work.guilds?.["200"]?.users).toEqual(["999"]);
+      expect(cfg.channels.discord.accounts.work.guilds?.["200"]?.roles).toEqual(["1010"]);
+      expect(cfg.channels.discord.accounts.work.guilds?.["200"]?.channels.help.users).toEqual([
         "1111",
       ]);
-      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.roles).toEqual([
+      expect(cfg.channels.discord.accounts.work.guilds?.["200"]?.channels.help.roles).toEqual([
         "1212",
       ]);
     });


### PR DESCRIPTION
## Summary
- update nested `accounts.work` assertions in `doctor-config-flow.test.ts` to use optional chaining
- keep the regression expectations unchanged while avoiding strict-nullability property access errors on optional account fields

## Testing
- `bash skills/openclaw-autonomous-contributor/scripts/quality_gate.sh <worktree>`
  - `pnpm build`
  - `pnpm format:check`
  - `pnpm tsgo`
  - `pnpm lint`
  - `pnpm test`

## AI-assisted
- This pull request was prepared with AI assistance and reviewed before submission.
