### PR TITLE
fix: compaction safeguard summary budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,7 @@ Docs: https://docs.openclaw.ai
 - Config/startup: keep bundled web-search allowlist compatibility on a lightweight manifest path so config validation no longer pulls bundled web-search registry imports into startup, while still avoiding accidental auto-allow of config-loaded override plugins. (#51574) Thanks @RichardCao.
 - Gateway/chat.send: persist uploaded image references across reloads and compaction without delaying first-turn dispatch or double-submitting the same image to vision models. (#51324) Thanks @fuller-stack-dev.
 - Plugins/runtime state: share plugin-facing infra singleton state across duplicate module graphs and keep session-binding adapter ownership stable until the active owner unregisters. (#50725) thanks @huntharo.
-- Agents/compaction safeguard: preserve split-turn context and preserved recent turns when capped retry fallback reuses the last successful summary. (#27727) thanks @Pandadadazxf.
+- Agents/compaction safeguard: preserve split-turn context and preserved recent turns when capped retry fallback reuses the last successful summary. (#27727) thanks @Pandadadadazxf.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,7 @@ Docs: https://docs.openclaw.ai
 - Config/startup: keep bundled web-search allowlist compatibility on a lightweight manifest path so config validation no longer pulls bundled web-search registry imports into startup, while still avoiding accidental auto-allow of config-loaded override plugins. (#51574) Thanks @RichardCao.
 - Gateway/chat.send: persist uploaded image references across reloads and compaction without delaying first-turn dispatch or double-submitting the same image to vision models. (#51324) Thanks @fuller-stack-dev.
 - Plugins/runtime state: share plugin-facing infra singleton state across duplicate module graphs and keep session-binding adapter ownership stable until the active owner unregisters. (#50725) thanks @huntharo.
+- Agents/compaction safeguard: preserve split-turn context and preserved recent turns when capped retry fallback reuses the last successful summary. (#27727) thanks @Pandadadazxf.
 
 ### Breaking
 

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -5,7 +5,7 @@ import {
   type AudioTranscriptionRequest,
   type MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
-import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "../../src/providers/openai-defaults.js";
+import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "openclaw/plugin-sdk/provider-models";
 
 export const DEFAULT_OPENAI_AUDIO_BASE_URL = "https://api.openai.com/v1";
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -15,11 +15,11 @@ import {
   DEFAULT_CONTEXT_TOKENS,
   normalizeModelCompat,
   normalizeProviderId,
+  OPENAI_CODEX_DEFAULT_MODEL,
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-models";
 import { createOpenAIAttributionHeadersWrapper } from "openclaw/plugin-sdk/provider-stream";
 import { fetchCodexUsage } from "openclaw/plugin-sdk/provider-usage";
-import { OPENAI_CODEX_DEFAULT_MODEL } from "../../src/providers/openai-defaults.js";
 import { buildOpenAICodexProvider } from "./openai-codex-catalog.js";
 import {
   cloneFirstTemplateModel,

--- a/extensions/telegram/src/setup-surface.test.ts
+++ b/extensions/telegram/src/setup-surface.test.ts
@@ -31,40 +31,62 @@ async function runFinalize(cfg: OpenClawConfig, accountId: string) {
   return prompter.note;
 }
 
+function expectPreparedResult(
+  prepared: Awaited<ReturnType<typeof runPrepare>>,
+): { cfg: OpenClawConfig } & Exclude<Awaited<ReturnType<typeof runPrepare>>, void | undefined> {
+  expect(prepared).toBeDefined();
+  if (
+    !prepared ||
+    typeof prepared !== "object" ||
+    !("cfg" in prepared) ||
+    prepared.cfg === undefined
+  ) {
+    throw new Error("Expected prepare result with cfg");
+  }
+  return prepared as { cfg: OpenClawConfig } & Exclude<
+    Awaited<ReturnType<typeof runPrepare>>,
+    void | undefined
+  >;
+}
+
 describe("telegramSetupWizard.prepare", () => {
   it('adds groups["*"].requireMention=true for fresh setups', async () => {
-    const prepared = await runPrepare(
-      {
-        channels: {
-          telegram: {
-            botToken: "tok",
+    const prepared = expectPreparedResult(
+      await runPrepare(
+        {
+          channels: {
+            telegram: {
+              botToken: "tok",
+            },
           },
         },
-      },
-      DEFAULT_ACCOUNT_ID,
+        DEFAULT_ACCOUNT_ID,
+      ),
     );
 
-    expect(prepared?.cfg.channels?.telegram?.groups).toEqual({
+    expect(prepared.cfg.channels?.telegram?.groups).toEqual({
       "*": { requireMention: true },
     });
   });
 
   it("preserves an explicit wildcard group mention setting", async () => {
-    const prepared = await runPrepare(
-      {
-        channels: {
-          telegram: {
-            botToken: "tok",
-            groups: {
-              "*": { requireMention: false },
+    const prepared = expectPreparedResult(
+      await runPrepare(
+        {
+          channels: {
+            telegram: {
+              botToken: "tok",
+              groups: {
+                "*": { requireMention: false },
+              },
             },
           },
         },
-      },
-      DEFAULT_ACCOUNT_ID,
+        DEFAULT_ACCOUNT_ID,
+      ),
     );
 
-    expect(prepared?.cfg.channels?.telegram?.groups).toEqual({
+    expect(prepared.cfg.channels?.telegram?.groups).toEqual({
       "*": { requireMention: false },
     });
   });

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1462,17 +1462,20 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(secondCall?.customInstructions).toContain("latest_user_ask_not_reflected");
   });
 
-  it("keeps last successful summary when a quality retry call fails", async () => {
+  it("preserves split-turn and recent-turn suffixes when retry fallback is capped", async () => {
     mockSummarizeInStages.mockReset();
+    const oversizedHistorySummary = "history detail ".repeat(MAX_COMPACTION_SUMMARY_CHARS);
+    const splitTurnPrefixSummary = "split-turn prefix context that must survive capping";
     mockSummarizeInStages
-      .mockResolvedValueOnce("short summary missing headings")
+      .mockResolvedValueOnce(oversizedHistorySummary)
+      .mockResolvedValueOnce(splitTurnPrefixSummary)
       .mockRejectedValueOnce(new Error("retry transient failure"));
 
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
     setCompactionSafeguardRuntime(sessionManager, {
       model,
-      recentTurnsPreserve: 0,
+      recentTurnsPreserve: 1,
       qualityGuardEnabled: true,
       qualityGuardMaxRetries: 1,
     });
@@ -1488,8 +1491,16 @@ describe("compaction-safeguard recent-turn preservation", () => {
         messagesToSummarize: [
           { role: "user", content: "older context", timestamp: 1 },
           { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+          { role: "user", content: "latest ask status", timestamp: 3 },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "latest assistant reply" }],
+            timestamp: 4,
+          } as unknown as AgentMessage,
         ],
-        turnPrefixMessages: [],
+        turnPrefixMessages: [
+          { role: "user", content: "prefix request that was split out", timestamp: 0 },
+        ],
         firstKeptEntryId: "entry-1",
         tokensBefore: 1_500,
         fileOps: {
@@ -1499,7 +1510,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         },
         settings: { reserveTokens: 4_000 },
         previousSummary: undefined,
-        isSplitTurn: false,
+        isSplitTurn: true,
       },
       customInstructions: "",
       signal: new AbortController().signal,
@@ -1511,8 +1522,15 @@ describe("compaction-safeguard recent-turn preservation", () => {
     };
 
     expect(result.cancel).not.toBe(true);
-    expect(result.compaction?.summary).toContain("short summary missing headings");
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    const summary = result.compaction?.summary ?? "";
+    expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(summary).toContain(SUMMARY_TRUNCATED_MARKER);
+    expect(summary).toContain("**Turn Context (split turn):**");
+    expect(summary).toContain(splitTurnPrefixSummary);
+    expect(summary).toContain("## Recent turns preserved verbatim");
+    expect(summary).toContain("latest ask status");
+    expect(summary).toContain("latest assistant reply");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(3);
   });
 
   it("keeps required headings when all turns are preserved and history is carried forward", async () => {

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -48,7 +48,6 @@ const {
   SAFETY_MARGIN,
   MAX_COMPACTION_SUMMARY_CHARS,
   MAX_FILE_OPS_SECTION_CHARS,
-  MAX_FILE_OPS_LIST_CHARS,
   SUMMARY_TRUNCATED_MARKER,
 } = __testing;
 
@@ -301,6 +300,21 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).toContain("<workspace-critical-rules>");
     expect(capped).toContain("## Session Startup");
     expect(capped.endsWith(suffix)).toBe(true);
+  });
+
+  it("preserves diagnostic sections (tool failures, file ops) when capping oversized body", () => {
+    const diagnosticSuffix =
+      "\n\n## Tool Failures\n- exec: failed\n\n<read-files>\nfoo.ts\n</read-files>\n\n" +
+      "<workspace-critical-rules>\n## Session Startup\nRead AGENTS.md\n</workspace-critical-rules>";
+    const body = "x".repeat(MAX_COMPACTION_SUMMARY_CHARS);
+
+    const capped = capCompactionSummaryPreservingSuffix(body, diagnosticSuffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(capped).toContain("## Tool Failures");
+    expect(capped).toContain("<read-files>");
+    expect(capped).toContain("<workspace-critical-rules>");
+    expect(capped.endsWith(diagnosticSuffix)).toBe(true);
   });
 });
 

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -263,7 +263,10 @@ describe("compaction-safeguard tool failures", () => {
 
 describe("compaction-safeguard summary budgets", () => {
   it("caps file operations summary and reports omitted entries", () => {
-    const readFiles = Array.from({ length: 200 }, (_, i) => `docs/very/long/path/${i}-read-file.md`);
+    const readFiles = Array.from(
+      { length: 200 },
+      (_, i) => `docs/very/long/path/${i}-read-file.md`,
+    );
     const modifiedFiles = Array.from(
       { length: 200 },
       (_, i) => `src/features/${i}/nested/component/file-${i}.ts`,

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -330,6 +330,16 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).not.toMatch(/None\.## Tool Failures/);
   });
 
+  it("keeps body prefix when truncation marker cannot fit (tiny budget)", () => {
+    const body = "## Decisions\nKeep flow.\n## Constraints\nFollow rules.";
+    const tinyBudget = 10; // Smaller than SUMMARY_TRUNCATED_MARKER.length
+    const capped = capCompactionSummary(body, tinyBudget);
+
+    expect(capped.length).toBeLessThanOrEqual(tinyBudget);
+    expect(capped).toContain("## Decis");
+    expect(capped).not.toContain("[Compaction summary truncated");
+  });
+
   it("preserves tail sections when suffix exceeds cap (workspace rules, diagnostics over preserved turns)", () => {
     const criticalTail =
       "\n\n## Tool Failures\n- exec: failed\n\n<read-files>\nfoo.ts\n</read-files>\n\n" +

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -37,12 +37,18 @@ const {
   resolveQualityGuardMaxRetries,
   extractOpaqueIdentifiers,
   auditSummaryQuality,
+  capCompactionSummary,
+  formatFileOperations,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
   readWorkspaceContextForSummary,
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
+  MAX_COMPACTION_SUMMARY_CHARS,
+  MAX_FILE_OPS_SECTION_CHARS,
+  MAX_FILE_OPS_LIST_CHARS,
+  SUMMARY_TRUNCATED_MARKER,
 } = __testing;
 
 function stubSessionManager(): ExtensionContext["sessionManager"] {
@@ -252,6 +258,32 @@ describe("compaction-safeguard tool failures", () => {
     const failures = collectToolFailures(messages);
     const section = formatToolFailuresSection(failures);
     expect(section).toBe("");
+  });
+});
+
+describe("compaction-safeguard summary budgets", () => {
+  it("caps file operations summary and reports omitted entries", () => {
+    const readFiles = Array.from({ length: 200 }, (_, i) => `docs/very/long/path/${i}-read-file.md`);
+    const modifiedFiles = Array.from(
+      { length: 200 },
+      (_, i) => `src/features/${i}/nested/component/file-${i}.ts`,
+    );
+
+    const section = formatFileOperations(readFiles, modifiedFiles);
+
+    expect(section).toContain("<read-files>");
+    expect(section).toContain("<modified-files>");
+    expect(section).toContain("...and ");
+    expect(section.length).toBeLessThanOrEqual(MAX_FILE_OPS_SECTION_CHARS);
+  });
+
+  it("caps final compaction summary with a truncation marker", () => {
+    const oversized = "x".repeat(MAX_COMPACTION_SUMMARY_CHARS + 500);
+    const capped = capCompactionSummary(oversized);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(capped).toContain(SUMMARY_TRUNCATED_MARKER.trim());
+    expect(capped.endsWith(SUMMARY_TRUNCATED_MARKER)).toBe(true);
   });
 });
 

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -329,6 +329,24 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).toContain("None.\n\n## Tool Failures");
     expect(capped).not.toMatch(/None\.## Tool Failures/);
   });
+
+  it("preserves tail sections when suffix exceeds cap (workspace rules, diagnostics over preserved turns)", () => {
+    const criticalTail =
+      "\n\n## Tool Failures\n- exec: failed\n\n<read-files>\nfoo.ts\n</read-files>\n\n" +
+      "<workspace-critical-rules>\n## Session Startup\nRead AGENTS.md\n</workspace-critical-rules>";
+    const preservedTurns =
+      "## Recent turns preserved verbatim\n- User: x\n- Assistant: y\n" +
+      "x".repeat(MAX_COMPACTION_SUMMARY_CHARS);
+    const oversizedSuffix = preservedTurns + criticalTail;
+
+    const capped = capCompactionSummaryPreservingSuffix("short body", oversizedSuffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(capped).toContain("<workspace-critical-rules>");
+    expect(capped).toContain("## Tool Failures");
+    expect(capped).toContain("<read-files>");
+    expect(capped).toContain("## Session Startup");
+  });
 });
 
 describe("computeAdaptiveChunkRatio", () => {

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -316,6 +316,19 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped).toContain("<workspace-critical-rules>");
     expect(capped.endsWith(diagnosticSuffix)).toBe(true);
   });
+
+  it("keeps section separator when body ends without newline (e.g. buildStructuredFallbackSummary)", () => {
+    const bodyNoNewline = "## Exact identifiers\nNone.";
+    const suffixNoLeadingNewline = "## Tool Failures\n- exec: failed";
+
+    const capped = capCompactionSummaryPreservingSuffix(
+      bodyNoNewline,
+      `\n\n${suffixNoLeadingNewline}`,
+    );
+
+    expect(capped).toContain("None.\n\n## Tool Failures");
+    expect(capped).not.toMatch(/None\.## Tool Failures/);
+  });
 });
 
 describe("computeAdaptiveChunkRatio", () => {

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -38,6 +38,7 @@ const {
   extractOpaqueIdentifiers,
   auditSummaryQuality,
   capCompactionSummary,
+  capCompactionSummaryPreservingSuffix,
   formatFileOperations,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
@@ -287,6 +288,19 @@ describe("compaction-safeguard summary budgets", () => {
     expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
     expect(capped).toContain(SUMMARY_TRUNCATED_MARKER.trim());
     expect(capped.endsWith(SUMMARY_TRUNCATED_MARKER)).toBe(true);
+  });
+
+  it("preserves workspace critical rules suffix when capping", () => {
+    const suffix =
+      "\n\n<workspace-critical-rules>\n## Session Startup\nRead AGENTS.md\n</workspace-critical-rules>";
+    const body = "x".repeat(MAX_COMPACTION_SUMMARY_CHARS);
+
+    const capped = capCompactionSummaryPreservingSuffix(body, suffix);
+
+    expect(capped.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
+    expect(capped).toContain("<workspace-critical-rules>");
+    expect(capped).toContain("## Session Startup");
+    expect(capped.endsWith(suffix)).toBe(true);
   });
 });
 

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -961,7 +961,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       let summary = "";
       let lastHistorySummary = "";
       let lastSplitTurnSection = "";
-      let usedLastSuccessfulSummary = false;
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
@@ -1023,7 +1022,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 }`,
             );
             summary = lastSuccessfulSummary;
-            usedLastSuccessfulSummary = true;
             break;
           }
           throw attemptError;
@@ -1086,18 +1084,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         fullReservedSuffix && !/^\s/.test(fullReservedSuffix)
           ? `\n\n${fullReservedSuffix}`
           : fullReservedSuffix;
-      const bodyToCap = usedLastSuccessfulSummary ? summary : lastHistorySummary;
-      const suffixToUse = usedLastSuccessfulSummary
-        ? (() => {
-            const diag = appendSummarySection(
-              appendSummarySection("", toolFailureSection),
-              fileOpsSummary,
-            );
-            const withWk = appendSummarySection(diag, workspaceContext);
-            return withWk && !/^\s/.test(withWk) ? `\n\n${withWk}` : withWk;
-          })()
-        : normalizedSuffix;
-      summary = capCompactionSummaryPreservingSuffix(bodyToCap, suffixToUse ?? "");
+      const bodyToCap = lastHistorySummary || summary;
+      summary = capCompactionSummaryPreservingSuffix(bodyToCap, normalizedSuffix ?? "");
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -38,6 +38,10 @@ const TURN_PREFIX_INSTRUCTIONS =
   " early progress, and any details needed to understand the retained suffix.";
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
+const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
+const MAX_FILE_OPS_SECTION_CHARS = 2_000;
+const MAX_FILE_OPS_LIST_CHARS = 900;
+const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
 const DEFAULT_RECENT_TURNS_PRESERVE = 3;
 const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
 const MAX_RECENT_TURNS_PRESERVE = 12;
@@ -194,17 +198,83 @@ function computeFileLists(fileOps: FileOperations): {
 }
 
 function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
-  const sections: string[] = [];
-  if (readFiles.length > 0) {
-    sections.push(`<read-files>\n${readFiles.join("\n")}\n</read-files>`);
+  function formatBoundedFileList(tag: string, files: string[], maxChars: number): string {
+    if (files.length === 0 || maxChars <= 0) {
+      return "";
+    }
+    const openTag = `<${tag}>\n`;
+    const closeTag = `\n</${tag}>`;
+    const lines: string[] = [];
+    let usedChars = openTag.length + closeTag.length;
+
+    for (let i = 0; i < files.length; i++) {
+      const line = `${files[i]}\n`;
+      const remaining = files.length - i - 1;
+      const overflowLine = remaining > 0 ? `...and ${remaining} more\n` : "";
+      const projected = usedChars + line.length + overflowLine.length;
+      if (projected > maxChars) {
+        const overflow = `...and ${files.length - i} more\n`;
+        if (usedChars + overflow.length <= maxChars) {
+          lines.push(overflow);
+        }
+        break;
+      }
+      lines.push(line);
+      usedChars += line.length;
+    }
+
+    return lines.length > 0 ? `${openTag}${lines.join("")}${closeTag}` : "";
   }
-  if (modifiedFiles.length > 0) {
-    sections.push(`<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>`);
+
+  const sections: string[] = [];
+  const readSection = formatBoundedFileList("read-files", readFiles, MAX_FILE_OPS_LIST_CHARS);
+  const modifiedSection = formatBoundedFileList(
+    "modified-files",
+    modifiedFiles,
+    MAX_FILE_OPS_LIST_CHARS,
+  );
+  if (readSection) {
+    sections.push(readSection);
+  }
+  if (modifiedSection) {
+    sections.push(modifiedSection);
   }
   if (sections.length === 0) {
     return "";
   }
-  return `\n\n${sections.join("\n\n")}`;
+  const combined = `\n\n${sections.join("\n\n")}`;
+  return capCompactionSummary(combined, MAX_FILE_OPS_SECTION_CHARS);
+}
+
+function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS): string {
+  if (maxChars <= 0 || summary.length <= maxChars) {
+    return summary;
+  }
+  const marker = SUMMARY_TRUNCATED_MARKER;
+  const budget = Math.max(0, maxChars - marker.length);
+  if (budget <= 0) {
+    return marker.slice(0, maxChars);
+  }
+  return `${summary.slice(0, budget)}${marker}`;
+}
+
+function capCompactionSummaryPreservingSuffix(
+  summaryBody: string,
+  suffix: string,
+  maxChars = MAX_COMPACTION_SUMMARY_CHARS,
+): string {
+  if (!suffix) {
+    return capCompactionSummary(summaryBody, maxChars);
+  }
+  if (maxChars <= 0) {
+    return capCompactionSummary(`${summaryBody}${suffix}`, maxChars);
+  }
+  if (suffix.length >= maxChars) {
+    return suffix.slice(0, maxChars);
+  }
+  const bodyBudget = Math.max(0, maxChars - suffix.length);
+  const cappedBody = capCompactionSummary(summaryBody, bodyBudget);
+  return `${cappedBody}${suffix}`;
 }
 
 function extractMessageText(message: AgentMessage): string {
@@ -987,10 +1057,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       summary = appendSummarySection(summary, fileOpsSummary);
 
       // Append workspace critical context (Session Startup + Red Lines from AGENTS.md)
+      // after capping the main summary body so the critical rules survive truncation.
       const workspaceContext = await readWorkspaceContextForSummary();
-      if (workspaceContext) {
-        summary = appendSummarySection(summary, workspaceContext);
-      }
+      summary = capCompactionSummaryPreservingSuffix(summary, workspaceContext);
 
       return {
         compaction: {
@@ -1023,10 +1092,17 @@ export const __testing = {
   resolveQualityGuardMaxRetries,
   extractOpaqueIdentifiers,
   auditSummaryQuality,
+  capCompactionSummary,
+  capCompactionSummaryPreservingSuffix,
+  formatFileOperations,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
   readWorkspaceContextForSummary,
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
+  MAX_COMPACTION_SUMMARY_CHARS,
+  MAX_FILE_OPS_SECTION_CHARS,
+  MAX_FILE_OPS_LIST_CHARS,
+  SUMMARY_TRUNCATED_MARKER,
 } as const;

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -270,7 +270,8 @@ function capCompactionSummaryPreservingSuffix(
     return capCompactionSummary(`${summaryBody}${suffix}`, maxChars);
   }
   if (suffix.length >= maxChars) {
-    return suffix.slice(0, maxChars);
+    // Preserve tail (workspace rules, diagnostics) over head (preserved turns).
+    return suffix.slice(-maxChars);
   }
   const bodyBudget = Math.max(0, maxChars - suffix.length);
   const cappedBody = capCompactionSummary(summaryBody, bodyBudget);

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -253,7 +253,8 @@ function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY
   const marker = SUMMARY_TRUNCATED_MARKER;
   const budget = Math.max(0, maxChars - marker.length);
   if (budget <= 0) {
-    return marker.slice(0, maxChars);
+    // Marker cannot fit; keep body prefix instead of a partial marker fragment.
+    return summary.slice(0, maxChars);
   }
   return `${summary.slice(0, budget)}${marker}`;
 }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -959,7 +959,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
 
       let summary = "";
-      let lastSummaryWithoutPreservedTurns = "";
+      let lastHistorySummary = "";
+      let lastSplitTurnSection = "";
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
@@ -985,6 +986,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
           summaryWithoutPreservedTurns = historySummary;
+          lastHistorySummary = historySummary;
+          lastSplitTurnSection = "";
           if (preparation.isSplitTurn && turnPrefixMessages.length > 0) {
             const prefixSummary = await summarizeInStages({
               messages: turnPrefixMessages,
@@ -1005,6 +1008,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             summaryWithoutPreservedTurns = historySummary.trim()
               ? `${historySummary}\n\n---\n\n${splitTurnSection}`
               : splitTurnSection;
+            lastSplitTurnSection = splitTurnSection;
           }
           summaryWithPreservedTurns = appendSummarySection(
             summaryWithoutPreservedTurns,
@@ -1024,7 +1028,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           throw attemptError;
         }
         lastSuccessfulSummary = summaryWithPreservedTurns;
-        lastSummaryWithoutPreservedTurns = summaryWithoutPreservedTurns;
 
         const canRegenerate =
           messagesToSummarize.length > 0 ||
@@ -1057,12 +1060,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           : `${structuredInstructions}\n\n${qualityFeedbackInstruction}`;
       }
 
-      // Cap the main history body first, then append preserved turns, diagnostics,
-      // and workspace rules so they survive truncation. Truncation keeps the prefix
-      // (slice(0, budget)), so sections at the end of the body would be dropped
-      // first—preserved turns, tool failures, and file ops must be in the suffix.
+      // Cap the main history body first, then append split-turn context, preserved
+      // turns, diagnostics, and workspace rules so they survive truncation.
+      // Truncation keeps the prefix (slice(0, budget)), so sections at the end
+      // of the body would be dropped first—split-turn, preserved turns, tool
+      // failures, and file ops must be in the suffix.
       const reservedSuffix = appendSummarySection(
-        appendSummarySection(appendSummarySection("", preservedTurnsSection), toolFailureSection),
+        appendSummarySection(
+          appendSummarySection(
+            appendSummarySection("", lastSplitTurnSection),
+            preservedTurnsSection,
+          ),
+          toolFailureSection,
+        ),
         fileOpsSummary,
       );
       const workspaceContext = await readWorkspaceContextForSummary();
@@ -1073,10 +1083,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         fullReservedSuffix && !/^\s/.test(fullReservedSuffix)
           ? `\n\n${fullReservedSuffix}`
           : fullReservedSuffix;
-      summary = capCompactionSummaryPreservingSuffix(
-        lastSummaryWithoutPreservedTurns,
-        normalizedSuffix,
-      );
+      summary = capCompactionSummaryPreservingSuffix(lastHistorySummary, normalizedSuffix);
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -957,6 +957,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
 
       let summary = "";
+      let lastSummaryWithoutPreservedTurns = "";
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
@@ -1021,6 +1022,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           throw attemptError;
         }
         lastSuccessfulSummary = summaryWithPreservedTurns;
+        lastSummaryWithoutPreservedTurns = summaryWithoutPreservedTurns;
 
         const canRegenerate =
           messagesToSummarize.length > 0 ||
@@ -1053,21 +1055,26 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           : `${structuredInstructions}\n\n${qualityFeedbackInstruction}`;
       }
 
-      // Cap the main history body first, then append diagnostics and workspace rules
-      // so they survive truncation. Truncation keeps the prefix (slice(0, budget)),
-      // so sections appended at the end would be dropped first—tool failures and
-      // file ops are high-signal diagnostics we want to preserve.
-      const diagnosticSuffix = appendSummarySection(
-        appendSummarySection("", toolFailureSection),
+      // Cap the main history body first, then append preserved turns, diagnostics,
+      // and workspace rules so they survive truncation. Truncation keeps the prefix
+      // (slice(0, budget)), so sections at the end of the body would be dropped
+      // first—preserved turns, tool failures, and file ops must be in the suffix.
+      const reservedSuffix = appendSummarySection(
+        appendSummarySection(appendSummarySection("", preservedTurnsSection), toolFailureSection),
         fileOpsSummary,
       );
       const workspaceContext = await readWorkspaceContextForSummary();
-      const reservedSuffix = appendSummarySection(diagnosticSuffix, workspaceContext);
+      const fullReservedSuffix = appendSummarySection(reservedSuffix, workspaceContext);
       // Ensure leading separator so suffix does not merge with body (e.g. when body
       // ends without newline from buildStructuredFallbackSummary: "...## Exact identifiers## Tool Failures").
       const normalizedSuffix =
-        reservedSuffix && !/^\s/.test(reservedSuffix) ? `\n\n${reservedSuffix}` : reservedSuffix;
-      summary = capCompactionSummaryPreservingSuffix(summary, normalizedSuffix);
+        fullReservedSuffix && !/^\s/.test(fullReservedSuffix)
+          ? `\n\n${fullReservedSuffix}`
+          : fullReservedSuffix;
+      summary = capCompactionSummaryPreservingSuffix(
+        lastSummaryWithoutPreservedTurns,
+        normalizedSuffix,
+      );
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -961,6 +961,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       let summary = "";
       let lastHistorySummary = "";
       let lastSplitTurnSection = "";
+      let usedLastSuccessfulSummary = false;
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
@@ -968,8 +969,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
         let summaryWithoutPreservedTurns = "";
         let summaryWithPreservedTurns = "";
+        let splitTurnSection = "";
+        let historySummary = "";
         try {
-          const historySummary =
+          historySummary =
             messagesToSummarize.length > 0
               ? await summarizeInStages({
                   messages: messagesToSummarize,
@@ -986,8 +989,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
           summaryWithoutPreservedTurns = historySummary;
-          lastHistorySummary = historySummary;
-          lastSplitTurnSection = "";
           if (preparation.isSplitTurn && turnPrefixMessages.length > 0) {
             const prefixSummary = await summarizeInStages({
               messages: turnPrefixMessages,
@@ -1004,11 +1005,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               summarizationInstructions,
               previousSummary: undefined,
             });
-            const splitTurnSection = `**Turn Context (split turn):**\n\n${prefixSummary}`;
+            splitTurnSection = `**Turn Context (split turn):**\n\n${prefixSummary}`;
             summaryWithoutPreservedTurns = historySummary.trim()
               ? `${historySummary}\n\n---\n\n${splitTurnSection}`
               : splitTurnSection;
-            lastSplitTurnSection = splitTurnSection;
           }
           summaryWithPreservedTurns = appendSummarySection(
             summaryWithoutPreservedTurns,
@@ -1023,11 +1023,14 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 }`,
             );
             summary = lastSuccessfulSummary;
+            usedLastSuccessfulSummary = true;
             break;
           }
           throw attemptError;
         }
         lastSuccessfulSummary = summaryWithPreservedTurns;
+        lastHistorySummary = historySummary;
+        lastSplitTurnSection = splitTurnSection;
 
         const canRegenerate =
           messagesToSummarize.length > 0 ||
@@ -1083,7 +1086,18 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         fullReservedSuffix && !/^\s/.test(fullReservedSuffix)
           ? `\n\n${fullReservedSuffix}`
           : fullReservedSuffix;
-      summary = capCompactionSummaryPreservingSuffix(lastHistorySummary, normalizedSuffix);
+      const bodyToCap = usedLastSuccessfulSummary ? summary : lastHistorySummary;
+      const suffixToUse = usedLastSuccessfulSummary
+        ? (() => {
+            const diag = appendSummarySection(
+              appendSummarySection("", toolFailureSection),
+              fileOpsSummary,
+            );
+            const withWk = appendSummarySection(diag, workspaceContext);
+            return withWk && !/^\s/.test(withWk) ? `\n\n${withWk}` : withWk;
+          })()
+        : normalizedSuffix;
+      summary = capCompactionSummaryPreservingSuffix(bodyToCap, suffixToUse ?? "");
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1053,13 +1053,17 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           : `${structuredInstructions}\n\n${qualityFeedbackInstruction}`;
       }
 
-      summary = appendSummarySection(summary, toolFailureSection);
-      summary = appendSummarySection(summary, fileOpsSummary);
-
-      // Append workspace critical context (Session Startup + Red Lines from AGENTS.md)
-      // after capping the main summary body so the critical rules survive truncation.
+      // Cap the main history body first, then append diagnostics and workspace rules
+      // so they survive truncation. Truncation keeps the prefix (slice(0, budget)),
+      // so sections appended at the end would be dropped first—tool failures and
+      // file ops are high-signal diagnostics we want to preserve.
+      const diagnosticSuffix = appendSummarySection(
+        appendSummarySection("", toolFailureSection),
+        fileOpsSummary,
+      );
       const workspaceContext = await readWorkspaceContextForSummary();
-      summary = capCompactionSummaryPreservingSuffix(summary, workspaceContext);
+      const reservedSuffix = appendSummarySection(diagnosticSuffix, workspaceContext);
+      summary = capCompactionSummaryPreservingSuffix(summary, reservedSuffix);
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1063,7 +1063,11 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       );
       const workspaceContext = await readWorkspaceContextForSummary();
       const reservedSuffix = appendSummarySection(diagnosticSuffix, workspaceContext);
-      summary = capCompactionSummaryPreservingSuffix(summary, reservedSuffix);
+      // Ensure leading separator so suffix does not merge with body (e.g. when body
+      // ends without newline from buildStructuredFallbackSummary: "...## Exact identifiers## Tool Failures").
+      const normalizedSuffix =
+        reservedSuffix && !/^\s/.test(reservedSuffix) ? `\n\n${reservedSuffix}` : reservedSuffix;
+      summary = capCompactionSummaryPreservingSuffix(summary, normalizedSuffix);
 
       return {
         compaction: {

--- a/src/memory/embeddings-openai.ts
+++ b/src/memory/embeddings-openai.ts
@@ -21,6 +21,8 @@ const OPENAI_MAX_INPUT_TOKENS: Record<string, number> = {
   "text-embedding-ada-002": 8191,
 };
 
+export const DEFAULT_OPENAI_EMBEDDING_MODEL = OPENAI_DEFAULT_EMBEDDING_MODEL;
+
 export function normalizeOpenAiModel(model: string): string {
   return normalizeEmbeddingModelWithPrefixes({
     model,

--- a/src/plugin-sdk/provider-models.ts
+++ b/src/plugin-sdk/provider-models.ts
@@ -31,7 +31,12 @@ export {
   applyGoogleGeminiModelDefault,
   GOOGLE_GEMINI_DEFAULT_MODEL,
 } from "../plugins/provider-model-defaults.js";
-export { applyOpenAIConfig, OPENAI_DEFAULT_MODEL } from "../plugins/provider-model-defaults.js";
+export {
+  applyOpenAIConfig,
+  OPENAI_CODEX_DEFAULT_MODEL,
+  OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
+  OPENAI_DEFAULT_MODEL,
+} from "../plugins/provider-model-defaults.js";
 export { OPENCODE_GO_DEFAULT_MODEL_REF } from "../plugins/provider-model-defaults.js";
 export { OPENCODE_ZEN_DEFAULT_MODEL } from "../plugins/provider-model-defaults.js";
 export { OPENCODE_ZEN_DEFAULT_MODEL_REF } from "../agents/opencode-zen-models.js";

--- a/src/plugins/provider-model-defaults.ts
+++ b/src/plugins/provider-model-defaults.ts
@@ -1,10 +1,18 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { OPENAI_DEFAULT_MODEL } from "../providers/openai-defaults.js";
+import {
+  OPENAI_CODEX_DEFAULT_MODEL,
+  OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
+  OPENAI_DEFAULT_MODEL,
+} from "../providers/openai-defaults.js";
 import { ensureModelAllowlistEntry } from "./provider-model-allowlist.js";
 import { applyAgentDefaultPrimaryModel } from "./provider-model-primary.js";
 
 export const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
-export { OPENAI_DEFAULT_MODEL } from "../providers/openai-defaults.js";
+export {
+  OPENAI_CODEX_DEFAULT_MODEL,
+  OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
+  OPENAI_DEFAULT_MODEL,
+} from "../providers/openai-defaults.js";
 export const OPENCODE_GO_DEFAULT_MODEL_REF = "opencode-go/kimi-k2.5";
 export const OPENCODE_ZEN_DEFAULT_MODEL = "opencode/claude-opus-4-6";
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -25,6 +25,10 @@ import type {
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
+import {
+  OPENAI_DEFAULT_TTS_MODEL as DEFAULT_OPENAI_MODEL,
+  OPENAI_DEFAULT_TTS_VOICE as DEFAULT_OPENAI_VOICE,
+} from "../providers/openai-defaults.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   getSpeechProvider,
@@ -32,10 +36,6 @@ import {
   normalizeSpeechProviderId,
 } from "./provider-registry.js";
 import type { SpeechVoiceOption } from "./provider-types.js";
-import {
-  OPENAI_DEFAULT_TTS_MODEL as DEFAULT_OPENAI_MODEL,
-  OPENAI_DEFAULT_TTS_VOICE as DEFAULT_OPENAI_VOICE,
-} from "../providers/openai-defaults.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
   isValidOpenAIModel,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `compaction-safeguard` can append large file operation lists (`read-files` / `modified-files`) and other metadata to the compaction summary, which can make the summary itself too large.
- Why it matters: Oversized compaction summaries reduce the effectiveness of compaction and can consume context budget that should be preserved for future turns.
- What changed: Added bounded formatting for file operation sections (with `...and N more`) and a final compaction summary length cap with a truncation marker; added tests for both behaviors.
- What did NOT change (scope boundary): No changes to compaction triggering, token estimation, summarization model selection, or pruning strategy logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Compaction summaries now truncate oversized file operation sections and may include `...and N more`.
- Compaction summaries now include a truncation marker when the final summary exceeds the configured internal size budget.
- No config/default changes exposed to users.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: local Node binary (`.tools/node-v22.22.0-darwin-arm64`)
- Model/provider: N/A (unit tests only)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Modify `src/agents/pi-extensions/compaction-safeguard.ts` to cap file-op summary size and final compaction summary length.
2. Add tests in `src/agents/pi-extensions/compaction-safeguard.test.ts` covering file-op truncation and summary truncation marker.
3. Run `PATH="$PWD/.tools/node-v22.22.0-darwin-arm64/bin:$PATH" npm exec vitest run src/agents/pi-extensions/compaction-safeguard.test.ts`.

### Expected

- File operation summary output is bounded and includes `...and N more` when truncated.
- Final compaction summary is capped and ends with a truncation marker when oversized.
- Test file passes.

### Actual

- Behavior matches expected.
- `compaction-safeguard` test file passes (24 tests).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `src/agents/pi-extensions/compaction-safeguard.test.ts` locally after changes; confirmed new tests pass and existing tests remain green.
- Edge cases checked: Very large file-op lists trigger truncation; oversized summary gets capped and appends truncation marker.
- What you did **not** verify: End-to-end compaction flow against a live provider/model; impact on real long-running sessions.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `afc741b` (or revert the PR commit) to restore previous compaction summary behavior.
- Files/config to restore: `src/agents/pi-extensions/compaction-safeguard.ts`, `src/agents/pi-extensions/compaction-safeguard.test.ts`
- Known bad symptoms reviewers should watch for: Missing file-op metadata in compaction summaries when lists are unexpectedly small; malformed truncation marker placement; over-aggressive truncation of summaries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Truncation budget may cut off useful compaction context in edge cases with unusually dense metadata.
  - Mitigation: File-op sections and final summary use separate caps; truncation is explicit via marker / `...and N more`, and core compaction logic is unchanged.
- Risk: New formatting helper could produce malformed section tags if the budget is too small.
  - Mitigation: Added unit tests for bounded file-op formatting and final summary capping behavior.

