### PR TITLE
fix(signal): ignore expiration timer update messages

### DIFF
--- a/src/signal/monitor/event-handler.expiration-timer.test.ts
+++ b/src/signal/monitor/event-handler.expiration-timer.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignalEventHandler } from "./event-handler.js";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+
+const { dispatchInboundMessageMock } = vi.hoisted(() => ({
+  dispatchInboundMessageMock: vi.fn(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: vi.fn().mockResolvedValue(true),
+  sendReadReceiptSignal: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+  upsertChannelPairingRequest: vi.fn(),
+}));
+
+describe("signal expiration timer updates (#27615)", () => {
+  beforeEach(() => {
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("ignores expiration timer change with no message content", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          expiresInSeconds: 2419200,
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores expiration timer set to zero (disabled)", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          expiresInSeconds: 0,
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("still processes a message that also has expiresInSeconds", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          expiresInSeconds: 604800,
+        },
+      }),
+    );
+
+    expect(dispatchInboundMessageMock).toHaveBeenCalled();
+  });
+});

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -27,6 +27,7 @@ export type SignalMention = {
 export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
+  expiresInSeconds?: number;
   attachments?: Array<SignalAttachment>;
   mentions?: Array<SignalMention> | null;
   groupInfo?: {


### PR DESCRIPTION
## Summary
Ignore Signal expiration timer change notifications (disappearing messages setting) when they contain no actual message content.

## Problem
signal-cli emits a `dataMessage` with `expiresInSeconds` when the disappearing messages timer is changed. These events are system-level updates (not user messages), but they can reach the inbound handler and confuse the agent.

## Changes
- Add `expiresInSeconds?: number` to `SignalDataMessage`
- Add early-return guard in Signal inbound event handler to skip expiration-only updates (`expiresInSeconds` present + no message + no attachments + no reaction)
- Add focused regression tests in `event-handler.expiration-timer.test.ts`:
  - ignores timer change updates
  - ignores timer disable (`0` seconds)
  - still processes regular messages that also include `expiresInSeconds`

## Validation
- `pnpm exec vitest run src/signal/ --config vitest.unit.config.ts` → 100 passing tests
- `pnpm lint` → clean

Fixes #27615
