### PR TITLE
fix: allow OpenAI providers to use cacheRetention for extended prompt cache

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.cache-retention-default.test.ts
@@ -99,7 +99,7 @@ describe("cacheRetention default behavior", () => {
     expect(agent.streamFn).toBeDefined();
   });
 
-  it("returns undefined for non-Anthropic providers", () => {
+  it("does not apply cacheRetention for OpenAI when not configured", () => {
     const agent: { streamFn?: StreamFn } = {};
     const cfg = undefined;
     const provider = "openai";
@@ -107,9 +107,80 @@ describe("cacheRetention default behavior", () => {
 
     applyExtraParamsToAgent(agent, cfg, provider, modelId);
 
-    // For OpenAI, the streamFn might be wrapped for other reasons (like OpenAI responses store)
-    // but cacheRetention should not be applied
-    // This is implicitly tested by the lack of cacheRetention-specific wrapping
+    // Without explicit cacheRetention config, OpenAI should not get cache retention.
+    // The streamFn may still be wrapped for other reasons (e.g. OpenAI responses store).
+  });
+
+  it("applies cacheRetention 'long' for OpenAI when explicitly configured", () => {
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.2": {
+              params: {
+                cacheRetention: "long" as const,
+              },
+            },
+          },
+        },
+      },
+    };
+    const provider = "openai";
+    const modelId = "gpt-5.2";
+
+    applyExtraParamsToAgent(agent, cfg, provider, modelId);
+
+    // pi-ai maps cacheRetention: "long" to prompt_cache_retention: "24h"
+    // for api.openai.com URLs in openai-responses.ts
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("applies cacheRetention for openai-codex provider", () => {
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.2-codex": {
+              params: {
+                cacheRetention: "long" as const,
+              },
+            },
+          },
+        },
+      },
+    };
+    const provider = "openai-codex";
+    const modelId = "gpt-5.2-codex";
+
+    applyExtraParamsToAgent(agent, cfg, provider, modelId);
+
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("does not apply cacheRetention for unsupported providers", () => {
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "google/gemini-2.5-pro": {
+              params: {
+                cacheRetention: "long" as const,
+              },
+            },
+          },
+        },
+      },
+    };
+    const provider = "google";
+    const modelId = "gemini-2.5-pro";
+
+    applyExtraParamsToAgent(agent, cfg, provider, modelId);
+
+    // Google provider should not get cacheRetention applied
+    // (Google has its own implicit caching mechanism)
   });
 
   it("prefers explicit cacheRetention over default", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -57,6 +57,8 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  * Applies to:
  * - direct Anthropic provider
  * - Anthropic Claude models on Bedrock when cache retention is explicitly configured
+ * - OpenAI providers when cache retention is explicitly configured
+ *   (pi-ai maps "long" → prompt_cache_retention: "24h" for api.openai.com)
  *
  * OpenRouter uses openai-completions API with hardcoded cache_control instead
  * of the cacheRetention stream option.
@@ -71,8 +73,10 @@ function resolveCacheRetention(
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
+  const isOpenAI = provider === "openai" || provider === "openai-codex";
+  const hasOpenAIOverride = isOpenAI && extraParams?.cacheRetention !== undefined;
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicBedrock && !hasOpenAIOverride) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- Allow OpenAI providers (`openai`, `openai-codex`) to pass `cacheRetention` through to pi-ai, enabling extended 24h prompt cache retention
- The underlying pi-ai library already maps `cacheRetention: "long"` to `prompt_cache_retention: "24h"` for api.openai.com URLs -- this change just removes the guard that blocked OpenAI from reaching that code path
- Add tests for OpenAI cache retention behavior

## Problem

`resolveCacheRetention()` in `extra-params.ts` only allows Anthropic and Bedrock providers through. When `cacheRetention: "long"` is configured for an OpenAI model, the guard clause returns `undefined` before the value can reach pi-ai's `getPromptCacheRetention()`, which already handles the mapping to `prompt_cache_retention: "24h"`.

This means OpenAI's extended prompt cache retention (24h TTL) cannot be activated through config, even though the full plumbing exists in pi-ai.

## Fix

Add `isOpenAI` and `hasOpenAIOverride` to the guard clause in `resolveCacheRetention()`. OpenAI only receives `cacheRetention` when explicitly configured in model params -- no default behavior change (unlike Anthropic which defaults to `"short"`).

## Config

```json5
{
  agents: {
    defaults: {
      models: {
        "openai/gpt-5.2": {
          params: {
            cacheRetention: "long"  // maps to prompt_cache_retention: "24h" via pi-ai
          }
        }
      }
    }
  }
}
```

## Impact

For automation workloads with recurring agent sessions (hourly heartbeats with identical bootstrap prefixes), the default 5-10 min in-memory cache expires between cycles. Extended 24h retention keeps prefixes cached at $0.175/M instead of $1.75/M (90% discount).

## Test plan

- [x] Updated existing "non-Anthropic providers" test to clarify unconfigured vs configured OpenAI behavior
- [x] Added test: OpenAI with explicit `cacheRetention: "long"` applies streamFn wrapper
- [x] Added test: `openai-codex` provider with explicit config applies streamFn wrapper
- [x] Added test: unsupported providers (e.g. Google) still do not get cacheRetention
- [ ] Verified end-to-end via local dist patch: `gpt-5.2` with `cacheRetention: "long"` achieves 87% cache hits on repeated API calls (vs 0% without)

Fixes #27515
