### PR TITLE
fix(heartbeat): pass sessionKey to exec/hook wake calls to target correct agent

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -362,11 +362,12 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, NS
     func shouldAutoNavigateToA2UI(lastAutoTarget: String?) -> Bool {
         let trimmed = (self.currentTarget ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty || trimmed == "/" { return true }
+        // Already showing the last auto-navigated target; no reload needed.
         if let lastAuto = lastAutoTarget?.trimmingCharacters(in: .whitespacesAndNewlines),
            !lastAuto.isEmpty,
            trimmed == lastAuto
         {
-            return true
+            return false
         }
         return false
     }

--- a/docs/channels/grammy.md
+++ b/docs/channels/grammy.md
@@ -18,7 +18,7 @@ title: grammY
 - **Single client path:** fetch-based implementation removed; grammY is now the sole Telegram client (send + gateway) with the grammY throttler enabled by default.
 - **Gateway:** `monitorTelegramProvider` builds a grammY `Bot`, wires mention/allowlist gating, media download via `getFile`/`download`, and delivers replies with `sendMessage/sendPhoto/sendVideo/sendAudio/sendDocument`. Supports long-poll or webhook via `webhookCallback`.
 - **Proxy:** optional `channels.telegram.proxy` uses `undici.ProxyAgent` through grammY’s `client.baseFetch`.
-- **Webhook support:** `webhook-set.ts` wraps `setWebhook/deleteWebhook`; `webhook.ts` hosts the callback with health + graceful shutdown. Gateway enables webhook mode when `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` are set (otherwise it long-polls).
+- **Webhook support:** `webhook-set.ts` wraps `setWebhook/deleteWebhook`; `webhook.ts` hosts the callback with health + graceful shutdown. Gateway enables webhook mode when `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` are set (otherwise it long-polls). Default webhook mode uses gateway HTTP ingress (webhook requests arrive on the gateway port); setting `webhookHost` or `webhookPort` explicitly switches to a dedicated legacy HTTP server.
 - **Sessions:** direct chats collapse into the agent main session (`agent:<agentId>:<mainKey>`); groups use `agent:<agentId>:telegram:group:<chatId>`; replies route back to the same channel.
 - **Config knobs:** `channels.telegram.botToken`, `channels.telegram.dmPolicy`, `channels.telegram.groups` (allowlist + mention defaults), `channels.telegram.allowFrom`, `channels.telegram.groupAllowFrom`, `channels.telegram.groupPolicy`, `channels.telegram.mediaMaxMb`, `channels.telegram.linkPreview`, `channels.telegram.proxy`, `channels.telegram.webhookSecret`, `channels.telegram.webhookUrl`, `channels.telegram.webhookHost`.
 - **Live stream preview:** `channels.telegram.streaming` (`off | partial | block | progress`) sends a temporary message and updates it with `editMessageText`. This is separate from channel block streaming.
@@ -28,4 +28,4 @@ Open questions
 
 - Optional grammY plugins (throttler) if we hit Bot API 429s.
 - Add more structured media tests (stickers, voice notes).
-- Make webhook listen port configurable (currently fixed to 8787 unless wired through the gateway).
+- ~~Make webhook listen port configurable~~ Resolved: gateway HTTP ingress is now the default; legacy dedicated server mode is available via explicit `webhookHost`/`webhookPort`.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -609,12 +609,38 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - set `channels.telegram.webhookUrl`
     - set `channels.telegram.webhookSecret` (required when webhook URL is set)
     - optional `channels.telegram.webhookPath` (default `/telegram-webhook`)
-    - optional `channels.telegram.webhookHost` (default `127.0.0.1`)
 
-    Default local listener for webhook mode binds to `127.0.0.1:8787`.
+    **Gateway HTTP ingress (default):** Webhook requests arrive on the gateway port (same port as WebSocket connections). No additional port needed — just point `webhookUrl` at your gateway's public URL with the webhook path. This is ideal when you have a reverse proxy forwarding to the gateway port.
 
-    If your public endpoint differs, place a reverse proxy in front and point `webhookUrl` at the public URL.
-    Set `webhookHost` (for example `0.0.0.0`) when you intentionally need external ingress.
+    **Legacy dedicated server:** If you set `channels.telegram.webhookHost` or `channels.telegram.webhookPort` explicitly, the webhook uses a dedicated HTTP server on that host/port (default `127.0.0.1:8787`). Use this for advanced setups where you need the webhook listener on a separate port.
+
+    Example (gateway mode — recommended):
+
+```json5
+{
+  channels: {
+    telegram: {
+      webhookUrl: "https://my-domain.com/telegram-webhook",
+      webhookSecret: "my-secret-token",
+    },
+  },
+}
+```
+
+    Example (legacy dedicated server):
+
+```json5
+{
+  channels: {
+    telegram: {
+      webhookUrl: "https://my-domain.com/telegram-webhook",
+      webhookSecret: "my-secret-token",
+      webhookHost: "0.0.0.0",
+      webhookPort: 8787,
+    },
+  },
+}
+```
 
   </Accordion>
 

--- a/docs/install/gcp.md
+++ b/docs/install/gcp.md
@@ -288,14 +288,10 @@ Anything installed at runtime will be lost on restart.
 
 All external binaries required by skills must be installed at image build time.
 
-The examples below show three common binaries only:
+The section below shows the Dockerfile pattern for installing skill binaries.
 
-- `gog` for Gmail access
-- `goplaces` for Google Places
-- `wacli` for WhatsApp
-
-These are examples, not a complete list.
-You may install as many binaries as needed using the same pattern.
+Replace the placeholder `RUN` lines with the actual binaries your skills need.
+Check each skill's documentation for download URLs and install instructions.
 
 If you add new skills later that depend on additional binaries, you must:
 
@@ -310,19 +306,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# Example binary 1: Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# Example binary 2: Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# Example binary 3: WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# Add more binaries below using the same pattern
+# Install skill binaries here. Example pattern:
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# Add one RUN line per binary your skills require.
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -361,20 +349,16 @@ docker compose run --rm openclaw-cli config set gateway.controlUi.allowedOrigins
 
 If you changed the gateway port, replace `18789` with your configured port.
 
-Verify binaries:
+Verify binaries (replace `BINARY` with the actual binary names you installed):
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 Expected output:
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---

--- a/docs/zh-CN/install/gcp.md
+++ b/docs/zh-CN/install/gcp.md
@@ -298,14 +298,10 @@ services:
 
 所有 Skills 所需的外部二进制文件必须在镜像构建时安装。
 
-以下示例仅显示三个常见的二进制文件：
+以下部分展示了安装 Skill 二进制文件的 Dockerfile 模式。
 
-- `gog` 用于 Gmail 访问
-- `goplaces` 用于 Google Places
-- `wacli` 用于 WhatsApp
-
-这些是示例，不是完整列表。
-你可以使用相同的模式安装任意数量的二进制文件。
+将占位符 `RUN` 行替换为你的 Skills 所需的实际二进制文件。
+查看每个 Skill 的文档以获取下载地址和安装说明。
 
 如果你以后添加依赖额外二进制文件的新 Skills，你必须：
 
@@ -320,19 +316,11 @@ FROM node:22-bookworm
 
 RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
-# 示例二进制文件 1：Gmail CLI
-RUN curl -L https://github.com/steipete/gog/releases/latest/download/gog_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/gog
-
-# 示例二进制文件 2：Google Places CLI
-RUN curl -L https://github.com/steipete/goplaces/releases/latest/download/goplaces_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/goplaces
-
-# 示例二进制文件 3：WhatsApp CLI
-RUN curl -L https://github.com/steipete/wacli/releases/latest/download/wacli_Linux_x86_64.tar.gz \
-  | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/wacli
-
-# 使用相同的模式在下面添加更多二进制文件
+# 在此处安装 Skill 二进制文件。示例模式：
+# RUN curl -L https://github.com/OWNER/REPO/releases/latest/download/BINARY_Linux_x86_64.tar.gz \
+#   | tar -xz -C /usr/local/bin && chmod +x /usr/local/bin/BINARY
+#
+# 为你的 Skills 需要的每个二进制文件添加一行 RUN 命令。
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
@@ -361,20 +349,16 @@ docker compose build
 docker compose up -d openclaw-gateway
 ```
 
-验证二进制文件：
+验证二进制文件（将 `BINARY` 替换为你安装的实际二进制文件名）：
 
 ```bash
-docker compose exec openclaw-gateway which gog
-docker compose exec openclaw-gateway which goplaces
-docker compose exec openclaw-gateway which wacli
+docker compose exec openclaw-gateway which BINARY
 ```
 
 预期输出：
 
 ```
-/usr/local/bin/gog
-/usr/local/bin/goplaces
-/usr/local/bin/wacli
+/usr/local/bin/BINARY
 ```
 
 ---

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -3,6 +3,14 @@
   "version": "2026.2.26",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/package.json
+++ b/package.json
@@ -227,9 +227,7 @@
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.15.1"
   },
-  "optionalDependencies": {
-    "@discordjs/opus": "^0.10.0"
-  },
+  "optionalDependencies": {},
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -238,7 +238,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 export function createApprovalSlug(id: string) {
@@ -264,7 +264,7 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event" });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -177,6 +177,13 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return "timeout";
   }
   if (status === 400) {
+    // Before defaulting to "format", check whether the error message indicates
+    // a billing/rate-limit issue (e.g. Anthropic "insufficient_quota" arrives
+    // as HTTP 400). Let the message-based classifier take precedence.
+    const messageReason = classifyFailoverReason(getErrorMessage(err));
+    if (messageReason) {
+      return messageReason;
+    }
     return "format";
   }
 

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -1,6 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
-import { maskApiKey } from "../utils/mask-api-key.js";
 import {
   ensureAuthProfileStore,
   resolveAuthProfileDisplayLabel,
@@ -9,27 +8,6 @@ import {
 import { getCustomProviderApiKey, resolveEnvApiKey } from "./model-auth.js";
 import { normalizeProviderId } from "./model-selection.js";
 
-function formatApiKeySnippet(apiKey: string): string {
-  const compact = apiKey.replace(/\s+/g, "");
-  if (!compact) {
-    return "unknown";
-  }
-  return maskApiKey(compact);
-}
-
-function formatCredentialSnippet(params: {
-  value: string | undefined;
-  ref: { source: string; id: string } | undefined;
-}): string {
-  const value = typeof params.value === "string" ? params.value.trim() : "";
-  if (value) {
-    return formatApiKeySnippet(value);
-  }
-  if (params.ref) {
-    return `ref(${params.ref.source}:${params.ref.id})`;
-  }
-  return "unknown";
-}
 
 export function resolveModelAuthLabel(params: {
   provider?: string;
@@ -69,13 +47,9 @@ export function resolveModelAuthLabel(params: {
       return `oauth${label ? ` (${label})` : ""}`;
     }
     if (profile.type === "token") {
-      return `token ${formatCredentialSnippet({ value: profile.token, ref: profile.tokenRef })}${
-        label ? ` (${label})` : ""
-      }`;
+      return `token${label ? ` (${label})` : ""}`;
     }
-    return `api-key ${formatCredentialSnippet({ value: profile.key, ref: profile.keyRef })}${
-      label ? ` (${label})` : ""
-    }`;
+    return `api-key${label ? ` (${label})` : ""}`;
   }
 
   const envKey = resolveEnvApiKey(providerKey);
@@ -83,12 +57,12 @@ export function resolveModelAuthLabel(params: {
     if (envKey.source.includes("OAUTH_TOKEN")) {
       return `oauth (${envKey.source})`;
     }
-    return `api-key ${formatApiKeySnippet(envKey.apiKey)} (${envKey.source})`;
+    return `api-key (${envKey.source})`;
   }
 
   const customKey = getCustomProviderApiKey(params.cfg, providerKey);
   if (customKey) {
-    return `api-key ${formatApiKeySnippet(customKey)} (models.json)`;
+    return `api-key (models.json)`;
   }
 
   return "unknown";

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -149,6 +149,19 @@ describe("normalizeModelCompat", () => {
     ).toBe(false);
   });
 
+  it("forces supportsDeveloperRole off for bailian provider", () => {
+    const model = {
+      ...baseModel(),
+      provider: "bailian",
+      baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
+
   it("forces supportsDeveloperRole off for DashScope-compatible endpoints", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -45,7 +45,10 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     model.provider === "moonshot" ||
     baseUrl.includes("moonshot.ai") ||
     baseUrl.includes("moonshot.cn");
-  const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
+  const isDashScope =
+    model.provider === "dashscope" ||
+    model.provider === "bailian" ||
+    isDashScopeCompatibleEndpoint(baseUrl);
   if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(model)) {
     return model;
   }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -565,9 +565,14 @@ describe("runWithModelFallback", () => {
         },
       },
     });
+    // Use a rate-limit error (not auth/billing) to avoid triggering
+    // the provider-level circuit breaker which would skip the second
+    // same-provider candidate.
     const run = vi
       .fn()
-      .mockImplementation(() => Promise.reject(Object.assign(new Error("nope"), { status: 401 })));
+      .mockImplementation(() =>
+        Promise.reject(Object.assign(new Error("rate limit"), { status: 429 })),
+      );
 
     await expect(
       runWithModelFallback({
@@ -1161,5 +1166,114 @@ describe("isAnthropicBillingError", () => {
     for (const sample of samples) {
       expect(isAnthropicBillingError(sample)).toBe(true);
     }
+
+describe("provider circuit breaker", () => {
+  it("skips same-provider candidates after auth failure", async () => {
+    const cfg = makeCfg();
+    // After interleaving: [anthropic/opus, openai/badgpt, anthropic/sonnet, openai/goodgpt]
+    const calls: Array<{ provider: string; model: string }> = [];
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "opus",
+      fallbacksOverride: ["openai/badgpt", "anthropic/sonnet", "openai/goodgpt"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (provider === "anthropic") {
+          throw Object.assign(new Error("Unauthorized"), { status: 401 });
+        }
+        if (model === "badgpt") {
+          throw Object.assign(new Error("rate limit"), { status: 429 });
+        }
+        return "ok";
+      },
+    });
+
+    expect(result.result).toBe("ok");
+    // anthropic/sonnet should be skipped by the circuit breaker
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "opus" },
+      { provider: "openai", model: "badgpt" },
+      { provider: "openai", model: "goodgpt" },
+    ]);
+    expect(result.attempts.find((a) => a.model === "sonnet")?.reason).toBe("auth");
+  });
+
+  it("skips same-provider candidates after billing failure", async () => {
+    const cfg = makeCfg();
+    const calls: Array<{ provider: string; model: string }> = [];
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "opus",
+      fallbacksOverride: ["openai/badgpt", "anthropic/sonnet", "openai/goodgpt"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (provider === "anthropic") {
+          throw Object.assign(new Error("payment required"), { status: 402 });
+        }
+        if (model === "badgpt") {
+          throw Object.assign(new Error("rate limit"), { status: 429 });
+        }
+        return "ok";
+      },
+    });
+
+    expect(result.result).toBe("ok");
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "opus" },
+      { provider: "openai", model: "badgpt" },
+      { provider: "openai", model: "goodgpt" },
+    ]);
+    expect(result.attempts.find((a) => a.model === "sonnet")?.reason).toBe("auth");
+  });
+
+  it("does NOT skip same-provider on rate_limit", async () => {
+    const cfg = makeCfg();
+    // 2 candidates → interleaving is a no-op
+    const calls: Array<{ provider: string; model: string }> = [];
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "opus",
+      fallbacksOverride: ["anthropic/sonnet"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (model === "opus") {
+          throw Object.assign(new Error("rate limit exceeded"), { status: 429 });
+        }
+        return "ok-sonnet";
+      },
+    });
+
+    expect(result.result).toBe("ok-sonnet");
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "opus" },
+      { provider: "anthropic", model: "sonnet" },
+    ]);
+  });
+
+  it("does NOT skip same-provider on timeout", async () => {
+    const cfg = makeCfg();
+    const calls: Array<{ provider: string; model: string }> = [];
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "opus",
+      fallbacksOverride: ["anthropic/sonnet"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (model === "opus") {
+          throw Object.assign(new Error("request timed out"), { code: "ETIMEDOUT" });
+        }
+        return "ok-sonnet";
+      },
+    });
+
+    expect(result.result).toBe("ok-sonnet");
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "opus" },
+      { provider: "anthropic", model: "sonnet" },
+    ]);
   });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -392,6 +392,9 @@ export function normalizeGoogleModelId(id: string): string {
 }
 
 function normalizeGoogleProvider(provider: ProviderConfig): ProviderConfig {
+  if (!provider.models) {
+    return provider;
+  }
   let mutated = false;
   const models = provider.models.map((model) => {
     const nextId = normalizeGoogleModelId(model.id);

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -79,6 +79,9 @@ describe("isBillingErrorMessage", () => {
       "Payment Required",
       "HTTP 402 Payment Required",
       "plans & billing",
+      "insufficient_quota",
+      "insufficient quota",
+      "insufficient_quota: Your account has insufficient quota to process this request.",
     ];
     for (const sample of samples) {
       expect(isBillingErrorMessage(sample)).toBe(true);
@@ -519,6 +522,15 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("Your api key has been revoked")).toBe("auth_permanent");
     expect(classifyFailoverReason("key has been disabled")).toBe("auth_permanent");
     expect(classifyFailoverReason("account has been deactivated")).toBe("auth_permanent");
+  });
+  it("classifies Anthropic insufficient_quota errors as billing", () => {
+    expect(classifyFailoverReason("insufficient_quota")).toBe("billing");
+    expect(classifyFailoverReason("insufficient quota")).toBe("billing");
+    expect(
+      classifyFailoverReason(
+        "insufficient_quota: Your account has insufficient quota to process this request.",
+      ),
+    ).toBe("billing");
   });
   it("classifies JSON api_error internal server failures as timeout", () => {
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -648,6 +648,8 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "insufficient_quota",
+    "insufficient quota",
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -36,7 +36,6 @@ import {
   classifyFailoverReason,
   formatAssistantErrorText,
   isAuthAssistantError,
-  isBillingAssistantError,
   isCompactionFailureError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
@@ -954,7 +953,6 @@ export async function runEmbeddedPiAgent(
 
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -834,6 +834,15 @@ export async function runEmbeddedAttempt(
         err.name = "AbortError";
         return err;
       };
+      const isAbortError = (err: unknown): boolean =>
+        err instanceof Error
+          ? err.name === "AbortError"
+          : Boolean(
+              err &&
+              typeof err === "object" &&
+              "name" in err &&
+              (err as { name?: unknown }).name === "AbortError",
+            );
       const abortRun = (isTimeout = false, reason?: unknown) => {
         aborted = true;
         if (isTimeout) {
@@ -844,8 +853,12 @@ export async function runEmbeddedAttempt(
         } else {
           runAbortController.abort(reason);
         }
-        // Catch AbortError from in-flight requests - expected during timeout aborts
-        activeSession.abort().catch(() => {});
+        // AbortError from in-flight requests is expected during timeout aborts.
+        activeSession.abort().catch((err) => {
+          if (!isAbortError(err)) {
+            log.warn(`activeSession.abort() failed unexpectedly: ${String(err)}`);
+          }
+        });
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -844,7 +844,8 @@ export async function runEmbeddedAttempt(
         } else {
           runAbortController.abort(reason);
         }
-        void activeSession.abort();
+        // Catch AbortError from in-flight requests - expected during timeout aborts
+        activeSession.abort().catch(() => {});
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -12,6 +12,7 @@ import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { isAbortError } from "../../../infra/unhandled-rejections.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import type {
@@ -834,15 +835,6 @@ export async function runEmbeddedAttempt(
         err.name = "AbortError";
         return err;
       };
-      const isAbortError = (err: unknown): boolean =>
-        err instanceof Error
-          ? err.name === "AbortError"
-          : Boolean(
-              err &&
-              typeof err === "object" &&
-              "name" in err &&
-              (err as { name?: unknown }).name === "AbortError",
-            );
       const abortRun = (isTimeout = false, reason?: unknown) => {
         aborted = true;
         if (isTimeout) {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -45,6 +45,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Read file contents",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "write",
@@ -52,6 +53,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Create or overwrite files",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "edit",
@@ -59,6 +61,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Make precise edits",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "apply_patch",
@@ -66,6 +69,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Patch files (OpenAI)",
     sectionId: "fs",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "exec",
@@ -73,6 +77,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Run shell commands",
     sectionId: "runtime",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "process",
@@ -80,6 +85,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: "Manage background processes",
     sectionId: "runtime",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
   },
   {
     id: "web_search",

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -125,4 +125,47 @@ describe("tool image sanitizing", () => {
       },
     ]);
   });
+
+  it("resizes images where decoded bytes < limit but base64 string > limit", async () => {
+    // This test verifies the fix for issue #5344:
+    // The API enforces the limit on base64 string length, not decoded bytes.
+    // Base64 encoding inflates data by ~33%, so an image with decoded size 4MB
+    // produces a base64 string of ~5.3MB, which exceeds the 5MB API limit.
+    const width = 2200;
+    const height = 2200;
+    const raw = Buffer.alloc(width * height * 3, 0xaa);
+    const png = await sharp(raw, {
+      raw: { width, height, channels: 3 },
+    })
+      .png({ compressionLevel: 0 })
+      .toBuffer();
+
+    const base64 = png.toString("base64");
+    const decodedBytes = png.byteLength;
+    const base64Length = base64.length;
+
+    // Verify test precondition: decoded bytes could be under 5MB but base64 over 5MB
+    // (due to compression this may vary, but the logic should handle both correctly)
+    expect(base64Length).toBeGreaterThan(decodedBytes);
+    expect(base64Length / decodedBytes).toBeCloseTo(4 / 3, 1); // ~1.33x inflation
+
+    const blocks = [
+      {
+        type: "image" as const,
+        data: base64,
+        mimeType: "image/png",
+      },
+    ];
+
+    // Use maxBytes as the limit for base64 string length
+    const maxBytes = 5 * 1024 * 1024;
+    const out = await sanitizeContentBlocksImages(blocks, "test", { maxBytes });
+    const image = out.find((b) => b.type === "image");
+    if (!image || image.type !== "image") {
+      throw new Error("expected image block");
+    }
+
+    // The output base64 string should be within the limit
+    expect(image.data.length).toBeLessThanOrEqual(maxBytes);
+  }, 20_000);
 });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -268,7 +268,6 @@ async function resizeImageBase64IfNeeded(params: {
     }
   }
 
-  const bestBase64 = smallest?.base64 ?? params.base64;
   const bestSize = smallest?.size ?? base64Length;
   const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
   const gotMb = (bestSize / (1024 * 1024)).toFixed(2);

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -163,7 +163,10 @@ async function resizeImageBase64IfNeeded(params: {
   const meta = await getImageMetadata(buf);
   const width = meta?.width;
   const height = meta?.height;
-  const overBytes = buf.byteLength > params.maxBytes;
+  // Compare base64 string length, not decoded buffer size.
+  // The Anthropic API enforces the 5MB limit on the base64 string, which is ~33% larger than the decoded bytes.
+  const base64Length = params.base64.length;
+  const overBytes = base64Length > params.maxBytes;
   const hasDimensions = typeof width === "number" && typeof height === "number";
   const overDimensions =
     hasDimensions && (width > params.maxDimensionPx || height > params.maxDimensionPx);
@@ -181,12 +184,34 @@ async function resizeImageBase64IfNeeded(params: {
       height,
     };
   }
+  if (
+    hasDimensions &&
+    (width > params.maxDimensionPx || height > params.maxDimensionPx || overBytes)
+  ) {
+    const sourcePixels =
+      typeof width === "number" && typeof height === "number"
+        ? `${width}x${height}px`
+        : "unknown";
+    log.warn(
+      `Image exceeds limits; resizing: ${sourcePixels} base64=${base64Length}`,
+      {
+        label: params.label,
+        width,
+        height,
+        maxDimensionPx: params.maxDimensionPx,
+        maxBytes: params.maxBytes,
+        base64Length,
+        triggerOverBytes: overBytes,
+        triggerOverDimensions: overDimensions,
+      },
+    );
+  }
 
   const maxDim = hasDimensions ? Math.max(width ?? 0, height ?? 0) : params.maxDimensionPx;
   const sideStart = maxDim > 0 ? Math.min(params.maxDimensionPx, maxDim) : params.maxDimensionPx;
   const sideGrid = buildImageResizeSideGrid(params.maxDimensionPx, sideStart);
 
-  let smallest: { buffer: Buffer; size: number } | null = null;
+  let smallest: { base64: string; size: number } | null = null;
   for (const side of sideGrid) {
     for (const quality of IMAGE_REDUCE_QUALITY_STEPS) {
       const out = await resizeToJpeg({
@@ -195,10 +220,12 @@ async function resizeImageBase64IfNeeded(params: {
         quality,
         withoutEnlargement: true,
       });
-      if (!smallest || out.byteLength < smallest.size) {
-        smallest = { buffer: out, size: out.byteLength };
+      const outBase64 = out.toString("base64");
+      const outBase64Length = outBase64.length;
+      if (!smallest || outBase64Length < smallest.size) {
+        smallest = { base64: outBase64, size: outBase64Length };
       }
-      if (out.byteLength <= params.maxBytes) {
+      if (outBase64Length <= params.maxBytes) {
         const sourcePixels =
           typeof width === "number" && typeof height === "number"
             ? `${width}x${height}px`
@@ -206,32 +233,32 @@ async function resizeImageBase64IfNeeded(params: {
         const sourceWithFile = params.fileName
           ? `${params.fileName} ${sourcePixels}`
           : sourcePixels;
-        const byteReductionPct =
-          buf.byteLength > 0
-            ? Number((((buf.byteLength - out.byteLength) / buf.byteLength) * 100).toFixed(1))
+        const reductionPct =
+          base64Length > 0
+            ? Number((((base64Length - outBase64Length) / base64Length) * 100).toFixed(1))
             : 0;
         log.info(
-          `Image resized to fit limits: ${sourceWithFile} ${formatBytesShort(buf.byteLength)} -> ${formatBytesShort(out.byteLength)} (-${byteReductionPct}%)`,
+          `Image resized to fit limits: ${sourceWithFile} base64 ${base64Length} -> ${outBase64Length} (-${reductionPct}%)`,
           {
             label: params.label,
             fileName: params.fileName,
             sourceMimeType: params.mimeType,
             sourceWidth: width,
             sourceHeight: height,
-            sourceBytes: buf.byteLength,
+            sourceBase64Length: base64Length,
             maxBytes: params.maxBytes,
             maxDimensionPx: params.maxDimensionPx,
             triggerOverBytes: overBytes,
             triggerOverDimensions: overDimensions,
             outputMimeType: "image/jpeg",
-            outputBytes: out.byteLength,
+            outputBase64Length: outBase64Length,
             outputQuality: quality,
             outputMaxSide: side,
-            byteReductionPct,
+            reductionPct,
           },
         );
         return {
-          base64: out.toString("base64"),
+          base64: outBase64,
           mimeType: "image/jpeg",
           resized: true,
           width,
@@ -241,24 +268,25 @@ async function resizeImageBase64IfNeeded(params: {
     }
   }
 
-  const best = smallest?.buffer ?? buf;
+  const bestBase64 = smallest?.base64 ?? params.base64;
+  const bestSize = smallest?.size ?? base64Length;
   const maxMb = (params.maxBytes / (1024 * 1024)).toFixed(0);
-  const gotMb = (best.byteLength / (1024 * 1024)).toFixed(2);
+  const gotMb = (bestSize / (1024 * 1024)).toFixed(2);
   const sourcePixels =
     typeof width === "number" && typeof height === "number" ? `${width}x${height}px` : "unknown";
   const sourceWithFile = params.fileName ? `${params.fileName} ${sourcePixels}` : sourcePixels;
   log.warn(
-    `Image resize failed to fit limits: ${sourceWithFile} best=${formatBytesShort(best.byteLength)} limit=${formatBytesShort(params.maxBytes)}`,
+    `Image resize failed to fit limits: ${sourceWithFile} bestBase64=${bestSize} limit=${params.maxBytes}`,
     {
       label: params.label,
       fileName: params.fileName,
       sourceMimeType: params.mimeType,
       sourceWidth: width,
       sourceHeight: height,
-      sourceBytes: buf.byteLength,
+      sourceBase64Length: base64Length,
       maxDimensionPx: params.maxDimensionPx,
       maxBytes: params.maxBytes,
-      smallestCandidateBytes: best.byteLength,
+      smallestCandidateBase64Length: bestSize,
       triggerOverBytes: overBytes,
       triggerOverDimensions: overDimensions,
     },

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -68,6 +68,14 @@ describe("tool-policy", () => {
     expect(group).toContain("subagents");
     expect(group).toContain("session_status");
     expect(group).toContain("tts");
+    // fs tools
+    expect(group).toContain("read");
+    expect(group).toContain("write");
+    expect(group).toContain("edit");
+    expect(group).toContain("apply_patch");
+    // runtime tools
+    expect(group).toContain("exec");
+    expect(group).toContain("process");
   });
 
   it("normalizes tool names and aliases", () => {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -155,11 +155,18 @@ function resolveFirecrawlEnabled(params: {
 }
 
 function resolveFirecrawlBaseUrl(firecrawl?: FirecrawlFetchConfig): string {
-  const raw =
+  const fromConfig =
     firecrawl && "baseUrl" in firecrawl && typeof firecrawl.baseUrl === "string"
       ? firecrawl.baseUrl.trim()
       : "";
-  return raw || DEFAULT_FIRECRAWL_BASE_URL;
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = process.env.FIRECRAWL_BASE_URL?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  return DEFAULT_FIRECRAWL_BASE_URL;
 }
 
 function resolveFirecrawlOnlyMainContent(firecrawl?: FirecrawlFetchConfig): boolean {

--- a/src/auto-reply/reply/fallback-notify.test.ts
+++ b/src/auto-reply/reply/fallback-notify.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { checkFallbackNotification } from "./fallback-notify.js";
+
+describe("checkFallbackNotification", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when no attempts (primary succeeded)", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-1",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns a notification when fallback model is used", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-2",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit",
+        },
+      ],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain("anthropic/claude-haiku-3-5");
+    expect(result).toContain("openai/gpt-4.1-mini");
+    expect(result).toContain("rate_limit");
+  });
+
+  it("suppresses duplicate notifications for the same fallback", () => {
+    const sessionKey = "test-session-3";
+    const params = {
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "rate limited",
+          reason: "rate_limit" as const,
+        },
+      ],
+    };
+
+    // First call should notify
+    const first = checkFallbackNotification(params);
+    expect(first).toBeDefined();
+
+    // Second call with same fallback should be suppressed
+    const second = checkFallbackNotification(params);
+    expect(second).toBeUndefined();
+  });
+
+  it("clears tracker when primary succeeds again", () => {
+    const sessionKey = "test-session-4";
+
+    // Fallback used — should notify
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Primary recovers — clears tracker
+    checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [],
+    });
+
+    // Fallback again — should notify again (new failover event)
+    const third = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(third).toBeDefined();
+  });
+
+  it("notifies again when fallback model changes", () => {
+    const sessionKey = "test-session-5";
+
+    // First fallback
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+    expect(first).toContain("claude-haiku-3-5");
+
+    // Different fallback model — should notify again
+    const second = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "google",
+      usedModel: "gemini-2.5-flash",
+      attempts: [
+        { provider: "openai", model: "gpt-4.1-mini", error: "rate limited" },
+        { provider: "anthropic", model: "claude-haiku-3-5", error: "also rate limited" },
+      ],
+    });
+    expect(second).toBeDefined();
+    expect(second).toContain("gemini-2.5-flash");
+  });
+
+  it("returns undefined when used model matches original despite attempts", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-6",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "openai",
+      usedModel: "gpt-4.1-mini",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "transient error" }],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("works without a session key", () => {
+    const result = checkFallbackNotification({
+      sessionKey: undefined,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("includes reason from the primary attempt when available", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-7",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [
+        {
+          provider: "openai",
+          model: "gpt-4.1-mini",
+          error: "billing error",
+          reason: "billing",
+        },
+      ],
+    });
+    expect(result).toContain("billing");
+  });
+
+  it("omits reason when not available on primary attempt", () => {
+    const result = checkFallbackNotification({
+      sessionKey: "test-session-8",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "unknown error" }],
+    });
+    expect(result).toBeDefined();
+    expect(result).not.toContain("(undefined)");
+  });
+
+  it("evicts oldest entries when exceeding max tracked sessions", () => {
+    // Fill up the tracker beyond the 1000-entry cap.
+    // We add 1002 unique sessions, then verify the first two were evicted
+    // by checking that a new call with those keys produces a notification
+    // (meaning they were forgotten).
+    for (let i = 0; i < 1002; i++) {
+      checkFallbackNotification({
+        sessionKey: `evict-cap-${i}`,
+        originalProvider: "openai",
+        originalModel: "gpt-4.1-mini",
+        usedProvider: "anthropic",
+        usedModel: "claude-haiku-3-5",
+        attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+      });
+    }
+
+    // Session 0 and 1 should have been evicted — calling again should notify
+    const evicted = checkFallbackNotification({
+      sessionKey: "evict-cap-0",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(evicted).toBeDefined();
+
+    // Session 1001 should still be tracked — calling again should suppress
+    const retained = checkFallbackNotification({
+      sessionKey: "evict-cap-1001",
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(retained).toBeUndefined();
+  });
+
+  it("evicts stale entries based on TTL", () => {
+    const sessionKey = "test-ttl-session";
+
+    // Record a fallback notification
+    const first = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(first).toBeDefined();
+
+    // Same call is suppressed (entry exists)
+    const suppressed = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(suppressed).toBeUndefined();
+
+    // Advance time by > 1 hour so the entry expires
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 61 * 60 * 1000);
+
+    // Entry should have been evicted — notification fires again
+    const afterTtl = checkFallbackNotification({
+      sessionKey,
+      originalProvider: "openai",
+      originalModel: "gpt-4.1-mini",
+      usedProvider: "anthropic",
+      usedModel: "claude-haiku-3-5",
+      attempts: [{ provider: "openai", model: "gpt-4.1-mini", error: "rate limited" }],
+    });
+    expect(afterTtl).toBeDefined();
+  });
+});

--- a/src/auto-reply/reply/fallback-notify.ts
+++ b/src/auto-reply/reply/fallback-notify.ts
@@ -1,0 +1,110 @@
+import type { RuntimeFallbackAttempt } from "./agent-runner-execution.js";
+
+/** Maximum number of sessions tracked before evicting the oldest entries. */
+const MAX_TRACKED_SESSIONS = 1000;
+
+/** Time-to-live for each entry (1 hour). */
+const ENTRY_TTL_MS = 60 * 60 * 1000;
+
+interface TrackedFallback {
+  model: string;
+  ts: number;
+}
+
+/**
+ * In-memory tracker for fallback model notifications.
+ *
+ * Ensures the user is notified only ONCE per failover event —
+ * i.e., when the fallback model changes or the primary recovers
+ * and then fails again.
+ *
+ * Entries are capped at {@link MAX_TRACKED_SESSIONS} and expire
+ * after {@link ENTRY_TTL_MS} to prevent unbounded memory growth.
+ */
+const lastNotifiedFallback = new Map<string, TrackedFallback>();
+
+/** Evict entries older than {@link ENTRY_TTL_MS}. */
+function evictStale(now: number): void {
+  for (const [key, entry] of lastNotifiedFallback) {
+    if (now - entry.ts > ENTRY_TTL_MS) {
+      lastNotifiedFallback.delete(key);
+    } else {
+      // Map iterates in insertion order; once we hit a fresh entry the rest are newer.
+      break;
+    }
+  }
+}
+
+/** Evict oldest entries until the map is within the size cap. */
+function evictOldest(): void {
+  while (lastNotifiedFallback.size > MAX_TRACKED_SESSIONS) {
+    const oldest = lastNotifiedFallback.keys().next().value;
+    if (oldest !== undefined) {
+      lastNotifiedFallback.delete(oldest);
+    } else {
+      break;
+    }
+  }
+}
+
+/**
+ * Determine whether a fallback notification should be shown to the user.
+ *
+ * Returns a notification message when:
+ * 1. The primary model failed and a different fallback model was used
+ * 2. We haven't already notified about this specific fallback for this session
+ *
+ * Clears the tracker when the primary model succeeds (no attempts).
+ */
+export function checkFallbackNotification(params: {
+  sessionKey: string | undefined;
+  originalProvider: string;
+  originalModel: string;
+  usedProvider: string;
+  usedModel: string;
+  attempts?: RuntimeFallbackAttempt[];
+}): string | undefined {
+  const { sessionKey, originalProvider, originalModel, usedProvider, usedModel } = params;
+  const attempts = params.attempts ?? [];
+
+  const now = Date.now();
+  evictStale(now);
+
+  // No failed attempts — primary model succeeded
+  if (attempts.length === 0) {
+    if (sessionKey) {
+      lastNotifiedFallback.delete(sessionKey);
+    }
+    return undefined;
+  }
+
+  // Fallback was used — check if it's actually a different model
+  const usedKey = `${usedProvider}/${usedModel}`;
+  const primaryKey = `${originalProvider}/${originalModel}`;
+
+  if (usedKey === primaryKey) {
+    return undefined;
+  }
+
+  // Already notified about this exact fallback for this session
+  if (sessionKey) {
+    const existing = lastNotifiedFallback.get(sessionKey);
+    if (existing && existing.model === usedKey) {
+      return undefined;
+    }
+  }
+
+  // Record notification
+  if (sessionKey) {
+    // Delete first so re-insertion moves the key to the end (freshest).
+    lastNotifiedFallback.delete(sessionKey);
+    lastNotifiedFallback.set(sessionKey, { model: usedKey, ts: now });
+    evictOldest();
+  }
+
+  // Build a concise reason from the first failed attempt
+  const primaryAttempt = attempts[0];
+  const reason = primaryAttempt?.reason ? ` (${primaryAttempt.reason})` : "";
+
+  return `⚡ Using fallback model \`${usedProvider}/${usedModel}\` — primary \`${primaryKey}\` is unavailable${reason}`;
+}

--- a/src/browser/navigation-guard.ts
+++ b/src/browser/navigation-guard.ts
@@ -29,6 +29,23 @@ export function withBrowserNavigationPolicy(
   return ssrfPolicy ? { ssrfPolicy } : {};
 }
 
+/**
+ * For loopback CDP profiles the browser already runs on the same host, so
+ * navigating to private/loopback addresses (e.g. http://localhost:3000) is
+ * legitimate and carries no SSRF risk.  Automatically merge
+ * `allowPrivateNetwork: true` into the policy when the profile is loopback.
+ */
+export function withLoopbackNavigationPolicy(
+  ssrfPolicy: SsrFPolicy | undefined,
+  cdpIsLoopback: boolean,
+): BrowserNavigationPolicyOptions {
+  if (!cdpIsLoopback) {
+    return withBrowserNavigationPolicy(ssrfPolicy);
+  }
+  const merged: SsrFPolicy = { ...ssrfPolicy, allowPrivateNetwork: true };
+  return { ssrfPolicy: merged };
+}
+
 export async function assertBrowserNavigationAllowed(
   opts: {
     url: string;

--- a/src/browser/paths.test.ts
+++ b/src/browser/paths.test.ts
@@ -244,6 +244,70 @@ describe("resolvePathWithinRoot", () => {
       expect(result.error).toContain("must stay within uploads directory");
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "accepts absolute paths through a symlinked parent directory (macOS /tmp scenario)",
+    async () => {
+      await withFixtureRoot(async ({ baseDir }) => {
+        const realDir = path.join(baseDir, "real");
+        const uploadsDir = path.join(realDir, "uploads");
+        await fs.mkdir(uploadsDir, { recursive: true });
+
+        const aliasLink = path.join(baseDir, "alias");
+        await fs.symlink(realDir, aliasLink);
+        const aliasedUploadsDir = path.join(aliasLink, "uploads");
+
+        await fs.writeFile(path.join(uploadsDir, "photo.jpg"), "img", "utf8");
+
+        // rootDir uses the symlink alias, requestedPath uses the real path
+        const result = resolvePathWithinRoot({
+          rootDir: aliasedUploadsDir,
+          requestedPath: path.join(uploadsDir, "photo.jpg"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.path).toBe(path.join(aliasedUploadsDir, "photo.jpg"));
+        }
+
+        // Vice-versa: rootDir uses the real path, requestedPath uses the alias
+        const result2 = resolvePathWithinRoot({
+          rootDir: uploadsDir,
+          requestedPath: path.join(aliasedUploadsDir, "photo.jpg"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result2.ok).toBe(true);
+        if (result2.ok) {
+          expect(result2.path).toBe(path.join(uploadsDir, "photo.jpg"));
+        }
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "still rejects paths outside root even when both go through symlinks",
+    async () => {
+      await withFixtureRoot(async ({ baseDir }) => {
+        const realDir = path.join(baseDir, "real");
+        const uploadsDir = path.join(realDir, "uploads");
+        const outsideDir = path.join(realDir, "outside");
+        await fs.mkdir(uploadsDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "secret.txt"), "nope", "utf8");
+
+        const aliasLink = path.join(baseDir, "alias");
+        await fs.symlink(realDir, aliasLink);
+        const aliasedUploadsDir = path.join(aliasLink, "uploads");
+
+        const result = resolvePathWithinRoot({
+          rootDir: aliasedUploadsDir,
+          requestedPath: path.join(realDir, "outside", "secret.txt"),
+          scopeLabel: "uploads directory",
+        });
+        expect(result.ok).toBe(false);
+      });
+    },
+  );
 });
 
 describe("resolveWritablePathWithinRoot", () => {

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot } from "../infra/fs-safe.js";
@@ -78,6 +79,33 @@ export function resolvePathWithinRoot(params: {
   const resolved = path.resolve(root, raw);
   const rel = path.relative(root, resolved);
   if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    // On macOS, /tmp is a symlink to /private/tmp. When the root and candidate
+    // use different aliases for the same directory, the lexical comparison fails
+    // even though they refer to the same location. Try canonicalizing both via
+    // realpathSync before giving up.
+    if (path.isAbsolute(raw)) {
+      try {
+        const rootReal = fsSync.realpathSync(root);
+        // Try resolving the full path first; fall back to resolving the parent
+        // directory and appending the filename so that non-existent files still
+        // pass validation (realpathSync requires the target to exist).
+        let resolvedReal: string;
+        try {
+          resolvedReal = fsSync.realpathSync(resolved);
+        } catch {
+          resolvedReal = path.join(
+            fsSync.realpathSync(path.dirname(resolved)),
+            path.basename(resolved),
+          );
+        }
+        const relReal = path.relative(rootReal, resolvedReal);
+        if (relReal && !relReal.startsWith("..") && !path.isAbsolute(relReal)) {
+          return { ok: true, path: path.join(root, relReal) };
+        }
+      } catch {
+        // realpathSync can fail if parent directories don't exist; fall through.
+      }
+    }
     return { ok: false, error: `Invalid path: must stay within ${params.scopeLabel}` };
   }
   return { ok: true, path: resolved };
@@ -200,7 +228,16 @@ async function resolveCheckedPathsWithinRoot(params: {
       return lexicalPathResult;
     }
     try {
-      const resolvedExistingPath = await fs.realpath(raw);
+      // Try resolving the full path; fall back to resolving the parent
+      // directory and appending the filename so that non-existent files
+      // (e.g. pending uploads) still pass validation when the root uses a
+      // symlink alias like /tmp vs /private/tmp on macOS.
+      let resolvedExistingPath: string;
+      try {
+        resolvedExistingPath = await fs.realpath(raw);
+      } catch {
+        resolvedExistingPath = path.join(await fs.realpath(path.dirname(raw)), path.basename(raw));
+      }
       const relativePath = path.relative(rootRealPath, resolvedExistingPath);
       if (!isInRoot(relativePath)) {
         return lexicalPathResult;

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_AI_SNAPSHOT_EFFICIENT_MAX_CHARS,
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
 } from "../constants.js";
-import { withBrowserNavigationPolicy } from "../navigation-guard.js";
+import { withLoopbackNavigationPolicy } from "../navigation-guard.js";
 import {
   DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
@@ -65,12 +65,15 @@ export function registerBrowserAgentSnapshotRoutes(
       ctx,
       targetId,
       feature: "navigate",
-      run: async ({ cdpUrl, tab, pw }) => {
+      run: async ({ cdpUrl, tab, pw, profileCtx }) => {
         const result = await pw.navigateViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
           url,
-          ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
+          ...withLoopbackNavigationPolicy(
+            ctx.state().resolved.ssrfPolicy,
+            profileCtx.profile.cdpIsLoopback,
+          ),
         });
         res.json({ ok: true, targetId: tab.targetId, ...result });
       },

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -19,7 +19,7 @@ import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
   InvalidBrowserNavigationUrlError,
-  withBrowserNavigationPolicy,
+  withLoopbackNavigationPolicy,
 } from "./navigation-guard.js";
 import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
@@ -137,7 +137,10 @@ function createProfileContext(
   };
 
   const openTab = async (url: string): Promise<BrowserTab> => {
-    const ssrfPolicyOpts = withBrowserNavigationPolicy(state().resolved.ssrfPolicy);
+    const ssrfPolicyOpts = withLoopbackNavigationPolicy(
+      state().resolved.ssrfPolicy,
+      profile.cdpIsLoopback,
+    );
 
     // For remote profiles, use Playwright's persistent connection to create tabs
     // This ensures the tab persists beyond a single request

--- a/src/canvas-host/a2ui.ts
+++ b/src/canvas-host/a2ui.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectMime } from "../media/mime.js";
-import { resolveFileWithinRoot } from "./file-resolver.js";
+import { mimeForCanvasFile, resolveFileWithinRoot } from "./file-resolver.js";
 
 export const A2UI_PATH = "/__openclaw__/a2ui";
 
@@ -180,11 +180,10 @@ export async function handleA2uiHttpRequest(
   }
 
   try {
-    const lower = result.realPath.toLowerCase();
-    const mime =
-      lower.endsWith(".html") || lower.endsWith(".htm")
-        ? "text/html"
-        : ((await detectMime({ filePath: result.realPath })) ?? "application/octet-stream");
+    const mime = mimeForCanvasFile(
+      result.realPath,
+      await detectMime({ filePath: result.realPath }),
+    );
     res.setHeader("Cache-Control", "no-store");
 
     if (req.method === "HEAD") {

--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -2,6 +2,39 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
+/** Extension-based MIME types for common web assets that content-sniffing misclassifies. */
+const WEB_ASSET_MIME: Record<string, string> = {
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".xml": "application/xml; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+};
+
+/**
+ * Resolve MIME type for a canvas/a2ui file path by extension first, falling
+ * back to the provided `fallback` callback (typically `detectMime`).
+ */
+export function mimeForCanvasFile(filePath: string, sniffed: string | undefined): string {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+    return "text/html";
+  }
+  const ext = path.extname(lower);
+  if (ext && WEB_ASSET_MIME[ext]) {
+    return WEB_ASSET_MIME[ext];
+  }
+  return sniffed ?? "application/octet-stream";
+}
+
 export function normalizeUrlPath(rawPath: string): string {
   const decoded = decodeURIComponent(rawPath || "/");
   const normalized = path.posix.normalize(decoded);

--- a/src/canvas-host/server.ts
+++ b/src/canvas-host/server.ts
@@ -17,7 +17,7 @@ import {
   handleA2uiHttpRequest,
   injectCanvasLiveReload,
 } from "./a2ui.js";
-import { normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
+import { mimeForCanvasFile, normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
 
 export type CanvasHostOpts = {
   runtime: RuntimeEnv;
@@ -352,11 +352,7 @@ export async function createCanvasHostHandler(
         await handle.close().catch(() => {});
       }
 
-      const lower = realPath.toLowerCase();
-      const mime =
-        lower.endsWith(".html") || lower.endsWith(".htm")
-          ? "text/html"
-          : ((await detectMime({ filePath: realPath })) ?? "application/octet-stream");
+      const mime = mimeForCanvasFile(realPath, await detectMime({ filePath: realPath }));
 
       res.setHeader("Cache-Control", "no-store");
       if (mime === "text/html") {

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -1,15 +1,24 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
+import { loadSessionStore } from "../config/sessions.js";
+import { recordInboundSession } from "./session.js";
 
 const recordSessionMetaFromInboundMock = vi.fn((_args?: unknown) => Promise.resolve(undefined));
 const updateLastRouteMock = vi.fn((_args?: unknown) => Promise.resolve(undefined));
 
-vi.mock("../config/sessions.js", () => ({
-  recordSessionMetaFromInbound: (args: unknown) => recordSessionMetaFromInboundMock(args),
-  updateLastRoute: (args: unknown) => updateLastRouteMock(args),
-}));
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    recordSessionMetaFromInbound: (args: unknown) => recordSessionMetaFromInboundMock(args),
+    updateLastRoute: (args: unknown) => updateLastRouteMock(args),
+  };
+});
 
-describe("recordInboundSession", () => {
+describe("recordInboundSession - session routing", () => {
   const ctx: MsgContext = {
     Provider: "telegram",
     From: "telegram:1234",
@@ -23,8 +32,6 @@ describe("recordInboundSession", () => {
   });
 
   it("does not pass ctx when updating a different session key", async () => {
-    const { recordInboundSession } = await import("./session.js");
-
     await recordInboundSession({
       storePath: "/tmp/openclaw-session-store.json",
       sessionKey: "agent:main:telegram:1234:thread:42",
@@ -50,8 +57,6 @@ describe("recordInboundSession", () => {
   });
 
   it("passes ctx when updating the same session key", async () => {
-    const { recordInboundSession } = await import("./session.js");
-
     await recordInboundSession({
       storePath: "/tmp/openclaw-session-store.json",
       sessionKey: "agent:main:telegram:1234:thread:42",
@@ -102,5 +107,120 @@ describe("recordInboundSession", () => {
         ctx,
       }),
     );
+  });
+});
+
+describe("recordInboundSession - webchat delivery context", () => {
+  let dir: string;
+  let storePath: string;
+
+  afterEach(async () => {
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("skips updateLastRoute when channel is webchat (internal)", async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-webchat-"));
+    storePath = path.join(dir, "sessions.json");
+
+    // Seed store with main session owned by telegram
+    const mainKey = "agent:main:main";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [mainKey]: {
+          sessionId: "sess-1",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "telegram:123",
+          lastAccountId: "default",
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:123",
+            accountId: "default",
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    // WebChat sends to main session
+    await recordInboundSession({
+      storePath,
+      sessionKey: mainKey,
+      ctx: {
+        Body: "hello from webchat",
+        SessionKey: mainKey,
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        ChatType: "direct",
+      },
+      updateLastRoute: {
+        sessionKey: mainKey,
+        channel: "webchat",
+        to: "",
+      },
+      onRecordError: () => {},
+    });
+
+    // Delivery context should still be telegram, not webchat
+    const store = loadSessionStore(storePath);
+    const entry = store[mainKey];
+    expect(entry?.lastChannel).toBe("telegram");
+    expect(entry?.deliveryContext?.channel).toBe("telegram");
+    expect(entry?.deliveryContext?.to).toBe("telegram:123");
+  });
+
+  it("updates lastRoute normally for external channels", async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-external-"));
+    storePath = path.join(dir, "sessions.json");
+
+    const mainKey = "agent:main:main";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [mainKey]: {
+          sessionId: "sess-1",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo: "telegram:123",
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:123",
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    // Discord sends to main session
+    await recordInboundSession({
+      storePath,
+      sessionKey: mainKey,
+      ctx: {
+        Body: "hello from discord",
+        SessionKey: mainKey,
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        ChatType: "group",
+      },
+      updateLastRoute: {
+        sessionKey: mainKey,
+        channel: "discord",
+        to: "channel:discord-456",
+        accountId: "bot-1",
+      },
+      onRecordError: () => {},
+    });
+
+    // Delivery context should now be discord
+    const store = loadSessionStore(storePath);
+    const entry = store[mainKey];
+    expect(entry?.lastChannel).toBe("discord");
+    expect(entry?.deliveryContext?.channel).toBe("discord");
+    expect(entry?.deliveryContext?.to).toBe("channel:discord-456");
   });
 });

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -100,6 +100,7 @@ describe("doctor config flow", () => {
       mode: "token",
       token: "ok",
     });
+    expect(result.shouldWriteConfig).toBe(true);
   });
 
   it("preserves discord streaming intent while stripping unsupported keys on repair", async () => {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -44,13 +44,13 @@ export type ModelDefinitionConfig = {
 };
 
 export type ModelProviderConfig = {
-  baseUrl: string;
+  baseUrl?: string;
   apiKey?: SecretInput;
   auth?: ModelProviderAuthMode;
   api?: ModelApi;
   headers?: Record<string, string>;
   authHeader?: boolean;
-  models: ModelDefinitionConfig[];
+  models?: ModelDefinitionConfig[];
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -305,6 +305,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const FirecrawlConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional().register(sensitive),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -314,6 +326,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: FirecrawlConfigSchema,
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -233,7 +233,7 @@ export const ModelDefinitionSchema = z
 
 export const ModelProviderSchema = z
   .object({
-    baseUrl: z.string().min(1),
+    baseUrl: z.string().min(1).optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
       .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
@@ -241,7 +241,7 @@ export const ModelProviderSchema = z
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
-    models: z.array(ModelDefinitionSchema),
+    models: z.array(ModelDefinitionSchema).optional(),
   })
   .strict();
 

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CHAT_CHANNEL } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { telegramPlugin } from "../../../extensions/telegram/src/channel.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 
 vi.mock("../../config/sessions.js", () => ({
-  loadSessionStore: vi.fn().mockReturnValue({}),
-  resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:test:main"),
-  resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
+  loadSessionStore: vi.fn(),
+  resolveAgentMainSessionKey: vi.fn(() => "agent:main:main"),
+  resolveStorePath: vi.fn(() => "/tmp/session-store.json"),
 }));
 
 vi.mock("../../infra/outbound/channel-selection.js", () => ({
@@ -44,7 +48,7 @@ const DEFAULT_TARGET = {
 type SessionStore = ReturnType<typeof loadSessionStore>;
 
 function setMainSessionEntry(entry?: SessionStore[string]) {
-  const store = entry ? ({ "agent:test:main": entry } as SessionStore) : ({} as SessionStore);
+  const store = entry ? ({ "agent:main:main": entry } as SessionStore) : ({} as SessionStore);
   vi.mocked(loadSessionStore).mockReturnValue(store);
 }
 
@@ -71,6 +75,12 @@ async function resolveForAgent(params: {
 }
 
 describe("resolveDeliveryTarget", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", plugin: telegramPlugin, source: "test" }]),
+    );
+  });
+
   it("reroutes implicit whatsapp delivery to authorized allowFrom recipient", async () => {
     setMainSessionEntry({
       sessionId: "sess-w1",
@@ -333,5 +343,28 @@ describe("resolveDeliveryTarget", () => {
 
     expect(result.ok).toBe(true);
     expect(result.accountId).toBe("explicit");
+  });
+
+  it("keeps telegram topic thread ids for explicit announce targets", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-1001111111111:topic:999",
+        lastThreadId: 999,
+      },
+    });
+
+    const resolved = await resolveDeliveryTarget({} as OpenClawConfig, "main", {
+      channel: "telegram",
+      to: "-1001234567890:topic:123",
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-1001234567890:topic:123");
+    expect(resolved.threadId).toBe(123);
+  });
+});
   });
 });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -14,6 +14,7 @@ import {
 import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { parseTelegramTarget } from "../../telegram/targets.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
 import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
@@ -100,6 +101,10 @@ export async function resolveDeliveryTarget(
   const channel = resolved.channel ?? fallbackChannel;
   const mode = resolved.mode as "explicit" | "implicit";
   let toCandidate = resolved.to;
+  const threadIdFromTarget =
+    channel === "telegram" && toCandidate
+      ? parseTelegramTarget(toCandidate).messageThreadId
+      : undefined;
 
   // When the session has no lastAccountId (e.g. first-run isolated cron
   // session), fall back to the agent's bound account from bindings config.
@@ -125,10 +130,11 @@ export async function resolveDeliveryTarget(
   // Session-derived threadIds are dropped when the target differs to prevent
   // stale thread IDs from leaking to a different chat.
   const threadId =
-    resolved.threadId &&
+    threadIdFromTarget ??
+    (resolved.threadId &&
     (resolved.threadIdExplicit || (resolved.to && resolved.to === resolved.lastTo))
       ? resolved.threadId
-      : undefined;
+      : undefined);
 
   if (!channel) {
     return {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -123,12 +123,19 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
+/**
+ * Known non-gateway openclaw service names that should NOT be flagged
+ * as duplicate gateway instances by the doctor command.
+ */
+const KNOWN_NON_GATEWAY_LAUNCHD_LABELS = new Set(["ai.openclaw.browser", "ai.openclaw.node"]);
+const KNOWN_NON_GATEWAY_SYSTEMD_NAMES = new Set(["openclaw-browser", "openclaw-node"]);
+
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  return label === resolveGatewayLaunchAgentLabel() || KNOWN_NON_GATEWAY_LAUNCHD_LABELS.has(label);
 }
 
 function isIgnoredSystemdName(name: string): boolean {
-  return name === resolveGatewaySystemdServiceName();
+  return name === resolveGatewaySystemdServiceName() || KNOWN_NON_GATEWAY_SYSTEMD_NAMES.has(name);
 }
 
 function isLegacyLabel(label: string): boolean {

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -59,10 +59,10 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
-    // KillMode=process ensures systemd only waits for the main process to exit.
-    // Without this, podman's conmon (container monitor) processes block shutdown
-    // since they run as children of the gateway and stay in the same cgroup.
-    "KillMode=process",
+    // Use KillMode=mixed so the main process gets SIGTERM for graceful shutdown
+    // while all remaining child processes (e.g. Chrome/Playwright) are cleaned up
+    // via SIGKILL after TimeoutStopSec, preventing orphan process accumulation.
+    "KillMode=mixed",
     workingDirLine,
     ...envLines,
     "",

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -63,6 +63,10 @@ export function buildSystemdUnit({
     // while all remaining child processes (e.g. Chrome/Playwright) are cleaned up
     // via SIGKILL after TimeoutStopSec, preventing orphan process accumulation.
     "KillMode=mixed",
+    // TimeoutStopSec bounds the worst-case shutdown time for container runtimes
+    // (podman/conmon). Without this, container processes may delay shutdown
+    // indefinitely waiting for container cleanup that may never complete.
+    "TimeoutStopSec=30",
     workingDirLine,
     ...envLines,
     "",

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -155,6 +155,8 @@ type OpusDecoder = {
 let warnedOpusFallback = false;
 
 function createOpusDecoder(): { decoder: OpusDecoder; name: string } | null {
+  // @discordjs/opus is the preferred native decoder but may not be available
+  // on all platforms (e.g. arm64). Falls back to the pure-JS opusscript.
   try {
     const { OpusEncoder } = require("@discordjs/opus") as {
       OpusEncoder: new (sampleRate: number, channels: number) => OpusDecoder;

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1,8 +1,9 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import type { IncomingMessage } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "./control-ui-contract.js";
 import { handleControlUiAvatarRequest, handleControlUiHttpRequest } from "./control-ui.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
@@ -373,5 +374,99 @@ describe("handleControlUiHttpRequest", () => {
         expectNotFoundResponse({ handled, res, end });
       },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleControlUiHttpRequest – SPA fallback vs /api/* routes
+// ---------------------------------------------------------------------------
+
+function mockReq(method: string, url: string): IncomingMessage {
+  return { method, url, headers: {} } as unknown as IncomingMessage;
+}
+
+function mockRes2(): ServerResponse & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: string;
+} {
+  const res = {
+    _status: 200,
+    _headers: {} as Record<string, string>,
+    _body: "",
+    set statusCode(v: number) {
+      this._status = v;
+    },
+    get statusCode() {
+      return this._status;
+    },
+    setHeader(k: string, v: string) {
+      this._headers[k.toLowerCase()] = v;
+    },
+    end(body?: string | Buffer) {
+      if (body != null) this._body = typeof body === "string" ? body : body.toString("utf8");
+    },
+  } as unknown as ServerResponse & {
+    _status: number;
+    _headers: Record<string, string>;
+    _body: string;
+  };
+  return res;
+}
+
+describe("handleControlUiHttpRequest – /api/ exclusion", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-cui-test-"));
+    fsSync.writeFileSync(path.join(tmpDir, "index.html"), "<html><body>SPA</body></html>", "utf8");
+  });
+
+  afterAll(() => {
+    fsSync.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const rootState = () => ({ kind: "resolved" as const, path: tmpDir });
+
+  it("serves SPA fallback for normal unknown routes", () => {
+    const req = mockReq("GET", "/some/page");
+    const res = mockRes2();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+    expect(res._headers["content-type"]).toContain("text/html");
+    expect(res._body).toContain("SPA");
+  });
+
+  it("returns JSON 404 for /api/ routes instead of SPA fallback", () => {
+    const req = mockReq("GET", "/api/some-endpoint");
+    const res = mockRes2();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api (no trailing slash)", () => {
+    const req = mockReq("GET", "/api");
+    const res = mockRes2();
+    const handled = handleControlUiHttpRequest(req, res, { root: rootState() });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
+  });
+
+  it("returns JSON 404 for /api/ routes under a basePath", () => {
+    const req = mockReq("GET", "/ui/api/foo");
+    const res = mockRes2();
+    const handled = handleControlUiHttpRequest(req, res, {
+      basePath: "/ui",
+      root: rootState(),
+    });
+    expect(handled).toBe(true);
+    expect(res._status).toBe(404);
+    expect(res._headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(res._body)).toEqual({ error: "Not found" });
   });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -437,6 +437,13 @@ export function handleControlUiHttpRequest(
     }
   }
 
+  // API routes should never fall through to the SPA fallback – return a proper
+  // JSON 404 so callers don't receive HTML when they expect JSON.
+  if (uiPath === "/api" || uiPath.startsWith("/api/")) {
+    sendJson(res, 404, { error: "Not found" });
+    return true;
+  }
+
   // If the requested path looks like a static asset (known extension), return
   // 404 rather than falling through to the SPA index.html fallback.  We check
   // against the same set of extensions that contentTypeForExt() recognises so

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -485,7 +485,7 @@ export async function handleOpenResponsesHttpRequest(
             {
               type: "function_call",
               id: functionCallItemId,
-              call_id: functionCall.id,
+              call_id: functionCall.id.slice(0, 64),
               name: functionCall.name,
               arguments: functionCall.arguments,
             },
@@ -754,7 +754,7 @@ export async function handleOpenResponsesHttpRequest(
           const functionCallItem = {
             type: "function_call" as const,
             id: functionCallItemId,
-            call_id: functionCall.id,
+            call_id: functionCall.id.slice(0, 64),
             name: functionCall.name,
             arguments: functionCall.arguments,
           };

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -233,6 +233,14 @@ function createAssistantOutputItem(params: {
   };
 }
 
+function normalizeFunctionCallId(id: unknown): string {
+  const raw = typeof id === "string" ? id.trim() : "";
+  if (raw) {
+    return raw.slice(0, 64);
+  }
+  return `call_${randomUUID()}`.slice(0, 64);
+}
+
 async function runResponsesAgentCommand(params: {
   message: string;
   images: ImageContent[];
@@ -485,7 +493,7 @@ export async function handleOpenResponsesHttpRequest(
             {
               type: "function_call",
               id: functionCallItemId,
-              call_id: functionCall.id.slice(0, 64),
+              call_id: normalizeFunctionCallId(functionCall.id),
               name: functionCall.name,
               arguments: functionCall.arguments,
             },
@@ -754,7 +762,7 @@ export async function handleOpenResponsesHttpRequest(
           const functionCallItem = {
             type: "function_call" as const,
             id: functionCallItemId,
-            call_id: functionCall.id.slice(0, 64),
+            call_id: normalizeFunctionCallId(functionCall.id),
             name: functionCall.name,
             arguments: functionCall.arguments,
           };

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -19,6 +19,7 @@ import { loadConfig } from "../config/config.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import { handleSlackHttpRequest } from "../slack/http/index.js";
+import { handleTelegramHttpRequest } from "../telegram/http/index.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH,
   createAuthRateLimiter,
@@ -525,6 +526,9 @@ export function createGatewayHttpServer(opts: {
         return;
       }
       if (await handleSlackHttpRequest(req, res)) {
+        return;
+      }
+      if (await handleTelegramHttpRequest(req, res)) {
         return;
       }
       if (handlePluginRequest) {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -516,7 +516,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event" });
+      requestHeartbeatNow({ reason: "exec-event", sessionKey });
       return;
     }
     case "push.apns.register": {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -33,7 +33,12 @@ import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
-import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
+import { formatDoctorNonInteractiveHint, writeRestartSentinel } from "../infra/restart-sentinel.js";
+import {
+  scheduleGatewaySigusr1Restart,
+  setGatewaySigusr1RestartPolicy,
+  setPreRestartDeferralCheck,
+} from "../infra/restart.js";
 import {
   primeRemoteSkillsCache,
   refreshRemoteBinsForConnectedNodes,
@@ -592,6 +597,16 @@ export async function startGatewayServer(
           const latest = loadConfig();
           void refreshRemoteBinsForConnectedNodes(latest);
         }, skillsRefreshDelayMs);
+        // Trigger gateway restart so new/changed skills take effect immediately.
+        void writeRestartSentinel({
+          kind: "skills-change",
+          status: "ok",
+          ts: Date.now(),
+          message: event.changedPath ? `Skill changed: ${event.changedPath}` : "Skills changed",
+          doctorHint: formatDoctorNonInteractiveHint(),
+          stats: { mode: "skills.change", reason: event.reason },
+        }).catch(() => {});
+        scheduleGatewaySigusr1Restart({ reason: "skills.change" });
       });
 
   const noopInterval = () => setInterval(() => {}, 1 << 30);

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -29,7 +29,7 @@ export function createGatewayHooksRequestHandler(params: {
     const sessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, { sessionKey });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake" });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
     }
   };
 
@@ -85,7 +85,7 @@ export function createGatewayHooksRequestHandler(params: {
             sessionKey: mainSessionKey,
           });
           if (value.wakeMode === "now") {
-            requestHeartbeatNow({ reason: `hook:${jobId}` });
+            requestHeartbeatNow({ reason: `hook:${jobId}`, sessionKey: mainSessionKey });
           }
         }
       } catch (err) {
@@ -94,7 +94,7 @@ export function createGatewayHooksRequestHandler(params: {
           sessionKey: mainSessionKey,
         });
         if (value.wakeMode === "now") {
-          requestHeartbeatNow({ reason: `hook:${jobId}:error` });
+          requestHeartbeatNow({ reason: `hook:${jobId}:error`, sessionKey: mainSessionKey });
         }
       }
     })();

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -13,10 +13,6 @@ import type {
   DeliverableMessageChannel,
   GatewayMessageChannel,
 } from "../../utils/message-channel.js";
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
-import { formatCliCommand } from "../../cli/command-format.js";
-import { normalizeAccountId } from "../../routing/session-key.js";
-import { parseTelegramTarget } from "../../telegram/targets.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
@@ -156,7 +152,6 @@ export function resolveSessionDeliveryTarget(params: {
   const threadIdFromTarget =
     channel === "telegram" && to ? parseTelegramTarget(to).messageThreadId : undefined;
 
-  const resolvedThreadId = explicitThreadId ?? threadId;
   return {
     channel,
     to,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -13,6 +13,10 @@ import type {
   DeliverableMessageChannel,
   GatewayMessageChannel,
 } from "../../utils/message-channel.js";
+import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { formatCliCommand } from "../../cli/command-format.js";
+import { normalizeAccountId } from "../../routing/session-key.js";
+import { parseTelegramTarget } from "../../telegram/targets.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
@@ -146,18 +150,19 @@ export function resolveSessionDeliveryTarget(params: {
     }
   }
 
-  const mode = params.mode ?? (explicitTo ? "explicit" : "implicit");
   const accountId = channel && channel === lastChannel ? lastAccountId : undefined;
   const threadId =
     mode !== "heartbeat" && channel && channel === lastChannel ? lastThreadId : undefined;
+  const threadIdFromTarget =
+    channel === "telegram" && to ? parseTelegramTarget(to).messageThreadId : undefined;
 
   const resolvedThreadId = explicitThreadId ?? threadId;
   return {
     channel,
     to,
     accountId,
-    threadId: resolvedThreadId,
-    threadIdExplicit: resolvedThreadId != null && explicitThreadId != null,
+    threadId: explicitThreadId ?? threadIdFromTarget ?? threadId,
+    threadIdExplicit: (explicitThreadId ?? threadIdFromTarget) != null,
     mode,
     lastChannel,
     lastTo,

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -28,7 +28,7 @@ export type RestartSentinelStats = {
 };
 
 export type RestartSentinelPayload = {
-  kind: "config-apply" | "config-patch" | "update" | "restart";
+  kind: "config-apply" | "config-patch" | "update" | "restart" | "skills-install" | "skills-change";
   status: "ok" | "error" | "skipped";
   ts: number;
   sessionKey?: string;

--- a/src/logging/logger.recursion-guard.test.ts
+++ b/src/logging/logger.recursion-guard.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { enableConsoleCapture } from "./console.js";
+import { resetLogger, setLoggerOverride } from "./logger.js";
+import { loggingState } from "./state.js";
+
+type ConsoleSnapshot = {
+  log: typeof console.log;
+  info: typeof console.info;
+  warn: typeof console.warn;
+  error: typeof console.error;
+  debug: typeof console.debug;
+  trace: typeof console.trace;
+};
+
+let snapshot: ConsoleSnapshot;
+let originalConfigPath: string | undefined;
+
+beforeEach(() => {
+  snapshot = {
+    log: console.log,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    trace: console.trace,
+  };
+  originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  loggingState.consolePatched = false;
+  loggingState.forceConsoleToStderr = false;
+  loggingState.consoleTimestampPrefix = false;
+  loggingState.rawConsole = null;
+  resetLogger();
+});
+
+afterEach(() => {
+  console.log = snapshot.log;
+  console.info = snapshot.info;
+  console.warn = snapshot.warn;
+  console.error = snapshot.error;
+  console.debug = snapshot.debug;
+  console.trace = snapshot.trace;
+  loggingState.consolePatched = false;
+  loggingState.forceConsoleToStderr = false;
+  loggingState.consoleTimestampPrefix = false;
+  loggingState.rawConsole = null;
+  resetLogger();
+  setLoggerOverride(null);
+  if (originalConfigPath === undefined) {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  } else {
+    process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+  }
+});
+
+describe("logger recursion guard", () => {
+  it("avoids recursive stack overflow when config loading fails under console capture", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-recursion-"));
+    try {
+      const configPath = path.join(tmpDir, "openclaw.json");
+
+      // Circular include: guaranteed config load failure for exercising error path.
+      await writeFile(configPath, `{ "$include": "./openclaw.json" }\n`, "utf-8");
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+      enableConsoleCapture();
+
+      expect(() => console.error("trigger config load")).not.toThrow();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -4,7 +4,11 @@ import { CHAT_CHANNEL_ORDER } from "../channels/registry.js";
 import { isVerbose } from "../globals.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { clearActiveProgressLine } from "../terminal/progress-line.js";
-import { getConsoleSettings, shouldLogSubsystemToConsole } from "./console.js";
+import {
+  formatConsoleTimestamp,
+  getConsoleSettings,
+  shouldLogSubsystemToConsole,
+} from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
@@ -209,10 +213,11 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      // Use local time (getHours/getMinutes/getSeconds) instead of UTC via toISOString()
+      return color.gray(formatConsoleTimestamp("pretty"));
     }
     if (loggingState.consoleTimestampPrefix) {
-      return color.gray(new Date().toISOString());
+      return color.gray(formatConsoleTimestamp(opts.style));
     }
     return "";
   })();

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -330,6 +330,50 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Audio]\nTranscript:\nremote transcript");
   });
 
+  it("skips URL-only audio when remote file is too small", async () => {
+    const { applyMediaUnderstanding } = await loadApply();
+    // Override the default mock to return a tiny buffer (below MIN_AUDIO_FILE_BYTES)
+    mockedFetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.alloc(100),
+      contentType: "audio/ogg",
+      fileName: "tiny.ogg",
+    });
+
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      MediaUrl: "https://example.com/tiny.ogg",
+      MediaType: "audio/ogg",
+      ChatType: "dm",
+    };
+    const transcribeAudio = vi.fn(async () => ({ text: "should-not-run" }));
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            maxBytes: 1024 * 1024,
+            scope: {
+              default: "deny",
+              rules: [{ action: "allow", match: { chatType: "direct" } }],
+            },
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {
+        groq: { id: "groq", transcribeAudio },
+      },
+    });
+
+    expect(transcribeAudio).not.toHaveBeenCalled();
+    expect(result.appliedAudio).toBe(false);
+  });
+
   it("skips audio transcription when attachment exceeds maxBytes", async () => {
     const ctx = await createAudioCtx({
       fileName: "large.wav",

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -58,3 +58,10 @@ export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
 };
 export const CLI_OUTPUT_MAX_BUFFER = 5 * MB;
 export const DEFAULT_MEDIA_CONCURRENCY = 2;
+
+/**
+ * Minimum audio file size in bytes below which transcription is skipped.
+ * Files smaller than this threshold are almost certainly empty or corrupt
+ * and would cause unhelpful API errors from Whisper/transcription providers.
+ */
+export const MIN_AUDIO_FILE_BYTES = 1024;

--- a/src/media-understanding/errors.ts
+++ b/src/media-understanding/errors.ts
@@ -1,4 +1,9 @@
-export type MediaUnderstandingSkipReason = "maxBytes" | "timeout" | "unsupported" | "empty";
+export type MediaUnderstandingSkipReason =
+  | "maxBytes"
+  | "timeout"
+  | "unsupported"
+  | "empty"
+  | "tooSmall";
 
 export class MediaUnderstandingSkipError extends Error {
   readonly reason: MediaUnderstandingSkipReason;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -36,7 +36,7 @@ const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
  * Normalize legacy single-brace placeholders to standard double-brace format.
  * Supports case-insensitive matching for convenience.
  */
-function normalizePlaceholders(value: string): string {
+export function normalizePlaceholders(value: string): string {
   let result = value;
   for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
     const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -20,6 +20,7 @@ import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
   DEFAULT_TIMEOUT_SECONDS,
+  MIN_AUDIO_FILE_BYTES,
 } from "./defaults.js";
 import { MediaUnderstandingSkipError } from "./errors.js";
 import { fileExists } from "./fs.js";
@@ -451,6 +452,12 @@ export async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
+    if (media.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${media.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
     const { apiKeys, baseUrl, headers } = await resolveProviderExecutionContext({
       providerId,
       cfg,
@@ -566,6 +573,15 @@ export async function runCliEntry(params: {
     maxBytes,
     timeoutMs,
   });
+  if (capability === "audio") {
+    const stat = await fs.stat(pathResult.path);
+    if (stat.size < MIN_AUDIO_FILE_BYTES) {
+      throw new MediaUnderstandingSkipError(
+        "tooSmall",
+        `Audio attachment ${params.attachmentIndex + 1} is too small (${stat.size} bytes, minimum ${MIN_AUDIO_FILE_BYTES})`,
+      );
+    }
+  }
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
   );

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -54,11 +54,18 @@ const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
 /**
  * Normalize legacy single-brace placeholders to standard double-brace format.
  * Supports case-insensitive matching for convenience.
+ * Uses negative lookbehind/lookahead to avoid corrupting already-correct double-braced placeholders.
  */
 export function normalizePlaceholders(value: string): string {
   let result = value;
   for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
-    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    // Extract the placeholder name (without braces) for the regex
+    const placeholderName = legacy.slice(1, -1);
+    // Use negative lookbehind/lookahead to avoid matching inside {{Placeholder}}
+    // (?<!\{) = not preceded by {
+    // \{...\} = match the literal placeholder with single braces
+    // (?!\}) = not followed by }
+    const pattern = new RegExp(`(?<!\\{)\\{${placeholderName}\\}(?!\\})`, "gi");
     result = result.replace(pattern, standard);
   }
   return result;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -16,6 +16,25 @@ import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+import {
+  CLI_OUTPUT_MAX_BUFFER,
+  DEFAULT_AUDIO_MODELS,
+  DEFAULT_TIMEOUT_SECONDS,
+} from "./defaults.js";
+import { MediaUnderstandingSkipError } from "./errors.js";
+import { fileExists } from "./fs.js";
+import { extractGeminiResponse } from "./output-extract.js";
+import { describeImageWithModel } from "./providers/image.js";
+import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
+import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingModelDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 /**
  * Legacy placeholder aliases for CLI args.
@@ -44,25 +63,6 @@ export function normalizePlaceholders(value: string): string {
   }
   return result;
 }
-import {
-  CLI_OUTPUT_MAX_BUFFER,
-  DEFAULT_AUDIO_MODELS,
-  DEFAULT_TIMEOUT_SECONDS,
-} from "./defaults.js";
-import { MediaUnderstandingSkipError } from "./errors.js";
-import { fileExists } from "./fs.js";
-import { extractGeminiResponse } from "./output-extract.js";
-import { describeImageWithModel } from "./providers/image.js";
-import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./providers/index.js";
-import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
-import type {
-  MediaUnderstandingCapability,
-  MediaUnderstandingDecision,
-  MediaUnderstandingModelDecision,
-  MediaUnderstandingOutput,
-  MediaUnderstandingProvider,
-} from "./types.js";
-import { estimateBase64Size, resolveVideoMaxBase64Bytes } from "./video.js";
 
 export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -16,6 +16,34 @@ import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runExec } from "../process/exec.js";
 import { MediaAttachmentCache } from "./attachments.js";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
 import {
   CLI_OUTPUT_MAX_BUFFER,
   DEFAULT_AUDIO_MODELS,
@@ -582,7 +610,7 @@ export async function runCliEntry(params: {
     MaxChars: maxChars,
   };
   const argv = [command, ...args].map((part, index) =>
-    index === 0 ? part : applyTemplate(part, templCtx),
+    index === 0 ? part : applyTemplate(normalizePlaceholders(part), templCtx),
   );
   try {
     if (shouldLogVerbose()) {

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,33 +1,5 @@
 import { describe, it, expect } from "vitest";
-
-/**
- * Legacy placeholder aliases for CLI args.
- * Maps intuitive single-brace placeholders to standard double-brace format.
- */
-const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
-  "{file}": "{{MediaPath}}",
-  "{input}": "{{MediaPath}}",
-  "{media}": "{{MediaPath}}",
-  "{output}": "{{OutputDir}}",
-  "{output_dir}": "{{OutputDir}}",
-  "{output_base}": "{{OutputBase}}",
-  "{prompt}": "{{Prompt}}",
-  "{media_dir}": "{{MediaDir}}",
-};
-
-/**
- * Normalize legacy single-brace placeholders to standard double-brace format.
- * Supports case-insensitive matching for convenience.
- */
-function normalizePlaceholders(value: string): string {
-  let result = value;
-  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
-    // Case-insensitive replacement
-    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
-    result = result.replace(pattern, standard);
-  }
-  return result;
-}
+import { normalizePlaceholders } from "./runner.entries.js";
 
 describe("normalizePlaceholders", () => {
   it("should convert {file} to {{MediaPath}}", () => {

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Legacy placeholder aliases for CLI args.
+ * Maps intuitive single-brace placeholders to standard double-brace format.
+ */
+const LEGACY_PLACEHOLDER_MAP: Record<string, string> = {
+  "{file}": "{{MediaPath}}",
+  "{input}": "{{MediaPath}}",
+  "{media}": "{{MediaPath}}",
+  "{output}": "{{OutputDir}}",
+  "{output_dir}": "{{OutputDir}}",
+  "{output_base}": "{{OutputBase}}",
+  "{prompt}": "{{Prompt}}",
+  "{media_dir}": "{{MediaDir}}",
+};
+
+/**
+ * Normalize legacy single-brace placeholders to standard double-brace format.
+ * Supports case-insensitive matching for convenience.
+ */
+function normalizePlaceholders(value: string): string {
+  let result = value;
+  for (const [legacy, standard] of Object.entries(LEGACY_PLACEHOLDER_MAP)) {
+    // Case-insensitive replacement
+    const pattern = new RegExp(legacy.replace(/[{}]/g, "\\$&"), "gi");
+    result = result.replace(pattern, standard);
+  }
+  return result;
+}
+
+describe("normalizePlaceholders", () => {
+  it("should convert {file} to {{MediaPath}}", () => {
+    expect(normalizePlaceholders("{file}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {FILE} case-insensitively", () => {
+    expect(normalizePlaceholders("{FILE}")).toBe("{{MediaPath}}");
+  });
+
+  it("should convert {File} mixed case", () => {
+    expect(normalizePlaceholders("{File}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {input} as MediaPath alias", () => {
+    expect(normalizePlaceholders("{input}")).toBe("{{MediaPath}}");
+  });
+
+  it("should handle {output} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {output_dir} as OutputDir alias", () => {
+    expect(normalizePlaceholders("{output_dir}")).toBe("{{OutputDir}}");
+  });
+
+  it("should handle {prompt} as Prompt alias", () => {
+    expect(normalizePlaceholders("{prompt}")).toBe("{{Prompt}}");
+  });
+
+  it("should preserve already-correct {{MediaPath}} format", () => {
+    expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
+  });
+
+  it("should work with mixed content", () => {
+    const input = "--input {file} --output {output}";
+    const expected = "--input {{MediaPath}} --output {{OutputDir}}";
+    expect(normalizePlaceholders(input)).toBe(expected);
+  });
+
+  it("should handle real whisper CLI args", () => {
+    const args = ["{file}", "--model", "large-v3-turbo", "--output_dir", "/tmp"];
+    const normalized = args.map(normalizePlaceholders);
+    expect(normalized[0]).toBe("{{MediaPath}}");
+    expect(normalized[1]).toBe("--model");
+    expect(normalized[2]).toBe("large-v3-turbo");
+  });
+
+  it("should not modify unrelated content", () => {
+    expect(normalizePlaceholders("--model turbo")).toBe("--model turbo");
+    expect(normalizePlaceholders("/path/to/file.txt")).toBe("/path/to/file.txt");
+  });
+});

--- a/src/media-understanding/runner.placeholders.test.ts
+++ b/src/media-understanding/runner.placeholders.test.ts
@@ -34,6 +34,10 @@ describe("normalizePlaceholders", () => {
     expect(normalizePlaceholders("{{MediaPath}}")).toBe("{{MediaPath}}");
   });
 
+  it("should preserve already-correct {{Prompt}} format (critical regression test)", () => {
+    expect(normalizePlaceholders("{{Prompt}}")).toBe("{{Prompt}}");
+  });
+
   it("should work with mixed content", () => {
     const input = "--input {file} --output {output}";
     const expected = "--input {{MediaPath}} --output {{OutputDir}}";

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { MIN_AUDIO_FILE_BYTES } from "./defaults.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  runCapability,
+} from "./runner.js";
+
+describe("runCapability skips tiny audio files", () => {
+  it("skips audio transcription when file is smaller than MIN_AUDIO_FILE_BYTES", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    // Create a tiny audio file (well below the 1KB threshold)
+    const tmpPath = path.join(os.tmpdir(), `openclaw-tiny-audio-${Date.now()}.wav`);
+    const tinyBuffer = Buffer.alloc(100); // 100 bytes, way below 1024
+    await fs.writeFile(tmpPath, tinyBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "should not happen", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      // The provider should never be called
+      expect(transcribeCalled).toBe(false);
+
+      // The result should indicate the attachment was skipped
+      expect(result.outputs).toHaveLength(0);
+      expect(result.decision.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
+      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("skips audio transcription for empty (0-byte) files", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-empty-audio-${Date.now()}.ogg`);
+    await fs.writeFile(tmpPath, Buffer.alloc(0));
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/ogg" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async () => {
+          transcribeCalled = true;
+          return { text: "nope", model: "whisper-1" };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(false);
+      expect(result.outputs).toHaveLength(0);
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("proceeds with transcription when file meets minimum size", async () => {
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/bin";
+
+    const tmpPath = path.join(os.tmpdir(), `openclaw-ok-audio-${Date.now()}.wav`);
+    const okBuffer = Buffer.alloc(MIN_AUDIO_FILE_BYTES + 100);
+    await fs.writeFile(tmpPath, okBuffer);
+
+    const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };
+    const media = normalizeMediaAttachments(ctx);
+    const cache = createMediaAttachmentCache(media);
+
+    let transcribeCalled = false;
+    const providerRegistry = buildProviderRegistry({
+      openai: {
+        id: "openai",
+        capabilities: ["audio"],
+        transcribeAudio: async (req) => {
+          transcribeCalled = true;
+          return { text: "hello world", model: req.model };
+        },
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: "test-key",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    try {
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(transcribeCalled).toBe(true);
+      expect(result.outputs).toHaveLength(1);
+      expect(result.outputs[0]?.text).toBe("hello world");
+      expect(result.decision.outcome).toBe("success");
+    } finally {
+      process.env.PATH = originalPath;
+      await cache.cleanup();
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+});

--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -65,8 +65,10 @@ describe("runCapability skips tiny audio files", () => {
       // The result should indicate the attachment was skipped
       expect(result.outputs).toHaveLength(0);
       expect(result.decision.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.outcome).toBe("skipped");
-      expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain("tooSmall");
+      expect(result.decision.attachments).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts).toHaveLength(1);
+      expect(result.decision.attachments[0].attempts[0].outcome).toBe("skipped");
+      expect(result.decision.attachments[0].attempts[0].reason).toContain("tooSmall");
     } finally {
       process.env.PATH = originalPath;
       await cache.cleanup();

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -323,9 +323,27 @@ function resolvePackageEntrySource(params: {
   packageDir: string;
   entryPath: string;
   sourceLabel: string;
+  origin?: PluginOrigin;
   diagnostics: PluginDiagnostic[];
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
+  // Bundled extensions are trusted — skip boundary file open which fails
+  // when .ts source files referenced in package.json don't exist in the
+  // published npm package (only compiled .js exists).
+  if (params.origin === "bundled") {
+    // Simple lexical containment check for bundled entries
+    const real = path.resolve(source);
+    const root = path.resolve(params.packageDir);
+    if (!real.startsWith(root + path.sep) && real !== root) {
+      params.diagnostics.push({
+        level: "error",
+        message: `extension entry escapes package directory: ${params.entryPath}`,
+        source: params.sourceLabel,
+      });
+      return null;
+    }
+    return source;
+  }
   const opened = openBoundaryFileSync({
     absolutePath: source,
     rootPath: params.packageDir,
@@ -402,6 +420,7 @@ function discoverInDirectory(params: {
           packageDir: fullPath,
           entryPath: extPath,
           sourceLabel: fullPath,
+          origin: params.origin,
           diagnostics: params.diagnostics,
         });
         if (!resolved) {
@@ -503,6 +522,7 @@ function discoverFromPath(params: {
           packageDir: resolved,
           entryPath: extPath,
           sourceLabel: resolved,
+          origin: params.origin,
           diagnostics: params.diagnostics,
         });
         if (!source) {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -58,7 +58,10 @@ export async function runExec(
           encoding: "utf8" as const,
         };
   try {
-    const { stdout, stderr } = await execFileAsync(resolveCommand(command), args, options);
+    const { stdout, stderr } = await execFileAsync(resolveCommand(command), args, {
+      ...options,
+      windowsHide: true,
+    });
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
         logDebug(stdout.trim());
@@ -139,6 +142,7 @@ export async function runCommandWithTimeout(
     stdio,
     cwd,
     env: resolvedEnv,
+    windowsHide: true,
     windowsVerbatimArguments,
     ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
       ? { shell: true }

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -83,6 +83,7 @@ function runTaskkill(args: string[]): void {
     spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
+      windowsHide: true,
     });
   } catch {
     // Ignore taskkill spawn failures

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -21,7 +21,7 @@ type SpawnWithFallbackParams = {
   onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
 
-const DEFAULT_RETRY_CODES = ["EBADF"];
+const DEFAULT_RETRY_CODES = ["EBADF", "EAGAIN"];
 
 export function resolveCommandStdio(params: {
   hasInput: boolean;

--- a/src/providers/github-copilot-token.test.ts
+++ b/src/providers/github-copilot-token.test.ts
@@ -46,6 +46,81 @@ describe("github-copilot token", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("uses separate cache files per githubToken to prevent cross-account leakage", async () => {
+    const now = Date.now();
+    const account1Cache = {
+      token: "account1;proxy-ep=proxy.example.com;",
+      expiresAt: now + 60 * 60 * 1000,
+      updatedAt: now,
+    };
+    const account2Cache = {
+      token: "account2;proxy-ep=proxy.other.com;",
+      expiresAt: now + 60 * 60 * 1000,
+      updatedAt: now,
+    };
+
+    // Track which cache paths are read/written per githubToken
+    const cacheStore = new Map<string, unknown>();
+    const loadImpl = vi.fn((p: string) => cacheStore.get(p));
+    const saveImpl = vi.fn((p: string, v: unknown) => cacheStore.set(p, v));
+    const fetchImpl = vi.fn();
+
+    // Resolve for account1 (cache miss -> fetch)
+    fetchImpl.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: account1Cache.token,
+        expires_at: Math.floor(account1Cache.expiresAt / 1000),
+      }),
+    });
+
+    const res1 = await resolveCopilotApiToken({
+      githubToken: "ghu_account1_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Resolve for account2 (cache miss -> fetch)
+    fetchImpl.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: account2Cache.token,
+        expires_at: Math.floor(account2Cache.expiresAt / 1000),
+      }),
+    });
+
+    const res2 = await resolveCopilotApiToken({
+      githubToken: "ghu_account2_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    // Each account gets its own token
+    expect(res1.token).toBe(account1Cache.token);
+    expect(res2.token).toBe(account2Cache.token);
+
+    // Two separate cache files were written (different paths)
+    expect(saveImpl).toHaveBeenCalledTimes(2);
+    const path1 = saveImpl.mock.calls[0][0];
+    const path2 = saveImpl.mock.calls[1][0];
+    expect(path1).not.toBe(path2);
+
+    // Now resolve again for account2 -- should hit cache, not fetch
+    fetchImpl.mockClear();
+    const res2Again = await resolveCopilotApiToken({
+      githubToken: "ghu_account2_token",
+      loadJsonFileImpl: loadImpl,
+      saveJsonFileImpl: saveImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(res2Again.token).toBe(account2Cache.token);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("fetches and stores token when cache is missing", async () => {
     loadJsonFile.mockReturnValue(undefined);
 

--- a/src/telegram/http/index.ts
+++ b/src/telegram/http/index.ts
@@ -1,0 +1,1 @@
+export * from "./registry.js";

--- a/src/telegram/http/registry.test.ts
+++ b/src/telegram/http/registry.test.ts
@@ -1,0 +1,202 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleTelegramHttpRequest,
+  normalizeTelegramWebhookPath,
+  registerTelegramHttpHandler,
+} from "./registry.js";
+
+function mockReq(opts: { method?: string; url?: string } = {}): IncomingMessage {
+  return {
+    method: opts.method ?? "POST",
+    url: opts.url ?? "/telegram-webhook",
+    headers: {},
+  } as unknown as IncomingMessage;
+}
+
+function mockRes(): ServerResponse {
+  return {
+    writeHead: vi.fn(),
+    end: vi.fn(),
+    headersSent: false,
+    writableEnded: false,
+  } as unknown as ServerResponse;
+}
+
+describe("normalizeTelegramWebhookPath", () => {
+  it("returns default path for undefined", () => {
+    expect(normalizeTelegramWebhookPath(undefined)).toBe("/telegram-webhook");
+  });
+
+  it("returns default path for empty string", () => {
+    expect(normalizeTelegramWebhookPath("")).toBe("/telegram-webhook");
+  });
+
+  it("adds leading slash to bare path", () => {
+    expect(normalizeTelegramWebhookPath("custom-path")).toBe("/custom-path");
+  });
+
+  it("preserves existing leading slash", () => {
+    expect(normalizeTelegramWebhookPath("/already-slashed")).toBe("/already-slashed");
+  });
+
+  it("returns default path for whitespace-only string", () => {
+    expect(normalizeTelegramWebhookPath("   ")).toBe("/telegram-webhook");
+  });
+
+  it("returns default path for null", () => {
+    expect(normalizeTelegramWebhookPath(null)).toBe("/telegram-webhook");
+  });
+});
+
+describe("registerTelegramHttpHandler / unregister", () => {
+  it("registers a handler that makes handleTelegramHttpRequest return true", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/test-reg", handler });
+    try {
+      const req = mockReq({ url: "/test-reg" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("unregistering makes handleTelegramHttpRequest return false", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/test-unreg", handler });
+    unregister();
+
+    const req = mockReq({ url: "/test-unreg" });
+    const res = mockRes();
+    const handled = await handleTelegramHttpRequest(req, res);
+    expect(handled).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when registering the same path twice", async () => {
+    const log = vi.fn();
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const unregister1 = registerTelegramHttpHandler({ path: "/dup-path", handler: handler1, log });
+    try {
+      const unregister2 = registerTelegramHttpHandler({
+        path: "/dup-path",
+        handler: handler2,
+        log,
+      });
+      // Second register returns a no-op unregister
+      unregister2();
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("/dup-path already registered"));
+
+      // Original handler is still in place
+      const req = mockReq({ url: "/dup-path" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler1).toHaveBeenCalled();
+      expect(handler2).not.toHaveBeenCalled();
+    } finally {
+      unregister1();
+    }
+  });
+});
+
+describe("handleTelegramHttpRequest", () => {
+  it("returns false for unregistered paths", async () => {
+    const req = mockReq({ url: "/nonexistent" });
+    const res = mockRes();
+    const handled = await handleTelegramHttpRequest(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for non-POST methods on registered paths", async () => {
+    // Note: the registry itself does not filter by method — the handler does.
+    // handleTelegramHttpRequest dispatches to the handler regardless of method.
+    // Method filtering is done inside the handler. So a GET on a registered path
+    // still returns true (handler is called).
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/method-test", handler });
+    try {
+      const req = mockReq({ method: "GET", url: "/method-test" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      // The registry dispatches to handler and returns true
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("returns true and calls handler for POST on registered path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/post-test", handler });
+    try {
+      const req = mockReq({ method: "POST", url: "/post-test" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("strips query params before matching path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ path: "/qp-test", handler });
+    try {
+      const req = mockReq({ url: "/qp-test?foo=bar&baz=1" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalledWith(req, res);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("works with multiple registered paths simultaneously", async () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    const unregister1 = registerTelegramHttpHandler({ path: "/multi-a", handler: handler1 });
+    const unregister2 = registerTelegramHttpHandler({ path: "/multi-b", handler: handler2 });
+    try {
+      const req1 = mockReq({ url: "/multi-a" });
+      const res1 = mockRes();
+      const req2 = mockReq({ url: "/multi-b" });
+      const res2 = mockRes();
+
+      const handled1 = await handleTelegramHttpRequest(req1, res1);
+      const handled2 = await handleTelegramHttpRequest(req2, res2);
+
+      expect(handled1).toBe(true);
+      expect(handled2).toBe(true);
+      expect(handler1).toHaveBeenCalledWith(req1, res1);
+      expect(handler2).toHaveBeenCalledWith(req2, res2);
+      expect(handler1).not.toHaveBeenCalledWith(req2, res2);
+      expect(handler2).not.toHaveBeenCalledWith(req1, res1);
+    } finally {
+      unregister1();
+      unregister2();
+    }
+  });
+
+  it("uses default path normalization when registering with no path", async () => {
+    const handler = vi.fn();
+    const unregister = registerTelegramHttpHandler({ handler });
+    try {
+      const req = mockReq({ url: "/telegram-webhook" });
+      const res = mockRes();
+      const handled = await handleTelegramHttpRequest(req, res);
+      expect(handled).toBe(true);
+      expect(handler).toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/src/telegram/http/registry.ts
+++ b/src/telegram/http/registry.ts
@@ -1,0 +1,49 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type TelegramHttpRequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => Promise<void> | void;
+
+type RegisterTelegramHttpHandlerArgs = {
+  path?: string | null;
+  handler: TelegramHttpRequestHandler;
+  log?: (message: string) => void;
+  accountId?: string;
+};
+
+const telegramHttpRoutes = new Map<string, TelegramHttpRequestHandler>();
+
+export function normalizeTelegramWebhookPath(path?: string | null): string {
+  const trimmed = path?.trim();
+  if (!trimmed) {
+    return "/telegram-webhook";
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+export function registerTelegramHttpHandler(params: RegisterTelegramHttpHandlerArgs): () => void {
+  const normalizedPath = normalizeTelegramWebhookPath(params.path);
+  if (telegramHttpRoutes.has(normalizedPath)) {
+    const suffix = params.accountId ? ` for account "${params.accountId}"` : "";
+    params.log?.(`telegram: webhook path ${normalizedPath} already registered${suffix}`);
+    return () => {};
+  }
+  telegramHttpRoutes.set(normalizedPath, params.handler);
+  return () => {
+    telegramHttpRoutes.delete(normalizedPath);
+  };
+}
+
+export async function handleTelegramHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const handler = telegramHttpRoutes.get(url.pathname);
+  if (!handler) {
+    return false;
+  }
+  await handler(req, res);
+  return true;
+}

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -432,7 +432,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(runSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("passes configured webhookHost to webhook listener", async () => {
+  it("passes configured webhookHost/webhookPort to webhook listener", async () => {
     await monitorTelegramProvider({
       token: "tok",
       useWebhook: true,
@@ -443,6 +443,7 @@ describe("monitorTelegramProvider (grammY)", () => {
         channels: {
           telegram: {
             webhookHost: "0.0.0.0",
+            webhookPort: 8999,
           },
         },
       },
@@ -451,6 +452,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(startTelegramWebhookSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         host: "0.0.0.0",
+        port: 8999,
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -165,7 +165,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         accountId: account.accountId,
         config: cfg,
         path: opts.webhookPath,
-        port: opts.webhookPort,
+        port: opts.webhookPort ?? account.config.webhookPort,
         secret: opts.webhookSecret ?? account.config.webhookSecret,
         host: opts.webhookHost ?? account.config.webhookHost,
         runtime: opts.runtime as RuntimeEnv,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -2,7 +2,6 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
-import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
@@ -165,7 +164,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         accountId: account.accountId,
         config: cfg,
         path: opts.webhookPath,
-        port: opts.webhookPort,
+        port: opts.webhookPort ?? account.config.webhookPort,
         secret: opts.webhookSecret ?? account.config.webhookSecret,
         host: opts.webhookHost ?? account.config.webhookHost,
         runtime: opts.runtime as RuntimeEnv,
@@ -173,7 +172,6 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
       });
-      await waitForAbortSignal(opts.abortSignal);
       return;
     }
 

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -235,6 +235,10 @@ describe("startTelegramWebhook", () => {
     expect(health.status).toBe(200);
     expect(initSpy).toHaveBeenCalledTimes(1);
     expect(setWebhookSpy).toHaveBeenCalled();
+    const webhookUrl = setWebhookSpy.mock.calls[0]?.[0];
+    expect(webhookUrl).toBeTypeOf("string");
+    expect(String(webhookUrl)).toContain(`${address.port}`);
+    expect(String(webhookUrl)).not.toContain(":0/");
     expect(webhookCallbackSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         api: expect.objectContaining({

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -16,10 +16,111 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import { registerTelegramHttpHandler } from "./http/index.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 const TELEGRAM_WEBHOOK_CALLBACK_TIMEOUT_MS = 10_000;
+
+const TELEGRAM_LEGACY_WEBHOOK_PORT = 8787;
+const TELEGRAM_LEGACY_WEBHOOK_HOST = "127.0.0.1";
+
+// ---------------------------------------------------------------------------
+// Shared webhook POST handler (used by both legacy and gateway modes)
+// ---------------------------------------------------------------------------
+
+function respondText(res: import("node:http").ServerResponse, statusCode: number, text = "") {
+  if (res.headersSent || res.writableEnded) {
+    return;
+  }
+  res.writeHead(statusCode, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end(text);
+}
+
+async function handleWebhookPostRequest(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  opts: {
+    handler: ReturnType<typeof webhookCallback>;
+    runtime?: RuntimeEnv;
+    diagnosticsEnabled: boolean;
+  },
+): Promise<void> {
+  const startTime = Date.now();
+  if (opts.diagnosticsEnabled) {
+    logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
+  }
+
+  try {
+    const body = await readJsonBodyWithLimit(req, {
+      maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
+      timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
+      emptyObjectOnEmpty: false,
+    });
+    if (!body.ok) {
+      if (body.code === "PAYLOAD_TOO_LARGE") {
+        respondText(res, 413, body.error);
+        return;
+      }
+      if (body.code === "REQUEST_BODY_TIMEOUT") {
+        respondText(res, 408, body.error);
+        return;
+      }
+      if (body.code === "CONNECTION_CLOSED") {
+        respondText(res, 400, body.error);
+        return;
+      }
+      respondText(res, 400, body.error);
+      return;
+    }
+
+    let replied = false;
+    const reply = async (json: string) => {
+      if (replied) {
+        return;
+      }
+      replied = true;
+      if (res.headersSent || res.writableEnded) {
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
+      res.end(json);
+    };
+    const unauthorized = async () => {
+      if (replied) {
+        return;
+      }
+      replied = true;
+      respondText(res, 401, "unauthorized");
+    };
+    const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
+    const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
+
+    await opts.handler(body.value, reply, secretHeader, unauthorized);
+    if (!replied) {
+      respondText(res, 200);
+    }
+
+    if (opts.diagnosticsEnabled) {
+      logWebhookProcessed({
+        channel: "telegram",
+        updateType: "telegram-post",
+        durationMs: Date.now() - startTime,
+      });
+    }
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    if (opts.diagnosticsEnabled) {
+      logWebhookError({
+        channel: "telegram",
+        updateType: "telegram-post",
+        error: errMsg,
+      });
+    }
+    opts.runtime?.log?.(`webhook handler failed: ${errMsg}`);
+    respondText(res, 500);
+  }
+}
 
 async function listenHttpServer(params: {
   server: ReturnType<typeof createServer>;
@@ -74,6 +175,15 @@ async function initializeTelegramWebhookBot(params: {
   });
 }
 
+/**
+ * Returns true if the user explicitly configured a webhook host or port,
+ * signaling they want the legacy dedicated HTTP server instead of gateway
+ * HTTP ingress.
+ */
+export function shouldUseLegacyWebhookServer(opts: { host?: string; port?: number }): boolean {
+  return opts.host !== undefined || opts.port !== undefined;
+}
+
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -89,9 +199,6 @@ export async function startTelegramWebhook(opts: {
   publicUrl?: string;
 }) {
   const path = opts.path ?? "/telegram-webhook";
-  const healthPath = opts.healthPath ?? "/healthz";
-  const port = opts.port ?? 8787;
-  const host = opts.host ?? "127.0.0.1";
   const secret = typeof opts.secret === "string" ? opts.secret.trim() : "";
   if (!secret) {
     throw new Error(
@@ -123,15 +230,60 @@ export async function startTelegramWebhook(opts: {
     startDiagnosticHeartbeat();
   }
 
-  const server = createServer((req, res) => {
-    const respondText = (statusCode: number, text = "") => {
-      if (res.headersSent || res.writableEnded) {
-        return;
-      }
-      res.writeHead(statusCode, { "Content-Type": "text/plain; charset=utf-8" });
-      res.end(text);
-    };
+  const useLegacy = shouldUseLegacyWebhookServer({
+    host: opts.host,
+    port: opts.port,
+  });
 
+  if (useLegacy) {
+    return startLegacyWebhookServer({
+      bot,
+      handler,
+      path,
+      port: opts.port ?? TELEGRAM_LEGACY_WEBHOOK_PORT,
+      host: opts.host ?? TELEGRAM_LEGACY_WEBHOOK_HOST,
+      healthPath: opts.healthPath ?? "/healthz",
+      secret,
+      runtime,
+      diagnosticsEnabled,
+      publicUrl: opts.publicUrl,
+      abortSignal: opts.abortSignal,
+    });
+  }
+
+  return startGatewayWebhook({
+    bot,
+    handler,
+    path,
+    secret,
+    runtime,
+    diagnosticsEnabled,
+    publicUrl: opts.publicUrl,
+    accountId: opts.accountId,
+    abortSignal: opts.abortSignal,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Legacy dedicated server mode (when webhookHost/webhookPort are explicit)
+// ---------------------------------------------------------------------------
+
+async function startLegacyWebhookServer(opts: {
+  bot: ReturnType<typeof createTelegramBot>;
+  handler: ReturnType<typeof webhookCallback>;
+  path: string;
+  port: number;
+  host: string;
+  healthPath: string;
+  secret: string;
+  runtime: RuntimeEnv;
+  diagnosticsEnabled: boolean;
+  publicUrl?: string;
+  abortSignal?: AbortSignal;
+}) {
+  const { bot, handler, path, port, host, healthPath, secret, runtime, diagnosticsEnabled } = opts;
+
+  const server = createServer((req, res) => {
     if (req.url === healthPath) {
       res.writeHead(200);
       res.end("ok");
@@ -142,86 +294,10 @@ export async function startTelegramWebhook(opts: {
       res.end();
       return;
     }
-    const startTime = Date.now();
-    if (diagnosticsEnabled) {
-      logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
-    }
-    void (async () => {
-      const body = await readJsonBodyWithLimit(req, {
-        maxBytes: TELEGRAM_WEBHOOK_MAX_BODY_BYTES,
-        timeoutMs: TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS,
-        emptyObjectOnEmpty: false,
-      });
-      if (!body.ok) {
-        if (body.code === "PAYLOAD_TOO_LARGE") {
-          respondText(413, body.error);
-          return;
-        }
-        if (body.code === "REQUEST_BODY_TIMEOUT") {
-          respondText(408, body.error);
-          return;
-        }
-        if (body.code === "CONNECTION_CLOSED") {
-          respondText(400, body.error);
-          return;
-        }
-        respondText(400, body.error);
-        return;
-      }
-
-      let replied = false;
-      const reply = async (json: string) => {
-        if (replied) {
-          return;
-        }
-        replied = true;
-        if (res.headersSent || res.writableEnded) {
-          return;
-        }
-        res.writeHead(200, { "Content-Type": "application/json; charset=utf-8" });
-        res.end(json);
-      };
-      const unauthorized = async () => {
-        if (replied) {
-          return;
-        }
-        replied = true;
-        respondText(401, "unauthorized");
-      };
-      const secretHeaderRaw = req.headers["x-telegram-bot-api-secret-token"];
-      const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
-
-      await handler(body.value, reply, secretHeader, unauthorized);
-      if (!replied) {
-        respondText(200);
-      }
-
-      if (diagnosticsEnabled) {
-        logWebhookProcessed({
-          channel: "telegram",
-          updateType: "telegram-post",
-          durationMs: Date.now() - startTime,
-        });
-      }
-    })().catch((err) => {
-      const errMsg = formatErrorMessage(err);
-      if (diagnosticsEnabled) {
-        logWebhookError({
-          channel: "telegram",
-          updateType: "telegram-post",
-          error: errMsg,
-        });
-      }
-      runtime.log?.(`webhook handler failed: ${errMsg}`);
-      respondText(500);
-    });
+    void handleWebhookPostRequest(req, res, { handler, runtime, diagnosticsEnabled });
   });
 
-  await listenHttpServer({
-    server,
-    port,
-    host,
-  });
+  await listenHttpServer({ server, port, host });
   const boundAddress = server.address();
   const boundPort = boundAddress && typeof boundAddress !== "string" ? boundAddress.port : port;
 
@@ -279,4 +355,105 @@ export async function startTelegramWebhook(opts: {
   }
 
   return { server, bot, stop: shutdown };
+}
+
+// ---------------------------------------------------------------------------
+// Gateway HTTP ingress mode (default — no dedicated server)
+// ---------------------------------------------------------------------------
+
+async function startGatewayWebhook(opts: {
+  bot: ReturnType<typeof createTelegramBot>;
+  handler: ReturnType<typeof webhookCallback>;
+  path: string;
+  secret: string;
+  runtime: RuntimeEnv;
+  diagnosticsEnabled: boolean;
+  publicUrl?: string;
+  accountId?: string;
+  abortSignal?: AbortSignal;
+}) {
+  const { bot, handler, path, secret, runtime, diagnosticsEnabled } = opts;
+
+  const publicUrl = opts.publicUrl;
+  if (!publicUrl) {
+    throw new Error(
+      "Telegram gateway webhook mode requires a webhookUrl (publicUrl). " +
+        "Set channels.telegram.webhookUrl in your config to the externally-reachable URL.",
+    );
+  }
+
+  // Register webhook handler on the gateway HTTP server
+  const unregister = registerTelegramHttpHandler({
+    path,
+    accountId: opts.accountId,
+    log: runtime.log,
+    handler: (req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      void handleWebhookPostRequest(req, res, { handler, runtime, diagnosticsEnabled });
+    },
+  });
+
+  // Set webhook with Telegram
+  try {
+    await withTelegramApiErrorLogging({
+      operation: "setWebhook",
+      runtime,
+      fn: () =>
+        bot.api.setWebhook(publicUrl, {
+          secret_token: secret,
+          allowed_updates: resolveTelegramAllowedUpdates(),
+        }),
+    });
+  } catch (err) {
+    unregister();
+    void bot.stop();
+    if (diagnosticsEnabled) {
+      stopDiagnosticHeartbeat();
+    }
+    throw err;
+  }
+
+  runtime.log?.(`webhook registered on gateway HTTP at path ${path}`);
+  runtime.log?.(`webhook advertised to telegram on ${publicUrl}`);
+
+  let shutDown = false;
+  const shutdown = () => {
+    if (shutDown) {
+      return;
+    }
+    shutDown = true;
+    void withTelegramApiErrorLogging({
+      operation: "deleteWebhook",
+      runtime,
+      fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
+    }).catch(() => {
+      // withTelegramApiErrorLogging has already emitted the failure.
+    });
+    unregister();
+    void bot.stop();
+    if (diagnosticsEnabled) {
+      stopDiagnosticHeartbeat();
+    }
+  };
+
+  if (opts.abortSignal) {
+    opts.abortSignal.addEventListener("abort", shutdown, { once: true });
+  }
+
+  // In gateway mode, wait for abort signal since there's no dedicated server
+  if (opts.abortSignal) {
+    await new Promise<void>((resolve) => {
+      if (opts.abortSignal!.aborted) {
+        resolve();
+        return;
+      }
+      opts.abortSignal!.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }
+
+  return { bot, stop: shutdown };
 }

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -2,43 +2,47 @@ import { describe, expect, it } from "vitest";
 import { ChatLog } from "./chat-log.js";
 
 describe("ChatLog", () => {
-  it("caps component growth to avoid unbounded render trees", () => {
-    const chatLog = new ChatLog(20);
-    for (let i = 1; i <= 40; i++) {
-      chatLog.addSystem(`system-${i}`);
-    }
+  describe("finalizeAssistant", () => {
+    it("does not add a component when text is NO_REPLY and no streaming entry exists", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
 
-    expect(chatLog.children.length).toBe(20);
-    const rendered = chatLog.render(120).join("\n");
-    expect(rendered).toContain("system-40");
-    expect(rendered).not.toContain("system-1");
-  });
+      log.finalizeAssistant("NO_REPLY", "run-1");
 
-  it("drops stale streaming references when old components are pruned", () => {
-    const chatLog = new ChatLog(20);
-    chatLog.startAssistant("first", "run-1");
-    for (let i = 0; i < 25; i++) {
-      chatLog.addSystem(`overflow-${i}`);
-    }
+      // No child should have been added
+      expect(log.children.length).toBe(childrenBefore);
+    });
 
-    // Should not throw if the original streaming component was pruned.
-    chatLog.updateAssistant("recreated", "run-1");
+    it("removes streaming entry when text is NO_REPLY and a streaming entry exists", () => {
+      const log = new ChatLog();
+      log.startAssistant("thinking...", "run-2");
+      const childrenAfterStart = log.children.length;
+      expect(childrenAfterStart).toBeGreaterThan(0);
 
-    const rendered = chatLog.render(120).join("\n");
-    expect(chatLog.children.length).toBe(20);
-    expect(rendered).toContain("recreated");
-  });
+      log.finalizeAssistant("NO_REPLY", "run-2");
 
-  it("drops stale tool references when old components are pruned", () => {
-    const chatLog = new ChatLog(20);
-    chatLog.startTool("tool-1", "read_file", { path: "a.txt" });
-    for (let i = 0; i < 25; i++) {
-      chatLog.addSystem(`overflow-${i}`);
-    }
+      // The streaming component should have been removed
+      expect(log.children.length).toBe(childrenAfterStart - 1);
+    });
 
-    // Should no-op safely after the tool component is pruned.
-    chatLog.updateToolResult("tool-1", { content: [{ type: "text", text: "done" }] });
+    it("adds a component for normal (non-silent) text without a streaming entry", () => {
+      const log = new ChatLog();
+      const childrenBefore = log.children.length;
 
-    expect(chatLog.children.length).toBe(20);
+      log.finalizeAssistant("Hello there!", "run-3");
+
+      expect(log.children.length).toBe(childrenBefore + 1);
+    });
+
+    it("updates the existing streaming entry for normal text", () => {
+      const log = new ChatLog();
+      log.startAssistant("partial...", "run-4");
+      const childrenAfterStart = log.children.length;
+
+      log.finalizeAssistant("Full response here.", "run-4");
+
+      // Same number of children — existing component was updated, not removed or duplicated
+      expect(log.children.length).toBe(childrenAfterStart);
+    });
   });
 });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -1,5 +1,6 @@
 import type { Component } from "@mariozechner/pi-tui";
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { theme } from "../theme/theme.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
@@ -91,6 +92,10 @@ export class ChatLog extends Container {
   }
 
   finalizeAssistant(text: string, runId?: string) {
+    if (isSilentReplyText(text)) {
+      this.dropAssistant(runId);
+      return;
+    }
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -81,6 +81,15 @@ export class ChatLog extends Container {
     existing.setText(text);
   }
 
+  dropAssistant(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      this.removeChild(existing);
+      this.streamingRuns.delete(effectiveRunId);
+    }
+  }
+
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -106,16 +106,6 @@ export class ChatLog extends Container {
     this.append(new AssistantMessageComponent(text));
   }
 
-  dropAssistant(runId?: string) {
-    const effectiveRunId = this.resolveRunId(runId);
-    const existing = this.streamingRuns.get(effectiveRunId);
-    if (!existing) {
-      return;
-    }
-    this.removeChild(existing);
-    this.streamingRuns.delete(effectiveRunId);
-  }
-
   startTool(toolCallId: string, toolName: string, args: unknown) {
     const existing = this.toolById.get(toolCallId);
     if (existing) {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -426,4 +426,52 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("suppresses display when final message is NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-noreply",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "NO_REPLY" },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-noreply");
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it("displays normal messages that are not NO_REPLY", () => {
+    const state = makeState({ activeChatRunId: null });
+    const { chatLog, tui, setActivityStatus } = makeContext(state);
+    const { handleChatEvent } = createEventHandlers({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      chatLog: chatLog as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tui: tui as any,
+      state,
+      setActivityStatus,
+    });
+
+    handleChatEvent({
+      runId: "run-normal",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: "Hello, how can I help?" },
+    });
+
+    expect(chatLog.dropAssistant).not.toHaveBeenCalled();
+    expect(chatLog.finalizeAssistant).toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,3 +1,4 @@
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
@@ -203,6 +204,17 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
+
+      if (isSilentReplyText(finalText)) {
+        chatLog.dropAssistant(evt.runId);
+        noteFinalizedRun(evt.runId);
+        state.activeChatRunId = null;
+        setActivityStatus("idle");
+        void refreshSessionInfo?.();
+        tui.requestRender();
+        return;
+      }
+
       const suppressEmptyExternalPlaceholder =
         finalText === "(no output)" && !isLocalRunId?.(evt.runId);
       if (suppressEmptyExternalPlaceholder) {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,4 +1,9 @@
-import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import {
+  asString,
+  extractTextFromMessage,
+  isCommandMessage,
+  isSystemGeneratedMessage,
+} from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
@@ -179,6 +184,12 @@ export function createEventHandlers(context: EventHandlerContext) {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
         maybeRefreshHistoryForRun(evt.runId);
+        chatLog.dropAssistant(evt.runId);
+        finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
+        tui.requestRender();
+        return;
+      }
+      if (isSystemGeneratedMessage(evt.message)) {
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -7,7 +7,12 @@ import {
 } from "../routing/session-key.js";
 import type { ChatLog } from "./components/chat-log.js";
 import type { GatewayAgentsList, GatewayChatClient } from "./gateway-chat.js";
-import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
+import {
+  asString,
+  extractTextFromMessage,
+  isCommandMessage,
+  isSystemGeneratedMessage,
+} from "./tui-formatters.js";
 import type { SessionInfo, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionContext = {
@@ -304,6 +309,9 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         const message = entry as Record<string, unknown>;
+        if (isSystemGeneratedMessage(message)) {
+          continue;
+        }
         if (isCommandMessage(message)) {
           const text = extractTextFromMessage(message);
           if (text) {

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -24,16 +24,45 @@ describe("delivery context helpers", () => {
     expect(normalizeDeliveryContext({ channel: "  " })).toBeUndefined();
   });
 
-  it("merges primary values over fallback", () => {
+  it("does not inherit route fields from fallback when channels conflict", () => {
     const merged = mergeDeliveryContext(
-      { channel: "whatsapp", to: "channel:abc" },
-      { channel: "slack", to: "channel:def", accountId: "acct" },
+      { channel: "telegram" },
+      { channel: "discord", to: "channel:def", accountId: "acct", threadId: "99" },
     );
 
     expect(merged).toEqual({
-      channel: "whatsapp",
-      to: "channel:abc",
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+    });
+    expect(merged?.threadId).toBeUndefined();
+  });
+
+  it("inherits missing route fields when channels match", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { channel: "telegram", to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
       accountId: "acct",
+      threadId: "99",
+    });
+  });
+
+  it("uses normal fallback merge when either side has no channel", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
+      accountId: "acct",
+      threadId: "99",
     });
   });
 
@@ -103,7 +132,7 @@ describe("delivery context helpers", () => {
     });
   });
 
-  it("normalizes delivery fields and mirrors them on session entries", () => {
+  it("normalizes delivery fields, mirrors session fields, and avoids cross-channel carryover", () => {
     const normalized = normalizeSessionDeliveryFields({
       deliveryContext: {
         channel: " Slack ",
@@ -118,12 +147,11 @@ describe("delivery context helpers", () => {
     expect(normalized.deliveryContext).toEqual({
       channel: "whatsapp",
       to: "+1555",
-      accountId: "acct-2",
-      threadId: "444",
+      accountId: undefined,
     });
     expect(normalized.lastChannel).toBe("whatsapp");
     expect(normalized.lastTo).toBe("+1555");
-    expect(normalized.lastAccountId).toBe("acct-2");
-    expect(normalized.lastThreadId).toBe("444");
+    expect(normalized.lastAccountId).toBeUndefined();
+    expect(normalized.lastThreadId).toBeUndefined();
   });
 });

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -121,11 +121,23 @@ export function mergeDeliveryContext(
   if (!normalizedPrimary && !normalizedFallback) {
     return undefined;
   }
+  const channelsConflict =
+    normalizedPrimary?.channel &&
+    normalizedFallback?.channel &&
+    normalizedPrimary.channel !== normalizedFallback.channel;
   return normalizeDeliveryContext({
     channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
-    to: normalizedPrimary?.to ?? normalizedFallback?.to,
-    accountId: normalizedPrimary?.accountId ?? normalizedFallback?.accountId,
-    threadId: normalizedPrimary?.threadId ?? normalizedFallback?.threadId,
+    // Keep route fields paired to the selected channel. If both inputs name
+    // different channels, do not inherit target/account/thread from fallback.
+    to: channelsConflict
+      ? normalizedPrimary?.to
+      : (normalizedPrimary?.to ?? normalizedFallback?.to),
+    accountId: channelsConflict
+      ? normalizedPrimary?.accountId
+      : (normalizedPrimary?.accountId ?? normalizedFallback?.accountId),
+    threadId: channelsConflict
+      ? normalizedPrimary?.threadId
+      : (normalizedPrimary?.threadId ?? normalizedFallback?.threadId),
   });
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
+      "ui/src/ui/app-render.helpers.node.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## The Problem

I have an agent called Snarf — a creative autonomous agent that runs in a Docker sandbox. His heartbeat is configured to fire every 12 hours:

```json
"heartbeat": {
  "every": "12h",
  "target": "telegram",
  "to": "-1003535833003"
}
```

Today I noticed Snarf was firing heartbeats every 1-2 minutes in bursts. 23 heartbeats in 7 hours, including a 14-minute window where it fired 10 times back-to-back. The `every: "12h"` setting was being completely ignored.

## How I Found It

I started by checking the config — the merge logic in `resolveHeartbeatConfig()` is correct: `{ ...defaults(every: "1h"), ...snarf_overrides(every: "12h") }` produces `every: "12h"`. The interval math is right too.

Then I looked at the session data. Snarf's main session had heartbeat prompts injected at these times today:

```
11:01 → 12:12  (70m)
12:12 → 13:02  (50m)
13:02 → 13:09  (7m)   ← burst starts
13:09 → 13:11  (2m)
...
15:44 → 15:45  (1m)   ← rapid fire
15:45 → 15:48  (2m)
15:48 → 15:49  (1m)
15:49 → 15:51  (1m)
15:51 → 15:52  (1m)
15:52 → 15:53  (1m)
15:53 → 15:55  (1m)
15:55 → 15:56  (1m)
15:56 → 15:58  (1m)
```

Going back further, the 12h interval **never worked** — it was always ~1h with occasional bursts:

| Period | Heartbeats | Expected (12h) |
|--------|-----------|----------------|
| Feb 19-20 (23h) | 17 | ~2 |
| Feb 20-21 (22h) | 23 | ~2 |
| Feb 21-22 (24h) | 30 | ~2 |
| Feb 26 today (7h) | 23 | ~1 |

## Root Cause

The heartbeat runner has two trigger paths:

1. **Interval timer** — respects per-agent `nextDueMs` ✅
2. **Event triggers** (exec-event, hook, wake) — bypasses `nextDueMs` check ❌

In the runner's main loop:

```typescript
for (const agent of state.agents.values()) {
  if (isInterval && now < agent.nextDueMs) {
    continue;  // only skips when reason === "interval"
  }
  // runs heartbeat for this agent
}
```

When `reason !== "interval"` (e.g. `"exec-event"`), `isInterval` is `false` and the schedule check is skipped — **all agents run regardless of their configured interval**.

The specific feedback loop for exec-heavy agents:

1. Heartbeat fires for Snarf
2. Snarf runs exec commands (git, file ops, sandbox work — his HEARTBEAT.md instructs CloudFarm PRs and sandbox coding)
3. Exec completes → `requestHeartbeatNow({ reason: "exec-event" })` — **without sessionKey**
4. Heartbeat runner wakes **ALL agents** (no targeting info)
5. Snarf runs again → back to step 2

The `requestHeartbeatNow` function already accepts `sessionKey` and `agentId` parameters. When provided, the handler takes a targeted code path that only wakes the owning agent. But the exec and hook callers never pass this information — even though `sessionKey` is available right next to the call.

## Why Most Users Don't Hit This

Most agents reply `HEARTBEAT_OK` to heartbeat prompts — a fast, no-exec response that doesn't generate new exec-events. The feedback loop only triggers for agents that:

1. Have a custom heartbeat prompt that does real work (exec commands)
2. Are configured with a longer interval than the default (so the schedule bypass is noticeable)
3. Coexist with other active agents generating exec-events

Snarf hits all three: custom exec-heavy heartbeat, 12h interval, running alongside 10+ other agents.

## The Fix

Pass the already-available `sessionKey` to `requestHeartbeatNow()` in all exec and hook call sites. This routes through the targeted path in the heartbeat runner, waking only the agent that owns the session.

### Changed files

**`src/agents/bash-tools.exec-runtime.ts`**
- `maybeNotifyOnExit`: pass `sessionKey` (background exec completion)
- `emitExecSystemEvent`: pass `sessionKey` (exec system event)

**`src/gateway/server-node-events.ts`**
- Node exec event handler: pass `sessionKey`

**`src/gateway/server/hooks.ts`**
- `dispatchWakeHook`: pass `sessionKey`
- Agent hook success/error: pass `mainSessionKey`

Each change is a single-field addition to an existing call. The `sessionKey` variable is already in scope at every call site.
