### PR TITLE
fix(skills): deduplicate slash commands by skillName across all interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Feishu/streaming card delivery synthesis: unify snapshot and delta streaming merge semantics, apply overlap-aware final merge, suppress duplicate final text delivery (including text+media final packets), prefer topic-thread `message.reply` routing when a reply target exists, and tune card print cadence to avoid duplicate incremental rendering. (from #33245, #32896, #33840) Thanks @rexl2018, @kcinzgg, and @aerelune.
 - Security/dependency audit: patch transitive Hono vulnerabilities by pinning `hono` to `4.12.5` and `@hono/node-server` to `1.19.10` in production resolution paths. Thanks @shakkernerd.
 - Security/dependency audit: bump `tar` to `7.5.10` (from `7.5.9`) to address the high-severity hardlink path traversal advisory (`GHSA-qffp-2rhf-9h96`). Thanks @shakkernerd.

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -72,8 +72,11 @@ let resolveSkillCommandInvocation: typeof import("./skill-commands.js").resolveS
 let skillCommandsTesting: typeof import("./skill-commands.js").__testing;
 
 beforeAll(async () => {
-  ({ listSkillCommandsForAgents, resolveSkillCommandInvocation, __testing: skillCommandsTesting } =
-    await import("./skill-commands.js"));
+  ({
+    listSkillCommandsForAgents,
+    resolveSkillCommandInvocation,
+    __testing: skillCommandsTesting,
+  } = await import("./skill-commands.js"));
 });
 
 describe("resolveSkillCommandInvocation", () => {

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -69,9 +69,10 @@ vi.mock("../agents/skills.js", () => {
 
 let listSkillCommandsForAgents: typeof import("./skill-commands.js").listSkillCommandsForAgents;
 let resolveSkillCommandInvocation: typeof import("./skill-commands.js").resolveSkillCommandInvocation;
+let skillCommandsTesting: typeof import("./skill-commands.js").__testing;
 
 beforeAll(async () => {
-  ({ listSkillCommandsForAgents, resolveSkillCommandInvocation } =
+  ({ listSkillCommandsForAgents, resolveSkillCommandInvocation, __testing: skillCommandsTesting } =
     await import("./skill-commands.js"));
 });
 
@@ -125,7 +126,7 @@ describe("listSkillCommandsForAgents", () => {
     );
   });
 
-  it("lists all agents when agentIds is omitted", async () => {
+  it("deduplicates by skillName across agents, keeping the first registration", async () => {
     const baseDir = await makeTempDir("openclaw-skills-");
     const mainWorkspace = path.join(baseDir, "main");
     const researchWorkspace = path.join(baseDir, "research");
@@ -143,8 +144,10 @@ describe("listSkillCommandsForAgents", () => {
       },
     });
     const names = commands.map((entry) => entry.name);
+    // demo-skill appears in both workspaces; only the first registration (demo_skill) survives.
     expect(names).toContain("demo_skill");
-    expect(names).toContain("demo_skill_2");
+    expect(names).not.toContain("demo_skill_2");
+    // extra-skill is unique to the research workspace and should be present.
     expect(names).toContain("extra_skill");
   });
 
@@ -295,5 +298,40 @@ describe("listSkillCommandsForAgents", () => {
     // The valid agent's skills should still be listed despite the broken one.
     expect(commands.length).toBeGreaterThan(0);
     expect(commands.map((entry) => entry.skillName)).toContain("demo-skill");
+  });
+});
+
+describe("dedupeBySkillName", () => {
+  it("keeps the first entry when multiple commands share a skillName", () => {
+    const input = [
+      { name: "github", skillName: "github", description: "GitHub" },
+      { name: "github_2", skillName: "github", description: "GitHub" },
+      { name: "weather", skillName: "weather", description: "Weather" },
+      { name: "weather_2", skillName: "weather", description: "Weather" },
+    ];
+    const output = skillCommandsTesting.dedupeBySkillName(input);
+    expect(output.map((e) => e.name)).toEqual(["github", "weather"]);
+  });
+
+  it("matches skillName case-insensitively", () => {
+    const input = [
+      { name: "ClawHub", skillName: "ClawHub", description: "ClawHub" },
+      { name: "clawhub_2", skillName: "clawhub", description: "ClawHub" },
+    ];
+    const output = skillCommandsTesting.dedupeBySkillName(input);
+    expect(output).toHaveLength(1);
+    expect(output[0]?.name).toBe("ClawHub");
+  });
+
+  it("passes through commands with an empty skillName", () => {
+    const input = [
+      { name: "a", skillName: "", description: "A" },
+      { name: "b", skillName: "", description: "B" },
+    ];
+    expect(skillCommandsTesting.dedupeBySkillName(input)).toHaveLength(2);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(skillCommandsTesting.dedupeBySkillName([])).toEqual([]);
   });
 });

--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -147,10 +147,8 @@ describe("listSkillCommandsForAgents", () => {
       },
     });
     const names = commands.map((entry) => entry.name);
-    // demo-skill appears in both workspaces; only the first registration (demo_skill) survives.
     expect(names).toContain("demo_skill");
     expect(names).not.toContain("demo_skill_2");
-    // extra-skill is unique to the research workspace and should be present.
     expect(names).toContain("extra_skill");
   });
 

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -46,6 +46,26 @@ export function listSkillCommandsForWorkspace(params: {
   });
 }
 
+// Deduplicate skill commands by skillName, keeping the first registration.
+// When multiple agents have a skill with the same name (e.g. one with a
+// workspace override and one from bundled), the suffix-renamed entries
+// (github_2, github_3…) are dropped so every interface sees a clean list.
+function dedupeBySkillName(commands: SkillCommandSpec[]): SkillCommandSpec[] {
+  const seen = new Set<string>();
+  const out: SkillCommandSpec[] = [];
+  for (const cmd of commands) {
+    const key = cmd.skillName.trim().toLowerCase();
+    if (key && seen.has(key)) {
+      continue;
+    }
+    if (key) {
+      seen.add(key);
+    }
+    out.push(cmd);
+  }
+  return out;
+}
+
 export function listSkillCommandsForAgents(params: {
   cfg: OpenClawConfig;
   agentIds?: string[];
@@ -109,8 +129,15 @@ export function listSkillCommandsForAgents(params: {
       entries.push(command);
     }
   }
-  return entries;
+  // Dedupe by skillName across workspaces so every interface (Discord, TUI,
+  // Slack, text) sees a consistent command list without platform-specific
+  // workarounds.
+  return dedupeBySkillName(entries);
 }
+
+export const __testing = {
+  dedupeBySkillName,
+};
 
 function normalizeSkillCommandLookup(value: string): string {
   return value

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -46,10 +46,6 @@ export function listSkillCommandsForWorkspace(params: {
   });
 }
 
-// Deduplicate skill commands by skillName, keeping the first registration.
-// When multiple agents have a skill with the same name (e.g. one with a
-// workspace override and one from bundled), the suffix-renamed entries
-// (github_2, github_3…) are dropped so every interface sees a clean list.
 function dedupeBySkillName(commands: SkillCommandSpec[]): SkillCommandSpec[] {
   const seen = new Set<string>();
   const out: SkillCommandSpec[] = [];
@@ -129,9 +125,6 @@ export function listSkillCommandsForAgents(params: {
       entries.push(command);
     }
   }
-  // Dedupe by skillName across workspaces so every interface (Discord, TUI,
-  // Slack, text) sees a consistent command list without platform-specific
-  // workarounds.
   return dedupeBySkillName(entries);
 }
 

--- a/src/discord/monitor/provider.skill-dedupe.test.ts
+++ b/src/discord/monitor/provider.skill-dedupe.test.ts
@@ -1,30 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { __testing } from "./provider.js";
 
-describe("dedupeSkillCommandsForDiscord", () => {
-  it("keeps first command per skillName and drops suffix duplicates", () => {
-    const input = [
-      { name: "github", skillName: "github", description: "GitHub" },
-      { name: "github_2", skillName: "github", description: "GitHub" },
-      { name: "weather", skillName: "weather", description: "Weather" },
-      { name: "weather_2", skillName: "weather", description: "Weather" },
-    ];
-
-    const output = __testing.dedupeSkillCommandsForDiscord(input);
-    expect(output.map((entry) => entry.name)).toEqual(["github", "weather"]);
-  });
-
-  it("treats skillName case-insensitively", () => {
-    const input = [
-      { name: "ClawHub", skillName: "ClawHub", description: "ClawHub" },
-      { name: "clawhub_2", skillName: "clawhub", description: "ClawHub" },
-    ];
-    const output = __testing.dedupeSkillCommandsForDiscord(input);
-    expect(output).toHaveLength(1);
-    expect(output[0]?.name).toBe("ClawHub");
-  });
-});
-
 describe("resolveThreadBindingsEnabled", () => {
   it("defaults to enabled when unset", () => {
     expect(

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -126,25 +126,6 @@ function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
   return label === "disabled" ? "off" : label;
 }
 
-function dedupeSkillCommandsForDiscord(
-  skillCommands: ReturnType<typeof listSkillCommandsForAgents>,
-) {
-  const seen = new Set<string>();
-  const deduped: ReturnType<typeof listSkillCommandsForAgents> = [];
-  for (const command of skillCommands) {
-    const key = command.skillName.trim().toLowerCase();
-    if (!key) {
-      deduped.push(command);
-      continue;
-    }
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(command);
-  }
-  return deduped;
-}
 
 function appendPluginCommandSpecs(params: {
   commandSpecs: NativeCommandSpec[];
@@ -434,7 +415,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const maxDiscordCommands = 100;
   let skillCommands =
     nativeEnabled && nativeSkillsEnabled
-      ? dedupeSkillCommandsForDiscord(listSkillCommandsForAgents({ cfg }))
+      ? listSkillCommandsForAgents({ cfg })
       : [];
   let commandSpecs = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })
@@ -819,7 +800,6 @@ async function clearDiscordNativeCommands(params: {
 
 export const __testing = {
   createDiscordGatewayPlugin,
-  dedupeSkillCommandsForDiscord,
   resolveDiscordRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -126,7 +126,6 @@ function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
   return label === "disabled" ? "off" : label;
 }
 
-
 function appendPluginCommandSpecs(params: {
   commandSpecs: NativeCommandSpec[];
   runtime: RuntimeEnv;

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -414,9 +414,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
   const maxDiscordCommands = 100;
   let skillCommands =
-    nativeEnabled && nativeSkillsEnabled
-      ? listSkillCommandsForAgents({ cfg })
-      : [];
+    nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];
   let commandSpecs = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })
     : [];


### PR DESCRIPTION
## Problem

When multiple agents have a skill with the same name, `listSkillCommandsForAgents` emits both a primary entry (`github`) and a suffix-renamed duplicate (`github_2`). Previously only Discord collapsed these via a local `dedupeSkillCommandsForDiscord` wrapper — every other interface (TUI autocomplete, Slack, text) could see the duplicate entries.

## Fix

Move the dedup-by-`skillName` logic into `listSkillCommandsForAgents` itself so the canonical function always returns one entry per skill name regardless of which interface calls it. The Discord-only wrapper is removed.

## Changes

- `src/auto-reply/skill-commands.ts` — add `dedupeBySkillName` helper; apply it at the end of `listSkillCommandsForAgents`; export via `__testing`
- `src/discord/monitor/provider.ts` — remove `dedupeSkillCommandsForDiscord` and its `__testing` export; update call site
- `src/discord/monitor/provider.skill-dedupe.test.ts` — remove now-deleted dedupe tests (thread-binding tests kept)
- `src/auto-reply/skill-commands.test.ts` — add `dedupeBySkillName` unit tests; update `listSkillCommandsForAgents` test to assert the duplicate is dropped

## Test plan

- [ ] `pnpm test -- src/auto-reply/skill-commands.test.ts` — 9 tests pass
- [ ] `pnpm test -- src/discord/monitor/provider.skill-dedupe.test.ts` — 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)