### PR TITLE
feat(discord): stable status queue with fresh/backlog states

### DIFF
--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_EMOJIS } from "../../channels/status-reactions.js";
 import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+import { DISCORD_STATUS_DEFAULT_PROJECTION } from "./status-reaction-lifecycle.js";
+import { __testing as queueTesting } from "./status-reaction-queue.js";
 import {
   __testing as threadBindingTesting,
   createThreadBindingManager,
@@ -136,6 +137,7 @@ beforeEach(() => {
   readSessionUpdatedAt.mockReturnValue(undefined);
   resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
   threadBindingTesting.resetThreadBindingsForTests();
+  queueTesting.resetQueueForTests();
 });
 
 function getLastRouteUpdate():
@@ -213,7 +215,7 @@ describe("processDiscordMessage ack reactions", () => {
     ]);
   });
 
-  it("debounces intermediate phase reactions and jumps to done for short runs", async () => {
+  it("keeps active status stable and reaches done for short runs", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onReasoningStream?.();
       await params?.replyOptions?.onToolStart?.({ name: "exec" });
@@ -229,37 +231,64 @@ describe("processDiscordMessage ack reactions", () => {
       sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
     ).map((call) => call[2]);
     expect(emojis).toContain("👀");
-    expect(emojis).toContain(DEFAULT_EMOJIS.done);
-    expect(emojis).not.toContain(DEFAULT_EMOJIS.thinking);
-    expect(emojis).not.toContain(DEFAULT_EMOJIS.coding);
+    expect(emojis).toContain(DISCORD_STATUS_DEFAULT_PROJECTION.active);
+    expect(emojis).toContain(DISCORD_STATUS_DEFAULT_PROJECTION.done);
+    expect(emojis).not.toContain("👨‍💻");
   });
 
-  it("shows stall emojis for long no-progress runs", async () => {
-    vi.useFakeTimers();
-    let releaseDispatch!: () => void;
-    const dispatchGate = new Promise<void>((resolve) => {
-      releaseDispatch = () => resolve();
+  it("shows backlog waiting only for later messages in the same channel", async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
     });
     dispatchInboundMessage.mockImplementationOnce(async () => {
-      await dispatchGate;
+      await firstGate;
+      return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
+    });
+    dispatchInboundMessage.mockImplementationOnce(async () => {
       return { queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } };
     });
 
-    const ctx = await createBaseContext();
+    const first = await createBaseContext({
+      message: {
+        id: "m1",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+      messageChannelId: "c1",
+    });
+    const second = await createBaseContext({
+      message: {
+        id: "m2",
+        channelId: "c1",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+      },
+      messageChannelId: "c1",
+    });
+
     // oxlint-disable-next-line typescript/no-explicit-any
-    const runPromise = processDiscordMessage(ctx as any);
+    const firstRun = processDiscordMessage(first as any);
+    await Promise.resolve();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const secondRun = processDiscordMessage(second as any);
 
-    await vi.advanceTimersByTimeAsync(30_001);
-    releaseDispatch();
-    await vi.runAllTimersAsync();
+    releaseFirst();
+    await Promise.all([firstRun, secondRun]);
 
-    await runPromise;
-    const emojis = (
-      sendMocks.reactMessageDiscord.mock.calls as unknown as Array<[unknown, unknown, string]>
-    ).map((call) => call[2]);
-    expect(emojis).toContain(DEFAULT_EMOJIS.stallSoft);
-    expect(emojis).toContain(DEFAULT_EMOJIS.stallHard);
-    expect(emojis).toContain(DEFAULT_EMOJIS.done);
+    const byMessage = new Map<string, string[]>();
+    for (const call of sendMocks.reactMessageDiscord.mock.calls as unknown as Array<
+      [string, string, string]
+    >) {
+      const [, messageId, emoji] = call;
+      byMessage.set(messageId, [...(byMessage.get(messageId) ?? []), emoji]);
+    }
+
+    expect(byMessage.get("m1") ?? []).toContain("👀");
+    expect(byMessage.get("m1") ?? []).not.toContain("⏳");
+    expect(byMessage.get("m2") ?? []).toContain("⏳");
+    expect(byMessage.get("m2") ?? []).not.toContain("👀");
   });
 
   it("applies status reaction emoji/timing overrides from config", async () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -695,7 +695,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
 
     let dispatchError = false;
     try {
-      void statusReactions.enterActive();
+      await statusReactions.enterActive();
       dispatchResult = await dispatchInboundMessage({
         ctx: ctxPayload,
         cfg,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -103,13 +103,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     discordRestFetch,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
-  const forwardedMediaList = await resolveForwardedMediaList(
-    message,
-    mediaMaxBytes,
-    discordRestFetch,
-  );
-  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);
@@ -135,6 +128,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }),
     );
   const statusReactionsEnabled = shouldAckReaction();
+  let statusQueueClaimed = false;
   const discordAdapter: DiscordStatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
@@ -164,464 +158,454 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   });
-
-  const fromLabel = isDirectMessage
-    ? buildDirectLabel(author)
-    : buildGuildLabel({
-        guild: data.guild ?? undefined,
-        channelName: channelName ?? messageChannelId,
-        channelId: messageChannelId,
-      });
-  const senderLabel = sender.label;
-  const isForumParent =
-    threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
-  const forumParentSlug =
-    isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
-  const threadChannelId = threadChannel?.id;
-  const isForumStarter =
-    Boolean(threadChannelId && isForumParent && forumParentSlug) && message.id === threadChannelId;
-  const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
-  const groupChannel = isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
-  const groupSubject = isDirectMessage ? undefined : groupChannel;
-  const untrustedChannelMetadata = isGuildMessage
-    ? buildUntrustedChannelMetadata({
-        source: "discord",
-        label: "Discord channel topic",
-        entries: [channelInfo?.topic],
-      })
-    : undefined;
-  const senderName = sender.isPluralKit
-    ? (sender.name ?? author.username)
-    : (data.member?.nickname ?? author.globalName ?? author.username);
-  const senderUsername = sender.isPluralKit
-    ? (sender.tag ?? sender.name ?? author.username)
-    : author.username;
-  const senderTag = sender.tag;
-  const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
-  const groupSystemPrompt =
-    systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
-  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
-  });
-  const storePath = resolveStorePath(cfg.session?.store, {
-    agentId: route.agentId,
-  });
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const previousTimestamp = readSessionUpdatedAt({
-    storePath,
-    sessionKey: route.sessionKey,
-  });
-  let combinedBody = formatInboundEnvelope({
-    channel: "Discord",
-    from: fromLabel,
-    timestamp: resolveTimestampMs(message.timestamp),
-    body: text,
-    chatType: isDirectMessage ? "direct" : "channel",
-    senderLabel,
-    previousTimestamp,
-    envelope: envelopeOptions,
-  });
-  const shouldIncludeChannelHistory =
-    !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
-  if (shouldIncludeChannelHistory) {
-    combinedBody = buildPendingHistoryContextFromMap({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-      currentMessage: combinedBody,
-      formatEntry: (entry) =>
-        formatInboundEnvelope({
-          channel: "Discord",
-          from: fromLabel,
-          timestamp: entry.timestamp,
-          body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
-          chatType: "channel",
-          senderLabel: entry.sender,
-          envelope: envelopeOptions,
-        }),
-    });
+  if (statusReactionsEnabled) {
+    const claim = claimDiscordStatusReactionQueue(messageChannelId, message.id);
+    statusQueueClaimed = true;
+    void statusReactions.enterWaiting(claim.hasPriorPendingWork);
   }
-  const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
-  if (forumContextLine) {
-    combinedBody = `${combinedBody}\n${forumContextLine}`;
-  }
+  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
 
-  let threadStarterBody: string | undefined;
-  let threadLabel: string | undefined;
-  let parentSessionKey: string | undefined;
-  if (threadChannel) {
-    const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
-    if (includeThreadStarter) {
-      const starter = await resolveDiscordThreadStarter({
-        channel: threadChannel,
-        client,
-        parentId: threadParentId,
-        parentType: threadParentType,
-        resolveTimestampMs,
-      });
-      if (starter?.text) {
-        // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
-        threadStarterBody = starter.text;
-      }
-    }
-    const parentName = threadParentName ?? "parent";
-    threadLabel = threadName
-      ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
-      : `Discord thread #${normalizeDiscordSlug(parentName)}`;
-    if (threadParentId) {
-      parentSessionKey = buildAgentSessionKey({
-        agentId: route.agentId,
-        channel: route.channel,
-        peer: { kind: "channel", id: threadParentId },
-      });
-    }
-  }
-  const mediaPayload = buildDiscordMediaPayload(mediaList);
-  const threadKeys = resolveThreadSessionKeys({
-    baseSessionKey,
-    threadId: threadChannel ? messageChannelId : undefined,
-    parentSessionKey,
-    useSuffix: false,
-  });
-  const replyPlan = await resolveDiscordAutoThreadReplyPlan({
-    client,
-    message,
-    messageChannelId,
-    isGuildMessage,
-    channelConfig,
-    threadChannel,
-    channelType: channelInfo?.type,
-    baseText: baseText ?? "",
-    combinedBody,
-    replyToMode,
-    agentId: route.agentId,
-    channel: route.channel,
-  });
-  const deliverTarget = replyPlan.deliverTarget;
-  const replyTarget = replyPlan.replyTarget;
-  const replyReference = replyPlan.replyReference;
-  const autoThreadContext = replyPlan.autoThreadContext;
-
-  const effectiveFrom = isDirectMessage
-    ? `discord:${author.id}`
-    : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
-  const effectiveTo = autoThreadContext?.To ?? replyTarget;
-  if (!effectiveTo) {
-    runtime.error?.(danger("discord: missing reply target"));
-    return;
-  }
-  // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
-  const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
-
-  const inboundHistory =
-    shouldIncludeChannelHistory && historyLimit > 0
-      ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
-      : undefined;
-
-  const ctxPayload = finalizeInboundContext({
-    Body: combinedBody,
-    BodyForAgent: baseText ?? text,
-    InboundHistory: inboundHistory,
-    RawBody: baseText,
-    CommandBody: baseText,
-    From: effectiveFrom,
-    To: effectiveTo,
-    SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
-    AccountId: route.accountId,
-    ChatType: isDirectMessage ? "direct" : "channel",
-    ConversationLabel: fromLabel,
-    SenderName: senderName,
-    SenderId: sender.id,
-    SenderUsername: senderUsername,
-    SenderTag: senderTag,
-    GroupSubject: groupSubject,
-    GroupChannel: groupChannel,
-    UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
-    GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
-    GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
-    OwnerAllowFrom: ownerAllowFrom,
-    Provider: "discord" as const,
-    Surface: "discord" as const,
-    WasMentioned: effectiveWasMentioned,
-    MessageSid: message.id,
-    ReplyToId: replyContext?.id,
-    ReplyToBody: replyContext?.body,
-    ReplyToSender: replyContext?.sender,
-    ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
-    MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
-    ThreadStarterBody: threadStarterBody,
-    ThreadLabel: threadLabel,
-    Timestamp: resolveTimestampMs(message.timestamp),
-    ...mediaPayload,
-    CommandAuthorized: commandAuthorized,
-    CommandSource: "text" as const,
-    // Originating channel for reply routing.
-    OriginatingChannel: "discord" as const,
-    OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
-  });
-  const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
-
-  await recordInboundSession({
-    storePath,
-    sessionKey: persistedSessionKey,
-    ctx: ctxPayload,
-    updateLastRoute: {
-      sessionKey: persistedSessionKey,
-      channel: "discord",
-      to: lastRouteTo,
-      accountId: route.accountId,
-    },
-    onRecordError: (err) => {
-      logVerbose(`discord: failed updating session meta: ${String(err)}`);
-    },
-  });
-
-  if (shouldLogVerbose()) {
-    const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
-    logVerbose(
-      `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
+  try {
+    const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
+    const forwardedMediaList = await resolveForwardedMediaList(
+      message,
+      mediaMaxBytes,
+      discordRestFetch,
     );
-  }
+    mediaList.push(...forwardedMediaList);
 
-  const typingChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-
-  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
-    cfg,
-    agentId: route.agentId,
-    channel: "discord",
-    accountId: route.accountId,
-  });
-  const tableMode = resolveMarkdownTableMode({
-    cfg,
-    channel: "discord",
-    accountId,
-  });
-  const chunkMode = resolveChunkMode(cfg, "discord", accountId);
-
-  const typingCallbacks = createTypingCallbacks({
-    start: () => sendTyping({ client, channelId: typingChannelId }),
-    onStartError: (err) => {
-      logTypingFailure({
-        log: logVerbose,
-        channel: "discord",
-        target: typingChannelId,
-        error: err,
-      });
-    },
-  });
-
-  // --- Discord draft stream (edit-based preview streaming) ---
-  const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
-  const draftMaxChars = Math.min(textLimit, 2000);
-  const accountBlockStreamingEnabled =
-    typeof discordConfig?.blockStreaming === "boolean"
-      ? discordConfig.blockStreaming
-      : cfg.agents?.defaults?.blockStreamingDefault === "on";
-  const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
-  const draftReplyToMessageId = () => replyReference.use();
-  const deliverChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-  const draftStream = canStreamDraft
-    ? createDiscordDraftStream({
-        rest: client.rest,
-        channelId: deliverChannelId,
-        maxChars: draftMaxChars,
-        replyToMessageId: draftReplyToMessageId,
-        minInitialChars: 30,
-        throttleMs: 1200,
-        log: logVerbose,
-        warn: logVerbose,
-      })
-    : undefined;
-  const draftChunking =
-    draftStream && discordStreamMode === "block"
-      ? resolveDiscordDraftStreamingChunking(cfg, accountId)
+    const fromLabel = isDirectMessage
+      ? buildDirectLabel(author)
+      : buildGuildLabel({
+          guild: data.guild ?? undefined,
+          channelName: channelName ?? messageChannelId,
+          channelId: messageChannelId,
+        });
+    const senderLabel = sender.label;
+    const isForumParent =
+      threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
+    const forumParentSlug =
+      isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+    const threadChannelId = threadChannel?.id;
+    const isForumStarter =
+      Boolean(threadChannelId && isForumParent && forumParentSlug) &&
+      message.id === threadChannelId;
+    const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
+    const groupChannel =
+      isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
+    const groupSubject = isDirectMessage ? undefined : groupChannel;
+    const untrustedChannelMetadata = isGuildMessage
+      ? buildUntrustedChannelMetadata({
+          source: "discord",
+          label: "Discord channel topic",
+          entries: [channelInfo?.topic],
+        })
       : undefined;
-  const shouldSplitPreviewMessages = discordStreamMode === "block";
-  const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
-  let lastPartialText = "";
-  let draftText = "";
-  let hasStreamedMessage = false;
-  let finalizedViaPreviewMessage = false;
-
-  const resolvePreviewFinalText = (text?: string) => {
-    if (typeof text !== "string") {
-      return undefined;
-    }
-    const formatted = convertMarkdownTables(text, tableMode);
-    const chunks = chunkDiscordTextWithMode(formatted, {
-      maxChars: draftMaxChars,
-      maxLines: discordConfig?.maxLinesPerMessage,
-      chunkMode,
+    const senderName = sender.isPluralKit
+      ? (sender.name ?? author.username)
+      : (data.member?.nickname ?? author.globalName ?? author.username);
+    const senderUsername = sender.isPluralKit
+      ? (sender.tag ?? sender.name ?? author.username)
+      : author.username;
+    const senderTag = sender.tag;
+    const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
+      (entry): entry is string => Boolean(entry),
+    );
+    const groupSystemPrompt =
+      systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+    const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
+      channelConfig,
+      guildInfo,
+      sender: { id: sender.id, name: sender.name, tag: sender.tag },
+      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
     });
-    if (!chunks.length && formatted) {
-      chunks.push(formatted);
+    const storePath = resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+    const previousTimestamp = readSessionUpdatedAt({
+      storePath,
+      sessionKey: route.sessionKey,
+    });
+    let combinedBody = formatInboundEnvelope({
+      channel: "Discord",
+      from: fromLabel,
+      timestamp: resolveTimestampMs(message.timestamp),
+      body: text,
+      chatType: isDirectMessage ? "direct" : "channel",
+      senderLabel,
+      previousTimestamp,
+      envelope: envelopeOptions,
+    });
+    const shouldIncludeChannelHistory =
+      !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
+    if (shouldIncludeChannelHistory) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: guildHistories,
+        historyKey: messageChannelId,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatInboundEnvelope({
+            channel: "Discord",
+            from: fromLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
+            chatType: "channel",
+            senderLabel: entry.sender,
+            envelope: envelopeOptions,
+          }),
+      });
     }
-    if (chunks.length !== 1) {
-      return undefined;
+    const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
+    if (forumContextLine) {
+      combinedBody = `${combinedBody}\n${forumContextLine}`;
     }
-    const trimmed = chunks[0].trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
-    if (
-      currentPreviewText &&
-      currentPreviewText.startsWith(trimmed) &&
-      trimmed.length < currentPreviewText.length
-    ) {
-      return undefined;
-    }
-    return trimmed;
-  };
 
-  const updateDraftFromPartial = (text?: string) => {
-    if (!draftStream || !text) {
-      return;
-    }
-    // Strip reasoning/thinking tags that may leak through the stream.
-    const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
-    // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
-    if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
-      return;
-    }
-    if (cleaned === lastPartialText) {
-      return;
-    }
-    hasStreamedMessage = true;
-    if (discordStreamMode === "partial") {
-      // Keep the longer preview to avoid visible punctuation flicker.
-      if (
-        lastPartialText &&
-        lastPartialText.startsWith(cleaned) &&
-        cleaned.length < lastPartialText.length
-      ) {
-        return;
+    let threadStarterBody: string | undefined;
+    let threadLabel: string | undefined;
+    let parentSessionKey: string | undefined;
+    if (threadChannel) {
+      const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
+      if (includeThreadStarter) {
+        const starter = await resolveDiscordThreadStarter({
+          channel: threadChannel,
+          client,
+          parentId: threadParentId,
+          parentType: threadParentType,
+          resolveTimestampMs,
+        });
+        if (starter?.text) {
+          // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
+          threadStarterBody = starter.text;
+        }
       }
-      lastPartialText = cleaned;
-      draftStream.update(cleaned);
-      return;
+      const parentName = threadParentName ?? "parent";
+      threadLabel = threadName
+        ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
+        : `Discord thread #${normalizeDiscordSlug(parentName)}`;
+      if (threadParentId) {
+        parentSessionKey = buildAgentSessionKey({
+          agentId: route.agentId,
+          channel: route.channel,
+          peer: { kind: "channel", id: threadParentId },
+        });
+      }
     }
+    const mediaPayload = buildDiscordMediaPayload(mediaList);
+    const threadKeys = resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: threadChannel ? messageChannelId : undefined,
+      parentSessionKey,
+      useSuffix: false,
+    });
+    const replyPlan = await resolveDiscordAutoThreadReplyPlan({
+      client,
+      message,
+      messageChannelId,
+      isGuildMessage,
+      channelConfig,
+      threadChannel,
+      channelType: channelInfo?.type,
+      baseText: baseText ?? "",
+      combinedBody,
+      replyToMode,
+      agentId: route.agentId,
+      channel: route.channel,
+    });
+    const deliverTarget = replyPlan.deliverTarget;
+    const replyTarget = replyPlan.replyTarget;
+    const replyReference = replyPlan.replyReference;
+    const autoThreadContext = replyPlan.autoThreadContext;
 
-    let delta = cleaned;
-    if (cleaned.startsWith(lastPartialText)) {
-      delta = cleaned.slice(lastPartialText.length);
-    } else {
-      // Streaming buffer reset (or non-monotonic stream). Start fresh.
-      draftChunker?.reset();
-      draftText = "";
-    }
-    lastPartialText = cleaned;
-    if (!delta) {
+    const effectiveFrom = isDirectMessage
+      ? `discord:${author.id}`
+      : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
+    const effectiveTo = autoThreadContext?.To ?? replyTarget;
+    if (!effectiveTo) {
+      runtime.error?.(danger("discord: missing reply target"));
       return;
     }
-    if (!draftChunker) {
-      draftText = cleaned;
-      draftStream.update(draftText);
-      return;
-    }
-    draftChunker.append(delta);
-    draftChunker.drain({
-      force: false,
-      emit: (chunk) => {
-        draftText += chunk;
-        draftStream.update(draftText);
+    // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
+    const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
+
+    const inboundHistory =
+      shouldIncludeChannelHistory && historyLimit > 0
+        ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+          }))
+        : undefined;
+
+    const ctxPayload = finalizeInboundContext({
+      Body: combinedBody,
+      BodyForAgent: baseText ?? text,
+      InboundHistory: inboundHistory,
+      RawBody: baseText,
+      CommandBody: baseText,
+      From: effectiveFrom,
+      To: effectiveTo,
+      SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isDirectMessage ? "direct" : "channel",
+      ConversationLabel: fromLabel,
+      SenderName: senderName,
+      SenderId: sender.id,
+      SenderUsername: senderUsername,
+      SenderTag: senderTag,
+      GroupSubject: groupSubject,
+      GroupChannel: groupChannel,
+      UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
+      GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
+      GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
+      OwnerAllowFrom: ownerAllowFrom,
+      Provider: "discord" as const,
+      Surface: "discord" as const,
+      WasMentioned: effectiveWasMentioned,
+      MessageSid: message.id,
+      ReplyToId: replyContext?.id,
+      ReplyToBody: replyContext?.body,
+      ReplyToSender: replyContext?.sender,
+      ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
+      MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
+      ThreadStarterBody: threadStarterBody,
+      ThreadLabel: threadLabel,
+      Timestamp: resolveTimestampMs(message.timestamp),
+      ...mediaPayload,
+      CommandAuthorized: commandAuthorized,
+      CommandSource: "text" as const,
+      // Originating channel for reply routing.
+      OriginatingChannel: "discord" as const,
+      OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    });
+    const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+
+    await recordInboundSession({
+      storePath,
+      sessionKey: persistedSessionKey,
+      ctx: ctxPayload,
+      updateLastRoute: {
+        sessionKey: persistedSessionKey,
+        channel: "discord",
+        to: lastRouteTo,
+        accountId: route.accountId,
+      },
+      onRecordError: (err) => {
+        logVerbose(`discord: failed updating session meta: ${String(err)}`);
       },
     });
-  };
 
-  const flushDraft = async () => {
-    if (!draftStream) {
-      return;
+    if (shouldLogVerbose()) {
+      const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
+      logVerbose(
+        `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
+      );
     }
-    if (draftChunker?.hasBuffered()) {
-      draftChunker.drain({
-        force: true,
-        emit: (chunk) => {
-          draftText += chunk;
-        },
-      });
-      draftChunker.reset();
-      if (draftText) {
-        draftStream.update(draftText);
+
+    const typingChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+
+    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+      cfg,
+      agentId: route.agentId,
+      channel: "discord",
+      accountId: route.accountId,
+    });
+    const tableMode = resolveMarkdownTableMode({
+      cfg,
+      channel: "discord",
+      accountId,
+    });
+    const chunkMode = resolveChunkMode(cfg, "discord", accountId);
+
+    const typingCallbacks = createTypingCallbacks({
+      start: () => sendTyping({ client, channelId: typingChannelId }),
+      onStartError: (err) => {
+        logTypingFailure({
+          log: logVerbose,
+          channel: "discord",
+          target: typingChannelId,
+          error: err,
+        });
+      },
+    });
+
+    // --- Discord draft stream (edit-based preview streaming) ---
+    const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
+    const draftMaxChars = Math.min(textLimit, 2000);
+    const accountBlockStreamingEnabled =
+      typeof discordConfig?.blockStreaming === "boolean"
+        ? discordConfig.blockStreaming
+        : cfg.agents?.defaults?.blockStreamingDefault === "on";
+    const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
+    const draftReplyToMessageId = () => replyReference.use();
+    const deliverChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+    const draftStream = canStreamDraft
+      ? createDiscordDraftStream({
+          rest: client.rest,
+          channelId: deliverChannelId,
+          maxChars: draftMaxChars,
+          replyToMessageId: draftReplyToMessageId,
+          minInitialChars: 30,
+          throttleMs: 1200,
+          log: logVerbose,
+          warn: logVerbose,
+        })
+      : undefined;
+    const draftChunking =
+      draftStream && discordStreamMode === "block"
+        ? resolveDiscordDraftStreamingChunking(cfg, accountId)
+        : undefined;
+    const shouldSplitPreviewMessages = discordStreamMode === "block";
+    const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
+    let lastPartialText = "";
+    let draftText = "";
+    let hasStreamedMessage = false;
+    let finalizedViaPreviewMessage = false;
+
+    const resolvePreviewFinalText = (text?: string) => {
+      if (typeof text !== "string") {
+        return undefined;
       }
-    }
-    await draftStream.flush();
-  };
+      const formatted = convertMarkdownTables(text, tableMode);
+      const chunks = chunkDiscordTextWithMode(formatted, {
+        maxChars: draftMaxChars,
+        maxLines: discordConfig?.maxLinesPerMessage,
+        chunkMode,
+      });
+      if (!chunks.length && formatted) {
+        chunks.push(formatted);
+      }
+      if (chunks.length !== 1) {
+        return undefined;
+      }
+      const trimmed = chunks[0].trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
+      if (
+        currentPreviewText &&
+        currentPreviewText.startsWith(trimmed) &&
+        trimmed.length < currentPreviewText.length
+      ) {
+        return undefined;
+      }
+      return trimmed;
+    };
 
-  // When draft streaming is active, suppress block streaming to avoid double-streaming.
-  const disableBlockStreamingForDraft = draftStream ? true : undefined;
-
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    ...prefixOptions,
-    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    typingCallbacks,
-    deliver: async (payload: ReplyPayload, info) => {
-      const isFinal = info.kind === "final";
-      if (payload.isReasoning) {
-        // Reasoning/thinking payloads should not be delivered to Discord.
+    const updateDraftFromPartial = (text?: string) => {
+      if (!draftStream || !text) {
         return;
       }
-      if (draftStream && isFinal) {
-        await flushDraft();
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-        const finalText = payload.text;
-        const previewFinalText = resolvePreviewFinalText(finalText);
-        const previewMessageId = draftStream.messageId();
-
-        // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
-        const canFinalizeViaPreviewEdit =
-          !finalizedViaPreviewMessage &&
-          !hasMedia &&
-          typeof previewFinalText === "string" &&
-          typeof previewMessageId === "string" &&
-          !payload.isError;
-
-        if (canFinalizeViaPreviewEdit) {
-          await draftStream.stop();
-          try {
-            await editMessageDiscord(
-              deliverChannelId,
-              previewMessageId,
-              { content: previewFinalText },
-              { rest: client.rest },
-            );
-            finalizedViaPreviewMessage = true;
-            replyReference.markSent();
-            return;
-          } catch (err) {
-            logVerbose(
-              `discord: preview final edit failed; falling back to standard send (${String(err)})`,
-            );
-          }
+      // Strip reasoning/thinking tags that may leak through the stream.
+      const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
+      // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
+      if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
+        return;
+      }
+      if (cleaned === lastPartialText) {
+        return;
+      }
+      hasStreamedMessage = true;
+      if (discordStreamMode === "partial") {
+        // Keep the longer preview to avoid visible punctuation flicker.
+        if (
+          lastPartialText &&
+          lastPartialText.startsWith(cleaned) &&
+          cleaned.length < lastPartialText.length
+        ) {
+          return;
         }
+        lastPartialText = cleaned;
+        draftStream.update(cleaned);
+        return;
+      }
 
-        // Check if stop() flushed a message we can edit
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.stop();
-          const messageIdAfterStop = draftStream.messageId();
-          if (
-            typeof messageIdAfterStop === "string" &&
-            typeof previewFinalText === "string" &&
+      let delta = cleaned;
+      if (cleaned.startsWith(lastPartialText)) {
+        delta = cleaned.slice(lastPartialText.length);
+      } else {
+        // Streaming buffer reset (or non-monotonic stream). Start fresh.
+        draftChunker?.reset();
+        draftText = "";
+      }
+      lastPartialText = cleaned;
+      if (!delta) {
+        return;
+      }
+      if (!draftChunker) {
+        draftText = cleaned;
+        draftStream.update(draftText);
+        return;
+      }
+      draftChunker.append(delta);
+      draftChunker.drain({
+        force: false,
+        emit: (chunk) => {
+          draftText += chunk;
+          draftStream.update(draftText);
+        },
+      });
+    };
+
+    const flushDraft = async () => {
+      if (!draftStream) {
+        return;
+      }
+      if (draftChunker?.hasBuffered()) {
+        draftChunker.drain({
+          force: true,
+          emit: (chunk) => {
+            draftText += chunk;
+          },
+        });
+        draftChunker.reset();
+        if (draftText) {
+          draftStream.update(draftText);
+        }
+      }
+      await draftStream.flush();
+    };
+
+    // When draft streaming is active, suppress block streaming to avoid double-streaming.
+    const disableBlockStreamingForDraft = draftStream ? true : undefined;
+
+    const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      deliver: async (payload: ReplyPayload, info) => {
+        const isFinal = info.kind === "final";
+        if (payload.isReasoning) {
+          // Reasoning/thinking payloads should not be delivered to Discord.
+          return;
+        }
+        if (draftStream && isFinal) {
+          await flushDraft();
+          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const finalText = payload.text;
+          const previewFinalText = resolvePreviewFinalText(finalText);
+          const previewMessageId = draftStream.messageId();
+
+          // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
+          const canFinalizeViaPreviewEdit =
+            !finalizedViaPreviewMessage &&
             !hasMedia &&
-            !payload.isError
-          ) {
+            typeof previewFinalText === "string" &&
+            typeof previewMessageId === "string" &&
+            !payload.isError;
+
+          if (canFinalizeViaPreviewEdit) {
+            await draftStream.stop();
             try {
               await editMessageDiscord(
                 deliverChannelId,
-                messageIdAfterStop,
+                previewMessageId,
                 { content: previewFinalText },
                 { rest: client.rest },
               );
@@ -630,129 +614,161 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               return;
             } catch (err) {
               logVerbose(
-                `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                `discord: preview final edit failed; falling back to standard send (${String(err)})`,
               );
             }
           }
+
+          // Check if stop() flushed a message we can edit
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.stop();
+            const messageIdAfterStop = draftStream.messageId();
+            if (
+              typeof messageIdAfterStop === "string" &&
+              typeof previewFinalText === "string" &&
+              !hasMedia &&
+              !payload.isError
+            ) {
+              try {
+                await editMessageDiscord(
+                  deliverChannelId,
+                  messageIdAfterStop,
+                  { content: previewFinalText },
+                  { rest: client.rest },
+                );
+                finalizedViaPreviewMessage = true;
+                replyReference.markSent();
+                return;
+              } catch (err) {
+                logVerbose(
+                  `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                );
+              }
+            }
+          }
+
+          // Clear the preview and fall through to standard delivery
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.clear();
+          }
         }
 
-        // Clear the preview and fall through to standard delivery
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.clear();
-        }
-      }
-
-      const replyToId = replyReference.use();
-      await deliverDiscordReply({
-        replies: [payload],
-        target: deliverTarget,
-        token,
-        accountId,
-        rest: client.rest,
-        runtime,
-        replyToId,
-        replyToMode,
-        textLimit,
-        maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
-        tableMode,
-        chunkMode,
-        sessionKey: ctxPayload.SessionKey,
-        threadBindings,
-      });
-      replyReference.markSent();
-    },
-    onError: (err, info) => {
-      runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
-    },
-    onReplyStart: async () => {
-      await typingCallbacks.onReplyStart();
-      await statusReactions.enterActive();
-    },
-  });
-
-  let statusQueueClaimed = false;
-  if (statusReactionsEnabled) {
-    const claim = claimDiscordStatusReactionQueue(messageChannelId, message.id);
-    statusQueueClaimed = true;
-    void statusReactions.enterWaiting(claim.hasPriorPendingWork);
-  }
-
-  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
-  let dispatchError = false;
-  try {
-    dispatchResult = await dispatchInboundMessage({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        skillFilter: channelConfig?.skills,
-        disableBlockStreaming:
-          disableBlockStreamingForDraft ??
-          (typeof discordConfig?.blockStreaming === "boolean"
-            ? !discordConfig.blockStreaming
-            : undefined),
-        onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
-        onAssistantMessageStart: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onReasoningEnd: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onModelSelected,
-        onReasoningStream: async () => {
-          await statusReactions.enterActive();
-        },
-        onToolStart: async (_payload) => {
-          await statusReactions.enterActive();
-        },
+        const replyToId = replyReference.use();
+        await deliverDiscordReply({
+          replies: [payload],
+          target: deliverTarget,
+          token,
+          accountId,
+          rest: client.rest,
+          runtime,
+          replyToId,
+          replyToMode,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode,
+          sessionKey: ctxPayload.SessionKey,
+          threadBindings,
+        });
+        replyReference.markSent();
+      },
+      onError: (err, info) => {
+        runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
+      },
+      onReplyStart: async () => {
+        await typingCallbacks.onReplyStart();
+        void statusReactions.enterActive();
       },
     });
-  } catch (err) {
-    dispatchError = true;
-    throw err;
-  } finally {
-    try {
-      // Must stop() first to flush debounced content before clear() wipes state.
-      await draftStream?.stop();
-      if (!finalizedViaPreviewMessage) {
-        await draftStream?.clear();
-      }
-    } catch (err) {
-      // Draft cleanup should never keep typing alive.
-      logVerbose(`discord: draft cleanup failed: ${String(err)}`);
-    } finally {
-      markDispatchIdle();
-    }
-    if (statusReactionsEnabled) {
-      if (statusQueueClaimed) {
-        releaseDiscordStatusReactionQueue(messageChannelId, message.id);
-      }
-      await statusReactions.enterActive();
-      await statusReactions.complete(!dispatchError);
-      if (removeAckAfterReply) {
-        statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
-      }
-    }
-  }
 
-  if (!dispatchResult?.queuedFinal) {
+    let dispatchError = false;
+    try {
+      dispatchResult = await dispatchInboundMessage({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            disableBlockStreamingForDraft ??
+            (typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined),
+          onPartialReply: draftStream
+            ? (payload) => updateDraftFromPartial(payload.text)
+            : undefined,
+          onAssistantMessageStart: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onReasoningEnd: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onModelSelected,
+          onReasoningStream: () => {
+            void statusReactions.enterActive();
+          },
+          onToolStart: (_payload) => {
+            void statusReactions.enterActive();
+          },
+        },
+      });
+    } catch (err) {
+      dispatchError = true;
+      throw err;
+    } finally {
+      try {
+        // Must stop() first to flush debounced content before clear() wipes state.
+        await draftStream?.stop();
+        if (!finalizedViaPreviewMessage) {
+          await draftStream?.clear();
+        }
+      } catch (err) {
+        // Draft cleanup should never keep typing alive.
+        logVerbose(`discord: draft cleanup failed: ${String(err)}`);
+      } finally {
+        markDispatchIdle();
+      }
+      if (statusReactionsEnabled) {
+        await statusReactions.complete(!dispatchError);
+        if (removeAckAfterReply) {
+          statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
+        }
+      }
+    }
+
+    if (!dispatchResult?.queuedFinal) {
+      if (isGuildMessage) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: guildHistories,
+          historyKey: messageChannelId,
+          limit: historyLimit,
+        });
+      }
+      return;
+    }
+    if (shouldLogVerbose()) {
+      const finalCount = dispatchResult.counts.final;
+      logVerbose(
+        `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+      );
+    }
     if (isGuildMessage) {
       clearHistoryEntriesIfEnabled({
         historyMap: guildHistories,
@@ -760,19 +776,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         limit: historyLimit,
       });
     }
-    return;
-  }
-  if (shouldLogVerbose()) {
-    const finalCount = dispatchResult.counts.final;
-    logVerbose(
-      `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
-    );
-  }
-  if (isGuildMessage) {
-    clearHistoryEntriesIfEnabled({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-    });
+  } finally {
+    if (statusQueueClaimed) {
+      releaseDiscordStatusReactionQueue(messageChannelId, message.id);
+    }
   }
 }

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -45,7 +45,6 @@ import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-
 import { deliverDiscordReply } from "./reply-delivery.js";
 import {
   createDiscordStatusReactionLifecycle,
-  DISCORD_STATUS_CLEAR_HOLD_MS,
   resolveDiscordStatusReactionProjection,
   type DiscordStatusReactionAdapter,
 } from "./status-reaction-lifecycle.js";
@@ -113,7 +112,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
-  const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -176,9 +174,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     }
     statusLifecycleSettled = true;
     await statusReactions.complete(succeeded);
-    if (removeAckAfterReply) {
-      statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
-    }
   };
 
   try {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -15,11 +15,6 @@ import { shouldAckReaction as shouldAckReactionGate } from "../../channels/ack-r
 import { logTypingFailure, logAckFailure } from "../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
-import {
-  createStatusReactionController,
-  DEFAULT_TIMING,
-  type StatusReactionAdapter,
-} from "../../channels/status-reactions.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
@@ -48,14 +43,18 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import {
+  createDiscordStatusReactionLifecycle,
+  DISCORD_STATUS_CLEAR_HOLD_MS,
+  resolveDiscordStatusReactionProjection,
+  type DiscordStatusReactionAdapter,
+} from "./status-reaction-lifecycle.js";
+import {
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+} from "./status-reaction-queue.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import { sendTyping } from "./typing.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 export async function processDiscordMessage(ctx: DiscordMessagePreflightContext) {
   const {
@@ -136,7 +135,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }),
     );
   const statusReactionsEnabled = shouldAckReaction();
-  const discordAdapter: StatusReactionAdapter = {
+  const discordAdapter: DiscordStatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: client.rest as never,
@@ -148,12 +147,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   };
-  const statusReactions = createStatusReactionController({
+  const statusReactions = createDiscordStatusReactionLifecycle({
     enabled: statusReactionsEnabled,
+    messageId: message.id,
     adapter: discordAdapter,
-    initialEmoji: ackReaction,
-    emojis: cfg.messages?.statusReactions?.emojis,
-    timing: cfg.messages?.statusReactions?.timing,
+    projection: resolveDiscordStatusReactionProjection(
+      cfg.messages?.statusReactions?.emojis,
+      ackReaction,
+    ),
     onError: (err) => {
       logAckFailure({
         log: logVerbose,
@@ -163,9 +164,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   });
-  if (statusReactionsEnabled) {
-    void statusReactions.setQueued();
-  }
 
   const fromLabel = isDirectMessage
     ? buildDirectLabel(author)
@@ -668,9 +666,16 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     },
     onReplyStart: async () => {
       await typingCallbacks.onReplyStart();
-      await statusReactions.setThinking();
+      await statusReactions.enterActive();
     },
   });
+
+  let statusQueueClaimed = false;
+  if (statusReactionsEnabled) {
+    const claim = claimDiscordStatusReactionQueue(messageChannelId, message.id);
+    statusQueueClaimed = true;
+    void statusReactions.enterWaiting(claim.hasPriorPendingWork);
+  }
 
   let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
   let dispatchError = false;
@@ -712,10 +717,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           : undefined,
         onModelSelected,
         onReasoningStream: async () => {
-          await statusReactions.setThinking();
+          await statusReactions.enterActive();
         },
-        onToolStart: async (payload) => {
-          await statusReactions.setTool(payload.name);
+        onToolStart: async (_payload) => {
+          await statusReactions.enterActive();
         },
       },
     });
@@ -736,18 +741,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       markDispatchIdle();
     }
     if (statusReactionsEnabled) {
-      if (dispatchError) {
-        await statusReactions.setError();
-      } else {
-        await statusReactions.setDone();
+      if (statusQueueClaimed) {
+        releaseDiscordStatusReactionQueue(messageChannelId, message.id);
       }
+      await statusReactions.enterActive();
+      await statusReactions.complete(!dispatchError);
       if (removeAckAfterReply) {
-        void (async () => {
-          await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
+        statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
       }
     }
   }

--- a/src/discord/monitor/status-reaction-lifecycle.test.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.test.ts
@@ -92,7 +92,7 @@ describe("status-reaction-lifecycle", () => {
   });
 });
 
-it("queues terminal transition behind an active interruption", async () => {
+it("requires a completed active transition before terminal transition", async () => {
   __testing.resetTraceEntriesForTests();
   const releaseActiveRef: { current?: () => void } = {};
   const setReaction = vi.fn((emoji: string) => {
@@ -115,13 +115,14 @@ it("queues terminal transition behind an active interruption", async () => {
   await Promise.resolve();
   expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
 
-  const completePromise = lifecycle.complete(true);
+  const blockedComplete = lifecycle.complete(true);
   await Promise.resolve();
   expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
 
   releaseActiveRef.current?.();
   await activePromise;
-  await completePromise;
+  await blockedComplete;
+  await lifecycle.complete(true);
 
   expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔", "✅"]);
 });

--- a/src/discord/monitor/status-reaction-lifecycle.test.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  createDiscordStatusReactionLifecycle,
+  resolveDiscordStatusReactionProjection,
+} from "./status-reaction-lifecycle.js";
+
+describe("status-reaction-lifecycle", () => {
+  it("keeps waiting-fresh and waiting-backlog mutually exclusive per message", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const removeReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m1",
+      adapter: { setReaction, removeReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toContain("⏳");
+    expect(emojis).not.toContain("👀");
+  });
+
+  it("allows waiting -> terminal transition when active reaction fails", async () => {
+    let activeFailed = false;
+    const setReaction = vi.fn(async (emoji: string) => {
+      if (emoji === "🤔" && !activeFailed) {
+        activeFailed = true;
+        throw new Error("active failed");
+      }
+    });
+    const onError = vi.fn();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m2",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+      onError,
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toEqual(["👀", "🤔", "✅"]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps queue order visible: backlog message can finish without showing fresh waiting", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m3",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.complete(true);
+
+    expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["⏳", "✅"]);
+  });
+
+  it("records failed transition when active update fails", async () => {
+    __testing.resetTraceEntriesForTests();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m4",
+      adapter: {
+        setReaction: async (emoji: string) => {
+          if (emoji === "🤔") {
+            throw new Error("boom");
+          }
+        },
+      },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+
+    const failed = __testing
+      .getTraceEntriesForTests()
+      .filter((entry) => entry.messageId === "m4" && entry.stage === "failed")
+      .map((entry) => entry.state);
+    expect(failed).toContain("active");
+  });
+});

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -176,8 +176,7 @@ export function createDiscordStatusReactionLifecycle(params: {
       });
       return chain;
     }
-    const transitionSource = lastRequestedState ?? state;
-    if (!canTransition(transitionSource, nextState)) {
+    if (!canTransition(state, nextState)) {
       trackTransition({
         messageId,
         state: nextState,

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -81,18 +81,16 @@ function canTransition(
   to: DiscordStatusLifecycleState,
 ): boolean {
   if (from === "idle") {
-    // Allow terminal transitions even if the initial waiting reaction is still in flight.
-    return isWaitingState(to) || to === "active" || to === "done" || to === "error";
-  }
-  if (to === "cleared") {
-    return from !== "cleared";
+    return isWaitingState(to) || to === "active";
   }
   if (isWaitingState(from)) {
-    // Allow terminal fallback even if active reaction fails.
-    return to === "active" || to === "done" || to === "error";
+    return to === "active";
   }
   if (from === "active") {
     return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
   }
   return false;
 }
@@ -178,7 +176,8 @@ export function createDiscordStatusReactionLifecycle(params: {
       });
       return chain;
     }
-    if (!canTransition(state, nextState)) {
+    const transitionSource = lastRequestedState ?? state;
+    if (!canTransition(transitionSource, nextState)) {
       trackTransition({
         messageId,
         state: nextState,

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -81,17 +81,18 @@ function canTransition(
   to: DiscordStatusLifecycleState,
 ): boolean {
   if (from === "idle") {
-    return isWaitingState(to) || to === "active";
+    // Allow terminal transitions even if the initial waiting reaction is still in flight.
+    return isWaitingState(to) || to === "active" || to === "done" || to === "error";
+  }
+  if (to === "cleared") {
+    return from !== "idle" && from !== "cleared";
   }
   if (isWaitingState(from)) {
-    // Allow terminal fallback even if active reaction failed.
+    // Allow terminal fallback even if active reaction fails.
     return to === "active" || to === "done" || to === "error";
   }
   if (from === "active") {
     return to === "done" || to === "error";
-  }
-  if (from === "done" || from === "error") {
-    return to === "cleared";
   }
   return false;
 }

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -1,0 +1,304 @@
+import type { StatusReactionEmojis } from "../../channels/status-reactions.js";
+
+export type DiscordStatusLifecycleState =
+  | "idle"
+  | "waiting-fresh"
+  | "waiting-backlog"
+  | "active"
+  | "done"
+  | "error"
+  | "cleared";
+
+type DiscordStatusTraceStage = "queued" | "applied" | "ignored" | "failed";
+
+export type DiscordStatusTraceEntry = {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  at: number;
+};
+
+export type DiscordStatusReactionAdapter = {
+  setReaction: (emoji: string) => Promise<void>;
+  removeReaction?: (emoji: string) => Promise<void>;
+};
+
+export type DiscordStatusReactionProjection = {
+  waitingFresh: string;
+  waitingBacklog: string;
+  active: string;
+  done: string;
+  error: string;
+};
+
+export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection = {
+  waitingFresh: "👀",
+  waitingBacklog: "⏳",
+  active: "🤔",
+  done: "✅",
+  error: "❌",
+};
+
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+
+const MAX_TRACE_ENTRIES = 2000;
+const traceEntries: DiscordStatusTraceEntry[] = [];
+
+function pushTrace(entry: DiscordStatusTraceEntry): void {
+  traceEntries.push(entry);
+  if (traceEntries.length > MAX_TRACE_ENTRIES) {
+    traceEntries.splice(0, traceEntries.length - MAX_TRACE_ENTRIES);
+  }
+}
+
+function resolveEmojiForState(
+  state: DiscordStatusLifecycleState,
+  projection: DiscordStatusReactionProjection,
+): string | null {
+  switch (state) {
+    case "waiting-fresh":
+      return projection.waitingFresh;
+    case "waiting-backlog":
+      return projection.waitingBacklog;
+    case "active":
+      return projection.active;
+    case "done":
+      return projection.done;
+    case "error":
+      return projection.error;
+    default:
+      return null;
+  }
+}
+
+function isWaitingState(state: DiscordStatusLifecycleState): boolean {
+  return state === "waiting-fresh" || state === "waiting-backlog";
+}
+
+function canTransition(
+  from: DiscordStatusLifecycleState,
+  to: DiscordStatusLifecycleState,
+): boolean {
+  if (from === "idle") {
+    return isWaitingState(to) || to === "active";
+  }
+  if (isWaitingState(from)) {
+    // Allow terminal fallback even if active reaction failed.
+    return to === "active" || to === "done" || to === "error";
+  }
+  if (from === "active") {
+    return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
+  }
+  return false;
+}
+
+function trackTransition(params: {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}): void {
+  const entry: DiscordStatusTraceEntry = {
+    messageId: params.messageId,
+    state: params.state,
+    stage: params.stage,
+    emoji: params.emoji,
+    at: Date.now(),
+  };
+  pushTrace(entry);
+  params.onTrace?.(entry);
+}
+
+export function resolveDiscordStatusReactionProjection(
+  overrides?: StatusReactionEmojis,
+  waitingFreshFallback?: string,
+): DiscordStatusReactionProjection {
+  const normalizedWaitingFreshFallback = waitingFreshFallback?.trim() || undefined;
+  return {
+    waitingFresh:
+      overrides?.queued ??
+      normalizedWaitingFreshFallback ??
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh,
+    waitingBacklog: overrides?.stallSoft ?? DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    active: overrides?.thinking ?? DISCORD_STATUS_DEFAULT_PROJECTION.active,
+    done: overrides?.done ?? DISCORD_STATUS_DEFAULT_PROJECTION.done,
+    error: overrides?.error ?? DISCORD_STATUS_DEFAULT_PROJECTION.error,
+  };
+}
+
+export function createDiscordStatusReactionLifecycle(params: {
+  enabled: boolean;
+  messageId: string;
+  adapter: DiscordStatusReactionAdapter;
+  projection: DiscordStatusReactionProjection;
+  onError?: (err: unknown) => void;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}) {
+  const { enabled, messageId, adapter, projection, onError, onTrace } = params;
+  let state: DiscordStatusLifecycleState = "idle";
+  let lastRequestedState: DiscordStatusLifecycleState | null = null;
+  let currentEmoji: string | null = null;
+  let chain = Promise.resolve();
+  let clearTimer: NodeJS.Timeout | null = null;
+  const knownEmojis = new Set<string>([
+    projection.waitingFresh,
+    projection.waitingBacklog,
+    projection.active,
+    projection.done,
+    projection.error,
+  ]);
+
+  function transition(nextState: DiscordStatusLifecycleState): Promise<void> {
+    const nextEmoji = resolveEmojiForState(nextState, projection);
+    trackTransition({
+      messageId,
+      state: nextState,
+      stage: "queued",
+      emoji: nextEmoji,
+      onTrace,
+    });
+
+    if (!enabled) {
+      state = nextState;
+      return Promise.resolve();
+    }
+    if (nextState === state || nextState === lastRequestedState) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+    if (!canTransition(state, nextState)) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+
+    lastRequestedState = nextState;
+    chain = chain.then(async () => {
+      const fromState = state;
+      try {
+        if (nextState === "cleared") {
+          let hadFailure = false;
+          if (adapter.removeReaction) {
+            for (const emoji of knownEmojis) {
+              try {
+                await adapter.removeReaction(emoji);
+              } catch (err) {
+                hadFailure = true;
+                onError?.(err);
+              }
+            }
+          }
+
+          if (hadFailure) {
+            state = fromState;
+            trackTransition({
+              messageId,
+              state: nextState,
+              stage: "failed",
+              emoji: null,
+              onTrace,
+            });
+            return;
+          }
+
+          state = nextState;
+          currentEmoji = null;
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "applied",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        if (!nextEmoji) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        const previousEmoji = currentEmoji;
+        await adapter.setReaction(nextEmoji);
+        if (adapter.removeReaction && previousEmoji && previousEmoji !== nextEmoji) {
+          await adapter.removeReaction(previousEmoji);
+        }
+        state = nextState;
+        currentEmoji = nextEmoji;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "applied",
+          emoji: nextEmoji,
+          onTrace,
+        });
+      } catch (err) {
+        state = fromState;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "failed",
+          emoji: nextEmoji,
+          onTrace,
+        });
+        onError?.(err);
+      } finally {
+        if (lastRequestedState === nextState) {
+          lastRequestedState = null;
+        }
+      }
+    });
+    return chain;
+  }
+
+  return {
+    enterWaiting: (hasPriorPendingWork: boolean): Promise<void> =>
+      transition(hasPriorPendingWork ? "waiting-backlog" : "waiting-fresh"),
+    enterActive: (): Promise<void> => transition("active"),
+    complete: (succeeded: boolean): Promise<void> => transition(succeeded ? "done" : "error"),
+    clearAfterHold: (holdMs = DISCORD_STATUS_CLEAR_HOLD_MS): void => {
+      if (!enabled || clearTimer) {
+        return;
+      }
+      clearTimer = setTimeout(() => {
+        clearTimer = null;
+        void transition("cleared");
+      }, holdMs);
+    },
+  };
+}
+
+function resetTraceEntriesForTests(): void {
+  traceEntries.length = 0;
+}
+
+function getTraceEntriesForTests(): DiscordStatusTraceEntry[] {
+  return traceEntries.map((entry) => ({ ...entry }));
+}
+
+export const __testing = {
+  getTraceEntriesForTests,
+  resetTraceEntriesForTests,
+};

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -85,7 +85,7 @@ function canTransition(
     return isWaitingState(to) || to === "active" || to === "done" || to === "error";
   }
   if (to === "cleared") {
-    return from !== "idle" && from !== "cleared";
+    return from !== "cleared";
   }
   if (isWaitingState(from)) {
     // Allow terminal fallback even if active reaction fails.

--- a/src/discord/monitor/status-reaction-queue.test.ts
+++ b/src/discord/monitor/status-reaction-queue.test.ts
@@ -3,6 +3,7 @@ import {
   __testing,
   claimDiscordStatusReactionQueue,
   releaseDiscordStatusReactionQueue,
+  waitForDiscordStatusReactionQueueTurn,
 } from "./status-reaction-queue.js";
 
 afterEach(() => {
@@ -24,6 +25,23 @@ describe("status-reaction-queue", () => {
 
     expect(c1.hasPriorPendingWork).toBe(false);
     expect(c2.hasPriorPendingWork).toBe(false);
+  });
+
+  it("waits until the message reaches the lane head", async () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+
+    let resolved = false;
+    const waitTurn = waitForDiscordStatusReactionQueueTurn("c1", "m2").then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseDiscordStatusReactionQueue("c1", "m1");
+    await waitTurn;
+    expect(resolved).toBe(true);
   });
 
   it("is idempotent for duplicate claims and cleans up on release", () => {

--- a/src/discord/monitor/status-reaction-queue.test.ts
+++ b/src/discord/monitor/status-reaction-queue.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __testing,
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+} from "./status-reaction-queue.js";
+
+afterEach(() => {
+  __testing.resetQueueForTests();
+});
+
+describe("status-reaction-queue", () => {
+  it("marks only later messages in same channel as backlog", () => {
+    const first = claimDiscordStatusReactionQueue("c1", "m1");
+    const second = claimDiscordStatusReactionQueue("c1", "m2");
+
+    expect(first).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(second).toMatchObject({ hasPriorPendingWork: true, position: 1 });
+  });
+
+  it("isolates queue lanes by channel", () => {
+    const c1 = claimDiscordStatusReactionQueue("c1", "m1");
+    const c2 = claimDiscordStatusReactionQueue("c2", "m2");
+
+    expect(c1.hasPriorPendingWork).toBe(false);
+    expect(c2.hasPriorPendingWork).toBe(false);
+  });
+
+  it("is idempotent for duplicate claims and cleans up on release", () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    const duplicate = claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+    releaseDiscordStatusReactionQueue("c1", "m1");
+
+    expect(duplicate).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(__testing.getQueueSnapshot()).toEqual({
+      size: 1,
+      lanes: [{ channelId: "c1", messageIds: ["m2"] }],
+    });
+  });
+});

--- a/src/discord/monitor/status-reaction-queue.ts
+++ b/src/discord/monitor/status-reaction-queue.ts
@@ -1,0 +1,89 @@
+type QueueLaneSnapshot = {
+  channelId: string;
+  messageIds: string[];
+};
+
+type QueueSnapshot = {
+  size: number;
+  lanes: QueueLaneSnapshot[];
+};
+
+const lanes = new Map<string, string[]>();
+
+function normalizeChannelId(channelId: string): string {
+  return channelId.trim();
+}
+
+function normalizeMessageId(messageId: string): string {
+  return messageId.trim();
+}
+
+/**
+ * Claim a queue slot for a Discord message lifecycle within a channel lane.
+ * hasPriorPendingWork means this message is not first in that lane.
+ */
+export function claimDiscordStatusReactionQueue(
+  channelId: string,
+  messageId: string,
+): {
+  hasPriorPendingWork: boolean;
+  position: number;
+} {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return { hasPriorPendingWork: false, position: 0 };
+  }
+
+  const lane = lanes.get(laneKey) ?? [];
+  let position = lane.indexOf(normalizedMessageId);
+  if (position < 0) {
+    lane.push(normalizedMessageId);
+    position = lane.length - 1;
+  }
+  lanes.set(laneKey, lane);
+  return {
+    hasPriorPendingWork: position > 0,
+    position,
+  };
+}
+
+/**
+ * Release a previously claimed queue slot.
+ */
+export function releaseDiscordStatusReactionQueue(channelId: string, messageId: string): void {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return;
+  }
+  const lane = lanes.get(laneKey);
+  if (!lane) {
+    return;
+  }
+  const nextLane = lane.filter((entry) => entry !== normalizedMessageId);
+  if (nextLane.length === 0) {
+    lanes.delete(laneKey);
+    return;
+  }
+  lanes.set(laneKey, nextLane);
+}
+
+function getQueueSnapshot(): QueueSnapshot {
+  const laneEntries = Array.from(lanes.entries())
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([channelId, messageIds]) => ({ channelId, messageIds: [...messageIds] }));
+  return {
+    size: laneEntries.reduce((sum, lane) => sum + lane.messageIds.length, 0),
+    lanes: laneEntries,
+  };
+}
+
+function resetQueueForTests(): void {
+  lanes.clear();
+}
+
+export const __testing = {
+  getQueueSnapshot,
+  resetQueueForTests,
+};


### PR DESCRIPTION
## Summary

- Problem: Discord status reactions were not reliably showing queue/backlog state, and reaction churn could create noisy mobile notifications.
- Why it matters: users could not clearly tell whether a message was queued, and frequent emoji flips degraded UX on mobile.
- What changed:
  - Added a per-channel FIFO lane queue (`status-reaction-queue.ts`) instead of global set-style occupancy.
  - Added a dedicated lifecycle state machine (`status-reaction-lifecycle.ts`) with explicit `waiting-fresh` and `waiting-backlog` states.
  - Moved queue claim earlier to preserve ordering semantics under async pre-processing.
  - Made active-state reaction updates non-blocking so reply delivery is not gated by reaction API latency.
  - Allowed terminal transitions from `idle` to avoid dropping `done/error` on very short runs.
- What did NOT change (scope boundary): no behavior changes for non-Discord channels; no config schema migrations.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #27451 (closed; this PR is the replacement implementation from latest `main`)

## User-visible / Behavior Changes

- Discord messages now show clear waiting intent with `👀` (fresh) or `⏳` (backlog).
- Fresh/backlog waiting states are mutually exclusive per message.
- Status transitions are smoother (less emoji jitter), reducing mobile notification noise.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: local Node/Vitest
- Model/provider: N/A
- Integration/channel: Discord
- Relevant config (redacted): default status-reaction settings + optional emoji overrides

### Steps

1. Send multiple messages quickly in the same Discord channel/thread.
2. Observe reaction state progression for each trigger message.

### Expected

- First message enters `👀` (fresh waiting), later messages can enter `⏳` (backlog waiting).
- On execution start, message enters active state.
- On terminal outcome, message moves to `✅` or `❌`.
- Fewer intermediate flips; no excessive reaction churn.

### Actual

- Behavior now matches expected transitions in targeted tests and local verification.

## Evidence

- [x] Failing test/log before + passing after

Targeted passing tests:
- `src/discord/monitor/status-reaction-queue.test.ts` (3)
- `src/discord/monitor/status-reaction-lifecycle.test.ts` (5)
- `src/discord/monitor/message-handler.process.test.ts` (19)

Additional regressions checked:
- `src/channels/status-reactions.test.ts`
- `src/discord/monitor/message-handler.preflight.test.ts`
- `src/discord/monitor/message-handler.inbound-contract.test.ts`
- `extensions/msteams/src/messenger.test.ts`

## Human Verification (required)

What I personally verified:

- Verified scenarios:
  - Single-message flow reaches terminal state cleanly.
  - Multi-message same-channel flow marks backlog consistently.
  - Short-run completion still reaches terminal state.
  - Reaction API failure paths keep terminal/cleanup progression viable.
- Edge cases checked:
  - Duplicate claims are idempotent.
  - Queue isolation across channels.
  - Non-blocking active updates preserve reply responsiveness.
- What I did **not** verify:
  - Large-scale production traffic behavior beyond local/integration tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commits or disable status reactions via config.
- Files/config to restore: `src/discord/monitor/status-reaction-*.ts`, `message-handler.process.ts`.
- Known bad symptoms reviewers should watch for:
  - Missing backlog reaction under concurrent arrivals.
  - Persistent stale reactions after terminal outcome.
  - Excessive reaction flip frequency.

## Risks and Mitigations

- Risk: ordering mistakes under high async contention.
  - Mitigation: explicit per-channel FIFO lanes + early claim semantics + dedicated tests.
- Risk: reaction API latency impacts user-perceived responsiveness.
  - Mitigation: active reaction updates are non-blocking; reply path is prioritized.
