### PR TITLE
docs: fix Mintlify-incompatible links in security docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docs/security hardening guidance: document Docker `DOCKER-USER` + UFW policy and add cross-linking from Docker install docs for VPS/public-host setups. (#27613) thanks @dorukardahan.
+- Docs/security threat-model links: replace relative `.md` links with Mintlify-compatible root-relative routes in security docs to prevent broken internal navigation. (#27698) thanks @clawdoo.
 - iOS/Voice timing safety: guard system speech start/finish callbacks to the active utterance to avoid misattributed start events during rapid stop/restart cycles. (#33304) thanks @mbelinky; original implementation direction by @ngutman.
 - iOS/Talk incremental speech pacing: allow long punctuation-free assistant chunks to start speaking at safe whitespace boundaries so voice responses begin sooner instead of waiting for terminal punctuation. (#33305) thanks @mbelinky; original implementation by @ngutman.
 - iOS/Watch reply reliability: make watch session activation waiters robust under concurrent requests so status/send calls no longer hang intermittently, and align delegate callbacks with Swift 6 actor safety. (#33306) thanks @mbelinky; original implementation by @Rocuts.

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [OpenClaw Threat Model](/security/threat-model-atlas)
 
 ## Contact
 

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [OpenClaw Threat Model](/security/THREAT-MODEL-ATLAS)
 
 ## Contact
 

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](/security/threat-model-atlas)
+- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
 
 ## Contact
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Threat Model](/security/threat-model-atlas) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](/security/contributing-threat-model) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Threat Model](/security/THREAT-MODEL-ATLAS) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](/security/CONTRIBUTING-THREAT-MODEL) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](/security/threat-model-atlas) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](/security/contributing-threat-model) - How to add threats, mitigations, and attack chains
+- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/contributing-threat-model) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/CONTRIBUTING-THREAT-MODEL) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/contributing-threat-model) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats


### PR DESCRIPTION
## Summary
Fix relative .md links to root-relative paths without extensions as required by Mintlify docs system.

## Changes
- 
./THREAT-MODEL-ATLAS.md -> /security/threat-model-atlas
- ./CONTRIBUTING-THREAT-MODEL.md -> /security/contributing-threat-model

## Files Updated
- docs/security/README.md
- docs/security/THREAT-MODEL-ATLAS.md  
- docs/security/CONTRIBUTING-THREAT-MODEL.md

## Checklist
- [x] Docs-only change
- [x] Links tested locally
- [x] Follows repo docs style guide