### PR TITLE
fix: allow OpenAI cacheRetention passthrough for extended prompt cache retention

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -557,6 +557,86 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
+  it("passes through explicit cacheRetention for OpenAI provider", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.2": {
+              params: {
+                cacheRetention: "long",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai", "gpt-5.2");
+
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "gpt-5.2",
+    } as Model<"openai-responses">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+  });
+
+  it("passes through explicit cacheRetention for OpenAI Codex provider", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.1-codex": {
+              params: {
+                cacheRetention: "long",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai-codex", "gpt-5.1-codex");
+
+    const model = {
+      api: "openai-responses",
+      provider: "openai-codex",
+      id: "gpt-5.1-codex",
+    } as Model<"openai-responses">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+  });
+
+  it("does not apply cacheRetention for OpenAI when not explicitly configured", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.2");
+
+    const model = {
+      api: "openai-responses",
+      provider: "openai",
+      id: "gpt-5.2",
+    } as Model<"openai-responses">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBeUndefined();
+  });
+
   it("adds Anthropic 1M beta header when context1m is enabled for Opus/Sonnet", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", { context1m: true });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -57,6 +57,8 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  * Applies to:
  * - direct Anthropic provider
  * - Anthropic Claude models on Bedrock when cache retention is explicitly configured
+ * - OpenAI / OpenAI Codex when cache retention is explicitly configured
+ *   (pi-ai maps "long" → prompt_cache_retention: "24h" for api.openai.com)
  *
  * OpenRouter uses openai-completions API with hardcoded cache_control instead
  * of the cacheRetention stream option.
@@ -71,8 +73,10 @@ function resolveCacheRetention(
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
+  const isOpenAI = provider === "openai" || provider === "openai-codex";
+  const hasOpenAIOverride = isOpenAI && extraParams?.cacheRetention !== undefined;
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicBedrock && !hasOpenAIOverride) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Closes #27515

- Allow `cacheRetention` config to pass through for `openai` and `openai-codex` providers when explicitly configured, so pi-ai's existing `prompt_cache_retention: "24h"` mapping fires for `api.openai.com`
- No default behavior change — OpenAI providers only receive `cacheRetention` when users explicitly set it in model config
- Add 3 test cases covering OpenAI passthrough, OpenAI Codex passthrough, and no-config-no-default behavior

## Root Cause

`resolveCacheRetention()` in `extra-params.ts` had a provider guard that only allowed Anthropic and Bedrock through. OpenAI providers were unconditionally blocked, even though pi-ai already handles the `cacheRetention → prompt_cache_retention` mapping for OpenAI URLs.

## Fix

Added OpenAI/OpenAI Codex to the provider guard clause (only when `cacheRetention` is explicitly configured):

```typescript
const isOpenAI = provider === "openai" || provider === "openai-codex";
const hasOpenAIOverride = isOpenAI && extraParams?.cacheRetention !== undefined;

if (!isAnthropicDirect && !isAnthropicBedrock && !hasOpenAIOverride) {
  return undefined;
}
```

## Test plan

- [x] Existing cache retention tests pass (36/36)
- [x] New test: OpenAI provider with explicit `cacheRetention: "long"` passes through
- [x] New test: OpenAI Codex provider with explicit `cacheRetention: "long"` passes through
- [x] New test: OpenAI without config does not apply any default cacheRetention
- [ ] Lint clean (`pnpm check`)
