### PR TITLE
fix(slack): extract attachment text for bot messages with empty text (#27616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Bot attachment-only messages: when `allowBots: true`, bot messages with empty `text` now include non-forwarded attachment `text`/`fallback` content so webhook alerts are not silently dropped. (#27616)
 - Slack/Security ingress mismatch guard: drop slash-command and interaction payloads when app/team identifiers do not match the active Slack account context (including nested `team.id` interaction payloads), preventing cross-app or cross-workspace payload injection into system-event handling. (#29091) Thanks @Solvely-Colin.
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.
 - Cron/Isolated model defaults: resolve isolated cron `subagents.model` (including object-form `primary`) through allowlist-aware model selection so isolated cron runs honor subagent model defaults unless explicitly overridden by job payload model. (#11474) Thanks @AnonO6.

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -255,6 +255,37 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("[Slack file: file]");
   });
 
+  it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const account = createSlackAccount({ allowBots: true });
+    const message = createSlackMessage({
+      text: "",
+      bot_id: "B0AGV8EQYA3",
+      subtype: "bot_message",
+      attachments: [
+        {
+          text: "Readiness probe failed: Get http://10.42.13.132:8000/status: context deadline exceeded",
+          title: "[K8S] Unhealthy: Pod/apprise-78447f9d-7ndvj",
+        },
+      ],
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, account, message);
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -275,7 +275,6 @@ describe("slack prepareSlackMessage inbound contract", () => {
       attachments: [
         {
           text: "Readiness probe failed: Get http://10.42.13.132:8000/status: context deadline exceeded",
-          title: "[K8S] Unhealthy: Pod/apprise-78447f9d-7ndvj",
         },
       ],
     });

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -352,8 +352,25 @@ export async function prepareSlackMessage(params: {
       : undefined;
   const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;
 
+  // Bot messages (e.g. Prometheus, Gatus webhooks) often carry content only in
+  // non-forwarded attachments (is_share !== true).  Extract their text/fallback
+  // so the message isn't silently dropped when `allowBots: true` (#27616).
+  const botAttachmentText =
+    isBotMessage && !attachmentContent?.text
+      ? (message.attachments ?? [])
+          .map((a) => a.text?.trim() || a.fallback?.trim())
+          .filter(Boolean)
+          .join("\n")
+      : undefined;
+
   const rawBody =
-    [(message.text ?? "").trim(), attachmentContent?.text, mediaPlaceholder, fileOnlyPlaceholder]
+    [
+      (message.text ?? "").trim(),
+      attachmentContent?.text,
+      botAttachmentText,
+      mediaPlaceholder,
+      fileOnlyPlaceholder,
+    ]
       .filter(Boolean)
       .join("\n") || "";
   if (!rawBody) {


### PR DESCRIPTION
## Summary

Bot messages with empty `text` but content in `attachments` now trigger sessions when `allowBots: true` is set.

## Problem

Monitoring webhooks (Prometheus Alertmanager, Gatus, etc.) send Slack messages with `text: ""` and all content in `attachments`. These messages were silently dropped because `resolveSlackAttachmentContent` only processes forwarded attachments (`is_share: true`), and the empty-body check at the end of `prepareSlackMessage` returned `null`.

Closes #27616

## Changes

- Added a `botAttachmentText` fallback in `prepareSlackMessage` that extracts `text` or `fallback` from non-forwarded attachments when the message is from a bot and would otherwise have an empty body.
- The fallback only activates for bot messages (`isBotMessage`) and only when `resolveSlackAttachmentContent` didn't already extract text, avoiding double-inclusion.

## Test plan

- Added regression test: bot message with `allowBots: true`, empty `text`, and non-forwarded attachments now produces a non-null prepared message with attachment text in `RawBody`.
- All 17 existing tests in `prepare.test.ts` continue to pass.
- `pnpm lint` and `pnpm format:check` pass clean.

## Effect on User Experience

Before: Bot messages from monitoring webhooks with empty `text` were silently ignored even with `allowBots: true`. Users had to manually reply in thread to trigger the agent.

After: The agent receives the attachment content and can autonomously react to alerts, enabling hands-free monitoring workflows.
