### PR TITLE
fix: skip cron delivery validation when mode is "none"

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -233,6 +233,27 @@ describe("applyJobPatch", () => {
 
     expect(() => applyJobPatch(job, { enabled: true })).not.toThrow();
   });
+
+  it('accepts delivery { mode: "none" } for sessionTarget="main"', () => {
+    const job = createMainSystemEventJob("job-delivery-none", {
+      mode: "none",
+    });
+
+    expect(() =>
+      applyJobPatch(job, { payload: { kind: "systemEvent", text: "updated" } }),
+    ).not.toThrow();
+    expect(job.delivery).toEqual({ mode: "none" });
+  });
+
+  it('does not clear delivery { mode: "none" } when switching to main', () => {
+    const job = createIsolatedAgentTurnJob("job-none-switch", {
+      mode: "none",
+    });
+
+    expect(() => applyJobPatch(job, switchToMainPatch())).not.toThrow();
+    expect(job.sessionTarget).toBe("main");
+    expect(job.delivery).toEqual({ mode: "none" });
+  });
 });
 
 function createMockState(now: number): CronServiceState {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -104,6 +104,9 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
   if (!job.delivery) {
     return;
   }
+  if (job.delivery.mode === "none") {
+    return;
+  }
   if (job.delivery.mode === "webhook") {
     const target = normalizeHttpWebhookUrl(job.delivery.to);
     if (!target) {
@@ -452,7 +455,11 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   if (patch.delivery) {
     job.delivery = mergeCronDelivery(job.delivery, patch.delivery);
   }
-  if (job.sessionTarget === "main" && job.delivery?.mode !== "webhook") {
+  if (
+    job.sessionTarget === "main" &&
+    job.delivery?.mode !== "webhook" &&
+    job.delivery?.mode !== "none"
+  ) {
     job.delivery = undefined;
   }
   if (patch.state) {


### PR DESCRIPTION
## Summary

- **Problem**: When an agent creates a cron job with `delivery: { mode: "none" }` and `sessionTarget: "main"`, `assertDeliverySupport()` rejects it with `cron channel delivery config is only supported for sessionTarget="isolated"`. The tool guidance explicitly defines `"none"` as a valid delivery mode, creating an inconsistency.
- **Fix**:
  1. Added early return in `assertDeliverySupport()` when `delivery.mode === "none"` — no channel delivery checks needed
  2. Preserved `mode: "none"` delivery when switching to main session (same treatment as `"webhook"`)

## Test plan

- [x] New test: `accepts delivery { mode: "none" } for sessionTarget="main"`
- [x] New test: `does not clear delivery { mode: "none" } when switching to main`
- [x] All 20 existing cron job tests pass
- [x] TypeScript compiles cleanly

Closes #27431
