### PR TITLE
fix(agents): enable turn validation for all non-OpenAI providers

### DIFF
--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -292,6 +292,68 @@ describe("validateAnthropicTurns", () => {
 });
 
 describe("mergeConsecutiveUserTurns", () => {
+  it("merges string content by converting to TextContent blocks", () => {
+    // This is critical for OpenAI-style messages where content is a string
+    // Previously this would silently drop the content (bug #27876)
+    const previous = {
+      role: "user",
+      content: "First message",
+      timestamp: 1000,
+    } as Extract<AgentMessage, { role: "user" }>;
+    const current = {
+      role: "user",
+      content: "Second message",
+      timestamp: 2000,
+    } as Extract<AgentMessage, { role: "user" }>;
+
+    const merged = mergeConsecutiveUserTurns(previous, current);
+
+    // String content should be converted to TextContent blocks
+    expect(merged.content).toEqual([
+      { type: "text", text: "First message" },
+      { type: "text", text: "Second message" },
+    ]);
+    expect(merged.timestamp).toBe(2000);
+  });
+
+  it("merges mixed string and array content", () => {
+    const previous = {
+      role: "user",
+      content: "String content",
+      timestamp: 1000,
+    } as Extract<AgentMessage, { role: "user" }>;
+    const current = {
+      role: "user",
+      content: [{ type: "text", text: "Array content" }],
+      timestamp: 2000,
+    } as Extract<AgentMessage, { role: "user" }>;
+
+    const merged = mergeConsecutiveUserTurns(previous, current);
+
+    expect(merged.content).toEqual([
+      { type: "text", text: "String content" },
+      { type: "text", text: "Array content" },
+    ]);
+  });
+
+  it("handles empty string content gracefully", () => {
+    const previous = {
+      role: "user",
+      content: "  ", // whitespace-only
+      timestamp: 1000,
+    } as Extract<AgentMessage, { role: "user" }>;
+    const current = {
+      role: "user",
+      content: "Real content",
+      timestamp: 2000,
+    } as Extract<AgentMessage, { role: "user" }>;
+
+    const merged = mergeConsecutiveUserTurns(previous, current);
+
+    // Empty/whitespace content should be filtered out
+    expect(merged.content).toEqual([{ type: "text", text: "Real content" }]);
+  });
+
   it("keeps newest metadata while merging content", () => {
     const previous = {
       role: "user",

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -128,6 +128,79 @@ describe("validateGeminiTurns", () => {
     expect(result[3].role).toBe("assistant");
     expect(result[4].role).toBe("user");
   });
+
+  it("should merge consecutive assistant messages with string content", () => {
+    // Test normalizeAssistantContentToArray string->TextContent conversion
+    // This covers the assistant-side equivalent of the user string content bug
+    const msgs = asMessages([
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: "First response as string",
+      },
+      {
+        role: "assistant",
+        content: "Second response as string",
+      },
+    ]);
+
+    const result = validateGeminiTurns(msgs);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+
+    // String content should be converted to TextContent blocks, not dropped
+    const assistantContent = (result[1] as { content: unknown[] }).content;
+    expect(assistantContent).toEqual([
+      { type: "text", text: "First response as string" },
+      { type: "text", text: "Second response as string" },
+    ]);
+  });
+
+  it("should handle mixed string and array content in assistant merges", () => {
+    const msgs = asMessages([
+      { role: "user", content: "Question" },
+      {
+        role: "assistant",
+        content: "String content",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Array content" }],
+      },
+    ]);
+
+    const result = validateGeminiTurns(msgs);
+
+    expect(result).toHaveLength(2);
+    const merged = result[1] as { content: unknown[] };
+    expect(merged.content).toEqual([
+      { type: "text", text: "String content" },
+      { type: "text", text: "Array content" },
+    ]);
+  });
+
+  it("filters empty/whitespace string content in assistant merges", () => {
+    const msgs = asMessages([
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: "   ",
+      },
+      {
+        role: "assistant",
+        content: "Real content",
+      },
+    ]);
+
+    const result = validateGeminiTurns(msgs);
+
+    expect(result).toHaveLength(2);
+    const merged = result[1] as { content: unknown[] };
+    // Whitespace-only content should be filtered out
+    expect(merged.content).toEqual([{ type: "text", text: "Real content" }]);
+  });
 });
 
 describe("validateAnthropicTurns", () => {

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ImageContent, TextContent, ThinkingContent, ToolCall } from "@mariozechner/pi-ai";
 
 function validateTurnsWithConsecutiveMerge<TRole extends "assistant" | "user">(params: {
   messages: AgentMessage[];
@@ -46,13 +47,43 @@ function validateTurnsWithConsecutiveMerge<TRole extends "assistant" | "user">(p
   return result;
 }
 
+/**
+ * Normalizes user message content to array form for merging.
+ * Converts string content to a TextContent block to preserve the text.
+ */
+function normalizeUserContentToArray(
+  content: string | (TextContent | ImageContent)[],
+): (TextContent | ImageContent)[] {
+  if (typeof content === "string") {
+    return content.trim() ? [{ type: "text", text: content }] : [];
+  }
+  return Array.isArray(content) ? content : [];
+}
+
+/**
+ * Normalizes assistant message content to array form for merging.
+ * Converts string content to a TextContent block to preserve the text.
+ */
+function normalizeAssistantContentToArray(
+  content: string | (TextContent | ThinkingContent | ToolCall)[],
+): (TextContent | ThinkingContent | ToolCall)[] {
+  if (typeof content === "string") {
+    return content.trim() ? [{ type: "text", text: content }] : [];
+  }
+  return Array.isArray(content) ? content : [];
+}
+
 function mergeConsecutiveAssistantTurns(
   previous: Extract<AgentMessage, { role: "assistant" }>,
   current: Extract<AgentMessage, { role: "assistant" }>,
 ): Extract<AgentMessage, { role: "assistant" }> {
   const mergedContent = [
-    ...(Array.isArray(previous.content) ? previous.content : []),
-    ...(Array.isArray(current.content) ? current.content : []),
+    ...normalizeAssistantContentToArray(
+      previous.content as string | (TextContent | ThinkingContent | ToolCall)[],
+    ),
+    ...normalizeAssistantContentToArray(
+      current.content as string | (TextContent | ThinkingContent | ToolCall)[],
+    ),
   ];
   return {
     ...previous,
@@ -83,8 +114,8 @@ export function mergeConsecutiveUserTurns(
   current: Extract<AgentMessage, { role: "user" }>,
 ): Extract<AgentMessage, { role: "user" }> {
   const mergedContent = [
-    ...(Array.isArray(previous.content) ? previous.content : []),
-    ...(Array.isArray(current.content) ? current.content : []),
+    ...normalizeUserContentToArray(previous.content),
+    ...normalizeUserContentToArray(current.content),
   ];
 
   return {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -23,6 +23,7 @@ describe("resolveTranscriptPolicy", () => {
       allowBase64Only: true,
       includeCamelCase: true,
     });
+    expect(policy.validateAnthropicTurns).toBe(true);
   });
 
   it("enables sanitizeToolCallIds for Mistral provider", () => {
@@ -34,7 +35,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict9");
   });
 
-  it("disables sanitizeToolCallIds for OpenAI provider", () => {
+  it("disables sanitizeToolCallIds and turn-merging for OpenAI provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
@@ -42,9 +43,10 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.toolCallIdMode).toBeUndefined();
+    expect(policy.validateAnthropicTurns).toBeFalsy();
   });
 
-  it("enables user-turn merge for strict OpenAI-compatible providers", () => {
+  it("enables turn validation for all non-OpenAI providers", () => {
     const policy = resolveTranscriptPolicy({
       provider: "moonshot",
       modelId: "kimi-k2.5",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -66,12 +66,12 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeMode).toBe("full");
   });
 
-  it("keeps OpenRouter on its existing turn-validation path", () => {
+  it("enables turn validation for OpenRouter (proxies strict-alternation models)", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",
       modelId: "openai/gpt-4.1",
       modelApi: "openai-completions",
     });
-    expect(policy.validateAnthropicTurns).toBe(false);
+    expect(policy.validateAnthropicTurns).toBe(true);
   });
 });

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -23,6 +23,7 @@ describe("resolveTranscriptPolicy", () => {
       allowBase64Only: true,
       includeCamelCase: true,
     });
+    expect(policy.validateGeminiTurns).toBe(true);
     expect(policy.validateAnthropicTurns).toBe(true);
   });
 
@@ -43,7 +44,7 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.toolCallIdMode).toBeUndefined();
-    expect(policy.validateAnthropicTurns).toBeFalsy();
+    expect(policy.validateAnthropicTurns).toBe(false);
   });
 
   it("enables turn validation for all non-OpenAI providers", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -38,8 +38,6 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-codex-responses",
 ]);
 const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
-// Previously used to exclude certain providers from turn validation; no longer needed
-// since all non-OpenAI providers now get validation (#27862).
 
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {
@@ -86,8 +84,6 @@ export function resolveTranscriptPolicy(params: {
   const isGoogle = isGoogleModelApi(params.modelApi);
   const isAnthropic = isAnthropicApi(params.modelApi, provider);
   const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
-  // isStrictOpenAiCompatible was previously used to gate turn validation for a subset
-  // of openai-completions providers. Now all non-OpenAI providers get validation (#27862).
   const isMistral = isMistralModel({ provider, modelId });
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&


### PR DESCRIPTION
## Summary

Fixes #27862 — Agent CLI permanently stuck in "Message ordering conflict", unrecoverable across restarts.
Fixes #25956 — Mercury-2 fails with "roles must alternate" in isolated sessions.
Related: #7693, #998, #9459 (all role ordering issues with third-party providers).

## Root Cause

`validateAnthropicTurns` (which merges consecutive same-role messages to enforce strict user↔assistant alternation) was only enabled for:
- Anthropic providers
- `openai-completions` API providers not in an exclusion set

Many third-party providers (GLM, Mercury-2, Kimi, Qwen, Ollama, local models) require strict alternation but use different API types or weren't flagged. When these providers reject the prompt with "roles must alternate", OpenClaw shows "Message ordering conflict" but the session reset doesn't fix the underlying message ordering in subsequent prompts.

## Fix

Enable `validateAnthropicTurns` for **all non-OpenAI providers**. OpenAI's own API is tolerant of consecutive same-role messages, so it remains excluded.

```diff
- validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
+ validateAnthropicTurns: !isOpenAi,
```

Also removes the now-unused `isStrictOpenAiCompatible` variable and `OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS` set.

## Impact

- Prevents "Message ordering conflict" for ALL third-party providers
- Fixes 5+ reported issues spanning GLM, Mercury-2, Kimi, Qwen, and custom OpenAI-compatible endpoints
- No impact on OpenAI (already tolerant of consecutive same-role messages)
- No impact on Anthropic/Google (already had validation enabled)

## Tests

All 9 transcript-policy tests pass, including updated OpenRouter test (now expects validation enabled since it proxies strict-alternation models).

@greptile-apps please review