### PR TITLE
feat(diagnostics): trace context propagation + log transport isolation fix

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -12,6 +12,10 @@ import {
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  createChildContext,
+  diagnosticTraceStore,
+} from "../../../infra/diagnostic-trace-context.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -303,7 +307,14 @@ function summarizeSessionContext(messages: AgentMessage[]): {
   };
 }
 
+/** Thin wrapper that establishes a child trace context for this LLM attempt. */
 export async function runEmbeddedAttempt(
+  params: EmbeddedRunAttemptParams,
+): Promise<EmbeddedRunAttemptResult> {
+  return diagnosticTraceStore.run(createChildContext(), () => runEmbeddedAttemptInner(params));
+}
+
+async function runEmbeddedAttemptInner(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -4,6 +4,7 @@ import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { createTraceContext, diagnosticTraceStore } from "../../infra/diagnostic-trace-context.js";
 import {
   logMessageProcessed,
   logMessageQueued,
@@ -81,7 +82,18 @@ export type DispatchFromConfigResult = {
   counts: Record<ReplyDispatchKind, number>;
 };
 
+/** Thin wrapper that establishes a root trace context for the full message lifecycle. */
 export async function dispatchReplyFromConfig(params: {
+  ctx: FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  dispatcher: ReplyDispatcher;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyResolver?: typeof getReplyFromConfig;
+}): Promise<DispatchFromConfigResult> {
+  return diagnosticTraceStore.run(createTraceContext(), () => dispatchReplyFromConfigInner(params));
+}
+
+async function dispatchReplyFromConfigInner(params: {
   ctx: FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -2,9 +2,20 @@ import type { OpenClawConfig } from "../config/config.js";
 
 export type DiagnosticSessionState = "idle" | "processing" | "waiting";
 
+/** Lightweight trace context carried on diagnostic events for span correlation. */
+export type DiagnosticTraceContext = {
+  /** 32 hex chars, same across one message lifecycle. */
+  traceId: string;
+  /** 16 hex chars, unique per operation. */
+  spanId: string;
+  /** 16 hex chars, links child to parent. */
+  parentSpanId?: string;
+};
+
 type DiagnosticBaseEvent = {
   ts: number;
   seq: number;
+  traceCtx?: DiagnosticTraceContext;
 };
 
 export type DiagnosticUsageEvent = DiagnosticBaseEvent & {

--- a/src/infra/diagnostic-trace-context.test.ts
+++ b/src/infra/diagnostic-trace-context.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  createChildContext,
+  createTraceContext,
+  currentTraceContext,
+  diagnosticTraceStore,
+} from "./diagnostic-trace-context.js";
+
+describe("diagnostic-trace-context", () => {
+  describe("createTraceContext", () => {
+    it("produces a valid root context with 32-char traceId and 16-char spanId", () => {
+      const ctx = createTraceContext();
+      expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(ctx.parentSpanId).toBeUndefined();
+    });
+
+    it("generates unique IDs across calls", () => {
+      const a = createTraceContext();
+      const b = createTraceContext();
+      expect(a.traceId).not.toBe(b.traceId);
+      expect(a.spanId).not.toBe(b.spanId);
+    });
+  });
+
+  describe("createChildContext", () => {
+    it("preserves parent traceId and sets parentSpanId", () => {
+      const parent = createTraceContext();
+      const child = createChildContext(parent);
+      expect(child.traceId).toBe(parent.traceId);
+      expect(child.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(child.spanId).not.toBe(parent.spanId);
+      expect(child.parentSpanId).toBe(parent.spanId);
+    });
+
+    it("reads parent from AsyncLocalStorage when no explicit parent given", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        const child = createChildContext();
+        expect(child.traceId).toBe(root.traceId);
+        expect(child.parentSpanId).toBe(root.spanId);
+      });
+    });
+
+    it("creates a new root context when no parent exists anywhere", () => {
+      // Outside any diagnosticTraceStore.run(), with no explicit parent
+      const ctx = createChildContext();
+      expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(ctx.parentSpanId).toBeUndefined();
+    });
+  });
+
+  describe("currentTraceContext", () => {
+    it("returns undefined outside of a store run", () => {
+      expect(currentTraceContext()).toBeUndefined();
+    });
+
+    it("returns the active context inside a store run", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        expect(currentTraceContext()).toBe(root);
+      });
+    });
+
+    it("returns nested child context after re-wrapping", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        expect(currentTraceContext()).toBe(root);
+        const child = createChildContext();
+        await diagnosticTraceStore.run(child, async () => {
+          expect(currentTraceContext()).toBe(child);
+          expect(currentTraceContext()?.traceId).toBe(root.traceId);
+          expect(currentTraceContext()?.parentSpanId).toBe(root.spanId);
+        });
+        // After child run completes, parent context is restored
+        expect(currentTraceContext()).toBe(root);
+      });
+    });
+  });
+
+  describe("async propagation", () => {
+    it("propagates trace context across async boundaries", async () => {
+      const root = createTraceContext();
+      await diagnosticTraceStore.run(root, async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        expect(currentTraceContext()).toBe(root);
+
+        // Simulate nested async work
+        const result = await Promise.resolve().then(() => {
+          return currentTraceContext();
+        });
+        expect(result).toBe(root);
+      });
+    });
+  });
+});

--- a/src/infra/diagnostic-trace-context.ts
+++ b/src/infra/diagnostic-trace-context.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+import type { DiagnosticTraceContext } from "./diagnostic-events.js";
+
+/**
+ * AsyncLocalStorage-based trace context for diagnostic events.
+ *
+ * Wrap hot-path entry points with `diagnosticTraceStore.run(ctx, fn)` to
+ * establish a trace context that nested code can read via `currentTraceContext()`.
+ * This avoids threading a `traceCtx` parameter through every function signature.
+ */
+export const diagnosticTraceStore = new AsyncLocalStorage<DiagnosticTraceContext>();
+
+/** Create a new root trace context (new traceId + spanId). */
+export function createTraceContext(): DiagnosticTraceContext {
+  return {
+    traceId: randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+  };
+}
+
+/**
+ * Create a child trace context that shares the parent's traceId.
+ * If no parent is provided, reads from AsyncLocalStorage.
+ * If no context exists at all, creates a new root context.
+ */
+export function createChildContext(parent?: DiagnosticTraceContext): DiagnosticTraceContext {
+  const p = parent ?? diagnosticTraceStore.getStore();
+  return {
+    traceId: p?.traceId ?? randomBytes(16).toString("hex"),
+    spanId: randomBytes(8).toString("hex"),
+    parentSpanId: p?.spanId,
+  };
+}
+
+/** Get the current trace context from AsyncLocalStorage, or undefined if none. */
+export function currentTraceContext(): DiagnosticTraceContext | undefined {
+  return diagnosticTraceStore.getStore();
+}


### PR DESCRIPTION
## Summary

- **Problem:** The `diagnostics-otel` extension produces only disconnected point
  spans with no parent-child hierarchy. Operators cannot see the end-to-end flow
  of a message through routing, agent execution, and LLM calls. Additionally,
  the log transport registry in `logger.ts` has the same module-isolation bug
  that PR #12897 fixed for the diagnostic event bus -- `externalTransports` is
  module-scoped and may not survive jiti/bundler splitting.
- **Why it matters:** Without trace hierarchy, OTel traces in Jaeger/Fiddler/etc.
  are a flat list of unrelated spans. This makes latency debugging and cost
  attribution impossible. The log transport bug means OTel log export may
  silently fail depending on how the bundler resolves modules.
- **What changed:** (1) Log transport registry now uses a `globalThis` singleton
  matching the pattern PR #12897 established for the event bus. (2) New
  `DiagnosticTraceContext` type on all diagnostic events. (3) New
  `AsyncLocalStorage`-based trace context store with factory functions. (4) Hot
  path entry points (`dispatchReplyFromConfig`, `runEmbeddedAttempt`) wrapped
  with thin wrapper functions that establish trace context -- original function
  bodies renamed to `*Inner` and left untouched to avoid indentation churn.
- **What did NOT change:** No new dependencies, no config schema changes, no new
  diagnostic event types emitted yet. The OTel plugin is not modified in this PR
  -- it will consume the trace context in a follow-up PR. This is a pure
  foundation PR.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #8249 (Enhanced OTel trace context for tool call correlation)
- Related #13608 (Add metrics and observability support)
- Builds on #12897 (globalThis event bus fix -- same pattern applied to log transport)
- Supersedes #12475 (log transport Symbol.for fix -- same intent, different pattern)

## User-visible / Behavior Changes

No user-visible changes in this PR. This is infrastructure that enables
hierarchical OTel traces in a follow-up PR. The log transport fix may resolve
silent OTel log export failures for users who had the module isolation issue.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node v22+
- Test framework: Vitest 4.0.18

### Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm build` (verify compilation)
3. `pnpm test -- --run src/infra/diagnostic-trace-context.test.ts src/logging/`
   (verify 54/54 tests pass)
4. `pnpm lint` (verify 0 warnings, 0 errors)

### Expected

All tests pass. Build succeeds. No lint errors.

### Actual

All tests pass. Build succeeds. No lint errors.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Test output (9 new tests, all passing):

```
 ✓ src/infra/diagnostic-trace-context.test.ts (9 tests) 4ms
   ✓ createTraceContext > produces a valid root context with 32-char traceId and 16-char spanId
   ✓ createTraceContext > generates unique IDs across calls
   ✓ createChildContext > preserves parent traceId and sets parentSpanId
   ✓ createChildContext > reads parent from AsyncLocalStorage when no explicit parent given
   ✓ createChildContext > creates a new root context when no parent exists anywhere
   ✓ currentTraceContext > returns undefined outside of a store run
   ✓ currentTraceContext > returns the active context inside a store run
   ✓ currentTraceContext > returns nested child context after re-wrapping
   ✓ async propagation > propagates trace context across async boundaries
```

Full targeted test run (54/54 passing, including all logging tests to verify
the globalThis change is safe):

```
 Test Files  11 passed (11)
       Tests  54 passed (54)
```

Diff stats: **183 insertions, 1 deletion across 6 files.** No indentation churn.

## Human Verification (required)

- Verified scenarios: Trace context factory produces valid hex IDs with correct
  lengths (32-char traceId, 16-char spanId). Child contexts correctly inherit
  parent traceId and link via parentSpanId. AsyncLocalStorage propagates context
  across async boundaries including `setTimeout`, `Promise.resolve().then()`.
  Nested `diagnosticTraceStore.run()` calls correctly scope and restore context.
- Edge cases checked: `createChildContext()` without any parent (outside ALS)
  creates a new root. `currentTraceContext()` returns undefined outside any run.
  All existing logging tests continue to pass after the globalThis migration.
- What I did **not** verify: Live OTel collector integration (no new spans are
  emitted by this PR -- that is the follow-up). Multi-process globalThis
  isolation (Vitest workers are isolated by default).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

The `traceCtx` field on `DiagnosticBaseEvent` is optional. Existing diagnostic
event listeners (including the OTel plugin) will receive events with
`traceCtx: undefined` until Phase 2 adds emission. No existing behavior changes.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two commits. The
  `globalThis` singleton degrades gracefully -- if removed, log transport
  returns to module-scoped behavior. The AsyncLocalStorage wrapping is inert
  (the trace context is created but not yet consumed by any event emission).
- Files/config to restore: `src/logging/logger.ts`,
  `src/infra/diagnostic-events.ts`,
  `src/auto-reply/reply/dispatch-from-config.ts`,
  `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: If `AsyncLocalStorage` context
  is lost across a specific async boundary (rare in Node 22+), child contexts
  would fall back to creating new root traces. This would manifest as
  disconnected spans once the OTel plugin consumes the context -- not a crash.

## Risks and Mitigations

- Risk: `globalThis` log transport state could cause test interference if tests
  share the same Vitest worker process.
  - Mitigation: The existing `resetLogger()` test helper clears cached state.
    The globalThis Set is shared but `registerLogTransport()` returns an
    unsubscribe function, and `attachExternalTransport` checks membership before
    dispatching. Existing logging tests (11 files, 45 tests) all pass.

- Risk: `AsyncLocalStorage` overhead on the hot path.
  - Mitigation: `getStore()` is ~50ns per call (Node.js core, zero-allocation
    read). Negligible vs. seconds of LLM latency. No measurable impact.

---

**AI disclosure:** This PR was developed with AI assistance (Claude). All
changes were manually reviewed and verified with the test suite.