### PR TITLE
fix(telegram): resolve channel_post commands swallowed by bot.command() middleware

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -444,7 +444,7 @@ export const registerTelegramNativeCommands = ({
       for (const command of nativeCommands) {
         const normalizedCommandName = normalizeTelegramCommandName(command.name);
         bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
-          const msg = ctx.message;
+          const msg = ctx.message ?? ctx.channelPost;
           if (!msg) {
             return;
           }
@@ -666,7 +666,7 @@ export const registerTelegramNativeCommands = ({
 
       for (const pluginCommand of pluginCatalog.commands) {
         bot.command(pluginCommand.command, async (ctx: TelegramNativeCommandContext) => {
-          const msg = ctx.message;
+          const msg = ctx.message ?? ctx.channelPost;
           if (!msg) {
             return;
           }

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -72,6 +72,11 @@ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 
 type TelegramNativeCommandContext = Context & { match?: string };
 
+/** Message from either a private/group chat or a channel post. */
+type TelegramCommandMessage =
+  | NonNullable<TelegramNativeCommandContext["message"]>
+  | NonNullable<TelegramNativeCommandContext["channelPost"]>;
+
 type TelegramCommandAuthResult = {
   chatId: number;
   isGroup: boolean;
@@ -137,7 +142,7 @@ type RegisterTelegramNativeCommandsParams = {
 };
 
 async function resolveTelegramCommandAuth(params: {
-  msg: NonNullable<TelegramNativeCommandContext["message"]>;
+  msg: TelegramCommandMessage;
   bot: Bot;
   cfg: OpenClawConfig;
   accountId: string;
@@ -384,7 +389,7 @@ export const registerTelegramNativeCommands = ({
   syncTelegramMenuCommands({ bot, runtime, commandsToRegister });
 
   const resolveCommandRuntimeContext = (params: {
-    msg: NonNullable<TelegramNativeCommandContext["message"]>;
+    msg: TelegramCommandMessage;
     isGroup: boolean;
     isForum: boolean;
     resolvedThreadId?: number;


### PR DESCRIPTION
## Summary

Fixes #27672 — Telegram channel_post commands (/status, /skill, etc.) are silently dropped by `bot.command()` middleware.

## Root Cause

`bot.command()` handlers in `bot-native-commands.ts` (lines 445 and 667) read `ctx.message`, which is `undefined` for `channel_post` updates. The handler exits early at `if (!msg) return`, consuming the update before `bot.on('channel_post')` in `bot-handlers.ts` can process it.

grammY's middleware chain means `bot.command()` runs first. Once it matches the command name and calls the handler, the update is consumed regardless of whether the handler actually did anything useful.

## Fix

Changed both command handler locations to read `ctx.message ?? ctx.channelPost`, matching the fallback pattern already used in `bot-updates.ts` `buildTelegramUpdateKey()`.

```diff
- const msg = ctx.message;
+ const msg = ctx.message ?? ctx.channelPost;
```

## Impact

- All native commands (`/status`, `/model`, `/agent`, etc.) now work via channel posts
- All plugin commands (skills) now work via channel posts
- Bot-to-bot communication via channels (#17850) is unblocked for commands
- No impact on regular group/DM command handling (`ctx.message` is still checked first)

## Files Changed

- `src/telegram/bot-native-commands.ts` — 2 lines changed (line 445, line 667)

@greptile-apps please review