### PR TITLE
fix(config): migrate plugins.allow when extensions exist (#19995)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12342,21 +12342,21 @@
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
         "is_verified": false,
-        "line_number": 665
+        "line_number": 700
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
         "is_verified": false,
-        "line_number": 811
+        "line_number": 846
       },
       {
         "type": "Secret Keyword",
         "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 1490
+        "line_number": 1525
       }
     ],
     "src/agents/sandbox/browser.novnc-url.test.ts": [
@@ -14725,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T15:49:22Z"
 }

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -70,6 +70,46 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("migrates plugins.allow when extension artifacts exist and allowlist is unset", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(path.join(configDir, "extensions", "zalo"), { recursive: true });
+      await fs.mkdir(path.join(configDir, "extensions", "matrix"), { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify({}, null, 2),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.shouldWriteConfig).toBe(true);
+      expect(result.cfg.plugins?.allow).toEqual(["matrix", "zalo"]);
+    });
+  });
+
+  it("does not alter explicit plugins.allow when extension artifacts exist", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(path.join(configDir, "extensions", "zalo"), { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify({ plugins: { allow: ["voice-call"] } }, null, 2),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      expect(result.cfg.plugins?.allow).toEqual(["voice-call"]);
+    });
+  });
+
   it("does not warn on mutable account allowlists when dangerous name matching is inherited", async () => {
     const doctorWarnings = await collectDoctorWarnings({
       channels: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, migrateLegacyConfig, readConfigFileSnapshot } from "../config/config.js";
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { resolveStateDir } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
@@ -29,6 +30,7 @@ import {
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import {
   formatChannelAccountsDefaultPath,
   formatSetExplicitDefaultInstruction,
@@ -218,6 +220,63 @@ function asObjectRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function hasExplicitPluginsAllow(cfg: OpenClawConfig): boolean {
+  return Boolean(cfg.plugins && Object.prototype.hasOwnProperty.call(cfg.plugins, "allow"));
+}
+
+async function maybeMigratePluginsAllowForExtensions(cfg: OpenClawConfig): Promise<{
+  config: OpenClawConfig;
+  changes: string[];
+}> {
+  if (hasExplicitPluginsAllow(cfg)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const stateDir = resolveStateDir(process.env);
+  const extensionsDir = path.join(stateDir, "extensions");
+  const entries = await fs.readdir(extensionsDir, { withFileTypes: true }).catch(() => []);
+  const extensionPluginIds = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name.trim().toLowerCase())
+    .filter(Boolean);
+  if (extensionPluginIds.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const normalizedPlugins = normalizePluginsConfig(cfg.plugins);
+  if (!normalizedPlugins.enabled) {
+    return { config: cfg, changes: [] };
+  }
+  const denySet = new Set(normalizedPlugins.deny.map((id) => id.toLowerCase()));
+  const entryById = new Map(
+    Object.entries(normalizedPlugins.entries).map(([id, entry]) => [
+      id.trim().toLowerCase(),
+      entry,
+    ]),
+  );
+  const allow = Array.from(new Set(extensionPluginIds))
+    .filter((id) => !denySet.has(id))
+    .filter((id) => entryById.get(id)?.enabled !== false)
+    .toSorted();
+  if (allow.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  return {
+    config: {
+      ...cfg,
+      plugins: {
+        ...cfg.plugins,
+        allow,
+      },
+    },
+    changes: [
+      `Migrated plugins.allow from installed extension artifacts (${allow.join(", ")}).`,
+      "Set plugins.allow explicitly to keep extension trust pinned after upgrade.",
+    ],
+  };
 }
 
 function normalizeBindingChannelKey(raw?: string | null): string {
@@ -1875,6 +1934,20 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg = autoEnable.config;
     } else {
       fixHints.push(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply these changes.`);
+    }
+  }
+
+  const pluginsAllowMigration = await maybeMigratePluginsAllowForExtensions(candidate);
+  if (pluginsAllowMigration.changes.length > 0) {
+    note(pluginsAllowMigration.changes.join("\n"), "Doctor changes");
+    candidate = pluginsAllowMigration.config;
+    pendingChanges = true;
+    if (shouldRepair) {
+      cfg = pluginsAllowMigration.config;
+    } else {
+      fixHints.push(
+        `Run "${formatCliCommand("openclaw doctor --fix")}" to migrate plugins.allow for discovered extensions.`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: upgrades can leave `plugins.allow` unset when extension artifacts already exist under state, which triggers `plugins.extensions_no_allowlist` and leaves trust unpinned.
- Why it matters: hosts can land in a security-audit critical state immediately after upgrade until operators manually harden config.
- What changed: `doctor` now migrates `plugins.allow` from discovered extension directories when allowlist is unset, while respecting `plugins.enabled`, `plugins.deny`, and explicit `plugins.entries.<id>.enabled=false`.
- What did NOT change (scope boundary): no change to explicit operator-defined `plugins.allow`; no plugin loading semantics changed beyond writing an explicit allowlist in the migration scenario.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #19995
- Related #

## User-visible / Behavior Changes

- Running `openclaw doctor --fix` on installs with extension artifacts and no explicit `plugins.allow` now writes a pinned allowlist.
- Non-fix doctor runs now include a specific fix hint for migrating `plugins.allow` in this scenario.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: local dev
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): empty config with extension dirs present

### Steps

1. Create `~/.openclaw/extensions/<plugin-id>` directories on a host with no `plugins.allow` set.
2. Run `openclaw security audit --deep` and observe `plugins.extensions_no_allowlist`.
3. Run `openclaw doctor --fix`.

### Expected

- `plugins.allow` is populated with discovered extension ids (minus denied/disabled ids), pinning trust.

### Actual

- Doctor migration now writes explicit allowlist and reports migration change/hint.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified changed tests pass: `pnpm vitest run src/commands/doctor-config-flow.test.ts` (18/18).
- Verified migration path in test creates `plugins.allow` from extension artifacts.
- Verified explicit `plugins.allow` remains unchanged in migration scenario.
- `pnpm build` and `pnpm check` passed.
- `pnpm test` in this environment was unstable/noisy (many 0-test vitest workers in parallel harness), so I included targeted verification for changed surface.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No (automatic via doctor fix path)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore:
  - `src/commands/doctor-config-flow.ts`
  - `src/commands/doctor-config-flow.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected population of `plugins.allow` when explicit allowlist already exists.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: auto-derived allowlist could include stale extension directories that operators forgot to remove.
  - Mitigation: migration only runs when allowlist is unset; operators can edit `plugins.allow` explicitly after migration.
