### PR TITLE
fix(cron): skip delivery validation when mode is 'none'

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -101,7 +101,7 @@ function validateTelegramDeliveryTarget(to: string | undefined): string | undefi
 }
 
 function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
-  if (!job.delivery) {
+  if (!job.delivery || job.delivery.mode === "none") {
     return;
   }
   if (job.delivery.mode === "webhook") {


### PR DESCRIPTION
## Summary

`assertDeliverySupport()` only returned early when `job.delivery` was falsy. When the agent set `delivery: { mode: 'none' }` (as guided by cron-tool.ts), the object was truthy so validation continued and rejected `sessionTarget='main'` with an error meant for channel delivery.

## Fix

Add `mode === 'none'` to the early-return check in `assertDeliverySupport()`.

One-line change.

fixes #27431