### PR TITLE
fix: exclude non-reasoning models from thinking output inference (#27533)

### DIFF
--- a/src/agents/huggingface-models.ts
+++ b/src/agents/huggingface-models.ts
@@ -125,7 +125,10 @@ export function buildHuggingfaceModelDefinition(
  */
 function inferredMetaFromModelId(id: string): { name: string; reasoning: boolean } {
   const base = id.split("/").pop() ?? id;
-  const reasoning = /r1|reasoning|thinking|reason/i.test(id) || /-\d+[tb]?-thinking/i.test(base);
+  const reasoning =
+    (/(?<!non-)reasoning|(?<!non-)thinking|(?<!non-)reason|\br1\b/i.test(id) ||
+      /-\d+[tb]?-thinking/i.test(base)) &&
+    !/non-?reasoning/i.test(id);
   const name = base.replace(/-/g, " ").replace(/\b(\w)/g, (c) => c.toUpperCase());
   return { name, reasoning };
 }


### PR DESCRIPTION
## Summary

- Problem: `xai/grok-4-1-fast-non-reasoning` outputs thinking/reasoning content because the regex in `inferredMetaFromModelId` matches the substring "reasoning" inside "non-reasoning".
- Why it matters: Users selecting a "non-reasoning" model variant explicitly expect no thinking output.
- What changed: Added a negative check so model IDs containing "non-reasoning" are excluded from the reasoning inference match.
- What did NOT change: Models with "reasoning", "thinking", "r1" etc. still correctly infer `reasoning: true`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #27533

## User-visible / Behavior Changes

Models with "non-reasoning" in their ID no longer display thinking output.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx vitest run src/agents/huggingface-models.test.ts` — all pass
- [x] `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: "non-reasoning" suffix correctly yields `reasoning: false`; "reasoning" suffix still yields `reasoning: true`
- What you did **not** verify: live xAI API call with non-reasoning model

## Compatibility / Migration

- Backward compatible? Yes
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; reasoning inference returns to previous regex behavior

## Risks and Mitigations

None