### PR TITLE
chore(telegram): remove unused createTelegramWebhookCallback helper

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -169,7 +169,6 @@ vi.mock("grammy", () => ({
     }
   },
   InputFile: class {},
-  webhookCallback: vi.fn(),
 }));
 
 const sequentializeMiddleware = vi.fn();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,7 +1,7 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
 import type { ApiClientOptions } from "grammy";
-import { Bot, webhookCallback } from "grammy";
+import { Bot } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/reply/history.js";
@@ -380,8 +380,4 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   });
 
   return bot;
-}
-
-export function createTelegramWebhookCallback(bot: Bot, path = "/telegram-webhook") {
-  return { path, handler: webhookCallback(bot, "http") };
 }

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -163,7 +163,6 @@ vi.mock("./bot.js", () => ({
       start: vi.fn(),
     };
   },
-  createTelegramWebhookCallback: vi.fn(),
 }));
 
 // Mock the grammyjs/runner to resolve immediately


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `createTelegramWebhookCallback` in `src/telegram/bot.ts` was unused.
- Why it matters: Unused exports and mocks add maintenance noise and can mislead future refactors.
- What changed: Removed the unused function and removed stale test mocks tied to it in Telegram monitor/bot harness tests.
- What did NOT change (scope boundary): Telegram webhook runtime behavior in `src/telegram/webhook.ts` was not changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): N/A

### Steps

1. Confirm `createTelegramWebhookCallback` has no call sites.
2. Remove the unused export and `webhookCallback` import from `src/telegram/bot.ts`.
3. Remove stale mocks in Telegram test files tied only to the removed function.

### Expected

- No references remain to `createTelegramWebhookCallback`.
- Telegram monitor/webhook tests continue to use only required mocks.

### Actual

- No references remain (`rg -n "createTelegramWebhookCallback" src` returns nothing).
- Targeted test command could not run in this environment because dependencies are unavailable (`vitest not found`) and install failed due DNS/network restrictions to npm registry.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Brought up gateway with Telegram webhook config - able to send messages to the bot still
- Edge cases checked: None
- What you did **not** verify: Not sure what else to check?

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `src/telegram/bot.ts`, `src/telegram/monitor.test.ts`, `src/telegram/bot.create-telegram-bot.test-harness.ts`.
- Known bad symptoms reviewers should watch for: Unexpected test failures from missing mock properties in Telegram tests.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A test still implicitly expected removed mock keys.
  - Mitigation: Removed only mocks tied to the deleted function and left webhook handler mocks used by webhook tests unchanged.
