### PR TITLE
feat(nano-banana-pro): default to Nano Banana 2 (Flash), add --model flag

### DIFF
--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -23,14 +23,27 @@ metadata:
   }
 ---
 
-# Nano Banana Pro (Gemini 3 Pro Image)
+# Nano Banana Pro (Gemini Image Generation)
 
-Use the bundled script to generate or edit images.
+Use the bundled script to generate or edit images using Gemini image models.
 
-Generate
+## Models
+
+- **flash** (default): Nano Banana 2 (`gemini-3.1-flash-image-preview`) — Fast, efficient for most tasks
+- **pro**: Nano Banana Pro (`gemini-3-pro-image-preview`) — High-fidelity for demanding tasks
+
+## Usage
+
+Generate (default: flash model)
 
 ```bash
 uv run {baseDir}/scripts/generate_image.py --prompt "your image description" --filename "output.png" --resolution 1K
+```
+
+Generate with Pro model (high-fidelity)
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "detailed artwork" --filename "output.png" --model pro --resolution 4K
 ```
 
 Edit (single image)
@@ -45,14 +58,24 @@ Multi-image composition (up to 14 images)
 uv run {baseDir}/scripts/generate_image.py --prompt "combine these into one scene" --filename "output.png" -i img1.png -i img2.png -i img3.png
 ```
 
-API key
+## Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--prompt` | `-p` | Image description/prompt (required) |
+| `--filename` | `-f` | Output filename (required) |
+| `--model` | `-m` | Model: `flash` (default) or `pro` |
+| `--resolution` | `-r` | Output resolution: `1K` (default), `2K`, `4K` |
+| `--input-image` | `-i` | Input image(s) for editing (repeatable, up to 14) |
+| `--api-key` | `-k` | Gemini API key (overrides env var) |
+
+## API Key
 
 - `GEMINI_API_KEY` env var
 - Or set `skills."nano-banana-pro".apiKey` / `skills."nano-banana-pro".env.GEMINI_API_KEY` in `~/.openclaw/openclaw.json`
 
-Notes
+## Notes
 
-- Resolutions: `1K` (default), `2K`, `4K`.
 - Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`.
 - The script prints a `MEDIA:` line for OpenClaw to auto-attach on supported chat providers.
 - Do not read the image back; report the saved path only.

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -7,13 +7,20 @@
 # ]
 # ///
 """
-Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
+Generate images using Google's Gemini image generation models.
+
+Models:
+    - flash: Nano Banana 2 (gemini-3.1-flash-image-preview) - Fast, efficient, default
+    - pro: Nano Banana Pro (gemini-3-pro-image-preview) - High-fidelity for demanding tasks
 
 Usage:
-    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    uv run generate_image.py --prompt "your image description" --filename "output.png" [--model flash|pro] [--resolution 1K|2K|4K] [--api-key KEY]
 
 Multi-image editing (up to 14 images):
     uv run generate_image.py --prompt "combine these images" --filename "output.png" -i img1.png -i img2.png -i img3.png
+
+High-fidelity generation:
+    uv run generate_image.py --prompt "detailed artwork" --filename "output.png" --model pro --resolution 4K
 """
 
 import argparse
@@ -31,7 +38,7 @@ def get_api_key(provided_key: str | None) -> str | None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate images using Nano Banana Pro (Gemini 3 Pro Image)"
+        description="Generate images using Gemini image models (Nano Banana 2 / Pro)"
     )
     parser.add_argument(
         "--prompt", "-p",
@@ -55,6 +62,12 @@ def main():
         choices=["1K", "2K", "4K"],
         default="1K",
         help="Output resolution: 1K (default), 2K, or 4K"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        choices=["flash", "pro"],
+        default="flash",
+        help="Model to use: flash (Nano Banana 2, default) or pro (Nano Banana Pro, high-fidelity)"
     )
     parser.add_argument(
         "--api-key", "-k",
@@ -126,9 +139,17 @@ def main():
         contents = args.prompt
         print(f"Generating image with resolution {output_resolution}...")
 
+    # Select model based on --model argument
+    model_map = {
+        "flash": "gemini-3.1-flash-image-preview",  # Nano Banana 2
+        "pro": "gemini-3-pro-image-preview",        # Nano Banana Pro
+    }
+    model_name = model_map[args.model]
+    print(f"Using model: {model_name}")
+
     try:
         response = client.models.generate_content(
-            model="gemini-3-pro-image-preview",
+            model=model_name,
             contents=contents,
             config=types.GenerateContentConfig(
                 response_modalities=["TEXT", "IMAGE"],


### PR DESCRIPTION
## Summary

This PR updates the nano-banana-pro skill to use **Nano Banana 2** (`gemini-3.1-flash-image-preview`) as the default model, while preserving access to the original Pro model.

## Changes

### `scripts/generate_image.py`
- **Default model changed** from `gemini-3-pro-image-preview` to `gemini-3.1-flash-image-preview`
- **Added `--model` flag** with choices:
  - `flash` (default): Nano Banana 2 — fast, efficient for most tasks
  - `pro`: Nano Banana Pro — high-fidelity for demanding tasks
- Updated docstring and help text to reflect both models

### `SKILL.md`
- Added Models section documenting both options
- Added Options table with all available flags
- Added example for Pro model usage
- Improved overall documentation structure

## Usage

```bash
# Default (flash model)
uv run generate_image.py --prompt "sunset over mountains" --filename "sunset.png"

# High-fidelity (pro model)
uv run generate_image.py --prompt "detailed artwork" --filename "art.png" --model pro --resolution 4K
```

## Backward Compatibility

Users who were explicitly using the Pro model quality can add `--model pro` to maintain the same behavior.