### PR TITLE
fix(daemon): treat EPERM as process-alive in waitForPidExit

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -350,10 +350,14 @@ async function waitForPidExit(pid: number): Promise<void> {
       process.kill(pid, 0);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH" || code === "EPERM") {
+      if (code === "ESRCH") {
         return;
       }
-      return;
+      // EPERM means the process exists but we lack permission to signal it;
+      // keep polling until it exits or the deadline is reached.
+      if (code !== "EPERM") {
+        return;
+      }
     }
     await sleepMs(RESTART_PID_WAIT_INTERVAL_MS);
   }


### PR DESCRIPTION
## Summary

- `waitForPidExit` currently treats `EPERM` from `process.kill(pid, 0)` the same as `ESRCH` (process gone) and returns early. However, `EPERM` means the process exists but the caller lacks permission to signal it -- the process is still alive.
- This can cause the new gateway to bootstrap while the old process still holds the port, leading to "address already in use" failures during restart.
- Fix: only treat `ESRCH` as confirmation that the process exited. For `EPERM`, continue polling until the deadline.

## Test plan

- Verify `openclaw gateway run` restart cycle on macOS where the old gateway process may briefly run under a different UID.
- Existing `launchd.test.ts` covers the happy path; the fix prevents a race in edge-case permission scenarios.

Made with [Cursor](https://cursor.com)