### PR TITLE
fix: harden temp dir perms for umask 0002

### DIFF
--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -218,7 +218,7 @@ describe("resolvePreferredOpenClawTmpDir", () => {
   it("repairs fallback directory permissions after create when umask makes it group-writable", () => {
     const fallbackPath = fallbackTmp();
     let fallbackMode = 0o40775;
-    const lstatSync = vi.fn(() => {
+    const lstatSync = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>(() => {
       throw nodeErrorWithCode("ENOENT");
     });
     const fallbackLstatSync = vi

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -27,12 +27,16 @@ function resolveWithMocks(params: {
   lstatSync: NonNullable<TmpDirOptions["lstatSync"]>;
   fallbackLstatSync?: NonNullable<TmpDirOptions["lstatSync"]>;
   accessSync?: NonNullable<TmpDirOptions["accessSync"]>;
+  chmodSync?: NonNullable<TmpDirOptions["chmodSync"]>;
+  warn?: NonNullable<TmpDirOptions["warn"]>;
   uid?: number;
   tmpdirPath?: string;
 }) {
   const uid = params.uid ?? 501;
   const fallbackPath = fallbackTmp(uid);
   const accessSync = params.accessSync ?? vi.fn();
+  const chmodSync = params.chmodSync ?? vi.fn();
+  const warn = params.warn ?? vi.fn();
   const wrappedLstatSync = vi.fn((target: string) => {
     if (target === POSIX_OPENCLAW_TMP_DIR) {
       return params.lstatSync(target);
@@ -50,10 +54,12 @@ function resolveWithMocks(params: {
   const tmpdir = vi.fn(() => params.tmpdirPath ?? "/var/fallback");
   const resolved = resolvePreferredOpenClawTmpDir({
     accessSync,
+    chmodSync,
     lstatSync: wrappedLstatSync,
     mkdirSync,
     getuid,
     tmpdir,
+    warn,
   });
   return { resolved, accessSync, lstatSync: wrappedLstatSync, mkdirSync, tmpdir };
 }
@@ -207,5 +213,96 @@ describe("resolvePreferredOpenClawTmpDir", () => {
 
     expect(resolved).toBe(fallbackTmp());
     expect(mkdirSync).toHaveBeenCalledWith(fallbackTmp(), { recursive: true, mode: 0o700 });
+  });
+
+  it("repairs fallback directory permissions after create when umask makes it group-writable", () => {
+    const fallbackPath = fallbackTmp();
+    let fallbackMode = 0o40775;
+    const lstatSync = vi.fn(() => {
+      throw nodeErrorWithCode("ENOENT");
+    });
+    const fallbackLstatSync = vi
+      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
+      .mockImplementationOnce(() => {
+        throw nodeErrorWithCode("ENOENT");
+      })
+      .mockImplementation(() => ({
+        isDirectory: () => true,
+        isSymbolicLink: () => false,
+        uid: 501,
+        mode: fallbackMode,
+      }));
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === fallbackPath && mode === 0o700) {
+        fallbackMode = 0o40700;
+      }
+    });
+
+    const resolved = resolvePreferredOpenClawTmpDir({
+      accessSync: vi.fn((target: string) => {
+        if (target === "/tmp") {
+          throw new Error("read-only");
+        }
+      }),
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_OPENCLAW_TMP_DIR) {
+          return lstatSync(target);
+        }
+        if (target === fallbackPath) {
+          return fallbackLstatSync(target);
+        }
+        return secureDirStat(501);
+      }),
+      mkdirSync: vi.fn(),
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn: vi.fn(),
+    });
+
+    expect(resolved).toBe(fallbackPath);
+    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
+  });
+
+  it("repairs existing fallback directory when permissions are too broad", () => {
+    const fallbackPath = fallbackTmp();
+    let fallbackMode = 0o40775;
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === fallbackPath && mode === 0o700) {
+        fallbackMode = 0o40700;
+      }
+    });
+    const warn = vi.fn();
+
+    const resolved = resolvePreferredOpenClawTmpDir({
+      accessSync: vi.fn((target: string) => {
+        if (target === "/tmp") {
+          throw new Error("read-only");
+        }
+      }),
+      lstatSync: vi.fn((target: string) => {
+        if (target === POSIX_OPENCLAW_TMP_DIR) {
+          throw nodeErrorWithCode("ENOENT");
+        }
+        if (target === fallbackPath) {
+          return {
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+            uid: 501,
+            mode: fallbackMode,
+          };
+        }
+        return secureDirStat(501);
+      }),
+      mkdirSync: vi.fn(),
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn,
+    });
+
+    expect(resolved).toBe(fallbackPath);
+    expect(chmodSync).toHaveBeenCalledWith(fallbackPath, 0o700);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tightened permissions on temp dir"));
   });
 });

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -7,6 +7,7 @@ const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
 
 type ResolvePreferredOpenClawTmpDirOptions = {
   accessSync?: (path: string, mode?: number) => void;
+  chmodSync?: (path: string, mode: number) => void;
   lstatSync?: (path: string) => {
     isDirectory(): boolean;
     isSymbolicLink(): boolean;
@@ -16,6 +17,7 @@ type ResolvePreferredOpenClawTmpDirOptions = {
   mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
   getuid?: () => number | undefined;
   tmpdir?: () => string;
+  warn?: (message: string) => void;
 };
 
 type MaybeNodeError = { code?: string };
@@ -35,6 +37,8 @@ export function resolvePreferredOpenClawTmpDir(
   const accessSync = options.accessSync ?? fs.accessSync;
   const lstatSync = options.lstatSync ?? fs.lstatSync;
   const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
+  const chmodSync = options.chmodSync ?? fs.chmodSync;
+  const warn = options.warn ?? ((message: string) => console.warn(message));
   const getuid =
     options.getuid ??
     (() => {
@@ -92,6 +96,26 @@ export function resolvePreferredOpenClawTmpDir(
     }
   };
 
+  const tryRepairWritableBits = (candidatePath: string): boolean => {
+    try {
+      const st = lstatSync(candidatePath);
+      if (!st.isDirectory() || st.isSymbolicLink()) {
+        return false;
+      }
+      if (uid !== undefined && typeof st.uid === "number" && st.uid !== uid) {
+        return false;
+      }
+      if (typeof st.mode !== "number" || (st.mode & 0o022) === 0) {
+        return false;
+      }
+      chmodSync(candidatePath, 0o700);
+      warn(`[openclaw] tightened permissions on temp dir: ${candidatePath}`);
+      return resolveDirState(candidatePath) === "available";
+    } catch {
+      return false;
+    }
+  };
+
   const ensureTrustedFallbackDir = (): string => {
     const fallbackPath = fallback();
     const state = resolveDirState(fallbackPath);
@@ -99,14 +123,18 @@ export function resolvePreferredOpenClawTmpDir(
       return fallbackPath;
     }
     if (state === "invalid") {
+      if (tryRepairWritableBits(fallbackPath)) {
+        return fallbackPath;
+      }
       throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);
     }
     try {
       mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+      chmodSync(fallbackPath, 0o700);
     } catch {
       throw new Error(`Unable to create fallback OpenClaw temp dir: ${fallbackPath}`);
     }
-    if (resolveDirState(fallbackPath) !== "available") {
+    if (resolveDirState(fallbackPath) !== "available" && !tryRepairWritableBits(fallbackPath)) {
       throw new Error(`Unsafe fallback OpenClaw temp dir: ${fallbackPath}`);
     }
     return fallbackPath;
@@ -117,6 +145,9 @@ export function resolvePreferredOpenClawTmpDir(
     return POSIX_OPENCLAW_TMP_DIR;
   }
   if (existingPreferredState === "invalid") {
+    if (tryRepairWritableBits(POSIX_OPENCLAW_TMP_DIR)) {
+      return POSIX_OPENCLAW_TMP_DIR;
+    }
     return ensureTrustedFallbackDir();
   }
 
@@ -124,7 +155,11 @@ export function resolvePreferredOpenClawTmpDir(
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
-    if (resolveDirState(POSIX_OPENCLAW_TMP_DIR) !== "available") {
+    chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);
+    if (
+      resolveDirState(POSIX_OPENCLAW_TMP_DIR) !== "available" &&
+      !tryRepairWritableBits(POSIX_OPENCLAW_TMP_DIR)
+    ) {
       return ensureTrustedFallbackDir();
     }
     return POSIX_OPENCLAW_TMP_DIR;


### PR DESCRIPTION
Closes #27853

Problem
Gateway can crash-loop after `npm i -g openclaw@latest` when the process runs with `umask 0002`, because temp dir startup rejects a group-writable fallback temp directory.

Root Cause
`mkdir(..., mode: 0700)` still respects process umask. With `umask 0002`, `/tmp/openclaw-<uid>` is created as `0775`, and the subsequent security check treats it as unsafe and aborts startup.

Fix
Explicitly `chmod 0700` after creating OpenClaw temp directories so permissions do not depend on umask. Also add a startup self-heal path that tightens writable bits on existing owned temp dirs (preferred or fallback) before failing, with a warning log.

Testing
- `pnpm exec vitest run src/infra/tmp-openclaw-dir.test.ts`
- Added regression tests covering fallback creation under simulated `umask 0002` and startup self-heal for existing broad permissions.
