### PR TITLE
fix(telegram): ensure polling initialization is abortable and retries…

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -115,6 +115,18 @@ describe("systemd availability", () => {
 
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
   });
+  it("returns true when systemctl exits non-zero without a known unavailable indicator", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("exit status 1") as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr = "";
+      err.code = 1;
+      cb(err, "Failed to get D-Bus connection: No such unit", "");
+    });
+    await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
+  });
 });
 
 describe("isSystemdServiceEnabled", () => {

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -325,7 +325,7 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
 
-    expect(api.deleteWebhook).toHaveBeenCalledWith({ drop_pending_updates: false });
+    expect(api.deleteWebhook).toHaveBeenCalledWith({ drop_pending_updates: false }, abort.signal);
     expect(order).toEqual(["deleteWebhook", "run"]);
   });
 
@@ -650,5 +650,97 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls bot.init with abort signal before starting polling", async () => {
+    const abort = new AbortController();
+    const order: string[] = [];
+    initSpy.mockImplementationOnce(async () => {
+      order.push("init");
+    });
+    api.deleteWebhook.mockReset();
+    api.deleteWebhook.mockImplementationOnce(async () => {
+      order.push("deleteWebhook");
+      return true;
+    });
+    runSpy.mockImplementationOnce(() => {
+      order.push("run");
+      return makeRunnerStub({
+        task: async () => {
+          abort.abort();
+        },
+      });
+    });
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(initSpy).toHaveBeenCalledWith(abort.signal);
+    expect(order).toEqual(["deleteWebhook", "init", "run"]);
+  });
+
+  it("retries bot.init on recoverable network errors", async () => {
+    const abort = new AbortController();
+    const initError = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("connect timeout"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+    initSpy.mockRejectedValueOnce(initError).mockResolvedValueOnce(undefined);
+    runSpy.mockImplementationOnce(() =>
+      makeRunnerStub({
+        task: async () => {
+          abort.abort();
+        },
+      }),
+    );
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(initSpy).toHaveBeenCalledTimes(2);
+    expect(computeBackoff).toHaveBeenCalled();
+    expect(sleepWithAbort).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries createPollingBot on recoverable error instead of returning undefined", async () => {
+    const abort = new AbortController();
+    const setupError = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("connect timeout"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+    createTelegramBotErrors.push(setupError);
+    runSpy.mockImplementationOnce(() =>
+      makeRunnerStub({
+        task: async () => {
+          abort.abort();
+        },
+      }),
+    );
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    // Bot creation should have been attempted twice (first fails, second succeeds)
+    // and polling should have run once
+    expect(computeBackoff).toHaveBeenCalled();
+    expect(sleepWithAbort).toHaveBeenCalled();
+    expect(runSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes abort signal to deleteWebhook", async () => {
+    const abort = new AbortController();
+    api.deleteWebhook.mockReset();
+    api.deleteWebhook.mockResolvedValueOnce(true);
+    runSpy.mockImplementationOnce(() =>
+      makeRunnerStub({
+        task: async () => {
+          abort.abort();
+        },
+      }),
+    );
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    expect(api.deleteWebhook).toHaveBeenCalledWith({ drop_pending_updates: false }, abort.signal);
   });
 });

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -262,11 +262,15 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         if (!shouldRetry) {
           return undefined;
         }
-        return undefined;
+        // Retry bot creation after backoff
+        return createPollingBot();
       }
     };
 
-    const ensureWebhookCleanup = async (bot: TelegramBot): Promise<"ready" | "retry" | "exit"> => {
+    const ensureWebhookCleanup = async (
+      bot: TelegramBot,
+      signal?: Parameters<(typeof bot)["init"]>[0],
+    ): Promise<"ready" | "retry" | "exit"> => {
       if (webhookCleared) {
         return "ready";
       }
@@ -274,7 +278,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         await withTelegramApiErrorLogging({
           operation: "deleteWebhook",
           runtime: opts.runtime,
-          fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
+          fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }, signal),
         });
         webhookCleared = true;
         return "ready";
@@ -402,12 +406,41 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         continue;
       }
 
-      const cleanupState = await ensureWebhookCleanup(bot);
+      // Cast the native AbortSignal to the grammY-compatible type.
+      // grammY re-exports AbortSignal from the `abort-controller` polyfill,
+      // which is structurally identical but nominally incompatible with the
+      // built-in AbortSignal. This mirrors the pattern used in webhook.ts.
+      const grammySignal = opts.abortSignal as Parameters<(typeof bot)["init"]>[0];
+
+      const cleanupState = await ensureWebhookCleanup(bot, grammySignal);
       if (cleanupState === "retry") {
         continue;
       }
       if (cleanupState === "exit") {
         return;
+      }
+
+      // Pre-initialize the bot with abort signal support before handing it
+      // to the grammY runner. The runner calls bot.init() internally but
+      // does not forward the abort signal, so a hanging getMe() would
+      // block indefinitely. Initializing here ensures the runner skips
+      // its own init() call (bot is already initialized) and allows the
+      // abort signal to cancel a stuck getMe() request.
+      try {
+        await withTelegramApiErrorLogging({
+          operation: "getMe",
+          runtime: opts.runtime,
+          fn: () => bot.init(grammySignal),
+        });
+      } catch (err) {
+        const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(
+          err,
+          "Telegram bot init failed",
+        );
+        if (!shouldRetry) {
+          return;
+        }
+        continue;
       }
 
       const state = await runPollingCycle(bot);


### PR DESCRIPTION
### Summary

This pull request addresses a critical issue where the Telegram polling provider hangs during initialization, particularly under poor network conditions or when webhook cleanup fails. This prevents the provider from starting correctly and processing messages. This PR introduces robust abort signal handling and corrects retry logic to ensure the provider can initialize reliably or be gracefully terminated.

*(Note: Previous commits in this PR regarding systemd availability detection and service installation status reporting have been dropped during rebase, as those issues were already resolved by recent refactoring in the `main` branch.)*

Fixes #27378

### Problem Description

As reported in issue #27378, users on versions 2026.2.24+ observed that the Telegram provider would get stuck after logging `starting provider`. The health status would show `running: false`, and while Telegram's message offset advanced (indicating messages were received by the server), they were never processed by the gateway. This occurred because the initialization process was hanging indefinitely without timing out or erroring.

### Root Causes

The investigation identified three primary causes for the hang:

1. **Indefinite `getMe()` Hang**: The `grammY` runner library calls `bot.init()` internally to fetch bot information (`getMe()`). However, it does not pass an abort signal. If the underlying `getMe()` network request stalled, it would hang forever, blocking the entire initialization sequence.
2. **Indefinite `deleteWebhook` Hang**: Similarly, the `deleteWebhook` API call, which is made to ensure a clean state, also lacked an abort signal, posing another risk of an indefinite hang.
3. **Flawed Retry Logic**: The `createPollingBot` function, responsible for setting up the bot, contained a logical error. On a recoverable setup error, it would fail to recursively call itself to retry. Instead, it returned `undefined`, causing the monitoring loop to spin without a proper backoff period, consuming resources unnecessarily.

### Solution Implemented

This PR implements a multi-faceted solution to address these root causes:

1. **Pre-emptive Bot Initialization**: Before handing control to the `grammY` runner, we now manually call `bot.init()` and pass the top-level `abortSignal` to it. This ensures the potentially long-running `getMe()` request is abortable. When the runner later calls `bot.init()` itself, it sees the bot is already initialized (`bot.isInited()` is true) and skips the step, avoiding the hang.
2. **Abortable Webhook Cleanup**: The `abortSignal` is now also passed to the `deleteWebhook` API call, ensuring this step can also be cancelled.
3. **Corrected Retry Mechanism**: The bug in `createPollingBot` has been fixed. It now correctly re-invokes itself after a calculated backoff period upon encountering a recoverable error, ensuring a robust retry mechanism.

### Changes

| File | Changes | Description |
| :--- | :--- | :--- |
| `src/telegram/monitor.ts` | +37 -4 | Core fix: pre-init with abort signal, abortable deleteWebhook, corrected retry logic |
| `src/telegram/monitor.test.ts` | +93 -1 | Tests for init with abort signal, retry on network errors, createPollingBot retry, deleteWebhook signal |
| `src/daemon/systemd.test.ts` | +12 -0 | Additional test for non-zero exit systemd detection |

**Note on Bundled Fix**: The correction to the retry path in `createPollingBot` (previously returning `undefined` twice — dead code on line 236) is a distinct bug fix that has been included in this PR for completeness.
