### PR TITLE
fix(line): avoid false WARN in status when tokenFile is used

### DIFF
--- a/extensions/line/src/channel.status-issues.test.ts
+++ b/extensions/line/src/channel.status-issues.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { linePlugin } from "./channel.js";
+
+const DEFAULT_ACCOUNT_ID = "default";
+
+describe("linePlugin.status.collectStatusIssues", () => {
+  it("does not warn when snapshot indicates token+secret present", () => {
+    const issues = linePlugin.status!.collectStatusIssues!([
+      {
+        accountId: DEFAULT_ACCOUNT_ID,
+        hasChannelAccessToken: true,
+        hasChannelSecret: true,
+      },
+    ] as any);
+
+    expect(issues).toEqual([]);
+  });
+
+  it("warns when snapshot indicates missing token", () => {
+    const issues = linePlugin.status!.collectStatusIssues!([
+      {
+        accountId: DEFAULT_ACCOUNT_ID,
+        hasChannelAccessToken: false,
+        hasChannelSecret: true,
+      },
+    ] as any);
+
+    expect(issues.map((i) => i.message)).toContain("LINE channel access token not configured");
+  });
+
+  it("warns when snapshot indicates missing secret", () => {
+    const issues = linePlugin.status!.collectStatusIssues!([
+      {
+        accountId: DEFAULT_ACCOUNT_ID,
+        hasChannelAccessToken: true,
+        hasChannelSecret: false,
+      },
+    ] as any);
+
+    expect(issues.map((i) => i.message)).toContain("LINE channel secret not configured");
+  });
+});

--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -27,6 +27,15 @@ describe("sameFileIdentity", () => {
     expect(sameFileIdentity(stat(7, 11), stat(8, 11), "win32")).toBe(false);
   });
 
+  it("accepts win32 inode mismatch when either side is 0", () => {
+    expect(sameFileIdentity(stat(7, 0), stat(7, 12), "win32")).toBe(true);
+    expect(sameFileIdentity(stat(7, 11), stat(7, 0), "win32")).toBe(true);
+  });
+
+  it("keeps inode strictness on non-windows", () => {
+    expect(sameFileIdentity(stat(7, 0), stat(7, 12), "linux")).toBe(false);
+  });
+
   it("handles bigint stats", () => {
     expect(sameFileIdentity(stat(0n, 11n), stat(8n, 11n), "win32")).toBe(true);
   });

--- a/src/infra/file-identity.ts
+++ b/src/infra/file-identity.ts
@@ -13,7 +13,11 @@ export function sameFileIdentity(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (left.ino !== right.ino) {
-    return false;
+    // On Windows, either side can report ino=0 for some filesystem / API combinations
+    // (especially path-based stats vs fd-based stats). Treat ino=0 as "unknown".
+    if (platform !== "win32" || (!isZero(left.ino) && !isZero(right.ino))) {
+      return false;
+    }
   }
 
   // On Windows, path-based stat calls can report dev=0 while fd-based stat


### PR DESCRIPTION
### Problem\n\n`openclaw status --deep` could show contradictory LINE results:\n\n- **Channels**: WARN ("LINE channel access token not configured")\n- **Health**: OK (probe succeeds)\n\nRoot cause: `collectStatusIssues()` receives **account snapshots** (from `buildAccountSnapshot`), which intentionally do not include secret values. The LINE plugin was incorrectly checking `account.channelAccessToken` / `account.channelSecret` on snapshots, producing false WARN.\n\n### Fix\n\n- Add boolean flags to LINE account snapshots: `hasChannelAccessToken` / `hasChannelSecret`\n- Update `collectStatusIssues()` to use those flags instead of secret fields\n- Add unit tests covering the behavior\n\n### Notes\n\nNo secrets are added to snapshots; only booleans.