### PR TITLE
fix(slack): reduce token bloat by skipping thread context on existing sessions

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -539,7 +539,8 @@ export async function prepareSlackMessage(params: {
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0) {
+    // Only fetch thread history for NEW sessions (when there's no previous timestamp)
+    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,
@@ -627,7 +628,8 @@ export async function prepareSlackMessage(params: {
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
-    ThreadStarterBody: threadStarterBody,
+    // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
+    ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadHistoryBody: threadHistoryBody,
     IsFirstThreadTurn:
       isThreadReply && threadTs && !threadSessionPreviousTimestamp ? true : undefined,


### PR DESCRIPTION
# BAD
<img width="1005" height="918" alt="Screenshot 2026-02-26 092554" src="https://github.com/user-attachments/assets/19b21b97-5723-4851-9091-030afa019bc7" />

# Good
<img width="944" height="767" alt="Screenshot 2026-02-26 091545" src="https://github.com/user-attachments/assets/ad0b9a9b-ff8e-4a2f-8f0a-54197cb1a555" />


Thread history and thread starter were being included on **every message** in a Slack thread
This PR Only fetches `ThreadHistoryBody` for new thread sessions

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

**Before:** Every message in a Slack thread included `[Thread starter - for context]` with the thread starter text.

**After:** Only the first message in a thread session includes context (`[Thread history - for context]` with full thread history or `[Thread starter - for context]` with just the starter). Subsequent messages rely on the session transcript which already has the full conversation history.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes` - REDUCE API calls to Slack for thread history)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  No additional endpoints touches just reduced calls to slack for hsitory

## Repro + Verification

1. Message your openclaw in a channel and wait for it respond in a thread
2. Send multiple follow-up replies in the thread
3. Check the session file in `~/.openclaw/agents/main/sessions/` or open the tui and `/session` to open the session
4. Verify: First message includes `[Thread history - for context]` with full thread
5. Verify: Subsequent messages do NOT include `[Thread history - for context]`

## AI-Assisted PR

- [x] Mark as AI-assisted in the PR title or description - mea culpa
- [x] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does

This PR was developed with GLM 5. I understand the changes and have verified they fix the token bloat issue.

**Session file evidence:** Before the fix, sessions included a Copy of every previous message in every new message in the thread. After the fix, only the first message should include this context wrapper.