### PR TITLE
fix(auto-reply): tighten isSilentReplyText to match whole-text only

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isSilentReplyText } from "./tokens.js";
+
+describe("isSilentReplyText", () => {
+  it("returns true for exact token", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
+  });
+
+  it("returns true for token with surrounding whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY  ")).toBe(true);
+    expect(isSilentReplyText("\nNO_REPLY\n")).toBe(true);
+  });
+
+  it("returns false for undefined/empty", () => {
+    expect(isSilentReplyText(undefined)).toBe(false);
+    expect(isSilentReplyText("")).toBe(false);
+  });
+
+  it("returns false for substantive text ending with token (#19537)", () => {
+    const text = "Here is a helpful response.\n\nNO_REPLY";
+    expect(isSilentReplyText(text)).toBe(false);
+  });
+
+  it("returns false for substantive text starting with token", () => {
+    const text = "NO_REPLY but here is more content";
+    expect(isSilentReplyText(text)).toBe(false);
+  });
+
+  it("returns false for token embedded in text", () => {
+    expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
+  });
+
+  it("works with custom token", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The suffix regex matched NO_REPLY at the end of any response, suppressing substantive replies when models (e.g. Gemini 3 Pro) appended NO_REPLY to real content.

## Fix

Replace prefix+suffix regexes with a single whole-string match. Only responses that are entirely the silent token (with optional whitespace) are now suppressed.

## Changes

- Modified `isSilentReplyText()` in `src/auto-reply/tokens.ts` to use `^\s*\s*$` regex
- Added unit tests in `src/auto-reply/tokens.test.ts`

## Testing

All 7 tests pass:

- Returns true for exact token
- Returns true for token with surrounding whitespace  
- Returns false for undefined/empty
- Returns false for substantive text ending with token (#19537)
- Returns false for substantive text starting with token
- Returns false for token embedded in text
- Works with custom token

Fixes #19537