### PR TITLE
feat: add proxy support for web search tools

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -256,6 +256,7 @@ function mapBraveLlmContextResults(
 }
 
 async function runBraveLlmContextSearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   apiKey: string;
   timeoutSeconds: number;
@@ -287,6 +288,7 @@ async function runBraveLlmContextSearch(params: {
     {
       url: url.toString(),
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       init: {
         method: "GET",
         headers: {
@@ -308,6 +310,7 @@ async function runBraveLlmContextSearch(params: {
 }
 
 async function runBraveWebSearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   count: number;
   apiKey: string;
@@ -348,6 +351,7 @@ async function runBraveWebSearch(params: {
     {
       url: url.toString(),
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       init: {
         method: "GET",
         headers: {
@@ -566,6 +570,7 @@ function createBraveToolDefinition(
 
       if (braveMode === "llm-context") {
         const { results, sources } = await runBraveLlmContextSearch({
+          searchConfig,
           query,
           apiKey,
           timeoutSeconds,
@@ -598,6 +603,7 @@ function createBraveToolDefinition(
       }
 
       const results = await runBraveWebSearch({
+        searchConfig,
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
         apiKey,

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -78,6 +78,7 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
 }
 
 async function runGeminiSearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   apiKey: string;
   model: string;
@@ -89,6 +90,7 @@ async function runGeminiSearch(params: {
     {
       url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       init: {
         method: "POST",
         headers: {
@@ -217,6 +219,7 @@ function createGeminiToolDefinition(
 
       const start = Date.now();
       const result = await runGeminiSearch({
+        searchConfig,
         query,
         apiKey,
         model,

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -139,6 +139,7 @@ function buildKimiToolResultContent(data: KimiSearchResponse): string {
 }
 
 async function runKimiSearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   apiKey: string;
   baseUrl: string;
@@ -154,6 +155,7 @@ async function runKimiSearch(params: {
       {
         url: endpoint,
         timeoutSeconds: params.timeoutSeconds,
+        searchConfig: params.searchConfig,
         init: {
           method: "POST",
           headers: {
@@ -287,6 +289,7 @@ function createKimiToolDefinition(
 
       const start = Date.now();
       const result = await runKimiSearch({
+        searchConfig,
         query,
         apiKey,
         baseUrl,

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -211,6 +211,7 @@ function extractPerplexityCitations(data: PerplexitySearchResponse): string[] {
 }
 
 async function runPerplexitySearchApi(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   apiKey: string;
   count: number;
@@ -242,6 +243,7 @@ async function runPerplexitySearchApi(params: {
     {
       url: PERPLEXITY_SEARCH_ENDPOINT,
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       init: {
         method: "POST",
         headers: {
@@ -271,6 +273,7 @@ async function runPerplexitySearchApi(params: {
 }
 
 async function runPerplexitySearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   apiKey: string;
   baseUrl: string;
@@ -291,6 +294,7 @@ async function runPerplexitySearch(params: {
     {
       url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       init: {
         method: "POST",
         headers: {
@@ -596,6 +600,7 @@ function createPerplexityToolDefinition(
               },
               ...(await (async () => {
                 const result = await runPerplexitySearch({
+                  searchConfig,
                   query,
                   apiKey: runtime.apiKey!,
                   baseUrl: runtime.baseUrl,
@@ -621,6 +626,7 @@ function createPerplexityToolDefinition(
                 wrapped: true,
               },
               results: await runPerplexitySearchApi({
+                searchConfig,
                 query,
                 apiKey: runtime.apiKey!,
                 count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),

--- a/extensions/xai/src/web-search-shared.ts
+++ b/extensions/xai/src/web-search-shared.ts
@@ -124,6 +124,7 @@ export function extractXaiWebSearchContent(data: XaiWebSearchResponse): {
 }
 
 export async function requestXaiWebSearch(params: {
+  searchConfig?: Record<string, unknown>;
   query: string;
   model: string;
   apiKey: string;
@@ -134,6 +135,7 @@ export async function requestXaiWebSearch(params: {
     {
       url: XAI_WEB_SEARCH_ENDPOINT,
       timeoutSeconds: params.timeoutSeconds,
+      searchConfig: params.searchConfig,
       apiKey: params.apiKey,
       body: {
         model: params.model,

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -143,6 +143,7 @@ async function runXaiSearchProviderSetup(
 }
 
 function runXaiWebSearch(params: {
+  searchConfig?: SearchConfigRecord;
   query: string;
   model: string;
   apiKey: string;
@@ -161,6 +162,7 @@ function runXaiWebSearch(params: {
   return (async () => {
     const startedAt = Date.now();
     const result = await requestXaiWebSearch({
+      searchConfig: params.searchConfig,
       query: params.query,
       model: params.model,
       apiKey: params.apiKey,
@@ -256,6 +258,7 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
           void readNumberParam(args, "count", { integer: true });
 
           return await runXaiWebSearch({
+            searchConfig,
             query,
             model: resolveXaiWebSearchModel(searchConfig),
             apiKey,

--- a/src/agents/tools/web-search-provider-common.test.ts
+++ b/src/agents/tools/web-search-provider-common.test.ts
@@ -15,3 +15,32 @@ describe("web_search shared cache", () => {
     ).toBeUndefined();
   });
 });
+
+describe("resolveSearchProxy", () => {
+  it("returns undefined when proxy config is missing or blank", async () => {
+    vi.resetModules();
+    const module = await import("./web-search-provider-common.js");
+    expect(module.resolveSearchProxy(undefined)).toBeUndefined();
+    expect(module.resolveSearchProxy({})).toBeUndefined();
+    expect(module.resolveSearchProxy({ proxy: "   " })).toBeUndefined();
+  });
+
+  it("reuses the same fetch wrapper for the same proxy URL and rotates on change", async () => {
+    vi.resetModules();
+    const module = await import("./web-search-provider-common.js");
+    const first = module.resolveSearchProxy({ proxy: "http://proxy-a.test:8080" });
+    const second = module.resolveSearchProxy({ proxy: "http://proxy-a.test:8080" });
+    const third = module.resolveSearchProxy({ proxy: "http://proxy-b.test:9090" });
+
+    expect(first).toBe(second);
+    expect(third).not.toBe(first);
+  });
+
+  it("throws a descriptive error for invalid proxy URLs", async () => {
+    vi.resetModules();
+    const module = await import("./web-search-provider-common.js");
+    expect(() => module.resolveSearchProxy({ proxy: "\x00not-a-url" })).toThrow(
+      /Invalid proxy URL in tools\.web\.search\.proxy/,
+    );
+  });
+});

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { makeProxyFetch } from "../../infra/net/proxy-fetch.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { withTrustedWebToolsEndpoint } from "./web-guarded-fetch.js";
 import {
@@ -31,6 +32,41 @@ type UnsupportedWebSearchFilterName =
 export const DEFAULT_SEARCH_COUNT = 5;
 export const MAX_SEARCH_COUNT = 10;
 export const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
+
+let cachedSearchProxy: { url: string; fetchImpl: typeof fetch } | undefined;
+
+function buildInvalidProxyUrlError(proxyUrl: string): Error {
+  return new Error(
+    `Invalid proxy URL in tools.web.search.proxy: "${proxyUrl}". Expected a valid HTTP/HTTPS URL (e.g. http://proxy:8080).`,
+  );
+}
+
+export function resolveSearchProxy(searchConfig?: SearchConfigRecord): typeof fetch | undefined {
+  const proxyUrl =
+    searchConfig && typeof searchConfig.proxy === "string" ? searchConfig.proxy.trim() : "";
+  if (!proxyUrl) {
+    cachedSearchProxy = undefined;
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(proxyUrl);
+  } catch {
+    throw buildInvalidProxyUrlError(proxyUrl);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw buildInvalidProxyUrlError(proxyUrl);
+  }
+
+  if (cachedSearchProxy?.url === proxyUrl) {
+    return cachedSearchProxy.fetchImpl;
+  }
+
+  const fetchImpl = makeProxyFetch(proxyUrl);
+  cachedSearchProxy = { url: proxyUrl, fetchImpl };
+  return fetchImpl;
+}
 
 export function resolveSearchTimeoutSeconds(searchConfig?: SearchConfigRecord): number {
   return resolveTimeoutSeconds(searchConfig?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
@@ -65,12 +101,14 @@ export async function withTrustedWebSearchEndpoint<T>(
     url: string;
     timeoutSeconds: number;
     init: RequestInit;
+    searchConfig?: SearchConfigRecord;
   },
   run: (response: Response) => Promise<T>,
 ): Promise<T> {
   return withTrustedWebToolsEndpoint(
     {
       url: params.url,
+      fetchImpl: resolveSearchProxy(params.searchConfig),
       init: params.init,
       timeoutSeconds: params.timeoutSeconds,
     },
@@ -87,6 +125,7 @@ export async function postTrustedWebToolsJson<T>(
     errorLabel: string;
     maxErrorBytes?: number;
     extraHeaders?: Record<string, string>;
+    searchConfig?: SearchConfigRecord;
   },
   parseResponse: (response: Response) => Promise<T>,
 ): Promise<T> {
@@ -94,6 +133,7 @@ export async function postTrustedWebToolsJson<T>(
     {
       url: params.url,
       timeoutSeconds: params.timeoutSeconds,
+      fetchImpl: resolveSearchProxy(params.searchConfig),
       init: {
         method: "POST",
         headers: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -38,4 +38,4 @@ export const __testing = {
   SEARCH_CACHE,
   resolveSearchProvider: (search?: Parameters<typeof resolveWebSearchProviderId>[0]["search"]) =>
     resolveWebSearchProviderId({ search }),
-};
+} as const;

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -515,6 +515,8 @@ export type ToolsConfig = {
       kimi?: WebSearchLegacyProviderConfig;
       /** @deprecated Legacy Perplexity scoped config. */
       perplexity?: WebSearchLegacyProviderConfig;
+      /** HTTP/HTTPS proxy URL for web search API requests (e.g. "http://proxy:8080"). Applies to all search providers. */
+      proxy?: string;
     } & Record<string, unknown>;
     /** X (formerly Twitter) search tool configuration using xAI Grok. */
     x_search?: XSearchToolConfig;

--- a/src/plugin-sdk/provider-web-search.ts
+++ b/src/plugin-sdk/provider-web-search.ts
@@ -28,6 +28,7 @@ export {
   readProviderEnvValue,
   resolveSearchCacheTtlMs,
   resolveSearchCount,
+  resolveSearchProxy,
   resolveSearchTimeoutSeconds,
   resolveSiteName,
   postTrustedWebToolsJson,


### PR DESCRIPTION
## Summary

Add universal HTTP/HTTPS proxy support to all web search providers via a new `tools.web.search.proxy` configuration field.

This follows the same pattern already used by Discord (`rest-fetch.ts`) and Telegram (`proxy.ts`), using `undici`'s `ProxyAgent` which is already a project dependency.

## Configuration

```yaml
tools:
  web:
    search:
      proxy: "http://127.0.0.1:7890"
```

The proxy applies to **all** search providers: Brave, Perplexity, Grok, Gemini, and Kimi.

## Changes

- **`src/config/types.tools.ts`** — Add `proxy?: string` field to `tools.web.search` config type
- **`src/agents/tools/web-search.ts`** — Add `resolveSearchProxy()` using `undici` `ProxyAgent`; plumb `fetchImpl` through `runWebSearch` and all provider-specific search functions (`runGeminiSearch`, `runPerplexitySearch`, `runGrokSearch`, `runKimiSearch`)
- **`src/agents/tools/web-search.test.ts`** — Add unit tests for `resolveSearchProxy`

## Testing

All 43 unit tests in `web-search.test.ts` pass.