### PR TITLE
fix(channels): add circuit breaker to typing keepalive loop

### DIFF
--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -73,6 +73,90 @@ describe("createTypingCallbacks", () => {
     }
   });
 
+  it("stops keepalive after consecutive start failures", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = vi.fn().mockRejectedValue(new Error("gone"));
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, onStartError });
+
+      // First call fails but keepalive still starts
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(onStartError).toHaveBeenCalledTimes(1);
+
+      // Second tick: consecutive failure #2 → circuit breaker trips
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(start).toHaveBeenCalledTimes(2);
+      expect(onStartError).toHaveBeenCalledTimes(2);
+
+      // No more ticks — loop was stopped
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets failure counter on success", async () => {
+    vi.useFakeTimers();
+    try {
+      let callCount = 0;
+      // Fail, succeed, fail, succeed — never hits 2 consecutive failures
+      const start = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount % 2 === 1) {
+          return Promise.reject(new Error("flaky"));
+        }
+        return Promise.resolve();
+      });
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, onStartError });
+
+      await callbacks.onReplyStart(); // call 1: fail
+      await vi.advanceTimersByTimeAsync(3_000); // call 2: success
+      await vi.advanceTimersByTimeAsync(3_000); // call 3: fail
+      await vi.advanceTimersByTimeAsync(3_000); // call 4: success
+
+      // Loop still running — never hit 2 consecutive failures
+      expect(start).toHaveBeenCalledTimes(4);
+      expect(onStartError).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(3_000); // call 5: fail
+      expect(start).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets failure counter on new reply start", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = vi.fn().mockRejectedValue(new Error("gone"));
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, onStartError });
+
+      // Trip the circuit breaker
+      await callbacks.onReplyStart();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      // Loop stopped
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      // New reply resets counter, loop restarts
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(3);
+
+      // Keepalive ticks again
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(start).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("deduplicates stop across idle and cleanup", async () => {
     const start = vi.fn().mockResolvedValue(undefined);
     const stop = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

When the typing indicator `start()` call fails (e.g., the target message has been deleted or the API returns an error), the keepalive loop previously continued firing requests every 3 seconds indefinitely. This caused cascading issues:

- Repeated requests to a non-existent resource
- API rate limiting (observed as Feishu 429 errors that blocked all subsequent API calls)
- Unnecessary load on both the gateway and upstream APIs

This PR adds a circuit breaker to `createTypingCallbacks`:

- Tracks consecutive `start()` failures
- Stops the keepalive loop after **2 consecutive failures** (configurable via `maxConsecutiveFailures`)
- Resets the failure counter on any successful call or when a new reply starts

## Changes

- `src/channels/typing.ts` — Added `consecutiveFailures` counter and `maxConsecutiveFailures` option (default: 2). The keepalive loop is stopped when the threshold is reached.
- `src/channels/typing.test.ts` — Added 3 test cases:
  - Circuit breaker trips after consecutive failures
  - Failure counter resets on intermittent success (flaky network)
  - Failure counter resets when a new reply starts

## Test plan

- [x] All existing typing tests pass
- [x] New circuit breaker tests pass (8/8 total)
- [x] Verified with `pnpm vitest run src/channels/typing.test.ts`