### PR TITLE
chore: migrate eslint-disable comments to oxlint-disable

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -16,7 +16,7 @@ const log = createSubsystemLogger("agent-scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
 function stripNullBytes(s: string): string {
-  // eslint-disable-next-line no-control-regex
+  // oxlint-disable-next-line no-control-regex
   return s.replace(/\0/g, "");
 }
 

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -37,7 +37,7 @@ describe("runEmbeddedPiAgent usage reporting", () => {
         stopReason: "end_turn",
       },
       attemptUsage: { input: 250, output: 100, total: 350 },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
     } as any);
 
     const result = await runEmbeddedPiAgent({

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -192,7 +192,7 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
       continue;
     }
 
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.warn(
       `[session-write-lock] releasing lock held for ${heldForMs}ms (max=${held.maxHoldMs}ms): ${held.lockPath}`,
     );

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -284,7 +284,7 @@ export async function evaluateViaPlaywright(opts: {
   try {
     if (opts.ref) {
       const locator = refLocator(page, opts.ref);
-      // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
+      // oxlint-disable-next-line typescript/no-implied-eval -- required for browser-context eval
       const elementEvaluator = new Function(
         "el",
         "args",
@@ -325,7 +325,7 @@ export async function evaluateViaPlaywright(opts: {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
+    // oxlint-disable-next-line typescript/no-implied-eval -- required for browser-context eval
     const browserEvaluator = new Function(
       "args",
       `

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -185,7 +185,7 @@ export async function runGatewayLoop(params: {
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
-    // eslint-disable-next-line no-constant-condition
+    // oxlint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
       server = await params.start();

--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -76,7 +76,7 @@ export async function collectIncludePathsRecursive(params: {
         }
       })();
       if (nestedParsed) {
-        // eslint-disable-next-line no-await-in-loop
+        // oxlint-disable-next-line no-await-in-loop
         await walk(resolved, nestedParsed, depth + 1);
       }
     }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -323,11 +323,11 @@ describe("config io write", () => {
       const next = structuredClone(snapshot.config);
       // Simulate doctor removing legacy keys while keeping dm enabled.
       if (next.channels?.discord?.dm && typeof next.channels.discord.dm === "object") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+        // oxlint-disable-next-line typescript/no-explicit-any -- test helper
         delete (next.channels.discord.dm as any).policy;
       }
       if (next.channels?.slack?.dm && typeof next.channels.slack.dm === "object") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+        // oxlint-disable-next-line typescript/no-explicit-any -- test helper
         delete (next.channels.slack.dm as any).policy;
       }
 

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -55,6 +55,6 @@ export type ChannelsConfig = {
   imessage?: IMessageConfig;
   msteams?: MSTeamsConfig;
   // Extension channels use dynamic keys - use ExtensionChannelConfig in extensions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
 };

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -150,7 +150,7 @@ describe("CronService read ops while job is running", () => {
         if (!internal.state?.running) {
           break;
         }
-        // eslint-disable-next-line no-await-in-loop
+        // oxlint-disable-next-line no-await-in-loop
         await Promise.resolve();
       }
       expect(internal.state?.running).toBe(false);

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -79,14 +79,14 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual.promises,
     mkdir: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.mkdir as any)(p, { recursive: true });
       }
       ensureDir(p);
     },
     readFile: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.readFile as any)(p, "utf-8");
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -97,7 +97,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     writeFile: async (p: string, data: string | Uint8Array) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.writeFile as any)(p, data, "utf-8");
       }
       const content = typeof data === "string" ? data : Buffer.from(data).toString("utf-8");
@@ -105,7 +105,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     rename: async (from: string, to: string) => {
       if (!isFixtureInMock(from) || !isFixtureInMock(to)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.rename as any)(from, to);
       }
       const fromAbs = absInMock(from);
@@ -120,7 +120,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     copyFile: async (from: string, to: string) => {
       if (!isFixtureInMock(from) || !isFixtureInMock(to)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.copyFile as any)(from, to);
       }
       const entry = fsState.entries.get(absInMock(from));
@@ -131,7 +131,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     stat: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.stat as any)(p);
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -146,7 +146,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     access: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.access as any)(p);
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -156,7 +156,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     unlink: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.unlink as any)(p);
       }
       fsState.entries.delete(absInMock(p));
@@ -173,14 +173,14 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     ...actual,
     mkdir: async (p: string, _opts?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.mkdir as any)(p, { recursive: true });
       }
       ensureDir(p);
     },
     writeFile: async (p: string, data: string, _enc?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.writeFile as any)(p, data, "utf-8");
       }
       setFile(p, data);

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1155,7 +1155,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           continue;
         }
         try {
-          // eslint-disable-next-line no-await-in-loop
+          // oxlint-disable-next-line no-await-in-loop
           const apiKeyInfo = await getApiKeyForModel({
             model,
             cfg,

--- a/src/gateway/server-restart-deferral.test.ts
+++ b/src/gateway/server-restart-deferral.test.ts
@@ -8,7 +8,7 @@ import { getTotalQueueSize } from "../process/command-queue.js";
 
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let i = 0; i < count; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     await Promise.resolve();
   }
 }

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -36,7 +36,7 @@ vi.mock("node:fs", async (importOriginal) => {
       isFixturePath(p) ? state.entries.has(absInMock(p)) : actual.existsSync(p),
     readFileSync: (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.readFileSync(p as any, encoding as any) as unknown;
       }
       const entry = readFixtureEntry(p);
@@ -47,7 +47,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     statSync: (p: string) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.statSync(p as any) as unknown;
       }
       const entry = readFixtureEntry(p);

--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -33,7 +33,7 @@ vi.mock("node:fs", async (importOriginal) => {
       isFixturePath(p) ? state.entries.has(abs(p)) : actual.existsSync(p),
     readFileSync: (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.readFileSync(p as any, encoding as any) as unknown;
       }
       const entry = state.entries.get(abs(p));
@@ -44,7 +44,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     statSync: (p: string) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.statSync(p as any) as unknown;
       }
       const entry = state.entries.get(abs(p));
@@ -76,7 +76,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     ...actual,
     readFile: async (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return (await actual.readFile(p as any, encoding as any)) as unknown;
       }
       const entry = state.entries.get(abs(p));

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -91,7 +91,7 @@ vi.mock("./manager.js", () => ({
 
 import { QmdMemoryManager } from "./qmd-manager.js";
 import { getMemorySearchManager } from "./search-manager.js";
-// eslint-disable-next-line @typescript-eslint/unbound-method -- mocked static function
+// oxlint-disable-next-line typescript/unbound-method -- mocked static function
 const createQmdManagerMock = vi.mocked(QmdMemoryManager.create);
 
 type SearchManagerResult = Awaited<ReturnType<typeof getMemorySearchManager>>;
@@ -147,7 +147,7 @@ describe("getMemorySearchManager caching", () => {
     const second = await getMemorySearchManager({ cfg, agentId: "main" });
 
     expect(first.manager).toBe(second.manager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
@@ -169,7 +169,7 @@ describe("getMemorySearchManager caching", () => {
     const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     requireManager(second);
     expect(second.manager).not.toBe(first.manager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
@@ -182,14 +182,14 @@ describe("getMemorySearchManager caching", () => {
 
     requireManager(first);
     requireManager(second);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ agentId, mode: "status" }),
     );
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ agentId, mode: "status" }),
@@ -216,7 +216,7 @@ describe("getMemorySearchManager caching", () => {
 
     const third = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     expect(third.manager).toBe(secondManager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -172,7 +172,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const scheme = gateway.tls ? "wss" : "ws";
   const url = `${scheme}://${host}:${port}`;
   const pathEnv = ensureNodePathEnv();
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.log(`node host PATH: ${pathEnv}`);
 
   const client = new GatewayClient({
@@ -211,11 +211,11 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     },
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)
-      // eslint-disable-next-line no-console
+      // oxlint-disable-next-line no-console
       console.error(`node host gateway connect failed: ${err.message}`);
     },
     onClose: (code, reason) => {
-      // eslint-disable-next-line no-console
+      // oxlint-disable-next-line no-console
       console.error(`node host gateway closed (${code}): ${reason}`);
     },
   });

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -632,7 +632,7 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "extensions", pluginId);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -695,7 +695,7 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "hooks", hookId);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -740,7 +740,7 @@ export async function collectIncludeFilePermFindings(params: {
   }
 
   for (const p of includePaths) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const perms = await inspectPathPermissions(p, {
       env: params.env,
       platform: params.platform,
@@ -855,7 +855,7 @@ export async function collectStateDeepFilesystemFindings(params: {
   for (const agentId of ids) {
     const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const authPerms = await inspectPathPermissions(authPath, {
       env: params.env,
       platform: params.platform,
@@ -894,7 +894,7 @@ export async function collectStateDeepFilesystemFindings(params: {
     }
 
     const storePath = path.join(params.stateDir, "agents", agentId, "sessions", "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const storePerms = await inspectPathPermissions(storePath, {
       env: params.env,
       platform: params.platform,

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -325,7 +325,7 @@ async function chmodCredentialsAndAgentState(params: {
       continue;
     }
     const p = path.join(credsDir, entry.name);
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: p, mode: 0o600, require: "file" }));
   }
 
@@ -349,26 +349,26 @@ async function chmodCredentialsAndAgentState(params: {
     const agentDir = path.join(agentRoot, "agent");
     const sessionsDir = path.join(agentRoot, "sessions");
 
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: agentRoot, mode: 0o700, require: "dir" }));
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: agentDir, mode: 0o700, require: "dir" }));
 
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: authPath, mode: 0o600, require: "file" }));
 
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(
       await params.applyPerms({ path: sessionsDir, mode: 0o700, require: "dir" }),
     );
 
     const storePath = path.join(sessionsDir, "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: storePath, mode: 0o600, require: "file" }));
 
     // Fix permissions on session transcript files (*.jsonl)
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const sessionEntries = await fs.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
     for (const entry of sessionEntries) {
       if (!entry.isFile()) {
@@ -378,7 +378,7 @@ async function chmodCredentialsAndAgentState(params: {
         continue;
       }
       const p = path.join(sessionsDir, entry.name);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       params.actions.push(await params.applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }
@@ -446,7 +446,7 @@ export async function fixSecurityFootguns(opts?: {
       parsed: snap.parsed,
     }).catch(() => []);
     for (const p of includePaths) {
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       actions.push(await applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -25,7 +25,7 @@ vi.mock("../sticker-cache.js", () => ({
   getCachedSticker: () => null,
 }));
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+// oxlint-disable-next-line typescript/consistent-type-imports
 const { resolveMedia } = await import("./delivery.js");
 const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -66,7 +66,7 @@ export async function getDeterministicFreePortBlock(params?: {
   // so probing every single offset is wasted work and slows large suites.
   for (let attempt = 0; attempt < usable; attempt += blockSize) {
     const start = base + ((nextTestPortOffset + attempt) % usable);
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(start + offset)))).every(
       Boolean,
     );
@@ -79,9 +79,9 @@ export async function getDeterministicFreePortBlock(params?: {
 
   // Fallback: let the OS pick a port block (best effort).
   for (let attempt = 0; attempt < 25; attempt += 1) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const port = await getOsFreePort();
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(port + offset)))).every(
       Boolean,
     );


### PR DESCRIPTION
## Summary

This project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting, but the codebase contained leftover ESLint comment directives that are not recognised by Oxlint. This PR standardises all inline disable comments to the Oxlint format across `src/`.

- Replace `eslint-disable-next-line` with `oxlint-disable-next-line`
- Replace `eslint-disable` / `eslint-enable` block comments with `oxlint-disable` / `oxlint-enable`
- Update TypeScript rule name prefix from `@typescript-eslint/<rule>` to `typescript/<rule>` (Oxlint convention)
- 20 files changed, no logic changes — comment directives only
- `extensions/`, `node_modules/`, and `dist/` directories are untouched

## Test plan

- [ ] Verify `pnpm check` (Oxlint) passes with no unknown directive warnings
- [ ] Confirm no ESLint-format directives remain in `src/`: `grep -r "eslint-disable" src/ --include="*.ts" --include="*.tsx"` should return empty
- [ ] Spot-check a few files (e.g. `src/security/fix.ts`, `src/memory/search-manager.test.ts`) to confirm surrounding code is unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)