### PR TITLE
fix: keep typing indicator alive during long tool executions

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -359,6 +359,13 @@ export async function runAgentTurnWithFallback(params: {
                   await params.typingSignals.signalToolStart();
                   await params.opts?.onToolStart?.({ name, phase });
                 }
+                // Keep typing alive when a tool finishes — the agent is still working
+                // (processing the result and likely invoking the next tool).
+                // Without this, long tool executions (>2min TTL) cause the typing
+                // indicator to silently stop, making the agent appear unresponsive.
+                if (phase === "result") {
+                  await params.typingSignals.signalToolStart();
+                }
               }
               // Track auto-compaction completion
               if (evt.stream === "compaction") {


### PR DESCRIPTION
## Summary

- Refreshes the typing TTL when tool results arrive (`phase === "result"`), not just on tool start/update
- Fixes the typing indicator silently dying after 2 minutes during long-running tool executions (browser automation, file writes, etc.)
- The agent appears unresponsive in Discord even though it's actively working

## Root cause

The `onAgentEvent` handler in `agent-runner-execution.ts` only calls `signalToolStart()` for `phase === "start"` and `phase === "update"`, but not `phase === "result"`. When a single tool takes >2min, no TTL refresh happens, and `cleanup()` fires mid-execution.

Gateway logs confirm:
```
typing TTL reached (2m); stopping typing indicator
```

## Test plan

- [ ] Trigger a long-running tool execution (>2min) and verify typing indicator persists
- [ ] Verify typing still stops correctly after run completes (`markRunComplete`)
- [ ] Verify existing typing mode tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)