### PR TITLE
fix(feishu): stop typing-indicator log spam and stuck emoji on message-not-found

### DIFF
--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isFeishuMessageNotFoundError } from "./typing.js";
+
+describe("isFeishuMessageNotFoundError", () => {
+  it("returns true for Axios error with code 231003 in response.data", () => {
+    const err = { response: { data: { code: 231003, msg: "The message is not found" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(true);
+  });
+
+  it("returns true for error with code 231003 at top level", () => {
+    const err = { code: 231003, message: "not found" };
+    expect(isFeishuMessageNotFoundError(err)).toBe(true);
+  });
+
+  it("returns false for other Feishu error codes", () => {
+    const err = { response: { data: { code: 99991672, msg: "Permission denied" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+
+  it("returns false for non-object errors", () => {
+    expect(isFeishuMessageNotFoundError(null)).toBe(false);
+    expect(isFeishuMessageNotFoundError(undefined)).toBe(false);
+    expect(isFeishuMessageNotFoundError("some string error")).toBe(false);
+    expect(isFeishuMessageNotFoundError(42)).toBe(false);
+  });
+
+  it("returns false for errors without a code field", () => {
+    const err = new Error("network error");
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+
+  it("returns false for errors with response.data but no code", () => {
+    const err = { response: { data: { msg: "unknown error" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #27418

Two related bugs in the Feishu typing-indicator (reaction emoji):

1. **Log spam** – `addTypingIndicator` silently caught failures and printed a `console.log` on every keepalive tick (every 3 s). When the target message no longer exists (Feishu error code 231003), the error repeated indefinitely.

2. **Typing emoji stuck on message** – the keepalive called `addTypingIndicator` on every tick. Because the reaction already existed (or the call failed), the SDK returned `reactionId: null`. The dispatcher overwrote `typingState` with `{ reactionId: null }`, so `removeTypingIndicator` had nothing to delete, leaving the Typing emoji on the user's message permanently.

## Root cause

```
// Every 3 s the keepalive fired start(), which called addTypingIndicator().
// addTypingIndicator caught all errors and returned { reactionId: null }.
// typingState was overwritten → removeTypingIndicator was a no-op.
```

## Fix

**`extensions/feishu/src/typing.ts`**
- Remove internal `console.log` / `try-catch` from `addTypingIndicator` and `removeTypingIndicator`; errors now propagate so structured error handlers are used.
- Export `isFeishuMessageNotFoundError()` helper that detects Feishu error code 231003.

**`extensions/feishu/src/reply-dispatcher.ts`**
- Add `typingDisabled` flag: set on the first 231003 error, causing all subsequent keepalive ticks to skip the API call (no more log spam).
- Guard `start()` with `if (typingState?.reactionId) return` so the keepalive never overwrites a valid `reactionId` with null — ensuring `removeTypingIndicator` can always clean up properly.
- Null `typingState` *before* awaiting removal to avoid a race where a second stop call finds stale state.

## Tests

Added `extensions/feishu/src/typing.test.ts` with 6 unit tests for `isFeishuMessageNotFoundError`.