### PR TITLE
feat(line): add file message type download support

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -232,7 +232,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -239,7 +239,13 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     message.type === "file"
   ) {
     try {
-      const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
+      const fileName = message.type === "file" ? message.fileName : undefined;
+      const media = await downloadLineMedia(
+        message.id,
+        account.channelAccessToken,
+        mediaMaxBytes,
+        fileName,
+      );
       allMedia.push({
         path: media.path,
         contentType: media.contentType,

--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -1,15 +1,13 @@
-import fs from "node:fs";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
-const getMessageContentMock = vi.hoisted(() => vi.fn());
+const getMessageContentWithHttpInfoMock = vi.hoisted(() => vi.fn());
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: {
     MessagingApiBlobClient: class {
-      getMessageContent(messageId: string) {
-        return getMessageContentMock(messageId);
+      getMessageContentWithHttpInfo(messageId: string) {
+        return getMessageContentWithHttpInfoMock(messageId);
       }
     },
   },
@@ -17,6 +15,10 @@ vi.mock("@line/bot-sdk", () => ({
 
 vi.mock("../globals.js", () => ({
   logVerbose: () => {},
+}));
+
+vi.mock("../media/store.js", () => ({
+  saveMediaBuffer: (...args: unknown[]) => saveMediaBufferMock(...args),
 }));
 
 import { downloadLineMedia } from "./download.js";
@@ -32,88 +34,63 @@ describe("downloadLineMedia", () => {
     vi.clearAllMocks();
   });
 
-  it("does not derive temp file path from external messageId", async () => {
-    const messageId = "a/../../../../etc/passwd";
+  it("saves media via saveMediaBuffer to inbound directory", async () => {
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([jpeg]),
+      httpResponse: { headers: new Headers({ "content-type": "image/jpeg" }) },
+    });
+    saveMediaBufferMock.mockResolvedValueOnce({
+      id: "test-uuid.jpg",
+      path: "/home/user/.openclaw/media/inbound/test-uuid.jpg",
+      size: jpeg.length,
+      contentType: "image/jpeg",
+    });
 
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+    const result = await downloadLineMedia("msg-123", "token");
 
-    const result = await downloadLineMedia(messageId, "token");
-    const writtenPath = writeSpy.mock.calls[0]?.[0];
+    expect(saveMediaBufferMock).toHaveBeenCalledOnce();
+    const [buffer, contentType, subdir, maxBytes, originalFilename] =
+      saveMediaBufferMock.mock.calls[0];
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.length).toBe(jpeg.length);
+    expect(contentType).toBe("image/jpeg");
+    expect(subdir).toBe("inbound");
+    expect(maxBytes).toBe(10 * 1024 * 1024);
+    expect(originalFilename).toBeUndefined();
 
-    expect(result.size).toBe(jpeg.length);
+    expect(result.path).toBe("/home/user/.openclaw/media/inbound/test-uuid.jpg");
     expect(result.contentType).toBe("image/jpeg");
-    expect(typeof writtenPath).toBe("string");
-    if (typeof writtenPath !== "string") {
-      throw new Error("expected string temp file path");
-    }
-    expect(result.path).toBe(writtenPath);
-    expect(writtenPath).toContain("line-media-");
-    expect(writtenPath).toMatch(/\.jpg$/);
-    expect(writtenPath).not.toContain(messageId);
-    expect(writtenPath).not.toContain("..");
-
-    const tmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-    const rel = path.relative(tmpRoot, path.resolve(writtenPath));
-    expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
+    expect(result.size).toBe(jpeg.length);
   });
 
-  it("rejects oversized media before writing to disk", async () => {
-    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.alloc(4), Buffer.alloc(4)]));
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined);
+  it("passes originalFilename and custom maxBytes to saveMediaBuffer", async () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([buf]),
+      httpResponse: { headers: new Headers({ "content-type": "image/png" }) },
+    });
+    saveMediaBufferMock.mockResolvedValueOnce({
+      id: "uuid.png",
+      path: "/home/user/.openclaw/media/inbound/uuid.png",
+      size: buf.length,
+      contentType: "image/png",
+    });
+
+    await downloadLineMedia("msg-456", "token", 5 * 1024 * 1024, "report.png");
+
+    const [, , , maxBytes, originalFilename] = saveMediaBufferMock.mock.calls[0];
+    expect(maxBytes).toBe(5 * 1024 * 1024);
+    expect(originalFilename).toBe("report.png");
+  });
+
+  it("rejects oversized media during streaming before saving", async () => {
+    getMessageContentWithHttpInfoMock.mockResolvedValueOnce({
+      body: chunks([Buffer.alloc(4), Buffer.alloc(4)]),
+      httpResponse: { headers: new Headers() },
+    });
 
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
-    expect(writeSpy).not.toHaveBeenCalled();
-  });
-
-  it("detects M4A audio from ftyp major brand (#29751)", async () => {
-    // Real M4A magic bytes: size(4) + "ftyp" + "M4A "
-    const m4a = Buffer.from([
-      0x00,
-      0x00,
-      0x00,
-      0x1c, // box size
-      0x66,
-      0x74,
-      0x79,
-      0x70, // "ftyp"
-      0x4d,
-      0x34,
-      0x41,
-      0x20, // "M4A " major brand
-    ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([m4a]));
-    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
-
-    const result = await downloadLineMedia("mid-m4a", "token");
-
-    expect(result.contentType).toBe("audio/mp4");
-    expect(result.path).toMatch(/\.m4a$/);
-  });
-
-  it("detects MP4 video from ftyp major brand (isom)", async () => {
-    // MP4 video magic bytes: size(4) + "ftyp" + "isom"
-    const mp4 = Buffer.from([
-      0x00,
-      0x00,
-      0x00,
-      0x1c,
-      0x66,
-      0x74,
-      0x79,
-      0x70,
-      0x69,
-      0x73,
-      0x6f,
-      0x6d, // "isom" major brand
-    ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([mp4]));
-    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
-
-    const result = await downloadLineMedia("mid-mp4", "token");
-
-    expect(result.contentType).toBe("video/mp4");
-    expect(result.path).toMatch(/\.mp4$/);
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
   });
 });

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs";
 import { messagingApi } from "@line/bot-sdk";
 import { logVerbose } from "../globals.js";
-import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
+import { saveMediaBuffer } from "../media/store.js";
 
 interface DownloadResult {
   path: string;
@@ -13,18 +12,21 @@ export async function downloadLineMedia(
   messageId: string,
   channelAccessToken: string,
   maxBytes = 10 * 1024 * 1024,
+  originalFilename?: string,
 ): Promise<DownloadResult> {
   const client = new messagingApi.MessagingApiBlobClient({
     channelAccessToken,
   });
 
-  const response = await client.getMessageContent(messageId);
+  const httpResponse = await client.getMessageContentWithHttpInfo(messageId);
 
-  // response is a Readable stream
+  const contentType = httpResponse.httpResponse.headers.get("content-type") ?? undefined;
+
+  // httpResponse.body is a Readable stream
   const chunks: Buffer[] = [];
   let totalSize = 0;
 
-  for await (const chunk of response as AsyncIterable<Buffer>) {
+  for await (const chunk of httpResponse.body as AsyncIterable<Buffer>) {
     totalSize += chunk.length;
     if (totalSize > maxBytes) {
       throw new Error(`Media exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`);
@@ -34,89 +36,15 @@ export async function downloadLineMedia(
 
   const buffer = Buffer.concat(chunks);
 
-  // Determine content type from magic bytes
-  const contentType = detectContentType(buffer);
-  const ext = getExtensionForContentType(contentType);
+  // Save to ~/.openclaw/media/inbound/ so sandbox can access the file.
+  // Previously saved to /tmp/openclaw/ which was outside the sandbox root.
+  const saved = await saveMediaBuffer(buffer, contentType, "inbound", maxBytes, originalFilename);
 
-  // Use random temp names; never derive paths from external message identifiers.
-  const filePath = buildRandomTempFilePath({ prefix: "line-media", extension: ext });
-
-  await fs.promises.writeFile(filePath, buffer);
-
-  logVerbose(`line: downloaded media ${messageId} to ${filePath} (${buffer.length} bytes)`);
+  logVerbose(`line: downloaded media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 
   return {
-    path: filePath,
-    contentType,
-    size: buffer.length,
+    path: saved.path,
+    contentType: saved.contentType,
+    size: saved.size,
   };
-}
-
-function detectContentType(buffer: Buffer): string {
-  // Check magic bytes
-  if (buffer.length >= 2) {
-    // JPEG
-    if (buffer[0] === 0xff && buffer[1] === 0xd8) {
-      return "image/jpeg";
-    }
-    // PNG
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
-      return "image/png";
-    }
-    // GIF
-    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) {
-      return "image/gif";
-    }
-    // WebP
-    if (
-      buffer[0] === 0x52 &&
-      buffer[1] === 0x49 &&
-      buffer[2] === 0x46 &&
-      buffer[3] === 0x46 &&
-      buffer[8] === 0x57 &&
-      buffer[9] === 0x45 &&
-      buffer[10] === 0x42 &&
-      buffer[11] === 0x50
-    ) {
-      return "image/webp";
-    }
-    // MPEG-4 container (ftyp box) — distinguish audio (M4A) from video (MP4)
-    // by checking the major brand at bytes 8-11.
-    if (
-      buffer.length >= 12 &&
-      buffer[4] === 0x66 &&
-      buffer[5] === 0x74 &&
-      buffer[6] === 0x79 &&
-      buffer[7] === 0x70
-    ) {
-      const brand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
-      if (brand === "M4A " || brand === "M4B ") {
-        return "audio/mp4";
-      }
-      return "video/mp4";
-    }
-  }
-
-  return "application/octet-stream";
-}
-
-function getExtensionForContentType(contentType: string): string {
-  switch (contentType) {
-    case "image/jpeg":
-      return ".jpg";
-    case "image/png":
-      return ".png";
-    case "image/gif":
-      return ".gif";
-    case "image/webp":
-      return ".webp";
-    case "video/mp4":
-      return ".mp4";
-    case "audio/mp4":
-      return ".m4a";
-    case "audio/mpeg":
-      return ".mp3";
-    default:
-      return ".bin";
-  }
 }


### PR DESCRIPTION
LINE's `file` message type (PDFs, documents, etc.) is not handled by the inbound media download logic — only `image`, `video`, and `audio` are checked. This means file attachments sent via LINE are silently dropped.

Additionally, `downloadLineMedia()` saves all media to `/tmp/openclaw/` via `buildRandomTempFilePath()`, but `stageSandboxMedia()` only allows files under `~/.openclaw/media/`. This means sandboxed agents cannot access any LINE-downloaded media (image/video/audio/file).

## Changes

- `src/line/bot-handlers.ts`: add `message.type === "file"` to the media download condition; pass `message.fileName` for file-type messages
- `src/line/download.ts`: switch from `buildRandomTempFilePath()` + `fs.writeFile` to `saveMediaBuffer()` (matching Telegram/Discord/Signal); extract Content-Type from LINE API response headers via `getMessageContentWithHttpInfo`; add `originalFilename` parameter
- `src/line/download.test.ts`: update tests for `saveMediaBuffer` mock-based approach

Closes #27722

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)