### PR TITLE
fix(discord): implement fire-and-forget for DiscordMessageListener and update tests

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -88,15 +88,6 @@ describe("DiscordMessageListener", () => {
     };
   }
 
-  async function expectPending(promise: Promise<unknown>) {
-    let resolved = false;
-    void promise.then(() => {
-      resolved = true;
-    });
-    await Promise.resolve();
-    expect(resolved).toBe(false);
-  }
-
   it("returns immediately without awaiting handler (fire-and-forget)", async () => {
     let handlerResolved = false;
     const deferred = createDeferred();


### PR DESCRIPTION
## Summary

Implements the fire-and-forget pattern for `DiscordMessageListener.handle()` and updates tests to match the new semantics, addressing code review feedback on PR #27693.

## Problem

PR #27693 describes implementing fire-and-forget to release the event lane immediately, but:
1. The current implementation still awaits handler completion
2. Three tests assert the old awaiting behavior and will break with fire-and-forget
3. Error handling needs `.catch()` before `.finally()` to avoid unhandled rejections

## Changes

### Implementation (`listeners.ts`)
- Modified `DiscordMessageListener.handle()` to start handler asynchronously and return immediately
- Handler promise tracked via `.catch().finally()` chain for error logging and slow listener detection
- `.catch()` placed before `.finally()` to properly handle errors
- Event lane released immediately after enqueueing handler

### Test Updates (`monitor.test.ts`)

#### 1. `awaits the handler before returning`  `returns immediately without awaiting handler (fire-and-forget)`
- **Old behavior**: `handle()` awaits handler completion
- **New behavior**: `handle()` returns immediately, handler completes in background
- **Test change**: Verifies `handle()` resolves before handler completes

#### 2. `logs handler failures`  `logs handler failures asynchronously`
- **Old behavior**: Error logging happens synchronously before `handle()` returns
- **New behavior**: Error logging happens asynchronously via `.catch()`
- **Test change**: Waits for async error logging with `setTimeout`

#### 3. `logs slow handlers after the threshold`  `logs slow handlers after the threshold (asynchronously)`
- **Old behavior**: Slow listener log fires before `handle()` returns
- **New behavior**: Slow listener log fires asynchronously via `.finally()`
- **Test change**: Switches to real timers after advancing fake time to avoid vitest timeout issues

## Testing

All tests passing:
```
 returns immediately without awaiting handler (fire-and-forget)
 logs handler failures asynchronously
 logs slow handlers after the threshold (asynchronously)
```

## Related

- Addresses code review feedback on PR #27693
- Fixes issue #27690 (Discord event lane blocking)