### PR TITLE
fix: preserve operator scopes for shared auth connections

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -481,7 +481,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         const clearUnboundScopes = () => {
-          if (scopes.length > 0 && !controlUiAuthPolicy.allowBypass) {
+          if (scopes.length > 0 && !controlUiAuthPolicy.allowBypass && !sharedAuthOk) {
             scopes = [];
             connectParams.scopes = scopes;
           }


### PR DESCRIPTION
## Summary

When connecting via shared gateway token (no device identity), the operator scopes were being cleared, causing API operations to fail with 'missing scope' errors.

## Fix

This fix preserves scopes when  is true, allowing headless/API operator clients to retain their requested scopes.

## Related Issue

Fixes #27494