### PR TITLE
fix: pass MCPORTER_CONFIG to mcporter subprocess

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -217,6 +217,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       ...process.env,
       XDG_CONFIG_HOME: this.xdgConfigHome,
       XDG_CACHE_HOME: this.xdgCacheHome,
+      MCPORTER_CONFIG: path.join(this.agentStateDir, "config", "mcporter.json"),
       NO_COLOR: "1",
     };
     this.sessionExporter = this.qmd.sessions.enabled


### PR DESCRIPTION
Fixes #27800

## Summary

When OpenClaw spawns mcporter via qmd-manager, it wasn't passing the `MCPORTER_CONFIG` environment variable. As a result, mcporter never finds the agent-specific config and the daemon is never activated.

## Changes

- Added `MCPORTER_CONFIG` env var pointing to `{agentStateDir}/config/mcporter.json` in qmd-manager.ts

## Impact

- mcporter daemon can now start with `lifecycle: "keep-alive"`
- QMD searches are faster (warm start ~1-3s vs cold start ~8-10s)