### PR TITLE
fix: avoid startup crash on stale plugins.entries keys (#27455)

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -65,17 +65,18 @@ describe("config plugin validation", () => {
     }
   });
 
-  it("rejects missing plugin ids in entries", async () => {
+  it("warns for missing plugin ids in entries instead of failing validation", async () => {
     const home = await createCaseHome();
     const res = validateInHome(home, {
       agents: { list: [{ id: "pi" }] },
       plugins: { enabled: false, entries: { "missing-plugin": { enabled: true } } },
     });
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.issues).toContainEqual({
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.warnings).toContainEqual({
         path: "plugins.entries.missing-plugin",
-        message: "plugin not found: missing-plugin",
+        message:
+          "plugin not found: missing-plugin (stale config entry ignored; remove it from plugins config)",
       });
     }
   });


### PR DESCRIPTION
## Summary

- Problem: `plugins.entries` containing a stale/removed plugin key causes a hard validation error, crash-looping the gateway on startup.
- Why it matters: Users upgrading across versions commonly carry stale config entries; a silent crash loop with no actionable log output wastes debugging time.
- What changed: Unknown plugin IDs in `plugins.entries` are now downgraded from validation errors to warnings. The gateway starts normally and logs a warning suggesting removal.
- What did NOT change (scope boundary): Plugin IDs referenced by agents or other explicit config paths still produce hard errors as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27455

## User-visible / Behavior Changes

Gateway no longer refuses to start when `plugins.entries` contains an unrecognized plugin key. A warning is logged instead.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A

### Steps

1. Add `plugins.entries["nonexistent-plugin"] = { enabled: true }` to config
2. Start the gateway

### Expected

- Gateway starts, logs a warning about the unknown plugin entry

### Actual (before fix)

- Gateway crashes with a validation error

## Evidence

- [x] Failing test/log before + passing after
- `npx vitest run src/config/config.plugin-validation.test.ts` — all 11 tests pass

## Human Verification (required)

- Verified scenarios: config with missing plugin key now produces warning, gateway starts
- Edge cases checked: legacy removed plugin IDs still produce separate warning; agent-referenced missing plugins still hard-fail
- What you did **not** verify: E2E gateway startup with live Telegram/Slack channels

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit; validation returns to hard-error behavior
- No config changes needed

## Risks and Mitigations

- Risk: Users never clean up stale entries because warnings are silent
  - Mitigation: Warning message explicitly tells users to remove the entry