### PR TITLE
feat(telegram): per-topic model override with shared forum session

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -199,7 +199,26 @@ export async function getReplyFromConfig(
   const hasSessionModelOverride = Boolean(
     sessionEntry.modelOverride?.trim() || sessionEntry.providerOverride?.trim(),
   );
-  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && channelModelOverride) {
+  // Per-topic model override (e.g., Telegram forum topic config) — more specific than channel override.
+  let hasResolvedTopicModelOverride = false;
+  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && opts?.topicModelOverride) {
+    const resolved = resolveModelRefFromString({
+      raw: opts.topicModelOverride,
+      defaultProvider,
+      aliasIndex,
+    });
+    if (resolved) {
+      provider = resolved.ref.provider;
+      model = resolved.ref.model;
+      hasResolvedTopicModelOverride = true;
+    }
+  }
+  if (
+    !hasResolvedHeartbeatModelOverride &&
+    !hasSessionModelOverride &&
+    !hasResolvedTopicModelOverride &&
+    channelModelOverride
+  ) {
     const resolved = resolveModelRefFromString({
       raw: channelModelOverride.model,
       defaultProvider,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -29,6 +29,8 @@ export type GetReplyOptions = {
   isHeartbeat?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
+  /** Per-topic model override (e.g., from Telegram forum topic config). */
+  topicModelOverride?: string;
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -183,7 +183,7 @@ export type TelegramTopicConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this topic. */
   systemPrompt?: string;
-  /** Per-topic model override (e.g., "anthropic/claude-opus-4-6"). Requires sharedTopicSession on the group. */
+  /** Per-topic model override (e.g., "anthropic/claude-opus-4-6"). Best paired with sharedTopicSession on the group for shared conversation history. */
   model?: string;
 };
 

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -183,6 +183,8 @@ export type TelegramTopicConfig = {
   allowFrom?: Array<string | number>;
   /** Optional system prompt snippet for this topic. */
   systemPrompt?: string;
+  /** Per-topic model override (e.g., "anthropic/claude-opus-4-6"). Requires sharedTopicSession on the group. */
+  model?: string;
 };
 
 export type TelegramGroupConfig = {
@@ -196,6 +198,8 @@ export type TelegramGroupConfig = {
   skills?: string[];
   /** Per-topic configuration (key is message_thread_id as string) */
   topics?: Record<string, TelegramTopicConfig>;
+  /** When true, all forum topics share a single session (conversation history). Pair with per-topic `model` to let users pick a model by topic. */
+  sharedTopicSession?: boolean;
   /** If false, disable the bot for this group (and its topics). */
   enabled?: boolean;
   /** Optional allowlist for group senders (numeric Telegram user IDs). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -60,6 +60,7 @@ export const TelegramTopicSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
   })
   .strict();
 
@@ -74,6 +75,7 @@ export const TelegramGroupSchema = z
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
+    sharedTopicSession: z.boolean().optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -119,6 +119,7 @@ export const dispatchTelegramMessage = async ({
     groupHistories,
     route,
     skillFilter,
+    topicModelOverride,
     sendTyping,
     sendRecordVoice,
     ackReactionPromise,
@@ -544,6 +545,7 @@ export const dispatchTelegramMessage = async ({
       },
       replyOptions: {
         skillFilter,
+        topicModelOverride,
         disableBlockStreaming,
         onPartialReply:
           answerLane.stream || reasoningLane.stream

--- a/src/telegram/group-config-helpers.ts
+++ b/src/telegram/group-config-helpers.ts
@@ -7,6 +7,7 @@ export function resolveTelegramGroupPromptSettings(params: {
 }): {
   skillFilter: string[] | undefined;
   groupSystemPrompt: string | undefined;
+  topicModelOverride: string | undefined;
 } {
   const skillFilter = firstDefined(params.topicConfig?.skills, params.groupConfig?.skills);
   const systemPromptParts = [
@@ -15,5 +16,6 @@ export function resolveTelegramGroupPromptSettings(params: {
   ].filter((entry): entry is string => Boolean(entry));
   const groupSystemPrompt =
     systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
-  return { skillFilter, groupSystemPrompt };
+  const topicModelOverride = params.topicConfig?.model?.trim() || undefined;
+  return { skillFilter, groupSystemPrompt, topicModelOverride };
 }


### PR DESCRIPTION
Add support for Telegram forum topics to use different AI models while sharing a single conversation history. When `sharedTopicSession: true` is set on a group, all forum topics route to the same session. Each topic can override the model via `topics.<threadId>.model`.

Config example:
```
channels.telegram.groups.<id>.sharedTopicSession = true
channels.telegram.groups.<id>.topics.2.model = "anthropic/claude-opus-4-6"
channels.telegram.groups.<id>.topics.3.model = "google/gemini-3-pro-preview"
```

## Summary

- **Problem:** Telegram forum topics get isolated sessions, so there's no way to share conversation history across topics or override the model per topic. The only workaround is running multiple bots.
- **Why it matters:** Users want a single forum group where each topic is powered by a different model (Opus, Gemini, Sonnet) with shared context — pick a topic to pick a model.
- **What changed:** Added `sharedTopicSession` to group config (routes all forum topics to one session) and `model` to per-topic config (overrides the model for that topic). The topic model override is threaded through the dispatch chain into `getReplyFromConfig` at a new priority tier above channel model overrides.
- **What did NOT change (scope boundary):** Binding resolution, agent routing, session storage format, DM behavior, non-forum group behavior. No changes to any other channel.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [X] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None (new feature proposal)

## User-visible / Behavior Changes

- New config field `channels.telegram.groups.<id>.sharedTopicSession` (boolean, default `false`). When `true`, all forum topics in that group share a single session.
- New config field `channels.telegram.groups.<id>.topics.<threadId>.model` (string). Overrides the model for messages in that topic.
- Both fields are opt-in. Existing behavior is unchanged when not set.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime/container: Node 24, pnpm, Vitest
- Model/provider: Anthropic Claude Opus 4.6, Google Gemini 3 Pro Preview
- Integration/channel: Telegram (forum group)
- Relevant config (redacted):
```json
{
  "channels": {
    "telegram": {
      "groups": {
        "-100XXXXXXXXXX": {
          "groupPolicy": "open",
          "requireMention": false,
          "sharedTopicSession": true,
          "topics": {
            "2": { "model": "anthropic/claude-opus-4-6" },
            "3": { "model": "google/gemini-3-pro-preview" }
          }
        }
      }
    }
  }
}
```

### Steps

1. Create a Telegram forum group with topics (e.g., "Opus", "Gemini")
2. Add the bot and configure sharedTopicSession: true with per-topic model overrides
3. Send a message in the Opus topic (for example what is 3 + 5?), then switch to the Gemini topic and ask "what did I just say?"

### Expected

- Opus topic responds using Claude Opus 4.6
- Gemini topic responds using Gemini 3 Pro and can see the conversation from the Opus topic and answer something like: "Your last question was "What is 3 + 5?" — over in the other topic."

### Actual

- Works as expected. Both topics share session history, each uses the configured model.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [X] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Shared session across two forum topics with different models; each topic responds with the correct model; conversation history visible across topics
- Edge cases checked: DMs unaffected; non-forum groups unaffected; topics without a model override use the default agent model; sharedTopicSession: false (or unset) preserves existing per-topic isolation
- Verified General topic (threadId=1) behavior; 
- What I did not verify: interaction with channels.modelByChannel (channel model override); interaction with /model session command

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — two new optional config fields (no migration needed; defaults preserve existing behavior)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove sharedTopicSession and per-topic model from config; restart gateway. Behavior reverts to isolated per-topic sessions.
- Files/config to restore: ~/.openclaw/openclaw.json (remove the two new fields)
- Known bad symptoms reviewers should watch for: Topics unexpectedly sharing sessions when sharedTopicSession is not set; model not switching between topics; session key format changes breaking existing session history

## Risks and Mitigations

- Risk: Existing forum topic sessions may have history under the old topic-suffixed session key. Enabling sharedTopicSession starts a new shared session — old per-topic history is orphaned.
- - Mitigation: This is opt-in and documented. Users enable it knowingly. Old sessions are not deleted, just no longer routed to.

<img width="954" height="554" alt="image" src="https://github.com/user-attachments/assets/710fd551-18d4-465a-9547-04578568dfdf" />
<img width="955" height="556" alt="image" src="https://github.com/user-attachments/assets/4ad7e6db-f90e-498c-9019-2a2715aed4ae" />

