### PR TITLE
msteams: allow replyStyle config override for DMs

### DIFF
--- a/extensions/msteams/src/policy.test.ts
+++ b/extensions/msteams/src/policy.test.ts
@@ -76,12 +76,20 @@ describe("msteams policy", () => {
   });
 
   describe("resolveMSTeamsReplyPolicy", () => {
-    it("forces thread replies for direct messages", () => {
+    it("defaults to thread replies for direct messages", () => {
+      const policy = resolveMSTeamsReplyPolicy({
+        isDirectMessage: true,
+        globalConfig: {},
+      });
+      expect(policy).toEqual({ requireMention: false, replyStyle: "thread" });
+    });
+
+    it("respects globalConfig replyStyle override for direct messages", () => {
       const policy = resolveMSTeamsReplyPolicy({
         isDirectMessage: true,
         globalConfig: { replyStyle: "top-level", requireMention: false },
       });
-      expect(policy).toEqual({ requireMention: false, replyStyle: "thread" });
+      expect(policy).toEqual({ requireMention: false, replyStyle: "top-level" });
     });
 
     it("defaults to requireMention=true and replyStyle=thread", () => {

--- a/extensions/msteams/src/policy.ts
+++ b/extensions/msteams/src/policy.ts
@@ -221,7 +221,12 @@ export function resolveMSTeamsReplyPolicy(params: {
   channelConfig?: MSTeamsChannelConfig;
 }): MSTeamsReplyPolicy {
   if (params.isDirectMessage) {
-    return { requireMention: false, replyStyle: "thread" };
+    const replyStyle: MSTeamsReplyStyle =
+      params.channelConfig?.replyStyle ??
+      params.teamConfig?.replyStyle ??
+      params.globalConfig?.replyStyle ??
+      "thread";
+    return { requireMention: false, replyStyle };
   }
 
   const requireMention =


### PR DESCRIPTION
## Summary

Direct message conversations currently hardcode `replyStyle: "thread"` in `resolveMSTeamsReplyPolicy()`, ignoring any config override. This causes reply failures in DMs when agent processing exceeds the Bot Framework TurnContext lifetime.

**The problem:** The `"thread"` reply style reuses the original webhook TurnContext. Bot Framework revokes this TurnContext proxy after the HTTP handler returns (~15-30 seconds). When agent processing takes longer — LLM inference, tool calls, multi-step workflows — the final reply attempt hits the revoked proxy and fails silently:

```
msteams final reply failed: Cannot perform 'set' on a proxy that has been revoked
msteams final reply failed: Cannot perform 'get' on a proxy that has been revoked
```

The user sees the agent's "thinking" preamble but never receives the actual response.

**The fix:** The `"top-level"` reply style uses `adapter.continueConversation()` which creates a fresh TurnContext per send — no proxy expiry issue. This change makes DMs respect the same config cascade (`channelConfig → teamConfig → globalConfig`) as group conversations, while preserving `"thread"` as the default for backwards compatibility.

After this change, operators hitting proxy-revoked errors in DMs can set `replyStyle: "top-level"` in their msteams channel config to resolve the issue.

## Changes

- `extensions/msteams/src/policy.ts`: Replace hardcoded `"thread"` return for DMs with config cascade resolution (same pattern as non-DM path), defaulting to `"thread"`
- `extensions/msteams/src/policy.test.ts`: Update test to verify default behavior + add test for config override

## Test plan

- [x] `pnpm test -- --run extensions/msteams/src/policy.test.ts` — all 17 tests pass
- [ ] Deploy with `replyStyle: "top-level"` in msteams config — verify DM replies deliver reliably regardless of agent processing time
- [ ] Deploy without explicit replyStyle — verify DMs still default to `"thread"` (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)