### PR TITLE
fix(nodes): resolve default node when multiple canvas-capable nodes are connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Canvas default node resolution: when multiple connected canvas-capable nodes exist and no single `mac-*` candidate is selected, default to the first connected candidate instead of failing with `node required` for implicit-node canvas tool calls. Landed from contributor PR #27444 by @carbaj03. Thanks @carbaj03.
 - TUI/stream assembly: preserve streamed text across real tool-boundary drops without keeping stale streamed text when non-text blocks appear only in the final payload. Landed from contributor PR #27711 by @scz2011. (#27674)
 - Hooks/Internal `message:sent`: forward `sessionKey` on outbound sends from agent delivery, cron isolated delivery, gateway receipt acks, heartbeat sends, session-maintenance warnings, and restart-sentinel recovery so internal `message:sent` hooks consistently dispatch with session context. Landed from contributor PR #27584 by @qualiobra. Thanks @qualiobra.
 - Models/MiniMax auth header defaults: set `authHeader: true` for both onboarding-generated MiniMax API providers and implicit built-in MiniMax (`minimax`, `minimax-portal`) provider templates so first requests no longer fail with MiniMax `401 authentication_error` due to missing `Authorization` header. Landed from contributor PRs #27622 by @riccoyuanft and #27631 by @kevinWangSheng. (#27600, #15303)

--- a/src/agents/tools/nodes-utils.test.ts
+++ b/src/agents/tools/nodes-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { NodeListNode } from "./nodes-utils.js";
+import { resolveNodeIdFromList } from "./nodes-utils.js";
+
+function node(overrides: Partial<NodeListNode> & { nodeId: string }): NodeListNode {
+  return {
+    nodeId: overrides.nodeId,
+    caps: ["canvas"],
+    connected: true,
+    ...overrides,
+  };
+}
+
+describe("resolveNodeIdFromList defaults", () => {
+  it("falls back to first connected canvas-capable node when multiple non-Mac candidates exist", () => {
+    const nodes: NodeListNode[] = [
+      node({ nodeId: "ios-1", platform: "ios" }),
+      node({ nodeId: "android-1", platform: "android" }),
+    ];
+
+    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("ios-1");
+  });
+
+  it("preserves local Mac preference when exactly one local Mac candidate exists", () => {
+    const nodes: NodeListNode[] = [
+      node({ nodeId: "ios-1", platform: "ios" }),
+      node({ nodeId: "mac-1", platform: "macos" }),
+    ];
+
+    expect(resolveNodeIdFromList(nodes, undefined, true)).toBe("mac-1");
+  });
+});

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -45,7 +45,10 @@ function pickDefaultNode(nodes: NodeListNode[]): NodeListNode | null {
     return local[0];
   }
 
-  return null;
+  // Multiple candidates — pick the first connected canvas-capable node.
+  // For A2UI and other canvas operations, any node works since multi-node
+  // setups broadcast surfaces across devices.
+  return candidates[0] ?? null;
 }
 
 export async function listNodes(opts: GatewayCallOptions): Promise<NodeListNode[]> {


### PR DESCRIPTION
## Summary

- `pickDefaultNode()` returns `null` when multiple connected canvas-capable nodes exist and none matches the local Mac heuristic (`mac-` prefix). This causes `"node required"` errors for agents calling the `canvas` tool without an explicit `node` parameter.
- Sub-agents spawned via `sessions_spawn` are especially affected — they don't know the node ID and rely on auto-resolution.
- In multi-node setups (e.g., desktop + mobile), any canvas-capable node is a valid target since the receiving node broadcasts A2UI surfaces to all other connected devices.
- Falls back to the first connected candidate instead of returning `null`.

## Reproduction

1. Connect 2+ devices with canvas capability (e.g., Mac app + mobile app)
2. Spawn a sub-agent via `sessions_spawn`
3. Sub-agent calls `canvas(action: "a2ui_push", jsonl: "...")` without a `node` parameter
4. Error: `"node required"` — `pickDefaultNode()` returned null because `candidates.length > 1`

## Test plan

- [ ] Single node connected: behavior unchanged (picks the one node)
- [ ] Two nodes connected, one local Mac (`mac-*`): picks the Mac (unchanged)
- [ ] Two nodes connected, neither `mac-*` prefix: now picks the first instead of failing
- [ ] Sub-agent canvas call without `node` param succeeds on multi-node setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)