### PR TITLE
fix: add suppressTyping option for system/internal messages (#27395)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -238,6 +238,7 @@ export async function runPreparedReply(
     isGroupChat,
     wasMentioned,
     isHeartbeat,
+    suppressTyping: opts?.suppressTyping,
   });
   const shouldInjectGroupIntro = Boolean(
     isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -257,6 +257,17 @@ describe("resolveTypingMode", () => {
         },
         expected: "never",
       },
+      {
+        name: "suppressTyping forces never",
+        input: {
+          configured: "instant" as const,
+          isGroupChat: false,
+          wasMentioned: false,
+          isHeartbeat: false,
+          suppressTyping: true,
+        },
+        expected: "never",
+      },
     ] as const;
 
     for (const testCase of cases) {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -7,6 +7,8 @@ export type TypingModeContext = {
   isGroupChat: boolean;
   wasMentioned: boolean;
   isHeartbeat: boolean;
+  /** Suppress typing for system/internal messages (cron results, subagent reports, exec completions). */
+  suppressTyping?: boolean;
 };
 
 export const DEFAULT_GROUP_TYPING_MODE: TypingMode = "message";
@@ -16,8 +18,9 @@ export function resolveTypingMode({
   isGroupChat,
   wasMentioned,
   isHeartbeat,
+  suppressTyping,
 }: TypingModeContext): TypingMode {
-  if (isHeartbeat) {
+  if (isHeartbeat || suppressTyping) {
     return "never";
   }
   if (configured) {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -27,6 +27,8 @@ export type GetReplyOptions = {
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
+  /** Suppress typing indicators for system/internal messages (cron results, subagent reports, exec completions). */
+  suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
   /** If true, suppress tool error warning payloads for this run. */


### PR DESCRIPTION
## Summary

- Problem: Cron results, subagent reports, and exec completions trigger typing indicators on Telegram, causing the bot to appear perpetually typing even when no user-facing response will be sent.
- Why it matters: Users with frequent cron jobs see constant "typing..." throughout the day, creating a noisy UX.
- What changed: Added a `suppressTyping` option to `GetReplyOptions` that forces typing mode to `"never"`. Wired through `resolveTypingMode` alongside the existing `isHeartbeat` suppression path.
- What did NOT change: Default typing behavior for user messages is unchanged. Callers must opt in.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #27395

## User-visible / Behavior Changes

Callers (channel monitors, cron runners) can pass `suppressTyping: true` to prevent typing indicators for system messages.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx vitest run src/auto-reply/reply/reply-utils.test.ts` — 28 tests pass (1 new suppressTyping test)
- [x] `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: suppressTyping forces "never"; normal messages unaffected
- What you did **not** verify: live Telegram bot with cron jobs

## Compatibility / Migration

- Backward compatible? Yes
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; typing returns to default behavior for all messages

## Risks and Mitigations

None — opt-in only