### PR TITLE
feat: add message hook without heartbeat prompt

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -11,7 +11,7 @@ export type HookMappingTransform = {
 export type HookMappingConfig = {
   id?: string;
   match?: HookMappingMatch;
-  action?: "wake" | "agent";
+  action?: "wake" | "agent" | "message";
   wakeMode?: "now" | "next-heartbeat";
   name?: string;
   /** Route this hook to a specific agent (unknown ids fall back to the default agent). */

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -39,7 +39,7 @@ export const HookMappingSchema = z
         source: z.string().optional(),
       })
       .optional(),
-    action: z.union([z.literal("wake"), z.literal("agent")]).optional(),
+    action: z.union([z.literal("wake"), z.literal("agent"), z.literal("message")]).optional(),
     wakeMode: z.union([z.literal("now"), z.literal("next-heartbeat")]).optional(),
     name: z.string().optional(),
     agentId: z.string().optional(),

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -45,7 +45,6 @@ export type HookAction =
   | {
       kind: "message";
       text: string;
-      mode: "now" | "next-heartbeat";
     }
   | {
       kind: "agent";
@@ -262,7 +261,6 @@ function buildActionFromMapping(
       action: {
         kind: "message",
         text,
-        mode: mapping.wakeMode ?? "now",
       },
     };
   }
@@ -305,9 +303,7 @@ function mergeAction(
   if (kind === "message") {
     const baseMessage = base.kind === "message" ? base : undefined;
     const text = typeof override.text === "string" ? override.text : (baseMessage?.text ?? "");
-    const mode =
-      override.mode === "next-heartbeat" ? "next-heartbeat" : (baseMessage?.mode ?? "now");
-    return validateAction({ kind: "message", text, mode });
+    return validateAction({ kind: "message", text });
   }
   const baseAgent = base.kind === "agent" ? base : undefined;
   const message =

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -219,6 +219,19 @@ export function normalizeWakePayload(
   return { ok: true, value: { text, mode } };
 }
 
+export function normalizeMessagePayload(
+  payload: Record<string, unknown>,
+):
+  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat" } }
+  | { ok: false; error: string } {
+  const text = typeof payload.text === "string" ? payload.text.trim() : "";
+  if (!text) {
+    return { ok: false, error: "text required" };
+  }
+  const mode = payload.mode === "next-heartbeat" ? "next-heartbeat" : "now";
+  return { ok: true, value: { text, mode } };
+}
+
 export type HookAgentPayload = {
   message: string;
   name: string;

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -221,15 +221,12 @@ export function normalizeWakePayload(
 
 export function normalizeMessagePayload(
   payload: Record<string, unknown>,
-):
-  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat" } }
-  | { ok: false; error: string } {
+): { ok: true; value: { text: string } } | { ok: false; error: string } {
   const text = typeof payload.text === "string" ? payload.text.trim() : "";
   if (!text) {
     return { ok: false, error: "text required" };
   }
-  const mode = payload.mode === "next-heartbeat" ? "next-heartbeat" : "now";
-  return { ok: true, value: { text, mode } };
+  return { ok: true, value: { text } };
 }
 
 export type HookAgentPayload = {

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -71,6 +71,7 @@ describe("createHooksRequestHandler timeout status mapping", () => {
   test("returns 408 for request body timeout", async () => {
     readJsonBodyMock.mockResolvedValue({ ok: false, error: "request body timeout" });
     const dispatchWakeHook = vi.fn();
+    const dispatchMessageHook = vi.fn(() => "run-1");
     const dispatchAgentHook = vi.fn(() => "run-1");
     const handler = createHooksRequestHandler({
       getHooksConfig: () => createHooksConfig(),
@@ -83,6 +84,7 @@ describe("createHooksRequestHandler timeout status mapping", () => {
         error: vi.fn(),
       } as unknown as ReturnType<typeof createSubsystemLogger>,
       dispatchWakeHook,
+      dispatchMessageHook,
       dispatchAgentHook,
     });
     const req = createRequest();
@@ -94,6 +96,7 @@ describe("createHooksRequestHandler timeout status mapping", () => {
     expect(res.statusCode).toBe(408);
     expect(end).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "request body timeout" }));
     expect(dispatchWakeHook).not.toHaveBeenCalled();
+    expect(dispatchMessageHook).not.toHaveBeenCalled();
     expect(dispatchAgentHook).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -66,7 +66,7 @@ const HOOK_AUTH_FAILURE_TRACK_MAX = 2048;
 
 type HookDispatchers = {
   dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
-  dispatchMessageHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => string;
+  dispatchMessageHook: (value: { text: string }) => string;
   dispatchAgentHook: (value: {
     message: string;
     name: string;
@@ -410,7 +410,6 @@ export function createHooksRequestHandler(
           if (mapped.action.kind === "message") {
             const runId = dispatchMessageHook({
               text: mapped.action.text,
-              mode: mapped.action.mode,
             });
             sendJson(res, 202, { ok: true, runId });
             return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -30,7 +30,7 @@ export function createGatewayHooksRequestHandler(params: {
     }
   };
 
-  const dispatchMessageHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
+  const dispatchMessageHook = (value: { text: string }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
     const runId = randomUUID();
     void (async () => {


### PR DESCRIPTION
## Summary
- Add a new `/hooks/message` endpoint that runs a normal agent turn on the main session without heartbeat prompt injection.
- Support `message` as a hook mapping action alongside `wake` and `agent`.
- Extend hooks schema/validation and gateway wiring to accept the new action.
- Add e2e coverage for the message hook flow.

## Behavior
- Payload shape: `{ text }` (message is sent immediately; no heartbeat prompt).
- Responds `202 Accepted` with a `runId` for async execution.

## Testing
- Not run (test added: src/gateway/server.hooks.e2e.test.ts covers `/hooks/message`).
