### PR TITLE
fix: support toolCall in post-compaction-audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -52,6 +52,65 @@ describe("extractReadPaths", () => {
     expect(paths).toEqual(["AGENTS.md"]);
   });
 
+  it("extracts file paths from toolCall blocks using arguments.file_path", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "read",
+            arguments: { file_path: "WORKFLOW_AUTO.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual(["WORKFLOW_AUTO.md"]);
+  });
+
+  it("extracts file paths from toolCall blocks using arguments.path", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "memory/2026-02-16.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual(["memory/2026-02-16.md"]);
+  });
+
+  it("supports mixed tool_use and toolCall formats", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "read",
+            input: { file_path: "WORKFLOW_AUTO.md" },
+          },
+          {
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "memory/2026-02-16.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual(["WORKFLOW_AUTO.md", "memory/2026-02-16.md"]);
+  });
+
   it("ignores non-assistant messages", () => {
     const messages = [
       {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extractReadPaths()` in `src/auto-reply/reply/post-compaction-audit.ts` only parses legacy `tool_use` blocks (`input.file_path` / `input.path`) and ignores newer `toolCall` blocks (`arguments.file_path` / `arguments.path`).
- Why it matters: When session transcripts record `read` tool calls in the newer `toolCall` format, the post-compaction audit can incorrectly warn that required startup files were not read.
- What changed: Added `toolCall` parsing support to `extractReadPaths()` while preserving existing `tool_use` behavior, and added unit tests covering `toolCall` and mixed-format scenarios.
- What did NOT change (scope boundary): This PR does not change compaction behavior, transcript write format, audit policy/rules, or required file lists; it only fixes path extraction compatibility in the post-compaction audit path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Reduces false-positive post-compaction audit warnings when `read` tool calls are recorded as `toolCall` blocks in session transcripts.
- No config/default/command behavior changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Local Node.js `v22.22.0` + pnpm `10.23.0`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create/parse assistant transcript messages containing `read` tool calls recorded as `toolCall` blocks with `arguments.file_path` or `arguments.path`.
2. Run `extractReadPaths()` via unit tests in `src/auto-reply/reply/post-compaction-audit.test.ts`.
3. Verify extracted paths include both legacy `tool_use` and newer `toolCall` formats.

### Expected

- `extractReadPaths()` extracts read paths from both `tool_use` and `toolCall` transcript formats.
- Post-compaction audit does not miss valid reads solely because of transcript block format differences.

### Actual

- Before fix: only `tool_use` blocks were parsed; `toolCall`-based reads were ignored.
- After fix: both formats are parsed correctly.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `toolCall` + `arguments.file_path`
  - `toolCall` + `arguments.path`
  - mixed `tool_use` + `toolCall` in the same assistant message
  - existing `tool_use` behavior still works
- Edge cases checked:
  - non-assistant messages are ignored
  - non-array content is ignored
  - non-`read` tool calls are ignored
  - malformed/non-object blocks are skipped safely
- What you did **not** verify:
  - End-to-end post-compaction audit behavior in a live channel/integration session
  - Real production transcript samples across all providers/channels

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit (change is isolated to post-compaction audit path extraction and tests).
- Files/config to restore:
  - `src/auto-reply/reply/post-compaction-audit.ts`
  - `src/auto-reply/reply/post-compaction-audit.test.ts`
- Known bad symptoms reviewers should watch for:
  - Legacy `tool_use` read paths no longer extracted (regression)
  - Non-`read` tool calls being incorrectly treated as reads

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Broader block-format support could accidentally parse unrelated objects with overlapping fields.
  - Mitigation:
    - Parsing remains gated by strict checks: assistant role, `name === "read"`, and `type` must be `tool_use` or `toolCall`.
- Risk:
  - Regression in legacy `tool_use` parsing behavior.
  - Mitigation:
    - Existing tests remain and new mixed-format tests cover backward compatibility.

