### PR TITLE
docs: add documentation plan v1 draft

### DIFF
--- a/docs/experiments/plans/my-plan-v1.md
+++ b/docs/experiments/plans/my-plan-v1.md
@@ -1,0 +1,135 @@
+---
+summary: "V1 plan for improving documentation discoverability, consistency, and maintenance workflow"
+read_when:
+  - Planning a docs cleanup or reorganization pass
+  - Prioritizing documentation improvements across guides and references
+  - Defining acceptance criteria for docs-only changes
+owner: "openclaw"
+status: "proposed"
+last_updated: "2026-02-26"
+title: "Documentation Plan V1"
+---
+
+# Documentation Plan V1
+
+## 1. Problem and goal
+
+Docs quality is generally strong, but navigation depth, page consistency, and maintenance hygiene vary across sections. This makes it harder to:
+
+- find the right page quickly
+- know whether a page is current
+- make small docs changes confidently without missing linked pages
+
+The goal of this plan is a practical v1 pass that improves discoverability and consistency without a large content rewrite.
+
+## 2. Scope and boundaries
+
+In scope:
+
+- docs information architecture improvements for high-traffic pages
+- consistency passes for headings, cross-links, and page metadata
+- a repeatable docs update checklist for future contributors
+- targeted validation for docs links and obvious formatting regressions
+
+Out of scope:
+
+- full docs redesign or wholesale navigation rewrite
+- broad content rewrites for every provider/channel page
+- localization content changes under `docs/zh-CN/**`
+- product behavior changes that require code changes outside docs support work
+
+## 3. V1 deliverables
+
+1. Docs inventory and prioritization
+
+- Identify top entry pages and frequent operator workflows (install, gateway config, channels, troubleshooting).
+- Mark pages as keep, merge, split, or refresh.
+- Record high-priority pages with stale or overlapping guidance.
+
+2. Navigation and linking cleanup
+
+- Normalize internal links to Mintlify-friendly root-relative paths.
+- Add or tighten "Related docs" sections on key workflow pages.
+- Remove dead-end pages that have no inbound links from common entry points.
+
+3. Page consistency pass
+
+- Align headings and section order on core docs categories where it improves scanability.
+- Add missing prerequisites, verification steps, and failure-mode notes on operational docs.
+- Reduce duplicated setup steps where a canonical page already exists.
+
+4. Maintenance checklist
+
+- Define a short docs change checklist (links, examples, placeholders, user-facing wording, changelog expectations when applicable).
+- Document when to update adjacent pages after product/config changes.
+
+## 4. Implementation plan
+
+### Phase 1: Inventory (small, fast)
+
+- Build a page list for target sections and group by workflow.
+- Note broken/misleading links and duplicate topics.
+- Produce a ranked punch list for the first cleanup pass.
+
+### Phase 2: High-impact cleanup
+
+- Update entry pages and high-traffic workflows first.
+- Add missing cross-links between setup, configuration, and troubleshooting pages.
+- Standardize inconsistent headings where it improves readability.
+
+### Phase 3: Maintenance guardrails
+
+- Add a lightweight docs checklist in contributor-facing guidance or docs contributor notes.
+- Capture recurring pitfalls (Mintlify links, headings/anchors, placeholders, generated zh-CN docs boundary).
+
+### Phase 4: Verification and follow-up
+
+- Run docs link/format checks used in repo CI or local docs workflows.
+- Spot-check high-impact pages in local preview/build.
+- Record remaining follow-up items as a v2 plan or tracked issues.
+
+## 5. Suggested file targets (initial)
+
+Prioritize pages that affect first-run success and operator troubleshooting:
+
+- `docs/install/*`
+- `docs/gateway/*`
+- `docs/channels/*` (entry points and onboarding-heavy pages first)
+- `docs/testing.md`
+- contributor docs that define docs conventions (where applicable)
+
+Exact file list should be derived from the inventory step to avoid broad churn.
+
+## 6. Validation
+
+Minimum validation for v1 docs-only changes:
+
+- internal links follow Mintlify path rules (root-relative, no `.md` suffix)
+- examples use placeholders instead of real secrets/devices
+- related docs links resolve to current pages
+- changed pages render cleanly in docs preview/build (when available)
+
+If a docs change reflects product behavior, confirm behavior in code before publishing wording.
+
+## 7. Risks and mitigations
+
+- Risk: Broad churn creates merge conflicts across active docs work.
+- Mitigation: Keep changes in small topical PRs after the inventory pass.
+
+- Risk: Cleanup removes useful nuance while deduplicating content.
+- Mitigation: Prefer canonical links and concise summaries over deleting context without replacement.
+
+- Risk: Inconsistent updates across channels/extensions.
+- Mitigation: Check all built-in and extension channel surfaces when changing shared guidance.
+
+## 8. Definition of done (v1)
+
+1. A prioritized inventory exists for the targeted docs areas.
+2. High-impact pages have improved navigation/cross-linking.
+3. Common formatting/linking issues are normalized in touched pages.
+4. A contributor-facing maintenance checklist is documented.
+5. Validation steps are run and results recorded in the PR.
+
+## 9. Summary
+
+This v1 plan keeps scope tight: improve findability, reduce inconsistency, and make future docs updates safer. It favors small, reviewable cleanup passes over a large rewrite.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: No standalone docs plan markdown existed on this branch for a scoped docs improvement pass.
- Why it matters: A written plan helps keep future docs cleanup work targeted and reviewable.
- What changed: Added `docs/experiments/plans/my-plan-v1.md` with a v1 documentation improvement plan (scope, phases, validation, risks, definition of done).
- What did NOT change (scope boundary): No runtime/code behavior, configs, schemas, or tests were changed.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local worktree)
- Runtime/container: N/A (docs-only)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create `docs/experiments/plans/my-plan-v1.md` using the existing docs experiment plan format.
2. Review the new file contents and frontmatter for consistency.
3. Commit and push branch.

### Expected

- New markdown plan file exists with a clear scope, implementation phases, validation, and definition of done.

### Actual

- Added and committed the new plan file as expected.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the new markdown file exists, renders as valid markdown structure, and follows repo docs conventions (frontmatter + sectioned plan format).
- Edge cases checked: Included explicit out-of-scope items and docs-specific validation notes to limit future churn.
- What you did **not** verify: Did not run docs preview/build or CI checks (docs-only draft).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `99ef301e3`.
- Files/config to restore: `docs/experiments/plans/my-plan-v1.md`
- Known bad symptoms reviewers should watch for: N/A (docs-only addition)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The plan may be too broad without a follow-up inventory issue set.
  - Mitigation: The file explicitly scopes v1 and requires an inventory-first phase before broad edits.
