### PR TITLE
fix: extend gpt-5.3-codex forward compat to github-copilot (#27379)

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -40,6 +40,8 @@ function cloneFirstTemplateModel(params: {
   return undefined;
 }
 
+const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+
 function resolveOpenAICodexGpt53FallbackModel(
   provider: string,
   modelId: string,
@@ -47,7 +49,7 @@ function resolveOpenAICodexGpt53FallbackModel(
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
   const trimmedModelId = modelId.trim();
-  if (normalizedProvider !== "openai-codex") {
+  if (!CODEX_GPT53_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {


### PR DESCRIPTION
## Summary

- Problem: The `github-copilot` provider does not list `gpt-5.3-codex` in its model catalog, and the existing forward-compat fallback only matches the `openai-codex` provider.
- Why it matters: GitHub Copilot users cannot use `gpt-5.3-codex` despite it being available on the Copilot API.
- What changed: Extended the codex gpt-5.3 forward-compat eligibility check from `openai-codex` only to also include `github-copilot`.
- What did NOT change: The fallback template logic and model cloning behavior are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #27379

## User-visible / Behavior Changes

`github-copilot/gpt-5.3-codex` now resolves via the forward-compat fallback to `gpt-5.2-codex` template.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx vitest run src/agents/pi-embedded-runner/model.forward-compat.test.ts` — all pass
- [x] `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: github-copilot provider now matches for gpt-5.3-codex; other providers unaffected
- What you did **not** verify: live GitHub Copilot API call with gpt-5.3-codex

## Compatibility / Migration

- Backward compatible? Yes
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; github-copilot returns to Unknown model for gpt-5.3-codex

## Risks and Mitigations

None