### PR TITLE
fix(cli): support versioned node executables without dashes

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -201,8 +201,16 @@ describe("argv helpers", () => {
         expected: ["node-22.2.exe", "openclaw", "status"],
       },
       {
+        rawArgs: ["node24", "openclaw", "status"],
+        expected: ["node24", "openclaw", "status"],
+      },
+      {
         rawArgs: ["/usr/bin/node-22.2.0", "openclaw", "status"],
         expected: ["/usr/bin/node-22.2.0", "openclaw", "status"],
+      },
+      {
+        rawArgs: ["/usr/bin/node24", "openclaw", "status"],
+        expected: ["/usr/bin/node24", "openclaw", "status"],
       },
       {
         rawArgs: ["nodejs", "openclaw", "status"],

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -172,7 +172,7 @@ export function buildParseArgv(params: {
   return ["node", programName || "openclaw", ...normalizedArgv];
 }
 
-const nodeExecutablePattern = /^node-\d+(?:\.\d+)*(?:\.exe)?$/;
+const nodeExecutablePattern = /^node(?:-\d+|\d+)(?:\.\d+)*(?:\.exe)?$/;
 
 function isNodeExecutable(executable: string): boolean {
   return (


### PR DESCRIPTION
Closes #27738

Problem
OpenSUSE Tumbleweed can expose Node as `/usr/bin/node24` (no symlink / no dash). The CLI argv re-parse logic did not recognize that executable name and prepended a fallback `node openclaw ...` wrapper, which left `/usr/bin/node24` in the parsed command args and caused Commander to treat it as an unknown subcommand.

Root Cause
`src/cli/argv.ts` only matched dash-style versioned Node binaries (for example `node-22` / `node-22.2.0.exe`) and rejected no-dash names like `node24`.

Fix
Expand the versioned Node executable regex to accept both `node-<digits>` and `node<digits>` forms, while still requiring numeric suffixes. Added regression tests for `node24` and `/usr/bin/node24`.

Testing
`pnpm vitest run src/cli/argv.test.ts`