### PR TITLE
fix: set authHeader: true by default for MiniMax API provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/MiniMax auth header defaults: set `authHeader: true` for both onboarding-generated MiniMax API providers and implicit built-in MiniMax (`minimax`, `minimax-portal`) provider templates so first requests no longer fail with MiniMax `401 authentication_error` due to missing `Authorization` header. Landed from contributor PRs #27622 by @riccoyuanft and #27631 by @kevinWangSheng. (#27600, #15303)
 - Pi image-token usage: stop re-injecting history image blocks each turn, process image references from the current prompt only, and prune already-answered user-image blocks in stored history to prevent runaway token growth. (#27602)
 - BlueBubbles/SSRF: auto-allowlist the configured `serverUrl` hostname for attachment fetches so localhost/private-IP BlueBubbles setups are no longer false-blocked by default SSRF checks. Landed from contributor PR #27648 by @lailoo. (#27599) Thanks @taylorhou for reporting.
 - Security/Gateway node pairing: pin paired-device `platform`/`deviceFamily` metadata across reconnects and bind those fields into device-auth signatures, so reconnect metadata spoofing cannot expand node command allowlists without explicit repair pairing. This ships in the next npm release (`2026.2.26`). Thanks @76embiid21 for reporting.

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -480,6 +480,7 @@ function buildMinimaxProvider(): ProviderConfig {
   return {
     baseUrl: MINIMAX_PORTAL_BASE_URL,
     api: "anthropic-messages",
+    authHeader: true,
     models: [
       buildMinimaxTextModel({
         id: MINIMAX_DEFAULT_MODEL_ID,
@@ -515,6 +516,7 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   return {
     baseUrl: MINIMAX_PORTAL_BASE_URL,
     api: "anthropic-messages",
+    authHeader: true,
     models: [
       buildMinimaxTextModel({
         id: MINIMAX_DEFAULT_MODEL_ID,

--- a/src/commands/onboard-auth.config-minimax.ts
+++ b/src/commands/onboard-auth.config-minimax.ts
@@ -181,6 +181,7 @@ function applyMinimaxApiProviderConfigWithBaseUrl(
     ...existingProviderRest,
     baseUrl: params.baseUrl,
     api: "anthropic-messages",
+    authHeader: true,
     ...(normalizedApiKey?.trim() ? { apiKey: normalizedApiKey } : {}),
     models: mergedModels.length > 0 ? mergedModels : [apiModel],
   };

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -365,6 +365,7 @@ describe("applyMinimaxApiConfig", () => {
     expect(cfg.models?.providers?.minimax).toMatchObject({
       baseUrl: "https://api.minimax.io/anthropic",
       api: "anthropic-messages",
+      authHeader: true,
     });
   });
 
@@ -404,6 +405,7 @@ describe("applyMinimaxApiConfig", () => {
     );
     expect(cfg.models?.providers?.minimax?.baseUrl).toBe("https://api.minimax.io/anthropic");
     expect(cfg.models?.providers?.minimax?.api).toBe("anthropic-messages");
+    expect(cfg.models?.providers?.minimax?.authHeader).toBe(true);
     expect(cfg.models?.providers?.minimax?.apiKey).toBe("old-key");
     expect(cfg.models?.providers?.minimax?.models.map((m) => m.id)).toEqual([
       "old-model",

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -109,11 +109,15 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     text: string;
     skipRegressive: "always" | "existingOnly";
     hadPreviewMessage: boolean;
-  }): boolean =>
-    Boolean(args.currentPreviewText) &&
-    args.currentPreviewText.startsWith(args.text) &&
-    args.text.length < args.currentPreviewText.length &&
-    (args.skipRegressive === "always" || args.hadPreviewMessage);
+  }): boolean => {
+    const currentPreviewText = args.currentPreviewText;
+    return (
+      currentPreviewText !== undefined &&
+      currentPreviewText.startsWith(args.text) &&
+      args.text.length < currentPreviewText.length &&
+      (args.skipRegressive === "always" || args.hadPreviewMessage)
+    );
+  };
 
   const tryEditPreviewMessage = async (args: {
     laneName: LaneName;


### PR DESCRIPTION
## Summary
- **Problem:** MiniMax API authentication fails with 401 error on first API call because `authHeader` is not set by default
- **Why it matters:** Users cannot use MiniMax provider without manually adding `authHeader: true` to their config
- **What changed:** Added `authHeader: true` as default in `applyMinimaxApiProviderConfigWithBaseUrl` function
- **What did NOT change:** Other providers, authentication flow, API key handling

## Change Type
- [x] Bug fix

## Scope
- [x] Auth / tokens

## Linked Issue/PR
- Closes #27600

## User-visible / Behavior Changes
- MiniMax API (both global and China) now works out-of-the-box without manual config

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (same key, just sent via different header)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Environment
- OS: Windows/macOS/Linux
- Runtime: OpenClaw Gateway
- Model: MiniMax-M2.5
- Integration: Any channel (Telegram, webchat, etc.)

### Steps
1. Configure MiniMax API key via onboarding
2. Start OpenClaw gateway
3. Send a message

### Expected
- API call succeeds

### Actual (before fix)
- First API call fails with 401 authentication error

## Human Verification
- Verified scenarios: Tested with user's config - adding `authHeader: true` resolves the issue
- Edge cases checked: Both `minimax` (global) and `minimax-cn` (China) endpoints
- What you did NOT verify: Long-term stability across restarts

## Compatibility / Migration
- Backward compatible? `Yes` - users who already have `authHeader` set will keep working
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery
- How to disable/revert this change quickly: Revert the code change in PR
- Files/config to restore: `src/commands/onboard-auth.config-minimax.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations
- Risk: None - this only adds a default value that matches MiniMax API requirements