### PR TITLE
fix(cron): allow delivery mode "none" with sessionTarget "main"

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -235,6 +235,46 @@ describe("applyJobPatch", () => {
   });
 });
 
+describe("delivery mode none with sessionTarget main", () => {
+  it("allows delivery mode none on main session (createJob)", () => {
+    const now = Date.now();
+    const state = {
+      deps: { nowMs: () => now },
+    } as unknown as CronServiceState;
+
+    expect(() =>
+      createJob(state, {
+        name: "reminder",
+        enabled: true,
+        schedule: { kind: "at", atMs: now + 300_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "meeting reminder" },
+        delivery: { mode: "none" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows delivery mode none on main session (applyJobPatch)", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-none-main",
+      name: "job-none-main",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "ping" },
+      delivery: { mode: "none" },
+      state: {},
+    };
+
+    expect(() => applyJobPatch(job, { enabled: false })).not.toThrow();
+  });
+});
+
 function createMockState(now: number): CronServiceState {
   return {
     deps: {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -101,7 +101,7 @@ function validateTelegramDeliveryTarget(to: string | undefined): string | undefi
 }
 
 function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
-  if (!job.delivery) {
+  if (!job.delivery || job.delivery.mode === "none") {
     return;
   }
   if (job.delivery.mode === "webhook") {


### PR DESCRIPTION
## Summary

Fixes #27431

`assertDeliverySupport()` only skipped delivery validation when `job.delivery` was falsy. When the agent set `delivery: { mode: "none" }` (as instructed by cron tool guidance), the truthy object triggered the isolated-only check, rejecting valid main-session cron jobs with:

```
cron channel delivery config is only supported for sessionTarget="isolated"
```

## Fix

One-line change: return early from `assertDeliverySupport()` when `job.delivery.mode === "none"`, consistent with the existing early return for absent delivery.

## Tests

Added 2 tests covering both `createJob` and `applyJobPatch` paths with `delivery: { mode: "none" }` on `sessionTarget: "main"`. All 20 tests pass.