### PR TITLE
fix(appcast): correct sparkle:version for 2026.2.25 to prevent Sparkle downgrade

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.25</title>
             <pubDate>Thu, 26 Feb 2026 05:14:17 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>14883</sparkle:version>
+            <sparkle:version>202602250</sparkle:version>
             <sparkle:shortVersionString>2026.2.25</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.25</h2>


### PR DESCRIPTION
Fixes #27720

## Problem

`appcast.xml` has the wrong `sparkle:version` for the 2026.2.25 entry.

| Release | Current `sparkle:version` | Correct `sparkle:version` |
|---------|--------------------------|--------------------------|
| 2026.2.14 | `202602140` ✅ | `202602140` |
| 2026.2.15 | `202602150` ✅ | `202602150` |
| **2026.2.25** | `14883` ❌ | `202602250` |

Sparkle uses **integer comparison** for `sparkle:version`. Since `14883 < 202602140`, macOS clients on 2026.2.25 (build 14883) see 2026.2.15 (version 202602150) as a "newer" version and get an incorrect downgrade prompt.

## Fix

Change `sparkle:version` for 2026.2.25 from `14883` to `202602250`, consistent with the YYYYMMDDX convention used by all other entries.

## Verification

After the fix, Sparkle version ordering becomes:
```
202602140 (2026.2.14) < 202602150 (2026.2.15) < 202602250 (2026.2.25)
```
No downgrade prompt will be shown to users on 2026.2.25.