### PR TITLE
fix(routing): include accountId in group/channel session keys

### DIFF
--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -115,3 +115,63 @@ describe("session key canonicalization", () => {
     ).toBe("agent:main:main");
   });
 });
+
+describe("buildAgentPeerSessionKey with accountId", () => {
+  it("includes accountId in group/channel session keys", async () => {
+    const { buildAgentPeerSessionKey } = await import("./session-key.js");
+
+    const groupKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "discord",
+      accountId: "designer",
+      peerKind: "group",
+      peerId: "123456",
+    });
+    expect(groupKey).toBe("agent:main:discord:designer:group:123456");
+
+    const channelKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "discord",
+      accountId: "designer",
+      peerKind: "channel",
+      peerId: "789012",
+    });
+    expect(channelKey).toBe("agent:main:discord:designer:channel:789012");
+  });
+
+  it("uses default accountId when not provided for group/channel", async () => {
+    const { buildAgentPeerSessionKey, DEFAULT_ACCOUNT_ID } = await import("./session-key.js");
+
+    const groupKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "discord",
+      peerKind: "group",
+      peerId: "123456",
+    });
+    expect(groupKey).toBe(`agent:main:discord:${DEFAULT_ACCOUNT_ID}:group:123456`);
+  });
+
+  it("distinguishes sessions from different accounts to same channel", async () => {
+    const { buildAgentPeerSessionKey } = await import("./session-key.js");
+
+    const key1 = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "discord",
+      accountId: "designer",
+      peerKind: "channel",
+      peerId: "123456",
+    });
+
+    const key2 = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "discord",
+      accountId: "erp",
+      peerKind: "channel",
+      peerId: "123456",
+    });
+
+    expect(key1).not.toBe(key2);
+    expect(key1).toBe("agent:main:discord:designer:channel:123456");
+    expect(key2).toBe("agent:main:discord:erp:channel:123456");
+  });
+});

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -158,7 +158,8 @@ export function buildAgentPeerSessionKey(params: {
   }
   const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
   const peerId = ((params.peerId ?? "").trim() || "unknown").toLowerCase();
-  return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
+  const accountId = normalizeAccountId(params.accountId);
+  return `agent:${normalizeAgentId(params.agentId)}:${channel}:${accountId}:${peerKind}:${peerId}`;
 }
 
 function resolveLinkedPeerId(params: {


### PR DESCRIPTION
Fixes #27731

When using multiple Discord bot accounts with agent bindings, all messages were routed to the main agent regardless of binding configuration. The root cause was that session keys for group/channel messages did not include the `accountId`, causing messages from different accounts to the same channel to share the same session key.

This led to routing conflicts where whichever agent was last matched would capture all subsequent messages to that channel, regardless of which Discord account received the message.

## Root Cause
The `buildAgentPeerSessionKey()` function in `src/routing/session-key.ts` was generating session keys for group/channel messages without including the `accountId`:

**Old format:** `agent:{agentId}:{channel}:{peerKind}:{peerId}`

This meant messages from different Discord accounts (e.g., `designer`, `erp`) to the same channel would get identical session keys, causing routing conflicts.

## Changes
- Modified `buildAgentPeerSessionKey()` to include `accountId` in group/channel session key format
- **New format:** `agent:{agentId}:{channel}:{accountId}:{peerKind}:{peerId}`
- Added comprehensive tests to verify accountId inclusion and multi-account isolation

## Impact
- Each Discord account now gets its own session namespace per channel
- Agent bindings with `accountId` matching now work correctly
- Messages route to the correct agent based on both channel and account
- Resolves "discord channels unresolved" routing fallback to main agent

## Testing
All existing tests pass, plus new tests added:
- Verifies accountId is included in group/channel session keys
- Verifies default accountId is used when not provided
- Verifies different accounts to same channel get different session keys

This fix applies to all channels (Discord, Telegram, WhatsApp, etc.) that use group/channel routing with multiple accounts.