### PR TITLE
docs(github skill): prefer gh PR workflow

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -43,6 +43,11 @@ Use the `gh` CLI to interact with GitHub repositories, issues, PRs, and CI.
 - Querying GitHub API for repository data
 - Listing repos, releases, or collaborators
 
+✅ **Also use this skill whenever you need to publish changes to GitHub**:
+
+- Prefer `gh pr create` + `gh pr merge` over directly pushing to `main`
+- Only push directly when the user explicitly asks for a direct push
+
 ## When NOT to Use
 
 ❌ **DON'T use this skill when:**


### PR DESCRIPTION
Update github skill guidance: whenever publishing changes, prefer gh pr create/merge instead of direct pushes to main unless explicitly requested.