### PR TITLE
fix: clear delivery routing state when creating isolated cron sessions

### DIFF
--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -69,11 +69,14 @@ export function resolveCronSession(params: {
     // state inherited from prior sessions. Without this, lastThreadId leaks into
     // the new session and causes announce-mode cron deliveries to post as thread
     // replies instead of channel top-level messages.
+    // deliveryContext must also be cleared because normalizeSessionEntryDelivery
+    // repopulates lastThreadId from deliveryContext.threadId on store writes.
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
+      deliveryContext: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -65,6 +65,16 @@ export function resolveCronSession(params: {
     sessionId,
     updatedAt: params.nowMs,
     systemSent,
+    // When starting a fresh session (forceNew / isolated), clear delivery routing
+    // state inherited from prior sessions. Without this, lastThreadId leaks into
+    // the new session and causes announce-mode cron deliveries to post as thread
+    // replies instead of channel top-level messages.
+    ...(isNewSession && {
+      lastChannel: undefined,
+      lastTo: undefined,
+      lastAccountId: undefined,
+      lastThreadId: undefined,
+    }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };
 }


### PR DESCRIPTION
## Summary

- Problem: Cron jobs with `sessionTarget: "isolated"` inherit `lastThreadId` from prior session, causing `announce` deliveries to post as thread replies instead of channel top-level messages.
- Why it matters: Scheduled reports/notifications get buried in unrelated threads and are easy to miss.
- What changed: `resolveCronSession()` now clears delivery routing metadata (`lastThreadId`, `lastTo`, `lastChannel`, `lastAccountId`) when creating a new session.
- What did NOT change: Per-session overrides (modelOverride, providerOverride, thinkingLevel, etc.) are still preserved across session resets.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #27751
- Related #24176, #25450

## User-visible / Behavior Changes

Cron jobs with `sessionTarget: "isolated"` and `delivery.mode: "announce"` will now correctly post to channel top-level instead of inheriting a thread target from prior conversations.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (aarch64)
- Runtime/container: Node 22, npm global install
- Integration/channel: Slack (socket mode)

### Steps

1. Have an agent converse in a Slack thread in a channel
2. Session store records `lastThreadId` from that thread
3. A cron job fires with `sessionTarget: "isolated"`, `delivery.mode: "announce"`, `delivery.to` pointing to the same channel
4. Observe where the result is posted

### Expected

- Cron result posted as top-level message in the channel

### Actual

- Cron result posted as thread reply to a previous conversation thread

## Evidence

- [x] Failing test/log before + passing after

New test cases in `session.test.ts`:
- `clears delivery routing metadata when forceNew is true`
- `clears delivery routing metadata when session is stale`
- `preserves delivery routing metadata when reusing fresh session`

## Human Verification (required)

- Verified scenarios: Deployed to production agent, confirmed cron jobs post to channel top-level
- Edge cases checked: Fresh session reuse still preserves delivery metadata (test coverage)
- What you did **not** verify: Matrix/Telegram channel behavior (only Slack tested)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit in `session.ts`
- Files/config to restore: `src/cron/isolated-agent/session.ts`
- Known bad symptoms: If delivery metadata clearing is too aggressive, fresh session reuse might lose routing context (mitigated by only clearing on `isNewSession`)

## Risks and Mitigations

- Risk: Clearing `lastTo`/`lastChannel` might affect non-announce delivery modes that legitimately need prior routing state in new sessions.
  - Mitigation: The clear only applies when `isNewSession` is true (forceNew or session expired). Fresh session reuse is unaffected. Announce mode is the primary consumer of these fields for cron, and it should always resolve targets from the explicit `delivery.to` config, not inherited state.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)