### PR TITLE
test: add unit tests for copilot-proxy, qwen-portal-auth, and minimax-portal-auth extensions

### DIFF
--- a/extensions/copilot-proxy/index.test.ts
+++ b/extensions/copilot-proxy/index.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBaseUrl, validateBaseUrl, parseModelIds, buildModelDefinition } from "./index.js";
+
+describe("normalizeBaseUrl", () => {
+  it("returns default URL for empty string", () => {
+    expect(normalizeBaseUrl("")).toBe("http://localhost:3000/v1");
+  });
+
+  it("returns default URL for whitespace-only string", () => {
+    expect(normalizeBaseUrl("   ")).toBe("http://localhost:3000/v1");
+  });
+
+  it("appends /v1 when URL does not end with /v1", () => {
+    expect(normalizeBaseUrl("http://localhost:3000")).toBe("http://localhost:3000/v1");
+  });
+
+  it("leaves URL unchanged when it already ends with /v1", () => {
+    expect(normalizeBaseUrl("http://localhost:3000/v1")).toBe("http://localhost:3000/v1");
+  });
+
+  it("strips trailing slashes before checking for /v1 suffix", () => {
+    expect(normalizeBaseUrl("http://localhost:3000/v1//")).toBe("http://localhost:3000/v1");
+  });
+
+  it("strips trailing slashes from URL without /v1 and then appends /v1", () => {
+    expect(normalizeBaseUrl("http://localhost:3000/")).toBe("http://localhost:3000/v1");
+  });
+
+  it("handles HTTPS URLs", () => {
+    expect(normalizeBaseUrl("https://proxy.example.com")).toBe("https://proxy.example.com/v1");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(normalizeBaseUrl("  http://localhost:8080  ")).toBe("http://localhost:8080/v1");
+  });
+
+  it("preserves custom path prefix when not already /v1", () => {
+    expect(normalizeBaseUrl("http://host/api")).toBe("http://host/api/v1");
+  });
+});
+
+describe("validateBaseUrl", () => {
+  it("returns undefined for a valid HTTP URL", () => {
+    expect(validateBaseUrl("http://localhost:3000")).toBeUndefined();
+  });
+
+  it("returns undefined for a valid HTTPS URL", () => {
+    expect(validateBaseUrl("https://proxy.example.com")).toBeUndefined();
+  });
+
+  it("returns undefined for URL already ending with /v1", () => {
+    expect(validateBaseUrl("http://localhost:3000/v1")).toBeUndefined();
+  });
+
+  it("returns error message for invalid URL", () => {
+    expect(validateBaseUrl("not-a-url")).toBe("Enter a valid URL");
+  });
+
+  it("returns undefined for empty string (defaults to valid localhost URL)", () => {
+    // Empty string normalizes to default URL which is valid
+    expect(validateBaseUrl("")).toBeUndefined();
+  });
+});
+
+describe("parseModelIds", () => {
+  it("parses comma-separated model IDs", () => {
+    expect(parseModelIds("gpt-4, claude-3, gemini-pro")).toEqual([
+      "gpt-4",
+      "claude-3",
+      "gemini-pro",
+    ]);
+  });
+
+  it("parses newline-separated model IDs", () => {
+    expect(parseModelIds("gpt-4\nclaude-3\ngemini-pro")).toEqual([
+      "gpt-4",
+      "claude-3",
+      "gemini-pro",
+    ]);
+  });
+
+  it("parses mixed comma and newline separators", () => {
+    expect(parseModelIds("gpt-4,claude-3\ngemini-pro")).toEqual([
+      "gpt-4",
+      "claude-3",
+      "gemini-pro",
+    ]);
+  });
+
+  it("trims whitespace from each model ID", () => {
+    expect(parseModelIds("  gpt-4  ,  claude-3  ")).toEqual(["gpt-4", "claude-3"]);
+  });
+
+  it("filters out empty entries", () => {
+    expect(parseModelIds("gpt-4,,claude-3")).toEqual(["gpt-4", "claude-3"]);
+  });
+
+  it("deduplicates model IDs", () => {
+    expect(parseModelIds("gpt-4,gpt-4,claude-3")).toEqual(["gpt-4", "claude-3"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseModelIds("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(parseModelIds("   ")).toEqual([]);
+  });
+
+  it("returns single model ID for single entry", () => {
+    expect(parseModelIds("gpt-4")).toEqual(["gpt-4"]);
+  });
+});
+
+describe("buildModelDefinition", () => {
+  it("returns a model definition with the given ID", () => {
+    const def = buildModelDefinition("gpt-4");
+    expect(def.id).toBe("gpt-4");
+  });
+
+  it("uses model ID as the name", () => {
+    const def = buildModelDefinition("claude-opus-4.6");
+    expect(def.name).toBe("claude-opus-4.6");
+  });
+
+  it("sets api to openai-completions", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.api).toBe("openai-completions");
+  });
+
+  it("sets reasoning to false", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.reasoning).toBe(false);
+  });
+
+  it("includes text and image as input modalities", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.input).toEqual(["text", "image"]);
+  });
+
+  it("sets all cost fields to zero", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it("sets contextWindow to 128000", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.contextWindow).toBe(128_000);
+  });
+
+  it("sets maxTokens to 8192", () => {
+    const def = buildModelDefinition("any-model");
+    expect(def.maxTokens).toBe(8192);
+  });
+});

--- a/extensions/copilot-proxy/index.ts
+++ b/extensions/copilot-proxy/index.ts
@@ -25,7 +25,7 @@ const DEFAULT_MODEL_IDS = [
   "grok-code-fast-1",
 ] as const;
 
-function normalizeBaseUrl(value: string): string {
+export function normalizeBaseUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return DEFAULT_BASE_URL;
@@ -40,7 +40,7 @@ function normalizeBaseUrl(value: string): string {
   return normalized;
 }
 
-function validateBaseUrl(value: string): string | undefined {
+export function validateBaseUrl(value: string): string | undefined {
   const normalized = normalizeBaseUrl(value);
   try {
     new URL(normalized);
@@ -50,7 +50,7 @@ function validateBaseUrl(value: string): string | undefined {
   return undefined;
 }
 
-function parseModelIds(input: string): string[] {
+export function parseModelIds(input: string): string[] {
   const parsed = input
     .split(/[\n,]/)
     .map((model) => model.trim())
@@ -58,7 +58,7 @@ function parseModelIds(input: string): string[] {
   return Array.from(new Set(parsed));
 }
 
-function buildModelDefinition(modelId: string) {
+export function buildModelDefinition(modelId: string) {
   return {
     id: modelId,
     name: modelId,

--- a/extensions/minimax-portal-auth/oauth.test.ts
+++ b/extensions/minimax-portal-auth/oauth.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loginMiniMaxPortalOAuth, type MiniMaxRegion } from "./oauth.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+
+describe("loginMiniMaxPortalOAuth", () => {
+  const mockOpenUrl = vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined);
+  const mockNote = vi
+    .fn<(message: string, title?: string) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const mockProgressUpdate = vi.fn<(message: string) => void>();
+  const mockProgressStop = vi.fn<(message?: string) => void>();
+
+  const mockProgress = {
+    update: mockProgressUpdate,
+    stop: mockProgressStop,
+  };
+
+  const baseParams = {
+    openUrl: mockOpenUrl,
+    note: mockNote,
+    progress: mockProgress,
+  };
+
+  // The MiniMax OAuth code uses `while (Date.now() < expireTimeMs)` where `expireTimeMs`
+  // is the raw `expired_in` value from the server. To keep the while-loop alive long enough
+  // for our poll mock to respond, we pass `expired_in` as a value far in the future
+  // relative to `Date.now()` (in the same millisecond scale that Date.now() returns).
+  const futureExpiry = () => Date.now() + 30_000;
+
+  function makeTokenResponse(
+    overrides?: Partial<{
+      status: string;
+      access_token: string;
+      refresh_token: string;
+      expired_in: number;
+      resource_url: string;
+      notification_message: string;
+    }>,
+  ) {
+    return {
+      status: "success",
+      access_token: "mm-access-token",
+      refresh_token: "mm-refresh-token",
+      expired_in: 3600,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Sets up a successful two-step fetch mock:
+   * 1. Code endpoint: captures the PKCE state, returns it in the response so validation passes.
+   * 2. Token endpoint: returns a success payload.
+   */
+  function setupSuccessfulFlow(
+    region: MiniMaxRegion = "global",
+    tokenOverrides?: Parameters<typeof makeTokenResponse>[0],
+  ) {
+    const baseUrl = region === "cn" ? "https://api.minimaxi.com" : "https://api.minimax.io";
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes("/oauth/code")) {
+        const body = init?.body as string | undefined;
+        const match = body?.match(/(?:^|&)state=([^&]+)/);
+        const state = match ? decodeURIComponent(match[1]) : "";
+
+        return new Response(
+          JSON.stringify({
+            user_code: "MINIMAX-1234",
+            verification_uri: `${baseUrl}/oauth/verify`,
+            expired_in: futureExpiry(),
+            interval: 1,
+            state,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/oauth/token")) {
+        return new Response(JSON.stringify(makeTokenResponse(tokenOverrides)), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    mockOpenUrl.mockReset().mockResolvedValue(undefined);
+    mockNote.mockReset().mockResolvedValue(undefined);
+    mockProgressUpdate.mockReset();
+    mockProgressStop.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("returns a token when flow completes successfully (global region)", async () => {
+    setupSuccessfulFlow("global");
+
+    const promise = loginMiniMaxPortalOAuth({ ...baseParams, region: "global" });
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("mm-access-token");
+    expect(token.refresh).toBe("mm-refresh-token");
+  });
+
+  it("returns a token when flow completes successfully (cn region)", async () => {
+    setupSuccessfulFlow("cn");
+
+    const promise = loginMiniMaxPortalOAuth({ ...baseParams, region: "cn" });
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("mm-access-token");
+    expect(token.refresh).toBe("mm-refresh-token");
+  });
+
+  it("defaults to global region when none is specified", async () => {
+    setupSuccessfulFlow("global");
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("mm-access-token");
+    // Verify the code endpoint was called against the global base URL
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("minimax.io"),
+      expect.anything(),
+    );
+  });
+
+  it("uses CN base URL when region is cn", async () => {
+    setupSuccessfulFlow("cn");
+
+    const promise = loginMiniMaxPortalOAuth({ ...baseParams, region: "cn" });
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("minimaxi.com"),
+      expect.anything(),
+    );
+  });
+
+  it("opens verification URL after requesting device code", async () => {
+    setupSuccessfulFlow("global");
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockOpenUrl).toHaveBeenCalledWith(expect.stringContaining("minimax.io"));
+  });
+
+  it("shows a note with verification URL and user code", async () => {
+    setupSuccessfulFlow("global");
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockNote).toHaveBeenCalledWith(expect.stringContaining("MINIMAX-1234"), "MiniMax OAuth");
+  });
+
+  it("includes resourceUrl in returned token when server provides it", async () => {
+    setupSuccessfulFlow("global", { resource_url: "https://api.minimax.io/anthropic" });
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.resourceUrl).toBe("https://api.minimax.io/anthropic");
+  });
+
+  it("includes notification_message in returned token when server provides it", async () => {
+    setupSuccessfulFlow("global", { notification_message: "Welcome to MiniMax!" });
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.notification_message).toBe("Welcome to MiniMax!");
+  });
+
+  it("throws when the code endpoint returns an HTTP error", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Service Unavailable", {
+        status: 503,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    // The function throws immediately (before any timers), so no runAllTimersAsync needed.
+    await expect(loginMiniMaxPortalOAuth(baseParams)).rejects.toThrow(
+      "MiniMax OAuth authorization failed",
+    );
+  });
+
+  it("throws when the code response is missing user_code", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          verification_uri: "https://api.minimax.io/oauth/verify",
+          expired_in: futureExpiry(),
+          state: "some-state",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(loginMiniMaxPortalOAuth(baseParams)).rejects.toThrow("incomplete payload");
+  });
+
+  it("throws when state in code response does not match sent state (CSRF protection)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          user_code: "MINIMAX-1234",
+          verification_uri: "https://api.minimax.io/oauth/verify",
+          expired_in: futureExpiry(),
+          interval: 1,
+          state: "tampered-state-value",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(loginMiniMaxPortalOAuth(baseParams)).rejects.toThrow("state mismatch");
+  });
+
+  it("throws when poll returns status=error", async () => {
+    let capturedState: string | undefined;
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes("/oauth/code")) {
+        const body = init?.body as string | undefined;
+        const match = body?.match(/(?:^|&)state=([^&]+)/);
+        capturedState = match ? decodeURIComponent(match[1]) : "";
+
+        return new Response(
+          JSON.stringify({
+            user_code: "MINIMAX-ERR",
+            verification_uri: "https://api.minimax.io/oauth/verify",
+            expired_in: futureExpiry(),
+            interval: 1,
+            state: capturedState,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/oauth/token")) {
+        return new Response(JSON.stringify({ status: "error" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+    await expect(promise).rejects.toThrow("MiniMax OAuth failed");
+  });
+
+  it("retries polling when status is not success and eventually succeeds", async () => {
+    let pollCount = 0;
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.includes("/oauth/code")) {
+        const body = init?.body as string | undefined;
+        const match = body?.match(/(?:^|&)state=([^&]+)/);
+        const state = match ? decodeURIComponent(match[1]) : "";
+
+        return new Response(
+          JSON.stringify({
+            user_code: "MINIMAX-POLL",
+            verification_uri: "https://api.minimax.io/oauth/verify",
+            expired_in: futureExpiry(),
+            interval: 1,
+            state,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (url.includes("/oauth/token")) {
+        pollCount++;
+        if (pollCount < 3) {
+          // Return "pending"-style non-success status
+          return new Response(
+            JSON.stringify({ status: "pending", base_resp: { status_msg: "Not yet" } }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("mm-access-token");
+    expect(pollCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("continues after openUrl throws (fallback to manual copy-paste)", async () => {
+    mockOpenUrl.mockRejectedValueOnce(new Error("Cannot open browser"));
+    setupSuccessfulFlow("global");
+
+    const promise = loginMiniMaxPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    // Should not throw even though openUrl threw
+    const token = await promise;
+
+    expect(token.access).toBe("mm-access-token");
+  });
+});

--- a/extensions/qwen-portal-auth/oauth.test.ts
+++ b/extensions/qwen-portal-auth/oauth.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loginQwenPortalOAuth } from "./oauth.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+
+describe("loginQwenPortalOAuth", () => {
+  const mockOpenUrl = vi.fn<(url: string) => Promise<void>>().mockResolvedValue(undefined);
+  const mockNote = vi
+    .fn<(message: string, title?: string) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const mockProgressUpdate = vi.fn<(message: string) => void>();
+  const mockProgressStop = vi.fn<(message?: string) => void>();
+
+  const mockProgress = {
+    update: mockProgressUpdate,
+    stop: mockProgressStop,
+  };
+
+  const baseParams = {
+    openUrl: mockOpenUrl,
+    note: mockNote,
+    progress: mockProgress,
+  };
+
+  // A device authorization response that expires in 1 second (just enough for tests)
+  function makeDeviceAuthResponse(
+    overrides?: Partial<{
+      device_code: string;
+      user_code: string;
+      verification_uri: string;
+      verification_uri_complete: string;
+      expires_in: number;
+      interval: number;
+    }>,
+  ) {
+    return {
+      device_code: "test-device-code",
+      user_code: "TEST-1234",
+      verification_uri: "https://chat.qwen.ai/activate",
+      verification_uri_complete: "https://chat.qwen.ai/activate?code=TEST-1234",
+      expires_in: 10,
+      interval: 1,
+      ...overrides,
+    };
+  }
+
+  function makeTokenResponse(
+    overrides?: Partial<{
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+      resource_url: string;
+    }>,
+  ) {
+    return {
+      access_token: "test-access-token",
+      refresh_token: "test-refresh-token",
+      expires_in: 3600,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+    mockOpenUrl.mockReset().mockResolvedValue(undefined);
+    mockNote.mockReset().mockResolvedValue(undefined);
+    mockProgressUpdate.mockReset();
+    mockProgressStop.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("returns a token when device code flow succeeds immediately", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeDeviceAuthResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("test-access-token");
+    expect(token.refresh).toBe("test-refresh-token");
+    expect(token.expires).toBeGreaterThan(Date.now());
+  });
+
+  it("opens the verification URL after requesting device code", async () => {
+    const deviceAuth = makeDeviceAuthResponse({
+      verification_uri_complete: "https://chat.qwen.ai/activate?code=XYZ",
+    });
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockOpenUrl).toHaveBeenCalledWith("https://chat.qwen.ai/activate?code=XYZ");
+  });
+
+  it("shows a note with the verification URI and user code", async () => {
+    const deviceAuth = makeDeviceAuthResponse({
+      user_code: "ABCD-5678",
+      verification_uri: "https://chat.qwen.ai/activate",
+    });
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockNote).toHaveBeenCalledWith(expect.stringContaining("ABCD-5678"), "Qwen OAuth");
+  });
+
+  it("retries polling when authorization is pending and succeeds on second attempt", async () => {
+    const pendingPayload = { error: "authorization_pending" };
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 30, interval: 1 });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      // First poll: pending
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(pendingPayload), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      // Second poll: success
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("test-access-token");
+    expect(mockFetch).toHaveBeenCalledTimes(3); // 1 device + 2 polls
+  });
+
+  it("increases poll interval when server responds with slow_down", async () => {
+    const slowDownPayload = { error: "slow_down" };
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 60, interval: 1 });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(slowDownPayload), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.access).toBe("test-access-token");
+  });
+
+  it("throws when device code request fails with HTTP error", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    // The function throws immediately (before any timers), so we don't need runAllTimersAsync.
+    await expect(loginQwenPortalOAuth(baseParams)).rejects.toThrow(
+      "Qwen device authorization failed",
+    );
+  });
+
+  it("throws when token poll returns a non-pending error", async () => {
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 30, interval: 1 });
+    const errorPayload = { error: "access_denied", error_description: "User denied access" };
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(errorPayload), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    // Attach a no-op catch handler before advancing timers so the rejection is not "unhandled"
+    // while runAllTimersAsync is running — the outer expect(...).rejects will handle it.
+    const promise = loginQwenPortalOAuth(baseParams);
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+    await expect(promise).rejects.toThrow("Qwen OAuth failed");
+  });
+
+  it("throws when token payload is missing required fields", async () => {
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 30, interval: 1 });
+    const incompleteToken = { access_token: "abc" }; // missing refresh_token and expires_in
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(incompleteToken), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    // Same pattern: prevent "unhandled rejection" while timers run.
+    const promise = loginQwenPortalOAuth(baseParams);
+    const caught = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await caught;
+    await expect(promise).rejects.toThrow("Qwen OAuth failed");
+  });
+
+  it("falls back to verification_uri when verification_uri_complete is absent", async () => {
+    const deviceAuth = {
+      device_code: "test-device-code",
+      user_code: "XYZ-0000",
+      verification_uri: "https://chat.qwen.ai/activate",
+      expires_in: 30,
+      interval: 1,
+    };
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockOpenUrl).toHaveBeenCalledWith("https://chat.qwen.ai/activate");
+  });
+
+  it("includes resourceUrl in returned token when server provides it", async () => {
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 30, interval: 1 });
+    const tokenWithResource = makeTokenResponse({ resource_url: "https://portal.qwen.ai/v1" });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(tokenWithResource), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    const token = await promise;
+
+    expect(token.resourceUrl).toBe("https://portal.qwen.ai/v1");
+  });
+
+  it("continues polling without crashing when openUrl throws", async () => {
+    mockOpenUrl.mockRejectedValueOnce(new Error("Browser not available"));
+    const deviceAuth = makeDeviceAuthResponse({ expires_in: 30, interval: 1 });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(deviceAuth), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeTokenResponse()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const promise = loginQwenPortalOAuth(baseParams);
+    await vi.runAllTimersAsync();
+    // Should not throw even though openUrl failed
+    const token = await promise;
+    expect(token.access).toBe("test-access-token");
+  });
+});

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -16,7 +16,7 @@ const log = createSubsystemLogger("agent-scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
 function stripNullBytes(s: string): string {
-  // eslint-disable-next-line no-control-regex
+  // oxlint-disable-next-line no-control-regex
   return s.replace(/\0/g, "");
 }
 

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -37,7 +37,7 @@ describe("runEmbeddedPiAgent usage reporting", () => {
         stopReason: "end_turn",
       },
       attemptUsage: { input: 250, output: 100, total: 350 },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // oxlint-disable-next-line typescript/no-explicit-any
     } as any);
 
     const result = await runEmbeddedPiAgent({

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -192,7 +192,7 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
       continue;
     }
 
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.warn(
       `[session-write-lock] releasing lock held for ${heldForMs}ms (max=${held.maxHoldMs}ms): ${held.lockPath}`,
     );

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -284,7 +284,7 @@ export async function evaluateViaPlaywright(opts: {
   try {
     if (opts.ref) {
       const locator = refLocator(page, opts.ref);
-      // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
+      // oxlint-disable-next-line typescript/no-implied-eval -- required for browser-context eval
       const elementEvaluator = new Function(
         "el",
         "args",
@@ -325,7 +325,7 @@ export async function evaluateViaPlaywright(opts: {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
+    // oxlint-disable-next-line typescript/no-implied-eval -- required for browser-context eval
     const browserEvaluator = new Function(
       "args",
       `

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -185,7 +185,7 @@ export async function runGatewayLoop(params: {
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
-    // eslint-disable-next-line no-constant-condition
+    // oxlint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
       server = await params.start();

--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -76,7 +76,7 @@ export async function collectIncludePathsRecursive(params: {
         }
       })();
       if (nestedParsed) {
-        // eslint-disable-next-line no-await-in-loop
+        // oxlint-disable-next-line no-await-in-loop
         await walk(resolved, nestedParsed, depth + 1);
       }
     }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -323,11 +323,11 @@ describe("config io write", () => {
       const next = structuredClone(snapshot.config);
       // Simulate doctor removing legacy keys while keeping dm enabled.
       if (next.channels?.discord?.dm && typeof next.channels.discord.dm === "object") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+        // oxlint-disable-next-line typescript/no-explicit-any -- test helper
         delete (next.channels.discord.dm as any).policy;
       }
       if (next.channels?.slack?.dm && typeof next.channels.slack.dm === "object") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper
+        // oxlint-disable-next-line typescript/no-explicit-any -- test helper
         delete (next.channels.slack.dm as any).policy;
       }
 

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -55,6 +55,6 @@ export type ChannelsConfig = {
   imessage?: IMessageConfig;
   msteams?: MSTeamsConfig;
   // Extension channels use dynamic keys - use ExtensionChannelConfig in extensions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   [key: string]: any;
 };

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -150,7 +150,7 @@ describe("CronService read ops while job is running", () => {
         if (!internal.state?.running) {
           break;
         }
-        // eslint-disable-next-line no-await-in-loop
+        // oxlint-disable-next-line no-await-in-loop
         await Promise.resolve();
       }
       expect(internal.state?.running).toBe(false);

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -79,14 +79,14 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual.promises,
     mkdir: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.mkdir as any)(p, { recursive: true });
       }
       ensureDir(p);
     },
     readFile: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.readFile as any)(p, "utf-8");
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -97,7 +97,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     writeFile: async (p: string, data: string | Uint8Array) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.writeFile as any)(p, data, "utf-8");
       }
       const content = typeof data === "string" ? data : Buffer.from(data).toString("utf-8");
@@ -105,7 +105,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     rename: async (from: string, to: string) => {
       if (!isFixtureInMock(from) || !isFixtureInMock(to)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.rename as any)(from, to);
       }
       const fromAbs = absInMock(from);
@@ -120,7 +120,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     copyFile: async (from: string, to: string) => {
       if (!isFixtureInMock(from) || !isFixtureInMock(to)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.copyFile as any)(from, to);
       }
       const entry = fsState.entries.get(absInMock(from));
@@ -131,7 +131,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     stat: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.stat as any)(p);
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -146,7 +146,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     access: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.access as any)(p);
       }
       const entry = fsState.entries.get(absInMock(p));
@@ -156,7 +156,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     unlink: async (p: string) => {
       if (!isFixtureInMock(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.promises.unlink as any)(p);
       }
       fsState.entries.delete(absInMock(p));
@@ -173,14 +173,14 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     ...actual,
     mkdir: async (p: string, _opts?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.mkdir as any)(p, { recursive: true });
       }
       ensureDir(p);
     },
     writeFile: async (p: string, data: string, _enc?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return await (actual.writeFile as any)(p, data, "utf-8");
       }
       setFile(p, data);

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1155,7 +1155,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           continue;
         }
         try {
-          // eslint-disable-next-line no-await-in-loop
+          // oxlint-disable-next-line no-await-in-loop
           const apiKeyInfo = await getApiKeyForModel({
             model,
             cfg,

--- a/src/gateway/server-restart-deferral.test.ts
+++ b/src/gateway/server-restart-deferral.test.ts
@@ -8,7 +8,7 @@ import { getTotalQueueSize } from "../process/command-queue.js";
 
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let i = 0; i < count; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     await Promise.resolve();
   }
 }

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -36,7 +36,7 @@ vi.mock("node:fs", async (importOriginal) => {
       isFixturePath(p) ? state.entries.has(absInMock(p)) : actual.existsSync(p),
     readFileSync: (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.readFileSync(p as any, encoding as any) as unknown;
       }
       const entry = readFixtureEntry(p);
@@ -47,7 +47,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     statSync: (p: string) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.statSync(p as any) as unknown;
       }
       const entry = readFixtureEntry(p);

--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -33,7 +33,7 @@ vi.mock("node:fs", async (importOriginal) => {
       isFixturePath(p) ? state.entries.has(abs(p)) : actual.existsSync(p),
     readFileSync: (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.readFileSync(p as any, encoding as any) as unknown;
       }
       const entry = state.entries.get(abs(p));
@@ -44,7 +44,7 @@ vi.mock("node:fs", async (importOriginal) => {
     },
     statSync: (p: string) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return actual.statSync(p as any) as unknown;
       }
       const entry = state.entries.get(abs(p));
@@ -76,7 +76,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     ...actual,
     readFile: async (p: string, encoding?: unknown) => {
       if (!isFixturePath(p)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // oxlint-disable-next-line typescript/no-explicit-any
         return (await actual.readFile(p as any, encoding as any)) as unknown;
       }
       const entry = state.entries.get(abs(p));

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -91,7 +91,7 @@ vi.mock("./manager.js", () => ({
 
 import { QmdMemoryManager } from "./qmd-manager.js";
 import { getMemorySearchManager } from "./search-manager.js";
-// eslint-disable-next-line @typescript-eslint/unbound-method -- mocked static function
+// oxlint-disable-next-line typescript/unbound-method -- mocked static function
 const createQmdManagerMock = vi.mocked(QmdMemoryManager.create);
 
 type SearchManagerResult = Awaited<ReturnType<typeof getMemorySearchManager>>;
@@ -147,7 +147,7 @@ describe("getMemorySearchManager caching", () => {
     const second = await getMemorySearchManager({ cfg, agentId: "main" });
 
     expect(first.manager).toBe(second.manager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
   });
 
@@ -169,7 +169,7 @@ describe("getMemorySearchManager caching", () => {
     const second = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     requireManager(second);
     expect(second.manager).not.toBe(first.manager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 
@@ -182,14 +182,14 @@ describe("getMemorySearchManager caching", () => {
 
     requireManager(first);
     requireManager(second);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ agentId, mode: "status" }),
     );
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ agentId, mode: "status" }),
@@ -216,7 +216,7 @@ describe("getMemorySearchManager caching", () => {
 
     const third = await getMemorySearchManager({ cfg, agentId: retryAgentId });
     expect(third.manager).toBe(secondManager);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // oxlint-disable-next-line typescript/unbound-method
     expect(createQmdManagerMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -172,7 +172,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const scheme = gateway.tls ? "wss" : "ws";
   const url = `${scheme}://${host}:${port}`;
   const pathEnv = ensureNodePathEnv();
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.log(`node host PATH: ${pathEnv}`);
 
   const client = new GatewayClient({
@@ -211,11 +211,11 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     },
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)
-      // eslint-disable-next-line no-console
+      // oxlint-disable-next-line no-console
       console.error(`node host gateway connect failed: ${err.message}`);
     },
     onClose: (code, reason) => {
-      // eslint-disable-next-line no-console
+      // oxlint-disable-next-line no-console
       console.error(`node host gateway closed (${code}): ${reason}`);
     },
   });

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -632,7 +632,7 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "extensions", pluginId);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -695,7 +695,7 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "hooks", hookId);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -740,7 +740,7 @@ export async function collectIncludeFilePermFindings(params: {
   }
 
   for (const p of includePaths) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const perms = await inspectPathPermissions(p, {
       env: params.env,
       platform: params.platform,
@@ -855,7 +855,7 @@ export async function collectStateDeepFilesystemFindings(params: {
   for (const agentId of ids) {
     const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const authPerms = await inspectPathPermissions(authPath, {
       env: params.env,
       platform: params.platform,
@@ -894,7 +894,7 @@ export async function collectStateDeepFilesystemFindings(params: {
     }
 
     const storePath = path.join(params.stateDir, "agents", agentId, "sessions", "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const storePerms = await inspectPathPermissions(storePath, {
       env: params.env,
       platform: params.platform,

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -325,7 +325,7 @@ async function chmodCredentialsAndAgentState(params: {
       continue;
     }
     const p = path.join(credsDir, entry.name);
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: p, mode: 0o600, require: "file" }));
   }
 
@@ -349,26 +349,26 @@ async function chmodCredentialsAndAgentState(params: {
     const agentDir = path.join(agentRoot, "agent");
     const sessionsDir = path.join(agentRoot, "sessions");
 
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: agentRoot, mode: 0o700, require: "dir" }));
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: agentDir, mode: 0o700, require: "dir" }));
 
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: authPath, mode: 0o600, require: "file" }));
 
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(
       await params.applyPerms({ path: sessionsDir, mode: 0o700, require: "dir" }),
     );
 
     const storePath = path.join(sessionsDir, "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: storePath, mode: 0o600, require: "file" }));
 
     // Fix permissions on session transcript files (*.jsonl)
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const sessionEntries = await fs.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
     for (const entry of sessionEntries) {
       if (!entry.isFile()) {
@@ -378,7 +378,7 @@ async function chmodCredentialsAndAgentState(params: {
         continue;
       }
       const p = path.join(sessionsDir, entry.name);
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       params.actions.push(await params.applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }
@@ -446,7 +446,7 @@ export async function fixSecurityFootguns(opts?: {
       parsed: snap.parsed,
     }).catch(() => []);
     for (const p of includePaths) {
-      // eslint-disable-next-line no-await-in-loop
+      // oxlint-disable-next-line no-await-in-loop
       actions.push(await applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -25,7 +25,7 @@ vi.mock("../sticker-cache.js", () => ({
   getCachedSticker: () => null,
 }));
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+// oxlint-disable-next-line typescript/consistent-type-imports
 const { resolveMedia } = await import("./delivery.js");
 const MAX_MEDIA_BYTES = 10_000_000;
 const BOT_TOKEN = "tok123";

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -66,7 +66,7 @@ export async function getDeterministicFreePortBlock(params?: {
   // so probing every single offset is wasted work and slows large suites.
   for (let attempt = 0; attempt < usable; attempt += blockSize) {
     const start = base + ((nextTestPortOffset + attempt) % usable);
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(start + offset)))).every(
       Boolean,
     );
@@ -79,9 +79,9 @@ export async function getDeterministicFreePortBlock(params?: {
 
   // Fallback: let the OS pick a port block (best effort).
   for (let attempt = 0; attempt < 25; attempt += 1) {
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const port = await getOsFreePort();
-    // eslint-disable-next-line no-await-in-loop
+    // oxlint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(port + offset)))).every(
       Boolean,
     );


### PR DESCRIPTION
## Summary

- **copilot-proxy**: Export and test 4 pure helper functions (`normalizeBaseUrl`, `validateBaseUrl`, `parseModelIds`, `buildModelDefinition`) — 31 tests covering URL normalization/trailing-slash handling, default URL fallback, model ID parsing with comma/newline separators, deduplication, validation, and model definition structure.
- **qwen-portal-auth**: Test the full `loginQwenPortalOAuth` device-code OAuth flow with mocked `fetch` — 11 tests covering: successful token return, verification URL display, user-code note, `authorization_pending` retry logic, `slow_down` backoff, HTTP error on device-code request, non-pending poll error, incomplete token payload, `verification_uri` fallback when `verification_uri_complete` is absent, `resourceUrl` propagation, and graceful fallback when `openUrl` throws.
- **minimax-portal-auth**: Test the full `loginMiniMaxPortalOAuth` flow with mocked `fetch` — 14 tests covering: global/CN region routing (correct base URL chosen), default-to-global when region omitted, verification URL and note display, `resourceUrl` and `notification_message` propagation, HTTP error on code endpoint, missing `user_code` in response, PKCE state-mismatch CSRF protection, `status=error` poll throws, multi-round pending polling succeeds on third attempt, and graceful fallback when `openUrl` throws.

## Test plan

- [x] All 56 new tests pass locally (`pnpm test` / `node_modules/.bin/vitest run extensions/copilot-proxy/index.test.ts extensions/qwen-portal-auth/oauth.test.ts extensions/minimax-portal-auth/oauth.test.ts`)
- [x] No new lint warnings/errors (`pnpm check` → "Found 0 warnings and 0 errors")
- [x] Format applied (`pnpm format`)
- [x] External dependencies (`fetch`, timers) are fully mocked — no real network calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)