### PR TITLE
ability to set config path for signal-cli

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -45,12 +45,13 @@ Minimal config:
 
 Field reference:
 
-| Field       | Description                                       |
-| ----------- | ------------------------------------------------- |
-| `account`   | Bot phone number in E.164 format (`+15551234567`) |
-| `cliPath`   | Path to `signal-cli` (`signal-cli` if on `PATH`)  |
-| `dmPolicy`  | DM access policy (`pairing` recommended)          |
-| `allowFrom` | Phone numbers or `uuid:<id>` values allowed to DM |
+| Field        | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `account`    | Bot phone number in E.164 format (`+15551234567`) |
+| `cliPath`    | Path to `signal-cli` (`signal-cli` if on `PATH`)  |
+| `configPath` | signal-cli config dir passed as `--config`        |
+| `dmPolicy`   | DM access policy (`pairing` recommended)          |
+| `allowFrom`  | Phone numbers or `uuid:<id>` values allowed to DM |
 
 ## What it is
 
@@ -300,6 +301,7 @@ Provider options:
 - `channels.signal.enabled`: enable/disable channel startup.
 - `channels.signal.account`: E.164 for the bot account.
 - `channels.signal.cliPath`: path to `signal-cli`.
+- `channels.signal.configPath`: optional `signal-cli --config` directory.
 - `channels.signal.httpUrl`: full daemon URL (overrides host/port).
 - `channels.signal.httpHost`, `channels.signal.httpPort`: daemon bind (default 127.0.0.1:8080).
 - `channels.signal.autoStart`: auto-spawn daemon (default true if `httpUrl` unset).

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -105,9 +105,9 @@ const STRUCTURED_CHANNEL_CONFIG_SPECS: Record<string, StructuredChannelConfigSpe
     accountStringKeys: ["botToken", "appToken", "userToken"],
   },
   signal: {
-    stringKeys: ["account", "httpUrl", "httpHost", "cliPath"],
+    stringKeys: ["account", "configPath", "httpUrl", "httpHost", "cliPath"],
     numberKeys: ["httpPort"],
-    accountStringKeys: ["account", "httpUrl", "httpHost", "cliPath"],
+    accountStringKeys: ["account", "configPath", "httpUrl", "httpHost", "cliPath"],
   },
   imessage: {
     stringKeys: ["cliPath"],

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -501,6 +501,7 @@ const CHANNELS_AGENTS_TARGET_KEYS = [
   "channels.msteams",
   "channels.signal",
   "channels.signal.account",
+  "channels.signal.configPath",
   "channels.slack",
   "channels.slack.appToken",
   "channels.slack.botToken",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1272,6 +1272,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow Signal to write config in response to channel events/commands (default: true).",
   "channels.signal.account":
     "Signal account identifier (phone/number handle) used to bind this channel config to a specific Signal identity. Keep this aligned with your linked device/session state.",
+  "channels.signal.configPath":
+    "Optional directory passed to signal-cli via --config to control where Signal account state is stored/read. Use this when your service runtime needs a non-default signal-cli data path.",
   "channels.imessage.configWrites":
     "Allow iMessage to write config in response to channel events/commands (default: true).",
   "channels.imessage.cliPath":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -713,6 +713,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.mattermost.oncharPrefixes": "Mattermost Onchar Prefixes",
   "channels.mattermost.requireMention": "Mattermost Require Mention",
   "channels.signal.account": "Signal Account",
+  "channels.signal.configPath": "Signal CLI Config Path",
   "channels.imessage.cliPath": "iMessage CLI Path",
   "agents.list[].skills": "Agent Skill Filter",
   "agents.list[].identity.avatar": "Agent Avatar",

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -6,6 +6,8 @@ export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
 export type SignalAccountConfig = CommonChannelMessagingConfig & {
   /** Optional explicit E.164 account for signal-cli. */
   account?: string;
+  /** Optional signal-cli config directory path (passed as --config). */
+  configPath?: string;
   /** Optional full base URL for signal-cli HTTP daemon. */
   httpUrl?: string;
   /** HTTP host for signal-cli daemon (default 127.0.0.1). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -735,6 +735,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    configPath: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),

--- a/src/signal/accounts.ts
+++ b/src/signal/accounts.ts
@@ -46,6 +46,7 @@ export function resolveSignalAccount(params: {
   const baseUrl = merged.httpUrl?.trim() || `http://${host}:${port}`;
   const configured = Boolean(
     merged.account?.trim() ||
+    merged.configPath?.trim() ||
     merged.httpUrl?.trim() ||
     merged.cliPath?.trim() ||
     merged.httpHost?.trim() ||

--- a/src/signal/daemon.ts
+++ b/src/signal/daemon.ts
@@ -3,6 +3,7 @@ import type { RuntimeEnv } from "../runtime.js";
 
 export type SignalDaemonOpts = {
   cliPath: string;
+  configPath?: string;
   account?: string;
   httpHost: string;
   httpPort: number;
@@ -65,6 +66,9 @@ function bindSignalCliOutput(params: {
 
 function buildDaemonArgs(opts: SignalDaemonOpts): string[] {
   const args: string[] = [];
+  if (opts.configPath?.trim()) {
+    args.push("--config", opts.configPath.trim());
+  }
   if (opts.account) {
     args.push("-a", opts.account);
   }

--- a/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -184,6 +184,42 @@ describe("monitorSignalProvider tool results", () => {
     );
   });
 
+  it("passes channels.signal.configPath to signal-cli daemon startup", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig({ configPath: "~/.openclaw/signal-cli" });
+    const abortController = createAutoAbortController();
+
+    await runMonitorWithMocks({
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      abortSignal: abortController.signal,
+      runtime,
+    });
+
+    expect(spawnSignalDaemonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configPath: "~/.openclaw/signal-cli",
+      }),
+    );
+  });
+
+  it("does not pass configPath when channels.signal.configPath is unset", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig({ configPath: "" });
+    const abortController = createAutoAbortController();
+
+    await runMonitorWithMocks({
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      abortSignal: abortController.signal,
+      runtime,
+    });
+
+    const spawnCall = spawnSignalDaemonMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(spawnCall).toBeDefined();
+    expect(spawnCall).not.toHaveProperty("configPath");
+  });
+
   it("uses startupTimeoutMs override when provided", async () => {
     const runtime = createMonitorRuntime();
     setSignalAutoStartConfig({ startupTimeoutMs: 60_000 });

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -38,6 +38,7 @@ export type MonitorSignalOpts = {
   autoStart?: boolean;
   startupTimeoutMs?: number;
   cliPath?: string;
+  configPath?: string;
   httpHost?: string;
   httpPort?: number;
   receiveMode?: "on-start" | "manual";
@@ -381,9 +382,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
 
   if (autoStart) {
     const cliPath = opts.cliPath ?? accountInfo.config.cliPath ?? "signal-cli";
+    const configPathRaw = opts.configPath ?? accountInfo.config.configPath;
+    const configPath = configPathRaw?.trim() || undefined;
     const httpHost = opts.httpHost ?? accountInfo.config.httpHost ?? "127.0.0.1";
     const httpPort = opts.httpPort ?? accountInfo.config.httpPort ?? 8080;
-    daemonHandle = spawnSignalDaemon({
+    const daemonOpts = {
       cliPath,
       account,
       httpHost,
@@ -393,7 +396,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       ignoreStories: opts.ignoreStories ?? accountInfo.config.ignoreStories,
       sendReadReceipts,
       runtime,
-    });
+    };
+    if (configPath) {
+      daemonOpts.configPath = configPath;
+    }
+    daemonHandle = spawnSignalDaemon(daemonOpts);
     daemonLifecycle.attach(daemonHandle);
   }
 

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -396,10 +396,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       ignoreStories: opts.ignoreStories ?? accountInfo.config.ignoreStories,
       sendReadReceipts,
       runtime,
+      ...(configPath ? { configPath } : {}),
     };
-    if (configPath) {
-      daemonOpts.configPath = configPath;
-    }
     daemonHandle = spawnSignalDaemon(daemonOpts);
     daemonLifecycle.attach(daemonHandle);
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: I need to be able to use a backed up/non-default location for my signal-cli config
- Why it matters: I put everything in one location so it's easier to back up and migrate
- What changed: All signal related files relevant to the feature
- What did NOT change (scope boundary): Anything unrelated

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macos
- Runtime/container: none
- Model/provider: kimi-k2
- Integration/channel (if any): signal
- Relevant config (redacted): openclaw.json

### Steps

Set 

```
  "channels": {
    "signal": {
      "capabilities": [],
      "enabled": true,
      "account": "+13XXXX",
      "cliPath": "/usr/local/bin/signal-cli",
      "configPath": "~/.openclaw/signal-cli",
 ```

### Expected

It uses `signal-cli --config ~/.openclaw/signal-cli` under the hood

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 
```
  "channels": {
    "signal": {
      "capabilities": [],
      "enabled": true,
      "account": "+134XXXX",
      "cliPath": "/usr/local/bin/signal-cli",
      "configPath": "~/.openclaw/signal-cli",
 ```
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Config, but only if you want to use it
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Don't use it.
- Files/config to restore: openclaw.json
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Nothing
  - Mitigation:
