### PR TITLE
fix(sandbox): mount skills at dedicated /skills path for sandboxed agents

### DIFF
--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -11,6 +11,8 @@ function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxConte
     workspaceAccess: "none",
     containerName: "openclaw-sbx-test",
     containerWorkdir: "/workspace",
+    skillsDir: "/tmp/sandbox/.sandbox-skills",
+    skillsMount: "/skills",
     docker: {
       image: "openclaw-sandbox:bookworm-slim",
       containerPrefix: "openclaw-sbx-",

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -395,6 +395,7 @@ export async function compactEmbeddedPiSessionDirect(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      containerSkillsMount: sandbox?.enabled ? sandbox.skillsMount : undefined,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -793,6 +793,7 @@ export async function runEmbeddedAttempt(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      containerSkillsMount: sandbox?.enabled ? sandbox.skillsMount : undefined,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -580,6 +580,8 @@ describe("Agent-specific tool filtering", () => {
         workspaceAccess: "none",
         containerName: "test-container",
         containerWorkdir: "/workspace",
+        skillsDir: "/tmp/sandbox/.sandbox-skills",
+        skillsMount: "/skills",
         docker: {
           image: "test-image",
           containerPrefix: "test-",

--- a/src/agents/sandbox-skills.test.ts
+++ b/src/agents/sandbox-skills.test.ts
@@ -30,7 +30,7 @@ describe("sandbox skill mirroring", () => {
     envSnapshot.restore();
   });
 
-  const runContext = async (workspaceAccess: "none" | "ro") => {
+  const runContext = async (workspaceAccess: "none" | "ro" | "rw") => {
     const bundledDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-skills-"));
     await fs.mkdir(bundledDir, { recursive: true });
 
@@ -65,13 +65,13 @@ describe("sandbox skill mirroring", () => {
     return { context, workspaceDir };
   };
 
-  it.each(["ro", "none"] as const)(
+  it.each(["ro", "none", "rw"] as const)(
     "copies skills into the sandbox when workspaceAccess is %s",
     async (workspaceAccess) => {
       const { context } = await runContext(workspaceAccess);
 
       expect(context?.enabled).toBe(true);
-      const skillPath = path.join(context?.workspaceDir ?? "", "skills", "demo-skill", "SKILL.md");
+      const skillPath = path.join(context?.skillsDir ?? "", "demo-skill", "SKILL.md");
       await expect(fs.readFile(skillPath, "utf-8")).resolves.toContain("demo-skill");
     },
     20_000,

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -6,6 +6,7 @@ type SandboxHashInput = {
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceDir: string;
   agentWorkspaceDir: string;
+  skillsDir?: string;
 };
 
 type SandboxBrowserHashInput = {

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULT_SANDBOX_BROWSER_NOVNC_PORT = 6080;
 export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
+export const SANDBOX_SKILLS_MOUNT = "/skills";
 
 export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");
 export const SANDBOX_REGISTRY_PATH = path.join(SANDBOX_STATE_DIR, "containers.json");

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -165,7 +165,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
-import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
+import { DEFAULT_SANDBOX_IMAGE, SANDBOX_SKILLS_MOUNT } from "./constants.js";
 import { readRegistry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
@@ -439,6 +439,7 @@ async function createSandboxContainer(params: {
   workspaceDir: string;
   workspaceAccess: SandboxWorkspaceAccess;
   agentWorkspaceDir: string;
+  skillsDir?: string;
   scopeKey: string;
   configHash?: string;
 }) {
@@ -451,7 +452,11 @@ async function createSandboxContainer(params: {
     scopeKey,
     configHash: params.configHash,
     includeBinds: false,
-    bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    bindSourceRoots: [
+      workspaceDir,
+      params.agentWorkspaceDir,
+      ...(params.skillsDir ? [params.skillsDir] : []),
+    ],
   });
   args.push("--workdir", cfg.workdir);
   appendWorkspaceMountArgs({
@@ -461,6 +466,9 @@ async function createSandboxContainer(params: {
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
   });
+  if (params.skillsDir) {
+    args.push("-v", `${params.skillsDir}:${SANDBOX_SKILLS_MOUNT}:ro`);
+  }
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
@@ -491,6 +499,7 @@ export async function ensureSandboxContainer(params: {
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
+  skillsDir?: string;
   cfg: SandboxConfig;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
@@ -502,6 +511,7 @@ export async function ensureSandboxContainer(params: {
     workspaceAccess: params.cfg.workspaceAccess,
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
+    skillsDir: params.skillsDir,
   });
   const now = Date.now();
   const state = await dockerContainerState(containerName);
@@ -547,6 +557,7 @@ export async function ensureSandboxContainer(params: {
       workspaceDir: params.workspaceDir,
       workspaceAccess: params.cfg.workspaceAccess,
       agentWorkspaceDir: params.agentWorkspaceDir,
+      skillsDir: params.skillsDir,
       scopeKey,
       configHash: expectedHash,
     });

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -10,7 +10,7 @@ export type SandboxFsMount = {
   hostRoot: string;
   containerRoot: string;
   writable: boolean;
-  source: "workspace" | "agent" | "bind";
+  source: "workspace" | "agent" | "skills" | "bind";
 };
 
 export type SandboxResolvedFsPath = {
@@ -66,6 +66,15 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
       source: "workspace",
     },
   ];
+
+  if (sandbox.skillsDir && sandbox.skillsMount) {
+    mounts.push({
+      hostRoot: path.resolve(sandbox.skillsDir),
+      containerRoot: normalizeContainerPath(sandbox.skillsMount),
+      writable: false,
+      source: "skills",
+    });
+  }
 
   if (
     sandbox.workspaceAccess !== "none" &&

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -34,6 +34,8 @@ export function createSandboxTestContext(params?: {
     workspaceAccess: "rw",
     containerName: "openclaw-sbx-test",
     containerWorkdir: "/workspace",
+    skillsDir: "/tmp/workspace/.sandbox-skills",
+    skillsMount: "/skills",
     tools: { allow: ["*"], deny: [] },
     browserAllowHostControl: false,
     ...sandboxOverrides,

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -77,6 +77,8 @@ export type SandboxContext = {
   workspaceAccess: SandboxWorkspaceAccess;
   containerName: string;
   containerWorkdir: string;
+  skillsDir: string;
+  skillsMount: string;
   docker: SandboxDockerConfig;
   tools: SandboxToolPolicy;
   browserAllowHostControl: boolean;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -777,8 +777,20 @@ export async function syncSkillsToWorkspace(params: {
       bundledSkillsDir: params.bundledSkillsDir,
     });
 
-    await fsp.rm(targetSkillsDir, { recursive: true, force: true });
-    await fsp.mkdir(targetSkillsDir, { recursive: true });
+    // Clear contents without removing the directory itself to preserve
+    // its inode — Docker bind mounts reference the inode, so rm + mkdir
+    // would silently break the mount inside the container.
+    try {
+      const existing = await fsp.readdir(targetSkillsDir);
+      await Promise.all(
+        existing.map((entry) =>
+          fsp.rm(path.join(targetSkillsDir, entry), { recursive: true, force: true }),
+        ),
+      );
+    } catch {
+      // Directory doesn't exist yet — create it.
+      await fsp.mkdir(targetSkillsDir, { recursive: true });
+    }
 
     const usedDirNames = new Set<string>();
     for (const entry of entries) {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -53,6 +53,34 @@ function compactSkillPaths(skills: Skill[]): Skill[] {
   }));
 }
 
+/**
+ * Rewrite skill file paths to point to the container's skills mount.
+ * Skills are synced to a dedicated host directory and mounted read-only
+ * at `containerSkillsMount` (e.g. `/skills`) inside the container.
+ *
+ * Uses the skill's baseDir name to construct the container path,
+ * independent of the host filesystem layout.
+ *
+ * Example: `/home/user/.openclaw/sandboxes/abc/skills/gog/SKILL.md`
+ *       → `/skills/gog/SKILL.md`
+ */
+export function rewriteSkillPathsForContainer(
+  skills: Skill[],
+  containerSkillsMount: string,
+): Skill[] {
+  const mount = containerSkillsMount.endsWith("/")
+    ? containerSkillsMount.slice(0, -1)
+    : containerSkillsMount;
+  return skills.map((s) => {
+    const dirName = path.basename(s.baseDir);
+    const relativePath = path.relative(s.baseDir, s.filePath);
+    return {
+      ...s,
+      filePath: `${mount}/${dirName}/${relativePath}`,
+    };
+  });
+}
+
 function debugSkillCommandOnce(
   messageKey: string,
   message: string,
@@ -598,6 +626,8 @@ type WorkspaceSkillBuildOptions = {
   /** If provided, only include skills with these names */
   skillFilter?: string[];
   eligibility?: SkillEligibilityContext;
+  /** When set, rewrite skill file paths for a sandbox container mount. */
+  containerSkillsMount?: string;
 };
 
 function resolveWorkspaceSkillPromptState(
@@ -630,7 +660,11 @@ function resolveWorkspaceSkillPromptState(
   const prompt = [
     remoteNote,
     truncationNote,
-    formatSkillsForPrompt(compactSkillPaths(skillsForPrompt)),
+    formatSkillsForPrompt(
+      opts?.containerSkillsMount
+        ? rewriteSkillPathsForContainer(skillsForPrompt, opts.containerSkillsMount)
+        : compactSkillPaths(skillsForPrompt),
+    ),
   ]
     .filter(Boolean)
     .join("\n");
@@ -642,7 +676,18 @@ export function resolveSkillsPromptForRun(params: {
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
+  containerSkillsMount?: string;
 }): string {
+  // When running inside a sandbox container, rewrite snapshot skill paths
+  // to the container mount point instead of returning the cached host-path prompt.
+  if (params.containerSkillsMount && params.skillsSnapshot?.resolvedSkills?.length) {
+    const rewritten = rewriteSkillPathsForContainer(
+      params.skillsSnapshot.resolvedSkills,
+      params.containerSkillsMount,
+    );
+    return formatSkillsForPrompt(rewritten);
+  }
+
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (snapshotPrompt) {
     return snapshotPrompt;
@@ -651,6 +696,7 @@ export function resolveSkillsPromptForRun(params: {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
+      containerSkillsMount: params.containerSkillsMount,
     });
     return prompt.trim() ? prompt : "";
   }
@@ -713,6 +759,8 @@ export async function syncSkillsToWorkspace(params: {
   config?: OpenClawConfig;
   managedSkillsDir?: string;
   bundledSkillsDir?: string;
+  /** Place skills directly under targetWorkspaceDir instead of a "skills" subdirectory. */
+  flat?: boolean;
 }) {
   const sourceDir = resolveUserPath(params.sourceWorkspaceDir);
   const targetDir = resolveUserPath(params.targetWorkspaceDir);
@@ -721,7 +769,7 @@ export async function syncSkillsToWorkspace(params: {
   }
 
   await serializeByKey(`syncSkills:${targetDir}`, async () => {
-    const targetSkillsDir = path.join(targetDir, "skills");
+    const targetSkillsDir = params.flat ? targetDir : path.join(targetDir, "skills");
 
     const entries = loadSkillEntries(sourceDir, {
       config: params.config,

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -24,6 +24,8 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
     workspaceAccess: params.workspaceAccess ?? "rw",
     containerName: params.containerName ?? "openclaw-sbx-test",
     containerWorkdir: params.containerWorkdir ?? "/workspace",
+    skillsDir: `${workspaceDir}/.sandbox-skills`,
+    skillsMount: "/skills",
     fsBridge: params.fsBridge,
     docker: {
       image: "openclaw-sandbox:bookworm-slim",


### PR DESCRIPTION
## Summary

- Problem: Sandboxed agents cannot `read` skill SKILL.md files — the `<location>` paths in the system prompt point to host filesystem paths that don't exist inside the Docker container, resulting in `ENOENT` or `Path escapes sandbox root` errors.
- Why it matters: Skills rely on agents reading SKILL.md for instructions. Without this, agents in sandbox mode cannot follow skill procedures and resort to expensive `find` workarounds.
- What changed: Skills are now synced to a dedicated `.sandbox-skills` directory, mounted read-only at `/skills` inside the container, with prompt paths rewritten from host paths to `/skills/<name>/SKILL.md`.
- Additional fix: `syncSkillsToWorkspace` previously did `rm -rf` + `mkdir` on the target skills directory, which changes its inode. Docker bind mounts reference the original inode, so after a skill re-sync the container's `/skills` mount pointed to the deleted (empty) inode. Now the directory contents are cleared without removing the directory itself, preserving the inode.
- What did NOT change (scope boundary): Non-sandboxed execution is unaffected. The skills content and discovery logic are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #17924
- Related #17931

## User-visible / Behavior Changes

- Sandboxed agents can now `read` skill SKILL.md files via `/skills/<name>/SKILL.md`.
- Skills are synced for all sandbox workspace access modes (previously skipped for `rw`).
- The sandbox config hash now includes skillsDir, so container recreation is triggered when the skills directory changes.
- Skill re-syncs no longer break the bind mount inside running containers (inode preserved).

## Security Impact (required)

- New permissions/capabilities? `No` — skills mount is read-only.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — read tool now accepts `/skills/...` paths via fs-bridge mount registration, but this is a read-only mount of skill files that were already accessible on the host.
- Data access scope changed? `No` — the same skill files are exposed, just via a container-accessible path.

## Repro + Verification

### Environment

- OS: Linux (Docker sandbox)
- Runtime/container: Any Docker-based sandbox container (e.g. debian:bookworm-slim based)
- Model/provider: Any
- Relevant config: `sandbox.workspaceAccess: "rw"` (the mode that was most broken)

### Steps

1. Configure an agent with sandbox enabled and skills installed
2. Send a message that triggers skill usage
3. Agent attempts to `read` the SKILL.md location path shown in the system prompt

### Expected

- Agent successfully reads SKILL.md content

### Actual (before fix)

- `Path escapes sandbox root` or `ENOENT: no such file or directory`

## Evidence

- [x] Failing test/log before + passing after
- Tests updated: `sandbox-skills.test.ts` now covers `rw` mode in addition to `ro` and `none`

## Human Verification (required)

- Verified scenarios: Sandbox agent with `workspaceAccess: "rw"` can read skill SKILL.md files at `/skills/<name>/SKILL.md` after container recreation. Inode preservation verified on production EC2 — skill re-sync no longer breaks the bind mount.
- Edge cases checked: All three workspace access modes (rw, ro, none) tested.
- What you did **not** verify: Skill name collision with `-2` suffix (theoretical edge case when multiple skills share a base directory name).

## Compatibility / Migration

- Backward compatible? `Yes` — existing containers need recreation (`openclaw sandbox recreate`) to pick up the new `/skills` mount, but this happens automatically when the config hash changes.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; agents fall back to pre-fix behavior (host paths in prompt, skills unreadable in sandbox).
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Skills appearing at wrong paths, `/skills` mount missing after container recreation.

## Risks and Mitigations

- Risk: Existing running containers don't get the `/skills` mount until recreated.
  - Mitigation: `skillsDir` is now included in the config hash, so idle containers are automatically recreated. Hot containers get a log message suggesting `openclaw sandbox recreate`.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)