### PR TITLE
test(telegram): align message context harness with chat action handler type

### DIFF
--- a/src/telegram/bot-message-context.test-harness.ts
+++ b/src/telegram/bot-message-context.test-harness.ts
@@ -21,6 +21,12 @@ type BuildTelegramMessageContextForTestParams = {
   resolveTelegramGroupConfig?: BuildTelegramMessageContextParams["resolveTelegramGroupConfig"];
 };
 
+const sendChatActionHandlerForTest: BuildTelegramMessageContextParams["sendChatActionHandler"] = {
+  sendChatAction: vi.fn(async () => undefined),
+  isSuspended: () => false,
+  reset: () => undefined,
+};
+
 export async function buildTelegramMessageContextForTest(
   params: BuildTelegramMessageContextForTestParams,
 ): Promise<Awaited<ReturnType<typeof buildTelegramMessageContext>>> {
@@ -61,6 +67,6 @@ export async function buildTelegramMessageContextForTest(
         groupConfig: { requireMention: false },
         topicConfig: undefined,
       })),
-    sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+    sendChatActionHandler: sendChatActionHandlerForTest,
   });
 }


### PR DESCRIPTION
## Summary
- update `buildTelegramMessageContextForTest` harness to provide a full `sendChatActionHandler` stub
- match the current `BuildTelegramMessageContextParams` contract (`sendChatAction`, `isSuspended`, `reset`)

## Why
`pnpm check` on latest `main` failed with TS2741 because the harness only stubbed `sendChatAction` after the handler type expanded.

## Validation
- `pnpm tsgo`
- `pnpm vitest run src/telegram/bot-message-context*.test.ts src/telegram/bot-message*.test.ts`
- `pnpm check`

