### PR TITLE
fix(heartbeat): target exec/hook wakes via sessionKey

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import { resolveWakeAgentId } from "../config/sessions/main-session.js";
 import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
@@ -238,8 +239,9 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const summary = output
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+  const agentId = resolveWakeAgentId(sessionKey);
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey, agentId });
 }
 
 export function createApprovalSlug(id: string) {
@@ -264,8 +266,9 @@ export function emitExecSystemEvent(
   if (!sessionKey) {
     return;
   }
+  const agentId = resolveWakeAgentId(sessionKey);
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow({ reason: "exec-event", sessionKey });
+  requestHeartbeatNow({ reason: "exec-event", sessionKey, agentId });
 }
 
 export async function runExecProcess(opts: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -6,7 +6,6 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -240,9 +239,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
   enqueueSystemEvent(summary, { sessionKey });
-  requestHeartbeatNow(
-    scopedHeartbeatWakeOptions(sessionKey, { reason: `exec:${session.id}:exit` }),
-  );
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit`, sessionKey });
 }
 
 export function createApprovalSlug(id: string) {
@@ -268,7 +265,7 @@ export function emitExecSystemEvent(
     return;
   }
   enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
-  requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
+  requestHeartbeatNow({ reason: "exec-event", sessionKey });
 }
 
 export async function runExecProcess(opts: {

--- a/src/config/sessions/main-session.test.ts
+++ b/src/config/sessions/main-session.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+
+const { resolveMainSessionKey, resolveDefaultAgentIdFromConfig, resolveWakeAgentId } =
+  await import("./main-session.js");
+
+describe("resolveMainSessionKey", () => {
+  it("returns 'global' when session.scope is global", () => {
+    expect(resolveMainSessionKey({ session: { scope: "global" } })).toBe("global");
+  });
+
+  it("returns agent:main:main when no agents configured", () => {
+    expect(resolveMainSessionKey({})).toBe("agent:main:main");
+  });
+
+  it("uses the default agent from config", () => {
+    const cfg = { agents: { list: [{ id: "assistant", default: true }] } };
+    expect(resolveMainSessionKey(cfg)).toBe("agent:assistant:main");
+  });
+
+  it("uses the first agent when none marked default", () => {
+    const cfg = { agents: { list: [{ id: "helper" }, { id: "worker" }] } };
+    expect(resolveMainSessionKey(cfg)).toBe("agent:helper:main");
+  });
+});
+
+describe("resolveDefaultAgentIdFromConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'main' when no agents configured", () => {
+    mockLoadConfig.mockReturnValue({});
+    expect(resolveDefaultAgentIdFromConfig()).toBe("main");
+  });
+
+  it("returns the default agent from config", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: { list: [{ id: "assistant", default: true }] },
+    });
+    expect(resolveDefaultAgentIdFromConfig()).toBe("assistant");
+  });
+
+  it("returns the first agent when none marked default", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: { list: [{ id: "helper" }, { id: "worker" }] },
+    });
+    expect(resolveDefaultAgentIdFromConfig()).toBe("helper");
+  });
+});
+
+describe("resolveWakeAgentId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts agent ID from agent:*:* keys", () => {
+    // agent:*:* keys should be parsed directly, no config lookup needed
+    expect(resolveWakeAgentId("agent:assistant:main")).toBe("assistant");
+    expect(resolveWakeAgentId("agent:worker:custom")).toBe("worker");
+  });
+
+  it("falls back to config default for 'global' key", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: { list: [{ id: "assistant", default: true }] },
+    });
+    expect(resolveWakeAgentId("global")).toBe("assistant");
+  });
+
+  it("falls back to config default for node-prefixed keys", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: { list: [{ id: "helper" }] },
+    });
+    expect(resolveWakeAgentId("node-abc123")).toBe("helper");
+  });
+
+  it("falls back to 'main' when no config agents and non-agent key", () => {
+    mockLoadConfig.mockReturnValue({});
+    expect(resolveWakeAgentId("global")).toBe("main");
+  });
+
+  it("falls back to config default for empty/null/undefined", () => {
+    mockLoadConfig.mockReturnValue({
+      agents: { list: [{ id: "assistant", default: true }] },
+    });
+    expect(resolveWakeAgentId(null)).toBe("assistant");
+    expect(resolveWakeAgentId(undefined)).toBe("assistant");
+    expect(resolveWakeAgentId("")).toBe("assistant");
+  });
+});

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
   normalizeMainKey,
+  parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { loadConfig } from "../config.js";
@@ -27,7 +28,35 @@ export function resolveMainSessionKeyFromConfig(): string {
   return resolveMainSessionKey(loadConfig());
 }
 
+/**
+ * Resolve the default agent ID from config.
+ * When session.scope is "global", resolveMainSessionKeyFromConfig() returns "global"
+ * which is not in agent:*:* format, so resolveAgentIdFromSessionKey falls back to "main".
+ * This helper returns the actual default agent, even in global scope.
+ */
+export function resolveDefaultAgentIdFromConfig(): string {
+  const cfg = loadConfig();
+  const agents = cfg?.agents?.list ?? [];
+  const defaultAgentId =
+    agents.find((agent) => agent?.default)?.id ?? agents[0]?.id ?? DEFAULT_AGENT_ID;
+  return normalizeAgentId(defaultAgentId);
+}
+
 export { resolveAgentIdFromSessionKey };
+
+/**
+ * Resolve the agent ID to use for heartbeat wakes from a sessionKey.
+ * For `agent:*:*` keys, extracts the agent ID from the key.
+ * For non-agent keys (e.g. "global", "node-xxx"), falls back to the
+ * config's default agent instead of the hardcoded "main" default.
+ */
+export function resolveWakeAgentId(sessionKey: string | undefined | null): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  return resolveDefaultAgentIdFromConfig();
+}
 
 export function resolveAgentMainSessionKey(params: {
   cfg?: { session?: { mainKey?: string } };

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,6 +4,7 @@ import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
+import { resolveWakeAgentId } from "../config/sessions/main-session.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
@@ -573,8 +574,9 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       }
 
+      const agentId = resolveWakeAgentId(sessionKey);
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      requestHeartbeatNow({ reason: "exec-event", sessionKey });
+      requestHeartbeatNow({ reason: "exec-event", sessionKey, agentId });
       return;
     }
     case "push.apns.register": {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -10,7 +10,7 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsToken } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { normalizeMainKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
@@ -574,10 +574,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       enqueueSystemEvent(text, { sessionKey, contextKey: runId ? `exec:${runId}` : "exec" });
-      // Scope wakes only for canonical agent sessions. Synthetic node-* fallback
-      // keys should keep legacy unscoped behavior so enabled non-main heartbeat
-      // agents still run when no explicit agent session is provided.
-      requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
+      requestHeartbeatNow({ reason: "exec-event", sessionKey });
       return;
     }
     case "push.apns.register": {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -29,7 +29,7 @@ export function createGatewayHooksRequestHandler(params: {
     const sessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, { sessionKey });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake" });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
     }
   };
 
@@ -85,7 +85,7 @@ export function createGatewayHooksRequestHandler(params: {
             sessionKey: mainSessionKey,
           });
           if (value.wakeMode === "now") {
-            requestHeartbeatNow({ reason: `hook:${jobId}` });
+            requestHeartbeatNow({ reason: `hook:${jobId}`, sessionKey: mainSessionKey });
           }
         }
       } catch (err) {
@@ -94,7 +94,7 @@ export function createGatewayHooksRequestHandler(params: {
           sessionKey: mainSessionKey,
         });
         if (value.wakeMode === "now") {
-          requestHeartbeatNow({ reason: `hook:${jobId}:error` });
+          requestHeartbeatNow({ reason: `hook:${jobId}:error`, sessionKey: mainSessionKey });
         }
       }
     })();

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { CliDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
-import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
+import {
+  resolveDefaultAgentIdFromConfig,
+  resolveMainSessionKeyFromConfig,
+} from "../../config/sessions.js";
 import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
 import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
@@ -27,9 +30,12 @@ export function createGatewayHooksRequestHandler(params: {
 
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
+    // Resolve the actual default agent so global-scope configs (sessionKey="global")
+    // still target the correct agent instead of falling back to "main".
+    const agentId = resolveDefaultAgentIdFromConfig();
     enqueueSystemEvent(value.text, { sessionKey });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey, agentId });
     }
   };
 
@@ -39,6 +45,7 @@ export function createGatewayHooksRequestHandler(params: {
       targetAgentId: value.agentId,
     });
     const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const mainAgentId = resolveDefaultAgentIdFromConfig();
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {
@@ -85,7 +92,11 @@ export function createGatewayHooksRequestHandler(params: {
             sessionKey: mainSessionKey,
           });
           if (value.wakeMode === "now") {
-            requestHeartbeatNow({ reason: `hook:${jobId}`, sessionKey: mainSessionKey });
+            requestHeartbeatNow({
+              reason: `hook:${jobId}`,
+              sessionKey: mainSessionKey,
+              agentId: mainAgentId,
+            });
           }
         }
       } catch (err) {
@@ -94,7 +105,11 @@ export function createGatewayHooksRequestHandler(params: {
           sessionKey: mainSessionKey,
         });
         if (value.wakeMode === "now") {
-          requestHeartbeatNow({ reason: `hook:${jobId}:error`, sessionKey: mainSessionKey });
+          requestHeartbeatNow({
+            reason: `hook:${jobId}:error`,
+            sessionKey: mainSessionKey,
+            agentId: mainAgentId,
+          });
         }
       }
     })();


### PR DESCRIPTION
## TL;DR

Exec/hook completions were waking **all** agents because the wake call omitted `sessionKey` (even though it was already available). Most setups don't notice this (agents reply `HEARTBEAT_OK`), but exec-heavy heartbeats can fall into a feedback loop. This PR threads `sessionKey` into those wake calls so the heartbeat runner takes its existing targeted path.

---

## Not a Regression — a Missing Connection

The exec/hook call sites never had `sessionKey`. The targeted wake infrastructure was built later and the callers were never updated:

- **Jan 14–22**: all `requestHeartbeatNow()` calls added to hooks and exec — none pass `sessionKey`
- **Feb 16**: targeted path added to the runner (`requestedSessionKey` branch) and per-target coalescing added to wake (`getWakeTargetKey`) — built for cron routing
- **Feb 16 → now**: no one went back to connect the exec/hook callers to the new infra

**~75 lines of targeting infrastructure were effectively idle** because no exec/hook caller was providing the info to reach them:

- `heartbeat-runner.ts` lines 1109-1138: a 30-line targeted code path (resolve agent from sessionKey → run only that agent → advance schedule → handle errors) — never reached by exec/hook events
- `heartbeat-wake.ts`: ~45 lines of per-target coalescing (`normalizeWakeTarget`, `getWakeTargetKey`, dedup in `pendingWakes` Map) — bypassed when every wake falls into the empty `""::""` target key

This PR is the missing wiring between the two halves. 6 lines of fix activate 75 lines of existing infra.

---

## What I Saw

I have an agent (Snarf) configured with `heartbeat.every: "12h"`. Today it started firing in bursts (every 1–2 minutes). At first I assumed my config/merge logic was broken. I verified:

- heartbeat config merging resolves to `every: "12h"` ✅
- interval math looks correct ✅

So I checked the session timeline and noticed the bursts correlate with other agents finishing execs.

<details>
<summary>Timeline / counts (for context)</summary>

The 12h cadence never truly held — it drifted toward ~1h with occasional bursts since the agent was created:

| Period | Heartbeats | Expected (12h) |
|--------|-----------|----------------|
| Feb 19-20 (23h) | 17 | ~2 |
| Feb 20-21 (22h) | 23 | ~2 |
| Feb 21-22 (24h) | 30 | ~2 |
| Feb 26 today (7h) | 23 | ~1 |

Today's worst burst — 10 heartbeats in 14 minutes:

```
15:44 → 15:45  (1m)
15:45 → 15:48  (2m)
15:48 → 15:49  (1m)
15:49 → 15:51  (1m)
15:51 → 15:52  (1m)
15:52 → 15:53  (1m)
15:53 → 15:55  (1m)
15:55 → 15:56  (1m)
15:56 → 15:58  (1m)
```

</details>

---

## Why This Happens

There are two ways a heartbeat can run:

1. **Interval timer** — respects each agent's schedule ✅
2. **Event-driven wakes** (exec/hook/wake) — meant to be reactive ✅

Event-driven wakes are fine — the problem is **targeting**:

- When a wake is triggered without `sessionKey` (or `agentId`), it becomes a **broadcast**
- Broadcast + exec-heavy heartbeat creates a feedback loop:
  - Snarf runs exec → exec completes → broadcast wake → Snarf runs again → …

Think "building intercom": a package arrives for one apartment, but the intercom rings every apartment. The apartment number was already on the package — it just wasn't passed to the intercom.

---

## Impact Beyond My Setup

1. **Multi-agent exec flood** (my case): exec completions from any agent wake all agents, creating cross-agent interference and self-reinforcing loops for exec-heavy heartbeats.

2. **Peer-specific session wake misrouting**: exec completion happens in a peer-specific session (Telegram/Discord/WhatsApp group), but the heartbeat wakes without `sessionKey`, inspects the wrong event queue, and falls through to `HEARTBEAT_OK`. Related: #14191.

---

## Why Most Users Don't Hit This

Most agents respond to heartbeat with `HEARTBEAT_OK` (no exec), so even if they get woken, nothing cascades. You mainly notice this when:

- the heartbeat does real work (exec-heavy)
- the configured interval is long (so the extra wakes are obvious)
- multiple agents are active (more exec/hook completions)

---

## The Fix

Pass the already-available `sessionKey` into `requestHeartbeatNow()` at exec/hook wake sites. This routes the wake through the heartbeat runner's targeted path, waking only the owning agent/session.

### Changes

- `src/agents/bash-tools.exec-runtime.ts`: include `sessionKey` on exec completion + exec system events
- `src/gateway/server-node-events.ts`: include `sessionKey` when handling node exec events
- `src/gateway/server/hooks.ts`: include `sessionKey` for wake hooks

Each change is a single field added where `sessionKey` is already in scope.

---

## Scope / Non-goals

- This does **not** change the design that exec/hook events can wake heartbeats.
- It only ensures those wakes are **targeted to the owning session** instead of broadcast.

---

## Regression Rule

> Whenever you call `enqueueSystemEvent(..., { sessionKey })`, the `requestHeartbeatNow()` right after should carry the same `sessionKey` (or `agentId`).

---

## Test Plan

- Run 2+ agents; make one exec-heavy heartbeat and another agent generating exec completions.
- Confirm exec completions only wake the agent owning that exec session (no cross-agent bursts).

