### PR TITLE
fix(onboard): add manual endpoint type selection when custom provider detection fails

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -163,9 +163,40 @@ describe("promptCustomApiConfig", () => {
     await runPromptCustomApi(prompter);
 
     expect(prompter.note).toHaveBeenCalledWith(
-      expect.stringContaining("did not respond"),
+      expect.stringContaining("select the type manually"),
       "Endpoint detection",
     );
+  });
+
+  it("allows manual type selection when detection fails", async () => {
+    const prompter = createTestPrompter({
+      text: [
+        "https://proxy.example.com/api/v1",
+        "test-key",
+        "us.anthropic.claude-3-7-sonnet",
+        "custom",
+        "",
+      ],
+      select: ["plaintext", "unknown", "selectType", "openai"],
+    });
+    stubFetchSequence([
+      { ok: false, status: 404 },
+      { ok: false, status: 404 },
+    ]);
+    const result = await runPromptCustomApi(prompter);
+
+    expect(result.config.models?.providers?.custom?.api).toBe("openai-completions");
+  });
+
+  it("allows manual type selection when verification fails", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://proxy.example.com/api/v1", "test-key", "my-model", "custom", ""],
+      select: ["plaintext", "openai", "selectType", "anthropic"],
+    });
+    stubFetchSequence([{ ok: false, status: 401 }, { ok: true }]);
+    const result = await runPromptCustomApi(prompter);
+
+    expect(result.config.models?.providers?.custom?.api).toBe("anthropic-messages");
   });
 
   it("renames provider id when baseUrl differs", async () => {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -391,15 +391,34 @@ async function promptBaseUrlAndKey(params: {
   };
 }
 
-type CustomApiRetryChoice = "baseUrl" | "model" | "both";
+type CustomApiRetryChoice = "baseUrl" | "model" | "both" | "selectType";
 
 async function promptCustomApiRetryChoice(prompter: WizardPrompter): Promise<CustomApiRetryChoice> {
   return await prompter.select({
     message: "What would you like to change?",
     options: [
+      { value: "selectType", label: "Select endpoint type manually" },
       { value: "baseUrl", label: "Change base URL" },
       { value: "model", label: "Change model" },
       { value: "both", label: "Change base URL and model" },
+    ],
+  });
+}
+
+async function promptManualEndpointType(prompter: WizardPrompter): Promise<CustomApiCompatibility> {
+  return await prompter.select({
+    message: "Endpoint type",
+    options: [
+      {
+        value: "openai" as CustomApiCompatibility,
+        label: "OpenAI-compatible",
+        hint: "Uses /chat/completions",
+      },
+      {
+        value: "anthropic" as CustomApiCompatibility,
+        label: "Anthropic-compatible",
+        hint: "Uses /messages",
+      },
     ],
   });
 }
@@ -685,10 +704,14 @@ export async function promptCustomApiConfig(params: {
         } else {
           probeSpinner.stop("Could not detect endpoint type.");
           await prompter.note(
-            "This endpoint did not respond to OpenAI or Anthropic style requests.",
+            "This endpoint did not respond to OpenAI or Anthropic style requests.\nYou can select the type manually if you know your endpoint is compatible.",
             "Endpoint detection",
           );
           const retryChoice = await promptCustomApiRetryChoice(prompter);
+          if (retryChoice === "selectType") {
+            compatibility = await promptManualEndpointType(prompter);
+            break;
+          }
           ({ baseUrl, apiKey, resolvedApiKey, modelId } = await applyCustomApiRetryChoice({
             prompter,
             config,
@@ -720,6 +743,10 @@ export async function promptCustomApiConfig(params: {
       verifySpinner.stop(`Verification failed: ${formatVerificationError(result.error)}`);
     }
     const retryChoice = await promptCustomApiRetryChoice(prompter);
+    if (retryChoice === "selectType") {
+      compatibility = await promptManualEndpointType(prompter);
+      continue;
+    }
     ({ baseUrl, apiKey, resolvedApiKey, modelId } = await applyCustomApiRetryChoice({
       prompter,
       config,


### PR DESCRIPTION
## Summary

- **Problem**: When `openclaw onboard` with "Custom Provider" fails to auto-detect the endpoint type (OpenAI/Anthropic), the wizard only offers retrying URL/model — no way to manually specify the type. Users with custom OpenAI-compatible proxies (Bedrock Access Gateway, LiteLLM, vLLM, corporate gateways) get stuck in a retry loop and must manually edit `openclaw.json`.
- **Why it matters**: Blocks all users whose proxy endpoints do not respond to probe requests from completing onboarding.
- **What changed**: Added "Select endpoint type manually" as the first option in the retry prompt. Selecting it lets the user choose OpenAI or Anthropic, then proceeds to write a working `models.providers` config entry.
- **What did NOT change**: Auto-detection logic, named provider flows, non-interactive onboarding, `applyCustomApiConfig`, and `applyCustomApiRetryChoice` are untouched.

Supersedes #23117 (rebased on latest main; fixes the infinite-loop bug Greptile caught in v1).

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX
- [x] Commands

## User-visible / Behavior Changes

When endpoint auto-detection fails during `openclaw onboard` with a custom provider, the retry prompt now shows a new first option: **"Select endpoint type manually"**. Choosing it presents an OpenAI/Anthropic selector and proceeds without re-probing.

This option also appears when **verification** fails after an explicit type choice, allowing the user to switch types and re-verify.

Existing retry options (Change base URL / Change model / Change both) remain unchanged.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Implementation Details

| Path | Trigger | `selectType` behavior |
|------|---------|----------------------|
| Detection failure | `compatibility === null`, both probes fail | Manual select → `break` (escape hatch, skip verification) |
| Verification failure | Explicit type chosen, verification HTTP fails | Manual select → `continue` (re-verify with new type) |

- `promptManualEndpointType` helper extracted to avoid duplication
- `selectType` is handled **before** `applyCustomApiRetryChoice` in both paths, so URL/model retry logic is never reached for this choice

## Evidence

All 16 tests pass (`pnpm exec vitest run src/commands/onboard-custom.test.ts --config vitest.unit.config.ts`):
- `allows manual type selection when detection fails` — detection failure → selectType → openai → correct config
- `allows manual type selection when verification fails` — verification failure → selectType → anthropic → re-verify → correct config

## Human Verification
- Verified: Full onboarding flow with a Bedrock proxy endpoint that fails auto-detection
- Edge cases: Existing retry flows (baseUrl/model/both) still work; test suite confirms
- Not verified: Anthropic-compatible manual selection path end-to-end (tested via unit test only)

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert the single commit
- Known bad symptoms: Wizard skipping verification when it should not

## Risks and Mitigations
- **Risk**: User selects wrong endpoint type manually → broken config
  - **Mitigation**: Same risk as the initial compatibility prompt. Manual selection is an escape hatch, not the default path.