### PR TITLE
fix(models): resolve antigravity configured model forward-compat

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -28,11 +28,12 @@ function buildGeminiTemplateIds(modelId: string): string[] {
     ids.add(lower.replace("gemini-3.1-", "gemini-2.5-"));
   }
 
-  for (const candidate of ids) {
-    if (candidate.startsWith("gemini-3-pro")) {
+  const candidates = [...ids];
+  for (const candidate of candidates) {
+    if (candidate.startsWith("gemini-3-pro") && !candidate.startsWith("gemini-3-pro-preview")) {
       ids.add(candidate.replace("gemini-3-pro", "gemini-3-pro-preview"));
     }
-    if (candidate.startsWith("gemini-3-flash")) {
+    if (candidate.startsWith("gemini-3-flash") && !candidate.startsWith("gemini-3-flash-preview")) {
       ids.add(candidate.replace("gemini-3-flash", "gemini-3-flash-preview"));
     }
   }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -232,6 +232,84 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds an antigravity forward-compat fallback for claude-sonnet-4-6", () => {
+    mockDiscoveredModel({
+      provider: "google-antigravity",
+      modelId: "claude-sonnet-4-5",
+      templateModel: buildForwardCompatTemplate({
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider: "google-antigravity",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      }),
+    });
+
+    expectResolvedForwardCompatFallback({
+      provider: "google-antigravity",
+      id: "claude-sonnet-4-6",
+      expectedModel: {
+        provider: "google-antigravity",
+        id: "claude-sonnet-4-6",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+        reasoning: true,
+      },
+    });
+  });
+
+  it("builds an antigravity forward-compat fallback for gemini-3.1-flash", () => {
+    mockDiscoveredModel({
+      provider: "google-antigravity",
+      modelId: "gemini-3-flash-preview",
+      templateModel: buildForwardCompatTemplate({
+        id: "gemini-3-flash-preview",
+        name: "Gemini 3 Flash Preview",
+        provider: "google-antigravity",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      }),
+    });
+
+    expectResolvedForwardCompatFallback({
+      provider: "google-antigravity",
+      id: "gemini-3.1-flash",
+      expectedModel: {
+        provider: "google-antigravity",
+        id: "gemini-3.1-flash",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+        reasoning: true,
+      },
+    });
+  });
+
+  it("builds an antigravity forward-compat fallback for gemini-3.1-pro", () => {
+    mockDiscoveredModel({
+      provider: "google-antigravity",
+      modelId: "gemini-3-pro-preview",
+      templateModel: buildForwardCompatTemplate({
+        id: "gemini-3-pro-preview",
+        name: "Gemini 3 Pro Preview",
+        provider: "google-antigravity",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      }),
+    });
+
+    expectResolvedForwardCompatFallback({
+      provider: "google-antigravity",
+      id: "gemini-3.1-pro",
+      expectedModel: {
+        provider: "google-antigravity",
+        id: "gemini-3.1-pro",
+        api: "google-gemini-cli",
+        baseUrl: "https://daily-cloudcode-pa.sandbox.googleapis.com",
+        reasoning: true,
+      },
+    });
+  });
+
   it("builds a zai forward-compat fallback for glm-5", () => {
     mockDiscoveredModel({
       provider: "zai",


### PR DESCRIPTION
## Summary
- Extend forward-compat model resolution for `google-antigravity` so configured but not-yet-discovered IDs can still resolve in cron/lane/background paths.
- Support Anthropic 4.6 aliases under `google-antigravity` (for example `claude-sonnet-4-6`) using the same template-clone approach as Anthropic provider.
- Add Gemini `3.1` fallback mapping for `google-antigravity` to discoverable template IDs (for example `gemini-3-flash-preview` / `gemini-3-pro-preview`).

## Testing
- pnpm vitest src/agents/pi-embedded-runner/model.test.ts
- pnpm vitest src/commands/models.list.test.ts
- pnpm tsgo

Fixes #27790