### PR TITLE
fix(telegram): Add detailed logging for group message blocking

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -485,24 +485,26 @@ export const registerTelegramHandlers = ({
     });
     if (!policyAccess.allowed) {
       if (policyAccess.reason === "group-policy-disabled") {
-        logVerbose("Blocked telegram group message (groupPolicy: disabled)");
+        logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy }, "Blocked telegram group message (groupPolicy: disabled)");
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-no-sender") {
-        logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
+        logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy }, "Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
-        logVerbose(
-          "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
-        );
+        logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy, hasEntries: effectiveGroupAllow.hasEntries }, "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)");
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
-        logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
+        logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy, senderId }, "Blocked telegram group message from sender (groupPolicy: allowlist)");
         return true;
       }
-      logger.info({ chatId, title: chatTitle, reason: "not-allowed" }, "skipping group message");
+      if (policyAccess.reason === "group-chat-not-allowed") {
+        logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy }, "Blocked telegram group message (chat not in allowlist)");
+        return true;
+      }
+      logger.info({ chatId, title: chatTitle, reason: policyAccess.reason, groupPolicy: policyAccess.groupPolicy }, "Blocked telegram group message (unknown reason)");
       return true;
     }
     return false;


### PR DESCRIPTION
Fixes #27695

## Problem

Telegram group messages are silently dropped with no log entries, making it impossible to diagnose why messages are being blocked. Users report:
- DMs work fine
- Group mentions are silently ignored
- No 'incoming', 'dispatch', 'drop' or error logs
- Messages marked as read (confirms updates ARE received)

## Root Cause

The shouldSkipGroupMessage() function uses logVerbose() for most block reasons, which doesn't appear in production logs. Additionally, the 'group-chat-not-allowed' reason was not explicitly handled, falling through to a generic logger.info() call.

## Solution

Replace all logVerbose() calls with logger.info() and add structured logging with context (chatId, title, reason, groupPolicy, etc.) for every block reason. This ensures all group message blocks are visible in gateway logs with enough detail to diagnose the issue.

## Changes

- Changed all logVerbose() to logger.info() in shouldSkipGroupMessage()
- Added structured logging context for all block reasons
- Added explicit handling for 'group-chat-not-allowed' reason
- Added fallback logging for unknown reasons
- Included groupPolicy value in all log entries
- Added hasEntries flag for allowlist-empty case
- Added senderId for allowlist-unauthorized case

## Impact

- Group message blocks now visible in gateway logs
- Operators can diagnose why messages are being dropped
- Structured logging enables better filtering and analysis
- No behavior change - only logging improvements

## Testing

- Existing tests pass (no behavior change)
- Log entries now include structured context
- All block reasons explicitly handled

## Next Steps for User

With this change, the user should:
1. Update to this version
2. Check gateway logs for group message block entries
3. Look for entries with reason field to identify the specific block cause
4. Adjust configuration based on the logged reason