### PR TITLE
fix: guard against undefined usage in Anthropic streaming response

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,0 +1,77 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..4aef99079685d6fc5b045ff2f27e516eacc49fe6 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -152,14 +152,17 @@ export const streamAnthropic = (model, context, options) => {
+                 if (event.type === "message_start") {
+                     // Capture initial token usage from message_start event
+                     // This ensures we have input token counts even if the stream is aborted early
+-                    output.usage.input = event.message.usage.input_tokens || 0;
+-                    output.usage.output = event.message.usage.output_tokens || 0;
+-                    output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;
+-                    output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;
+-                    // Anthropic doesn't provide total_tokens, compute from components
+-                    output.usage.totalTokens =
+-                        output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+-                    calculateCost(model, output.usage);
++                    const msgUsage = event.message?.usage;
++                    if (msgUsage) {
++                        output.usage.input = msgUsage.input_tokens || 0;
++                        output.usage.output = msgUsage.output_tokens || 0;
++                        output.usage.cacheRead = msgUsage.cache_read_input_tokens || 0;
++                        output.usage.cacheWrite = msgUsage.cache_creation_input_tokens || 0;
++                        // Anthropic doesn't provide total_tokens, compute from components
++                        output.usage.totalTokens =
++                            output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
++                        calculateCost(model, output.usage);
++                    }
+                 }
+                 else if (event.type === "content_block_start") {
+                     if (event.content_block.type === "text") {
+@@ -280,27 +283,30 @@ export const streamAnthropic = (model, context, options) => {
+                     }
+                 }
+                 else if (event.type === "message_delta") {
+-                    if (event.delta.stop_reason) {
++                    if (event.delta?.stop_reason) {
+                         output.stopReason = mapStopReason(event.delta.stop_reason);
+                     }
+                     // Only update usage fields if present (not null).
+                     // Preserves input_tokens from message_start when proxies omit it in message_delta.
+-                    if (event.usage.input_tokens != null) {
+-                        output.usage.input = event.usage.input_tokens;
+-                    }
+-                    if (event.usage.output_tokens != null) {
+-                        output.usage.output = event.usage.output_tokens;
+-                    }
+-                    if (event.usage.cache_read_input_tokens != null) {
+-                        output.usage.cacheRead = event.usage.cache_read_input_tokens;
+-                    }
+-                    if (event.usage.cache_creation_input_tokens != null) {
+-                        output.usage.cacheWrite = event.usage.cache_creation_input_tokens;
++                    const deltaUsage = event.usage;
++                    if (deltaUsage) {
++                        if (deltaUsage.input_tokens != null) {
++                            output.usage.input = deltaUsage.input_tokens;
++                        }
++                        if (deltaUsage.output_tokens != null) {
++                            output.usage.output = deltaUsage.output_tokens;
++                        }
++                        if (deltaUsage.cache_read_input_tokens != null) {
++                            output.usage.cacheRead = deltaUsage.cache_read_input_tokens;
++                        }
++                        if (deltaUsage.cache_creation_input_tokens != null) {
++                            output.usage.cacheWrite = deltaUsage.cache_creation_input_tokens;
++                        }
++                        // Anthropic doesn't provide total_tokens, compute from components
++                        output.usage.totalTokens =
++                            output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
++                        calculateCost(model, output.usage);
+                     }
+-                    // Anthropic doesn't provide total_tokens, compute from components
+-                    output.usage.totalTokens =
+-                        output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+-                    calculateCost(model, output.usage);
+                 }
+             }
+             if (options?.signal?.aborted) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,20 @@ settings:
 
 overrides:
   hono: 4.11.10
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
   '@sinclair/typebox': 0.34.48
   tar: 7.5.9
   tough-cookie: 4.1.3
+
+patchedDependencies:
+  '@mariozechner/pi-ai':
+    hash: eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6
+    path: patches/@mariozechner__pi-ai.patch
 
 importers:
 
@@ -58,7 +63,7 @@ importers:
         version: 0.55.1(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.55.1
-        version: 0.55.1(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.1(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.55.1
         version: 0.55.1(ws@8.19.0)(zod@4.3.6)
@@ -3051,8 +3056,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -6892,7 +6897,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6904,7 +6909,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6914,7 +6919,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.0(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
@@ -6938,7 +6943,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.1(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
@@ -6966,7 +6971,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -6995,7 +7000,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -8744,7 +8749,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
       lru-cache: 11.2.6
       music-metadata: 11.12.1
       p-queue: 9.1.0
@@ -8759,7 +8764,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
@@ -10527,7 +10532,7 @@ snapshots:
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
       '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.0(patch_hash=eddfdb6837beb970353297d62a711ac5ce375a6af07c57b62d3dcf5f8a6821d6)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent': 0.55.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.0
       '@mozilla/readability': 0.6.0


### PR DESCRIPTION
## Summary

- **Problem**: Third-party Claude API relays may return `message_start` or `message_delta` events without a `usage` object. The `@mariozechner/pi-ai` Anthropic provider directly accesses `event.message.usage.input_tokens` without null-checking, causing `Cannot read properties of undefined (reading 'input_tokens')` and crashing the embedded run.
- **Root cause**: In `pi-ai/dist/providers/anthropic.js`, both `message_start` and `message_delta` handlers assume `usage` is always present. The official Anthropic API always includes it, but third-party relays/proxies may omit it.
- **Fix**: pnpm patch for `@mariozechner/pi-ai` that:
  1. Null-checks `event.message?.usage` in the `message_start` handler before accessing token fields
  2. Null-checks `event.usage` in the `message_delta` handler before accessing token fields
  3. Also adds `event.delta?.stop_reason` optional chaining for robustness

Usage data simply stays at zero defaults when the relay omits it, instead of crashing.

## Test plan

- [x] TypeScript compiles cleanly
- [x] Patch file correctly targets the two crash sites in `anthropic.js`
- [ ] Manual: configure third-party Claude API relay, send message, verify no crash

Closes #27331
