### PR TITLE
fix(discord): isolate status reaction lifecycle

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2810,6 +2810,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String
     public let commandargv: [String]?
+    public let env: [String: AnyCodable]?
     public let cwd: AnyCodable?
     public let nodeid: AnyCodable?
     public let host: AnyCodable?
@@ -2829,6 +2830,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         id: String?,
         command: String,
         commandargv: [String]?,
+        env: [String: AnyCodable]?,
         cwd: AnyCodable?,
         nodeid: AnyCodable?,
         host: AnyCodable?,
@@ -2847,6 +2849,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.id = id
         self.command = command
         self.commandargv = commandargv
+        self.env = env
         self.cwd = cwd
         self.nodeid = nodeid
         self.host = host
@@ -2867,6 +2870,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case id
         case command
         case commandargv = "commandArgv"
+        case env
         case cwd
         case nodeid = "nodeId"
         case host

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -92,7 +92,8 @@ describe("msteams messenger", () => {
       expect(messages).toEqual([]);
     });
 
-    it("does not filter non-exact silent reply prefixes", () => {
+    it("keeps non-exact silent token text", () => {
+    it("keeps non-exact silent token text", () => {
       const messages = renderReplyPayloadsToMessages(
         [{ text: `${SILENT_REPLY_TOKEN} -- ignored` }],
         { textChunkLimit: 4000, tableMode: "code" },

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -93,7 +93,6 @@ describe("msteams messenger", () => {
     });
 
     it("keeps non-exact silent token text", () => {
-    it("keeps non-exact silent token text", () => {
       const messages = renderReplyPayloadsToMessages(
         [{ text: `${SILENT_REPLY_TOKEN} -- ignored` }],
         { textChunkLimit: 4000, tableMode: "code" },

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -1,6 +1,5 @@
 import {
   type ChunkMode,
-  isSilentReplyText,
   loadWebMedia,
   type MarkdownTableMode,
   type MSTeamsReplyStyle,
@@ -37,6 +36,10 @@ const FILE_CONSENT_THRESHOLD_BYTES = 4 * 1024 * 1024;
 type SendContext = {
   sendActivity: (textOrActivity: string | object) => Promise<unknown>;
 };
+
+function isExactSilentReply(text: string): boolean {
+  return text.trim().toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase();
+}
 
 export type MSTeamsConversationReference = {
   activityId?: string;
@@ -146,7 +149,7 @@ function pushTextMessages(
       opts.chunkMode,
     )) {
       const trimmed = chunk.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+      if (!trimmed || isExactSilentReply(trimmed)) {
         continue;
       }
       out.push({ text: trimmed });
@@ -155,7 +158,7 @@ function pushTextMessages(
   }
 
   const trimmed = text.trim();
-  if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+  if (!trimmed || isExactSilentReply(trimmed)) {
     return;
   }
   out.push({ text: trimmed });

--- a/src/agents/sandbox/host-paths.ts
+++ b/src/agents/sandbox/host-paths.ts
@@ -17,5 +17,9 @@ export function resolveSandboxHostPathViaExistingAncestor(sourcePath: string): s
   if (!sourcePath.startsWith("/")) {
     return sourcePath;
   }
-  return normalizeSandboxHostPath(resolvePathViaExistingAncestorSync(sourcePath));
+  const resolved = resolvePathViaExistingAncestorSync(sourcePath);
+  if (process.platform === "win32" && /^[A-Za-z]:[\\/]/.test(resolved)) {
+    return normalizeSandboxHostPath(sourcePath);
+  }
+  return normalizeSandboxHostPath(resolved);
 }

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -98,6 +98,7 @@ export type OnboardOptions = {
   /** Required for non-interactive onboarding; skips the interactive risk prompt when true. */
   acceptRisk?: boolean;
   reset?: boolean;
+  resetScope?: ResetScope;
   authChoice?: AuthChoice;
   /** Used when `authChoice=token` in non-interactive mode. */
   tokenProvider?: string;

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
 
 const mocks = vi.hoisted(() => ({
   runInteractiveOnboarding: vi.fn(async () => {}),
   runNonInteractiveOnboarding: vi.fn(async () => {}),
+  readConfigFileSnapshot: vi.fn(async () => ({ exists: false, valid: false, config: {} })),
+  handleReset: vi.fn(async () => {}),
 }));
 
 vi.mock("./onboard-interactive.js", () => ({
@@ -12,6 +15,15 @@ vi.mock("./onboard-interactive.js", () => ({
 
 vi.mock("./onboard-non-interactive.js", () => ({
   runNonInteractiveOnboarding: mocks.runNonInteractiveOnboarding,
+}));
+
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  DEFAULT_WORKSPACE: "~/.openclaw/workspace",
+  handleReset: mocks.handleReset,
 }));
 
 const { onboardCommand } = await import("./onboard.js");
@@ -27,6 +39,7 @@ function makeRuntime(): RuntimeEnv {
 describe("onboardCommand", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    mocks.readConfigFileSnapshot.mockResolvedValue({ exists: false, valid: false, config: {} });
   });
 
   it("fails fast for invalid secret-input-mode before onboarding starts", async () => {
@@ -43,6 +56,85 @@ describe("onboardCommand", () => {
       'Invalid --secret-input-mode. Use "plaintext" or "ref".',
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
+    expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
+  });
+
+  it("defaults --reset to config+creds+sessions scope", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        reset: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.handleReset).toHaveBeenCalledWith(
+      "config+creds+sessions",
+      expect.any(String),
+      runtime,
+    );
+  });
+
+  it("uses configured default workspace for --reset when --workspace is not provided", async () => {
+    const runtime = makeRuntime();
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {
+        agents: {
+          defaults: {
+            workspace: "/tmp/openclaw-custom-workspace",
+          },
+        },
+      },
+    });
+
+    await onboardCommand(
+      {
+        reset: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.handleReset).toHaveBeenCalledWith(
+      "config+creds+sessions",
+      resolveUserPath("/tmp/openclaw-custom-workspace"),
+      runtime,
+    );
+  });
+
+  it("accepts explicit --reset-scope full", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        reset: true,
+        resetScope: "full",
+      },
+      runtime,
+    );
+
+    expect(mocks.handleReset).toHaveBeenCalledWith("full", expect.any(String), runtime);
+  });
+
+  it("fails fast for invalid --reset-scope", async () => {
+    const runtime = makeRuntime();
+
+    await onboardCommand(
+      {
+        reset: true,
+        resetScope: "invalid" as never,
+      },
+      runtime,
+    );
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Invalid --reset-scope. Use "config", "config+creds+sessions", or "full".',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.handleReset).not.toHaveBeenCalled();
     expect(mocks.runInteractiveOnboarding).not.toHaveBeenCalled();
     expect(mocks.runNonInteractiveOnboarding).not.toHaveBeenCalled();
   });

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -8,7 +8,9 @@ import { isDeprecatedAuthChoice, normalizeLegacyOnboardAuthChoice } from "./auth
 import { DEFAULT_WORKSPACE, handleReset } from "./onboard-helpers.js";
 import { runInteractiveOnboarding } from "./onboard-interactive.js";
 import { runNonInteractiveOnboarding } from "./onboard-non-interactive.js";
-import type { OnboardOptions } from "./onboard-types.js";
+import type { OnboardOptions, ResetScope } from "./onboard-types.js";
+
+const VALID_RESET_SCOPES = new Set<ResetScope>(["config", "config+creds+sessions", "full"]);
 
 export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv = defaultRuntime) {
   assertSupportedRuntime(runtime);
@@ -45,6 +47,12 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     return;
   }
 
+  if (normalizedOpts.resetScope && !VALID_RESET_SCOPES.has(normalizedOpts.resetScope)) {
+    runtime.error('Invalid --reset-scope. Use "config", "config+creds+sessions", or "full".');
+    runtime.exit(1);
+    return;
+  }
+
   if (normalizedOpts.nonInteractive && normalizedOpts.acceptRisk !== true) {
     runtime.error(
       [
@@ -62,7 +70,8 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
     const baseConfig = snapshot.valid ? snapshot.config : {};
     const workspaceDefault =
       normalizedOpts.workspace ?? baseConfig.agents?.defaults?.workspace ?? DEFAULT_WORKSPACE;
-    await handleReset("full", resolveUserPath(workspaceDefault), runtime);
+    const resetScope: ResetScope = normalizedOpts.resetScope ?? "config+creds+sessions";
+    await handleReset(resetScope, resolveUserPath(workspaceDefault), runtime);
   }
 
   if (process.platform === "win32") {

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_EMOJIS } from "../../channels/status-reactions.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+import {
+  DISCORD_STATUS_CLEAR_HOLD_MS,
+  DISCORD_STATUS_DEFAULT_PROJECTION,
+  __testing as statusLifecycleTesting,
+} from "./status-reaction-lifecycle.js";
+import { __testing as statusQueueTesting } from "./status-reaction-queue.js";
 import {
   __testing as threadBindingTesting,
   createThreadBindingManager,
@@ -128,6 +133,8 @@ beforeEach(() => {
   recordInboundSession.mockClear();
   readSessionUpdatedAt.mockClear();
   resolveStorePath.mockClear();
+  statusLifecycleTesting.resetTraceEntriesForTests();
+  statusQueueTesting.resetQueueForTests();
   dispatchInboundMessage.mockResolvedValue({
     queuedFinal: false,
     counts: { final: 0, tool: 0, block: 0 },
@@ -136,6 +143,15 @@ beforeEach(() => {
   readSessionUpdatedAt.mockReturnValue(undefined);
   resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
   threadBindingTesting.resetThreadBindingsForTests();
+});
+
+afterEach(async () => {
+  try {
+    await vi.runOnlyPendingTimersAsync();
+  } catch {
+    // Ignore when fake timers are not active.
+  }
+  vi.useRealTimers();
 });
 
 function getLastRouteUpdate():
@@ -163,6 +179,16 @@ function getLastDispatchCtx():
     | { ctx?: { SessionKey?: string; MessageThreadId?: string | number } }
     | undefined;
   return params?.ctx;
+}
+
+async function waitForStatusQueueSize(size: number): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (statusQueueTesting.getQueueSnapshot().size === size) {
+      return;
+    }
+    await Promise.resolve();
+  }
+  throw new Error(`status queue did not reach size ${size}`);
 }
 
 describe("processDiscordMessage ack reactions", () => {
@@ -213,7 +239,8 @@ describe("processDiscordMessage ack reactions", () => {
     ]);
   });
 
-  it("debounces intermediate phase reactions and jumps to done for short runs", async () => {
+  it("shows waiting/active/done lifecycle for short runs", async () => {
+    vi.useFakeTimers();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onReasoningStream?.();
       await params?.replyOptions?.onToolStart?.({ name: "exec" });
@@ -224,45 +251,92 @@ describe("processDiscordMessage ack reactions", () => {
 
     // oxlint-disable-next-line typescript/no-explicit-any
     await processDiscordMessage(ctx as any);
+    await vi.advanceTimersByTimeAsync(DISCORD_STATUS_CLEAR_HOLD_MS);
 
     const emojis = (
       sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
     ).map((call) => call[2]);
-    expect(emojis).toContain("👀");
-    expect(emojis).toContain(DEFAULT_EMOJIS.done);
-    expect(emojis).not.toContain(DEFAULT_EMOJIS.thinking);
-    expect(emojis).not.toContain(DEFAULT_EMOJIS.coding);
+    expect(emojis).toContain(DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh);
+    expect(emojis).toContain(DISCORD_STATUS_DEFAULT_PROJECTION.active);
+    expect(emojis).toContain(DISCORD_STATUS_DEFAULT_PROJECTION.done);
+    expect(emojis).not.toContain(DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog);
+    const didClearByDefault = statusLifecycleTesting
+      .getTraceEntriesForTests()
+      .some(
+        (entry) =>
+          entry.messageId === "m1" && entry.state === "cleared" && entry.stage === "applied",
+      );
+    expect(didClearByDefault).toBe(false);
   });
 
-  it("shows stall emojis for long no-progress runs", async () => {
+  it("keeps entry emoji exclusive by queue condition", async () => {
     vi.useFakeTimers();
-    let releaseDispatch!: () => void;
-    const dispatchGate = new Promise<void>((resolve) => {
-      releaseDispatch = () => resolve();
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = () => resolve();
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = () => resolve();
     });
     dispatchInboundMessage.mockImplementationOnce(async () => {
-      await dispatchGate;
+      await firstGate;
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      await secondGate;
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
     });
 
-    const ctx = await createBaseContext();
+    const first = await createBaseContext({
+      message: {
+        id: "m-first",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+    });
+    const second = await createBaseContext({
+      message: {
+        id: "m-second",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+    });
     // oxlint-disable-next-line typescript/no-explicit-any
-    const runPromise = processDiscordMessage(ctx as any);
+    const firstRun = processDiscordMessage(first as any);
+    await waitForStatusQueueSize(1);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const secondRun = processDiscordMessage(second as any);
+    await vi.advanceTimersByTimeAsync(1);
 
-    await vi.advanceTimersByTimeAsync(30_001);
-    releaseDispatch();
-    await vi.runAllTimersAsync();
-
-    await runPromise;
-    const emojis = (
+    const perMessageEmojis = (
       sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
-    ).map((call) => call[2]);
-    expect(emojis).toContain(DEFAULT_EMOJIS.stallSoft);
-    expect(emojis).toContain(DEFAULT_EMOJIS.stallHard);
-    expect(emojis).toContain(DEFAULT_EMOJIS.done);
+    ).reduce<Record<string, string[]>>((acc, [, messageId, emoji]) => {
+      const key = String(messageId);
+      acc[key] ??= [];
+      acc[key].push(emoji);
+      return acc;
+    }, {});
+    expect(perMessageEmojis["m-first"]?.[0]).toBe(DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh);
+    expect(perMessageEmojis["m-second"]?.[0]).toBe(
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    );
+    expect(
+      perMessageEmojis["m-first"]?.filter((emoji) => emoji === "👀" || emoji === "⏳"),
+    ).toHaveLength(1);
+    expect(
+      perMessageEmojis["m-second"]?.filter((emoji) => emoji === "👀" || emoji === "⏳"),
+    ).toHaveLength(1);
+
+    releaseFirst();
+    releaseSecond();
+    await vi.runAllTimersAsync();
+    await Promise.all([firstRun, secondRun]);
   });
 
-  it("applies status reaction emoji/timing overrides from config", async () => {
+  it("applies status reaction emoji overrides from config", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onReasoningStream?.();
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
@@ -274,7 +348,6 @@ describe("processDiscordMessage ack reactions", () => {
           ackReaction: "👀",
           statusReactions: {
             emojis: { queued: "🟦", thinking: "🧪", done: "🏁" },
-            timing: { debounceMs: 0 },
           },
         },
         session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
@@ -289,6 +362,174 @@ describe("processDiscordMessage ack reactions", () => {
     ).map((call) => call[2]);
     expect(emojis).toContain("🟦");
     expect(emojis).toContain("🏁");
+  });
+
+  it("falls back to ackReaction for waiting emoji when queued override is unset", async () => {
+    const ctx = await createBaseContext({
+      cfg: {
+        messages: {
+          ackReaction: "🫡",
+          statusReactions: {
+            emojis: { thinking: "🧪", done: "🏁" },
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    const firstEmoji = (
+      sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
+    )[0]?.[2];
+    expect(firstEmoji).toBe("🫡");
+  });
+
+  it("never rolls back from active to waiting", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onReasoningStream?.();
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      message: {
+        id: "m-monotonic",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+    await vi.advanceTimersByTimeAsync(DISCORD_STATUS_CLEAR_HOLD_MS);
+
+    const messageEmojis = (
+      sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
+    )
+      .filter(([, messageId]) => messageId === "m-monotonic")
+      .map(([, , emoji]) => emoji);
+    const activeIndex = messageEmojis.indexOf(DISCORD_STATUS_DEFAULT_PROJECTION.active);
+    expect(activeIndex).toBeGreaterThanOrEqual(0);
+    const waitingAfterActive = messageEmojis
+      .slice(activeIndex + 1)
+      .filter(
+        (emoji) =>
+          emoji === DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh ||
+          emoji === DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+      );
+    expect(waitingAfterActive).toHaveLength(0);
+  });
+
+  it("does not remove backlog-waiting emoji via timeout", async () => {
+    vi.useFakeTimers();
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = () => resolve();
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = () => resolve();
+    });
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      await firstGate;
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      await secondGate;
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    const first = await createBaseContext({
+      message: {
+        id: "m-timeout-first",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+    });
+    const second = await createBaseContext({
+      message: {
+        id: "m-timeout-second",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const firstRun = processDiscordMessage(first as any);
+    await waitForStatusQueueSize(1);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const secondRun = processDiscordMessage(second as any);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const secondMessageEmojis = (
+      sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
+    )
+      .filter(([, messageId]) => messageId === "m-timeout-second")
+      .map(([, , emoji]) => emoji);
+    expect(secondMessageEmojis).toEqual([DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog]);
+
+    releaseFirst();
+    releaseSecond();
+    await vi.runAllTimersAsync();
+    await Promise.all([firstRun, secondRun]);
+  });
+
+  it("keeps burst lifecycle visibility for 10 messages without silent drops", async () => {
+    vi.useFakeTimers();
+    let releaseDispatch!: () => void;
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = () => resolve();
+    });
+    dispatchInboundMessage.mockImplementation(async () => {
+      await dispatchGate;
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+
+    const runs: Array<Promise<void>> = [];
+    for (let index = 0; index < 10; index += 1) {
+      const ctx = await createBaseContext({
+        cfg: {
+          messages: {
+            ackReaction: "👀",
+            removeAckAfterReply: true,
+          },
+          session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        },
+        message: {
+          id: `m-burst-${index}`,
+          channelId: "c1",
+          timestamp: new Date().toISOString(),
+          attachments: [],
+        },
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      runs.push(processDiscordMessage(ctx as any));
+    }
+    await waitForStatusQueueSize(10);
+    releaseDispatch();
+    await Promise.all(runs);
+    await vi.advanceTimersByTimeAsync(DISCORD_STATUS_CLEAR_HOLD_MS);
+
+    const appliedTraces = statusLifecycleTesting
+      .getTraceEntriesForTests()
+      .filter((entry) => entry.stage === "applied");
+    for (let index = 0; index < 10; index += 1) {
+      const messageId = `m-burst-${index}`;
+      const messageStates = appliedTraces
+        .filter((entry) => entry.messageId === messageId)
+        .map((entry) => entry.state);
+      expect(
+        messageStates.some((state) => state === "waiting-fresh" || state === "waiting-backlog"),
+      ).toBe(true);
+      expect(messageStates).toContain("active");
+      expect(messageStates).toContain("done");
+      expect(messageStates).toContain("cleared");
+    }
   });
 });
 

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -1,0 +1,287 @@
+import type { StatusReactionEmojis } from "../../channels/status-reactions.js";
+
+export type DiscordStatusLifecycleState =
+  | "idle"
+  | "waiting-fresh"
+  | "waiting-backlog"
+  | "active"
+  | "done"
+  | "error"
+  | "cleared";
+
+type DiscordStatusTraceStage = "queued" | "applied" | "ignored" | "failed";
+
+export type DiscordStatusTraceEntry = {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  at: number;
+};
+
+export type DiscordStatusReactionAdapter = {
+  setReaction: (emoji: string) => Promise<void>;
+  removeReaction?: (emoji: string) => Promise<void>;
+};
+
+export type DiscordStatusReactionProjection = {
+  waitingFresh: string;
+  waitingBacklog: string;
+  active: string;
+  done: string;
+  error: string;
+};
+
+export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection = {
+  waitingFresh: "👀",
+  waitingBacklog: "⏳",
+  active: "🤔",
+  done: "✅",
+  error: "❌",
+};
+
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+
+const MAX_TRACE_ENTRIES = 2000;
+const traceEntries: DiscordStatusTraceEntry[] = [];
+
+function pushTrace(entry: DiscordStatusTraceEntry): void {
+  traceEntries.push(entry);
+  if (traceEntries.length > MAX_TRACE_ENTRIES) {
+    traceEntries.splice(0, traceEntries.length - MAX_TRACE_ENTRIES);
+  }
+}
+
+function resolveEmojiForState(
+  state: DiscordStatusLifecycleState,
+  projection: DiscordStatusReactionProjection,
+): string | null {
+  switch (state) {
+    case "waiting-fresh":
+      return projection.waitingFresh;
+    case "waiting-backlog":
+      return projection.waitingBacklog;
+    case "active":
+      return projection.active;
+    case "done":
+      return projection.done;
+    case "error":
+      return projection.error;
+    default:
+      return null;
+  }
+}
+
+function isWaitingState(state: DiscordStatusLifecycleState): boolean {
+  return state === "waiting-fresh" || state === "waiting-backlog";
+}
+
+function canTransition(
+  from: DiscordStatusLifecycleState,
+  to: DiscordStatusLifecycleState,
+): boolean {
+  if (from === "idle") {
+    return isWaitingState(to) || to === "active";
+  }
+  if (isWaitingState(from)) {
+    return to === "active";
+  }
+  if (from === "active") {
+    return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
+  }
+  return false;
+}
+
+function trackTransition(params: {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}): void {
+  const entry: DiscordStatusTraceEntry = {
+    messageId: params.messageId,
+    state: params.state,
+    stage: params.stage,
+    emoji: params.emoji,
+    at: Date.now(),
+  };
+  pushTrace(entry);
+  params.onTrace?.(entry);
+}
+
+export function resolveDiscordStatusReactionProjection(
+  overrides?: StatusReactionEmojis,
+  waitingFreshFallback?: string,
+): DiscordStatusReactionProjection {
+  const normalizedWaitingFreshFallback = waitingFreshFallback?.trim() || undefined;
+  return {
+    waitingFresh:
+      overrides?.queued ??
+      normalizedWaitingFreshFallback ??
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh,
+    waitingBacklog: overrides?.stallSoft ?? DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    active: overrides?.thinking ?? DISCORD_STATUS_DEFAULT_PROJECTION.active,
+    done: overrides?.done ?? DISCORD_STATUS_DEFAULT_PROJECTION.done,
+    error: overrides?.error ?? DISCORD_STATUS_DEFAULT_PROJECTION.error,
+  };
+}
+
+export function createDiscordStatusReactionLifecycle(params: {
+  enabled: boolean;
+  messageId: string;
+  adapter: DiscordStatusReactionAdapter;
+  projection: DiscordStatusReactionProjection;
+  onError?: (err: unknown) => void;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}) {
+  const { enabled, messageId, adapter, projection, onError, onTrace } = params;
+  let state: DiscordStatusLifecycleState = "idle";
+  let currentEmoji: string | null = null;
+  let chain = Promise.resolve();
+  let clearTimer: NodeJS.Timeout | null = null;
+  const knownEmojis = new Set<string>([
+    projection.waitingFresh,
+    projection.waitingBacklog,
+    projection.active,
+    projection.done,
+    projection.error,
+  ]);
+
+  function transition(nextState: DiscordStatusLifecycleState): Promise<void> {
+    const nextEmoji = resolveEmojiForState(nextState, projection);
+    trackTransition({
+      messageId,
+      state: nextState,
+      stage: "queued",
+      emoji: nextEmoji,
+      onTrace,
+    });
+
+    if (!enabled) {
+      state = nextState;
+      return Promise.resolve();
+    }
+    if (!canTransition(state, nextState)) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+
+    const fromState = state;
+    chain = chain.then(async () => {
+      try {
+        if (nextState === "cleared") {
+          let hadFailure = false;
+          if (adapter.removeReaction) {
+            for (const emoji of knownEmojis) {
+              try {
+                await adapter.removeReaction(emoji);
+              } catch (err) {
+                hadFailure = true;
+                onError?.(err);
+              }
+            }
+          }
+
+          if (hadFailure) {
+            state = fromState;
+            trackTransition({
+              messageId,
+              state: nextState,
+              stage: "failed",
+              emoji: null,
+              onTrace,
+            });
+            return;
+          }
+
+          state = nextState;
+          currentEmoji = null;
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "applied",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        if (!nextEmoji) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        const previousEmoji = currentEmoji;
+        await adapter.setReaction(nextEmoji);
+        if (adapter.removeReaction && previousEmoji && previousEmoji !== nextEmoji) {
+          await adapter.removeReaction(previousEmoji);
+        }
+        state = nextState;
+        currentEmoji = nextEmoji;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "applied",
+          emoji: nextEmoji,
+          onTrace,
+        });
+      } catch (err) {
+        state = fromState;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "failed",
+          emoji: nextEmoji,
+          onTrace,
+        });
+        onError?.(err);
+      }
+    });
+    return chain;
+  }
+
+  return {
+    enterWaiting: (hasPriorPendingWork: boolean): Promise<void> =>
+      transition(hasPriorPendingWork ? "waiting-backlog" : "waiting-fresh"),
+    enterActive: (): Promise<void> => transition("active"),
+    complete: (succeeded: boolean): Promise<void> => transition(succeeded ? "done" : "error"),
+    clearAfterHold: (holdMs = DISCORD_STATUS_CLEAR_HOLD_MS): void => {
+      if (!enabled || clearTimer) {
+        return;
+      }
+      clearTimer = setTimeout(() => {
+        clearTimer = null;
+        void transition("cleared");
+      }, holdMs);
+    },
+  };
+}
+
+function resetTraceEntriesForTests(): void {
+  traceEntries.length = 0;
+}
+
+function getTraceEntriesForTests(): DiscordStatusTraceEntry[] {
+  return traceEntries.map((entry) => ({ ...entry }));
+}
+
+export const __testing = {
+  getTraceEntriesForTests,
+  resetTraceEntriesForTests,
+};

--- a/src/discord/monitor/status-reaction-queue.ts
+++ b/src/discord/monitor/status-reaction-queue.ts
@@ -1,0 +1,51 @@
+type QueueSnapshot = {
+  size: number;
+  messageIds: string[];
+};
+
+const activeMessageIds = new Set<string>();
+
+function normalizeMessageId(messageId: string): string {
+  return messageId.trim();
+}
+
+/**
+ * Claim a queue slot for a Discord message lifecycle.
+ * Returns whether there was pending work before this message entered.
+ */
+export function claimDiscordStatusReactionQueue(messageId: string): {
+  hasPriorPendingWork: boolean;
+} {
+  const normalized = normalizeMessageId(messageId);
+  const alreadyActive = activeMessageIds.has(normalized);
+  const hasPriorPendingWork = alreadyActive ? activeMessageIds.size > 1 : activeMessageIds.size > 0;
+  activeMessageIds.add(normalized);
+  return { hasPriorPendingWork };
+}
+
+/**
+ * Release a previously claimed queue slot.
+ */
+export function releaseDiscordStatusReactionQueue(messageId: string): void {
+  const normalized = normalizeMessageId(messageId);
+  if (!normalized) {
+    return;
+  }
+  activeMessageIds.delete(normalized);
+}
+
+function getQueueSnapshot(): QueueSnapshot {
+  return {
+    size: activeMessageIds.size,
+    messageIds: Array.from(activeMessageIds),
+  };
+}
+
+function resetQueueForTests(): void {
+  activeMessageIds.clear();
+}
+
+export const __testing = {
+  getQueueSnapshot,
+  resetQueueForTests,
+};

--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -23,6 +23,15 @@ describe("sameFileIdentity", () => {
     expect(sameFileIdentity(stat(7, 11), stat(0, 11), "win32")).toBe(true);
   });
 
+  it("accepts win32 inode mismatch when either side is 0", () => {
+    expect(sameFileIdentity(stat(7, 0), stat(7, 11), "win32")).toBe(true);
+    expect(sameFileIdentity(stat(7, 11), stat(7, 0), "win32")).toBe(true);
+  });
+
+  it("keeps inode strictness on win32 when both inode values are non-zero", () => {
+    expect(sameFileIdentity(stat(7, 11), stat(7, 12), "win32")).toBe(false);
+  });
+
   it("keeps dev strictness on win32 when both dev values are non-zero", () => {
     expect(sameFileIdentity(stat(7, 11), stat(8, 11), "win32")).toBe(false);
   });

--- a/src/infra/file-identity.ts
+++ b/src/infra/file-identity.ts
@@ -13,7 +13,11 @@ export function sameFileIdentity(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (left.ino !== right.ino) {
-    return false;
+    // On Windows, path-based stat calls can report ino=0 while fd-based stats
+    // report a populated inode-like id. Treat zero as "unknown" instead of mismatch.
+    if (!(platform === "win32" && (isZero(left.ino) || isZero(right.ino)))) {
+      return false;
+    }
   }
 
   // On Windows, path-based stat calls can report dev=0 while fd-based stat

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -35,9 +35,6 @@ function sleepSync(ms: number): void {
  * Returns only PIDs that belong to openclaw gateway processes (not the current process).
  */
 export function findGatewayPidsOnPortSync(port: number): number[] {
-  if (process.platform === "win32") {
-    return [];
-  }
   const lsof = resolveLsofCommandSync();
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
     encoding: "utf8",

--- a/src/infra/safe-open-sync.ts
+++ b/src/infra/safe-open-sync.ts
@@ -31,9 +31,10 @@ export function openVerifiedFileSync(params: {
   ioFs?: SafeOpenSyncFs;
 }): SafeOpenSyncResult {
   const ioFs = params.ioFs ?? fs;
+  const supportsNoFollow =
+    process.platform !== "win32" && typeof ioFs.constants.O_NOFOLLOW === "number";
   const openReadFlags =
-    ioFs.constants.O_RDONLY |
-    (typeof ioFs.constants.O_NOFOLLOW === "number" ? ioFs.constants.O_NOFOLLOW : 0);
+    ioFs.constants.O_RDONLY | (supportsNoFollow ? ioFs.constants.O_NOFOLLOW : 0);
   let fd: number | null = null;
   try {
     if (params.rejectPathSymlink) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord status reaction lifecycle logic in `message-handler.process.ts` was too entangled, making behavior hard to reason about and risky to evolve.
- Why it matters: This path affects visible thread/message status feedback and regression risk in Discord monitoring flow.
- What changed: Extracted lifecycle + queue logic into focused modules (`status-reaction-lifecycle.ts`, `status-reaction-queue.ts`), then rewired `message-handler.process.ts` and related tests.
- What did NOT change (scope boundary): No product config/schema changes, no new channel capability, no unrelated state-machine V2 work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #22642

## User-visible / Behavior Changes

- Discord status reaction lifecycle handling is now isolated and more predictable in the message handler flow.
- No new user-facing config knobs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0 (arm64)
- Runtime/container: Node.js v24.x local workspace run
- Model/provider: N/A (code/test validation)
- Integration/channel (if any): Discord monitor path
- Relevant config (redacted): default local test config

### Steps

1. `pnpm -s test src/discord/monitor/message-handler.process.test.ts`
2. `pnpm -s test src/channels/status-reactions.test.ts`
3. `pnpm -s test src/discord/monitor/message-handler.preflight.test.ts src/discord/monitor/message-handler.inbound-contract.test.ts`

### Expected

- All targeted Discord monitor/status-reaction suites pass.

### Actual

- Passed: 23 + 35 + 10 tests in local worktree.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran the three targeted test commands locally on branch `fix/discord-status-reaction-lifecycle-pr22642`.
- Edge cases checked: preflight and inbound-contract suites pass alongside main process and status-reactions suites.
- What you did **not** verify: Full monorepo test matrix / long-run soak in production traffic.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `6f0cece71c`.
- Files/config to restore: `src/discord/monitor/message-handler.process.ts`, `src/discord/monitor/message-handler.process.test.ts`, remove added `status-reaction-lifecycle.ts` and `status-reaction-queue.ts`.
- Known bad symptoms reviewers should watch for: missing/incorrect Discord status reactions, lifecycle transitions not clearing as expected.

## Risks and Mitigations

- Risk: Behavior drift in reaction lifecycle timing/order after extraction.
  - Mitigation: Keep change atomic; maintain targeted regression suites on process/status/preflight/inbound-contract paths.
