### PR TITLE
fix: configurable announce expiry timeout (fixes #27758)

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -796,7 +796,7 @@ describe("sessions tools", () => {
       cleanup: "keep",
       createdAt: now - 15 * 60_000,
       startedAt: now - 14 * 60_000,
-      endedAt: now - 5 * 60_000,
+      endedAt: now - 10 * 60_000,
       outcome: { status: "ok" },
     });
     addSubagentRunForTests({
@@ -806,9 +806,9 @@ describe("sessions tools", () => {
       requesterDisplayKey: "main",
       task: "old completed run",
       cleanup: "keep",
-      createdAt: now - 90 * 60_000,
-      startedAt: now - 89 * 60_000,
-      endedAt: now - 80 * 60_000,
+      createdAt: now - 120 * 60_000,
+      startedAt: now - 110 * 60_000,
+      endedAt: now - 100 * 60_000,
       outcome: { status: "ok" },
     });
 

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -110,18 +110,18 @@ describe("announce loop guard (#18264)", () => {
     {
       name: "expired entries with high retry count are skipped by resumeSubagentRun",
       createEntry: (now: number) => ({
-        // Ended 10 minutes ago (well past ANNOUNCE_EXPIRY_MS of 5 min).
+        // Ended 70 minutes ago (well past ANNOUNCE_EXPIRY_MS of 60 min).
         runId: "test-expired-loop",
         childSessionKey: "agent:main:subagent:expired-child",
         requesterSessionKey: "agent:main:main",
         requesterDisplayKey: "agent:main:main",
         task: "expired test task",
         cleanup: "keep" as const,
-        createdAt: now - 15 * 60_000,
-        startedAt: now - 14 * 60_000,
-        endedAt: now - 10 * 60_000,
+        createdAt: now - 80 * 60_000,
+        startedAt: now - 75 * 60_000,
+        endedAt: now - 70 * 60_000,
         announceRetryCount: 3,
-        lastAnnounceRetryAt: now - 9 * 60_000,
+        lastAnnounceRetryAt: now - 65 * 60_000,
       }),
     },
     {

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -563,8 +563,8 @@ describe("subagent registry steer restarts", () => {
       runId: "run-parent-expiry",
       data: {
         phase: "end",
-        startedAt: Date.now() - 7 * 60_000,
-        endedAt: Date.now() - 6 * 60_000,
+        startedAt: Date.now() - 75 * 60_000,
+        endedAt: Date.now() - 70 * 60_000,
       },
     });
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -245,6 +245,8 @@ export type AgentDefaultsConfig = {
     maxChildrenPerAgent?: number;
     /** Auto-archive sub-agent sessions after N minutes (default: 60). */
     archiveAfterMinutes?: number;
+    /** Announce expiry time in minutes (default: 60). Announces older than this are force-expired. */
+    announceExpiryMinutes?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -144,6 +144,8 @@ export const AgentDefaultsSchema = z
             "Maximum number of active children a single agent session can spawn (default: 5).",
           ),
         archiveAfterMinutes: z.number().int().positive().optional(),
+        /** Announce expiry time in minutes (default: 60). Announces older than this are force-expired. */
+        announceExpiryMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary

Makes the subagent announce expiry timeout configurable instead of hardcoded to 5 minutes.

## Changes

- Added &#96;announceExpiryMinutes&#96; config option under &#96;agents.defaults.subagents&#96; in Zod schema and TypeScript types
- Added &#96;resolveAnnounceExpiryMs()&#96; function that reads from config with a 60-minute fallback
- Replaced all usages of hardcoded &#96;ANNOUNCE_EXPIRY_MS&#96; (5 min) with the new configurable function

## Configuration

Users can now configure the timeout in their config file:

```json5
{
  agents: {
    defaults: {
      subagents: {
        announceExpiryMinutes: 120  // 2 hours instead of default 60 minutes
      }
    }
  }
}
```

## Backwards Compatibility

- Falls back to 60 minutes if not configured (safer than previous 5-minute default)
- Existing configs without this option will work without changes

fixes #27758