### PR TITLE
fix(slack): inherit parent session thinking level + filter reasoning from stream

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.thinking-inheritance.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.thinking-inheritance.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { ThinkLevel } from "../thinking.js";
+import { resolveParentSessionKeyCandidate } from "./model-selection.js";
+
+const makeEntry = (overrides: Partial<SessionEntry> = {}): SessionEntry => ({
+  sessionId: "session-id",
+  updatedAt: Date.now(),
+  ...overrides,
+});
+
+function resolveThinkLevelWithParent(params: {
+  directiveThinkLevel?: ThinkLevel;
+  sessionThinkLevel?: ThinkLevel;
+  sessionKey?: string;
+  parentSessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  agentDefault?: ThinkLevel;
+}): ThinkLevel | undefined {
+  const parentKey = resolveParentSessionKeyCandidate({
+    sessionKey: params.sessionKey,
+    parentSessionKey: params.parentSessionKey,
+  });
+  const parentThinkLevel = (() => {
+    if (!parentKey || !params.sessionStore) {
+      return undefined;
+    }
+    return params.sessionStore[parentKey]?.thinkingLevel as ThinkLevel | undefined;
+  })();
+
+  return (
+    params.directiveThinkLevel ??
+    params.sessionThinkLevel ??
+    parentThinkLevel ??
+    params.agentDefault
+  );
+}
+
+describe("thinking level parent session inheritance", () => {
+  it("falls through to agentCfg default when no parent exists", () => {
+    const result = resolveThinkLevelWithParent({
+      sessionKey: "agent:main:slack:group:G123",
+      sessionStore: {},
+      agentDefault: "low",
+    });
+    expect(result).toBe("low");
+  });
+
+  it("inherits parent thinking level via explicit parentSessionKey", () => {
+    const parentKey = "agent:main:slack:group:G123";
+    const sessionKey = "agent:main:slack:group:G123:thread:abc";
+    const sessionStore: Record<string, SessionEntry> = {
+      [parentKey]: makeEntry({ thinkingLevel: "xhigh" }),
+    };
+
+    const result = resolveThinkLevelWithParent({
+      sessionKey,
+      parentSessionKey: parentKey,
+      sessionStore,
+      agentDefault: "off",
+    });
+    expect(result).toBe("xhigh");
+  });
+
+  it("own session thinking level takes precedence over parent", () => {
+    const parentKey = "agent:main:slack:group:G123";
+    const sessionKey = "agent:main:slack:group:G123:thread:abc";
+    const sessionStore: Record<string, SessionEntry> = {
+      [parentKey]: makeEntry({ thinkingLevel: "xhigh" }),
+    };
+
+    const result = resolveThinkLevelWithParent({
+      sessionKey,
+      parentSessionKey: parentKey,
+      sessionStore,
+      sessionThinkLevel: "low",
+      agentDefault: "off",
+    });
+    expect(result).toBe("low");
+  });
+
+  it("inline directive takes precedence over everything", () => {
+    const parentKey = "agent:main:slack:group:G123";
+    const sessionKey = "agent:main:slack:group:G123:thread:abc";
+    const sessionStore: Record<string, SessionEntry> = {
+      [parentKey]: makeEntry({ thinkingLevel: "xhigh" }),
+    };
+
+    const result = resolveThinkLevelWithParent({
+      directiveThinkLevel: "minimal",
+      sessionKey,
+      parentSessionKey: parentKey,
+      sessionStore,
+      sessionThinkLevel: "low",
+      agentDefault: "off",
+    });
+    expect(result).toBe("minimal");
+  });
+
+  it("derives parent key from thread session suffix", () => {
+    const parentKey = "agent:main:slack:group:G123";
+    const sessionKey = "agent:main:slack:group:G123:thread:abc";
+    const sessionStore: Record<string, SessionEntry> = {
+      [parentKey]: makeEntry({ thinkingLevel: "high" }),
+    };
+
+    const result = resolveThinkLevelWithParent({
+      sessionKey,
+      sessionStore,
+      agentDefault: "off",
+    });
+    expect(result).toBe("high");
+  });
+
+  it("returns undefined when no level is set anywhere", () => {
+    const result = resolveThinkLevelWithParent({
+      sessionKey: "agent:main:slack:group:G123",
+      sessionStore: {},
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips parent lookup when sessionStore is not provided", () => {
+    const parentKey = "agent:main:slack:group:G123";
+    const sessionKey = "agent:main:slack:group:G123:thread:abc";
+
+    const result = resolveThinkLevelWithParent({
+      sessionKey,
+      parentSessionKey: parentKey,
+      // no sessionStore
+      agentDefault: "medium",
+    });
+    expect(result).toBe("medium");
+  });
+});

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -16,7 +16,11 @@ import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
 import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "./mentions.js";
-import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
+import {
+  createModelSelectionState,
+  resolveContextTokens,
+  resolveParentSessionKeyCandidate,
+} from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
@@ -336,9 +340,21 @@ export async function resolveReplyDirectives(params: {
     groupResolution,
   });
   const defaultActivation = defaultGroupActivation(requireMention);
+  const parentThinkLevel = (() => {
+    const parentKey = resolveParentSessionKeyCandidate({
+      sessionKey,
+      parentSessionKey: ctx.ParentSessionKey,
+    });
+    if (!parentKey || !sessionStore) {
+      return undefined;
+    }
+    return sessionStore[parentKey]?.thinkingLevel as ThinkLevel | undefined;
+  })();
+
   const resolvedThinkLevel =
     directives.thinkLevel ??
     (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+    parentThinkLevel ??
     (agentCfg?.thinkingDefault as ThinkLevel | undefined);
 
   const resolvedVerboseLevel =

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -114,7 +114,7 @@ function resolveModelOverrideFromEntry(entry?: SessionEntry): {
   return { provider, model };
 }
 
-function resolveParentSessionKeyCandidate(params: {
+export function resolveParentSessionKeyCandidate(params: {
   sessionKey?: string;
   parentSessionKey?: string;
 }): string | null {

--- a/src/slack/monitor/message-handler/dispatch.streaming.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isSlackStreamingEnabled, resolveSlackStreamingThreadHint } from "./dispatch.js";
+import {
+  filterReasoningFromPartial,
+  isSlackStreamingEnabled,
+  resolveSlackStreamingThreadHint,
+} from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
   it("is enabled for partial mode when native streaming is on", () => {
@@ -43,5 +47,33 @@ describe("slack native streaming thread hint", () => {
         messageTs: "1000.3",
       }),
     ).toBe("2000.1");
+  });
+});
+
+describe("filterReasoningFromPartial", () => {
+  it("returns undefined for empty/undefined input", () => {
+    expect(filterReasoningFromPartial(undefined)).toBeUndefined();
+    expect(filterReasoningFromPartial("")).toBeUndefined();
+    expect(filterReasoningFromPartial("   ")).toBeUndefined();
+  });
+
+  it("passes through normal text unchanged", () => {
+    expect(filterReasoningFromPartial("Hello, world!")).toBe("Hello, world!");
+  });
+
+  it("strips thinking tags and returns answer text", () => {
+    expect(filterReasoningFromPartial("<think>reasoning here</think>answer")).toBe("answer");
+  });
+
+  it("returns undefined for text that is only thinking content", () => {
+    expect(filterReasoningFromPartial("<think>only reasoning</think>")).toBeUndefined();
+  });
+
+  it('returns undefined for "Reasoning:\\n" prefixed messages', () => {
+    expect(filterReasoningFromPartial("Reasoning:\nsome thought process")).toBeUndefined();
+  });
+
+  it("handles trailing whitespace gracefully", () => {
+    expect(filterReasoningFromPartial("answer text   ")).toBe("answer text");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Slack group sessions create isolated `SessionEntry` objects with `thinkingLevel: undefined`. Unlike model overrides (which cascade via `resolveParentSessionKeyCandidate()`), thinking level has no parent lookup and falls through to the global default or `"off"`. Separately, Slack's `updateDraftFromPartial()` streams raw text to the channel with no reasoning filtering, unlike Discord which already strips `<think>` tags and `"Reasoning:\n"` prefixes.
- Why it matters: Users setting `/think:high` in a Slack group see it silently ignored in threads. Internal reasoning content leaks into visible channel messages.
- What changed: (1) Added parent session thinking level lookup in the resolution chain between session-persisted and agent config default. (2) Added `filterReasoningFromPartial()` to Slack dispatch, matching Discord's existing filtering. Exported `resolveParentSessionKeyCandidate` from `model-selection.ts` to reuse rather than duplicate.
- What did NOT change (scope boundary): No changes to model override inheritance, Discord filtering, or any other directive resolution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25233

## User-visible / Behavior Changes

- Slack group thread sessions now inherit the parent session's thinking level (e.g. `/think:high` set in the main channel carries into threads).
- Reasoning/thinking content (`<think>` tags, `Reasoning:\n` prefixes) no longer leaks into Slack channel draft streams.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: any with thinking support
- Integration/channel (if any): Slack
- Relevant config (redacted): group session with `/think:high`

### Steps

1. Set `/think:high` in a Slack group channel
2. Reply in a thread within that channel
3. Observe that thinking level is inherited (was previously `undefined`/`off`)

### Expected

- Thread inherits parent session thinking level

### Actual

- Before: thread gets `thinkingLevel: undefined`, falls through to default
- After: thread resolves parent's `thinkingLevel` via `resolveParentSessionKeyCandidate()`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New tests: 7 thinking inheritance tests + 6 reasoning filtering tests (all pass). Existing model-selection tests (12) continue to pass.

## Human Verification (required)

- Verified scenarios: `pnpm lint` (0 errors), `tsgo --noEmit` (0 errors), all 30 tests pass (thinking inheritance + streaming + model-selection)
- Edge cases checked: no parent key, no session store, own level takes precedence, inline directive takes precedence, derived thread key, empty/whitespace input to filter, thinking-only content, `Reasoning:\n` prefix
- What you did **not** verify: live Slack instance end-to-end (no test workspace available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit; the parent lookup is additive (returns `undefined` if no parent found, preserving existing fallback chain)
- Files/config to restore: `src/auto-reply/reply/get-reply-directives.ts`, `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms reviewers should watch for: thinking level unexpectedly changing in group threads, or Slack draft stream messages being dropped

## Risks and Mitigations

- Risk: Parent session store lookup returns stale `thinkingLevel` from a previous session
  - Mitigation: Same lookup pattern already used by `resolveStoredModelOverride()` for model inheritance; session store is kept current by the same lifecycle