### PR TITLE
fix: add Chinese model provider error pattern recognition

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -527,4 +527,46 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  // Chinese model provider error classification
+  it("classifies Chinese provider rate limit errors", () => {
+    expect(classifyFailoverReason("请求频率超限")).toBe("rate_limit");
+    expect(classifyFailoverReason("请求过于频繁，请稍后再试")).toBe("rate_limit");
+    expect(classifyFailoverReason("调用频率超出限制")).toBe("rate_limit");
+    expect(classifyFailoverReason("频率限制")).toBe("rate_limit");
+    expect(classifyFailoverReason("请求次数超出配额")).toBe("rate_limit");
+  });
+
+  it("classifies Chinese provider billing errors", () => {
+    expect(classifyFailoverReason("余额不足")).toBe("billing");
+    expect(classifyFailoverReason("账户余额不足，请充值")).toBe("billing");
+    expect(classifyFailoverReason("额度不足")).toBe("billing");
+    expect(classifyFailoverReason("账户欠费")).toBe("billing");
+    expect(classifyFailoverReason("额度已用完")).toBe("billing");
+    expect(classifyFailoverReason("配额不足，请升级")).toBe("billing");
+  });
+
+  it("classifies Chinese provider auth errors", () => {
+    expect(classifyFailoverReason("鉴权失败")).toBe("auth");
+    expect(classifyFailoverReason("认证失败")).toBe("auth");
+    expect(classifyFailoverReason("密钥错误")).toBe("auth");
+    expect(classifyFailoverReason("无效的API密钥")).toBe("auth");
+    expect(classifyFailoverReason("apikey无效")).toBe("auth");
+    expect(classifyFailoverReason("无权访问该资源")).toBe("auth");
+    expect(classifyFailoverReason("权限不足")).toBe("auth");
+  });
+
+  it("classifies Chinese provider timeout errors", () => {
+    expect(classifyFailoverReason("请求超时")).toBe("timeout");
+    expect(classifyFailoverReason("连接超时")).toBe("timeout");
+    expect(classifyFailoverReason("响应超时")).toBe("timeout");
+  });
+
+  it("classifies Chinese provider overloaded errors as rate_limit", () => {
+    expect(classifyFailoverReason("服务繁忙，请稍后再试")).toBe("rate_limit");
+    expect(classifyFailoverReason("系统繁忙")).toBe("rate_limit");
+    expect(classifyFailoverReason("服务暂时不可用")).toBe("rate_limit");
+    expect(classifyFailoverReason("服务器繁忙")).toBe("rate_limit");
+    expect(classifyFailoverReason("当前服务负载过高")).toBe("rate_limit");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -538,6 +538,17 @@ export function formatAssistantErrorText(
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
+  if (isAuthErrorMessage(raw)) {
+    const providerName = opts?.provider?.trim();
+    const modelName = opts?.model?.trim() ?? msg.model?.trim();
+    const providerLabel =
+      providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
+    if (providerLabel) {
+      return `⚠️ ${providerLabel} returned an authentication error — please check your API key or credentials.`;
+    }
+    return "⚠️ API provider returned an authentication error — please check your API key or credentials.";
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
@@ -624,12 +635,26 @@ const ERROR_PATTERNS = {
     "usage limit",
     "tpm",
     "tokens per minute",
+    // Chinese provider rate limit messages (MiniMax, Kimi/Moonshot, Doubao, Qwen, etc.)
+    "请求频率超限",
+    "请求过于频繁",
+    "调用频率",
+    "频率限制",
+    "请求次数超",
+    "concurrency exceeds",
+    /request[_ ]?rate[_ ]?limit/i,
   ],
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,
     "overloaded",
     "service unavailable",
     "high demand",
+    // Chinese provider overloaded messages
+    "服务繁忙",
+    "系统繁忙",
+    "服务暂时不可用",
+    "服务器繁忙",
+    "当前服务负载过高",
   ],
   timeout: [
     "timeout",
@@ -640,6 +665,10 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*abort\b/i,
     /\breason:\s*abort\b/i,
     /\bunhandled stop reason:\s*abort\b/i,
+    // Chinese provider timeout messages
+    "请求超时",
+    "连接超时",
+    "响应超时",
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
@@ -648,6 +677,15 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    // Chinese provider billing messages (MiniMax, Kimi/Moonshot, Doubao, Qwen, etc.)
+    "余额不足",
+    "额度不足",
+    "账户余额",
+    "账户欠费",
+    "欠费",
+    "充值",
+    "额度已用完",
+    "配额不足",
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,
@@ -676,6 +714,15 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
+    // Chinese provider auth messages (MiniMax, Kimi/Moonshot, Doubao, Qwen, etc.)
+    "无效的api",
+    "api密钥无效",
+    "鉴权失败",
+    "认证失败",
+    "密钥错误",
+    "apikey无效",
+    "无权访问",
+    "权限不足",
   ],
   format: [
     "string should match pattern",


### PR DESCRIPTION
## Summary

Adds error pattern matching for Chinese API providers (MiniMax, Kimi/Moonshot, Doubao, Qwen, etc.) to the failover error classification system.

## Problem

When Chinese model providers return error messages in Chinese (e.g. "余额不足", "请求频率超限", "鉴权失败"), OpenClaw fails to classify them. This causes:
- Silent failures with empty responses instead of actionable error messages
- No failover to backup models when Chinese providers return errors
- Users have no idea what went wrong

Closes #26463

## Changes

### `src/agents/pi-embedded-helpers/errors.ts`
- **ERROR_PATTERNS.rateLimit**: Added Chinese rate limit patterns (请求频率超限, 请求过于频繁, 调用频率, 频率限制, etc.)
- **ERROR_PATTERNS.overloaded**: Added Chinese overloaded patterns (服务繁忙, 系统繁忙, 服务暂时不可用, etc.)
- **ERROR_PATTERNS.timeout**: Added Chinese timeout patterns (请求超时, 连接超时, 响应超时)
- **ERROR_PATTERNS.billing**: Added Chinese billing patterns (余额不足, 额度不足, 账户欠费, 配额不足, etc.)
- **ERROR_PATTERNS.auth**: Added Chinese auth patterns (鉴权失败, 认证失败, 密钥错误, 无权访问, etc.)
- **formatAssistantErrorText()**: Added explicit auth error formatting with provider/model context, so auth failures get a user-friendly message instead of raw error text

### `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Added 5 new test cases covering all Chinese error categories (rate_limit, billing, auth, timeout, overloaded)
- 26 new assertions total

## Testing

All 46 tests pass (including 26 new assertions):
```
✓ classifies Chinese provider rate limit errors
✓ classifies Chinese provider billing errors
✓ classifies Chinese provider auth errors
✓ classifies Chinese provider timeout errors
✓ classifies Chinese provider overloaded errors as rate_limit
```

Existing tests remain green — no regressions.

## Providers Affected

MiniMax, Kimi/Moonshot, Doubao/Volcengine, Qwen/DashScope, Zhipu/GLM, Baidu/ERNIE, and other Chinese providers that may return error messages in Chinese.

---

🤖 AI-assisted (OpenClaw + Claude). Fully tested.