### PR TITLE
fix: pass sessionKey to deliverOutboundPayloads for message:sent hook dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - TUI/stream assembly: preserve streamed text across real tool-boundary drops without keeping stale streamed text when non-text blocks appear only in the final payload. Landed from contributor PR #27711 by @scz2011. (#27674)
+- Hooks/Internal `message:sent`: forward `sessionKey` on outbound sends from agent delivery, cron isolated delivery, gateway receipt acks, heartbeat sends, session-maintenance warnings, and restart-sentinel recovery so internal `message:sent` hooks consistently dispatch with session context. Landed from contributor PR #27584 by @qualiobra. Thanks @qualiobra.
 - Models/MiniMax auth header defaults: set `authHeader: true` for both onboarding-generated MiniMax API providers and implicit built-in MiniMax (`minimax`, `minimax-portal`) provider templates so first requests no longer fail with MiniMax `401 authentication_error` due to missing `Authorization` header. Landed from contributor PRs #27622 by @riccoyuanft and #27631 by @kevinWangSheng. (#27600, #15303)
 - Pi image-token usage: stop re-injecting history image blocks each turn, process image references from the current prompt only, and prune already-answered user-image blocks in stored history to prevent runaway token growth. (#27602)
 - BlueBubbles/SSRF: auto-allowlist the configured `serverUrl` hostname for attachment fetches so localhost/private-IP BlueBubbles setups are no longer false-blocked by default SSRF checks. Landed from contributor PR #27648 by @lailoo. (#27599) Thanks @taylorhou for reporting.

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -230,6 +230,7 @@ export async function deliverAgentCommandResult(params: {
         onError: (err) => logDeliveryError(err),
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
+        sessionKey: opts.sessionKey,
       });
     }
   }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -182,6 +182,7 @@ export async function dispatchCronDelivery(
         bestEffort: params.deliveryBestEffort,
         deps: createOutboundSendDeps(params.deps),
         abortSignal: params.abortSignal,
+        sessionKey: params.agentSessionKey,
       });
       delivered = deliveryResults.length > 0;
       return null;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -241,6 +241,7 @@ async function sendReceiptAck(params: {
     agentId,
     bestEffort: true,
     deps: createOutboundSendDeps(params.deps),
+    sessionKey: params.sessionKey,
   });
 }
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -95,6 +95,7 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
       payloads: [{ text: message }],
       agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
       bestEffort: true,
+      sessionKey,
     });
   } catch (err) {
     enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -723,6 +723,7 @@ export async function runHeartbeatOnce(opts: {
       payloads: [{ text: heartbeatOkText }],
       agentId,
       deps: opts.deps,
+      sessionKey,
     });
     return true;
   };
@@ -928,6 +929,7 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
+      sessionKey,
     });
 
     // Record last delivered heartbeat payload for dedupe.

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -233,6 +233,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
             mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
           }
         : undefined,
+      sessionKey: params.mirror?.sessionKey,
     });
 
     return {

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -104,6 +104,7 @@ export async function deliverSessionMaintenanceWarning(params: WarningParams): P
       threadId: target.threadId,
       payloads: [{ text }],
       agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg }),
+      sessionKey: params.sessionKey,
     });
   } catch (err) {
     log.warn(`Failed to deliver session maintenance warning: ${String(err)}`);


### PR DESCRIPTION
## Problem

The `message:sent` internal hook event never fires because most call sites of `deliverOutboundPayloads()` don't pass the `sessionKey` parameter. In `deliver.ts`, the guard:

```ts
const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.sessionKey;
if (!sessionKeyForInternalHooks) return;
```

...silently skips the `triggerInternalHook()` call, so hooks registered for `message:sent` never receive events.

## Root Cause

The `sessionKey` parameter was added to `DeliverOutboundPayloadsCoreParams` but was only being passed from `route-reply.ts` (via `mirror`). The other 5 call sites never passed it.

## Fix

Pass `sessionKey` from all call sites where it's available:

| File | Source of sessionKey |
|------|---------------------|
| `commands/agent/delivery.ts` | `opts.sessionKey` |
| `infra/heartbeat-runner.ts` (×2) | `sessionKey` (from preflight) |
| `infra/outbound/message.ts` | `params.mirror?.sessionKey` |
| `cron/isolated-agent/delivery-dispatch.ts` | `params.agentSessionKey` |
| `gateway/server-node-events.ts` | `params.sessionKey` |

## Impact

- Custom hooks listening for `message:sent` will now fire correctly
- The bundled hook system and plugins using `message_sent` plugin hooks are unaffected (they use a separate code path via `hookRunner.runMessageSent`)
- No behavioral changes for users without `message:sent` hooks

## Testing

Verified with a custom hook that logs to Supabase — before this fix, only `message:received` events were captured. After, both directions work.