### PR TITLE
feat(gateway): add dangerouslyAllowPlaintextInternal config option

### DIFF
--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -61,6 +61,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     url: connection.url,
     token: creds.token,
     password: creds.password,
+    allowPrivateWs: connection.allowPrivateWs,
     clientName: GATEWAY_CLIENT_NAMES.CLI,
     clientDisplayName: "ACP",
     clientVersion: "acp",

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -165,6 +165,7 @@ export async function gatewayStatusCommand(
               url: target.url,
               auth,
               timeoutMs,
+              allowPrivateWs: cfg.gateway?.dangerouslyAllowPlaintextInternal === true,
             });
             const configSummary = probe.configSnapshot
               ? extractConfigSummary(probe.configSnapshot)

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -126,6 +126,7 @@ export async function statusAllCommand(
       url: connection.url,
       auth: probeAuth,
       timeoutMs: Math.min(5000, opts?.timeoutMs ?? 10_000),
+      allowPrivateWs: connection.allowPrivateWs,
     }).catch(() => null);
     const gatewayReachable = gatewayProbe?.ok === true;
     const gatewaySelf = pickGatewaySelfPresence(gatewayProbe?.presence ?? null);

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -75,7 +75,7 @@ async function resolveGatewayProbeSnapshot(params: {
   cfg: ReturnType<typeof loadConfig>;
   opts: { timeoutMs?: number; all?: boolean };
 }): Promise<GatewayProbeSnapshot> {
-  const gatewayConnection = buildGatewayConnectionDetails();
+  const gatewayConnection = buildGatewayConnectionDetails({ config: params.cfg });
   const isRemoteMode = params.cfg.gateway?.mode === "remote";
   const remoteUrlRaw =
     typeof params.cfg.gateway?.remote?.url === "string" ? params.cfg.gateway.remote.url : "";
@@ -89,6 +89,7 @@ async function resolveGatewayProbeSnapshot(params: {
         url: gatewayConnection.url,
         auth: gatewayProbeAuthResolution.auth,
         timeoutMs: Math.min(params.opts.all ? 5000 : 2500, params.opts.timeoutMs ?? 10_000),
+        allowPrivateWs: gatewayConnection.allowPrivateWs,
       }).catch(() => null);
   if (gatewayProbeAuthWarning && gatewayProbe?.ok === false) {
     gatewayProbe.error = gatewayProbe.error

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -101,6 +101,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+  "gateway.dangerouslyAllowPlaintextInternal":
+    "DANGEROUS: Allow plaintext ws:// connections to non-loopback internal addresses (RFC1918 private IPs: 10.x.x.x, 172.16-31.x.x, 192.168.x.x, and CGNAT 100.64/10). This enables layered security where an external TLS gateway terminates encryption and forwards plaintext to internal OpenClaw gateways. Only enable if you understand the security implications. Default: false (secure by default).",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -102,7 +102,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
   "gateway.dangerouslyAllowPlaintextInternal":
-    "DANGEROUS: Allow plaintext ws:// connections to non-loopback internal addresses (RFC1918 private IPs: 10.x.x.x, 172.16-31.x.x, 192.168.x.x, and CGNAT 100.64/10). This enables layered security where an external TLS gateway terminates encryption and forwards plaintext to internal OpenClaw gateways. Only enable if you understand the security implications. Default: false (secure by default).",
+    "DANGEROUS: Allow plaintext ws:// connections to private/loopback targets on trusted networks. This enables layered security where an external TLS gateway terminates encryption and forwards plaintext to internal OpenClaw gateways. The allowlist follows the same break-glass policy as OPENCLAW_ALLOW_INSECURE_PRIVATE_WS. Only enable if you understand the security implications. Default: false (secure by default).",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -248,6 +248,7 @@ export const FIELD_LABELS: Record<string, string> = {
     "Dangerously Allow Host-Header Origin Fallback",
   "gateway.controlUi.allowInsecureAuth": "Insecure Control UI Auth Toggle",
   "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
+  "gateway.dangerouslyAllowPlaintextInternal": "Dangerously Allow Plaintext WebSocket to Internal Addresses",
   "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
   "gateway.reload.mode": "Config Reload Mode",
   "gateway.reload.debounceMs": "Config Reload Debounce (ms)",

--- a/src/config/schema.tags.ts
+++ b/src/config/schema.tags.ts
@@ -49,6 +49,7 @@ const TAG_OVERRIDES: Record<string, ConfigTag[]> = {
   ],
   "gateway.controlUi.dangerouslyDisableDeviceAuth": ["security", "access", "network", "advanced"],
   "gateway.controlUi.allowInsecureAuth": ["security", "access", "network", "advanced"],
+  "gateway.dangerouslyAllowPlaintextInternal": ["security", "network", "advanced"],
   "tools.exec.applyPatch.workspaceOnly": ["tools", "security", "access", "advanced"],
 };
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -364,4 +364,13 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * DANGEROUS: Allow plaintext ws:// connections to non-loopback internal addresses
+   * (RFC1918 private IPs: 10.x.x.x, 172.16-31.x.x, 192.168.x.x, and CGNAT 100.64/10).
+   * This enables layered security where an external TLS gateway
+   * terminates encryption and forwards plaintext to internal OpenClaw gateways.
+   * Only enable if you understand the security implications.
+   * Default: false (secure by default).
+   */
+  dangerouslyAllowPlaintextInternal?: boolean;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -365,8 +365,8 @@ export type GatewayConfig = {
    */
   channelHealthCheckMinutes?: number;
   /**
-   * DANGEROUS: Allow plaintext ws:// connections to non-loopback internal addresses
-   * (RFC1918 private IPs: 10.x.x.x, 172.16-31.x.x, 192.168.x.x, and CGNAT 100.64/10).
+   * DANGEROUS: Allow plaintext ws:// connections to private/loopback targets
+   * on trusted networks, matching the OPENCLAW_ALLOW_INSECURE_PRIVATE_WS break-glass policy.
    * This enables layered security where an external TLS gateway
    * terminates encryption and forwards plaintext to internal OpenClaw gateways.
    * Only enable if you understand the security implications.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -659,6 +659,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        dangerouslyAllowPlaintextInternal: z.boolean().optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -407,6 +407,7 @@ export class DiscordExecApprovalHandler {
 
     this.gatewayClient = new GatewayClient({
       url: gatewayUrl,
+      allowPrivateWs: this.opts.cfg.gateway?.dangerouslyAllowPlaintextInternal === true,
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: "Discord Exec Approvals",
       mode: GATEWAY_CLIENT_MODES.BACKEND,

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -13,6 +13,7 @@ let lastClientOptions: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  allowPrivateWs?: boolean;
   scopes?: string[];
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
@@ -38,6 +39,7 @@ vi.mock("./client.js", () => ({
       url?: string;
       token?: string;
       password?: string;
+      allowPrivateWs?: boolean;
       scopes?: string[];
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
@@ -492,6 +494,24 @@ describe("buildGatewayConnectionDetails", () => {
 
     expect(details.url).toBe("ws://127.0.0.1:18789");
   });
+
+  it("returns the plaintext-internal override when enabled in config", () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        dangerouslyAllowPlaintextInternal: true,
+        remote: { url: "ws://192.168.1.42:18789" },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://192.168.1.42:18789");
+    expect(details.allowPrivateWs).toBe(true);
+  });
 });
 
 describe("callGateway error details", () => {
@@ -581,6 +601,24 @@ describe("callGateway error details", () => {
         requiredMethods: ["secrets.resolve"],
       }),
     ).rejects.toThrow(/does not support required method "secrets\.resolve"/i);
+  });
+
+  it("propagates plaintext-internal override from loaded config to GatewayClient", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        dangerouslyAllowPlaintextInternal: true,
+        remote: { url: "ws://192.168.1.42:18789" },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+    pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.url).toBe("ws://192.168.1.42:18789");
+    expect(lastClientOptions?.allowPrivateWs).toBe(true);
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -71,6 +71,7 @@ export type GatewayConnectionDetails = {
   urlSource: string;
   bindDetail?: string;
   remoteFallbackNote?: string;
+  allowPrivateWs?: boolean;
   message: string;
 };
 
@@ -175,18 +176,30 @@ export function buildGatewayConnectionDetails(
     ? "Warn: gateway.mode=remote but gateway.remote.url is missing; set gateway.remote.url or switch gateway.mode=local."
     : undefined;
 
-  const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
+  const allowPrivateWs =
+    process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1" ||
+    config.gateway?.dangerouslyAllowPlaintextInternal === true;
   // Security check: block ALL insecure ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
   // This applies to the FINAL resolved URL, regardless of source (config, CLI override, etc).
   // Both credentials and chat/conversation data must not be transmitted over plaintext to remote hosts.
   if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
+    const fixLines = allowPrivateWs
+      ? [
+          "Fix: The URL is not a recognized private/loopback target for plaintext ws://.",
+          "Use wss:// for public or unrecognized addresses.",
+        ]
+      : [
+          "Fix: Use wss:// for remote gateway URLs.",
+          "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1",
+          "or gateway.dangerouslyAllowPlaintextInternal=true.",
+        ];
     throw new Error(
       [
         `SECURITY ERROR: Gateway URL "${url}" uses plaintext ws:// to a non-loopback address.`,
         "Both credentials and chat data would be exposed to network interception.",
         `Source: ${urlSource}`,
         `Config: ${configPath}`,
-        "Fix: Use wss:// for remote gateway URLs.",
+        ...fixLines,
         "Safe remote access defaults:",
         "- keep gateway.bind=loopback and use an SSH tunnel (ssh -N -L 18789:127.0.0.1:18789 user@gateway-host)",
         "- or use Tailscale Serve/Funnel for HTTPS remote access",
@@ -214,6 +227,7 @@ export function buildGatewayConnectionDetails(
     urlSource,
     bindDetail,
     remoteFallbackNote,
+    allowPrivateWs,
     message,
   };
 }
@@ -634,6 +648,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
       role: "operator",
       scopes,
+      allowPrivateWs: params.connectionDetails.allowPrivateWs,
       deviceIdentity: loadOrCreateDeviceIdentity(),
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -65,6 +65,7 @@ export type GatewayClientOptions = {
   minProtocol?: number;
   maxProtocol?: number;
   tlsFingerprint?: string;
+  allowPrivateWs?: boolean;
   onEvent?: (evt: EventFrame) => void;
   onHelloOk?: (hello: HelloOk) => void;
   onConnectError?: (err: Error) => void;
@@ -115,7 +116,8 @@ export class GatewayClient {
       return;
     }
 
-    const allowPrivateWs = process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
+    const allowPrivateWs =
+      this.opts.allowPrivateWs === true || process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS === "1";
     // Security check: block ALL plaintext ws:// to non-loopback addresses (CWE-319, CVSS 9.8)
     // This protects both credentials AND chat/conversation data from MITM attacks.
     // Device tokens may be loaded later in sendConnect(), so we block regardless of hasCredentials.
@@ -134,7 +136,7 @@ export class GatewayClient {
           "(ssh -N -L 18789:127.0.0.1:18789 user@gateway-host), or use Tailscale Serve/Funnel. " +
           (allowPrivateWs
             ? ""
-            : "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1. ") +
+            : "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 or gateway.dangerouslyAllowPlaintextInternal=true. ") +
           "Run `openclaw doctor --fix` for guidance.",
       );
       this.opts.onConnectError?.(error);

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -6,6 +6,7 @@ import {
   isIpInCidr,
   isLoopbackIpAddress,
   isPrivateOrLoopbackIpAddress,
+  normalizeIpAddress,
 } from "../shared/net/ip.js";
 
 /**

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -6,8 +6,6 @@ import {
   isIpInCidr,
   isLoopbackIpAddress,
   isPrivateOrLoopbackIpAddress,
-  normalizeIpAddress,
-  parseLooseIpAddress,
 } from "../shared/net/ip.js";
 
 /**

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -7,6 +7,7 @@ import {
   isLoopbackIpAddress,
   isPrivateOrLoopbackIpAddress,
   normalizeIpAddress,
+  parseLooseIpAddress,
 } from "../shared/net/ip.js";
 
 /**
@@ -345,6 +346,14 @@ export function isLocalishHost(hostHeader?: string): boolean {
   return isLoopbackHost(host) || host.endsWith(".ts.net");
 }
 
+export type IsSecureWebSocketUrlOptions = {
+  /**
+   * DANGEROUS: When true, allows plaintext ws:// connections to private/loopback
+   * targets for trusted-network break-glass scenarios.
+   */
+  allowPrivateWs?: boolean;
+};
+
 /**
  * Check if a hostname or IP refers to a private or loopback address.
  * Handles the same hostname formats as isLoopbackHost, but also accepts
@@ -408,12 +417,7 @@ function parseHostForAddressChecks(
  * All other ws:// URLs are considered insecure because both credentials
  * AND chat/conversation data would be exposed to network interception.
  */
-export function isSecureWebSocketUrl(
-  url: string,
-  opts?: {
-    allowPrivateWs?: boolean;
-  },
-): boolean {
+export function isSecureWebSocketUrl(url: string, opts?: IsSecureWebSocketUrlOptions): boolean {
   let parsed: URL;
   try {
     parsed = new URL(url);

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -50,4 +50,15 @@ describe("probeGateway", () => {
     expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
     expect(result.ok).toBe(true);
   });
+
+  it("passes the plaintext-internal override through to GatewayClient", async () => {
+    await probeGateway({
+      url: "ws://192.168.1.42:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      allowPrivateWs: true,
+    });
+
+    expect(gatewayClientState.options?.allowPrivateWs).toBe(true);
+  });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -32,6 +32,7 @@ export async function probeGateway(opts: {
   url: string;
   auth?: GatewayProbeAuth;
   timeoutMs: number;
+  allowPrivateWs?: boolean;
 }): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
   const instanceId = randomUUID();
@@ -55,6 +56,7 @@ export async function probeGateway(opts: {
       url: opts.url,
       token: opts.auth?.token,
       password: opts.auth?.password,
+      allowPrivateWs: opts.allowPrivateWs,
       scopes: [READ_SCOPE],
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       clientVersion: "dev",

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -228,8 +228,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
 
   const client = new GatewayClient({
     url,
-    token: token || undefined,
-    password: password || undefined,
+    token: token?.trim() || undefined,
+    password: password?.trim() || undefined,
+    allowPrivateWs: cfg.gateway?.dangerouslyAllowPlaintextInternal === true,
     instanceId: nodeId,
     clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
     clientDisplayName: displayName,

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -71,6 +71,7 @@ describe("resolveGatewayConnection", () => {
     expect(result).toEqual({
       url: "wss://override.example/ws",
       ...expected,
+      allowPrivateWs: false,
     });
   });
 

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -46,6 +46,7 @@ type ResolvedGatewayConnection = {
   url: string;
   token?: string;
   password?: string;
+  allowPrivateWs?: boolean;
 };
 
 function trimToUndefined(value: unknown): string | undefined {
@@ -150,6 +151,7 @@ export class GatewayChatClient {
       url: connection.url,
       token: connection.token,
       password: connection.password,
+      allowPrivateWs: connection.allowPrivateWs,
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: "openclaw-tui",
       clientVersion: VERSION,
@@ -285,10 +287,11 @@ export async function resolveGatewayConnection(
     explicitAuth,
     errorHint: "Fix: pass --token or --password when using --url.",
   });
-  const url = buildGatewayConnectionDetails({
+  const connectionDetails = buildGatewayConnectionDetails({
     config,
     ...(urlOverride ? { url: urlOverride } : {}),
-  }).url;
+  });
+  const url = connectionDetails.url;
 
   if (urlOverride) {
     return {
@@ -326,7 +329,7 @@ export async function resolveGatewayConnection(
           "Missing gateway auth credentials.",
       );
     }
-    return { url, token, password };
+    return { url, token, password, allowPrivateWs: connectionDetails.allowPrivateWs };
   }
 
   if (gatewayAuthMode === "none" || gatewayAuthMode === "trusted-proxy") {
@@ -334,6 +337,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password: explicitAuth.password ?? envPassword,
+      allowPrivateWs: connectionDetails.allowPrivateWs,
     };
   }
 
@@ -366,6 +370,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password,
+      allowPrivateWs: connectionDetails.allowPrivateWs,
     };
   }
 
@@ -389,6 +394,7 @@ export async function resolveGatewayConnection(
       url,
       token,
       password: explicitAuth.password ?? envPassword,
+      allowPrivateWs: connectionDetails.allowPrivateWs,
     };
   }
 
@@ -415,6 +421,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password,
+      allowPrivateWs: connectionDetails.allowPrivateWs,
     };
   }
 
@@ -437,5 +444,6 @@ export async function resolveGatewayConnection(
     url,
     token,
     password: explicitAuth.password ?? envPassword,
+    allowPrivateWs: connectionDetails.allowPrivateWs,
   };
 }

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -298,6 +298,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token,
       password: explicitAuth.password,
+      allowPrivateWs: connectionDetails.allowPrivateWs,
     };
   }
 


### PR DESCRIPTION
## Summary

Add a new configuration option `gateway.dangerouslyAllowPlaintextInternal` to allow plaintext ws:// connections to non-loopback internal addresses.

## Problem

PR #20803 introduced a security check that blocks all ws:// connections to non-loopback addresses. While this is a good security default, it breaks legitimate use cases like:

- **Layered security architecture**: External TLS gateway terminates encryption and forwards plaintext to internal OpenClaw gateways
- **Home lab setups**: Users with TLS termination at the network edge and internal plaintext communication

Example error:
```
SECURITY ERROR: Gateway URL "ws://192.168.100.5:18789" uses plaintext ws:// to a non-loopback address.
```

## Solution

This PR introduces a **config-driven** escape hatch:

```json
{
  "gateway": {
    "dangerouslyAllowPlaintextInternal": true
  }
}
```

When enabled, ws:// connections to RFC1918 private addresses are allowed:
- 10.x.x.x
- 172.16-31.x.x  
- 192.168.x.x
- CGNAT 100.64/10

## Security Considerations

- **Default is false** (secure by default) - no behavioral change for existing users
- **Config file only** - requires explicit user action to enable
- **Named dangerously** - the setting name makes the risk clear
- **Only allows internal addresses** - public IPs still require wss://

## Changes

- Add `dangerouslyAllowPlaintextInternal` to GatewayConfig type
- Update zod schema, help text, labels, and tags
- Modify `isSecureWebSocketUrl` to respect the config option
- Pass config through `client.ts` and `call.ts`
- Update error messages to guide users to the config option

Fixes the issue reported in PR #20803 discussion and Issue #21689