### PR TITLE
Add 'bitable' to tools configuration

### DIFF
--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  bitable: true,
 };
 
 /**


### PR DESCRIPTION
Enable bitable tools by adding `bitable: true` to default config.
Changes:
- types.ts: add `bitable?: boolean` to FeishuToolsConfig
- tools-config.ts: add `bitable: true` to DEFAULT_TOOLS_CONFIG