### PR TITLE
fix(ui): preserve unsafe Discord snowflake IDs in config form saves

### DIFF
--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -468,4 +468,27 @@ describe("coerceFormValues", () => {
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
     expect(coerced.flag).toBe(true);
   });
+
+  it("preserves large discord snowflake strings in string|number union arrays", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean" },
+        users: {
+          type: "array",
+          items: {
+            anyOf: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      },
+    };
+    const snowflake = "123456789012345678";
+    const form = { enabled: true, users: [snowflake] };
+
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    const users = coerced.users as unknown[];
+
+    expect(typeof users[0]).toBe("string");
+    expect(users[0]).toBe(snowflake);
+  });
 });


### PR DESCRIPTION
Closes #27775

Problem
Web UI config saves could fail with `invalid config` after editing unrelated fields when Discord snowflake IDs (18-19 digits) were present in `channels.discord.guilds.*.users[]`.

Root Cause
Before `config.set`, the UI runs schema-based form coercion. For `string|number` union fields, numeric-looking strings were coerced with `Number(...)`, which loses precision for values beyond JavaScript's safe integer range.

Fix
Preserve string values in `anyOf/oneOf` `string|number` unions when coercion would produce an unsafe integer, preventing snowflake IDs from being rounded during form serialization.

Testing
- Added UI regression test covering a large Discord snowflake in a `string|number` union array
- `pnpm -C ui exec vitest run --config vitest.node.config.ts src/ui/controllers/config/form-utils.node.test.ts`
