### PR TITLE
fix: pass sessionKey to after_compaction hook

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -74,7 +74,9 @@ export function handleAutoCompactionEnd(
             messageCount: ctx.params.session.messages?.length ?? 0,
             compactedCount: ctx.getCompactionCount(),
           },
-          {},
+          {
+            sessionKey: ctx.params.sessionKey,
+          },
         )
         .catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);


### PR DESCRIPTION
## Summary

The after_compaction hook was passing an empty object as context,
while before_compaction correctly passed { sessionKey: ctx.params.sessionKey }.

This caused any plugin after_compaction hook that depends on ctx.sessionKey
to silently fail.

## Fix

Pass sessionKey to runAfterCompaction instead of empty object.

## Related Issue

Fixes #27836
