### PR TITLE
fix: pass MCPORTER_CONFIG to mcporter subprocess

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -217,6 +217,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       ...process.env,
       XDG_CONFIG_HOME: this.xdgConfigHome,
       XDG_CACHE_HOME: this.xdgCacheHome,
+      MCPORTER_CONFIG: path.join(this.agentStateDir, "config", "mcporter.json"),
       NO_COLOR: "1",
     };
     this.sessionExporter = this.qmd.sessions.enabled


### PR DESCRIPTION
## Summary

When spawning mcporter via qmd-manager, the config path was not being passed. This caused mcporter to never find the agent-specific config and the daemon was never activated.

## Fix

Adds MCPORTER_CONFIG to the environment, pointing to the agent's mcporter.json config file.

This allows mcporter to find the config at {agentStateDir}/config/mcporter.json.

## Related Issue

Fixes #27800
