### PR TITLE
feat(ios): add Live Activity + Dynamic Island support

### DIFF
--- a/apps/ios/ActivityWidget/Assets.xcassets/Contents.json
+++ b/apps/ios/ActivityWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/ios/ActivityWidget/Info.plist
+++ b/apps/ios/ActivityWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenClawTests</string>
+	<string>OpenClaw Activity</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,10 +15,17 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2026.2.27</string>
+	<string>2026.2.26</string>
 	<key>CFBundleVersion</key>
-	<string>20260227</string>
+	<string>20260226</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/ios/ActivityWidget/OpenClawActivityWidgetBundle.swift
+++ b/apps/ios/ActivityWidget/OpenClawActivityWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct OpenClawActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        OpenClawLiveActivity()
+    }
+}

--- a/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
+++ b/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
@@ -30,11 +30,11 @@ struct OpenClawLiveActivity: Widget {
                         } else if context.state.isConnecting {
                             Text("Connecting...")
                                 .font(.subheadline)
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(.secondary)
                         } else if context.state.isIdle {
                             Text("Idle")
                                 .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(.green)
                         } else if context.state.isFinished {
                             Text("Complete")
                                 .font(.subheadline)
@@ -62,7 +62,7 @@ struct OpenClawLiveActivity: Widget {
                     } else if context.state.isIdle {
                         Image(systemName: "antenna.radiowaves.left.and.right")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.green)
                     } else if context.state.isFinished || context.state.isError {
                         if let endedAt = context.state.endedAt {
                             let elapsed = endedAt.timeIntervalSince(context.state.startedAt)
@@ -103,13 +103,13 @@ struct OpenClawLiveActivity: Widget {
                 } else if context.state.isConnecting {
                     Text("Connecting...")
                         .font(.caption2)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .frame(maxWidth: 64)
                 } else if context.state.isIdle {
                     Image(systemName: "antenna.radiowaves.left.and.right")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.green)
                 } else if context.state.isFinished {
                     Text("Done")
                         .font(.caption2)
@@ -147,9 +147,9 @@ struct OpenClawLiveActivity: Widget {
     private func dotColor(state: OpenClawActivityAttributes.ContentState) -> Color {
         if state.isDisconnected { return .red }
         if state.isError { return .red }
-        if state.isConnecting { return .orange }
+        if state.isConnecting { return .gray }
         if state.isFinished { return .green }
-        if state.isIdle { return .gray }
+        if state.isIdle { return .green }
         return .blue
     }
 
@@ -181,7 +181,7 @@ struct OpenClawLiveActivity: Widget {
                             .foregroundStyle(.secondary)
                         Text("Connecting...")
                             .font(.subheadline)
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(.secondary)
                     } else if state.isIdle {
                         Text("OpenClaw")
                             .font(.subheadline.bold())
@@ -189,7 +189,7 @@ struct OpenClawLiveActivity: Widget {
                             .foregroundStyle(.secondary)
                         Text("Idle")
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.green)
                     } else if let subject = state.subject, !state.isFinished, !state.isError {
                         Text(subject)
                             .font(.subheadline.bold())
@@ -215,7 +215,7 @@ struct OpenClawLiveActivity: Widget {
                 } else if state.isIdle {
                     Image(systemName: "antenna.radiowaves.left.and.right")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.green)
                 } else if state.isFinished || state.isError, let endedAt = state.endedAt {
                     let elapsed = endedAt.timeIntervalSince(state.startedAt)
                     Text(Duration.seconds(elapsed).formatted(.time(pattern: .minuteSecond)))
@@ -245,15 +245,15 @@ struct OpenClawLiveActivity: Widget {
                         .controlSize(.small)
                     Text("Connecting...")
                         .font(.body)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(.secondary)
                 }
             } else if state.isIdle {
                 HStack(spacing: 6) {
                     Image(systemName: "antenna.radiowaves.left.and.right")
-                        .foregroundStyle(.gray)
+                        .foregroundStyle(.green)
                     Text("Idle")
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.green)
                 }
             } else if state.isFinished {
                 HStack(spacing: 6) {

--- a/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
+++ b/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
@@ -27,6 +27,10 @@ struct OpenClawLiveActivity: Widget {
                             Text("Disconnected")
                                 .font(.subheadline)
                                 .foregroundStyle(.red)
+                        } else if context.state.isConnecting {
+                            Text("Connecting...")
+                                .font(.subheadline)
+                                .foregroundStyle(.orange)
                         } else if context.state.isIdle {
                             Text("Idle")
                                 .font(.subheadline)
@@ -52,6 +56,9 @@ struct OpenClawLiveActivity: Widget {
                         Image(systemName: "wifi.slash")
                             .font(.caption)
                             .foregroundStyle(.red)
+                    } else if context.state.isConnecting {
+                        ProgressView()
+                            .controlSize(.small)
                     } else if context.state.isIdle {
                         Image(systemName: "antenna.radiowaves.left.and.right")
                             .font(.caption)
@@ -73,7 +80,7 @@ struct OpenClawLiveActivity: Widget {
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     if let prev = context.state.previousToolLabel,
-                       !context.state.isFinished, !context.state.isError, !context.state.isIdle
+                       !context.state.isFinished, !context.state.isError, !context.state.isIdle, !context.state.isConnecting
                     {
                         HStack(spacing: 6) {
                             Image(systemName: "checkmark")
@@ -93,6 +100,12 @@ struct OpenClawLiveActivity: Widget {
                     Image(systemName: "wifi.slash")
                         .font(.caption2)
                         .foregroundStyle(.red)
+                } else if context.state.isConnecting {
+                    Text("Connecting...")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .lineLimit(1)
+                        .frame(maxWidth: 64)
                 } else if context.state.isIdle {
                     Image(systemName: "antenna.radiowaves.left.and.right")
                         .font(.caption2)
@@ -134,6 +147,7 @@ struct OpenClawLiveActivity: Widget {
     private func dotColor(state: OpenClawActivityAttributes.ContentState) -> Color {
         if state.isDisconnected { return .red }
         if state.isError { return .red }
+        if state.isConnecting { return .orange }
         if state.isFinished { return .green }
         if state.isIdle { return .gray }
         return .blue
@@ -160,6 +174,14 @@ struct OpenClawLiveActivity: Widget {
                         Text("Disconnected")
                             .font(.subheadline)
                             .foregroundStyle(.red)
+                    } else if state.isConnecting {
+                        Text("OpenClaw")
+                            .font(.subheadline.bold())
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                        Text("Connecting...")
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
                     } else if state.isIdle {
                         Text("OpenClaw")
                             .font(.subheadline.bold())
@@ -187,6 +209,9 @@ struct OpenClawLiveActivity: Widget {
                     Image(systemName: "wifi.slash")
                         .font(.caption)
                         .foregroundStyle(.red)
+                } else if state.isConnecting {
+                    ProgressView()
+                        .controlSize(.small)
                 } else if state.isIdle {
                     Image(systemName: "antenna.radiowaves.left.and.right")
                         .font(.caption)
@@ -213,6 +238,14 @@ struct OpenClawLiveActivity: Widget {
                     Text("Disconnected")
                         .font(.body)
                         .foregroundStyle(.red)
+                }
+            } else if state.isConnecting {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Connecting...")
+                        .font(.body)
+                        .foregroundStyle(.orange)
                 }
             } else if state.isIdle {
                 HStack(spacing: 6) {
@@ -265,7 +298,7 @@ struct OpenClawLiveActivity: Widget {
             }
 
             // Footer: step counter + previous tool (only during active run)
-            if !state.isIdle {
+            if !state.isIdle, !state.isConnecting {
                 HStack {
                     if state.toolStepCount > 0 {
                         Text("Step \(state.toolStepCount)")

--- a/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
+++ b/apps/ios/ActivityWidget/OpenClawLiveActivity.swift
@@ -1,0 +1,318 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct OpenClawLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: OpenClawActivityAttributes.self) { context in
+            lockScreenBanner(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded regions
+                DynamicIslandExpandedRegion(.leading) {
+                    statusDot(state: context.state)
+                        .padding(.top, 6)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if let subject = context.state.subject {
+                            Text(subject)
+                                .font(.headline)
+                                .lineLimit(1)
+                        } else {
+                            Text(context.attributes.agentName)
+                                .font(.headline)
+                        }
+                        if context.state.isDisconnected {
+                            Text("Disconnected")
+                                .font(.subheadline)
+                                .foregroundStyle(.red)
+                        } else if context.state.isIdle {
+                            Text("Idle")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        } else if context.state.isFinished {
+                            Text("Complete")
+                                .font(.subheadline)
+                                .foregroundStyle(.green)
+                        } else if context.state.isError {
+                            Text("Error")
+                                .font(.subheadline)
+                                .foregroundStyle(.red)
+                        } else {
+                            Text(context.state.statusText)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    if context.state.isDisconnected {
+                        Image(systemName: "wifi.slash")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    } else if context.state.isIdle {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if context.state.isFinished || context.state.isError {
+                        if let endedAt = context.state.endedAt {
+                            let elapsed = endedAt.timeIntervalSince(context.state.startedAt)
+                            Text(Duration.seconds(elapsed).formatted(.time(pattern: .minuteSecond)))
+                                .font(.caption)
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text(context.state.startedAt, style: .timer)
+                            .font(.caption)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    if let prev = context.state.previousToolLabel,
+                       !context.state.isFinished, !context.state.isError, !context.state.isIdle
+                    {
+                        HStack(spacing: 6) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 8, weight: .bold))
+                                .foregroundStyle(.green)
+                            Text(prev)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            } compactLeading: {
+                statusDot(state: context.state)
+            } compactTrailing: {
+                if context.state.isDisconnected {
+                    Image(systemName: "wifi.slash")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                } else if context.state.isIdle {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                } else if context.state.isFinished {
+                    Text("Done")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                } else if context.state.isError {
+                    Text("Error")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                } else if let toolLabel = context.state.currentToolLabel {
+                    Text(toolLabel)
+                        .font(.caption2)
+                        .lineLimit(1)
+                        .frame(maxWidth: 64)
+                } else {
+                    Text("Thinking...")
+                        .font(.caption2)
+                        .lineLimit(1)
+                        .frame(maxWidth: 64)
+                }
+            } minimal: {
+                statusDot(state: context.state)
+            }
+        }
+    }
+
+    // MARK: - Status Dot
+
+    @ViewBuilder
+    private func statusDot(state: OpenClawActivityAttributes.ContentState) -> some View {
+        Circle()
+            .fill(dotColor(state: state))
+            .frame(width: 6, height: 6)
+    }
+
+    private func dotColor(state: OpenClawActivityAttributes.ContentState) -> Color {
+        if state.isDisconnected { return .red }
+        if state.isError { return .red }
+        if state.isFinished { return .green }
+        if state.isIdle { return .gray }
+        return .blue
+    }
+
+    // MARK: - Lock Screen Banner
+
+    @ViewBuilder
+    private func lockScreenBanner(context: ActivityViewContext<OpenClawActivityAttributes>) -> some View {
+        let state = context.state
+
+        VStack(alignment: .leading, spacing: 8) {
+            // Header: subject or "OpenClaw" + agent name + timer/status icon
+            HStack {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(dotColor(state: state))
+                        .frame(width: 8, height: 8)
+                    if state.isDisconnected {
+                        Text("OpenClaw")
+                            .font(.subheadline.bold())
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                        Text("Disconnected")
+                            .font(.subheadline)
+                            .foregroundStyle(.red)
+                    } else if state.isIdle {
+                        Text("OpenClaw")
+                            .font(.subheadline.bold())
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                        Text("Idle")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    } else if let subject = state.subject, !state.isFinished, !state.isError {
+                        Text(subject)
+                            .font(.subheadline.bold())
+                            .lineLimit(1)
+                    } else {
+                        Text("OpenClaw")
+                            .font(.subheadline.bold())
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                        Text(context.attributes.agentName)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                if state.isDisconnected {
+                    Image(systemName: "wifi.slash")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                } else if state.isIdle {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if state.isFinished || state.isError, let endedAt = state.endedAt {
+                    let elapsed = endedAt.timeIntervalSince(state.startedAt)
+                    Text(Duration.seconds(elapsed).formatted(.time(pattern: .minuteSecond)))
+                        .font(.caption)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(state.startedAt, style: .timer)
+                        .font(.caption)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Body: current status / tool label with icon / completion / idle / disconnected
+            if state.isDisconnected {
+                HStack(spacing: 6) {
+                    Image(systemName: "wifi.slash")
+                        .foregroundStyle(.red)
+                    Text("Disconnected")
+                        .font(.body)
+                        .foregroundStyle(.red)
+                }
+            } else if state.isIdle {
+                HStack(spacing: 6) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .foregroundStyle(.gray)
+                    Text("Idle")
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            } else if state.isFinished {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(state.subject ?? "Complete")
+                        .font(.body.bold())
+                        .lineLimit(1)
+                }
+            } else if state.isError {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundStyle(.red)
+                    Text("Error")
+                        .font(.body.bold())
+                }
+            } else if let toolLabel = state.currentToolLabel {
+                HStack(spacing: 6) {
+                    Image(systemName: state.currentToolIcon ?? "gearshape")
+                        .foregroundStyle(.blue)
+                    Text(toolLabel)
+                        .font(.body)
+                        .lineLimit(1)
+                }
+            } else if let streaming = state.streamingText {
+                HStack(spacing: 6) {
+                    Image(systemName: "text.bubble")
+                        .foregroundStyle(.blue)
+                    Text(streaming)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            } else {
+                HStack(spacing: 6) {
+                    Image(systemName: "brain")
+                        .foregroundStyle(.blue)
+                    Text(state.statusText)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Footer: step counter + previous tool (only during active run)
+            if !state.isIdle {
+                HStack {
+                    if state.toolStepCount > 0 {
+                        Text("Step \(state.toolStepCount)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let prev = state.previousToolLabel, !state.isFinished {
+                        Text("·")
+                            .foregroundStyle(.tertiary)
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 8, weight: .bold))
+                                .foregroundStyle(.green)
+                            Text(prev)
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    Spacer()
+                }
+            }
+        }
+        .padding(16)
+        .activityBackgroundTint(.black.opacity(0.75))
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Lock Screen - Idle", as: .content, using: OpenClawActivityAttributes.preview) {
+    OpenClawLiveActivity()
+} contentStates: {
+    OpenClawActivityAttributes.ContentState.idle
+    OpenClawActivityAttributes.ContentState.thinking
+    OpenClawActivityAttributes.ContentState.toolRunning
+    OpenClawActivityAttributes.ContentState.multiTool
+    OpenClawActivityAttributes.ContentState.streaming
+    OpenClawActivityAttributes.ContentState.finished
+}
+
+#Preview("Dynamic Island", as: .dynamicIsland(.expanded), using: OpenClawActivityAttributes.preview) {
+    OpenClawLiveActivity()
+} contentStates: {
+    OpenClawActivityAttributes.ContentState.idle
+    OpenClawActivityAttributes.ContentState.toolRunning
+    OpenClawActivityAttributes.ContentState.multiTool
+    OpenClawActivityAttributes.ContentState.finished
+}
+#endif

--- a/apps/ios/Config/Signing.xcconfig
+++ b/apps/ios/Config/Signing.xcconfig
@@ -4,6 +4,7 @@ OPENCLAW_IOS_SELECTED_TEAM = $(OPENCLAW_IOS_DEFAULT_TEAM)
 OPENCLAW_APP_BUNDLE_ID = ai.openclaw.ios
 OPENCLAW_WATCH_APP_BUNDLE_ID = ai.openclaw.ios.watchkitapp
 OPENCLAW_WATCH_EXTENSION_BUNDLE_ID = ai.openclaw.ios.watchkitapp.extension
+OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID = ai.openclaw.ios.activitywidget
 
 // Local contributors can override this by running scripts/ios-configure-signing.sh.
 // Keep include after defaults: xcconfig is evaluated top-to-bottom.

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>ai.openclaw.ios.bgrefresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -54,6 +58,8 @@
 	<string>OpenClaw needs microphone access for voice wake.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>OpenClaw uses on-device speech recognition for voice wake.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -63,10 +69,6 @@
 	<array>
 		<string>audio</string>
 		<string>remote-notification</string>
-	</array>
-	<key>BGTaskSchedulerPermittedIdentifiers</key>
-	<array>
-		<string>ai.openclaw.ios.bgrefresh</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
+++ b/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
@@ -1,0 +1,695 @@
+import ActivityKit
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+import os
+
+/// Manages the lifecycle of the OpenClaw Live Activity (Dynamic Island + Lock Screen).
+///
+/// The activity is **persistent**: it starts when the gateway connects and only ends
+/// when the gateway disconnects. Between agent runs, the activity shows an idle
+/// "Connected" state. After a run completes, it briefly shows "Done" then transitions
+/// back to idle.
+///
+/// All public API is MainActor-isolated; the debounce timer fires on the main run loop.
+@MainActor
+final class LiveActivityManager {
+    static let shared = LiveActivityManager()
+
+    private let logger = Logger(subsystem: "ai.openclaw.ios", category: "LiveActivity")
+
+    private var currentActivity: Activity<OpenClawActivityAttributes>?
+    private var activityStartDate: Date = .now
+
+    // Debounce: buffer rapid updates and flush at most once per second.
+    private var pendingContent: ActivityContent<OpenClawActivityAttributes.ContentState>?
+    private var debounceTimer: Timer?
+    private let debounceInterval: TimeInterval = 1.0
+
+    // Timer that transitions from "Done"/"Error" back to idle after a delay.
+    private var idleTransitionTimer: Timer?
+    private let idleTransitionDelay: TimeInterval = 5.0
+
+    // Running state for step tracking.
+    private var stepCount: Int = 0
+    private var currentToolLabel: String?
+    private var currentToolIcon: String?
+    private var previousToolLabel: String?
+    private var latestStreamingText: String?
+    /// Latched subject — set by on-device AI or first streaming text.
+    private var subject: String?
+    private var summaryTask: Task<Void, Never>?
+
+    /// Whether an agent run is currently in progress.
+    private var isRunning: Bool = false
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Start a persistent Live Activity when the gateway connects.
+    /// The activity stays visible until `endActivity()` is called (on gateway disconnect).
+    func startActivity(agentName: String, sessionKey: String) {
+        if currentActivity != nil {
+            logger.info("[LA] activity already running, skipping start")
+            return
+        }
+
+        let authInfo = ActivityAuthorizationInfo()
+        logger.info("[LA] areActivitiesEnabled=\(authInfo.areActivitiesEnabled)")
+        guard authInfo.areActivitiesEnabled else {
+            logger.info("[LA] Live Activities not enabled — skipping")
+            return
+        }
+
+        activityStartDate = .now
+        resetRunState()
+
+        let attributes = OpenClawActivityAttributes(
+            agentName: agentName,
+            sessionKey: sessionKey)
+        let initialState = OpenClawActivityAttributes.ContentState(
+            subject: nil,
+            statusText: "Idle",
+            currentToolLabel: nil,
+            currentToolIcon: nil,
+            previousToolLabel: nil,
+            toolStepCount: 0,
+            streamingText: nil,
+            isFinished: false,
+            isError: false,
+            isIdle: true,
+            isDisconnected: false,
+            startedAt: activityStartDate)
+        let content = ActivityContent(state: initialState, staleDate: nil)
+
+        do {
+            currentActivity = try Activity.request(
+                attributes: attributes,
+                content: content,
+                pushType: nil)
+            logger.info("Live Activity started (persistent) id=\(self.currentActivity?.id ?? "?")")
+        } catch {
+            logger.error("Failed to start Live Activity: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Begin a new agent run. Transitions from idle → active.
+    /// - Parameter userMessage: The user's message (used for on-device AI title generation).
+    func beginRun(userMessage: String? = nil) {
+        guard currentActivity != nil else { return }
+        idleTransitionTimer?.invalidate()
+        idleTransitionTimer = nil
+        isRunning = true
+        resetRunState()
+
+        // Fire off on-device AI title generation (iOS 26+).
+        if let msg = userMessage, !msg.isEmpty {
+            summaryTask = Task {
+                let title = await Self.generateAITitle(for: [msg])
+                guard !Task.isCancelled, self.currentActivity != nil else { return }
+                if let title {
+                    self.subject = title
+                    self.flushImmediately(
+                        statusText: self.currentToolLabel ?? "Thinking...")
+                }
+            }
+        }
+
+        flushImmediately(statusText: "Thinking...")
+    }
+
+    /// A tool started executing.
+    func handleToolStart(name: String, args: [String: Any]?) {
+        guard currentActivity != nil else { return }
+        if !isRunning { beginRun() }
+        previousToolLabel = currentToolLabel
+        let classified = Self.classifyTool(name: name, args: args)
+        currentToolLabel = classified.label
+        currentToolIcon = classified.icon
+        stepCount += 1
+        logger.info("[LA] handleToolStart step=\(self.stepCount) label=\(classified.label, privacy: .public) icon=\(classified.icon, privacy: .public)")
+        flushImmediately(statusText: classified.label)
+    }
+
+    /// A tool finished executing.
+    func handleToolResult() {
+        guard currentActivity != nil else { return }
+        logger.info("[LA] handleToolResult prev=\(self.currentToolLabel ?? "nil", privacy: .public)")
+        previousToolLabel = currentToolLabel
+        currentToolLabel = nil
+        currentToolIcon = nil
+        flushImmediately(statusText: "Thinking...")
+    }
+
+    /// Streaming assistant text arrived.
+    func handleStreamingText(_ text: String) {
+        guard currentActivity != nil else { return }
+        let truncated = text.count > 80 ? String(text.prefix(80)) + "..." : text
+        latestStreamingText = truncated
+        currentToolLabel = nil
+        currentToolIcon = nil
+        // Latch subject from streaming text only when long enough (≥10 chars).
+        // Foundation Models title generation takes priority and overwrites this.
+        if subject == nil, text.count >= 10 {
+            let firstLine = Self.extractFirstSentence(from: text)
+            if firstLine.count >= 4 {
+                subject = firstLine
+            }
+        }
+        scheduleUpdate(statusText: "Responding...")
+    }
+
+    /// Extract the first sentence or meaningful fragment (up to ~60 chars).
+    private static func extractFirstSentence(from text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        let separators = CharacterSet(charactersIn: ".!?\n")
+        let parts = trimmed.components(separatedBy: separators)
+        let first = (parts.first ?? trimmed).trimmingCharacters(in: .whitespacesAndNewlines)
+        if first.count > 60 {
+            return String(first.prefix(57)) + "..."
+        }
+        return first
+    }
+
+    /// The run completed successfully. Shows "Done" then transitions to idle.
+    func handleRunFinished() {
+        guard currentActivity != nil else { return }
+        logger.info("[LA] handleRunFinished steps=\(self.stepCount) subject=\(self.subject ?? "nil", privacy: .public)")
+        isRunning = false
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        pendingContent = nil
+        summaryTask?.cancel()
+        summaryTask = nil
+
+        let capturedActivity = currentActivity
+        let capturedSubject = subject
+        let capturedPrevTool = previousToolLabel
+        let capturedSteps = stepCount
+        let capturedStart = activityStartDate
+
+        // Show "Done" immediately, then try Foundation Models for a nicer message.
+        let doneState = OpenClawActivityAttributes.ContentState(
+            subject: capturedSubject,
+            statusText: "Done",
+            currentToolLabel: nil,
+            currentToolIcon: nil,
+            previousToolLabel: capturedPrevTool,
+            toolStepCount: capturedSteps,
+            streamingText: nil,
+            isFinished: true,
+            isError: false,
+            isIdle: false,
+            isDisconnected: false,
+            startedAt: capturedStart,
+            endedAt: .now)
+        Task { await capturedActivity?.update(ActivityContent(state: doneState, staleDate: nil)) }
+
+        // Schedule transition back to idle immediately — don't wait for Foundation Models.
+        scheduleIdleTransition()
+
+        // Try to generate a nicer completion message in the background.
+        if let title = capturedSubject {
+            Task {
+                if let completion = await Self.generateCompletionMessage(for: title) {
+                    logger.info("[LA] completion message: \(completion, privacy: .public)")
+                    var updated = doneState
+                    updated.subject = completion
+                    await capturedActivity?.update(ActivityContent(state: updated, staleDate: nil))
+                }
+            }
+        }
+    }
+
+    /// The run was aborted or errored. Shows "Error" then transitions to idle.
+    func handleRunError() {
+        guard currentActivity != nil else { return }
+        isRunning = false
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        pendingContent = nil
+        summaryTask?.cancel()
+        summaryTask = nil
+
+        let errorState = OpenClawActivityAttributes.ContentState(
+            subject: subject,
+            statusText: "Error",
+            currentToolLabel: nil,
+            currentToolIcon: nil,
+            previousToolLabel: previousToolLabel,
+            toolStepCount: stepCount,
+            streamingText: nil,
+            isFinished: false,
+            isError: true,
+            isIdle: false,
+            isDisconnected: false,
+            startedAt: activityStartDate,
+            endedAt: .now)
+        guard let activity = currentActivity else { return }
+        Task { await activity.update(ActivityContent(state: errorState, staleDate: nil)) }
+
+        // Schedule transition back to idle after a delay.
+        scheduleIdleTransition()
+    }
+
+    /// Gateway disconnected — show red "Disconnected" but keep the activity alive.
+    func handleDisconnect() {
+        guard let activity = currentActivity else { return }
+        logger.info("[LA] handleDisconnect — showing Disconnected")
+        isRunning = false
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        idleTransitionTimer?.invalidate()
+        idleTransitionTimer = nil
+        pendingContent = nil
+        summaryTask?.cancel()
+        summaryTask = nil
+        resetRunState()
+
+        let disconnectedState = OpenClawActivityAttributes.ContentState(
+            subject: nil,
+            statusText: "Disconnected",
+            currentToolLabel: nil,
+            currentToolIcon: nil,
+            previousToolLabel: nil,
+            toolStepCount: 0,
+            streamingText: nil,
+            isFinished: false,
+            isError: false,
+            isIdle: false,
+            isDisconnected: true,
+            startedAt: activityStartDate)
+        Task { await activity.update(ActivityContent(state: disconnectedState, staleDate: nil)) }
+    }
+
+    /// Gateway reconnected — transition back to idle from disconnected.
+    func handleReconnect() {
+        guard currentActivity != nil else { return }
+        logger.info("[LA] handleReconnect — transitioning to idle")
+        transitionToIdle()
+    }
+
+    /// End the activity entirely (called only on explicit user action or app termination).
+    func endActivity() {
+        guard let activity = currentActivity else { return }
+        logger.info("[LA] endActivity — removing Live Activity")
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        idleTransitionTimer?.invalidate()
+        idleTransitionTimer = nil
+        pendingContent = nil
+        currentActivity = nil
+        summaryTask?.cancel()
+        summaryTask = nil
+        isRunning = false
+
+        let capturedStart = activityStartDate
+
+        Task {
+            let finalState = OpenClawActivityAttributes.ContentState(
+                subject: nil,
+                statusText: "Disconnected",
+                currentToolLabel: nil,
+                currentToolIcon: nil,
+                previousToolLabel: nil,
+                toolStepCount: 0,
+                streamingText: nil,
+                isFinished: false,
+                isError: false,
+                isIdle: false,
+                isDisconnected: true,
+                startedAt: capturedStart,
+                endedAt: .now)
+            let content = ActivityContent(state: finalState, staleDate: nil)
+            await activity.end(content, dismissalPolicy: .after(.now + 4))
+        }
+    }
+
+    // MARK: - On-Device AI Helpers
+
+    /// Generate a task title using on-device Foundation Models (iOS 26+).
+    private static func generateAITitle(for messages: [String]) async -> String? {
+        if #available(iOS 26.0, *) {
+            return await TaskSummaryService.shared.generateTitle(for: messages)
+        }
+        return nil
+    }
+
+    /// Generate a completion message using on-device Foundation Models (iOS 26+).
+    private static func generateCompletionMessage(for taskTitle: String) async -> String? {
+        if #available(iOS 26.0, *) {
+            return await TaskSummaryService.shared.generateCompletionMessage(for: taskTitle)
+        }
+        return nil
+    }
+
+    /// Whether a Live Activity is currently running.
+    var isActive: Bool { currentActivity != nil }
+
+    // MARK: - Gateway Event Dispatch
+
+    /// Parse a gateway "agent" event payload and update the activity.
+    /// If an activity is running but no run is in progress, auto-starts a run.
+    func dispatchAgentEvent(_ payload: AnyCodable, agentName: String = "main", sessionKey: String = "main") {
+        struct AgentEvt: Decodable {
+            var stream: String
+            var data: [String: AnyCodable]?
+        }
+        let decoded: AgentEvt
+        do {
+            decoded = try GatewayPayloadDecoding.decode(payload, as: AgentEvt.self)
+        } catch {
+            logger.error("[LA] DECODE FAIL agent: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        logger.info("[LA] agent stream=\(decoded.stream, privacy: .public) isRunning=\(self.isRunning)")
+
+        // If no activity is running at all, start the persistent activity.
+        if currentActivity == nil {
+            startActivity(agentName: agentName, sessionKey: sessionKey)
+        }
+
+        // If we're idle, begin a new run.
+        if !isRunning {
+            beginRun()
+        }
+
+        switch decoded.stream {
+        case "tool":
+            let phase = decoded.data?["phase"]?.value as? String
+            let name = decoded.data?["name"]?.value as? String
+            logger.info("[LA] tool phase=\(phase ?? "nil", privacy: .public) name=\(name ?? "nil", privacy: .public)")
+            guard let phase else { return }
+            if phase == "start" {
+                let rawArgs = decoded.data?["args"]?.value as? [String: Any]
+                logger.info("[LA] tool start name=\(name ?? "nil", privacy: .public) hasArgs=\(rawArgs != nil)")
+                handleToolStart(name: name ?? "tool", args: rawArgs)
+            } else if phase == "result" {
+                handleToolResult()
+            }
+        case "assistant":
+            if let text = decoded.data?["text"]?.value as? String {
+                handleStreamingText(text)
+            }
+        default:
+            break
+        }
+    }
+
+    /// Parse a gateway "chat" event payload and update the activity.
+    func dispatchChatEvent(_ payload: AnyCodable) {
+        struct ChatEvt: Decodable {
+            var state: String?
+            var message: AnyCodable?
+        }
+        guard let decoded = try? GatewayPayloadDecoding.decode(payload, as: ChatEvt.self) else {
+            logger.error("[LA] DECODE FAIL chat")
+            return
+        }
+        logger.info("[LA] chat state=\(decoded.state ?? "nil", privacy: .public) hasMessage=\(decoded.message != nil)")
+
+        // If the chat event includes the user's message, fire AI title generation.
+        // message is OpenClawChatMessage shape: { role, content: [{type, text}] } or { role, content: "string" }
+        let userText: String? = {
+            guard let msgDict = decoded.message?.value as? [String: Any],
+                  let role = msgDict["role"] as? String, role == "user" else { return nil }
+            // content can be an array of {type, text, ...} or a plain string.
+            if let contentArray = msgDict["content"] as? [[String: Any]] {
+                return contentArray.first?["text"] as? String
+            }
+            return msgDict["content"] as? String
+        }()
+        logger.info("[LA] userText=\(userText ?? "nil", privacy: .public) subject=\(self.subject ?? "nil", privacy: .public)")
+        if subject == nil, summaryTask == nil,
+           let text = userText, !text.isEmpty
+        {
+            logger.info("[LA] firing AI title generation for: \(text.prefix(60), privacy: .public)")
+            summaryTask = Task {
+                let title = await Self.generateAITitle(for: [text])
+                guard !Task.isCancelled, self.currentActivity != nil else { return }
+                if let title {
+                    self.subject = title
+                    self.flushImmediately(
+                        statusText: self.currentToolLabel ?? "Thinking...")
+                }
+            }
+        }
+
+        switch decoded.state {
+        case "final":
+            handleRunFinished()
+        case "aborted", "error":
+            handleRunError()
+        default:
+            break
+        }
+    }
+
+    // MARK: - Tool Classification
+
+    private struct ToolClassification {
+        let label: String
+        let icon: String
+    }
+
+    /// Classify a tool name + args into a friendly label and SF Symbol icon.
+    private static func classifyTool(name: String, args: [String: Any]?) -> ToolClassification {
+        let lowName = name.lowercased()
+
+        // Bash / exec / shell commands — inspect the command string.
+        if lowName == "bash" || lowName == "exec" || lowName.hasPrefix("shell") {
+            guard let command = args?["command"] as? String else {
+                return ToolClassification(label: "Running a command...", icon: "terminal")
+            }
+            if command.contains("curl") || command.contains("wget") || command.contains("http") {
+                if let host = hostFromCommand(command) {
+                    return ToolClassification(label: "Fetching \(host)...", icon: "arrow.down.circle")
+                }
+                return ToolClassification(label: "Fetching data...", icon: "arrow.down.circle")
+            }
+            if command.contains("git ") {
+                return ToolClassification(label: "Running git...", icon: "terminal")
+            }
+            if command.hasPrefix("grep ") || command.hasPrefix("rg ") || command.hasPrefix("find ") {
+                return ToolClassification(label: "Searching files...", icon: "magnifyingglass")
+            }
+            if command.hasPrefix("cat ") || command.hasPrefix("head ") || command.hasPrefix("tail ") {
+                return ToolClassification(label: "Reading file...", icon: "doc")
+            }
+            if command.hasPrefix("ls") || command.hasPrefix("pwd") {
+                return ToolClassification(label: "Checking files...", icon: "folder")
+            }
+            if command.hasPrefix("mkdir ") || command.hasPrefix("cp ") || command.hasPrefix("mv ") || command.hasPrefix("rm ") {
+                return ToolClassification(label: "Managing files...", icon: "folder")
+            }
+            return ToolClassification(label: "Running a command...", icon: "terminal")
+        }
+
+        // Read / file read
+        if lowName == "read" || lowName.hasPrefix("file_read") || lowName.hasPrefix("fs.read") {
+            if let path = args?["file_path"] as? String ?? args?["path"] as? String {
+                let filename = (path as NSString).lastPathComponent
+                return ToolClassification(label: "Reading \(filename)...", icon: "doc")
+            }
+            return ToolClassification(label: "Reading file...", icon: "doc")
+        }
+
+        // Write / file write
+        if lowName == "write" || lowName.hasPrefix("file_write") || lowName.hasPrefix("fs.write") {
+            if let path = args?["file_path"] as? String ?? args?["path"] as? String {
+                let filename = (path as NSString).lastPathComponent
+                return ToolClassification(label: "Writing \(filename)...", icon: "doc.badge.plus")
+            }
+            return ToolClassification(label: "Writing file...", icon: "doc.badge.plus")
+        }
+
+        // Edit
+        if lowName == "edit" {
+            if let path = args?["file_path"] as? String ?? args?["path"] as? String {
+                let filename = (path as NSString).lastPathComponent
+                return ToolClassification(label: "Editing \(filename)...", icon: "pencil")
+            }
+            return ToolClassification(label: "Editing file...", icon: "pencil")
+        }
+
+        // Glob / file search
+        if lowName == "glob" {
+            if let pattern = args?["pattern"] as? String {
+                return ToolClassification(label: "Finding \(pattern)...", icon: "magnifyingglass")
+            }
+            return ToolClassification(label: "Finding files...", icon: "magnifyingglass")
+        }
+
+        // Grep / content search
+        if lowName == "grep" {
+            if let pattern = args?["pattern"] as? String {
+                let short = pattern.count > 20 ? String(pattern.prefix(17)) + "..." : pattern
+                return ToolClassification(label: "Searching \"\(short)\"...", icon: "magnifyingglass")
+            }
+            return ToolClassification(label: "Searching code...", icon: "magnifyingglass")
+        }
+
+        // Web fetch
+        if lowName == "webfetch" || lowName == "web_fetch" || lowName == "fetch" {
+            if let url = args?["url"] as? String, let host = hostFromURL(url) {
+                return ToolClassification(label: "Fetching \(host)...", icon: "globe")
+            }
+            return ToolClassification(label: "Fetching web page...", icon: "globe")
+        }
+
+        // Web search
+        if lowName == "websearch" || lowName == "web_search" {
+            if let query = args?["query"] as? String {
+                let short = query.count > 25 ? String(query.prefix(22)) + "..." : query
+                return ToolClassification(label: "Searching \"\(short)\"...", icon: "globe")
+            }
+            return ToolClassification(label: "Searching the web...", icon: "globe")
+        }
+
+        // Notebook edit
+        if lowName == "notebookedit" || lowName == "notebook_edit" {
+            return ToolClassification(label: "Editing notebook...", icon: "pencil")
+        }
+
+        // Task / agent
+        if lowName == "task" {
+            return ToolClassification(label: "Running sub-agent...", icon: "person.2")
+        }
+
+        // MCP tools (format: mcp__server__tool)
+        if lowName.hasPrefix("mcp_") {
+            let parts = name.split(separator: "_").filter { !$0.isEmpty }
+            let toolPart = parts.count >= 3 ? String(parts.last!) : name
+            return ToolClassification(label: "Using \(toolPart)...", icon: "puzzlepiece")
+        }
+
+        // Fallback
+        return ToolClassification(label: "Using \(name)...", icon: "gearshape")
+    }
+
+    /// Extract hostname from a URL string.
+    private static func hostFromURL(_ urlString: String) -> String? {
+        guard let url = URL(string: urlString) else { return nil }
+        return url.host
+    }
+
+    /// Extract hostname from a curl/wget command string.
+    private static func hostFromCommand(_ command: String) -> String? {
+        // Try to find a URL-like pattern in the command.
+        let pattern = #"https?://([^/\s\"']+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: command, range: NSRange(command.startIndex..., in: command)),
+              let range = Range(match.range(at: 1), in: command)
+        else { return nil }
+        return String(command[range])
+    }
+
+    // MARK: - Private
+
+    /// Reset per-run state (tool tracking, streaming text, subject).
+    private func resetRunState() {
+        stepCount = 0
+        currentToolLabel = nil
+        currentToolIcon = nil
+        previousToolLabel = nil
+        latestStreamingText = nil
+        subject = nil
+        summaryTask?.cancel()
+        summaryTask = nil
+    }
+
+    /// Schedule transition from Done/Error back to idle after a delay.
+    private func scheduleIdleTransition() {
+        idleTransitionTimer?.invalidate()
+        logger.info("[LA] scheduling idle transition in \(self.idleTransitionDelay)s")
+        idleTransitionTimer = Timer.scheduledTimer(
+            withTimeInterval: idleTransitionDelay, repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.transitionToIdle()
+            }
+        }
+    }
+
+    /// Transition the activity to idle/connected state.
+    private func transitionToIdle() {
+        logger.info("[LA] transitionToIdle")
+        guard let activity = currentActivity else { return }
+        idleTransitionTimer?.invalidate()
+        idleTransitionTimer = nil
+        resetRunState()
+
+        let idleState = OpenClawActivityAttributes.ContentState(
+            subject: nil,
+            statusText: "Idle",
+            currentToolLabel: nil,
+            currentToolIcon: nil,
+            previousToolLabel: nil,
+            toolStepCount: 0,
+            streamingText: nil,
+            isFinished: false,
+            isError: false,
+            isIdle: true,
+            isDisconnected: false,
+            startedAt: activityStartDate)
+        Task { await activity.update(ActivityContent(state: idleState, staleDate: nil)) }
+    }
+
+    /// Flush an update immediately — used for important state changes (tool start/result).
+    private func flushImmediately(statusText: String) {
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        pendingContent = nil
+        let state = OpenClawActivityAttributes.ContentState(
+            subject: subject,
+            statusText: statusText,
+            currentToolLabel: currentToolLabel,
+            currentToolIcon: currentToolIcon,
+            previousToolLabel: previousToolLabel,
+            toolStepCount: stepCount,
+            streamingText: latestStreamingText,
+            isFinished: false,
+            isError: false,
+            isIdle: false,
+            isDisconnected: false,
+            startedAt: activityStartDate)
+        guard let activity = currentActivity else { return }
+        Task { await activity.update(ActivityContent(state: state, staleDate: nil)) }
+    }
+
+    /// Schedule a debounced update — used for rapid streaming text.
+    private func scheduleUpdate(statusText: String) {
+        let state = OpenClawActivityAttributes.ContentState(
+            subject: subject,
+            statusText: statusText,
+            currentToolLabel: currentToolLabel,
+            currentToolIcon: currentToolIcon,
+            previousToolLabel: previousToolLabel,
+            toolStepCount: stepCount,
+            streamingText: latestStreamingText,
+            isFinished: false,
+            isError: false,
+            isIdle: false,
+            isDisconnected: false,
+            startedAt: activityStartDate)
+        pendingContent = ActivityContent(state: state, staleDate: nil)
+
+        debounceTimer?.invalidate()
+        debounceTimer = Timer.scheduledTimer(withTimeInterval: debounceInterval, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.flushPendingUpdate()
+            }
+        }
+    }
+
+    private func flushPendingUpdate() {
+        guard let activity = currentActivity, let content = pendingContent else { return }
+        pendingContent = nil
+        Task {
+            await activity.update(content)
+        }
+    }
+}

--- a/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
+++ b/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
@@ -31,6 +31,8 @@ struct OpenClawActivityAttributes: ActivityAttributes {
         var isIdle: Bool
         /// Whether the gateway is disconnected.
         var isDisconnected: Bool
+        /// Whether the gateway is currently connecting.
+        var isConnecting: Bool
         /// When the activity started (drives the live timer).
         var startedAt: Date
         /// When the last run ended (nil while running or idle).
@@ -46,54 +48,63 @@ extension OpenClawActivityAttributes {
 }
 
 extension OpenClawActivityAttributes.ContentState {
+    static let connecting = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Connecting...",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
+        toolStepCount: 0, streamingText: nil,
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, isConnecting: true, startedAt: .now)
+
     static let idle = OpenClawActivityAttributes.ContentState(
         subject: nil, statusText: "Idle",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
         toolStepCount: 0, streamingText: nil,
-        isFinished: false, isError: false, isIdle: true, isDisconnected: false, startedAt: .now)
+        isFinished: false, isError: false, isIdle: true, isDisconnected: false, isConnecting: false, startedAt: .now)
 
     static let disconnected = OpenClawActivityAttributes.ContentState(
         subject: nil, statusText: "Disconnected",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
         toolStepCount: 0, streamingText: nil,
-        isFinished: false, isError: false, isIdle: false, isDisconnected: true, startedAt: .now)
+        isFinished: false, isError: false, isIdle: false, isDisconnected: true, isConnecting: false, startedAt: .now)
 
     static let thinking = OpenClawActivityAttributes.ContentState(
         subject: nil, statusText: "Thinking...",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
         toolStepCount: 0, streamingText: nil,
-        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now)
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, isConnecting: false, startedAt: .now)
 
     static let toolRunning = OpenClawActivityAttributes.ContentState(
         subject: nil, statusText: "Searching the web...",
         currentToolLabel: "Searching the web...", currentToolIcon: "globe", previousToolLabel: nil,
         toolStepCount: 1, streamingText: nil,
-        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-5))
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, isConnecting: false,
+        startedAt: .now.addingTimeInterval(-5))
 
     static let multiTool = OpenClawActivityAttributes.ContentState(
         subject: "Updating auth module", statusText: "Editing auth.swift...",
         currentToolLabel: "Editing auth.swift...", currentToolIcon: "doc", previousToolLabel: "Searched the web",
         toolStepCount: 3, streamingText: nil,
-        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-18))
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, isConnecting: false,
+        startedAt: .now.addingTimeInterval(-18))
 
     static let streaming = OpenClawActivityAttributes.ContentState(
         subject: "Updating auth module", statusText: "Responding...",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: "Edited auth.swift",
         toolStepCount: 3, streamingText: "Here are the changes I made to the authentication module...",
-        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-25))
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, isConnecting: false,
+        startedAt: .now.addingTimeInterval(-25))
 
     static let finished = OpenClawActivityAttributes.ContentState(
         subject: "Updated auth module", statusText: "Done",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: "Edited auth.swift",
         toolStepCount: 3, streamingText: nil,
-        isFinished: true, isError: false, isIdle: false, isDisconnected: false,
+        isFinished: true, isError: false, isIdle: false, isDisconnected: false, isConnecting: false,
         startedAt: .now.addingTimeInterval(-32), endedAt: .now)
 
     static let error = OpenClawActivityAttributes.ContentState(
         subject: nil, statusText: "Error",
         currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
         toolStepCount: 1, streamingText: nil,
-        isFinished: false, isError: true, isIdle: false, isDisconnected: false,
+        isFinished: false, isError: true, isIdle: false, isDisconnected: false, isConnecting: false,
         startedAt: .now.addingTimeInterval(-10), endedAt: .now)
 }
 #endif

--- a/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
+++ b/apps/ios/Sources/LiveActivity/OpenClawActivityAttributes.swift
@@ -1,0 +1,99 @@
+import ActivityKit
+import Foundation
+
+/// Shared definition compiled by both the main app and the widget extension.
+struct OpenClawActivityAttributes: ActivityAttributes {
+    /// Agent display name (set once when the activity starts).
+    var agentName: String
+    /// Session key so the widget can scope its display.
+    var sessionKey: String
+
+    struct ContentState: Codable, Hashable {
+        /// Short AI-generated subject line (latched from first streaming text).
+        var subject: String?
+        /// Human-readable status ("Thinking...", "Reading config.json...", "Done", "Connected").
+        var statusText: String
+        /// Friendly label for the current tool (nil when idle/thinking).
+        var currentToolLabel: String?
+        /// SF Symbol name for the current tool category.
+        var currentToolIcon: String?
+        /// Friendly label for the most recently completed tool.
+        var previousToolLabel: String?
+        /// Number of tool steps executed so far.
+        var toolStepCount: Int
+        /// First ~80 chars of streaming assistant text (truncated).
+        var streamingText: String?
+        /// Activity completed successfully (last run).
+        var isFinished: Bool
+        /// Activity ended with an error (last run).
+        var isError: Bool
+        /// Whether the gateway is connected but idle (no active run).
+        var isIdle: Bool
+        /// Whether the gateway is disconnected.
+        var isDisconnected: Bool
+        /// When the activity started (drives the live timer).
+        var startedAt: Date
+        /// When the last run ended (nil while running or idle).
+        var endedAt: Date?
+    }
+}
+
+// MARK: - Preview Helpers
+
+#if DEBUG
+extension OpenClawActivityAttributes {
+    static let preview = OpenClawActivityAttributes(agentName: "main", sessionKey: "main")
+}
+
+extension OpenClawActivityAttributes.ContentState {
+    static let idle = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Idle",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
+        toolStepCount: 0, streamingText: nil,
+        isFinished: false, isError: false, isIdle: true, isDisconnected: false, startedAt: .now)
+
+    static let disconnected = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Disconnected",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
+        toolStepCount: 0, streamingText: nil,
+        isFinished: false, isError: false, isIdle: false, isDisconnected: true, startedAt: .now)
+
+    static let thinking = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Thinking...",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
+        toolStepCount: 0, streamingText: nil,
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now)
+
+    static let toolRunning = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Searching the web...",
+        currentToolLabel: "Searching the web...", currentToolIcon: "globe", previousToolLabel: nil,
+        toolStepCount: 1, streamingText: nil,
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-5))
+
+    static let multiTool = OpenClawActivityAttributes.ContentState(
+        subject: "Updating auth module", statusText: "Editing auth.swift...",
+        currentToolLabel: "Editing auth.swift...", currentToolIcon: "doc", previousToolLabel: "Searched the web",
+        toolStepCount: 3, streamingText: nil,
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-18))
+
+    static let streaming = OpenClawActivityAttributes.ContentState(
+        subject: "Updating auth module", statusText: "Responding...",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: "Edited auth.swift",
+        toolStepCount: 3, streamingText: "Here are the changes I made to the authentication module...",
+        isFinished: false, isError: false, isIdle: false, isDisconnected: false, startedAt: .now.addingTimeInterval(-25))
+
+    static let finished = OpenClawActivityAttributes.ContentState(
+        subject: "Updated auth module", statusText: "Done",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: "Edited auth.swift",
+        toolStepCount: 3, streamingText: nil,
+        isFinished: true, isError: false, isIdle: false, isDisconnected: false,
+        startedAt: .now.addingTimeInterval(-32), endedAt: .now)
+
+    static let error = OpenClawActivityAttributes.ContentState(
+        subject: nil, statusText: "Error",
+        currentToolLabel: nil, currentToolIcon: nil, previousToolLabel: nil,
+        toolStepCount: 1, streamingText: nil,
+        isFinished: false, isError: true, isIdle: false, isDisconnected: false,
+        startedAt: .now.addingTimeInterval(-10), endedAt: .now)
+}
+#endif

--- a/apps/ios/Sources/LiveActivity/TaskSummaryService.swift
+++ b/apps/ios/Sources/LiveActivity/TaskSummaryService.swift
@@ -1,0 +1,113 @@
+import Foundation
+import os
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Generates short task titles using Apple's on-device Foundation Models (iOS 26+).
+/// Falls back to first-sentence extraction when unavailable.
+@available(iOS 26.0, *)
+actor TaskSummaryService {
+    static let shared = TaskSummaryService()
+
+    private let logger = Logger(subsystem: "ai.openclaw.ios", category: "TaskSummary")
+
+    private init() {}
+
+    /// Whether on-device Foundation Models are available.
+    var isAvailable: Bool {
+        #if canImport(FoundationModels)
+        SystemLanguageModel.default.availability == .available
+        #else
+        false
+        #endif
+    }
+
+    /// Generate a 2-4 word title for the task from recent user messages.
+    func generateTitle(for messages: [String]) async -> String? {
+        #if canImport(FoundationModels)
+        guard !messages.isEmpty else { return nil }
+        guard isAvailable else {
+            logger.info("Foundation Models not available")
+            return nil
+        }
+
+        let session = LanguageModelSession(
+            model: .init(useCase: .general, guardrails: .permissiveContentTransformations))
+
+        let numbered = messages.enumerated().map { i, msg in
+            "\(i + 1). \"\(msg)\""
+        }.joined(separator: "\n")
+
+        let prompt = """
+        Analyze these user messages from a conversation with an AI assistant \
+        and identify the overall task being worked on. \
+        It should read like the task that the assistant will perform. \
+        It should sound like an imperative command. Like "Verb Noun".
+
+        Messages (oldest to newest):
+        \(numbered)
+
+        The latest message may just be a follow-up. \
+        Look at all messages to understand what the user is ultimately trying to accomplish.
+
+        Give a short 2-4 word title for the overall task. \
+        Make the title specific to the details in the message. \
+        Prioritise proper nouns and details that the user has sent.
+
+        Only output the title, nothing else.
+        """
+
+        do {
+            let response = try await session.respond(to: prompt)
+            let result = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.info("Generated title: \(result, privacy: .public)")
+            return result.isEmpty ? nil : result
+        } catch {
+            logger.error("Title generation failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+
+    /// Generate a completion message from a task title (e.g. "Book flights" → "Your flights have been booked").
+    func generateCompletionMessage(for taskTitle: String) async -> String? {
+        #if canImport(FoundationModels)
+        guard !taskTitle.isEmpty, isAvailable else { return nil }
+
+        let session = LanguageModelSession(
+            model: .init(useCase: .general, guardrails: .permissiveContentTransformations))
+
+        let prompt = """
+        Transform this task title into a short completion message.
+
+        Task title: "\(taskTitle)"
+
+        Rules:
+        - Convert to past tense
+        - Keep it concise (under 8 words)
+        - Make it sound like a friendly notification
+        - Do not use exclamation marks
+
+        Examples:
+        - "Book train tickets" → "Your tickets have been booked"
+        - "Find restaurants" → "Restaurants found"
+        - "Send email to John" → "Email sent to John"
+
+        Only output the completion message, nothing else.
+        """
+
+        do {
+            let response = try await session.respond(to: prompt)
+            return response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+}

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1913,6 +1913,10 @@ private extension NodeAppModel {
                     self.gatewayStatusText = (attempt == 0) ? "Connecting…" : "Reconnecting…"
                     self.gatewayServerName = nil
                     self.gatewayRemoteAddress = nil
+                    // Show "Connecting" in Live Activity / Dynamic Island.
+                    let la = LiveActivityManager.shared
+                    if la.isActive { la.handleConnecting() }
+                    else { la.startActivity(agentName: self.selectedAgentId ?? "main", sessionKey: self.mainSessionKey) }
                 }
 
                 do {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -99,6 +99,7 @@ final class NodeAppModel {
     private var nodeGatewayTask: Task<Void, Never>?
     private var operatorGatewayTask: Task<Void, Never>?
     private var voiceWakeSyncTask: Task<Void, Never>?
+    private var liveActivityTask: Task<Void, Never>?
     @ObservationIgnored private var cameraHUDDismissTask: Task<Void, Never>?
     @ObservationIgnored private lazy var capabilityRouter: NodeCapabilityRouter = self.buildCapabilityRouter()
     private let gatewayHealthMonitor = GatewayHealthMonitor()
@@ -635,6 +636,31 @@ final class NodeAppModel {
                     self.applyTalkModeSync(enabled: decoded.enabled, phase: decoded.phase)
                 default:
                     continue
+                }
+            }
+        }
+    }
+
+    /// Subscribe to operator gateway server events and drive the Live Activity.
+    func startLiveActivityEventLoop() {
+        self.liveActivityTask?.cancel()
+        let la = LiveActivityManager.shared
+        if la.isActive { la.handleReconnect() }
+        else { la.startActivity(agentName: self.selectedAgentId ?? "main", sessionKey: self.mainSessionKey) }
+        self.liveActivityTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.operatorGateway.subscribeServerEvents(bufferingNewest: 200)
+            for await evt in stream {
+                if Task.isCancelled { return }
+                guard evt.event == "agent" || evt.event == "chat",
+                      let payload = evt.payload else { continue }
+                await MainActor.run {
+                    let agent = self.selectedAgentId ?? "main", session = self.mainSessionKey
+                    switch evt.event {
+                    case "agent": LiveActivityManager.shared.dispatchAgentEvent(payload, agentName: agent, sessionKey: session)
+                    case "chat": LiveActivityManager.shared.dispatchChatEvent(payload)
+                    default: break
+                    }
                 }
             }
         }
@@ -1693,6 +1719,9 @@ extension NodeAppModel {
         self.operatorGatewayTask = nil
         self.voiceWakeSyncTask?.cancel()
         self.voiceWakeSyncTask = nil
+        self.liveActivityTask?.cancel()
+        self.liveActivityTask = nil
+        LiveActivityManager.shared.handleDisconnect()
         self.gatewayHealthMonitor.stop()
         Task {
             await self.operatorGateway.disconnect()
@@ -1729,6 +1758,8 @@ private extension NodeAppModel {
         self.operatorConnected = false
         self.voiceWakeSyncTask?.cancel()
         self.voiceWakeSyncTask = nil
+        self.liveActivityTask?.cancel()
+        self.liveActivityTask = nil
         self.gatewayDefaultAgentId = nil
         self.gatewayAgents = []
         self.selectedAgentId = GatewaySettingsStore.loadGatewaySelectedAgentId(stableID: stableID)
@@ -1809,6 +1840,7 @@ private extension NodeAppModel {
                             await self.refreshAgentsFromGateway()
                             await self.refreshShareRouteFromGateway()
                             await self.startVoiceWakeSync()
+                            await MainActor.run { self.startLiveActivityEventLoop() }
                             await MainActor.run { self.startGatewayHealthMonitor() }
                         },
                         onDisconnected: { [weak self] reason in
@@ -1816,6 +1848,7 @@ private extension NodeAppModel {
                             await MainActor.run {
                                 self.operatorConnected = false
                                 self.talkMode.updateGatewayConnected(false)
+                                LiveActivityManager.shared.handleDisconnect()
                             }
                             GatewayDiagnostics.log("operator gateway disconnected reason=\(reason)")
                             await MainActor.run { self.stopGatewayHealthMonitor() }

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -62,3 +62,7 @@ Sources/Voice/VoiceWakePreferences.swift
 ../../Swabble/Sources/SwabbleKit/WakeWordGate.swift
 Sources/Voice/TalkModeManager.swift
 Sources/Voice/TalkOrbOverlay.swift
+Sources/LiveActivity/OpenClawActivityAttributes.swift
+Sources/LiveActivity/LiveActivityManager.swift
+ActivityWidget/OpenClawActivityWidgetBundle.swift
+ActivityWidget/OpenClawLiveActivity.swift

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -37,6 +37,8 @@ targets:
     dependencies:
       - target: OpenClawShareExtension
         embed: true
+      - target: OpenClawActivityWidget
+        embed: true
       - target: OpenClawWatchApp
       - package: OpenClawKit
       - package: OpenClawKit
@@ -82,6 +84,7 @@ targets:
         PROVISIONING_PROFILE_SPECIFIER: "$(OPENCLAW_APP_PROFILE)"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
+        SUPPORTS_LIVE_ACTIVITIES: YES
         ENABLE_APPINTENTS_METADATA: NO
     info:
       path: Sources/Info.plist
@@ -94,6 +97,7 @@ targets:
               - openclaw
         CFBundleShortVersionString: "2026.2.27"
         CFBundleVersion: "20260227"
+        NSSupportsLiveActivities: true
         UILaunchScreen: {}
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -159,6 +163,38 @@ targets:
               NSExtensionActivationSupportsWebURLWithMaxCount: 1
               NSExtensionActivationSupportsImageWithMaxCount: 10
               NSExtensionActivationSupportsMovieWithMaxCount: 1
+
+  OpenClawActivityWidget:
+    type: app-extension
+    platform: iOS
+    configFiles:
+      Debug: Signing.xcconfig
+      Release: Signing.xcconfig
+    sources:
+      - path: ActivityWidget
+      - path: Sources/LiveActivity/OpenClawActivityAttributes.swift
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: ActivityKit.framework
+    settings:
+      base:
+        CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_STYLE: "$(OPENCLAW_CODE_SIGN_STYLE)"
+        DEVELOPMENT_TEAM: "$(OPENCLAW_DEVELOPMENT_TEAM)"
+        PRODUCT_BUNDLE_IDENTIFIER: "$(OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID)"
+        PROVISIONING_PROFILE_SPECIFIER: "$(OPENCLAW_ACTIVITY_WIDGET_PROFILE)"
+        SWIFT_VERSION: "6.0"
+        SWIFT_STRICT_CONCURRENCY: complete
+        SUPPORTS_LIVE_ACTIVITIES: YES
+    info:
+      path: ActivityWidget/Info.plist
+      properties:
+        CFBundleDisplayName: OpenClaw Activity
+        CFBundleShortVersionString: "2026.2.26"
+        CFBundleVersion: "20260226"
+        NSSupportsLiveActivities: true
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
 
   OpenClawWatchApp:
     type: application.watchapp2


### PR DESCRIPTION
## Summary

- Add ActivityWidget extension with Dynamic Island (compact/expanded) and Lock Screen banner views
- LiveActivityManager singleton manages activity lifecycle with 1s debounce — shows thinking, streaming, tool execution, done, idle, and disconnected states
- Idle state (gray) persists as long as the app is in background; disconnected state (red) shows when gateway connection drops
- watchOS 11+ automatically mirrors iPhone Live Activities in Smart Stack — no watch code changes needed

## Changes

### New files
- `ActivityWidget/` — WidgetKit extension with Dynamic Island + Lock Screen views
- `Sources/LiveActivity/LiveActivityManager.swift` — Activity lifecycle management
- `Sources/LiveActivity/OpenClawActivityAttributes.swift` — Shared ActivityAttributes definition
- `Sources/LiveActivity/TaskSummaryService.swift` — AI-powered task summary for activity titles

### Modified files
- `project.yml` — Added `OpenClawActivityWidget` target + `NSSupportsLiveActivities`
- `Config/Signing.xcconfig` — Added `OPENCLAW_ACTIVITY_WIDGET_BUNDLE_ID`
- `Sources/Model/NodeAppModel.swift` — Gateway event subscription for live activity updates
- `Sources/Info.plist` — Added `NSSupportsLiveActivities` + alphabetized keys
- `Tests/Info.plist` — Fixed indentation
- `SwiftSources.input.xcfilelist` — Added new Swift source files

## Test plan

- [x] Build with `xcodegen generate && xcodebuild -scheme OpenClaw`
- [x] Send a message — Live Activity appears on Dynamic Island + Lock Screen
- [x] Agent runs tools — steps increment, tool names update in Dynamic Island
- [x] Agent completes — "Done" state shown, transitions to "Idle" after delay
- [x] Background app — Live Activity persists showing "Idle" state
- [x] Disconnect gateway — Live Activity shows red "Disconnected" state
- [x] Reconnect gateway — transitions back to "Idle"
- [x] Pair Apple Watch (watchOS 11+) — Live Activity mirrors in Smart Stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)