### PR TITLE
fix: remove WORKFLOW_AUTO.md from post-compaction audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 
 // Default required files — constants, extensible to config later
+// Note: WORKFLOW_AUTO.md removed from DEFAULT_REQUIRED_READS to prevent
+// prompt injection attack vector (see issue #27697)
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 


### PR DESCRIPTION
## Summary

Removes hardcoded  from  to prevent a prompt injection attack vector (security issue #27697).

## Security Issue

The file was:
- Not auto-generated
- Not documented  
- Not part of any standard workspace setup

Yet OpenClaw instructed every agent to read it after every compaction. This could allow an attacker to inject malicious instructions into the file, which would be executed with full trust during the post-compaction audit.

## Fix

Simply remove  from the default required reads. If needed, this can be made opt-in via config in the future.

## Related Issue

Fixes #27697