### PR TITLE
fix: strip ANSI escape sequences from skills list JSON output (#27530)

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,4 +1,5 @@
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
+import { stripAnsi } from "../terminal/ansi.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
@@ -72,8 +73,8 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
       managedSkillsDir: report.managedSkillsDir,
       skills: skills.map((s) => ({
         name: s.name,
-        description: s.description,
-        emoji: s.emoji,
+        description: s.description ? stripAnsi(s.description) : s.description,
+        emoji: s.emoji ? stripAnsi(s.emoji) : s.emoji,
         eligible: s.eligible,
         disabled: s.disabled,
         blockedByAllowlist: s.blockedByAllowlist,


### PR DESCRIPTION
## Summary

- Problem: `openclaw skills list --json` includes raw ANSI terminal escape sequences in `emoji` and `description` fields, producing malformed JSON that all standard parsers reject.
- Why it matters: Blocks programmatic use and automation of the skills list command.
- What changed: Applied `stripAnsi()` to `description` and `emoji` fields before JSON serialization.
- What did NOT change: Non-JSON (table) output retains ANSI formatting as before.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #27530

## User-visible / Behavior Changes

`openclaw skills list --json | jq .` now produces valid, parseable JSON.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx tsc --noEmit` — clean

## Human Verification (required)

- Verified scenarios: ANSI codes stripped from emoji/description in JSON mode; table mode unaffected
- What you did **not** verify: live `openclaw skills list --json` with skills containing exotic emoji

## Compatibility / Migration

- Backward compatible? Yes
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; JSON output returns to including ANSI codes

## Risks and Mitigations

None