### PR TITLE
fix(gateway): hide assistant NO_REPLY token in chat.history

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -110,7 +110,7 @@ afterAll(() => {
   }
 });
 
-describe("loadOpenClawPlugins", () => {
+describe.sequential("loadOpenClawPlugins", () => {
   it("disables bundled plugins by default", () => {
     const bundledDir = makeTempDir();
     writePlugin({


### PR DESCRIPTION
## Summary
- sanitize `chat.history` assistant text fields to strip silent-token-only `NO_REPLY` content
- apply the same filtering to string, `text`, and text content-block forms after directive stripping
- add gateway history coverage to ensure assistant `NO_REPLY` is hidden while user `NO_REPLY` remains unchanged

## Testing
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-chat.agent-events.test.ts`
- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat.test.ts`

Fixes #27238
