### PR TITLE
Config: preserve core channel settings when plugin validation fails

### DIFF
--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -26,14 +26,18 @@ async function writeConfig(
   return configPath;
 }
 
+function createIoForHome(home: string, env: NodeJS.ProcessEnv = {} as NodeJS.ProcessEnv) {
+  return createConfigIO({
+    env,
+    homedir: () => home,
+  });
+}
+
 describe("config io paths", () => {
   it("uses ~/.openclaw/openclaw.json when config exists", async () => {
     await withTempHome(async (home) => {
       const configPath = await writeConfig(home, ".openclaw", 19001);
-      const io = createConfigIO({
-        env: {} as NodeJS.ProcessEnv,
-        homedir: () => home,
-      });
+      const io = createIoForHome(home);
       expect(io.configPath).toBe(configPath);
       expect(io.loadConfig().gateway?.port).toBe(19001);
     });
@@ -41,10 +45,7 @@ describe("config io paths", () => {
 
   it("defaults to ~/.openclaw/openclaw.json when config is missing", async () => {
     await withTempHome(async (home) => {
-      const io = createConfigIO({
-        env: {} as NodeJS.ProcessEnv,
-        homedir: () => home,
-      });
+      const io = createIoForHome(home);
       expect(io.configPath).toBe(path.join(home, ".openclaw", "openclaw.json"));
     });
   });
@@ -62,12 +63,116 @@ describe("config io paths", () => {
   it("honors explicit OPENCLAW_CONFIG_PATH override", async () => {
     await withTempHome(async (home) => {
       const customPath = await writeConfig(home, ".openclaw", 20002, "custom.json");
-      const io = createConfigIO({
-        env: { OPENCLAW_CONFIG_PATH: customPath } as NodeJS.ProcessEnv,
-        homedir: () => home,
-      });
+      const io = createIoForHome(home, { OPENCLAW_CONFIG_PATH: customPath } as NodeJS.ProcessEnv);
       expect(io.configPath).toBe(customPath);
       expect(io.loadConfig().gateway?.port).toBe(20002);
+    });
+  });
+
+  it("honors legacy CLAWDBOT_CONFIG_PATH override", async () => {
+    await withTempHome(async (home) => {
+      const customPath = await writeConfig(home, ".openclaw", 20003, "legacy-custom.json");
+      const io = createIoForHome(home, { CLAWDBOT_CONFIG_PATH: customPath } as NodeJS.ProcessEnv);
+      expect(io.configPath).toBe(customPath);
+      expect(io.loadConfig().gateway?.port).toBe(20003);
+    });
+  });
+
+  it("normalizes safe-bin config entries at config load time", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            tools: {
+              exec: {
+                safeBinTrustedDirs: [" /custom/bin ", "", "/custom/bin", "/agent/bin"],
+                safeBinProfiles: {
+                  " MyFilter ": {
+                    allowedValueFlags: ["--limit", " --limit ", ""],
+                  },
+                },
+              },
+            },
+            agents: {
+              list: [
+                {
+                  id: "ops",
+                  tools: {
+                    exec: {
+                      safeBinTrustedDirs: [" /ops/bin ", "/ops/bin"],
+                      safeBinProfiles: {
+                        " Custom ": {
+                          deniedFlags: ["-f", " -f ", ""],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      const io = createIoForHome(home);
+      expect(io.configPath).toBe(configPath);
+      const cfg = io.loadConfig();
+      expect(cfg.tools?.exec?.safeBinProfiles).toEqual({
+        myfilter: {
+          allowedValueFlags: ["--limit"],
+        },
+      });
+      expect(cfg.tools?.exec?.safeBinTrustedDirs).toEqual(["/custom/bin", "/agent/bin"]);
+      expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinProfiles).toEqual({
+        custom: {
+          deniedFlags: ["-f"],
+        },
+      });
+      expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinTrustedDirs).toEqual(["/ops/bin"]);
+    });
+  });
+
+  it("preserves channel security config when plugin validation fails", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            agents: { list: [{ id: "pi" }] },
+            channels: {
+              whatsapp: {
+                dmPolicy: "allowlist",
+                allowFrom: ["+15555550123"],
+              },
+            },
+            plugins: {
+              enabled: false,
+              entries: {
+                "missing-plugin": { enabled: true },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const io = createIoForHome(home);
+      expect(io.configPath).toBe(configPath);
+
+      const cfg = io.loadConfig();
+      expect(cfg.channels?.whatsapp?.dmPolicy).toBe("allowlist");
+      expect(cfg.channels?.whatsapp?.allowFrom).toEqual(["+15555550123"]);
     });
   });
 });

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -26,18 +26,14 @@ async function writeConfig(
   return configPath;
 }
 
-function createIoForHome(home: string, env: NodeJS.ProcessEnv = {} as NodeJS.ProcessEnv) {
-  return createConfigIO({
-    env,
-    homedir: () => home,
-  });
-}
-
 describe("config io paths", () => {
   it("uses ~/.openclaw/openclaw.json when config exists", async () => {
     await withTempHome(async (home) => {
       const configPath = await writeConfig(home, ".openclaw", 19001);
-      const io = createIoForHome(home);
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
       expect(io.configPath).toBe(configPath);
       expect(io.loadConfig().gateway?.port).toBe(19001);
     });
@@ -45,7 +41,10 @@ describe("config io paths", () => {
 
   it("defaults to ~/.openclaw/openclaw.json when config is missing", async () => {
     await withTempHome(async (home) => {
-      const io = createIoForHome(home);
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
       expect(io.configPath).toBe(path.join(home, ".openclaw", "openclaw.json"));
     });
   });
@@ -63,78 +62,12 @@ describe("config io paths", () => {
   it("honors explicit OPENCLAW_CONFIG_PATH override", async () => {
     await withTempHome(async (home) => {
       const customPath = await writeConfig(home, ".openclaw", 20002, "custom.json");
-      const io = createIoForHome(home, { OPENCLAW_CONFIG_PATH: customPath } as NodeJS.ProcessEnv);
+      const io = createConfigIO({
+        env: { OPENCLAW_CONFIG_PATH: customPath } as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
       expect(io.configPath).toBe(customPath);
       expect(io.loadConfig().gateway?.port).toBe(20002);
-    });
-  });
-
-  it("honors legacy CLAWDBOT_CONFIG_PATH override", async () => {
-    await withTempHome(async (home) => {
-      const customPath = await writeConfig(home, ".openclaw", 20003, "legacy-custom.json");
-      const io = createIoForHome(home, { CLAWDBOT_CONFIG_PATH: customPath } as NodeJS.ProcessEnv);
-      expect(io.configPath).toBe(customPath);
-      expect(io.loadConfig().gateway?.port).toBe(20003);
-    });
-  });
-
-  it("normalizes safe-bin config entries at config load time", async () => {
-    await withTempHome(async (home) => {
-      const configDir = path.join(home, ".openclaw");
-      await fs.mkdir(configDir, { recursive: true });
-      const configPath = path.join(configDir, "openclaw.json");
-      await fs.writeFile(
-        configPath,
-        JSON.stringify(
-          {
-            tools: {
-              exec: {
-                safeBinTrustedDirs: [" /custom/bin ", "", "/custom/bin", "/agent/bin"],
-                safeBinProfiles: {
-                  " MyFilter ": {
-                    allowedValueFlags: ["--limit", " --limit ", ""],
-                  },
-                },
-              },
-            },
-            agents: {
-              list: [
-                {
-                  id: "ops",
-                  tools: {
-                    exec: {
-                      safeBinTrustedDirs: [" /ops/bin ", "/ops/bin"],
-                      safeBinProfiles: {
-                        " Custom ": {
-                          deniedFlags: ["-f", " -f ", ""],
-                        },
-                      },
-                    },
-                  },
-                },
-              ],
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      const io = createIoForHome(home);
-      expect(io.configPath).toBe(configPath);
-      const cfg = io.loadConfig();
-      expect(cfg.tools?.exec?.safeBinProfiles).toEqual({
-        myfilter: {
-          allowedValueFlags: ["--limit"],
-        },
-      });
-      expect(cfg.tools?.exec?.safeBinTrustedDirs).toEqual(["/custom/bin", "/agent/bin"]);
-      expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinProfiles).toEqual({
-        custom: {
-          deniedFlags: ["-f"],
-        },
-      });
-      expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinTrustedDirs).toEqual(["/ops/bin"]);
     });
   });
 
@@ -167,7 +100,10 @@ describe("config io paths", () => {
         "utf-8",
       );
 
-      const io = createIoForHome(home);
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
       expect(io.configPath).toBe(configPath);
 
       const cfg = io.loadConfig();

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import JSON5 from "json5";
-import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -36,7 +35,6 @@ import { applyConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import { applyMergePatch } from "./merge-patch.js";
-import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
@@ -117,11 +115,6 @@ export type ConfigWriteOptions = {
    * same config file path that produced the snapshot.
    */
   expectedConfigPath?: string;
-  /**
-   * Paths that must be explicitly removed from the persisted file payload,
-   * even if schema/default normalization reintroduces them.
-   */
-  unsetPaths?: string[][];
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -134,86 +127,6 @@ function hashConfigRaw(raw: string | null): string {
     .createHash("sha256")
     .update(raw ?? "")
     .digest("hex");
-}
-
-function isNumericPathSegment(raw: string): boolean {
-  return /^[0-9]+$/.test(raw);
-}
-
-function isWritePlainObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function unsetPathForWrite(root: Record<string, unknown>, pathSegments: string[]): boolean {
-  if (pathSegments.length === 0) {
-    return false;
-  }
-
-  const traversal: Array<{ container: unknown; key: string | number }> = [];
-  let cursor: unknown = root;
-
-  for (let i = 0; i < pathSegments.length - 1; i += 1) {
-    const segment = pathSegments[i];
-    if (Array.isArray(cursor)) {
-      if (!isNumericPathSegment(segment)) {
-        return false;
-      }
-      const index = Number.parseInt(segment, 10);
-      if (!Number.isFinite(index) || index < 0 || index >= cursor.length) {
-        return false;
-      }
-      traversal.push({ container: cursor, key: index });
-      cursor = cursor[index];
-      continue;
-    }
-    if (!isWritePlainObject(cursor) || !(segment in cursor)) {
-      return false;
-    }
-    traversal.push({ container: cursor, key: segment });
-    cursor = cursor[segment];
-  }
-
-  const leaf = pathSegments[pathSegments.length - 1];
-  if (Array.isArray(cursor)) {
-    if (!isNumericPathSegment(leaf)) {
-      return false;
-    }
-    const index = Number.parseInt(leaf, 10);
-    if (!Number.isFinite(index) || index < 0 || index >= cursor.length) {
-      return false;
-    }
-    cursor.splice(index, 1);
-  } else {
-    if (!isWritePlainObject(cursor) || !(leaf in cursor)) {
-      return false;
-    }
-    delete cursor[leaf];
-  }
-
-  // Prune now-empty object branches after unsetting to avoid dead config scaffolding.
-  for (let i = traversal.length - 1; i >= 0; i -= 1) {
-    const { container, key } = traversal[i];
-    let child: unknown;
-    if (Array.isArray(container)) {
-      child = typeof key === "number" ? container[key] : undefined;
-    } else if (isWritePlainObject(container)) {
-      child = container[String(key)];
-    } else {
-      break;
-    }
-    if (!isWritePlainObject(child) || Object.keys(child).length > 0) {
-      break;
-    }
-    if (Array.isArray(container) && typeof key === "number") {
-      if (key >= 0 && key < container.length) {
-        container.splice(key, 1);
-      }
-    } else if (isWritePlainObject(container)) {
-      delete container[String(key)];
-    }
-  }
-
-  return true;
 }
 
 export function resolveConfigSnapshotHash(snapshot: {
@@ -616,79 +529,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   function loadConfig(): OpenClawConfig {
     let resolvedConfigForInvalidFallback: unknown;
-    const finalizeLoadedConfig = (config: OpenClawConfig): OpenClawConfig => {
-      warnIfConfigFromFuture(config, deps.logger);
-      const cfg = applyModelDefaults(
-        applyCompactionDefaults(
-          applyContextPruningDefaults(
-            applyAgentDefaults(
-              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(config))),
-            ),
-          ),
-        ),
-      );
-      normalizeConfigPaths(cfg);
-      normalizeExecSafeBinProfilesInConfig(cfg);
-
-      const duplicates = findDuplicateAgentDirs(cfg, {
-        env: deps.env,
-        homedir: deps.homedir,
-      });
-      if (duplicates.length > 0) {
-        throw new DuplicateAgentDirError(duplicates);
-      }
-
-      applyConfigEnvVars(cfg, deps.env);
-
-      const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
-      if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
-        loadShellEnvFallback({
-          enabled: true,
-          env: deps.env,
-          expectedKeys: SHELL_ENV_EXPECTED_KEYS,
-          logger: deps.logger,
-          timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
-        });
-      }
-
-      const pendingSecret = AUTO_OWNER_DISPLAY_SECRET_BY_PATH.get(configPath);
-      const ownerDisplaySecretResolution = ensureOwnerDisplaySecret(
-        cfg,
-        () => pendingSecret ?? crypto.randomBytes(32).toString("hex"),
-      );
-      const cfgWithOwnerDisplaySecret = ownerDisplaySecretResolution.config;
-      if (ownerDisplaySecretResolution.generatedSecret) {
-        AUTO_OWNER_DISPLAY_SECRET_BY_PATH.set(
-          configPath,
-          ownerDisplaySecretResolution.generatedSecret,
-        );
-        if (!AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.has(configPath)) {
-          AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.add(configPath);
-          void writeConfigFile(cfgWithOwnerDisplaySecret, { expectedConfigPath: configPath })
-            .then(() => {
-              AUTO_OWNER_DISPLAY_SECRET_BY_PATH.delete(configPath);
-              AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.delete(configPath);
-            })
-            .catch((err) => {
-              if (!AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.has(configPath)) {
-                AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.add(configPath);
-                deps.logger.warn(
-                  `Failed to persist auto-generated commands.ownerDisplaySecret at ${configPath}: ${String(err)}`,
-                );
-              }
-            })
-            .finally(() => {
-              AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.delete(configPath);
-            });
-        }
-      } else {
-        AUTO_OWNER_DISPLAY_SECRET_BY_PATH.delete(configPath);
-        AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.delete(configPath);
-      }
-
-      return applyConfigOverrides(cfgWithOwnerDisplaySecret);
-    };
-
     try {
       maybeLoadDotEnvForConfig(deps.env);
       if (!deps.fs.existsSync(configPath)) {
@@ -741,7 +581,40 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           .join("\n");
         deps.logger.warn(`Config warnings:\\n${details}`);
       }
-      return finalizeLoadedConfig(validated.config);
+      warnIfConfigFromFuture(validated.config, deps.logger);
+      const cfg = applyModelDefaults(
+        applyCompactionDefaults(
+          applyContextPruningDefaults(
+            applyAgentDefaults(
+              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+            ),
+          ),
+        ),
+      );
+      normalizeConfigPaths(cfg);
+
+      const duplicates = findDuplicateAgentDirs(cfg, {
+        env: deps.env,
+        homedir: deps.homedir,
+      });
+      if (duplicates.length > 0) {
+        throw new DuplicateAgentDirError(duplicates);
+      }
+
+      applyConfigEnvVars(cfg, deps.env);
+
+      const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
+      if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
+        loadShellEnvFallback({
+          enabled: true,
+          env: deps.env,
+          expectedKeys: SHELL_ENV_EXPECTED_KEYS,
+          logger: deps.logger,
+          timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
+        });
+      }
+
+      return applyConfigOverrides(cfg);
     } catch (err) {
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);
@@ -754,7 +627,41 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           deps.logger.warn(
             `Config at ${configPath} failed plugin validation; loading core settings without plugin checks.`,
           );
-          return finalizeLoadedConfig(fallback.config);
+          warnIfConfigFromFuture(fallback.config, deps.logger);
+          const cfg = applyModelDefaults(
+            applyCompactionDefaults(
+              applyContextPruningDefaults(
+                applyAgentDefaults(
+                  applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(fallback.config))),
+                ),
+              ),
+            ),
+          );
+          normalizeConfigPaths(cfg);
+
+          const duplicates = findDuplicateAgentDirs(cfg, {
+            env: deps.env,
+            homedir: deps.homedir,
+          });
+          if (duplicates.length > 0) {
+            throw new DuplicateAgentDirError(duplicates);
+          }
+
+          applyConfigEnvVars(cfg, deps.env);
+
+          const enabled =
+            shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
+          if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
+            loadShellEnvFallback({
+              enabled: true,
+              env: deps.env,
+              expectedKeys: SHELL_ENV_EXPECTED_KEYS,
+              logger: deps.logger,
+              timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
+            });
+          }
+
+          return applyConfigOverrides(cfg);
         }
         return {};
       }
@@ -891,16 +798,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
 
       warnIfConfigFromFuture(validated.config, deps.logger);
-      const snapshotConfig = normalizeConfigPaths(
-        applyTalkApiKey(
-          applyModelDefaults(
-            applyAgentDefaults(
-              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
-            ),
-          ),
-        ),
-      );
-      normalizeExecSafeBinProfilesInConfig(snapshotConfig);
       return {
         snapshot: {
           path: configPath,
@@ -911,7 +808,17 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           // for config set/unset operations (issue #6070)
           resolved: coerceConfig(resolvedConfigRaw),
           valid: true,
-          config: snapshotConfig,
+          config: normalizeConfigPaths(
+            applyTalkApiKey(
+              applyModelDefaults(
+                applyAgentDefaults(
+                  applySessionDefaults(
+                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                  ),
+                ),
+              ),
+            ),
+          ),
           hash,
           issues: [],
           warnings: validated.warnings,
@@ -1029,14 +936,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
         : cfgToWrite;
-    if (options.unsetPaths?.length) {
-      for (const unsetPath of options.unsetPaths) {
-        if (!Array.isArray(unsetPath) || unsetPath.length === 0) {
-          continue;
-        }
-        unsetPathForWrite(outputConfig as Record<string, unknown>, unsetPath);
-      }
-    }
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
     const stampedOutputConfig = stampConfigVersion(outputConfig);
@@ -1201,9 +1100,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 // module scope. `OPENCLAW_CONFIG_PATH` (and friends) are expected to work even
 // when set after the module has been imported (tests, one-off scripts, etc.).
 const DEFAULT_CONFIG_CACHE_MS = 200;
-const AUTO_OWNER_DISPLAY_SECRET_BY_PATH = new Map<string, string>();
-const AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT = new Set<string>();
-const AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED = new Set<string>();
 let configCache: {
   configPath: string;
   expiresAt: number;
@@ -1277,6 +1173,5 @@ export async function writeConfigFile(
     options.expectedConfigPath === undefined || options.expectedConfigPath === io.configPath;
   await io.writeConfigFile(cfg, {
     envSnapshotForRestore: sameConfigPath ? options.envSnapshotForRestore : undefined,
-    unsetPaths: options.unsetPaths,
   });
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import JSON5 from "json5";
+import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -35,11 +36,13 @@ import { applyConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import { applyMergePatch } from "./merge-patch.js";
+import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
+  validateConfigObject,
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
@@ -114,6 +117,11 @@ export type ConfigWriteOptions = {
    * same config file path that produced the snapshot.
    */
   expectedConfigPath?: string;
+  /**
+   * Paths that must be explicitly removed from the persisted file payload,
+   * even if schema/default normalization reintroduces them.
+   */
+  unsetPaths?: string[][];
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -126,6 +134,86 @@ function hashConfigRaw(raw: string | null): string {
     .createHash("sha256")
     .update(raw ?? "")
     .digest("hex");
+}
+
+function isNumericPathSegment(raw: string): boolean {
+  return /^[0-9]+$/.test(raw);
+}
+
+function isWritePlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function unsetPathForWrite(root: Record<string, unknown>, pathSegments: string[]): boolean {
+  if (pathSegments.length === 0) {
+    return false;
+  }
+
+  const traversal: Array<{ container: unknown; key: string | number }> = [];
+  let cursor: unknown = root;
+
+  for (let i = 0; i < pathSegments.length - 1; i += 1) {
+    const segment = pathSegments[i];
+    if (Array.isArray(cursor)) {
+      if (!isNumericPathSegment(segment)) {
+        return false;
+      }
+      const index = Number.parseInt(segment, 10);
+      if (!Number.isFinite(index) || index < 0 || index >= cursor.length) {
+        return false;
+      }
+      traversal.push({ container: cursor, key: index });
+      cursor = cursor[index];
+      continue;
+    }
+    if (!isWritePlainObject(cursor) || !(segment in cursor)) {
+      return false;
+    }
+    traversal.push({ container: cursor, key: segment });
+    cursor = cursor[segment];
+  }
+
+  const leaf = pathSegments[pathSegments.length - 1];
+  if (Array.isArray(cursor)) {
+    if (!isNumericPathSegment(leaf)) {
+      return false;
+    }
+    const index = Number.parseInt(leaf, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= cursor.length) {
+      return false;
+    }
+    cursor.splice(index, 1);
+  } else {
+    if (!isWritePlainObject(cursor) || !(leaf in cursor)) {
+      return false;
+    }
+    delete cursor[leaf];
+  }
+
+  // Prune now-empty object branches after unsetting to avoid dead config scaffolding.
+  for (let i = traversal.length - 1; i >= 0; i -= 1) {
+    const { container, key } = traversal[i];
+    let child: unknown;
+    if (Array.isArray(container)) {
+      child = typeof key === "number" ? container[key] : undefined;
+    } else if (isWritePlainObject(container)) {
+      child = container[String(key)];
+    } else {
+      break;
+    }
+    if (!isWritePlainObject(child) || Object.keys(child).length > 0) {
+      break;
+    }
+    if (Array.isArray(container) && typeof key === "number") {
+      if (key >= 0 && key < container.length) {
+        container.splice(key, 1);
+      }
+    } else if (isWritePlainObject(container)) {
+      delete container[String(key)];
+    }
+  }
+
+  return true;
 }
 
 export function resolveConfigSnapshotHash(snapshot: {
@@ -527,6 +615,80 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     candidatePaths.find((candidate) => deps.fs.existsSync(candidate)) ?? requestedConfigPath;
 
   function loadConfig(): OpenClawConfig {
+    let resolvedConfigForInvalidFallback: unknown;
+    const finalizeLoadedConfig = (config: OpenClawConfig): OpenClawConfig => {
+      warnIfConfigFromFuture(config, deps.logger);
+      const cfg = applyModelDefaults(
+        applyCompactionDefaults(
+          applyContextPruningDefaults(
+            applyAgentDefaults(
+              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(config))),
+            ),
+          ),
+        ),
+      );
+      normalizeConfigPaths(cfg);
+      normalizeExecSafeBinProfilesInConfig(cfg);
+
+      const duplicates = findDuplicateAgentDirs(cfg, {
+        env: deps.env,
+        homedir: deps.homedir,
+      });
+      if (duplicates.length > 0) {
+        throw new DuplicateAgentDirError(duplicates);
+      }
+
+      applyConfigEnvVars(cfg, deps.env);
+
+      const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
+      if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
+        loadShellEnvFallback({
+          enabled: true,
+          env: deps.env,
+          expectedKeys: SHELL_ENV_EXPECTED_KEYS,
+          logger: deps.logger,
+          timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
+        });
+      }
+
+      const pendingSecret = AUTO_OWNER_DISPLAY_SECRET_BY_PATH.get(configPath);
+      const ownerDisplaySecretResolution = ensureOwnerDisplaySecret(
+        cfg,
+        () => pendingSecret ?? crypto.randomBytes(32).toString("hex"),
+      );
+      const cfgWithOwnerDisplaySecret = ownerDisplaySecretResolution.config;
+      if (ownerDisplaySecretResolution.generatedSecret) {
+        AUTO_OWNER_DISPLAY_SECRET_BY_PATH.set(
+          configPath,
+          ownerDisplaySecretResolution.generatedSecret,
+        );
+        if (!AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.has(configPath)) {
+          AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.add(configPath);
+          void writeConfigFile(cfgWithOwnerDisplaySecret, { expectedConfigPath: configPath })
+            .then(() => {
+              AUTO_OWNER_DISPLAY_SECRET_BY_PATH.delete(configPath);
+              AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.delete(configPath);
+            })
+            .catch((err) => {
+              if (!AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.has(configPath)) {
+                AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.add(configPath);
+                deps.logger.warn(
+                  `Failed to persist auto-generated commands.ownerDisplaySecret at ${configPath}: ${String(err)}`,
+                );
+              }
+            })
+            .finally(() => {
+              AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT.delete(configPath);
+            });
+        }
+      } else {
+        AUTO_OWNER_DISPLAY_SECRET_BY_PATH.delete(configPath);
+        AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.delete(configPath);
+      }
+
+      return applyConfigOverrides(cfgWithOwnerDisplaySecret);
+    };
+
     try {
       maybeLoadDotEnvForConfig(deps.env);
       if (!deps.fs.existsSync(configPath)) {
@@ -547,6 +709,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         resolveConfigIncludesForRead(parsed, configPath, deps),
         deps.env,
       );
+      resolvedConfigForInvalidFallback = resolvedConfig;
       warnOnConfigMiskeys(resolvedConfig, deps.logger);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
         return {};
@@ -578,40 +741,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           .join("\n");
         deps.logger.warn(`Config warnings:\\n${details}`);
       }
-      warnIfConfigFromFuture(validated.config, deps.logger);
-      const cfg = applyModelDefaults(
-        applyCompactionDefaults(
-          applyContextPruningDefaults(
-            applyAgentDefaults(
-              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
-            ),
-          ),
-        ),
-      );
-      normalizeConfigPaths(cfg);
-
-      const duplicates = findDuplicateAgentDirs(cfg, {
-        env: deps.env,
-        homedir: deps.homedir,
-      });
-      if (duplicates.length > 0) {
-        throw new DuplicateAgentDirError(duplicates);
-      }
-
-      applyConfigEnvVars(cfg, deps.env);
-
-      const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
-      if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
-        loadShellEnvFallback({
-          enabled: true,
-          env: deps.env,
-          expectedKeys: SHELL_ENV_EXPECTED_KEYS,
-          logger: deps.logger,
-          timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
-        });
-      }
-
-      return applyConfigOverrides(cfg);
+      return finalizeLoadedConfig(validated.config);
     } catch (err) {
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);
@@ -619,6 +749,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const error = err as { code?: string };
       if (error?.code === "INVALID_CONFIG") {
+        const fallback = validateConfigObject(resolvedConfigForInvalidFallback);
+        if (fallback.ok) {
+          deps.logger.warn(
+            `Config at ${configPath} failed plugin validation; loading core settings without plugin checks.`,
+          );
+          return finalizeLoadedConfig(fallback.config);
+        }
         return {};
       }
       deps.logger.error(`Failed to read config at ${configPath}`, err);
@@ -754,6 +891,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
 
       warnIfConfigFromFuture(validated.config, deps.logger);
+      const snapshotConfig = normalizeConfigPaths(
+        applyTalkApiKey(
+          applyModelDefaults(
+            applyAgentDefaults(
+              applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+            ),
+          ),
+        ),
+      );
+      normalizeExecSafeBinProfilesInConfig(snapshotConfig);
       return {
         snapshot: {
           path: configPath,
@@ -764,17 +911,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           // for config set/unset operations (issue #6070)
           resolved: coerceConfig(resolvedConfigRaw),
           valid: true,
-          config: normalizeConfigPaths(
-            applyTalkApiKey(
-              applyModelDefaults(
-                applyAgentDefaults(
-                  applySessionDefaults(
-                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
-                  ),
-                ),
-              ),
-            ),
-          ),
+          config: snapshotConfig,
           hash,
           issues: [],
           warnings: validated.warnings,
@@ -892,6 +1029,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
         : cfgToWrite;
+    if (options.unsetPaths?.length) {
+      for (const unsetPath of options.unsetPaths) {
+        if (!Array.isArray(unsetPath) || unsetPath.length === 0) {
+          continue;
+        }
+        unsetPathForWrite(outputConfig as Record<string, unknown>, unsetPath);
+      }
+    }
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
     const stampedOutputConfig = stampConfigVersion(outputConfig);
@@ -1056,6 +1201,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 // module scope. `OPENCLAW_CONFIG_PATH` (and friends) are expected to work even
 // when set after the module has been imported (tests, one-off scripts, etc.).
 const DEFAULT_CONFIG_CACHE_MS = 200;
+const AUTO_OWNER_DISPLAY_SECRET_BY_PATH = new Map<string, string>();
+const AUTO_OWNER_DISPLAY_SECRET_PERSIST_IN_FLIGHT = new Set<string>();
+const AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED = new Set<string>();
 let configCache: {
   configPath: string;
   expiresAt: number;
@@ -1129,5 +1277,6 @@ export async function writeConfigFile(
     options.expectedConfigPath === undefined || options.expectedConfigPath === io.configPath;
   await io.writeConfigFile(cfg, {
     envSnapshotForRestore: sameConfigPath ? options.envSnapshotForRestore : undefined,
+    unsetPaths: options.unsetPaths,
   });
 }


### PR DESCRIPTION
## Summary
- preserve core config when plugin validation fails with `INVALID_CONFIG` instead of dropping all settings
- validate the fallback with core schema checks and run it through the normal load finalization path
- add a regression test proving `channels.whatsapp.dmPolicy` and `channels.whatsapp.allowFrom` survive plugin validation failure

## Validation
- before fix (repro): `pnpm vitest run --config vitest.unit.config.ts src/config/io.compat.test.ts` failed at the new regression case
- after fix:
  - `pnpm vitest run --config vitest.unit.config.ts src/config/io.compat.test.ts`
  - `pnpm vitest run --config vitest.unit.config.ts src/config/config.plugin-validation.test.ts`

Fixes #5052
