### PR TITLE
fix: trim whitespace in incoming tool call names before lookup

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -148,6 +148,22 @@ describe("buildAssistantMessage", () => {
     expect(toolCall.id).toMatch(/^ollama_call_[0-9a-f-]{36}$/);
   });
 
+  it.each([" read", "read ", " read "])("trims tool call name %s", (rawName) => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [{ function: { name: rawName, arguments: { path: "/tmp/a" } } }],
+      },
+      done: true,
+    };
+
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.content[0]).toMatchObject({ type: "toolCall", name: "read" });
+  });
+
   it("sets all costs to zero for local models", () => {
     const response = {
       model: "qwen3:32b",

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -333,7 +333,7 @@ export function buildAssistantMessage(
       content.push({
         type: "toolCall",
         id: `ollama_call_${randomUUID()}`,
-        name: tc.function.name,
+        name: tc.function.name.trim(),
         arguments: tc.function.arguments,
       });
     }


### PR DESCRIPTION
## Summary
- trim leading/trailing whitespace from incoming Ollama tool call names before dispatch lookup
- preserve existing behavior for already-valid tool names (no broader matching logic)
- add regression coverage for `' read'`, `'read '`, and `' read '`

Fixes #27045