### PR TITLE
fix: add enabled field to firecrawl config schema (#27833)

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -314,6 +314,17 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional(),
+        baseUrl: z.string().url().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

The firecrawl config block in openclaw.json was being rejected by the schema validator as an unrecognized key, even though the official docs showed it as a valid configuration option.

This fix adds the missing `enabled` property to the `ToolsWebFetchSchema` firecrawl object, aligning the Zod schema with the TypeScript types defined in `types.tools.ts`.

## Fixes

\#27833