### PR TITLE
fix(mattermost): respect replyToMode config for reply threading

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -242,6 +242,32 @@ describe("mattermostPlugin", () => {
     });
   });
 
+  describe("threading", () => {
+    it("resolves replyToMode from config", () => {
+      const resolve = mattermostPlugin.threading?.resolveReplyToMode;
+      expect(resolve).toBeTruthy();
+
+      expect(
+        resolve?.({
+          cfg: { channels: { mattermost: { replyToMode: "all" } } },
+          accountId: "default",
+          chatType: "direct",
+        }),
+      ).toBe("all");
+    });
+
+    it("defaults replyToMode to off", () => {
+      const resolve = mattermostPlugin.threading?.resolveReplyToMode;
+      expect(
+        resolve?.({
+          cfg: { channels: { mattermost: {} } },
+          accountId: "default",
+          chatType: "direct",
+        }),
+      ).toBe("off");
+    });
+  });
+
   describe("config", () => {
     it("formats allowFrom entries", () => {
       const formatAllowFrom = mattermostPlugin.config.formatAllowFrom!;

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -247,6 +247,9 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
   groups: {
     resolveRequireMention: resolveMattermostGroupRequireMention,
   },
+  threading: {
+    resolveReplyToMode: ({ cfg }) => cfg.channels?.mattermost?.replyToMode ?? "off",
+  },
   actions: mattermostMessageActions,
   messaging: {
     normalizeTarget: normalizeMattermostMessagingTarget,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -756,6 +756,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         deliver: async (payload: ReplyPayload) => {
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          const replyToId = payload.replyToId ?? threadRootId;
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,
@@ -769,7 +770,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               }
               await sendMessageMattermost(to, chunk, {
                 accountId: account.accountId,
-                replyToId: threadRootId,
+                replyToId,
               });
             }
           } else {
@@ -780,7 +781,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               await sendMessageMattermost(to, caption, {
                 accountId: account.accountId,
                 mediaUrl,
-                replyToId: threadRootId,
+                replyToId,
               });
             }
           }


### PR DESCRIPTION
## Summary

- Add `threading.resolveReplyToMode` to the Mattermost channel plugin definition (matching the pattern used by Telegram, Slack, Discord, Google Chat, and Matrix)
- Update the deliver callback in `monitor.ts` to use `payload.replyToId ?? threadRootId` instead of hardcoding `threadRootId`, allowing the core reply-threading system (`applyReplyThreading` / `resolveReplyThreadingForPayload`) to control threading behavior
- Add tests verifying `replyToMode` resolution from config with `"off"` as default

## Test plan

- [x] Existing `channel.test.ts` passes (14 → 16 tests with 2 new threading tests)
- [ ] Set `channels.mattermost.replyToMode: "all"` and verify bot replies thread to the triggering message
- [ ] Set `channels.mattermost.replyToMode: "first"` and verify only the first reply threads
- [ ] Verify default `"off"` behavior: bot replies as standalone messages (unless already in a thread)

Fixes #27729

🤖 Generated with [Claude Code](https://claude.com/claude-code)