### PR TITLE
fix: add firecrawl and readability to web fetch config schema (#27373)

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -305,6 +305,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -314,6 +326,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -308,7 +308,7 @@ export const ToolsWebSearchSchema = z
 export const ToolsWebFetchFirecrawlSchema = z
   .object({
     enabled: z.boolean().optional(),
-    apiKey: z.string().optional(),
+    apiKey: z.string().optional().register(sensitive),
     baseUrl: z.string().optional(),
     onlyMainContent: z.boolean().optional(),
     maxAgeMs: z.number().nonnegative().optional(),


### PR DESCRIPTION
## Summary

- Problem: The Zod schema for `tools.web.fetch` uses `.strict()` but is missing `firecrawl` and `readability` fields, causing valid config keys to be reported as "Unknown config keys" and stripped by `openclaw doctor --fix`.
- Why it matters: Users cannot configure Firecrawl fallback for bot-protected sites despite the feature being implemented and documented.
- What changed: Added `readability` (boolean) and `firecrawl` (object with enabled, apiKey, baseUrl, onlyMainContent, maxAgeMs, timeoutSeconds) to `ToolsWebFetchSchema`.
- What did NOT change: The web_fetch tool implementation and Firecrawl fallback logic are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #27373

## User-visible / Behavior Changes

`tools.web.fetch.firecrawl` and `tools.web.fetch.readability` config keys are now accepted without warnings.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: Zod schema accepts firecrawl sub-keys; strict mode rejects truly unknown keys
- What you did **not** verify: live Firecrawl API fallback

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; config keys return to being flagged as unknown

## Risks and Mitigations

None