### PR TITLE
fix(ui): remove unsupported image-paste hint from webchat composer

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -181,6 +181,38 @@ describe("chat view", () => {
     nowSpy.mockRestore();
   });
 
+  it("uses compose placeholder text without image paste hint", () => {
+    const container = document.createElement("div");
+    render(renderChat(createProps()), container);
+
+    const input = container.querySelector("textarea");
+    expect(input?.getAttribute("placeholder")).toBe("Message (↩ to send, Shift+↩ for line breaks)");
+  });
+
+  it("uses attachment placeholder text without image paste hint", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          attachments: [
+            {
+              id: "att-1",
+              kind: "file",
+              name: "note.txt",
+              size: 42,
+              mimeType: "text/plain",
+              source: "picker",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const input = container.querySelector("textarea");
+    expect(input?.getAttribute("placeholder")).toBe("Add a message...");
+  });
+
   it("shows a stop button when aborting is available", () => {
     const container = document.createElement("div");
     const onAbort = vi.fn();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -197,11 +197,8 @@ describe("chat view", () => {
           attachments: [
             {
               id: "att-1",
-              kind: "file",
-              name: "note.txt",
-              size: 42,
+              dataUrl: "data:text/plain;base64,bm90ZQ==",
               mimeType: "text/plain",
-              source: "picker",
             },
           ],
         }),

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -252,8 +252,8 @@ export function renderChat(props: ChatProps) {
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
   const composePlaceholder = props.connected
     ? hasAttachments
-      ? "Add a message or paste more images..."
-      : "Message (↩ to send, Shift+↩ for line breaks, paste images)"
+      ? "Add a message..."
+      : "Message (↩ to send, Shift+↩ for line breaks)"
     : "Connect to the gateway to start chatting…";
 
   const splitRatio = props.splitRatio ?? 0.6;


### PR DESCRIPTION
## Summary
- remove `paste images` wording from WebChat composer placeholder
- keep guidance accurate until clipboard-image paste is actually wired end-to-end
- add chat view tests covering both default and attachment placeholder text

## Why
Issue #27471 reports that WebChat advertises image paste support, but pasted images are not delivered to the agent. This patch makes the UX honest and avoids a false affordance.

Fixes #27471

## Testing
- pre-commit checks passed on changed files
- added assertions in `ui/src/ui/views/chat.test.ts` for placeholder text
