### PR TITLE
fix: handle accountId in session key parsing for send policy and Discord exec approvals

### DIFF
--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -231,6 +231,21 @@ describe("extractDiscordChannelId", () => {
         expected: "111222333",
       },
       {
+        name: "new format with accountId - channel",
+        input: "agent:main:discord:acc-1:channel:123456789",
+        expected: "123456789",
+      },
+      {
+        name: "new format with accountId - group",
+        input: "agent:main:discord:work-account:group:987654321",
+        expected: "987654321",
+      },
+      {
+        name: "new format with accountId and thread",
+        input: "agent:main:discord:acc-1:channel:111222333:thread:444555",
+        expected: "111222333",
+      },
+      {
         name: "non-discord session key",
         input: "agent:main:telegram:channel:123456789",
         expected: null,

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -37,13 +37,14 @@ const EXEC_APPROVAL_KEY = "execapproval";
 
 export type { ExecApprovalRequest, ExecApprovalResolved };
 
-/** Extract Discord channel ID from a session key like "agent:main:discord:channel:123456789" */
+/** Extract Discord channel ID from a session key like "agent:main:discord:channel:123456789" or "agent:main:discord:<accountId>:channel:123456789" */
 export function extractDiscordChannelId(sessionKey?: string | null): string | null {
   if (!sessionKey) {
     return null;
   }
-  // Session key format: agent:<id>:discord:channel:<channelId> or agent:<id>:discord:group:<channelId>
-  const match = sessionKey.match(/discord:(?:channel|group):(\d+)/);
+  // Session key format (new): agent:<id>:discord:<accountId>:channel:<channelId> or agent:<id>:discord:<accountId>:group:<channelId>
+  // Session key format (old): agent:<id>:discord:channel:<channelId> or agent:<id>:discord:group:<channelId>
+  const match = sessionKey.match(/discord:(?:[^:]+:)?(?:channel|group):(\d+)/);
   return match ? match[1] : null;
 }
 

--- a/src/sessions/send-policy.test.ts
+++ b/src/sessions/send-policy.test.ts
@@ -68,4 +68,25 @@ describe("resolveSendPolicy", () => {
     expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:discord:group:dev" })).toBe("deny");
     expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:slack:group:dev" })).toBe("allow");
   });
+
+  it("derives channel from new session key format with accountId", () => {
+    const cfg = {
+      session: {
+        sendPolicy: {
+          default: "allow",
+          rules: [{ action: "deny", match: { channel: "discord" } }],
+        },
+      },
+    } as OpenClawConfig;
+    // New format: agent:<agentId>:<channel>:<accountId>:<peerKind>:<peerId>
+    expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:discord:acc-1:channel:123" })).toBe(
+      "deny",
+    );
+    expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:discord:acc-1:group:456" })).toBe(
+      "deny",
+    );
+    // Old format should still work
+    expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:discord:channel:123" })).toBe("deny");
+    expect(resolveSendPolicy({ cfg, sessionKey: "agent:main:discord:group:456" })).toBe("deny");
+  });
 });

--- a/src/sessions/send-policy.ts
+++ b/src/sessions/send-policy.ts
@@ -39,8 +39,18 @@ function deriveChannelFromKey(key?: string) {
     return undefined;
   }
   const parts = normalizedKey.split(":").filter(Boolean);
-  if (parts.length >= 3 && (parts[1] === "group" || parts[1] === "channel")) {
-    return normalizeMatchValue(parts[0]);
+  // New format: <channel>:<accountId>:<peerKind>:<peerId>
+  // Old format: <channel>:<peerKind>:<peerId>
+  // Check if parts[1] or parts[2] is "group" or "channel"
+  if (parts.length >= 3) {
+    if (parts[1] === "group" || parts[1] === "channel") {
+      // Old format
+      return normalizeMatchValue(parts[0]);
+    }
+    if (parts.length >= 4 && (parts[2] === "group" || parts[2] === "channel")) {
+      // New format with accountId
+      return normalizeMatchValue(parts[0]);
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by PR #27750 which changed the session key format for group/channel keys to include `accountId`.

## Problem

PR #27750 changed the session key format:
- **Old format**: `agent:<agentId>:<channel>:<peerKind>:<peerId>`
- **New format**: `agent:<agentId>:<channel>:<accountId>:<peerKind>:<peerId>`

This broke two critical features:

### 1. Channel derivation in send policy (`deriveChannelFromKey`)
- Expected `parts[1]` to be `peerKind` (group/channel)
- Now `parts[1]` is `accountId`, causing channel-scoped deny rules to be skipped
- Impact: First-use sessions with group/channel keys bypass channel-based send policies

### 2. Discord exec approvals channel extraction (`extractDiscordChannelId`)
- Regex `/discord:(?:channel|group):(\d+)/` no longer matches new format
- New format: `discord:<accountId>:channel:<id>`
- Impact: Channel-targeted approval workflows cannot resolve channelId and silently fall back to DM-only behavior

## Solution

### Updated `deriveChannelFromKey`
- Now checks both `parts[1]` and `parts[2]` for peerKind markers
- Supports both old and new session key formats
- Correctly extracts channel from both formats

### Updated `extractDiscordChannelId`
- Changed regex to `/discord:(?:[^:]+:)?(?:channel|group):(\d+)/`
- Optionally matches accountId segment: `[^:]+:`
- Works with both old and new formats

## Testing

Added comprehensive test cases:
-  Old format session keys (backward compatibility)
-  New format session keys with accountId
-  Channel-scoped send policy rules
-  Discord channel ID extraction for both formats

All tests passing.