### PR TITLE
fix(cron): gateway default timezone + time drift detection (#27780)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1103,6 +1103,20 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum bytes per cron run-log file before pruning rewrites to the last keepLines entries (for example `2mb`, default `2000000`).",
   "cron.runLog.keepLines":
     "How many trailing run-log lines to retain when a file exceeds maxBytes (default `2000`). Increase for longer forensic history or lower for smaller disks.",
+  "cron.timezone":
+    "Default IANA timezone for cron expressions that omit an explicit tz field (for example `America/New_York`). Falls back to the gateway process timezone when unset. Containers often default to UTC, causing cron jobs to fire hours off from operator intent.",
+  "cron.timeSyncCheck":
+    "Internet time-sync drift detection. Compares the local clock against an HTTP Date header on startup and periodically to warn when the host clock has drifted.",
+  "cron.timeSyncCheck.enabled":
+    "Enable startup and periodic time-drift checks (default `true`). Disable on air-gapped hosts where outbound HTTP is unavailable.",
+  "cron.timeSyncCheck.source":
+    "URL queried via HTTP HEAD for its Date header (default `https://www.google.com`). Use any reliable endpoint that returns a standard Date header.",
+  "cron.timeSyncCheck.thresholdSeconds":
+    "Maximum acceptable clock drift in seconds before a warning is logged (default `60`).",
+  "cron.timeSyncCheck.intervalMinutes":
+    "How often to re-check drift in minutes (default `60`). Set to `0` to disable periodic checks while keeping the startup check.",
+  "cron.timeSyncCheck.blockStartup":
+    "When true, the gateway refuses to start if the initial drift check exceeds the threshold (default `false`). Useful for environments where accurate scheduling is critical.",
   hooks:
     "Inbound webhook automation surface for mapping external events into wake or agent actions in OpenClaw. Keep this locked down with explicit token/session/agent controls before exposing it beyond trusted networks.",
   "hooks.enabled":

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -57,4 +57,25 @@ export type CronConfig = {
   failureAlert?: CronFailureAlertConfig;
   /** Default destination for failure notifications across all cron jobs. */
   failureDestination?: CronFailureDestinationConfig;
+  /**
+   * Default IANA timezone for cron expressions that do not specify an explicit
+   * tz field (e.g. "America/New_York", "Europe/Paris", "Asia/Tokyo").
+   * Falls back to the gateway process timezone when not set.
+   * Common cause of "hours-off" scheduling: containers default to UTC while
+   * the operator writes cron expressions in their local timezone.
+   */
+  timezone?: string;
+  /** Internet time-sync drift detection to catch misconfigured host clocks. */
+  timeSyncCheck?: {
+    /** Enable startup + periodic drift checks (default: true). */
+    enabled?: boolean;
+    /** URL to query for a Date header (default: "https://www.google.com"). */
+    source?: string;
+    /** Maximum acceptable drift in seconds (default: 60). */
+    thresholdSeconds?: number;
+    /** Periodic re-check interval in minutes; 0 disables periodic checks (default: 60). */
+    intervalMinutes?: number;
+    /** Block gateway startup when drift exceeds threshold (default: false). */
+    blockStartup?: boolean;
+  };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -469,6 +469,17 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        timezone: z.string().optional(),
+        timeSyncCheck: z
+          .object({
+            enabled: z.boolean().optional(),
+            source: z.string().optional(),
+            thresholdSeconds: z.number().positive().optional(),
+            intervalMinutes: z.number().min(0).optional(),
+            blockStartup: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .superRefine((val, ctx) => {
@@ -481,6 +492,20 @@ export const OpenClawSchema = z
               path: ["sessionRetention"],
               message: "invalid duration (use ms, s, m, h, d)",
             });
+          }
+        }
+        if (val.timezone !== undefined) {
+          const tz = val.timezone.trim();
+          if (tz) {
+            try {
+              Intl.DateTimeFormat(undefined, { timeZone: tz });
+            } catch {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["timezone"],
+                message: `invalid IANA timezone: "${tz}" (examples: America/New_York, Europe/London, Asia/Tokyo)`,
+              });
+            }
           }
         }
         if (val.runLog?.maxBytes !== undefined) {

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -5,10 +5,15 @@ import type { CronSchedule } from "./types.js";
 const CRON_EVAL_CACHE_MAX = 512;
 const cronEvalCache = new Map<string, Cron>();
 
-function resolveCronTimezone(tz?: string) {
+function resolveCronTimezone(tz?: string, defaultTimezone?: string) {
   const trimmed = typeof tz === "string" ? tz.trim() : "";
   if (trimmed) {
     return trimmed;
+  }
+  // Use gateway-level default before falling back to process timezone.
+  const trimmedDefault = typeof defaultTimezone === "string" ? defaultTimezone.trim() : "";
+  if (trimmedDefault) {
+    return trimmedDefault;
   }
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
@@ -30,7 +35,11 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   return next;
 }
 
-export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
+export function computeNextRunAtMs(
+  schedule: CronSchedule,
+  nowMs: number,
+  defaultTimezone?: string,
+): number | undefined {
   if (schedule.kind === "at") {
     // Handle both canonical `at` (string) and legacy `atMs` (number) fields.
     // The store migration should convert atMs→at, but be defensive in case
@@ -70,7 +79,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
   if (!expr) {
     return undefined;
   }
-  const cron = resolveCachedCron(expr, resolveCronTimezone(schedule.tz));
+  const cron = resolveCachedCron(expr, resolveCronTimezone(schedule.tz, defaultTimezone));
   let next = cron.nextRun(new Date(nowMs));
   if (!next) {
     return undefined;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -52,22 +52,22 @@ function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
   return offset;
 }
 
-function computeStaggeredCronNextRunAtMs(job: CronJob, nowMs: number) {
+function computeStaggeredCronNextRunAtMs(job: CronJob, nowMs: number, defaultTimezone?: string) {
   if (job.schedule.kind !== "cron") {
-    return computeNextRunAtMs(job.schedule, nowMs);
+    return computeNextRunAtMs(job.schedule, nowMs, defaultTimezone);
   }
 
   const staggerMs = resolveCronStaggerMs(job.schedule);
   const offsetMs = resolveStableCronOffsetMs(job.id, staggerMs);
   if (offsetMs <= 0) {
-    return computeNextRunAtMs(job.schedule, nowMs);
+    return computeNextRunAtMs(job.schedule, nowMs, defaultTimezone);
   }
 
   // Shift the schedule cursor backwards by the per-job offset so we can still
   // target the current schedule window if its staggered slot has not passed yet.
   let cursorMs = Math.max(0, nowMs - offsetMs);
   for (let attempt = 0; attempt < 4; attempt += 1) {
-    const baseNext = computeNextRunAtMs(job.schedule, cursorMs);
+    const baseNext = computeNextRunAtMs(job.schedule, cursorMs, defaultTimezone);
     if (baseNext === undefined) {
       return undefined;
     }
@@ -196,7 +196,11 @@ export function findJobOrThrow(state: CronServiceState, id: string) {
   return job;
 }
 
-export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
+export function computeJobNextRunAtMs(
+  job: CronJob,
+  nowMs: number,
+  defaultTimezone?: string,
+): number | undefined {
   if (!job.enabled) {
     return undefined;
   }
@@ -240,10 +244,10 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     }
     return atMs !== null && Number.isFinite(atMs) ? atMs : undefined;
   }
-  const next = computeStaggeredCronNextRunAtMs(job, nowMs);
+  const next = computeStaggeredCronNextRunAtMs(job, nowMs, defaultTimezone);
   if (next === undefined && job.schedule.kind === "cron") {
     const nextSecondMs = Math.floor(nowMs / 1000) * 1000 + 1000;
-    return computeStaggeredCronNextRunAtMs(job, nextSecondMs);
+    return computeStaggeredCronNextRunAtMs(job, nextSecondMs, defaultTimezone);
   }
   return isFiniteTimestamp(next) ? next : undefined;
 }
@@ -362,7 +366,11 @@ function walkSchedulableJobs(
 function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob; nowMs: number }) {
   let changed = false;
   try {
-    const newNext = computeJobNextRunAtMs(params.job, params.nowMs);
+    const newNext = computeJobNextRunAtMs(
+      params.job,
+      params.nowMs,
+      params.state.deps.cronConfig?.timezone,
+    );
     if (params.job.state.nextRunAtMs !== newNext) {
       params.job.state.nextRunAtMs = newNext;
       changed = true;
@@ -490,7 +498,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
-  job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+  job.state.nextRunAtMs = computeJobNextRunAtMs(job, now, state.deps.cronConfig?.timezone);
   return job;
 }
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -116,11 +116,16 @@ export async function start(state: CronServiceState) {
     recomputeNextRuns(state);
     await persist(state);
     armTimer(state);
+    // Log the effective default timezone so operators can diagnose
+    // cron jobs firing at unexpected times in containers/VMs.
+    const effectiveTimezone =
+      state.deps.cronConfig?.timezone?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
     state.deps.log.info(
       {
         enabled: true,
         jobs: state.store?.jobs.length ?? 0,
         nextWakeAtMs: nextWakeAtMs(state) ?? null,
+        timezone: effectiveTimezone,
       },
       "cron: started",
     );
@@ -293,7 +298,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     job.updatedAtMs = now;
     if (scheduleChanged || enabledChanged) {
       if (job.enabled) {
-        job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+        job.state.nextRunAtMs = computeJobNextRunAtMs(job, now, state.deps.cronConfig?.timezone);
       } else {
         job.state.nextRunAtMs = undefined;
         job.state.runningAtMs = undefined;
@@ -303,7 +308,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
       // missing/corrupt nextRunAtMs for the updated job.
       const nextRun = job.state.nextRunAtMs;
       if (typeof nextRun !== "number" || !Number.isFinite(nextRun)) {
-        job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+        job.state.nextRunAtMs = computeJobNextRunAtMs(job, now, state.deps.cronConfig?.timezone);
       }
     }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -384,7 +384,7 @@ export function applyJobResult(
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
       let normalNext: number | undefined;
       try {
-        normalNext = computeJobNextRunAtMs(job, result.endedAt);
+        normalNext = computeJobNextRunAtMs(job, result.endedAt, state.deps.cronConfig?.timezone);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)
@@ -407,7 +407,7 @@ export function applyJobResult(
     } else if (job.enabled) {
       let naturalNext: number | undefined;
       try {
-        naturalNext = computeJobNextRunAtMs(job, result.endedAt);
+        naturalNext = computeJobNextRunAtMs(job, result.endedAt, state.deps.cronConfig?.timezone);
       } catch (err) {
         // If the schedule expression/timezone throws (croner edge cases),
         // record the schedule error (auto-disables after repeated failures)

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -14,6 +14,7 @@ export function createGatewayCloseHandler(params: {
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
   cron: { stop: () => void };
+  getTimeDriftMonitor?: () => { stop: () => void } | null;
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
@@ -70,6 +71,7 @@ export function createGatewayCloseHandler(params: {
     }
     await stopGmailWatcher();
     params.cron.stop();
+    params.getTimeDriftMonitor?.()?.stop();
     params.heartbeatRunner.stop();
     try {
       params.updateCheckStop?.();

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -14,6 +14,7 @@ import {
   emitGatewayRestart,
   setGatewaySigusr1RestartPolicy,
 } from "../infra/restart.js";
+import { createTimeDriftMonitor, type TimeDriftMonitor } from "../infra/time-drift-monitor.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
@@ -27,6 +28,7 @@ type GatewayHotReloadState = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
+  timeDriftMonitor: TimeDriftMonitor | null;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
   channelHealthMonitor: ChannelHealthMonitor | null;
 };
@@ -45,7 +47,11 @@ export function createGatewayReloadHandlers(params: {
   };
   logBrowser: { error: (msg: string) => void };
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
-  logCron: { error: (msg: string) => void };
+  logCron: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
   createHealthMonitor: (checkIntervalMs: number) => ChannelHealthMonitor;
 }) {
@@ -73,11 +79,27 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartCron) {
       state.cronState.cron.stop();
+      state.timeDriftMonitor?.stop();
       nextState.cronState = buildGatewayCronService({
         cfg: nextConfig,
         deps: params.deps,
         broadcast: params.broadcast,
       });
+      // Rewire time-drift monitor from updated cron config.
+      // Only start if cron itself is enabled — no egress when cron is off.
+      const tsc = nextConfig.cron?.timeSyncCheck;
+      if (nextConfig.cron?.enabled !== false && tsc?.enabled !== false) {
+        // Create but don't start yet — deferred until after setState to avoid
+        // leaking a running interval if a later reload step throws.
+        nextState.timeDriftMonitor = createTimeDriftMonitor({
+          source: tsc?.source,
+          thresholdSeconds: tsc?.thresholdSeconds,
+          intervalMinutes: tsc?.intervalMinutes,
+          log: params.logCron,
+        });
+      } else {
+        nextState.timeDriftMonitor = null;
+      }
       void nextState.cronState.cron
         .start()
         .catch((err) => params.logCron.error(`failed to start: ${String(err)}`));
@@ -142,6 +164,13 @@ export function createGatewayReloadHandlers(params: {
     }
 
     params.setState(nextState);
+
+    // Start drift monitor after state is committed so a throw above
+    // cannot leak a running interval that the runtime can't stop.
+    if (nextState.timeDriftMonitor && nextState.timeDriftMonitor !== state.timeDriftMonitor) {
+      void nextState.timeDriftMonitor.checkOnce();
+      nextState.timeDriftMonitor.start();
+    }
   };
 
   let restartPending = false;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -41,6 +41,7 @@ import {
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { createTimeDriftMonitor, type TimeDriftMonitor } from "../infra/time-drift-monitor.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
@@ -699,6 +700,33 @@ export async function startGatewayServer(
         checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
       });
 
+  // Time-drift detection: warn when the host clock has drifted from internet time.
+  let timeDriftMonitor: TimeDriftMonitor | null = null;
+  if (
+    !minimalTestGateway &&
+    cfgAtStart.cron?.enabled !== false &&
+    cfgAtStart.cron?.timeSyncCheck?.enabled !== false
+  ) {
+    const tsc = cfgAtStart.cron?.timeSyncCheck;
+    timeDriftMonitor = createTimeDriftMonitor({
+      source: tsc?.source,
+      thresholdSeconds: tsc?.thresholdSeconds,
+      intervalMinutes: tsc?.intervalMinutes,
+      log: logCron,
+    });
+    if (tsc?.blockStartup) {
+      const exceeds = await timeDriftMonitor.checkOnce();
+      if (exceeds) {
+        throw new Error(
+          "gateway startup blocked: host clock drift exceeds threshold (cron.timeSyncCheck.blockStartup is enabled)",
+        );
+      }
+    } else {
+      void timeDriftMonitor.checkOnce();
+    }
+    timeDriftMonitor.start();
+  }
+
   if (!minimalTestGateway) {
     void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
   }
@@ -887,6 +915,7 @@ export async function startGatewayServer(
             hooksConfig,
             heartbeatRunner,
             cronState,
+            timeDriftMonitor,
             browserControl,
             channelHealthMonitor,
           }),
@@ -896,6 +925,7 @@ export async function startGatewayServer(
             cronState = nextState.cronState;
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
+            timeDriftMonitor = nextState.timeDriftMonitor;
             browserControl = nextState.browserControl;
             channelHealthMonitor = nextState.channelHealthMonitor;
           },
@@ -951,6 +981,7 @@ export async function startGatewayServer(
     stopChannel,
     pluginServices,
     cron,
+    getTimeDriftMonitor: () => timeDriftMonitor,
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,
     nodePresenceTimers,

--- a/src/infra/time-drift-monitor.test.ts
+++ b/src/infra/time-drift-monitor.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the time-drift module before importing the monitor.
+vi.mock("./time-drift.js", () => ({
+  checkTimeDrift: vi.fn(),
+  formatDriftForLog: vi.fn((r: { exceeds: boolean }) => (r.exceeds ? "clock drifted" : "clock ok")),
+}));
+
+import { createTimeDriftMonitor } from "./time-drift-monitor.js";
+import { checkTimeDrift } from "./time-drift.js";
+
+function makeLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("createTimeDriftMonitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("logs info when drift is within tolerance", async () => {
+    vi.mocked(checkTimeDrift).mockResolvedValueOnce({
+      driftMs: 100,
+      absDriftMs: 100,
+      exceeds: false,
+      source: "https://www.google.com",
+      thresholdMs: 60_000,
+    });
+
+    const log = makeLog();
+    const monitor = createTimeDriftMonitor({ log });
+    const exceeds = await monitor.checkOnce();
+
+    expect(exceeds).toBe(false);
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining("time-drift:"));
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs warn when drift exceeds threshold", async () => {
+    vi.mocked(checkTimeDrift).mockResolvedValueOnce({
+      driftMs: 120_000,
+      absDriftMs: 120_000,
+      exceeds: true,
+      source: "https://www.google.com",
+      thresholdMs: 60_000,
+    });
+
+    const log = makeLog();
+    const monitor = createTimeDriftMonitor({ log });
+    const exceeds = await monitor.checkOnce();
+
+    expect(exceeds).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("time-drift:"));
+  });
+
+  it("logs error and returns false on fetch failure", async () => {
+    vi.mocked(checkTimeDrift).mockRejectedValueOnce(new Error("network error"));
+
+    const log = makeLog();
+    const monitor = createTimeDriftMonitor({ log });
+    const exceeds = await monitor.checkOnce();
+
+    expect(exceeds).toBe(false);
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("check failed"));
+  });
+
+  it("start/stop lifecycle with periodic checks", async () => {
+    vi.mocked(checkTimeDrift).mockResolvedValue({
+      driftMs: 0,
+      absDriftMs: 0,
+      exceeds: false,
+      source: "https://www.google.com",
+      thresholdMs: 60_000,
+    });
+
+    const log = makeLog();
+    const monitor = createTimeDriftMonitor({ log, intervalMinutes: 1 });
+
+    monitor.start();
+    // Advance past one interval (1 minute).
+    await vi.advanceTimersByTimeAsync(60_001);
+    expect(checkTimeDrift).toHaveBeenCalled();
+
+    const callCount = vi.mocked(checkTimeDrift).mock.calls.length;
+    monitor.stop();
+    // Advance again — should not fire after stop.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(vi.mocked(checkTimeDrift).mock.calls.length).toBe(callCount);
+  });
+
+  it("does not start periodic checks when intervalMinutes is 0", () => {
+    const log = makeLog();
+    const monitor = createTimeDriftMonitor({ log, intervalMinutes: 0 });
+    monitor.start();
+    // No error, just a no-op.
+    monitor.stop();
+  });
+});

--- a/src/infra/time-drift-monitor.ts
+++ b/src/infra/time-drift-monitor.ts
@@ -1,0 +1,59 @@
+import { type CheckTimeDriftOpts, checkTimeDrift, formatDriftForLog } from "./time-drift.js";
+
+export interface TimeDriftMonitorOpts extends CheckTimeDriftOpts {
+  /** Periodic check interval in minutes.  0 disables periodic checks. */
+  intervalMinutes?: number;
+  /** Logger with `.info(msg)`, `.warn(msg)`, `.error(msg)`. */
+  log: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+export interface TimeDriftMonitor {
+  /** Run a single drift check, logging the result. Returns whether drift exceeds threshold. */
+  checkOnce: () => Promise<boolean>;
+  /** Start periodic checks (no-op if intervalMinutes is 0). */
+  start: () => void;
+  /** Stop periodic checks. */
+  stop: () => void;
+}
+
+const DEFAULT_INTERVAL_MINUTES = 60;
+
+export function createTimeDriftMonitor(opts: TimeDriftMonitorOpts): TimeDriftMonitor {
+  const { log } = opts;
+  const intervalMinutes = opts.intervalMinutes ?? DEFAULT_INTERVAL_MINUTES;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function checkOnce(): Promise<boolean> {
+    try {
+      const result = await checkTimeDrift(opts);
+      const msg = `time-drift: ${formatDriftForLog(result)}`;
+      if (result.exceeds) {
+        log.warn(msg);
+      } else {
+        log.info(msg);
+      }
+      return result.exceeds;
+    } catch (err) {
+      log.error(`time-drift: check failed — ${String(err)}`);
+      return false;
+    }
+  }
+
+  function start(): void {
+    if (intervalMinutes <= 0 || timer) {
+      return;
+    }
+    const ms = intervalMinutes * 60_000;
+    timer = setInterval(() => void checkOnce(), ms);
+    timer.unref();
+  }
+
+  function stop(): void {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return { checkOnce, start, stop };
+}

--- a/src/infra/time-drift.test.ts
+++ b/src/infra/time-drift.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkTimeDrift, formatDriftForLog, type TimeDriftCheckResult } from "./time-drift.js";
+
+describe("checkTimeDrift", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 1_700_000_000_000 });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("reports low drift when clocks agree", async () => {
+    const serverDate = new Date(1_700_000_000_000).toUTCString();
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { headers: { date: serverDate } }));
+
+    const result = await checkTimeDrift({ thresholdSeconds: 60 });
+    expect(result.absDriftMs).toBeLessThan(1_000);
+    expect(result.exceeds).toBe(false);
+    expect(result.source).toBe("https://www.google.com");
+  });
+
+  it("detects drift when local clock is ahead", async () => {
+    // Server says it's 120 seconds behind local.
+    const serverDate = new Date(1_700_000_000_000 - 120_000).toUTCString();
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { headers: { date: serverDate } }));
+
+    const result = await checkTimeDrift({ thresholdSeconds: 60 });
+    expect(result.driftMs).toBeGreaterThanOrEqual(119_000);
+    expect(result.exceeds).toBe(true);
+  });
+
+  it("detects drift when local clock is behind", async () => {
+    const serverDate = new Date(1_700_000_000_000 + 90_000).toUTCString();
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { headers: { date: serverDate } }));
+
+    const result = await checkTimeDrift({ thresholdSeconds: 60 });
+    expect(result.driftMs).toBeLessThan(0);
+    expect(result.exceeds).toBe(true);
+  });
+
+  it("throws when Date header is missing", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null));
+
+    await expect(checkTimeDrift()).rejects.toThrow("no Date header");
+  });
+
+  it("throws when Date header is unparseable", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { headers: { date: "not-a-date" } }));
+
+    await expect(checkTimeDrift()).rejects.toThrow("unparseable Date header");
+  });
+
+  it("uses custom source URL", async () => {
+    const serverDate = new Date(1_700_000_000_000).toUTCString();
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { headers: { date: serverDate } }));
+
+    const result = await checkTimeDrift({ source: "https://example.com" });
+    expect(result.source).toBe("https://example.com");
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "https://example.com",
+      expect.objectContaining({ method: "HEAD" }),
+    );
+  });
+
+  it("propagates fetch errors (e.g. timeout)", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("timeout"));
+
+    await expect(checkTimeDrift()).rejects.toThrow("timeout");
+  });
+});
+
+describe("formatDriftForLog", () => {
+  it("formats within-tolerance result", () => {
+    const result: TimeDriftCheckResult = {
+      driftMs: 500,
+      absDriftMs: 500,
+      exceeds: false,
+      source: "https://www.google.com",
+      thresholdMs: 60_000,
+    };
+    const msg = formatDriftForLog(result);
+    expect(msg).toContain("within tolerance");
+    expect(msg).toContain("0.5s ahead");
+  });
+
+  it("formats exceeding result", () => {
+    const result: TimeDriftCheckResult = {
+      driftMs: -120_000,
+      absDriftMs: 120_000,
+      exceeds: true,
+      source: "https://www.google.com",
+      thresholdMs: 60_000,
+    };
+    const msg = formatDriftForLog(result);
+    expect(msg).toContain("clock is");
+    expect(msg).toContain("behind");
+  });
+});

--- a/src/infra/time-drift.ts
+++ b/src/infra/time-drift.ts
@@ -1,0 +1,79 @@
+export interface TimeDriftCheckResult {
+  /** Estimated drift in milliseconds (positive = local clock ahead). */
+  driftMs: number;
+  /** Absolute drift value. */
+  absDriftMs: number;
+  /** Whether drift exceeds the configured threshold. */
+  exceeds: boolean;
+  /** The source URL that was queried. */
+  source: string;
+  /** The threshold used for the check (ms). */
+  thresholdMs: number;
+}
+
+export interface CheckTimeDriftOpts {
+  /** URL to HTTP HEAD for the `Date` header. */
+  source?: string;
+  /** Maximum acceptable drift in seconds. */
+  thresholdSeconds?: number;
+  /** Request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_SOURCE = "https://www.google.com";
+const DEFAULT_THRESHOLD_SECONDS = 60;
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Measures local clock drift by comparing `Date.now()` against the `Date`
+ * header returned by an HTTP HEAD request.  Uses the midpoint of the request
+ * window to reduce RTT bias.
+ */
+export async function checkTimeDrift(opts?: CheckTimeDriftOpts): Promise<TimeDriftCheckResult> {
+  const source = opts?.source?.trim() || DEFAULT_SOURCE;
+  const thresholdMs = (opts?.thresholdSeconds ?? DEFAULT_THRESHOLD_SECONDS) * 1_000;
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const before = Date.now();
+  const res = await fetch(source, {
+    method: "HEAD",
+    signal: AbortSignal.timeout(timeoutMs),
+    redirect: "follow",
+  });
+  const after = Date.now();
+
+  const dateHeader = res.headers.get("date");
+  if (!dateHeader) {
+    throw new Error(`time-drift: no Date header from ${source}`);
+  }
+
+  const remoteMs = new Date(dateHeader).getTime();
+  if (!Number.isFinite(remoteMs)) {
+    throw new Error(`time-drift: unparseable Date header: ${dateHeader}`);
+  }
+
+  // Midpoint of the request window approximates when the server generated the
+  // Date header, reducing network round-trip bias.
+  const localMidpoint = (before + after) / 2;
+  const driftMs = localMidpoint - remoteMs;
+  const absDriftMs = Math.abs(driftMs);
+
+  return {
+    driftMs,
+    absDriftMs,
+    exceeds: absDriftMs > thresholdMs,
+    source,
+    thresholdMs,
+  };
+}
+
+/** Human-readable one-liner describing drift. */
+export function formatDriftForLog(result: TimeDriftCheckResult): string {
+  const seconds = (result.driftMs / 1_000).toFixed(1);
+  const direction = result.driftMs >= 0 ? "ahead" : "behind";
+  const threshold = (result.thresholdMs / 1_000).toFixed(0);
+  if (result.exceeds) {
+    return `clock is ${seconds}s ${direction} of ${result.source} (threshold: ${threshold}s)`;
+  }
+  return `clock within tolerance (${seconds}s ${direction}, threshold: ${threshold}s)`;
+}


### PR DESCRIPTION
## Summary

Closes #27780

Adds two features to address gateway time drift causing cron jobs to fire at incorrect times:

- **Gateway-level default timezone** (`cron.timezone`): fallback IANA timezone for cron expressions without an explicit `tz` field, resolving the classic "UTC container vs local-time expression" mismatch
- **Time drift detection** (`cron.timeSyncCheck`): compares local clock against an HTTP Date header on startup and periodically, warning when the host clock has drifted beyond a configurable threshold

### Timezone resolution order

1. Per-job `tz` field (unchanged)
2. `cron.timezone` gateway config (new)
3. Node.js process timezone (existing fallback)

### Time drift detection

- HTTP HEAD to configurable endpoint (default: google.com), compare `Date` header against `Date.now()` midpoint
- Warn when drift exceeds threshold (default: 60s)
- Periodic re-checks (default: every 60 minutes) via `.unref()` timer
- Optional `blockStartup: true` to refuse startup when badly desynced
- Rewired on cron hot-reload so runtime config changes take effect without a full gateway restart

### Changes

**Default timezone:**
- `src/config/types.cron.ts` — add `timezone?: string` to `CronConfig`
- `src/config/zod-schema.ts` — add zod schema for `timezone`
- `src/cron/schedule.ts` — `resolveCronTimezone` accepts `defaultTimezone?`; `computeNextRunAtMs` threads it through
- `src/cron/service/jobs.ts` — all call sites pass `state.deps.cronConfig?.timezone`
- `src/cron/service/timer.ts` — both `computeJobNextRunAtMs` calls pass timezone
- `src/cron/service/ops.ts` — startup log includes effective timezone; update calls pass timezone

**Time drift detection:**
- `src/infra/time-drift.ts` — `checkTimeDrift()` core utility + `formatDriftForLog()`
- `src/infra/time-drift-monitor.ts` — `createTimeDriftMonitor()` periodic wrapper
- `src/infra/time-drift.test.ts` — 9 tests (drift calc, missing/bad header, custom source, timeout)
- `src/infra/time-drift-monitor.test.ts` — 5 tests (info/warn/error logging, start/stop lifecycle)
- `src/config/types.cron.ts` — add `timeSyncCheck` type with 5 sub-fields
- `src/config/zod-schema.ts` — zod validation for `timeSyncCheck`
- `src/config/schema.help.ts` — help strings for `cron.timezone` + all `cron.timeSyncCheck.*`
- `src/gateway/server.impl.ts` — wire monitor before `cron.start()`
- `src/gateway/server-close.ts` — cleanup via `timeDriftMonitor?.stop()`
- `src/gateway/server-reload-handlers.ts` — stop/recreate drift monitor on cron hot-reload

### Config

```yaml
cron:
  timezone: "America/New_York"
  timeSyncCheck:
    enabled: true              # default
    source: "https://www.google.com"  # default
    thresholdSeconds: 60       # default
    intervalMinutes: 60        # default, 0 disables periodic
    blockStartup: false        # default
```

### Test plan

- [x] `pnpm tsgo` — type check passes
- [x] `pnpm test src/infra/time-drift` — 14/14 new tests pass
- [x] `pnpm test src/cron` — 378/378 existing cron tests pass
- [x] `pnpm format` — clean