### PR TITLE
fix: prioritize model override over runtime model in resolveSessionModelRef

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -650,10 +650,27 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
-  // Prefer the last runtime model recorded on the session entry.
-  // This is the actual model used by the latest run and must win over defaults.
+  // Prefer explicit per-session override (set via /model or at spawn time).
+  // This reflects the user's *intent* for the next run and should take
+  // precedence over the runtime model recorded from a previous run.
   let provider = resolved.provider;
   let model = resolved.model;
+  const storedModelOverride = entry?.modelOverride?.trim();
+  if (storedModelOverride) {
+    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
+    if (parsedOverride) {
+      provider = parsedOverride.provider;
+      model = parsedOverride.model;
+    } else {
+      provider = overrideProvider;
+      model = storedModelOverride;
+    }
+    return { provider, model };
+  }
+
+  // Fall back to the last runtime model recorded on the session entry.
+  // This is the actual model used by the latest run and wins over defaults.
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {
@@ -676,20 +693,6 @@ export function resolveSessionModelRef(
     return { provider, model };
   }
 
-  // Fall back to explicit per-session override (set at spawn/model-patch time),
-  // then finally to configured defaults.
-  const storedModelOverride = entry?.modelOverride?.trim();
-  if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
-    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
-    if (parsedOverride) {
-      provider = parsedOverride.provider;
-      model = parsedOverride.model;
-    } else {
-      provider = overrideProvider;
-      model = storedModelOverride;
-    }
-  }
   return { provider, model };
 }
 


### PR DESCRIPTION
## Problem

After switching models via `/model` command in the TUI, the status bar continues showing the **previous model** until a new agent run completes. For example, after `/model provider-b/model-x`, the status bar might still show `provider-a/model-y` (the model used by the last run).

## Root Cause

`resolveSessionModelRef()` in `session-utils.ts` prioritizes the runtime `model`/`modelProvider` fields (written by the last agent run) over the `modelOverride`/`providerOverride` fields (set by the `/model` command).

This is the same issue described in:
- #21524 (exact match: "TUI status bar shows last active session model instead of main agent model")
- #21615 (related: model override during heartbeat)
- #26782 (related: incorrect model provider display)
- #7794 (related: periodic session info refresh)

## Fix

Swap the priority order in `resolveSessionModelRef()`:

```
Before: runtime (model/modelProvider) > override (modelOverride/providerOverride) > defaults
After:  override > runtime > defaults
```

This aligns the display logic with the actual runtime model selection logic, which already uses `modelOverride`.

## Changes

- `src/gateway/session-utils.ts`: Reorder override vs runtime priority
- `src/gateway/session-utils.test.ts`: Update test expectations + add new test case

## Testing

All 44 existing tests pass.

Closes #21524
