### PR TITLE
fix(line): avoid reading config from ChannelAccountSnapshot

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -580,7 +580,6 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
 
         const hasToken = Boolean(
           account.channelAccessToken?.trim() ||
-          account.config?.tokenFile?.trim() ||
           (accountId == DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim()) ||
           (account.tokenSource && account.tokenSource !== "none"),
         );
@@ -595,7 +594,6 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
 
         const hasSecret = Boolean(
           account.channelSecret?.trim() ||
-          account.config?.secretFile?.trim() ||
           (accountId == DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_SECRET?.trim()),
         );
         if (!hasSecret) {

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -580,7 +580,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
 
         const hasToken = Boolean(
           account.channelAccessToken?.trim() ||
-          (accountId == DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim()) ||
+          (accountId === DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim()) ||
           (account.tokenSource && account.tokenSource !== "none"),
         );
         if (!hasToken) {
@@ -594,7 +594,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
 
         const hasSecret = Boolean(
           account.channelSecret?.trim() ||
-          (accountId == DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_SECRET?.trim()),
+          (accountId === DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_SECRET?.trim()),
         );
         if (!hasSecret) {
           issues.push({
@@ -614,12 +614,12 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       const configured = Boolean(
         (account.channelAccessToken?.trim() ||
           account.config?.tokenFile?.trim() ||
-          (account.accountId == DEFAULT_ACCOUNT_ID &&
+          (account.accountId === DEFAULT_ACCOUNT_ID &&
             process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim()) ||
           (account.tokenSource && account.tokenSource !== "none")) &&
         (account.channelSecret?.trim() ||
           account.config?.secretFile?.trim() ||
-          (account.accountId == DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_SECRET?.trim())),
+          (account.accountId === DEFAULT_ACCOUNT_ID && process.env.LINE_CHANNEL_SECRET?.trim())),
       );
       return {
         accountId: account.accountId,


### PR DESCRIPTION
This is a clean re-spin of #25253.

The previous PR accidentally included a large repo-wide formatting change and was auto-closed as dirty. This PR contains only the intended fix: stop reading `account.config?.tokenFile/secretFile` from `ChannelAccountSnapshot` in LINE plugin status collection.

- Fixes TS2339 in `extensions/line/src/channel.ts`
- Keeps existing behavior for token/env and tokenSource checks

Supersedes: #25253