### PR TITLE
feat(android): add node device status/info commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - ACP/Thread-bound agents: make ACP agents first-class runtimes for thread sessions with `acp` spawn/send dispatch integration, acpx backend bridging, lifecycle controls, startup reconciliation, runtime cleanup, and coalesced thread replies. (#23580) thanks @osolmaz.
 - Onboarding/Plugins: let channel plugins own interactive onboarding flows with optional `configureInteractive` and `configureWhenConfigured` hooks while preserving the generic fallback path. (#27191) thanks @gumadeiras.
 - Android/Nodes: add `notifications.list` support on Android nodes and expose `nodes notifications_list` in agent tooling for listing active device notifications. (#27344) thanks @obviyus.
+- Android/Nodes: add Android `device` capability plus `device.status` and `device.info` node commands, including runtime handler wiring and protocol/registry coverage for device status/info payloads. (#27664) Thanks @obviyus.
 
 ### Fixes
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -92,6 +92,10 @@ class NodeRuntime(context: Context) {
     locationPreciseEnabled = { locationPreciseEnabled.value },
   )
 
+  private val deviceHandler: DeviceHandler = DeviceHandler(
+    appContext = appContext,
+  )
+
   private val notificationsHandler: NotificationsHandler = NotificationsHandler(
     appContext = appContext,
   )
@@ -127,6 +131,7 @@ class NodeRuntime(context: Context) {
     canvas = canvas,
     cameraHandler = cameraHandler,
     locationHandler = locationHandler,
+    deviceHandler = deviceHandler,
     notificationsHandler = notificationsHandler,
     screenHandler = screenHandler,
     smsHandler = smsHandlerImpl,

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -85,6 +85,7 @@ class ConnectionManager(
     buildList {
       add(OpenClawCapability.Canvas.rawValue)
       add(OpenClawCapability.Screen.rawValue)
+      add(OpenClawCapability.Device.rawValue)
       if (cameraEnabled()) add(OpenClawCapability.Camera.rawValue)
       if (smsAvailable()) add(OpenClawCapability.Sms.rawValue)
       if (voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission()) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
@@ -129,9 +129,6 @@ class DeviceHandler(
   }
 
   private fun mapThermalState(powerManager: PowerManager?): String {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-      return "nominal"
-    }
     val thermal = powerManager?.currentThermalStatus ?: return "nominal"
     return when (thermal) {
       PowerManager.THERMAL_STATUS_NONE, PowerManager.THERMAL_STATUS_LIGHT -> "nominal"

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
@@ -1,0 +1,174 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Environment
+import android.os.PowerManager
+import android.os.StatFs
+import android.os.SystemClock
+import ai.openclaw.android.BuildConfig
+import ai.openclaw.android.gateway.GatewaySession
+import java.util.Locale
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class DeviceHandler(
+  private val appContext: Context,
+) {
+  fun handleDeviceStatus(_paramsJson: String?): GatewaySession.InvokeResult {
+    return GatewaySession.InvokeResult.ok(statusPayloadJson())
+  }
+
+  fun handleDeviceInfo(_paramsJson: String?): GatewaySession.InvokeResult {
+    return GatewaySession.InvokeResult.ok(infoPayloadJson())
+  }
+
+  private fun statusPayloadJson(): String {
+    val batteryIntent = appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+    val batteryStatus =
+      batteryIntent?.getIntExtra(BatteryManager.EXTRA_STATUS, BatteryManager.BATTERY_STATUS_UNKNOWN)
+        ?: BatteryManager.BATTERY_STATUS_UNKNOWN
+    val batteryLevel = batteryLevelFraction(batteryIntent)
+    val powerManager = appContext.getSystemService(PowerManager::class.java)
+    val storage = StatFs(Environment.getDataDirectory().absolutePath)
+    val totalBytes = storage.totalBytes
+    val freeBytes = storage.availableBytes
+    val usedBytes = (totalBytes - freeBytes).coerceAtLeast(0L)
+    val connectivity = appContext.getSystemService(ConnectivityManager::class.java)
+    val activeNetwork = connectivity?.activeNetwork
+    val caps = activeNetwork?.let { connectivity.getNetworkCapabilities(it) }
+    val uptimeSeconds = SystemClock.elapsedRealtime() / 1_000.0
+
+    return buildJsonObject {
+      put(
+        "battery",
+        buildJsonObject {
+          batteryLevel?.let { put("level", JsonPrimitive(it)) }
+          put("state", JsonPrimitive(mapBatteryState(batteryStatus)))
+          put("lowPowerModeEnabled", JsonPrimitive(powerManager?.isPowerSaveMode == true))
+        },
+      )
+      put(
+        "thermal",
+        buildJsonObject {
+          put("state", JsonPrimitive(mapThermalState(powerManager)))
+        },
+      )
+      put(
+        "storage",
+        buildJsonObject {
+          put("totalBytes", JsonPrimitive(totalBytes))
+          put("freeBytes", JsonPrimitive(freeBytes))
+          put("usedBytes", JsonPrimitive(usedBytes))
+        },
+      )
+      put(
+        "network",
+        buildJsonObject {
+          put("status", JsonPrimitive(mapNetworkStatus(caps)))
+          put(
+            "isExpensive",
+            JsonPrimitive(
+              caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)?.not() ?: false,
+            ),
+          )
+          put(
+            "isConstrained",
+            JsonPrimitive(
+              caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)?.not() ?: false,
+            ),
+          )
+          put("interfaces", networkInterfacesJson(caps))
+        },
+      )
+      put("uptimeSeconds", JsonPrimitive(uptimeSeconds))
+    }.toString()
+  }
+
+  private fun infoPayloadJson(): String {
+    val model = Build.MODEL?.trim().orEmpty()
+    val manufacturer = Build.MANUFACTURER?.trim().orEmpty()
+    val modelIdentifier = Build.DEVICE?.trim().orEmpty()
+    val systemVersion = Build.VERSION.RELEASE?.trim().orEmpty()
+    val locale = Locale.getDefault().toLanguageTag().trim()
+    val appVersion = BuildConfig.VERSION_NAME.trim()
+    val appBuild = BuildConfig.VERSION_CODE.toString()
+
+    return buildJsonObject {
+      put("deviceName", JsonPrimitive(model.ifEmpty { "Android" }))
+      put("modelIdentifier", JsonPrimitive(modelIdentifier.ifEmpty { listOf(manufacturer, model).filter { it.isNotEmpty() }.joinToString(" ") }))
+      put("systemName", JsonPrimitive("Android"))
+      put("systemVersion", JsonPrimitive(systemVersion.ifEmpty { Build.VERSION.SDK_INT.toString() }))
+      put("appVersion", JsonPrimitive(appVersion.ifEmpty { "dev" }))
+      put("appBuild", JsonPrimitive(appBuild.ifEmpty { "0" }))
+      put("locale", JsonPrimitive(locale.ifEmpty { Locale.getDefault().toString() }))
+    }.toString()
+  }
+
+  private fun batteryLevelFraction(intent: Intent?): Double? {
+    val rawLevel = intent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+    val rawScale = intent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+    if (rawLevel < 0 || rawScale <= 0) return null
+    return rawLevel.toDouble() / rawScale.toDouble()
+  }
+
+  private fun mapBatteryState(status: Int): String {
+    return when (status) {
+      BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
+      BatteryManager.BATTERY_STATUS_FULL -> "full"
+      BatteryManager.BATTERY_STATUS_DISCHARGING, BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "unplugged"
+      else -> "unknown"
+    }
+  }
+
+  private fun mapThermalState(powerManager: PowerManager?): String {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return "nominal"
+    }
+    val thermal = powerManager?.currentThermalStatus ?: return "nominal"
+    return when (thermal) {
+      PowerManager.THERMAL_STATUS_NONE, PowerManager.THERMAL_STATUS_LIGHT -> "nominal"
+      PowerManager.THERMAL_STATUS_MODERATE -> "fair"
+      PowerManager.THERMAL_STATUS_SEVERE -> "serious"
+      PowerManager.THERMAL_STATUS_CRITICAL,
+      PowerManager.THERMAL_STATUS_EMERGENCY,
+      PowerManager.THERMAL_STATUS_SHUTDOWN -> "critical"
+      else -> "nominal"
+    }
+  }
+
+  private fun mapNetworkStatus(caps: NetworkCapabilities?): String {
+    if (caps == null) return "unsatisfied"
+    return if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+      "satisfied"
+    } else {
+      "requiresConnection"
+    }
+  }
+
+  private fun networkInterfacesJson(caps: NetworkCapabilities?) =
+    buildJsonArray {
+      if (caps == null) return@buildJsonArray
+      var hasKnownTransport = false
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+        hasKnownTransport = true
+        add(JsonPrimitive("wifi"))
+      }
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+        hasKnownTransport = true
+        add(JsonPrimitive("cellular"))
+      }
+      if (caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+        hasKnownTransport = true
+        add(JsonPrimitive("wired"))
+      }
+      if (!hasKnownTransport) add(JsonPrimitive("other"))
+    }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceHandler.kt
@@ -143,10 +143,10 @@ class DeviceHandler(
 
   private fun mapNetworkStatus(caps: NetworkCapabilities?): String {
     if (caps == null) return "unsatisfied"
-    return if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
-      "satisfied"
-    } else {
-      "requiresConnection"
+    return when {
+      caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) -> "satisfied"
+      caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) -> "requiresConnection"
+      else -> "unsatisfied"
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeCommandRegistry.kt
@@ -3,6 +3,7 @@ package ai.openclaw.android.node
 import ai.openclaw.android.protocol.OpenClawCanvasA2UICommand
 import ai.openclaw.android.protocol.OpenClawCanvasCommand
 import ai.openclaw.android.protocol.OpenClawCameraCommand
+import ai.openclaw.android.protocol.OpenClawDeviceCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
 import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawScreenCommand
@@ -74,6 +75,12 @@ object InvokeCommandRegistry {
       InvokeCommandSpec(
         name = OpenClawLocationCommand.Get.rawValue,
         availability = InvokeCommandAvailability.LocationEnabled,
+      ),
+      InvokeCommandSpec(
+        name = OpenClawDeviceCommand.Status.rawValue,
+      ),
+      InvokeCommandSpec(
+        name = OpenClawDeviceCommand.Info.rawValue,
       ),
       InvokeCommandSpec(
         name = OpenClawNotificationsCommand.List.rawValue,

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -4,6 +4,7 @@ import ai.openclaw.android.gateway.GatewaySession
 import ai.openclaw.android.protocol.OpenClawCanvasA2UICommand
 import ai.openclaw.android.protocol.OpenClawCanvasCommand
 import ai.openclaw.android.protocol.OpenClawCameraCommand
+import ai.openclaw.android.protocol.OpenClawDeviceCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
 import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawScreenCommand
@@ -13,6 +14,7 @@ class InvokeDispatcher(
   private val canvas: CanvasController,
   private val cameraHandler: CameraHandler,
   private val locationHandler: LocationHandler,
+  private val deviceHandler: DeviceHandler,
   private val notificationsHandler: NotificationsHandler,
   private val screenHandler: ScreenHandler,
   private val smsHandler: SmsHandler,
@@ -115,6 +117,10 @@ class InvokeDispatcher(
 
       // Location command
       OpenClawLocationCommand.Get.rawValue -> locationHandler.handleLocationGet(paramsJson)
+
+      // Device commands
+      OpenClawDeviceCommand.Status.rawValue -> deviceHandler.handleDeviceStatus(paramsJson)
+      OpenClawDeviceCommand.Info.rawValue -> deviceHandler.handleDeviceInfo(paramsJson)
 
       // Notifications command
       OpenClawNotificationsCommand.List.rawValue -> notificationsHandler.handleNotificationsList(paramsJson)

--- a/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/protocol/OpenClawProtocolConstants.kt
@@ -7,6 +7,7 @@ enum class OpenClawCapability(val rawValue: String) {
   Sms("sms"),
   VoiceWake("voiceWake"),
   Location("location"),
+  Device("device"),
 }
 
 enum class OpenClawCanvasCommand(val rawValue: String) {
@@ -67,6 +68,16 @@ enum class OpenClawLocationCommand(val rawValue: String) {
 
   companion object {
     const val NamespacePrefix: String = "location."
+  }
+}
+
+enum class OpenClawDeviceCommand(val rawValue: String) {
+  Status("device.status"),
+  Info("device.info"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "device."
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/DeviceHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/DeviceHandlerTest.kt
@@ -1,0 +1,82 @@
+package ai.openclaw.android.node
+
+import android.content.Context
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceHandlerTest {
+  @Test
+  fun handleDeviceInfo_returnsStablePayload() {
+    val handler = DeviceHandler(appContext())
+
+    val result = handler.handleDeviceInfo(null)
+
+    assertTrue(result.ok)
+    val payload = parsePayload(result.payloadJson)
+    assertEquals("Android", payload.getValue("systemName").jsonPrimitive.content)
+    assertTrue(payload.getValue("deviceName").jsonPrimitive.content.isNotBlank())
+    assertTrue(payload.getValue("modelIdentifier").jsonPrimitive.content.isNotBlank())
+    assertTrue(payload.getValue("systemVersion").jsonPrimitive.content.isNotBlank())
+    assertTrue(payload.getValue("appVersion").jsonPrimitive.content.isNotBlank())
+    assertTrue(payload.getValue("appBuild").jsonPrimitive.content.isNotBlank())
+    assertTrue(payload.getValue("locale").jsonPrimitive.content.isNotBlank())
+  }
+
+  @Test
+  fun handleDeviceStatus_returnsExpectedShape() {
+    val handler = DeviceHandler(appContext())
+
+    val result = handler.handleDeviceStatus(null)
+
+    assertTrue(result.ok)
+    val payload = parsePayload(result.payloadJson)
+    val battery = payload.getValue("battery").jsonObject
+    val storage = payload.getValue("storage").jsonObject
+    val thermal = payload.getValue("thermal").jsonObject
+    val network = payload.getValue("network").jsonObject
+
+    val state = battery.getValue("state").jsonPrimitive.content
+    assertTrue(state in setOf("unknown", "unplugged", "charging", "full"))
+    battery["level"]?.jsonPrimitive?.double?.let { level ->
+      assertTrue(level in 0.0..1.0)
+    }
+    battery.getValue("lowPowerModeEnabled").jsonPrimitive.boolean
+
+    val totalBytes = storage.getValue("totalBytes").jsonPrimitive.content.toLong()
+    val freeBytes = storage.getValue("freeBytes").jsonPrimitive.content.toLong()
+    val usedBytes = storage.getValue("usedBytes").jsonPrimitive.content.toLong()
+    assertTrue(totalBytes >= 0L)
+    assertTrue(freeBytes >= 0L)
+    assertTrue(usedBytes >= 0L)
+    assertEquals((totalBytes - freeBytes).coerceAtLeast(0L), usedBytes)
+
+    val thermalState = thermal.getValue("state").jsonPrimitive.content
+    assertTrue(thermalState in setOf("nominal", "fair", "serious", "critical"))
+
+    val networkStatus = network.getValue("status").jsonPrimitive.content
+    assertTrue(networkStatus in setOf("satisfied", "unsatisfied", "requiresConnection"))
+    val interfaces = network.getValue("interfaces").jsonArray.map { it.jsonPrimitive.content }
+    assertTrue(interfaces.all { it in setOf("wifi", "cellular", "wired", "other") })
+
+    assertTrue(payload.getValue("uptimeSeconds").jsonPrimitive.double >= 0.0)
+  }
+
+  private fun appContext(): Context = RuntimeEnvironment.getApplication()
+
+  private fun parsePayload(payloadJson: String?): JsonObject {
+    val jsonString = payloadJson ?: error("expected payload")
+    return Json.parseToJsonElement(jsonString).jsonObject
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.node
 
 import ai.openclaw.android.protocol.OpenClawCameraCommand
+import ai.openclaw.android.protocol.OpenClawDeviceCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
 import ai.openclaw.android.protocol.OpenClawNotificationsCommand
 import ai.openclaw.android.protocol.OpenClawSmsCommand
@@ -22,6 +23,8 @@ class InvokeCommandRegistryTest {
     assertFalse(commands.contains(OpenClawCameraCommand.Snap.rawValue))
     assertFalse(commands.contains(OpenClawCameraCommand.Clip.rawValue))
     assertFalse(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(OpenClawDeviceCommand.Status.rawValue))
+    assertTrue(commands.contains(OpenClawDeviceCommand.Info.rawValue))
     assertTrue(commands.contains(OpenClawNotificationsCommand.List.rawValue))
     assertFalse(commands.contains(OpenClawSmsCommand.Send.rawValue))
     assertFalse(commands.contains("debug.logs"))
@@ -42,6 +45,8 @@ class InvokeCommandRegistryTest {
     assertTrue(commands.contains(OpenClawCameraCommand.Snap.rawValue))
     assertTrue(commands.contains(OpenClawCameraCommand.Clip.rawValue))
     assertTrue(commands.contains(OpenClawLocationCommand.Get.rawValue))
+    assertTrue(commands.contains(OpenClawDeviceCommand.Status.rawValue))
+    assertTrue(commands.contains(OpenClawDeviceCommand.Info.rawValue))
     assertTrue(commands.contains(OpenClawNotificationsCommand.List.rawValue))
     assertTrue(commands.contains(OpenClawSmsCommand.Send.rawValue))
     assertTrue(commands.contains("debug.logs"))

--- a/apps/android/app/src/test/java/ai/openclaw/android/protocol/OpenClawProtocolConstantsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/protocol/OpenClawProtocolConstantsTest.kt
@@ -26,6 +26,9 @@ class OpenClawProtocolConstantsTest {
     assertEquals("camera", OpenClawCapability.Camera.rawValue)
     assertEquals("screen", OpenClawCapability.Screen.rawValue)
     assertEquals("voiceWake", OpenClawCapability.VoiceWake.rawValue)
+    assertEquals("location", OpenClawCapability.Location.rawValue)
+    assertEquals("sms", OpenClawCapability.Sms.rawValue)
+    assertEquals("device", OpenClawCapability.Device.rawValue)
   }
 
   @Test
@@ -36,5 +39,11 @@ class OpenClawProtocolConstantsTest {
   @Test
   fun notificationsCommandsUseStableStrings() {
     assertEquals("notifications.list", OpenClawNotificationsCommand.List.rawValue)
+  }
+
+  @Test
+  fun deviceCommandsUseStableStrings() {
+    assertEquals("device.status", OpenClawDeviceCommand.Status.rawValue)
+    assertEquals("device.info", OpenClawDeviceCommand.Info.rawValue)
   }
 }


### PR DESCRIPTION
## Summary
- add Android node `device` capability with `device.status` and `device.info` commands
- implement `DeviceHandler` and wire dispatcher/runtime/command registry
- add protocol + registry + handler tests

## Validation
- emulator + gateway smoke via `openclaw nodes invoke` for `device.status` and `device.info` returned `ok: true`
