### PR TITLE
Make openclaw-cli be in the same bridge host as openclaw-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
       CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
       CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+    network_mode: "service:openclaw-gateway"
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace


### PR DESCRIPTION
Otherwise, how should the CLI access the gateway websocket?

- It would work with `network_mode: host`, but fuller isolation via bridge mode should be supported, too.
- It could theoretically work with `--url ws://openclaw-gateway:<port>`, but it is ugly, and the gateway then complains about it not using `wss`.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In the current Docker compose setup (bridge mode), the CLI container cannot reach the gateway container when trying on `ws://127.0.0.1:<port>`.
- Why it matters: The CLI container is useless therefore.
- What changed: The CLI container is now in the very same network (and host) as the gateway container.
- What did NOT change (scope boundary): Only Docker compose changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
- [x] Docker

## Linked Issue/PR

None.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No