### PR TITLE
fix(slack): remove redundant thread starter wrapper and system event preview

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -328,13 +328,12 @@ export async function runPreparedReply(
     prefixedBodyBase,
   });
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
-  const threadStarterBody = ctx.ThreadStarterBody?.trim();
   const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
+  // Only include thread history for context (full thread with replies)
+  // Thread starter wrapper is removed as redundant - the history already includes it
   const threadContextNote = threadHistoryBody
     ? `[Thread history - for context]\n${threadHistoryBody}`
-    : threadStarterBody
-      ? `[Thread starter - for context]\n${threadStarterBody}`
-      : undefined;
+    : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -539,7 +539,8 @@ export async function prepareSlackMessage(params: {
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0) {
+    // Only fetch thread history for NEW sessions (when there's no previous timestamp)
+    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,
@@ -627,7 +628,8 @@ export async function prepareSlackMessage(params: {
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
-    ThreadStarterBody: threadStarterBody,
+    // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
+    ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadHistoryBody: threadHistoryBody,
     IsFirstThreadTurn:
       isThreadReply && threadTs && !threadSessionPreviousTimestamp ? true : undefined,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -421,17 +421,17 @@ export async function prepareSlackMessage(params: {
       : null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
+  // Keep preview for logging/debugging
   const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-  const inboundLabel = isDirectMessage
-    ? `Slack DM from ${senderName}`
-    : `Slack message in ${roomLabel} from ${senderName}`;
   const slackFrom = isDirectMessage
     ? `slack:${message.user}`
     : isRoom
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+  // Add simple sender preamble for context (who is speaking in the thread)
+  // This is important for multi-human threads so the LLM can track participants
+  enqueueSystemEvent(`Slack message from ${senderName}`, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
   });


### PR DESCRIPTION
## Summary

- **Problem:** After the initial fix in #27609, there was still unnecessary token bloat from redundant context elements, while losing important sender information for multi-human threads.
- **Why it matters:** The LLM needs to know WHO is speaking in threads with multiple participants, but doesn't need verbose metadata like timestamps, channel names, and message previews.
- **What changed:**
  - Removed `[Thread starter - for context]` wrapper (thread starter is already in the thread history)
  - Reduced verbose system event from "System: [timestamp] Slack message in #channel from Sender: preview" to simple "Slack message from Sender"
- **What did NOT change:** Thread history is still correctly injected on the first message with full context including the thread starter and all replies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #27609 (initial fix for thread history bloat)

## User-visible / Behavior Changes

**Before this PR (after #27609):**
```
[Thread starter - for context]
<@U0AF3PBGARJ> hello

System: [2026-02-25 23:49:28 UTC] Slack message in #all-slack from Ahmed Mansour: great can you checnge the server setup so it is ET?

great can you checnge the server setup so it is ET?
```

**After this PR:**
```
Slack message from Ahmed Mansour

great can you checnge the server setup so it is ET?
```

For the first message in a new thread session, full thread history is provided:
```
[Thread history - for context]
[Slack Ahmed Mansour (user) Wed 2026-02-25 23:47 UTC] <@U0AF3PBGARJ> hello
[slack message id: 1772063261.652889 channel: C07KS209JKG]

[Slack comply (assistant) Wed 2026-02-25 23:47 UTC] Hello, Ahmed. What do you need?
[slack message id: 1772063271.635929 channel: C07KS209JKG]

Slack message from Ahmed Mansour

what time is it on the server currently
```

This preserves sender context for multi-human threads while removing verbose metadata.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

1. Start a Slack thread with multiple people (or simulate with different senders)
2. Send multiple follow-up replies
3. Check the session file in `~/.openclaw/agents/main/sessions/`
4. Verify: First message includes `[Thread history - for context]` with full thread
5. Verify: Subsequent messages show "Slack message from SenderName" (clean sender identification)
6. Verify: No `[Thread starter - for context]` wrapper appears

## AI-Assisted PR

- [x] Mark as AI-assisted in the PR title or description
- [ ] Include prompts or session logs if possible (super helpful!)
- [x] Confirm you understand what the code does

This PR was developed with Claude Sonnet 4.6. I understand the changes and have verified they reduce token bloat while preserving sender context for multi-human threads.

**Combined impact of #27609 + this PR:**
- #27609: Prevents thread history from being re-fetched on every message
- This PR: Removes redundant `[Thread starter - for context]` wrapper and reduces verbose system events to simple sender preamble