### PR TITLE
fix: normalize edit aliases and stabilize mutation fingerprint

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -21,8 +21,8 @@ describe("createOpenClawCodingTools", () => {
 
       await editTool?.execute("tool-alias-2", {
         file_path: filePath,
-        old_string: "world",
-        new_string: "universe",
+        oldString: "world",
+        newString: "universe",
       });
 
       const result = await readTool?.execute("tool-alias-3", {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -427,10 +427,20 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
     normalized.oldText = normalized.old_string;
     delete normalized.old_string;
   }
+  // oldString → oldText (edit)
+  if ("oldString" in normalized && !("oldText" in normalized)) {
+    normalized.oldText = normalized.oldString;
+    delete normalized.oldString;
+  }
   // new_string → newText (edit)
   if ("new_string" in normalized && !("newText" in normalized)) {
     normalized.newText = normalized.new_string;
     delete normalized.new_string;
+  }
+  // newString → newText (edit)
+  if ("newString" in normalized && !("newText" in normalized)) {
+    normalized.newText = normalized.newString;
+    delete normalized.newString;
   }
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -211,7 +211,9 @@ export function resolveWriteDetail(toolKey: string, args: unknown): string | und
         ? record.newText
         : typeof record.new_string === "string"
           ? record.new_string
-          : undefined;
+          : typeof record.newString === "string"
+            ? record.newString
+            : undefined;
 
   if (content && content.length > 0) {
     return `${destinationPrefix} ${path} (${content.length} chars)`;

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -68,7 +68,7 @@ describe("tool display details", () => {
     const editDetail = formatToolDetail(
       resolveToolDisplay({
         name: "edit",
-        args: { path: "/tmp/a.txt", newText: "abcd" },
+        args: { path: "/tmp/a.txt", newString: "abcd" },
       }),
     );
 

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -37,6 +37,17 @@ describe("tool mutation helpers", () => {
     expect(readFingerprint).toBeUndefined();
   });
 
+  it("includes file_path targets in mutation fingerprint", () => {
+    const editFingerprint = buildToolActionFingerprint("edit", {
+      file_path: "/tmp/demo.txt",
+      oldText: "a",
+      newText: "b",
+    });
+
+    expect(editFingerprint).toContain("tool=edit");
+    expect(editFingerprint).toContain("file_path=/tmp/demo.txt");
+  });
+
   it("exposes mutation state for downstream payload rendering", () => {
     expect(
       buildToolMutationState("message", { action: "send", to: "telegram:1" }).mutatingAction,

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -154,6 +154,7 @@ export function buildToolActionFingerprint(
   let hasStableTarget = false;
   for (const key of [
     "path",
+    "file_path",
     "filePath",
     "oldPath",
     "newPath",


### PR DESCRIPTION
## Summary
- normalize edit aliases in `normalizeToolParams`: support `oldString/newString` in addition to existing `old_string/new_string` and map to `oldText/newText`
- include `file_path` in `buildToolActionFingerprint` stable keys to improve failed/successful mutation pairing
- add `newString` compatibility in write/edit tool detail resolver to avoid display-layer mismatch
- add/adjust tests to cover alias normalization, mutation fingerprint keying, and display detail compatibility

## Root Cause
- some model/tool-call outputs use camelCase edit aliases (`oldString/newString`) that were not normalized
- mutation fingerprint previously missed `file_path`, making retries and state matching less deterministic in Claude-style tool args

## Test Plan
- `pnpm vitest run src/agents/tool-mutation.test.ts src/agents/tool-display.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts`
- `pnpm build`
