### PR TITLE
fix: prevent head-of-line blocking in delivery queue recovery

### DIFF
--- a/src/infra/outbound/delivery-queue.hol-blocking.test.ts
+++ b/src/infra/outbound/delivery-queue.hol-blocking.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { recoverPendingDeliveries, type DeliverFn } from "./delivery-queue.js";
+
+const QUEUE_DIRNAME = "delivery-queue";
+
+function makeEntry(id: string, retryCount: number, enqueuedAt: number): Record<string, unknown> {
+  return {
+    id,
+    channel: "slack",
+    to: "C123",
+    accountId: "acct",
+    payloads: [{ text: `test-${id}` }],
+    retryCount,
+    enqueuedAt,
+    lastAttemptAt: enqueuedAt + 1000,
+  };
+}
+
+describe("recoverPendingDeliveries — head-of-line blocking fix (#27638)", () => {
+  let tmpDir: string;
+  let queueDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dq-hol-test-"));
+    queueDir = path.join(tmpDir, QUEUE_DIRNAME);
+    fs.mkdirSync(queueDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeEntry(entry: Record<string, unknown>) {
+    const filePath = path.join(queueDir, `${String(entry.id)}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(entry));
+  }
+
+  it("skips high-backoff entries and still processes lower-retry entries", async () => {
+    const now = Date.now();
+    // Entry A: retryCount=3 → backoff=120s (exceeds 60s budget)
+    // Entry B: retryCount=0 → backoff=5s (fits in budget)
+    // Entry C: retryCount=0 → backoff=5s (fits in budget)
+    writeEntry(makeEntry("entry-a", 3, now - 30_000)); // oldest, high retry
+    writeEntry(makeEntry("entry-b", 0, now - 20_000)); // newer, low retry
+    writeEntry(makeEntry("entry-c", 0, now - 10_000)); // newest, low retry
+
+    const delivered: string[] = [];
+    const deliverFn: DeliverFn = async (params) => {
+      const text = (params.payloads as Array<{ text?: string }>)?.[0]?.text ?? "";
+      delivered.push(text);
+    };
+
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const result = await recoverPendingDeliveries({
+      deliver: deliverFn,
+      log,
+      cfg: {} as never,
+      stateDir: tmpDir,
+      delay: async () => {}, // instant delays for test
+      maxRecoveryMs: 60_000,
+    });
+
+    // Entry A should be skipped (backoff exceeds budget), B and C recovered
+    expect(result.recovered).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(delivered).toContain("test-entry-b");
+    expect(delivered).toContain("test-entry-c");
+    expect(delivered).not.toContain("test-entry-a");
+
+    // Verify the skip was logged
+    const skipLogs = log.info.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("skipping to next entry"),
+    );
+    expect(skipLogs.length).toBe(1);
+    expect(skipLogs[0][0]).toContain("entry-a");
+  });
+});


### PR DESCRIPTION
## Problem

`recoverPendingDeliveries()` in `delivery-queue.ts` sorts pending entries oldest-first and iterates with exponential backoff. When **any** entry's computed backoff exceeds the remaining recovery budget (default 60s), the code `break`s the entire loop — **permanently starving every subsequent entry**, regardless of their retry count.

With the default backoff schedule (`5s, 25s, 120s, 600s`), any entry at `retryCount >= 2` (backoff = 120s) will block all entries behind it. Since oldest-first sorting ensures high-retry entries are always processed first, this creates a permanent deadlock:

```
Found 7 pending delivery entries — starting recovery
Recovery time budget exceeded — 7 entries deferred to next restart
```

This repeats every restart indefinitely, with 0 entries ever recovered.

## Fix

Change the budget-exceeded `break` to `continue` + `skipped++`, so individual high-backoff entries are skipped while newer entries with shorter backoffs are still processed. The skipped entries will be retried on a subsequent recovery pass when their backoff period has elapsed.

```diff
 if (now + backoff >= deadline) {
-  const deferred = pending.length - recovered - failed - skipped;
-  opts.log.warn(`Recovery time budget exceeded — ...`);
-  break;
+  skipped += 1;
+  opts.log.info(`Backoff ...ms exceeds remaining budget for ... — skipping to next entry`);
+  continue;
 }
```

The first `break` (wall-clock deadline exceeded) is preserved — it correctly stops the loop when we've genuinely run out of time.

## Test

Added `delivery-queue.hol-blocking.test.ts` that verifies:
- A high-retry entry (retryCount=3, backoff=120s) is skipped
- Two low-retry entries (retryCount=0, backoff=5s) behind it are still recovered
- The skip is properly logged

Fixes #27638