### PR TITLE
accept legacy gateway.mode and gateway.bind IPv4 host”

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,31 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it('accepts legacy gateway.mode="gateway" (alias of local)', () => {
+    const res = validateConfigObject({
+      gateway: {
+        mode: "gateway",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.gateway?.mode).toBe("local");
+    }
+  });
+
+  it('accepts legacy gateway.bind="0.0.0.0" by mapping to customBindHost', () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "0.0.0.0",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.gateway?.bind).toBe("custom");
+      expect(res.config.gateway?.customBindHost).toBe("0.0.0.0");
+    }
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -157,4 +157,15 @@ describe("config schema regressions", () => {
       expect(res.config.gateway?.customBindHost).toBe("0.0.0.0");
     }
   });
+
+  it("rejects legacy gateway.bind IPv4 when gateway.customBindHost conflicts", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "0.0.0.0",
+        customBindHost: "127.0.0.1",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -192,9 +192,44 @@ export function mapSensitivePaths(
   let currentSchema = schema;
   let isSensitive = sensitive.has(currentSchema);
 
-  while (isUnwrappable(currentSchema)) {
-    currentSchema = currentSchema.unwrap();
-    isSensitive ||= sensitive.has(currentSchema);
+  // Unwrap schema wrappers so we can traverse nested schemas for hints.
+  // Order matters: preprocess returns ZodPipe (v4) or ZodEffects (older), and
+  // the output may still be optional/nullable/etc.
+  const ZodEffectsCtor = (z as unknown as { ZodEffects?: unknown }).ZodEffects;
+  while (true) {
+    if (isUnwrappable(currentSchema)) {
+      currentSchema = currentSchema.unwrap();
+      isSensitive ||= sensitive.has(currentSchema);
+      continue;
+    }
+
+    if (currentSchema instanceof z.ZodPipe) {
+      currentSchema = currentSchema._def.out as z.ZodType;
+      isSensitive ||= sensitive.has(currentSchema);
+      continue;
+    }
+
+    if (
+      ZodEffectsCtor &&
+      typeof ZodEffectsCtor === "function" &&
+      currentSchema instanceof (ZodEffectsCtor as new (...args: never[]) => z.ZodType)
+    ) {
+      currentSchema = (currentSchema as unknown as { _def: { schema: z.ZodType } })._def.schema;
+      isSensitive ||= sensitive.has(currentSchema);
+      continue;
+    }
+
+    if (
+      (currentSchema as unknown as { _def?: { typeName?: string; schema?: z.ZodType } })._def
+        ?.typeName === "ZodEffects" &&
+      (currentSchema as unknown as { _def?: { schema?: z.ZodType } })._def?.schema
+    ) {
+      currentSchema = (currentSchema as unknown as { _def: { schema: z.ZodType } })._def.schema;
+      isSensitive ||= sensitive.has(currentSchema);
+      continue;
+    }
+
+    break;
   }
 
   if (isSensitive) {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,29 +1,12 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
+import { parseDurationMs } from "../cli/parse-duration.js";
+import { isCanonicalDottedDecimalIPv4 } from "../shared/net/ip.js";
+import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
-
-function isValidIPv4String(value: string): boolean {
-  const parts = value.trim().split(".");
-  if (parts.length !== 4) {
-    return false;
-  }
-  for (const part of parts) {
-    if (!/^[0-9]{1,3}$/.test(part)) {
-      return false;
-    }
-    const num = Number(part);
-    if (!Number.isInteger(num) || num < 0 || num > 255) {
-      return false;
-    }
-  }
-  return true;
-}
-
-import { parseDurationMs } from "../cli/parse-duration.js";
-import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
 import { HexColorSchema, ModelsConfigSchema } from "./zod-schema.core.js";
@@ -529,7 +512,7 @@ export const OpenClawSchema = z
 
         // Back-compat: allow gateway.bind to be a raw IPv4 host (commonly 0.0.0.0).
         // Canonical form is gateway.bind="custom" + gateway.customBindHost="<ip>".
-        if (typeof next.bind === "string" && isValidIPv4String(next.bind)) {
+        if (typeof next.bind === "string" && isCanonicalDottedDecimalIPv4(next.bind)) {
           if (typeof next.customBindHost !== "string" || next.customBindHost.trim().length === 0) {
             next.customBindHost = next.bind;
           }


### PR DESCRIPTION
## Summary
- Problem: Config validation rejects `gateway.mode: "gateway"` and `gateway.bind: "0.0.0.0"` as “Invalid input” in v2026.2.25.
- Why it matters: Operators following older docs/config examples can get blocked from starting the gateway after upgrade, causing outages/confusion.
- What changed: Added config schema preprocessing to accept legacy values and normalize them to canonical config (`mode=local`, `bind=custom + customBindHost=<ip>`), plus regression tests.
- What did NOT change (scope boundary): No runtime gateway behavior changes; only config validation/normalization at load/validate time.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #27820

## User-visible / Behavior Changes
- Legacy `gateway.mode: "gateway"` is now accepted and treated as `gateway.mode: "local"`.
- Legacy `gateway.bind: "<IPv4>"` (e.g. `0.0.0.0`) is now accepted and normalized to `gateway.bind: "custom"` with `gateway.customBindHost` set to that IPv4.

## Security Impact (required)
- New permissions/capabilities? (Yes/No) **No**
- Secrets/tokens handling changed? (Yes/No) **No**
- New/changed network calls? (Yes/No) **No**
- Command/tool execution surface changed? (Yes/No) **No**
- Data access scope changed? (Yes/No) **No**
- If any `Yes`, explain risk + mitigation: **N/A**

## Repro + Verification
### Environment
- OS: macOS (dev)
- Runtime/container: local pnpm + vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `gateway.mode: "gateway"`
  - `gateway.bind: "0.0.0.0"`

### Steps
1. Validate config containing `gateway.mode: "gateway"` and/or `gateway.bind: "0.0.0.0"`.
2. Observe schema validation failure (“Invalid input”) on current release behavior.
3. Apply fix and re-run validation/tests.

### Expected
- Config validates successfully.
- Normalized config uses canonical values (`mode=local`, `bind=custom`, `customBindHost=<ip>`).

### Actual
- Before: validation error “Invalid input”.
- After: validation passes; normalization occurs.

## Evidence
Attach at least one:
- [x] Failing test/log before + passing after

## Human Verification (required)
- Verified scenarios:
  - `validateConfigObject({ gateway: { mode: "gateway" } })` passes and normalizes to `local`.
  - `validateConfigObject({ gateway: { bind: "0.0.0.0" } })` passes and normalizes to `custom` + `customBindHost`.
- Edge cases checked:
  - Existing `customBindHost` is preserved if already set when `bind` is an IPv4.
- What you did **not** verify:
  - Full end-to-end gateway startup on Linux using these legacy values (relies on schema normalization only).

## Compatibility / Migration
- Backward compatible? (Yes/No) **Yes**
- Config/env changes? (Yes/No) **No** (normalization only; no required changes)
- Migration needed? (Yes/No) **No**

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly:
  - Revert commit on this branch.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected normalization of `gateway.bind` values that are not intended to be IPv4 literals.

## Risks and Mitigations
- Risk: Treating any IPv4 string in `gateway.bind` as legacy host could surprise users who typo’d a bind mode.
- Mitigation: Only triggers when `gateway.bind` is a valid IPv4 literal; canonical modes remain unchanged and still validated.

