### PR TITLE
fix: include /new-archived transcripts in sessions usage statistics

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -318,7 +318,11 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter(
+          (entry) =>
+            entry.isFile() &&
+            (entry.name.endsWith(".jsonl") || entry.name.includes(".jsonl.reset.")),
+        )
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);


### PR DESCRIPTION
## Summary

- **Problem**: After running `/new` to reset a session, all token usage from the previous conversation disappears from `sessions usage` statistics and the Web UI cost dashboard. The archived transcript files (`.jsonl.reset.<timestamp>`) are silently excluded from every usage scan because `loadCostUsageSummary()` only scans files ending in `.jsonl`.
- **Fix**: Widened the file filter in `loadCostUsageSummary()` to also include `.jsonl.reset.*` archive files, so usage totals reflect cumulative consumption across session resets within the retention window.

## Test plan

- [x] New test: verifies that usage from reset-archived transcripts is included in totals
- [x] All 10 existing session cost usage tests pass
- [x] TypeScript compiles cleanly

Closes #27417
