### PR TITLE
feat(cron): support custom named session targets for agentTurn jobs

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -200,8 +200,8 @@ export function registerCronAddCommand(cron: Command) {
           const inferredSessionTarget = payload.kind === "agentTurn" ? "isolated" : "main";
           const sessionTarget =
             sessionSource === "cli" ? sessionTargetRaw || "" : inferredSessionTarget;
-          if (sessionTarget !== "main" && sessionTarget !== "isolated") {
-            throw new Error("--session must be main or isolated");
+          if (!sessionTarget) {
+            throw new Error("--session is required (main, isolated, or a custom session name)");
           }
 
           if (opts.deleteAfterRun && opts.keepAfterRun) {
@@ -211,18 +211,18 @@ export function registerCronAddCommand(cron: Command) {
           if (sessionTarget === "main" && payload.kind !== "systemEvent") {
             throw new Error("Main jobs require --system-event (systemEvent).");
           }
-          if (sessionTarget === "isolated" && payload.kind !== "agentTurn") {
-            throw new Error("Isolated jobs require --message (agentTurn).");
+          if (sessionTarget !== "main" && payload.kind !== "agentTurn") {
+            throw new Error("Non-main jobs require --message (agentTurn).");
           }
           if (
             (opts.announce || typeof opts.deliver === "boolean") &&
-            (sessionTarget !== "isolated" || payload.kind !== "agentTurn")
+            (sessionTarget === "main" || payload.kind !== "agentTurn")
           ) {
-            throw new Error("--announce/--no-deliver require --session isolated.");
+            throw new Error("--announce/--no-deliver require a non-main session with --message.");
           }
 
           const deliveryMode =
-            sessionTarget === "isolated" && payload.kind === "agentTurn"
+            sessionTarget !== "main" && payload.kind === "agentTurn"
               ? hasAnnounce
                 ? "announce"
                 : hasNoDeliver

--- a/src/cron/isolated-agent/run.session-key.test.ts
+++ b/src/cron/isolated-agent/run.session-key.test.ts
@@ -25,4 +25,16 @@ describe("resolveCronAgentSessionKey", () => {
       "agent:main:hook:webhook:42",
     );
   });
+
+  it("resolves custom named session target to agent-scoped key", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "scheduled", agentId: "myagent" })).toBe(
+      "agent:myagent:scheduled",
+    );
+  });
+
+  it("resolves custom named session target with mixed case", () => {
+    expect(resolveCronAgentSessionKey({ sessionKey: "Research", agentId: "main" })).toBe(
+      "agent:main:research",
+    );
+  });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -220,7 +220,9 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
-    // Isolated cron runs must not carry prior turn context across executions.
+    // "isolated" sessions get a fresh context per execution.
+    // Custom named sessions (e.g. "scheduled") preserve context across runs,
+    // similar to heartbeat sessions.
     forceNew: params.job.sessionTarget === "isolated",
   });
   const runSessionId = cronSession.sessionEntry.sessionId;

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -360,6 +360,31 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.wakeMode).toBe("now");
   });
 
+  it("accepts custom named session target for agentTurn jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "custom-session",
+      schedule: { kind: "cron", expr: "0 * * * *" },
+      sessionTarget: "scheduled",
+      payload: { kind: "agentTurn", message: "run scheduled task" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("scheduled");
+    expect((normalized.payload as Record<string, unknown>).kind).toBe("agentTurn");
+    // Custom named sessions should default to announce delivery like isolated sessions
+    expect((normalized.delivery as Record<string, unknown>)?.mode).toBe("announce");
+  });
+
+  it("normalizes custom session target casing and whitespace", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "custom-casing",
+      schedule: { kind: "cron", expr: "0 * * * *" },
+      sessionTarget: " Research ",
+      payload: { kind: "agentTurn", message: "hello" },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("research");
+  });
+
   it("strips invalid delivery mode from partial delivery objects", () => {
     const normalized = normalizeCronJobCreate({
       name: "delivery mode",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -204,6 +204,14 @@ function normalizeSessionTarget(raw: unknown) {
   if (!trimmed) {
     return undefined;
   }
+  // Reject values that look like canonical session keys (e.g. "agent:main:main")
+  // to prevent custom targets from bypassing session isolation boundaries.
+  if (trimmed.includes(":")) {
+    if (trimmed === "main" || trimmed === "isolated") {
+      return trimmed;
+    }
+    return undefined;
+  }
   return trimmed;
 }
 

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -201,10 +201,10 @@ function normalizeSessionTarget(raw: unknown) {
     return undefined;
   }
   const trimmed = raw.trim().toLowerCase();
-  if (trimmed === "main" || trimmed === "isolated") {
-    return trimmed;
+  if (!trimmed) {
+    return undefined;
   }
-  return undefined;
+  return trimmed;
 }
 
 function normalizeWakeMode(raw: unknown) {
@@ -444,11 +444,12 @@ export function normalizeCronJobInput(
     const payload = isRecord(next.payload) ? next.payload : null;
     const payloadKind = payload && typeof payload.kind === "string" ? payload.kind : "";
     const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
-    const isIsolatedAgentTurn =
-      sessionTarget === "isolated" || (sessionTarget === "" && payloadKind === "agentTurn");
+    // Any non-main agentTurn job (isolated, custom named, or unset) defaults to announce delivery.
+    const isNonMainAgentTurn =
+      sessionTarget !== "main" && (sessionTarget !== "" || payloadKind === "agentTurn");
     const hasDelivery = "delivery" in next && next.delivery !== undefined;
     const hasLegacyDelivery = payload ? hasLegacyDeliveryHints(payload) : false;
-    if (!hasDelivery && isIsolatedAgentTurn && payloadKind === "agentTurn") {
+    if (!hasDelivery && isNonMainAgentTurn && payloadKind === "agentTurn") {
       if (payload && hasLegacyDelivery) {
         next.delivery = buildDeliveryFromLegacyPayload(payload);
         stripLegacyDeliveryFields(payload);

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -761,7 +761,7 @@ describe("CronService", () => {
         wakeMode: "next-heartbeat",
         payload: { kind: "systemEvent", text: "nope" },
       }),
-    ).rejects.toThrow(/isolated cron jobs require/);
+    ).rejects.toThrow(/non-main cron jobs require/);
 
     cron.stop();
     await store.cleanup();

--- a/src/cron/service/jobs.custom-session-target.test.ts
+++ b/src/cron/service/jobs.custom-session-target.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { assertSupportedJobSpec } from "./jobs.js";
+
+describe("assertSupportedJobSpec with custom session targets", () => {
+  it("allows main + systemEvent", () => {
+    expect(() =>
+      assertSupportedJobSpec({
+        sessionTarget: "main",
+        payload: { kind: "systemEvent", text: "hello" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects main + agentTurn", () => {
+    expect(() =>
+      assertSupportedJobSpec({
+        sessionTarget: "main",
+        payload: { kind: "agentTurn", message: "hello" },
+      }),
+    ).toThrow('main cron jobs require payload.kind="systemEvent"');
+  });
+
+  it("allows isolated + agentTurn", () => {
+    expect(() =>
+      assertSupportedJobSpec({
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "hello" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows custom named session + agentTurn", () => {
+    expect(() =>
+      assertSupportedJobSpec({
+        sessionTarget: "scheduled",
+        payload: { kind: "agentTurn", message: "run task" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects custom named session + systemEvent", () => {
+    expect(() =>
+      assertSupportedJobSpec({
+        sessionTarget: "scheduled",
+        payload: { kind: "systemEvent", text: "hello" },
+      }),
+    ).toThrow('non-main cron jobs require payload.kind="agentTurn"');
+  });
+
+  it("allows any kebab-case session name + agentTurn", () => {
+    for (const name of ["research", "daily-scan", "market-watch", "act"]) {
+      expect(() =>
+        assertSupportedJobSpec({
+          sessionTarget: name,
+          payload: { kind: "agentTurn", message: "hello" },
+        }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -78,8 +78,9 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
   if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
     throw new Error('main cron jobs require payload.kind="systemEvent"');
   }
-  if (job.sessionTarget === "isolated" && job.payload.kind !== "agentTurn") {
-    throw new Error('isolated cron jobs require payload.kind="agentTurn"');
+  // Any non-main session target (including "isolated" and custom names) requires agentTurn.
+  if (job.sessionTarget !== "main" && job.payload.kind !== "agentTurn") {
+    throw new Error('non-main cron jobs require payload.kind="agentTurn"');
   }
 }
 
@@ -112,8 +113,8 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     job.delivery.to = target;
     return;
   }
-  if (job.sessionTarget !== "isolated") {
-    throw new Error('cron channel delivery config is only supported for sessionTarget="isolated"');
+  if (job.sessionTarget === "main") {
+    throw new Error('cron channel delivery config is not supported for sessionTarget="main"');
   }
   if (job.delivery.channel === "telegram") {
     const telegramError = validateTelegramDeliveryTarget(job.delivery.to);

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -442,11 +442,7 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   if (!patch.delivery && patch.payload?.kind === "agentTurn") {
     // Back-compat: legacy clients still update delivery via payload fields.
     const legacyDeliveryPatch = buildLegacyDeliveryPatch(patch.payload);
-    if (
-      legacyDeliveryPatch &&
-      job.sessionTarget === "isolated" &&
-      job.payload.kind === "agentTurn"
-    ) {
+    if (legacyDeliveryPatch && job.sessionTarget !== "main" && job.payload.kind === "agentTurn") {
       job.delivery = mergeCronDelivery(job.delivery, legacyDeliveryPatch);
     }
   }

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -430,12 +430,12 @@ export async function ensureLoaded(
       payloadRecord && typeof payloadRecord.kind === "string" ? payloadRecord.kind : "";
     const sessionTarget =
       typeof raw.sessionTarget === "string" ? raw.sessionTarget.trim().toLowerCase() : "";
-    const isIsolatedAgentTurn =
-      sessionTarget === "isolated" || (sessionTarget === "" && payloadKind === "agentTurn");
+    const isNonMainAgentTurn =
+      sessionTarget !== "main" && (sessionTarget !== "" || payloadKind === "agentTurn");
     const hasDelivery = delivery && typeof delivery === "object" && !Array.isArray(delivery);
     const hasLegacyDelivery = payloadRecord ? hasLegacyDeliveryHints(payloadRecord) : false;
 
-    if (isIsolatedAgentTurn && payloadKind === "agentTurn") {
+    if (isNonMainAgentTurn && payloadKind === "agentTurn") {
       if (!hasDelivery) {
         raw.delivery =
           payloadRecord && hasLegacyDelivery

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -701,7 +701,7 @@ export async function executeJobCore(
   }
 
   if (job.payload.kind !== "agentTurn") {
-    return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
+    return { status: "skipped", error: "non-main job requires payload.kind=agentTurn" };
   }
   if (abortSignal?.aborted) {
     return resolveAbortError();

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -11,7 +11,15 @@ export type CronSchedule =
       staggerMs?: number;
     };
 
-export type CronSessionTarget = "main" | "isolated";
+/**
+ * Session target for cron jobs.
+ *
+ * - `"main"` — inject systemEvent into the agent's main session (requires payload.kind="systemEvent").
+ * - `"isolated"` — run agentTurn in a fresh isolated session per execution (requires payload.kind="agentTurn").
+ * - Any other string — run agentTurn in a named persistent session (e.g. `"scheduled"` → `agent:<agentId>:scheduled`).
+ *   Named sessions preserve context across cron runs, similar to heartbeat's `session` config.
+ */
+export type CronSessionTarget = "main" | "isolated" | (string & {});
 export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId | "last";

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -19,7 +19,15 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   );
 }
 
-const CronSessionTargetSchema = Type.Union([Type.Literal("main"), Type.Literal("isolated")]);
+/**
+ * Session target for cron jobs.
+ *
+ * - "main" — systemEvent injected into the agent's main session.
+ * - "isolated" — agentTurn in a fresh session per execution.
+ * - Any other non-empty string — agentTurn in a named persistent session
+ *   (e.g. "scheduled" → agent:<agentId>:scheduled), preserving context across runs.
+ */
+const CronSessionTargetSchema = Type.String({ minLength: 1 });
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
 const CronRunStatusSchema = Type.Union([
   Type.Literal("ok"),


### PR DESCRIPTION
## Summary

Allow cron `agentTurn` jobs to target custom named sessions beyond `main` and `isolated`.

A custom session target (e.g. `--session scheduled`) creates a persistent named session (`agent:<agentId>:scheduled`) that preserves context across cron runs, similar to how heartbeat's `session` config already works.

## Motivation

Heartbeat supports custom session names (e.g. `session: "loop"` creates `agent:<agentId>:loop`), but cron was limited to:
- `main` — systemEvent only, no full agent turn
- `isolated` — fresh session per execution, no context preservation

Users need cron `agentTurn` jobs to run in named persistent sessions so:
1. **TUI windows can observe them** — connect a TUI to `agent:<agentId>:scheduled` and watch cron runs live
2. **Context is preserved** — the agent remembers previous cron runs in the same session
3. **Parity with heartbeat** — heartbeat and cron should have the same session targeting capabilities

## Changes

### Type + Schema
- `CronSessionTarget` type: `"main" | "isolated"` → `"main" | "isolated" | (string & {})`
- `CronSessionTargetSchema`: `Union(Literal("main"), Literal("isolated"))` → `String({ minLength: 1 })`

### Normalization + Validation
- `normalizeSessionTarget()`: accepts any non-empty string (was main/isolated only)
- `assertSupportedJobSpec()`: `main` requires `systemEvent`, everything else requires `agentTurn`
- Delivery defaults: all non-main `agentTurn` jobs default to `announce` delivery

### Runtime
- `server-cron.ts`: custom named sessions use `job.sessionTarget` as the session key instead of hardcoded `cron:<jobId>` — producing `agent:<agentId>:<name>` via `resolveCronAgentSessionKey()`
- `run.ts`: `forceNew` only applies to `"isolated"` sessions (custom named sessions preserve context)

### CLI
- `register.cron-add.ts`: removed hard `main`/`isolated` validation, accepts any non-empty string

### Agent docs
- `cron-tool.ts`: updated agent-facing tool prompt with custom session target documentation

## Behavior

| `--session` | `payload.kind` | Session key | Context | `forceNew` |
|-------------|---------------|-------------|---------|------------|
| `main` | `systemEvent` | `agent:<id>:main` | Shared with main | N/A |
| `isolated` | `agentTurn` | `agent:<id>:cron:<jobId>:run:<uuid>` | Fresh each run | `true` |
| `scheduled` | `agentTurn` | `agent:<id>:scheduled` | Preserved | `false` |
| `research` | `agentTurn` | `agent:<id>:research` | Preserved | `false` |

## Backward compatibility

Fully backward compatible. Existing `main` and `isolated` behavior is unchanged. Custom session names are opt-in via explicit `--session <name>`.

## Tests

- 10 new tests across 3 files (normalization, session key resolution, job spec validation)
- 1 existing test updated for changed error message
- Full cron test suite: **279 tests passing** across 40 test files
