### PR TITLE
fix(ios): remove talk voice directive hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron/Hooks isolated routing: preserve canonical `agent:*` session keys in isolated runs so already-qualified keys are not double-prefixed (for example `agent:main:main` no longer becomes `agent:main:agent:main:main`). Landed from contributor PR #27333 by @MaheshBhushan. (#27289, #27282)
+- iOS/Talk mode: stop injecting the voice directive hint into iOS Talk prompts and remove the Voice Directive Hint setting, reducing model bias toward tool-style TTS directives and keeping relay responses text-first by default. (#27543) thanks @ngutman.
 - Queue/Drain/Cron reliability: harden lane draining with guaranteed `draining` flag reset on synchronous pump failures, reject new queue enqueues during gateway restart drain windows (instead of silently killing accepted tasks), add `/stop` queued-backlog cutoff metadata with stale-message skipping (while avoiding cross-session native-stop cutoff bleed), and raise isolated cron `agentTurn` outer safety timeout to avoid false 10-minute timeout races against longer agent session timeouts. (#27407, #27332, #27427)
 - Security/Plugin channel HTTP auth: normalize protected `/api/channels` path checks against canonicalized request paths (case + percent-decoding + slash normalization), and fail closed on malformed `%`-encoded channel prefixes so alternate-path variants cannot bypass gateway auth.
 - Security/Exec approvals forwarding: prefer turn-source channel/account/thread metadata when resolving approval delivery targets so stale session routes do not misroute approval prompts.

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -22,7 +22,6 @@ struct SettingsTab: View {
     @AppStorage("talk.enabled") private var talkEnabled: Bool = false
     @AppStorage("talk.button.enabled") private var talkButtonEnabled: Bool = true
     @AppStorage("talk.background.enabled") private var talkBackgroundEnabled: Bool = false
-    @AppStorage("talk.voiceDirectiveHint.enabled") private var talkVoiceDirectiveHintEnabled: Bool = true
     @AppStorage("camera.enabled") private var cameraEnabled: Bool = true
     @AppStorage("location.enabledMode") private var locationEnabledModeRaw: String = OpenClawLocationMode.off.rawValue
     @AppStorage("screen.preventSleep") private var preventSleep: Bool = true
@@ -326,10 +325,6 @@ struct SettingsTab: View {
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
-                            self.featureToggle(
-                                "Voice Directive Hint",
-                                isOn: self.$talkVoiceDirectiveHintEnabled,
-                                help: "Adds voice-switching instructions to Talk prompts. Disable to reduce prompt size.")
                             self.featureToggle(
                                 "Show Talk Button",
                                 isOn: self.$talkButtonEnabled,

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -850,11 +850,10 @@ final class TalkModeManager: NSObject {
     private func buildPrompt(transcript: String) -> String {
         let interrupted = self.lastInterruptedAtSeconds
         self.lastInterruptedAtSeconds = nil
-        let includeVoiceDirectiveHint = (UserDefaults.standard.object(forKey: "talk.voiceDirectiveHint.enabled") as? Bool) ?? true
         return TalkPromptBuilder.build(
             transcript: transcript,
             interruptedAtSeconds: interrupted,
-            includeVoiceDirectiveHint: includeVoiceDirectiveHint)
+            includeVoiceDirectiveHint: false)
     }
 
     private enum ChatCompletionState: CustomStringConvertible {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Talk mode prompts on iOS included a voice directive hint that encouraged JSON voice/tool routing.
- Why it matters: it could bias replies toward TTS/tool behavior instead of plain text relay.
- What changed: iOS now always builds Talk prompts with `includeVoiceDirectiveHint: false`, and the iOS Settings toggle for "Voice Directive Hint" was removed.
- What did NOT change (scope boundary): shared TalkPromptBuilder behavior and non-iOS runtimes were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- iOS Talk mode no longer injects the voice-directive hint into prompt text.
- The "Voice Directive Hint" toggle is removed from iOS Settings.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Xcode build (iOS Simulator target)
- Model/provider: N/A
- Integration/channel (if any): iOS app Talk mode
- Relevant config (redacted): default iOS app settings

### Steps

1. Enable Talk mode in iOS app.
2. Send spoken input and inspect Talk prompt generation path.
3. Verify prompt build call hard-disables voice directive hint and settings no longer expose the toggle.

### Expected

- Talk prompt does not include voice directive hint text.
- No Voice Directive Hint toggle in iOS settings.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Built iOS app with `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`.
  - Confirmed TalkModeManager now passes `includeVoiceDirectiveHint: false`.
  - Confirmed SettingsTab no longer defines or renders the Voice Directive Hint toggle.
- Edge cases checked:
  - Existing unrelated SwiftLint warnings remain unchanged.
- What you did **not** verify:
  - On-device/manual interactive Talk conversation runtime behavior.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `apps/ios/Sources/Voice/TalkModeManager.swift`
  - `apps/ios/Sources/Settings/SettingsTab.swift`
- Known bad symptoms reviewers should watch for:
  - If any flow depended on voice-directive prompt hints for tool routing, Talk replies may remain text-only.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some users may have depended on previous voice-directive behavior.
  - Mitigation:
  - Change is limited to iOS Talk prompt composition and is easy to revert.
