### PR TITLE
fix: remove WORKFLOW_AUTO.md hardcoded default to close prompt injection vector

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -110,7 +110,7 @@ describe("auditPostCompactionReads", () => {
   const workspaceDir = "/Users/test/workspace";
 
   it("passes when all required files are read", () => {
-    const readPaths = ["WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -121,16 +121,14 @@ describe("auditPostCompactionReads", () => {
     const result = auditPostCompactionReads([], workspaceDir);
 
     expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
     expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
   });
 
   it("reports only missing files", () => {
-    const readPaths = ["WORKFLOW_AUTO.md"];
+    const readPaths = ["AGENTS.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(false);
-    expect(result.missingPatterns).not.toContain("WORKFLOW_AUTO.md");
     expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
   });
 
@@ -138,13 +136,12 @@ describe("auditPostCompactionReads", () => {
     const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
-    expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.length).toBe(1);
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
   });
 
   it("normalizes relative paths when matching", () => {
-    const readPaths = ["./WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const readPaths = ["./memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -152,10 +149,7 @@ describe("auditPostCompactionReads", () => {
   });
 
   it("normalizes absolute paths when matching", () => {
-    const readPaths = [
-      "/Users/test/workspace/WORKFLOW_AUTO.md",
-      "/Users/test/workspace/memory/2026-02-16.md",
-    ];
+    const readPaths = ["/Users/test/workspace/memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -174,24 +168,24 @@ describe("auditPostCompactionReads", () => {
 
 describe("formatAuditWarning", () => {
   it("formats warning message with missing patterns", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
+    const missingPatterns = ["AGENTS.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
     const message = formatAuditWarning(missingPatterns);
 
     expect(message).toContain("⚠️ Post-Compaction Audit");
-    expect(message).toContain("WORKFLOW_AUTO.md");
+    expect(message).toContain("AGENTS.md");
     expect(message).toContain("memory");
     expect(message).toContain("Please read them now");
   });
 
   it("formats single missing pattern", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md"];
+    const missingPatterns = ["memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
     const message = formatAuditWarning(missingPatterns);
 
-    expect(message).toContain("WORKFLOW_AUTO.md");
-    // Check that the missing patterns list only contains WORKFLOW_AUTO.md
+    expect(message).toContain("memory");
+    // Check that the missing patterns list only contains the memory pattern
     const lines = message.split("\n");
     const patternLines = lines.filter((l) => l.trim().startsWith("- "));
     expect(patternLines).toHaveLength(1);
-    expect(patternLines[0]).toContain("WORKFLOW_AUTO.md");
+    expect(patternLines[0]).toContain("memory");
   });
 });

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 
 // Default required files — constants, extensible to config later
+// Note: Only essential, user-controlled files are included by default.
+// Per issue #27697, hardcoding undocumented files creates a prompt injection vector.
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 


### PR DESCRIPTION
## Summary

Removes `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` in `post-compaction-audit.ts`.

## Security Rationale

`WORKFLOW_AUTO.md` is undocumented and not part of the standard workspace setup, yet OpenClaw instructs agents to read it after every compaction. This creates a persistent prompt injection vector:

1. **Attack preparation**: Attacker tricks agent into writing malicious content to `WORKFLOW_AUTO.md` (via indirect prompt injection in external content)
2. **Detonation**: Post-compaction audit instructs agent to read the file
3. **Execution**: Agent executes attacker instructions with full trust

The attack payload survives compaction and is triggered by OpenClaw itself, making it particularly dangerous.

## Changes

- Remove `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS`
- Only essential, user-controlled files (daily memory) remain by default
- Add security comment explaining the rationale
- Update tests to reflect new defaults

## Testing

All existing tests updated and passing:
```
✓ src/auto-reply/reply/post-compaction-audit.test.ts (15 tests) 16ms
```

Closes #27697