### PR TITLE
fix(signal): ignore expiration timer update messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal/Expiration updates: silently drop disappearing-messages timer change notifications instead of routing them to the agent as empty media messages. (#27615)
 - Cron/Hooks isolated routing: preserve canonical `agent:*` session keys in isolated runs so already-qualified keys are not double-prefixed (for example `agent:main:main` no longer becomes `agent:main:agent:main:main`). Landed from contributor PR #27333 by @MaheshBhushan. (#27289, #27282)
 - Queue/Drain/Cron reliability: harden lane draining with guaranteed `draining` flag reset on synchronous pump failures, reject new queue enqueues during gateway restart drain windows (instead of silently killing accepted tasks), add `/stop` queued-backlog cutoff metadata with stale-message skipping (while avoiding cross-session native-stop cutoff bleed), and raise isolated cron `agentTurn` outer safety timeout to avoid false 10-minute timeout races against longer agent session timeouts. (#27407, #27332, #27427)
 - Security/Plugin channel HTTP auth: normalize protected `/api/channels` path checks against canonicalized request paths (case + percent-decoding + slash normalization), and fail closed on malformed `%`-encoded channel prefixes so alternate-path variants cannot bypass gateway auth.

--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -113,6 +113,53 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(context.OriginatingTo).toBe("+15550002222");
   });
 
+  it("silently drops expiration timer update messages (#27615)", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    // Simulate Signal's disappearing messages setting change
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: null,
+          expiresInSeconds: 2419200,
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    expect(capture.ctx).toBeUndefined();
+  });
+
+  it("still dispatches messages that have expiresInSeconds AND text content", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          expiresInSeconds: 2419200,
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalled();
+    expect(capture.ctx).toBeTruthy();
+  });
+
   it("sends typing + read receipt for allowed DMs", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -489,6 +489,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return;
     }
 
+    // Skip expiration timer update messages (disappearing messages setting changes).
+    // These have expiresInSeconds but no actual user content.
+    if (
+      typeof dataMessage.expiresInSeconds === "number" &&
+      !messageText &&
+      !quoteText &&
+      !dataMessage.attachments?.length &&
+      !reaction
+    ) {
+      logVerbose(`signal: ignoring expiration timer update from ${senderDisplay}`);
+      return;
+    }
+
     const senderRecipient = resolveSignalRecipient(sender);
     const senderPeerId = resolveSignalPeerId(sender);
     const senderAllowId = formatSignalSenderId(sender);

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -27,6 +27,7 @@ export type SignalMention = {
 export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
+  expiresInSeconds?: number;
   attachments?: Array<SignalAttachment>;
   mentions?: Array<SignalMention> | null;
   groupInfo?: {


### PR DESCRIPTION
## Summary

Silently drop Signal's disappearing-messages timer change notifications instead of routing them to the agent.

## Problem

When a user configures disappearing messages on a Signal conversation with the OpenClaw bot, Signal sends an expiration timer update message. This message has a `dataMessage` with `expiresInSeconds` but no actual text, attachments, or quotes. The event handler was not filtering these out, so they could reach the agent and produce a confusing reply like "I got a media message, but I can't tell what it contains."

Closes #27615

## Changes

- Added `expiresInSeconds` field to `SignalDataMessage` type definition
- Added early return in the Signal event handler to skip messages that are expiration-only updates (have `expiresInSeconds` but no text, no quote, no attachments, and no reaction)
- Logs a verbose message when dropping these messages for debuggability

## Test plan

- Added regression test: expiration-only messages are silently dropped (dispatch is never called)
- Added regression test: messages with both `expiresInSeconds` AND text content are still dispatched normally
- All 99 existing Signal tests pass
- Lint and format checks pass

## Effect on User Experience

Before: Changing disappearing messages settings on a Signal conversation with the bot would trigger a confusing agent reply about an unreadable media message.

After: Timer change notifications are silently ignored. Normal messages (including those on conversations with disappearing messages enabled) continue to work as expected.