### PR TITLE
fix(feishu): fall back to direct send when reply target is withdrawn

### DIFF
--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertFeishuMessageApiSuccess,
+  isFeishuMessageGoneError,
+  toFeishuSendResult,
+} from "./send-result.js";
+
+describe("isFeishuMessageGoneError", () => {
+  it("returns true for withdrawn message (230011)", () => {
+    expect(isFeishuMessageGoneError({ code: 230011, msg: "message withdrawn" })).toBe(true);
+  });
+
+  it("returns true for deleted/not-found message (231003)", () => {
+    expect(isFeishuMessageGoneError({ code: 231003, msg: "message not found" })).toBe(true);
+  });
+
+  it("returns false for success response", () => {
+    expect(isFeishuMessageGoneError({ code: 0 })).toBe(false);
+  });
+
+  it("returns false for other error codes", () => {
+    expect(isFeishuMessageGoneError({ code: 99999, msg: "other error" })).toBe(false);
+  });
+
+  it("returns false when code is undefined", () => {
+    expect(isFeishuMessageGoneError({})).toBe(false);
+  });
+});
+
+describe("assertFeishuMessageApiSuccess", () => {
+  it("does not throw for code 0", () => {
+    expect(() => assertFeishuMessageApiSuccess({ code: 0 }, "test")).not.toThrow();
+  });
+
+  it("throws for non-zero code with msg", () => {
+    expect(() =>
+      assertFeishuMessageApiSuccess({ code: 230011, msg: "withdrawn" }, "Feishu reply failed"),
+    ).toThrow("Feishu reply failed: withdrawn");
+  });
+
+  it("throws for non-zero code without msg", () => {
+    expect(() => assertFeishuMessageApiSuccess({ code: 99999 }, "Feishu send failed")).toThrow(
+      "Feishu send failed: code 99999",
+    );
+  });
+});
+
+describe("toFeishuSendResult", () => {
+  it("extracts message_id from response data", () => {
+    const result = toFeishuSendResult({ code: 0, data: { message_id: "om_abc" } }, "oc_chat");
+    expect(result).toEqual({ messageId: "om_abc", chatId: "oc_chat" });
+  });
+
+  it("falls back to 'unknown' when message_id is missing", () => {
+    const result = toFeishuSendResult({ code: 0 }, "oc_chat");
+    expect(result).toEqual({ messageId: "unknown", chatId: "oc_chat" });
+  });
+});

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -15,6 +15,16 @@ export function assertFeishuMessageApiSuccess(
   }
 }
 
+/**
+ * Detect whether the Feishu API error indicates the target message no longer
+ * exists — either withdrawn by the sender (230011) or deleted/not found (231003).
+ * Callers use this to fall back to a direct send instead of silently dropping
+ * the reply.
+ */
+export function isFeishuMessageGoneError(response: FeishuMessageApiResponse): boolean {
+  return response.code === 230011 || response.code === 231003;
+}
+
 export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const messageCreateMock = vi.hoisted(() => vi.fn());
+const messageReplyMock = vi.hoisted(() => vi.fn());
+const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send-target.js", () => ({
+  resolveFeishuSendTarget: resolveFeishuSendTargetMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      text: {
+        resolveMarkdownTableMode: () => "plain",
+        convertMarkdownTables: (t: string) => t,
+      },
+    },
+  }),
+}));
+
+import { sendMessageFeishu, sendCardFeishu } from "./send.js";
+
+describe("reply fallback on withdrawn/deleted message", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    resolveFeishuSendTargetMock.mockReturnValue({
+      client: {
+        im: {
+          message: {
+            create: messageCreateMock,
+            reply: messageReplyMock,
+          },
+        },
+      },
+      receiveId: "ou_target",
+      receiveIdType: "open_id",
+    });
+
+    messageCreateMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "msg_fallback" },
+    });
+  });
+
+  describe("sendMessageFeishu", () => {
+    it("falls back to direct send when reply target is withdrawn (230011)", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 230011,
+        msg: "message has been withdrawn",
+      });
+
+      const result = await sendMessageFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        text: "hello",
+        replyToMessageId: "om_withdrawn",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).toHaveBeenCalledOnce();
+      expect(result.messageId).toBe("msg_fallback");
+    });
+
+    it("falls back to direct send when reply target is deleted (231003)", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 231003,
+        msg: "message not found",
+      });
+
+      const result = await sendMessageFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        text: "hello",
+        replyToMessageId: "om_deleted",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).toHaveBeenCalledOnce();
+      expect(result.messageId).toBe("msg_fallback");
+    });
+
+    it("throws when reply fails with a non-gone error", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 99999,
+        msg: "other error",
+      });
+
+      await expect(
+        sendMessageFeishu({
+          cfg: {} as any,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_other",
+        }),
+      ).rejects.toThrow("Feishu reply failed: other error");
+
+      expect(messageCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("replies normally when the target message exists", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 0,
+        data: { message_id: "msg_reply" },
+      });
+
+      const result = await sendMessageFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        text: "hello",
+        replyToMessageId: "om_valid",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).not.toHaveBeenCalled();
+      expect(result.messageId).toBe("msg_reply");
+    });
+
+    it("sends directly when no replyToMessageId is given", async () => {
+      const result = await sendMessageFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        text: "hello",
+      });
+
+      expect(messageReplyMock).not.toHaveBeenCalled();
+      expect(messageCreateMock).toHaveBeenCalledOnce();
+      expect(result.messageId).toBe("msg_fallback");
+    });
+  });
+
+  describe("sendCardFeishu", () => {
+    it("falls back to direct send when reply target is withdrawn (230011)", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 230011,
+        msg: "message has been withdrawn",
+      });
+
+      const result = await sendCardFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        card: { schema: "2.0" },
+        replyToMessageId: "om_withdrawn",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ msg_type: "interactive" }),
+        }),
+      );
+      expect(result.messageId).toBe("msg_fallback");
+    });
+
+    it("falls back to direct send when reply target is deleted (231003)", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 231003,
+        msg: "message not found",
+      });
+
+      const result = await sendCardFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        card: { schema: "2.0" },
+        replyToMessageId: "om_deleted",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).toHaveBeenCalledOnce();
+      expect(result.messageId).toBe("msg_fallback");
+    });
+
+    it("throws when reply fails with a non-gone error", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 99999,
+        msg: "other error",
+      });
+
+      await expect(
+        sendCardFeishu({
+          cfg: {} as any,
+          to: "user:ou_target",
+          card: { schema: "2.0" },
+          replyToMessageId: "om_other",
+        }),
+      ).rejects.toThrow("Feishu card reply failed: other error");
+
+      expect(messageCreateMock).not.toHaveBeenCalled();
+    });
+
+    it("replies normally when the target message exists", async () => {
+      messageReplyMock.mockResolvedValue({
+        code: 0,
+        data: { message_id: "msg_reply" },
+      });
+
+      const result = await sendCardFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        card: { schema: "2.0" },
+        replyToMessageId: "om_valid",
+      });
+
+      expect(messageReplyMock).toHaveBeenCalledOnce();
+      expect(messageCreateMock).not.toHaveBeenCalled();
+      expect(result.messageId).toBe("msg_reply");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a Feishu user withdraws (撤回) a message while the bot is composing a reply, `im.message.reply` returns error 230011 or 231003. The reply is silently dropped — the user sees nothing.

This affects all message types: text, cards, images, and files.

## Root Cause

All four send functions (`sendMessageFeishu`, `sendCardFeishu`, `sendImageFeishu`, `sendFileFeishu`) call `im.message.reply` and immediately assert success. There's no handling for the "target message gone" case:

```typescript
// BEFORE — hard failure when target is withdrawn
const response = await client.im.message.reply({
  path: { message_id: replyToMessageId },
  data: { content, msg_type: msgType },
});
assertFeishuMessageApiSuccess(response, "Feishu reply failed");
// ^ throws on 230011/231003, reply is lost
```

## Fix

Added `isFeishuMessageGoneError()` to detect codes 230011 (withdrawn) and 231003 (not found). When a reply target is gone, fall back to `im.message.create` (direct send) instead of throwing:

```typescript
// AFTER — fallback to direct send
const response = await client.im.message.reply({
  path: { message_id: replyToMessageId },
  data: { content, msg_type: msgType },
});
if (isFeishuMessageGoneError(response)) {
  const fallback = await client.im.message.create({
    params: { receive_id_type: receiveIdType },
    data: { receive_id: receiveId, content, msg_type: msgType },
  });
  assertFeishuMessageApiSuccess(fallback, "Feishu send failed");
  return toFeishuSendResult(fallback, receiveId);
}
assertFeishuMessageApiSuccess(response, "Feishu reply failed");
```

Applied consistently across all four send functions. Non-gone errors still throw as before.

## Tests

35 tests across 3 files:
- `send-result.test.ts` — `isFeishuMessageGoneError` for both codes, success, other errors, undefined
- `send.test.ts` — text and card fallback (230011, 231003), non-gone error propagation, normal reply, direct send
- `media.test.ts` — image and file fallback, `msg_type` preservation for media vs file

```
pnpm vitest run extensions/feishu/src/send-result.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/media.test.ts
```

Fixes #27103

Related #27525 (addresses typing indicator spam — a separate symptom from the same issue)
