### PR TITLE
fix(telegram): add diagnostic logging for update offset skipping

### DIFF
--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [OpenClaw Threat Model](/security/threat-model-atlas)
 
 ## Contact
 

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
+- [OpenClaw Threat Model](/security/THREAT-MODEL-ATLAS)
 
 ## Contact
 

--- a/docs/security/CONTRIBUTING-THREAT-MODEL.md
+++ b/docs/security/CONTRIBUTING-THREAT-MODEL.md
@@ -77,7 +77,7 @@ If you're unsure about the risk level, just describe the impact and we'll assess
 - [ATLAS Website](https://atlas.mitre.org/)
 - [ATLAS Techniques](https://atlas.mitre.org/techniques/)
 - [ATLAS Case Studies](https://atlas.mitre.org/studies/)
-- [OpenClaw Threat Model](/security/threat-model-atlas)
+- [OpenClaw Threat Model](./THREAT-MODEL-ATLAS.md)
 
 ## Contact
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Threat Model](/security/threat-model-atlas) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](/security/contributing-threat-model) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Threat Model](/security/THREAT-MODEL-ATLAS) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](/security/CONTRIBUTING-THREAT-MODEL) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,8 +4,8 @@
 
 ## Documents
 
-- [Threat Model](/security/threat-model-atlas) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
-- [Contributing to the Threat Model](/security/contributing-threat-model) - How to add threats, mitigations, and attack chains
+- [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
+- [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/contributing-threat-model) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/CONTRIBUTING-THREAT-MODEL) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -21,7 +21,7 @@ This threat model is built on [MITRE ATLAS](https://atlas.mitre.org/), the indus
 
 ### Contributing to This Threat Model
 
-This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](/security/contributing-threat-model) for guidelines on contributing:
+This is a living document maintained by the OpenClaw community. See [CONTRIBUTING-THREAT-MODEL.md](./CONTRIBUTING-THREAT-MODEL.md) for guidelines on contributing:
 
 - Reporting new threats
 - Updating existing threats


### PR DESCRIPTION
## Summary
Adds INFO-level logging to help diagnose when Telegram updates are silently skipped due to stale offset values.

## Problem
When the persisted Telegram update offset becomes stale or desynchronized, group messages are silently skipped. There is zero logging when this happens, making it extremely difficult to diagnose (can take hours of debugging).

## Solution
- Log initial update offset value on startup
- Log when updates are skipped due to offset cutoff

## Changes
- Modified `src/telegram/bot.ts`
- Added `telegramLogger` using `createSubsystemLogger`
- Added startup log showing the loaded offset value
- Added skip log showing which update IDs are being skipped and the current cutoff

## Impact
This reduces debugging time from hours to seconds when group messages are silently dropped while DMs work fine.

## Testing
- [ ] Start gateway with existing offset file
- [ ] Verify startup log shows offset value
- [ ] Verify skip logs appear when updates are filtered

Fixes #27695