### PR TITLE
fix: suppress SUBAGENT_SPAWN_ACCEPTED_NOTE for cron isolated sessions

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
@@ -42,14 +42,16 @@ describe("sessions_spawn: cron isolated session note suppression", () => {
     expect(details.status).toBe("accepted");
   });
 
-  it("suppresses ACCEPTED_NOTE for any agent with :cron: in session key", async () => {
+  it("does not suppress ACCEPTED_NOTE for non-canonical cron-like keys", async () => {
     setupSessionsSpawnGatewayMock({});
-    // Ensure the check uses includes(":cron:") not startsWith("cron:")
     const tool = await getSessionsSpawnTool({
-      agentSessionKey: "agent:marian-job-search:cron:a7c7874a:run:abc123",
+      agentSessionKey: "agent:main:slack:cron:job:run:uuid",
     });
-    const result = await tool.execute("call-other-agent-cron", { task: "test task", mode: "run" });
-    expect((result.details as SpawnResult).note).toBeUndefined();
+    const result = await tool.execute("call-cron-like-noncanonical", {
+      task: "test task",
+      mode: "run",
+    });
+    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
   });
 
   it("does not suppress note when agentSessionKey is undefined", async () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.cron-note.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+  setupSessionsSpawnGatewayMock,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+import { SUBAGENT_SPAWN_ACCEPTED_NOTE } from "./subagent-spawn.js";
+
+const callGatewayMock = getCallGatewayMock();
+
+type SpawnResult = { status?: string; note?: string };
+
+describe("sessions_spawn: cron isolated session note suppression", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    resetSubagentRegistryForTests();
+    resetSessionsSpawnConfigOverride();
+  });
+
+  it("suppresses ACCEPTED_NOTE for cron isolated sessions (mode=run)", async () => {
+    setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:main:cron:dd871818:run:cf959c9f",
+    });
+    const result = await tool.execute("call-cron-run", { task: "test task", mode: "run" });
+    const details = result.details as SpawnResult;
+    expect(details.note).toBeUndefined();
+    expect(details.status).toBe("accepted");
+  });
+
+  it("preserves ACCEPTED_NOTE for regular sessions (mode=run)", async () => {
+    setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:main:telegram:63448508",
+    });
+    const result = await tool.execute("call-regular-run", { task: "test task", mode: "run" });
+    const details = result.details as SpawnResult;
+    expect(details.note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
+    expect(details.status).toBe("accepted");
+  });
+
+  it("suppresses ACCEPTED_NOTE for any agent with :cron: in session key", async () => {
+    setupSessionsSpawnGatewayMock({});
+    // Ensure the check uses includes(":cron:") not startsWith("cron:")
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:marian-job-search:cron:a7c7874a:run:abc123",
+    });
+    const result = await tool.execute("call-other-agent-cron", { task: "test task", mode: "run" });
+    expect((result.details as SpawnResult).note).toBeUndefined();
+  });
+
+  it("does not suppress note when agentSessionKey is undefined", async () => {
+    setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: undefined,
+    });
+    const result = await tool.execute("call-no-key", { task: "test task", mode: "run" });
+    expect((result.details as SpawnResult).note).toBe(SUBAGENT_SPAWN_ACCEPTED_NOTE);
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -4,7 +4,11 @@ import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  isCronSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
@@ -527,7 +531,7 @@ export async function spawnSubagentDirect(
   // Check if we're in a cron isolated session - don't add "do not poll" note
   // because cron sessions end immediately after the agent produces a response,
   // so the agent needs to wait for subagent results to keep the turn alive.
-  const isCronSession = ctx.agentSessionKey?.includes(":cron:");
+  const isCronSession = isCronSessionKey(ctx.agentSessionKey);
   const note =
     spawnMode === "session"
       ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -524,13 +524,23 @@ export async function spawnSubagentDirect(
     }
   }
 
+  // Check if we're in a cron isolated session - don't add "do not poll" note
+  // because cron sessions end immediately after the agent produces a response,
+  // so the agent needs to wait for subagent results to keep the turn alive.
+  const isCronSession = ctx.agentSessionKey?.includes(":cron:");
+  const note =
+    spawnMode === "session"
+      ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE
+      : isCronSession
+        ? undefined
+        : SUBAGENT_SPAWN_ACCEPTED_NOTE;
+
   return {
     status: "accepted",
     childSessionKey,
     runId: childRunId,
     mode: spawnMode,
-    note:
-      spawnMode === "session" ? SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE : SUBAGENT_SPAWN_ACCEPTED_NOTE,
+    note,
     modelApplied: resolvedModel ? modelApplied : undefined,
   };
 }


### PR DESCRIPTION
Fixes #27308
Fixes #25069

## Problem

The `SUBAGENT_SPAWN_ACCEPTED_NOTE` ("do not poll/sleep") causes cron isolated agents to immediately end their turn, because the note tells them not to wait for subagent results. In cron isolated sessions, the agent turn IS the entire run — ending early means subagent results are never collected.

## Root Cause

PR #27330 attempted to fix this but used `startsWith("cron:")` which **never matches** because `agentSessionKey` format is `agent:main:cron:...` (starts with `"agent:"`).

## Fix

Detect cron sessions via `includes(":cron:")` in `agentSessionKey` and suppress the note, allowing the agent to poll/wait for subagent results naturally.

## Tests

Added `openclaw-tools.subagents.sessions-spawn.cron-note.test.ts` with 4 tests:
1. Suppresses note for cron isolated sessions (mode=run)
2. Preserves note for regular sessions (mode=run)
3. Suppresses note for any agent with `:cron:` in session key (not just `agent:main:...`)
4. Preserves note when `agentSessionKey` is undefined

## Verified

Tested locally on v2026.2.25 (commit `c5d040bbe`):

| Check | Duration | Result |
|-------|----------|--------|
| No fix (baseline) | 43s | ❌ "Sub-agents launched. Waiting..." |
| `startsWith("cron:")` (PR #27330) | 43s | ❌ Same — never matches |
| `includes(":cron:")` (this PR) | 257s | ✅ Full news digest delivered |