### PR TITLE
fix(podman): default run-openclaw-podman bind to loopback (AI-assisted)

### DIFF
--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -85,6 +85,7 @@ To add quadlet **after** an initial setup that did not use it, re-run: `./setup-
 - **Token:** Stored in `~openclaw/.openclaw/.env` as `OPENCLAW_GATEWAY_TOKEN`. `setup-podman.sh` and `run-openclaw-podman.sh` generate it if missing (uses `openssl`, `python3`, or `od`).
 - **Optional:** In that `.env` you can set provider keys (e.g. `GROQ_API_KEY`, `OLLAMA_API_KEY`) and other OpenClaw env vars.
 - **Host ports:** By default the script maps `18789` (gateway) and `18790` (bridge). Override the **host** port mapping with `OPENCLAW_PODMAN_GATEWAY_HOST_PORT` and `OPENCLAW_PODMAN_BRIDGE_HOST_PORT` when launching.
+- **Gateway bind:** By default, `run-openclaw-podman.sh` starts the gateway with `--bind loopback` for safe local access. To expose on LAN, set `OPENCLAW_GATEWAY_BIND=lan` and configure `gateway.controlUi.allowedOrigins` (or explicitly enable host-header fallback) in `openclaw.json`.
 - **Paths:** Host config and workspace default to `~openclaw/.openclaw` and `~openclaw/.openclaw/workspace`. Override the host paths used by the launch script with `OPENCLAW_CONFIG_DIR` and `OPENCLAW_WORKSPACE_DIR`.
 
 ## Useful commands

--- a/openclaw.podman.env
+++ b/openclaw.podman.env
@@ -17,7 +17,9 @@ OPENCLAW_PODMAN_GATEWAY_HOST_PORT=18789
 OPENCLAW_PODMAN_BRIDGE_HOST_PORT=18790
 
 # Gateway bind (used by the launch script)
-OPENCLAW_GATEWAY_BIND=lan
+# Default is loopback for safe local access. If you set lan, configure
+# gateway.controlUi.allowedOrigins (or explicitly enable host-header fallback).
+OPENCLAW_GATEWAY_BIND=loopback
 
 # Optional: LLM provider API keys (for zero cost use Ollama locally or Groq free tier)
 # OLLAMA_API_KEY=ollama-local

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -75,7 +75,9 @@ OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-openclaw:local}"
 PODMAN_PULL="${OPENCLAW_PODMAN_PULL:-never}"
 HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
 HOST_BRIDGE_PORT="${OPENCLAW_PODMAN_BRIDGE_HOST_PORT:-${OPENCLAW_BRIDGE_PORT:-18790}}"
-GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-lan}"
+# Keep Podman default local-only unless explicitly overridden.
+# Non-loopback binds require gateway.controlUi.allowedOrigins (security hardening).
+GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 
 # Safe cwd for podman (openclaw is nologin; avoid inherited cwd from sudo)
 cd "$EFFECTIVE_HOME" 2>/dev/null || cd /tmp 2>/dev/null || true

--- a/src/telegram/bot-message-context.test-harness.ts
+++ b/src/telegram/bot-message-context.test-harness.ts
@@ -55,6 +55,11 @@ export async function buildTelegramMessageContextForTest(
     logger: { info: vi.fn() },
     resolveGroupActivation: params.resolveGroupActivation ?? (() => undefined),
     resolveGroupRequireMention: params.resolveGroupRequireMention ?? (() => false),
+    sendChatActionHandler: {
+      sendChatAction: vi.fn().mockResolvedValue(undefined),
+      isSuspended: () => false,
+      reset: vi.fn(),
+    },
     resolveTelegramGroupConfig:
       params.resolveTelegramGroupConfig ??
       (() => ({


### PR DESCRIPTION
## Summary
- change Podman launch default bind from `lan` to `loopback`
- prevent startup failure on fresh Podman installs when `gateway.controlUi.allowedOrigins` is unset
- align `openclaw.podman.env` example with `OPENCLAW_GATEWAY_BIND=loopback`
- add `sendChatActionHandler` mock to telegram test harness to satisfy current typed params in this branch

## Why
`setup-podman.sh` writes a minimal config (`gateway.mode=local`) without `gateway.controlUi.allowedOrigins`.
With `run-openclaw-podman.sh` defaulting to `--bind lan`, gateway startup is blocked by control-ui origin hardening.

## AI-assisted transparency
- AI-assisted: **yes**
- Testing level: **lightly tested**
  - `bash -n scripts/run-openclaw-podman.sh`
  - `pnpm tsgo`
- Code understanding confirmation: yes — runtime behavior change is only Podman default bind (`loopback`), docs/env example alignment, and a test-harness typing stub needed by current `BuildTelegramMessageContextParams`.

Fixes #27473

Supersedes closed #27491.
