### PR TITLE
fix: correct appcast sparkle:version and derive build number from calver

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -212,7 +212,7 @@
             <title>2026.2.25</title>
             <pubDate>Thu, 26 Feb 2026 05:14:17 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>14883</sparkle:version>
+            <sparkle:version>202602250</sparkle:version>
             <sparkle:shortVersionString>2026.2.25</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.25</h2>


### PR DESCRIPTION
## Summary

- **appcast.xml**: fix `sparkle:version` for 2026.2.25 (`14883` → `202602250`). The old value was a git commit count, which is less than `202602150` (2026.2.15), causing Sparkle to offer a downgrade instead of recognizing 2026.2.25 as the latest version.
- **scripts/package-mac-app.sh**: derive `APP_BUILD` from `APP_VERSION` in `YYYYMMDD0` format by default, so omitting `APP_BUILD` no longer falls back to git commit count.
- **test/appcast.test.ts**: validate all appcast items use `YYYYMMDD0` format and versions are monotonically increasing.

## Test plan

- [x] `pnpm vitest run test/appcast.test.ts` passes (2 tests)
- [ ] Verify Sparkle update prompt shows correct version after appcast is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)