### PR TITLE
fix(sessions): add --fix-missing cleanup for missing transcripts

### DIFF
--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -180,7 +180,10 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             "Also preview pruning entries with missing transcript files.",
           ],
           ["openclaw sessions cleanup --enforce", "Apply maintenance now."],
-          ["openclaw sessions cleanup --fix-missing", "Prune entries with missing transcript files."],
+          [
+            "openclaw sessions cleanup --fix-missing",
+            "Prune entries with missing transcript files.",
+          ],
           ["openclaw sessions cleanup --agent work --dry-run", "Preview one agent store."],
           ["openclaw sessions cleanup --all-agents --dry-run", "Preview all agent stores."],
           [

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -180,6 +180,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             "Also preview pruning entries with missing transcript files.",
           ],
           ["openclaw sessions cleanup --enforce", "Apply maintenance now."],
+          ["openclaw sessions cleanup --fix-missing", "Prune entries with missing transcript files."],
           ["openclaw sessions cleanup --agent work --dry-run", "Preview one agent store."],
           ["openclaw sessions cleanup --all-agents --dry-run", "Preview all agent stores."],
           [

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -167,10 +167,10 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = stateIntegrityText();
     expect(text).toContain("recent sessions are missing transcripts");
     expect(text).toMatch(/openclaw sessions --store ".*sessions\.json"/);
-    expect(text).toMatch(/openclaw sessions cleanup --store ".*sessions\.json" --dry-run/);
     expect(text).toMatch(
-      /openclaw sessions cleanup --store ".*sessions\.json" --enforce --fix-missing/,
+      /openclaw sessions cleanup --store ".*sessions\.json" --dry-run --fix-missing/,
     );
+    expect(text).toMatch(/openclaw sessions cleanup --store ".*sessions\.json" --fix-missing/);
     expect(text).not.toContain("--active");
     expect(text).not.toContain(" ls ");
   });

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -437,8 +437,8 @@ export async function noteStateIntegrity(
         [
           `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
           `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${absoluteStorePath}"`)}`,
-          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run`)}`,
-          `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --enforce --fix-missing`)}`,
+          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run --fix-missing`)}`,
+          `  Apply missing transcript cleanup: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --fix-missing`)}`,
         ].join("\n"),
       );
     }

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -172,11 +172,12 @@ function pruneMissingTranscriptEntries(params: {
     } catch {
       continue;
     }
-    if (classifyTranscriptFile(transcriptPath) === "missing") {
-      delete params.store[key];
-      removed += 1;
-      params.onPruned?.(key);
+    if (classifyTranscriptFile(transcriptPath) !== "missing") {
+      continue;
     }
+    delete params.store[key];
+    removed += 1;
+    params.onPruned?.(key);
   }
   return removed;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw doctor` reports missing recent transcripts, but suggested `openclaw sessions cleanup` cannot remove those index entries because cleanup only applies stale/cap/budget rules.
- Why it matters: users get stuck in a state-integrity deadlock where the recommended command cannot resolve the warning.
- What changed: added opt-in `--fix-missing` to `openclaw sessions cleanup`, wired it into dry-run/action reporting and apply path, and updated doctor hints to point to this exact remediation.
- What did NOT change (scope boundary): default cleanup behavior remains unchanged unless `--fix-missing` is passed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27422
- Related #27200

## User-visible / Behavior Changes

- New CLI option: `openclaw sessions cleanup --fix-missing` prunes session-store entries whose transcript files are missing.
- Dry-run output now reports `Would prune missing transcripts: N` and marks those entries as `prune-missing` in planned actions.
- `doctor` state-integrity guidance for missing transcripts now points to:
  - `openclaw sessions cleanup --store "..." --dry-run --fix-missing`
  - `openclaw sessions cleanup --store "..." --fix-missing`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No (opt-in local session-store cleanup only)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): CLI doctor + sessions maintenance
- Relevant config (redacted): default local session store

### Steps

1. Create a session-store entry whose `sessionId` transcript file does not exist.
2. Run `openclaw doctor` and observe missing transcript warning + cleanup hint.
3. Run `openclaw sessions cleanup --store "..." --dry-run --fix-missing`.
4. Run `openclaw sessions cleanup --store "..." --fix-missing`.

### Expected

- Dry-run explicitly shows missing-transcript prune plan.
- Apply run removes orphaned session-store entries even if they are recent.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `bunx vitest run --config vitest.unit.config.ts src/commands/sessions-cleanup.test.ts src/commands/doctor-state-integrity.test.ts src/cli/program/register.status-health-sessions.test.ts`
  - `pnpm canvas:a2ui:bundle`
  - `pnpm check`
  - `pnpm test`
  - `pnpm build`
- Edge cases checked:
  - existing transcripts are preserved
  - dry-run reports `prune-missing` action without mutating store
  - CLI forwarding of `--fix-missing` from `sessions cleanup`
- What you did **not** verify:
  - manual live run on a production store with real long-lived session history

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: do not use `--fix-missing` (default behavior unchanged), or revert this PR.
- Files/config to restore: `src/commands/sessions-cleanup.ts`, `src/commands/doctor-state-integrity.ts`, `src/cli/program/register.status-health-sessions.ts`.
- Known bad symptoms reviewers should watch for: false-positive removal of sessions if transcript file paths are unexpectedly inaccessible.

## Risks and Mitigations

- Risk: optional cleanup could prune an entry when transcript path is invalid/missing due to local filesystem issues.
  - Mitigation: behavior is opt-in via `--fix-missing` and previewable with `--dry-run --fix-missing` before mutation.

## GRG TDD Proof

1. Ground truth: reproduced #27422 deadlock path via existing doctor missing-transcript flow and cleanup command behavior.
2. Red: added failing regressions in:
   - `src/commands/sessions-cleanup.test.ts`
   - `src/commands/doctor-state-integrity.test.ts`
   - `src/cli/program/register.status-health-sessions.test.ts`
3. Green: implemented `--fix-missing` cleanup + doctor hint updates in:
   - `src/commands/sessions-cleanup.ts`
   - `src/commands/doctor-state-integrity.ts`
   - `src/cli/program/register.status-health-sessions.ts`
4. Guard: added action-table + applied JSON coverage for missing-transcript prune counts.

## AI Assistance Disclosure

- AI-assisted: Yes
- Testing depth: Fully tested (targeted regressions + full local check/build/test lanes)
- Author reviewed and understands all changes in this PR.
