### PR TITLE
fix(acp): declare authMethods in initialize response

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -138,7 +138,14 @@ export class AcpGatewayAgent implements Agent {
         },
       },
       agentInfo: ACP_AGENT_INFO,
-      authMethods: [],
+      authMethods: [
+        {
+          id: "gateway-token",
+          name: "Gateway Token",
+          description:
+            "Authenticate using OPENCLAW_GATEWAY_TOKEN environment variable or --gateway-token CLI flag",
+        },
+      ],
     };
   }
 


### PR DESCRIPTION
## Summary

Add gateway token auth method to the initialize response to comply with ACP Registry validation requirements.

## Problem

The `authMethods` field in the ACP initialize response is empty, blocking OpenClaw from being submitted to the ACP Registry.

## Solution

Declare the gateway token authentication method that OpenClaw already supports via `OPENCLAW_GATEWAY_TOKEN` env var and `--gateway-token` CLI flag.

Fixes #27724