### PR TITLE
fix: catch unhandled rejections in fire-and-forget async calls

### DIFF
--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -315,7 +315,9 @@ export async function runGmailService(opts: GmailRunOptions) {
 
   const renewMs = runtimeConfig.renewEveryMinutes * 60_000;
   const renewTimer = setInterval(() => {
-    void startGmailWatch(runtimeConfig);
+    void startGmailWatch(runtimeConfig).catch((err) => {
+      defaultRuntime.error?.(`Gmail watch renew failed: ${String(err)}`);
+    });
   }, renewMs);
 
   const detachSignals = () => {

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -210,7 +210,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       if (!payload) {
         return;
       }
-      void handleInvoke(payload, client, skillBins);
+      void handleInvoke(payload, client, skillBins).catch((err) => {
+        console.error(`node host invoke failed: ${String(err)}`);
+      });
     },
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)


### PR DESCRIPTION
## Summary

- `handleInvoke` in `src/node-host/runner.ts` and `startGmailWatch` in `src/hooks/gmail-ops.ts` are both async functions called with `void` (fire-and-forget) but without `.catch()`.
- If either rejects, Node emits an unhandled rejection which can crash the process or cause silent failures.
- Fix: add `.catch()` with appropriate error logging to both call sites.

## Test plan

- Verify no unhandled rejection warnings appear when node-host invoke or Gmail watch renewal fails.

Made with [Cursor](https://cursor.com)