### PR TITLE
Add 'bitable' property to AgentConfig type

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -86,6 +86,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    bitable: z.boolean().optional(), // Multidimensional table operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -41,10 +41,11 @@ export function resolveAnyEnabledFeishuToolsConfig(
 ): Required<FeishuToolsConfig> {
   const merged: Required<FeishuToolsConfig> = {
     doc: false,
-    wiki: false,
+    wiki: false,0
     drive: false,
     perm: false,
     scopes: false,
+    bitable: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -53,6 +54,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.bitable = merged.bitable || cfg.bitable;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  bitable: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -71,6 +71,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  bitable?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary

- Problem: bitable tools are implemented but not enabled in default config
- Why it matters: users cannot access Feishu multidimensional table (bitable) operations
- What changed: added `bitable?: boolean` to types.ts, `bitable: true` to tools-config.ts, and `bitable: z.boolean().optional()` to config-schema.ts
- What did NOT change: no changes to bitable implementation

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## User-visible / Behavior Changes

`feishu_bitable_*` tools are now available by default.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None - this only enables existing code.