### PR TITLE
fix: enable store=true for Azure OpenAI Responses API

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -14,7 +14,7 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // NOTE: We only force `store=true` for *direct* OpenAI Responses.
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
-const OPENAI_RESPONSES_PROVIDERS = new Set(["openai"]);
+const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -184,10 +184,10 @@ function isDirectOpenAIBaseUrl(baseUrl: unknown): boolean {
 
   try {
     const host = new URL(baseUrl).hostname.toLowerCase();
-    return host === "api.openai.com" || host === "chatgpt.com";
+    return host === "api.openai.com" || host === "chatgpt.com" || host.endsWith(".openai.azure.com");
   } catch {
     const normalized = baseUrl.toLowerCase();
-    return normalized.includes("api.openai.com") || normalized.includes("chatgpt.com");
+    return normalized.includes("api.openai.com") || normalized.includes("chatgpt.com") || normalized.includes(".openai.azure.com");
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `"azure-openai-responses"` to `OPENAI_RESPONSES_PROVIDERS` whitelist
- Add `*.openai.azure.com` pattern to `isDirectOpenAIBaseUrl()` URL check
- Fix: `shouldForceResponsesStore()` now correctly returns `true` for Azure OpenAI

## Problem

Azure OpenAI users hitting HTTP 400 on every multi-turn conversation:

```
HTTP 400: Item with id 'rs_xxx' not found.
Items are not persisted when `store` is set to false.
```

`shouldForceResponsesStore()` always returned `false` for Azure because:
1. Provider `"azure-openai-responses"` was not in `OPENAI_RESPONSES_PROVIDERS`
2. Azure URLs (`*.openai.azure.com`) were not recognized by `isDirectOpenAIBaseUrl()`

This caused the pi-ai library to default to `store=false`, so Azure never persisted responses. On the next turn, `previous_response_id` referenced a non-existent response → 400 error.

Azure OpenAI fully supports the `store` parameter and `previous_response_id` per [Microsoft docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/responses).

## Changes

3-line fix in `src/agents/pi-embedded-runner/extra-params.ts`:

```diff
- const OPENAI_RESPONSES_PROVIDERS = new Set(["openai"]);
+ const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);

- return host === "api.openai.com" || host === "chatgpt.com";
+ return host === "api.openai.com" || host === "chatgpt.com" || host.endsWith(".openai.azure.com");

- return normalized.includes("api.openai.com") || normalized.includes("chatgpt.com");
+ return normalized.includes("api.openai.com") || normalized.includes("chatgpt.com") || normalized.includes(".openai.azure.com");
```

## Test plan

- [x] Tested locally: Docker deployment with Azure OpenAI `gpt-5.2-chat-latest`
- [x] Multi-turn conversations now work without 400 errors
- [x] First message, follow-up messages, and personality setup all persist correctly
- [ ] Verify no regression with direct OpenAI provider
- [ ] Verify Codex responses still use `store=false` as intended

Fixes #27497

---
🤖 AI-assisted (Claude Code) — fully tested on Azure OpenAI deployment