### PR TITLE
fix(anthropic): skip cache_control for thinking/redacted_thinking blocks

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -91,3 +91,95 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
     expect(payload.messages[0].content).toBe("Hello");
   });
 });
+
+it("skips cache_control injection for thinking blocks in system messages", () => {
+  const payload = {
+    messages: [
+      {
+        role: "system",
+        content: [
+          { type: "text", text: "System prompt" },
+          { type: "thinking", thinking: "Internal reasoning" },
+        ],
+      },
+    ],
+  };
+
+  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+
+  const content = payload.messages[0].content as Array<Record<string, unknown>>;
+  expect(content[0]).toEqual({ type: "text", text: "System prompt" });
+  // thinking block should not have cache_control added
+  expect(content[1]).toEqual({ type: "thinking", thinking: "Internal reasoning" });
+  expect(content[1].cache_control).toBeUndefined();
+});
+
+it("removes cache_control from thinking blocks in assistant messages", () => {
+  const payload = {
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me think", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "Here is my response" },
+        ],
+      },
+    ],
+  };
+
+  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+
+  const content = payload.messages[0].content as Array<Record<string, unknown>>;
+  // cache_control should be removed from thinking block
+  expect(content[0]).toEqual({ type: "thinking", thinking: "Let me think" });
+  expect(content[0].cache_control).toBeUndefined();
+  // text block should remain unchanged
+  expect(content[1]).toEqual({ type: "text", text: "Here is my response" });
+});
+
+it("removes cache_control from redacted_thinking blocks in assistant messages", () => {
+  const payload = {
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "redacted_thinking",
+            redacted_thinking: "...",
+            cache_control: { type: "ephemeral" },
+          },
+          { type: "text", text: "Response" },
+        ],
+      },
+    ],
+  };
+
+  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+
+  const content = payload.messages[0].content as Array<Record<string, unknown>>;
+  expect(content[0]).toEqual({ type: "redacted_thinking", redacted_thinking: "..." });
+  expect(content[0].cache_control).toBeUndefined();
+});
+
+it("handles mixed content with thinking blocks correctly", () => {
+  const payload = {
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Before thinking" },
+          { type: "thinking", thinking: "Reasoning", cache_control: { type: "ephemeral" } },
+          { type: "text", text: "After thinking" },
+        ],
+      },
+    ],
+  };
+
+  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+
+  const content = payload.messages[0].content as Array<Record<string, unknown>>;
+  expect(content[0]).toEqual({ type: "text", text: "Before thinking" });
+  expect(content[1]).toEqual({ type: "thinking", thinking: "Reasoning" });
+  expect(content[1].cache_control).toBeUndefined();
+  expect(content[2]).toEqual({ type: "text", text: "After thinking" });
+});

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -90,96 +90,96 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
 
     expect(payload.messages[0].content).toBe("Hello");
   });
-});
 
-it("skips cache_control injection for thinking blocks in system messages", () => {
-  const payload = {
-    messages: [
-      {
-        role: "system",
-        content: [
-          { type: "text", text: "System prompt" },
-          { type: "thinking", thinking: "Internal reasoning" },
-        ],
-      },
-    ],
-  };
+  it("skips cache_control injection for thinking blocks in system messages", () => {
+    const payload = {
+      messages: [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "System prompt" },
+            { type: "thinking", thinking: "Internal reasoning" },
+          ],
+        },
+      ],
+    };
 
-  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
-  const content = payload.messages[0].content as Array<Record<string, unknown>>;
-  expect(content[0]).toEqual({ type: "text", text: "System prompt" });
-  // thinking block should not have cache_control added
-  expect(content[1]).toEqual({ type: "thinking", thinking: "Internal reasoning" });
-  expect(content[1].cache_control).toBeUndefined();
-});
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "text", text: "System prompt" });
+    // thinking block should not have cache_control added
+    expect(content[1]).toEqual({ type: "thinking", thinking: "Internal reasoning" });
+    expect(content[1].cache_control).toBeUndefined();
+  });
 
-it("removes cache_control from thinking blocks in assistant messages", () => {
-  const payload = {
-    messages: [
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "Let me think", cache_control: { type: "ephemeral" } },
-          { type: "text", text: "Here is my response" },
-        ],
-      },
-    ],
-  };
+  it("removes cache_control from thinking blocks in assistant messages", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Let me think", cache_control: { type: "ephemeral" } },
+            { type: "text", text: "Here is my response" },
+          ],
+        },
+      ],
+    };
 
-  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
-  const content = payload.messages[0].content as Array<Record<string, unknown>>;
-  // cache_control should be removed from thinking block
-  expect(content[0]).toEqual({ type: "thinking", thinking: "Let me think" });
-  expect(content[0].cache_control).toBeUndefined();
-  // text block should remain unchanged
-  expect(content[1]).toEqual({ type: "text", text: "Here is my response" });
-});
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    // cache_control should be removed from thinking block
+    expect(content[0]).toEqual({ type: "thinking", thinking: "Let me think" });
+    expect(content[0].cache_control).toBeUndefined();
+    // text block should remain unchanged
+    expect(content[1]).toEqual({ type: "text", text: "Here is my response" });
+  });
 
-it("removes cache_control from redacted_thinking blocks in assistant messages", () => {
-  const payload = {
-    messages: [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "redacted_thinking",
-            redacted_thinking: "...",
-            cache_control: { type: "ephemeral" },
-          },
-          { type: "text", text: "Response" },
-        ],
-      },
-    ],
-  };
+  it("removes cache_control from redacted_thinking blocks in assistant messages", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "redacted_thinking",
+              redacted_thinking: "...",
+              cache_control: { type: "ephemeral" },
+            },
+            { type: "text", text: "Response" },
+          ],
+        },
+      ],
+    };
 
-  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
-  const content = payload.messages[0].content as Array<Record<string, unknown>>;
-  expect(content[0]).toEqual({ type: "redacted_thinking", redacted_thinking: "..." });
-  expect(content[0].cache_control).toBeUndefined();
-});
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "redacted_thinking", redacted_thinking: "..." });
+    expect(content[0].cache_control).toBeUndefined();
+  });
 
-it("handles mixed content with thinking blocks correctly", () => {
-  const payload = {
-    messages: [
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Before thinking" },
-          { type: "thinking", thinking: "Reasoning", cache_control: { type: "ephemeral" } },
-          { type: "text", text: "After thinking" },
-        ],
-      },
-    ],
-  };
+  it("handles mixed content with thinking blocks correctly", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Before thinking" },
+            { type: "thinking", thinking: "Reasoning", cache_control: { type: "ephemeral" } },
+            { type: "text", text: "After thinking" },
+          ],
+        },
+      ],
+    };
 
-  runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
+    runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
-  const content = payload.messages[0].content as Array<Record<string, unknown>>;
-  expect(content[0]).toEqual({ type: "text", text: "Before thinking" });
-  expect(content[1]).toEqual({ type: "thinking", thinking: "Reasoning" });
-  expect(content[1].cache_control).toBeUndefined();
-  expect(content[2]).toEqual({ type: "text", text: "After thinking" });
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "text", text: "Before thinking" });
+    expect(content[1]).toEqual({ type: "thinking", thinking: "Reasoning" });
+    expect(content[1].cache_control).toBeUndefined();
+    expect(content[2]).toEqual({ type: "text", text: "After thinking" });
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -380,17 +380,37 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
         const messages = (payload as Record<string, unknown>)?.messages;
         if (Array.isArray(messages)) {
           for (const msg of messages as PayloadMessage[]) {
-            if (msg.role !== "system" && msg.role !== "developer") {
-              continue;
+            // Handle system/developer messages
+            if (msg.role === "system" || msg.role === "developer") {
+              if (typeof msg.content === "string") {
+                msg.content = [
+                  { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
+                ];
+              } else if (Array.isArray(msg.content) && msg.content.length > 0) {
+                const last = msg.content[msg.content.length - 1];
+                if (last && typeof last === "object") {
+                  const lastBlock = last as Record<string, unknown>;
+                  // Skip thinking/redacted_thinking blocks - Anthropic requires these
+                  // to remain unmodified
+                  if (lastBlock.type !== "thinking" && lastBlock.type !== "redacted_thinking") {
+                    lastBlock.cache_control = { type: "ephemeral" };
+                  }
+                }
+              }
             }
-            if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
-            } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-              const last = msg.content[msg.content.length - 1];
-              if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+            // Handle assistant messages - skip thinking/redacted_thinking blocks
+            else if (msg.role === "assistant" && Array.isArray(msg.content)) {
+              for (const block of msg.content) {
+                if (block && typeof block === "object") {
+                  const contentBlock = block as Record<string, unknown>;
+                  // Remove cache_control from thinking/redacted_thinking blocks if present
+                  if (
+                    contentBlock.type === "thinking" ||
+                    contentBlock.type === "redacted_thinking"
+                  ) {
+                    delete contentBlock.cache_control;
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #27752

When `thinkingDefault` is enabled and sessions are long (~100+ turns), Anthropic's API rejects requests with a 400 error because thinking or redacted_thinking blocks in assistant messages appear to be modified during context rebuild by the prompt caching `cache_control` injection.

## Root Cause
Anthropic requires thinking/redacted_thinking blocks to remain byte-for-byte unmodified from the original response (see [Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks)). The OpenRouter Anthropic `cache_control` injection logic was adding `cache_control: { type: "ephemeral" }` to the last content block of messages, including thinking/redacted_thinking blocks, which violates this requirement.

Error observed:
\\\
LLM request rejected: messages.135.content.13: thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.
\\\

## Changes
- Modified OpenRouter Anthropic `cache_control` injection to skip thinking/redacted_thinking blocks in system/developer messages
- Added logic to remove `cache_control` from thinking/redacted_thinking blocks in assistant messages if present (defensive measure)
- Added comprehensive tests to verify thinking blocks are not modified:
  - Skips `cache_control` injection for thinking blocks in system messages
  - Removes `cache_control` from thinking blocks in assistant messages
  - Removes `cache_control` from redacted_thinking blocks
  - Handles mixed content with thinking blocks correctly

## Impact
- Long sessions with `thinkingDefault` enabled no longer break after ~100+ turns
- Users can continue conversations without needing to issue `/new` to start fresh
- Thinking blocks remain compliant with Anthropic's requirements
- No impact on non-thinking content blocks or prompt caching functionality

## Testing
All tests pass, including 4 new tests specifically for thinking block handling.