### PR TITLE
fix(bluebubbles): auto-allowlist serverUrl hostname in SSRF policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles/SSRF: auto-allowlist the configured `serverUrl` hostname when fetching attachments so localhost and private-IP BlueBubbles setups work without requiring explicit `allowPrivateNetwork` config. (#27599)
 - Cron/Hooks isolated routing: preserve canonical `agent:*` session keys in isolated runs so already-qualified keys are not double-prefixed (for example `agent:main:main` no longer becomes `agent:main:agent:main:main`). Landed from contributor PR #27333 by @MaheshBhushan. (#27289, #27282)
 - Queue/Drain/Cron reliability: harden lane draining with guaranteed `draining` flag reset on synchronous pump failures, reject new queue enqueues during gateway restart drain windows (instead of silently killing accepted tasks), add `/stop` queued-backlog cutoff metadata with stale-message skipping (while avoiding cross-session native-stop cutoff bleed), and raise isolated cron `agentTurn` outer safety timeout to avoid false 10-minute timeout races against longer agent session timeouts. (#27407, #27332, #27427)
 - Security/Plugin channel HTTP auth: normalize protected `/api/channels` path checks against canonicalized request paths (case + percent-decoding + slash normalization), and fail closed on malformed `%`-encoded channel prefixes so alternate-path variants cannot bypass gateway auth.

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -294,7 +294,7 @@ describe("downloadBlueBubblesAttachment", () => {
     expect(fetchMediaArgs.ssrfPolicy).toEqual({ allowPrivateNetwork: true });
   });
 
-  it("does not pass ssrfPolicy when allowPrivateNetwork is not set", async () => {
+  it("auto-allowlists serverUrl hostname when allowPrivateNetwork is not set", async () => {
     const mockBuffer = new Uint8Array([1]);
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -309,7 +309,25 @@ describe("downloadBlueBubblesAttachment", () => {
     });
 
     const fetchMediaArgs = fetchRemoteMediaMock.mock.calls[0][0] as Record<string, unknown>;
-    expect(fetchMediaArgs.ssrfPolicy).toBeUndefined();
+    expect(fetchMediaArgs.ssrfPolicy).toEqual({ allowedHostnames: ["localhost"] });
+  });
+
+  it("auto-allowlists private IP serverUrl hostname for SSRF policy", async () => {
+    const mockBuffer = new Uint8Array([1]);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers(),
+      arrayBuffer: () => Promise.resolve(mockBuffer.buffer),
+    });
+
+    const attachment: BlueBubblesAttachment = { guid: "att-private-ip" };
+    await downloadBlueBubblesAttachment(attachment, {
+      serverUrl: "http://192.168.1.5:1234",
+      password: "test",
+    });
+
+    const fetchMediaArgs = fetchRemoteMediaMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(fetchMediaArgs.ssrfPolicy).toEqual({ allowedHostnames: ["192.168.1.5"] });
   });
 });
 


### PR DESCRIPTION
## Summary

Auto-allowlist the configured `serverUrl` hostname when fetching BlueBubbles attachments, so localhost and private-IP setups work out of the box without requiring explicit `allowPrivateNetwork` config.

## Problem

After the SSRF security guard was introduced, BlueBubbles attachment downloads from the user's own configured `serverUrl` (typically `http://localhost:1234`) are silently blocked because `localhost` is classified as a private/special-use hostname. Users have no obvious workaround since the `allowPrivateNetwork` config field exists but is not discoverable.

Closes #27599

## Changes

- `extensions/bluebubbles/src/attachments.ts`: When `allowPrivateNetwork` is not explicitly set, extract the hostname from the resolved `serverUrl` and pass it as `allowedHostnames` in the SSRF policy. This is more targeted than blanket `allowPrivateNetwork: true` — only the specific configured server host is trusted.
- `extensions/bluebubbles/src/attachments.test.ts`: Updated existing test and added regression test for private IP serverUrl (`192.168.1.5`).
- `CHANGELOG.md`: Added fix entry.

## Test plan

- Existing test updated: verifies `allowedHostnames: ["localhost"]` is passed when `serverUrl` is `http://localhost:1234` and `allowPrivateNetwork` is not set.
- New regression test: verifies `allowedHostnames: ["192.168.1.5"]` for a private IP serverUrl.
- Existing `allowPrivateNetwork: true` test still passes (explicit config takes precedence).
- All 23 BlueBubbles attachment tests pass.
- `pnpm lint` and `pnpm format:check` clean.

## Effect on User Experience

Before: Inbound iMessage attachments silently dropped for any BlueBubbles user running the server on localhost or a private IP (the standard setup). Users had to discover and set `allowPrivateNetwork: true` manually.

After: Attachment downloads work automatically for the configured `serverUrl`. Zero config change needed for users. The explicit `allowPrivateNetwork` escape hatch still works for edge cases.
