### PR TITLE
fix: restore nested SKILL.md watching on chokidar v4 (#27404)

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -20,24 +20,22 @@ describe("ensureSkillsWatcher", () => {
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown; depth?: number }]>
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
     expect(opts.ignored).toBe(mod.DEFAULT_SKILLS_WATCH_IGNORED);
+    expect(opts.depth).toBe(2);
     const posix = (p: string) => p.replaceAll("\\", "/");
     expect(targets).toEqual(
       expect.arrayContaining([
-        posix(path.join("/tmp/workspace", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", "skills", "*", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "*", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "*", "SKILL.md")),
+        posix(path.join("/tmp/workspace", "skills")),
+        posix(path.join("/tmp/workspace", ".agents", "skills")),
+        posix(path.join(os.homedir(), ".agents", "skills")),
       ]),
     );
-    expect(targets.every((target) => target.includes("SKILL.md"))).toBe(true);
+    expect(targets.every((target) => !target.includes("*"))).toBe(true);
     const ignored = mod.DEFAULT_SKILLS_WATCH_IGNORED;
 
     // Node/JS paths


### PR DESCRIPTION
## Summary

- Problem: chokidar v4 changed glob handling, causing the skills watcher to miss nested `SKILL.md` file changes silently.
- Why it matters: Users editing or adding skills see no live reload, forcing manual gateway restarts.
- What changed: Replaced glob-pattern-based watch targets with explicit skill root directories passed to `chokidar.watch`, added `depth: 2` to limit recursion, and filtered file events to `SKILL.md` paths only.
- What did NOT change (scope boundary): Skill discovery/loading logic itself is untouched; only the watcher setup is modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27404

## User-visible / Behavior Changes

Skills watcher now correctly detects `SKILL.md` changes in nested directories on chokidar v4+.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js with chokidar v4
- Model/provider: N/A

### Steps

1. Configure extra skill directories in config
2. Edit a nested `<skill-dir>/<skill>/SKILL.md` file
3. Observe whether the gateway picks up the change

### Expected

- Gateway detects and reloads the changed skill

### Actual (before fix)

- No change detection; requires manual restart

## Evidence

- [x] Failing test/log before + passing after
- `npx vitest run src/agents/skills/refresh.test.ts` — passes

## Human Verification (required)

- Verified scenarios: watcher receives events for nested SKILL.md; non-SKILL.md files are ignored
- Edge cases checked: depth limit prevents scanning deep trees; empty extra dirs are tolerated
- What you did **not** verify: live chokidar v4 watcher on Linux inotify

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit to restore glob-based watching
- Skills still load on startup; only live reload is affected

## Risks and Mitigations

- Risk: `depth: 2` may be too shallow for unusual directory layouts
  - Mitigation: Standard skill layout is `<root>/<skill>/SKILL.md` (depth 1-2); deeper nesting is not documented or supported