### PR TITLE
feat: add MiniMax M2 and highspeed variants to minimax-portal-auth

### DIFF
--- a/extensions/minimax-portal-auth/index.ts
+++ b/extensions/minimax-portal-auth/index.ts
@@ -85,13 +85,29 @@ function createOAuthHandler(region: MiniMaxRegion) {
                 api: "anthropic-messages",
                 models: [
                   buildModelDefinition({
+                    id: "MiniMax-M2",
+                    name: "MiniMax M2",
+                    input: ["text"],
+                  }),
+                  buildModelDefinition({
                     id: "MiniMax-M2.1",
                     name: "MiniMax M2.1",
                     input: ["text"],
                   }),
                   buildModelDefinition({
+                    id: "MiniMax-M2.1-highspeed",
+                    name: "MiniMax M2.1 Highspeed",
+                    input: ["text"],
+                  }),
+                  buildModelDefinition({
                     id: "MiniMax-M2.5",
                     name: "MiniMax M2.5",
+                    input: ["text"],
+                    reasoning: true,
+                  }),
+                  buildModelDefinition({
+                    id: "MiniMax-M2.5-highspeed",
+                    name: "MiniMax M2.5 Highspeed",
                     input: ["text"],
                     reasoning: true,
                   }),
@@ -102,8 +118,11 @@ function createOAuthHandler(region: MiniMaxRegion) {
           agents: {
             defaults: {
               models: {
+                [modelRef("MiniMax-M2")]: { alias: "minimax-m2" },
                 [modelRef("MiniMax-M2.1")]: { alias: "minimax-m2.1" },
+                [modelRef("MiniMax-M2.1-highspeed")]: { alias: "minimax-m2.1-highspeed" },
                 [modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
+                [modelRef("MiniMax-M2.5-highspeed")]: { alias: "minimax-m2.5-highspeed" },
               },
             },
           },

--- a/extensions/minimax-portal-auth/index.ts
+++ b/extensions/minimax-portal-auth/index.ts
@@ -95,11 +95,6 @@ function createOAuthHandler(region: MiniMaxRegion) {
                     input: ["text"],
                   }),
                   buildModelDefinition({
-                    id: "MiniMax-M2.1-highspeed",
-                    name: "MiniMax M2.1 Highspeed",
-                    input: ["text"],
-                  }),
-                  buildModelDefinition({
                     id: "MiniMax-M2.5",
                     name: "MiniMax M2.5",
                     input: ["text"],
@@ -120,7 +115,6 @@ function createOAuthHandler(region: MiniMaxRegion) {
               models: {
                 [modelRef("MiniMax-M2")]: { alias: "minimax-m2" },
                 [modelRef("MiniMax-M2.1")]: { alias: "minimax-m2.1" },
-                [modelRef("MiniMax-M2.1-highspeed")]: { alias: "minimax-m2.1-highspeed" },
                 [modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
                 [modelRef("MiniMax-M2.5-highspeed")]: { alias: "minimax-m2.5-highspeed" },
               },


### PR DESCRIPTION
## Summary

- Problem: MiniMax-M2 and MiniMax-M2.5-highspeed models were not available in minimax-portal-auth plugin
- Why it matters: Users want access to these additional MiniMax model variants available in Coding Plan
- What changed: Added 4 model definitions with their corresponding aliases in agent defaults
- What did NOT change: Existing auth flow and plugin structure remain unchanged

**Note:** MiniMax-M2.1-highspeed is NOT available in the Coding Plan, so it was removed from this PR.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Related # TODO

## User-visible / Behavior Changes

Four MiniMax models are now available for OAuth users in both global and CN regions:

- `MiniMax-M2` (alias: `minimax-m2`)
- `MiniMax-M2.1` (alias: `minimax-m2.1`)
- `MiniMax-M2.5` (alias: `minimax-m2.5`) - with reasoning: true
- `MiniMax-M2.5-highspeed` (alias: `minimax-m2.5-highspeed`) - with reasoning: true

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

Run OpenClaw with minimax-portal-auth plugin, initialize OAuth, and verify all 4 models appear in provider config.

## Evidence

Added 4 new MiniMax models to `extensions/minimax-portal-auth/index.ts`:

```typescript
// In models array:
{ id: "MiniMax-M2", name: "MiniMax M2", input: ["text"] },
{ id: "MiniMax-M2.1", name: "MiniMax M2.1", input: ["text"] },
{ id: "MiniMax-M2.5", name: "MiniMax M2.5", input: ["text"], reasoning: true },
{ id: "MiniMax-M2.5-highspeed", name: "MiniMax M2.5 Highspeed", input: ["text"], reasoning: true },

// In agents.defaults.models:
[modelRef("MiniMax-M2")]: { alias: "minimax-m2" },
[modelRef("MiniMax-M2.1")]: { alias: "minimax-m2.1" },
[modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
[modelRef("MiniMax-M2.5-highspeed")]: { alias: "minimax-m2.5-highspeed" },
```

**Total:** +13 lines, -6 lines (removed M2.1-highspeed)

## Human Verification (required)

- Model definitions follow existing pattern
- Aliases properly formatted
- No breaking changes

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

None