### PR TITLE
fix: preserve thinking signatures for Anthropic after compaction (#27504)

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -546,6 +546,25 @@ describe("sanitizeSessionHistory", () => {
     expect(types).toContain("thinking");
   });
 
+  it("preserves signatures for Anthropic provider (preserveSignatures: true)", async () => {
+    setNonGoogleModelApi();
+
+    await sanitizeSessionHistory({
+      messages: makeThinkingAndTextAssistantMessages("anthropic_sig_abc123"),
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      expect.anything(),
+      "session:history",
+      expect.objectContaining({ preserveSignatures: true }),
+    );
+  });
+
   it("does not drop thinking blocks for non-claude copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -66,6 +66,42 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeMode).toBe("full");
   });
 
+  it("preserves signatures for Anthropic provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("preserves signatures for Bedrock provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("does not preserve signatures for Google provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google",
+      modelId: "gemini-2.0-flash",
+      modelApi: "google-generative-ai",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
+  it("does not preserve signatures for OpenAI provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai-responses",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -120,7 +120,7 @@ export function resolveTranscriptPolicy(params: {
     sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: false,
+    preserveSignatures: isAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

- Problem: Session compaction/sanitization strips `thinkingSignature` from thinking blocks. When these blocks appear as the latest assistant message in an Anthropic API request, the API permanently rejects the session with "thinking blocks cannot be modified".
- Why it matters: Any long-running session with extended thinking enabled becomes permanently broken after compaction — the only recovery is deleting the entire session JSONL.
- What changed: `resolveTranscriptPolicy()` now sets `preserveSignatures: true` for Anthropic and Bedrock providers, so `stripThoughtSignatures()` is skipped and thinking block signatures are kept intact through the sanitization pipeline.
- What did NOT change (scope boundary): Google/Gemini and OpenAI providers still strip non-base64 signatures as before. No compaction logic itself was modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27504

## User-visible / Behavior Changes

Long-running Anthropic sessions with extended thinking no longer break after compaction. Existing broken sessions still require manual JSONL cleanup.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js
- Model/provider: Anthropic (claude-sonnet-4-6)

### Steps

1. Use Anthropic provider with extended thinking enabled
2. Run a session long enough to trigger compaction
3. Send a follow-up message

### Expected

- Session continues working normally after compaction

### Actual (before fix)

- API rejects with "thinking blocks in the latest assistant message cannot be modified"

## Evidence

- [x] Failing test/log before + passing after
- `npx vitest run src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts` — 32 tests pass
- `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: Anthropic and Bedrock providers get `preserveSignatures: true`; sanitization passes signatures through unmodified
- Edge cases checked: Google/OpenAI providers still strip as before; Copilot Claude still drops thinking blocks via separate path
- What you did **not** verify: live compaction with extended-thinking session on Anthropic

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No (already-broken sessions need manual JSONL cleanup)

## Failure Recovery (if this breaks)

- Revert commit; behavior returns to stripping all signatures
- No config changes needed

## Risks and Mitigations

- Risk: Preserving signatures increases token count for Anthropic sessions
  - Mitigation: Signatures are small relative to thinking content; Anthropic requires them for API correctness