### PR TITLE
security(media): harden MIME sanitization for #9795

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -890,6 +890,22 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain('mime="application/json"');
   });
 
+  it("rejects MIME values with trailing junk instead of prefix-matching", async () => {
+    const filePath = await createTempMediaFile({
+      fileName: "binary.bin",
+      // Keep payload empty so text heuristics do not override the provided MIME.
+      content: Buffer.alloc(0),
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:document>",
+      mediaPath: filePath,
+      mediaType: "application/xml\njunk",
+    });
+
+    expectFileNotApplied({ ctx, result, body: "<media:document>" });
+  });
+
   it("handles path traversal attempts in filenames safely", async () => {
     // Even if a file somehow got a path-like name, it should be handled safely
     const filePath = await createTempMediaFile({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -90,12 +90,13 @@ function sanitizeMimeType(value?: string): string | undefined {
   if (!value) {
     return undefined;
   }
-  const trimmed = value.trim().toLowerCase();
+  const trimmed = value.trim();
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/);
-  return match?.[1];
+  const normalized = trimmed.normalize("NFKC");
+  const match = normalized.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)(?:\s*;[^\r\n]*)?$/i);
+  return match?.[1]?.toLowerCase();
 }
 
 function resolveFileLimits(cfg: OpenClawConfig) {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -13,10 +13,15 @@ async function waitForMicrotaskTurn(): Promise<void> {
 let fetchWithGuard: typeof import("./input-files.js").fetchWithGuard;
 let extractImageContentFromSource: typeof import("./input-files.js").extractImageContentFromSource;
 let extractFileContentFromSource: typeof import("./input-files.js").extractFileContentFromSource;
+let normalizeInputMimeType: typeof import("./input-files.js").normalizeMimeType;
 
 beforeAll(async () => {
-  ({ fetchWithGuard, extractImageContentFromSource, extractFileContentFromSource } =
-    await import("./input-files.js"));
+  ({
+    fetchWithGuard,
+    extractImageContentFromSource,
+    extractFileContentFromSource,
+    normalizeMimeType: normalizeInputMimeType,
+  } = await import("./input-files.js"));
 });
 
 describe("fetchWithGuard", () => {
@@ -150,5 +155,13 @@ describe("input image base64 validation", () => {
       },
     );
     expect(image.data).toBe("aGVsbG8=");
+  });
+});
+
+describe("normalizeMimeType", () => {
+  it("normalizes NFKC fullwidth MIME inputs", () => {
+    expect(normalizeInputMimeType("Ａｐｐｌｉｃａｔｉｏｎ／ＸＭＬ； charset=utf-8")).toBe(
+      "application/xml",
+    );
   });
 });

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -156,7 +156,8 @@ export function parseContentType(value: string | undefined): {
   if (!value) {
     return {};
   }
-  const parts = value.split(";").map((part) => part.trim());
+  const normalizedValue = value.normalize("NFKC");
+  const parts = normalizedValue.split(";").map((part) => part.trim());
   const mimeType = normalizeMimeType(parts[0]);
   const charset = parts
     .map((part) => part.match(/^charset=(.+)$/i)?.[1]?.trim())

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -143,7 +143,8 @@ export function normalizeMimeType(value: string | undefined): string | undefined
   if (!value) {
     return undefined;
   }
-  const [raw] = value.split(";");
+  const normalizedValue = value.normalize("NFKC");
+  const [raw] = normalizedValue.split(";");
   const normalized = raw?.trim().toLowerCase();
   return normalized || undefined;
 }

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -114,6 +114,7 @@ describe("isAudioFileName", () => {
 describe("normalizeMimeType", () => {
   it.each([
     { input: "Audio/MP4; codecs=mp4a.40.2", expected: "audio/mp4" },
+    { input: "Ａｐｐｌｉｃａｔｉｏｎ／Ｊｓｏｎ； charset=utf-8", expected: "application/json" },
     { input: "   ", expected: undefined },
     { input: null, expected: undefined },
     { input: undefined, expected: undefined },

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -57,7 +57,8 @@ export function normalizeMimeType(mime?: string | null): string | undefined {
   if (!mime) {
     return undefined;
   }
-  const cleaned = mime.split(";")[0]?.trim().toLowerCase();
+  const normalizedMime = mime.normalize("NFKC");
+  const cleaned = normalizedMime.split(";")[0]?.trim().toLowerCase();
   return cleaned || undefined;
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: MIME sanitization accepted prefix matches without end anchoring, allowing trailing junk in some paths.
- Why it matters: malformed MIME strings can bypass intended sanitization boundaries and enter downstream extraction logic.
- What changed: anchored `sanitizeMimeType()` regex and added NFKC normalization before validation.
- What changed: added NFKC normalization to both `normalizeMimeType()` implementations used by media parsing paths.
- What did NOT change (scope boundary): no changes to media routing, network fetching, or channel behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9795
- Related #9791

## User-visible / Behavior Changes

- Malformed MIME values with trailing junk are now rejected instead of being prefix-matched.
- Fullwidth Unicode MIME inputs are normalized with NFKC before MIME normalization/sanitization.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): media-understanding pipeline
- Relevant config (redacted): default local test config

### Steps

1. Apply MIME sanitization hardening in `src/media-understanding/apply.ts`.
2. Add NFKC normalization in `src/media/input-files.ts` and `src/media/mime.ts`.
3. Add/adjust tests for trailing-junk rejection and NFKC normalization.

### Expected

- Trailing junk in MIME is rejected by `sanitizeMimeType()`.
- Fullwidth MIME strings normalize to canonical ASCII MIME values.

### Actual

- Behavior matches expected; targeted tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed no existing open PR for #9795 before creating this branch/PR.
  - Confirmed branch is isolated from unrelated commits.
  - Ran targeted tests: `pnpm test src/media-understanding/apply.test.ts src/media/mime.test.ts src/media/input-files.fetch-guard.test.ts`.
- Edge cases checked:
  - MIME with trailing newline junk rejected in media-understanding test path.
  - Fullwidth MIME inputs normalize correctly via NFKC.
- What you did **not** verify:
  - Full repository test suite was not executed.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `48d5ed02f`.
- Files/config to restore:
  - `src/media-understanding/apply.ts`
  - `src/media/input-files.ts`
  - `src/media/mime.ts`
  - related tests in `src/media-understanding/apply.test.ts`, `src/media/input-files.fetch-guard.test.ts`, `src/media/mime.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected skipping of file extraction for legitimate MIME inputs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some previously tolerated malformed MIME values may now be rejected.
  - Mitigation:
    - Validation is explicit and covered by focused tests; legitimate MIME values with parameters remain accepted.
