### PR TITLE
fix: strip Anthropic-style tool XML leaking into user-facing text

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -18,7 +18,11 @@ import type {
 } from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  stripAnthropicToolCallXml,
+  stripDowngradedToolCallText,
+} from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -468,7 +472,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
+    const chunk = stripDowngradedToolCallText(
+      stripAnthropicToolCallXml(stripBlockTags(text, state.blockState)),
+    ).trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -591,6 +591,7 @@ describe("extractAssistantText strips Anthropic tool XML", () => {
           text: `Let me check that.\n\n<tool_call>\n{"name": "memory_search", "arguments": {"query": "test"}}\n</tool_call>`,
         },
       ],
+      timestamp: Date.now(),
     });
     expect(extractAssistantText(msg)).toBe("Let me check that.");
   });

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -29,6 +29,7 @@ export {
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
+  stripAnthropicToolCallXml,
   stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
   stripThinkingTagsFromText,
@@ -141,7 +142,9 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  return stripThinkingTagsFromText(
+    stripDowngradedToolCallText(stripAnthropicToolCallXml(stripMinimaxToolCallXml(text))),
+  );
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
## Problem

When Anthropic models are accessed via OpenAI-compatible proxies (e.g. LiteLLM), `tool_use`/`tool_result` content blocks can be serialized as XML within the text content field. These raw tool interaction blocks (`<antml_function_calls>`, `<tool_call>`, `<tool_result>`, etc.) leak through to channel delivery (Matrix, Telegram, etc.) because existing sanitization only handles Minimax and Gemini downgraded formats.

## Root Cause

`extractAssistantText()` applies `stripMinimaxToolCallXml()` and `stripDowngradedToolCallText()` but has no handler for Anthropic-native XML tool format that appears when proxied through OpenAI-compatible endpoints.

## Fix

Add `stripAnthropicToolCallXml()` to the sanitization pipeline, applied in all three text extraction paths:

- **`extractAssistantText`** (`pi-embedded-utils.ts`) — primary response extraction
- **`emitBlockChunk`** (`pi-embedded-subscribe.ts`) — streaming block replies
- **`sanitizeTextContent`** (`sessions-helpers.ts`) — session history display

Strips:
- `<antml_function_calls>...</antml_function_calls>` blocks
- `<antml_invoke>...</antml_invoke>` blocks
- `<tool_call>...</tool_call>` blocks
- `<tool_result>...</tool_result>` blocks

Includes fast-path check (skip regex when no tool XML markers present) for zero overhead on clean text.

## Tests

7 new test cases covering the new function + integration with `extractAssistantText`. All 37 tests in `pi-embedded-utils.test.ts` pass.