### PR TITLE
fix(tests): mock resolvePinnedHostnameWithPolicy to align with SSRF fetch guard

### DIFF
--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -1,8 +1,14 @@
 import { vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 
+// Store the original implementation before any mocking.
+const originalResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+
 export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.34"]) {
-  return vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
+  const fakeLookup: ssrf.LookupFn = async () =>
+    addresses.map((addr) => ({ address: addr, family: addr.includes(":") ? 6 : 4 }));
+
+  const mockImpl = async (hostname: string) => {
     const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
     const pinnedAddresses = [...addresses];
     return {
@@ -10,5 +16,20 @@ export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.
       addresses: pinnedAddresses,
       lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses: pinnedAddresses }),
     };
-  });
+  };
+
+  // Mock resolvePinnedHostnameWithPolicy: delegate to the real implementation
+  // with a fake DNS lookup, preserving SSRF policy checks (private IP blocking etc.).
+  vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+    async (hostname, params = {}) => {
+      return await originalResolvePinnedHostnameWithPolicy(hostname, {
+        ...params,
+        lookupFn: fakeLookup,
+      });
+    },
+  );
+
+  return vi
+    .spyOn(ssrf, "resolvePinnedHostname")
+    .mockImplementation(async (hostname) => mockImpl(hostname));
 }

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -5,8 +5,10 @@ import * as ssrf from "../infra/net/ssrf.js";
 const originalResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
 
 export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.34"]) {
-  const fakeLookup: ssrf.LookupFn = async () =>
-    addresses.map((addr) => ({ address: addr, family: addr.includes(":") ? 6 : 4 }));
+  const fakeLookup = (async () => ({
+    address: addresses[0] ?? "93.184.216.34",
+    family: (addresses[0] ?? "").includes(":") ? 6 : 4,
+  })) as unknown as ssrf.LookupFn;
 
   const mockImpl = async (hostname: string) => {
     const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");

--- a/src/web/auto-reply.test-harness.ts
+++ b/src/web/auto-reply.test-harness.ts
@@ -139,8 +139,10 @@ export function installWebAutoReplyUnitTestHooks(opts?: { pinDns?: boolean }) {
     _resetLoadConfigMock();
     if (opts?.pinDns) {
       const addresses = [TEST_NET_IP];
-      const fakeLookup: ssrf.LookupFn = async () =>
-        addresses.map((addr) => ({ address: addr, family: addr.includes(":") ? 6 : 4 }));
+      const fakeLookup = (async () => ({
+        address: addresses[0] ?? "93.184.216.34",
+        family: (addresses[0] ?? "").includes(":") ? 6 : 4,
+      })) as unknown as ssrf.LookupFn;
       resolvePinnedHostnameSpy = vi
         .spyOn(ssrf, "resolvePinnedHostname")
         .mockImplementation(async (hostname) => {

--- a/src/web/auto-reply.test-harness.ts
+++ b/src/web/auto-reply.test-harness.ts
@@ -27,7 +27,9 @@ type MockWebListener = {
   sendComposingTo: () => Promise<void>;
 };
 
-export const TEST_NET_IP = "203.0.113.10";
+// Use a genuinely public IP (example.com) so resolvePinnedHostnameWithPolicy
+// does not block it as a special-use address (TEST-NET-3 203.0.113.x is reserved).
+export const TEST_NET_IP = "93.184.216.34";
 
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
@@ -124,25 +126,39 @@ export async function makeSessionStore(
   };
 }
 
+// Store the original before any mocking.
+const _originalResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+
 export function installWebAutoReplyUnitTestHooks(opts?: { pinDns?: boolean }) {
   let resolvePinnedHostnameSpy: { mockRestore: () => unknown } | undefined;
+  let resolvePinnedHostnameWithPolicySpy: { mockRestore: () => unknown } | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     _resetBaileysMocks();
     _resetLoadConfigMock();
     if (opts?.pinDns) {
+      const addresses = [TEST_NET_IP];
+      const fakeLookup: ssrf.LookupFn = async () =>
+        addresses.map((addr) => ({ address: addr, family: addr.includes(":") ? 6 : 4 }));
       resolvePinnedHostnameSpy = vi
         .spyOn(ssrf, "resolvePinnedHostname")
         .mockImplementation(async (hostname) => {
           // SSRF guard pins DNS; stub resolution to avoid live lookups in unit tests.
           const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-          const addresses = [TEST_NET_IP];
           return {
             hostname: normalized,
             addresses,
             lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses }),
           };
+        });
+      resolvePinnedHostnameWithPolicySpy = vi
+        .spyOn(ssrf, "resolvePinnedHostnameWithPolicy")
+        .mockImplementation(async (hostname, params = {}) => {
+          return await _originalResolvePinnedHostnameWithPolicy(hostname, {
+            ...params,
+            lookupFn: fakeLookup,
+          });
         });
     }
   });
@@ -150,6 +166,8 @@ export function installWebAutoReplyUnitTestHooks(opts?: { pinDns?: boolean }) {
   afterEach(() => {
     resolvePinnedHostnameSpy?.mockRestore();
     resolvePinnedHostnameSpy = undefined;
+    resolvePinnedHostnameWithPolicySpy?.mockRestore();
+    resolvePinnedHostnameWithPolicySpy = undefined;
     resetLogger();
     setLoggerOverride(null);
     vi.useRealTimers();


### PR DESCRIPTION
## Summary

The SSRF hardening introduced `fetchWithSsrFGuard` which calls `resolvePinnedHostnameWithPolicy` instead of `resolvePinnedHostname`. Test mocks only covered the latter, causing **17 test failures** across web media, Slack media, and web auto-reply suites.

## Changes

- **`src/test-helpers/ssrf.ts`**: `mockPinnedHostnameResolution` now also mocks `resolvePinnedHostnameWithPolicy` by delegating to the real implementation with a fake `lookupFn`, preserving SSRF policy checks (private IP blocking etc.) while avoiding live DNS lookups.

- **`src/web/auto-reply.test-harness.ts`**: Same pattern applied to `installWebAutoReplyUnitTestHooks` pinDns mock. Changed `TEST_NET_IP` from `203.0.113.10` (RFC 5737 TEST-NET-3, blocked by SSRF) to `93.184.216.34` (public IP) to avoid false SSRF rejections.

## Tests Fixed (17 total)

- `src/web/media.test.ts` — 4 tests
- `src/web/auto-reply.*.test.ts` — 6 tests  
- `src/slack/monitor/media.test.ts` — 7 tests

All 229 web tests pass with zero regressions.