### PR TITLE
fix: suppress NO_REPLY before Slack API call (#27387)

### DIFF
--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -9,6 +9,7 @@ import {
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -231,6 +232,10 @@ export async function sendMessageSlack(
   opts: SlackSendOpts = {},
 ): Promise<SlackSendResult> {
   const trimmedMessage = message?.trim() ?? "";
+  if (isSilentReplyText(trimmedMessage) && !opts.mediaUrl && !opts.blocks) {
+    logVerbose("slack send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", channelId: "" };
+  }
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
   if (!trimmedMessage && !opts.mediaUrl && !blocks) {
     throw new Error("Slack send requires text, blocks, or media");


### PR DESCRIPTION
## Summary

- Problem: When an agent sends a Slack thread reply via the `message` tool followed by a `NO_REPLY` session response, the `NO_REPLY` text reaches the Slack API before filtering, causing a truncated "NO" push notification to appear on the user's device.
- Why it matters: Users see confusing ghost notifications showing "NO" even though the message is eventually suppressed from the channel.
- What changed: Added an early `isSilentReplyText` guard at the top of `sendMessageSlack()` that intercepts `NO_REPLY` tokens before any Slack API call is made. The guard only fires for text-only sends (not when media or blocks are attached).
- What did NOT change (scope boundary): The existing NO_REPLY filtering in `deliverReplies()` is preserved. The guard is additive — it catches the outbound message-tool path that previously bypassed filtering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27387

## User-visible / Behavior Changes

Slack users will no longer see spurious "NO" push notifications when agents use `NO_REPLY` after thread replies.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (prevented unnecessary API calls)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js
- Integration/channel: Slack DM

### Steps

1. Configure Slack DM channel
2. Agent sends a thread reply via `message(action=send, replyTo=<ts>)`
3. Agent session response is `NO_REPLY`

### Expected

- No push notification appears

### Actual (before fix)

- Slack push notification shows "NO"

## Evidence

- [x] Failing test/log before + passing after
- `npx vitest run src/slack/send.blocks.test.ts` — 12 tests pass (4 new NO_REPLY guard tests)
- `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: exact NO_REPLY token suppressed; whitespace-padded NO_REPLY suppressed; substantive text containing NO_REPLY NOT suppressed; NO_REPLY with blocks NOT suppressed (blocks still sent)
- Edge cases checked: media-attached NO_REPLY bypasses guard (media should still be delivered)
- What you did **not** verify: live Slack push notification behavior

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; NO_REPLY tokens return to previous behavior (leaking to API)
- No config changes needed

## Risks and Mitigations

- Risk: Legitimate messages that are exactly "NO_REPLY" would be suppressed
  - Mitigation: `isSilentReplyText` uses strict whole-text matching; only exact `NO_REPLY` tokens are suppressed, not substrings