### PR TITLE
fix(tmp): chmod temp dir to 0700 after mkdir

### DIFF
--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -14,6 +14,7 @@ type ResolvePreferredOpenClawTmpDirOptions = {
     uid?: number;
   };
   mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
+  chmodSync?: (path: string, mode: number) => void;
   getuid?: () => number | undefined;
   tmpdir?: () => string;
 };
@@ -35,6 +36,7 @@ export function resolvePreferredOpenClawTmpDir(
   const accessSync = options.accessSync ?? fs.accessSync;
   const lstatSync = options.lstatSync ?? fs.lstatSync;
   const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
+  const chmodSync = options.chmodSync ?? fs.chmodSync;
   const getuid =
     options.getuid ??
     (() => {
@@ -103,6 +105,8 @@ export function resolvePreferredOpenClawTmpDir(
     }
     try {
       mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+      // mkdir mode is filtered through umask; enforce strict permissions.
+      chmodSync(fallbackPath, 0o700);
     } catch {
       throw new Error(`Unable to create fallback OpenClaw temp dir: ${fallbackPath}`);
     }
@@ -124,6 +128,8 @@ export function resolvePreferredOpenClawTmpDir(
     accessSync("/tmp", TMP_DIR_ACCESS_MODE);
     // Create with a safe default; subsequent callers expect it exists.
     mkdirSync(POSIX_OPENCLAW_TMP_DIR, { recursive: true, mode: 0o700 });
+    // mkdir mode is filtered through umask; enforce strict permissions.
+    chmodSync(POSIX_OPENCLAW_TMP_DIR, 0o700);
     if (resolveDirState(POSIX_OPENCLAW_TMP_DIR) !== "available") {
       return ensureTrustedFallbackDir();
     }


### PR DESCRIPTION
## Summary
- Problem: On Linux with a permissive umask (e.g. `0002`), OpenClaw may create its temp dir (`/tmp/openclaw` or fallback `.../openclaw-<uid>`) as **group-writable** (e.g. `0775`). Later, OpenClaw’s security checks reject group/other-writable temp dirs as unsafe, causing the gateway to fail/crash-loop.
- Why it matters: This can brick upgrades / restarts in common systemd user setups and lead to rapid restart loops (service instability / downtime).
- What changed: After creating the temp dir with `mkdir(..., mode: 0700)`, we now explicitly `chmod(dir, 0700)` to **override umask effects** and guarantee strict permissions.
- What did NOT change (scope boundary): No changes to security policy/criteria (we still reject unsafe dirs). No changes to runtime networking/auth/tooling—only temp-dir creation hardening.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #27853

## User-visible / Behavior Changes
- OpenClaw now **forces temp dir permissions to `0700`** after creation, even under permissive umask. This prevents crash-loops caused by group-writable temp dirs.

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`) **No**
- Secrets/tokens handling changed? (`Yes/No`) **No**
- New/changed network calls? (`Yes/No`) **No**
- Command/tool execution surface changed? (`Yes/No`) **No**
- Data access scope changed? (`Yes/No`) **No**
- If any `Yes`, explain risk + mitigation: **N/A**
- Note: This *tightens* filesystem permissions (defense-in-depth) and aligns temp dir creation with existing safety checks.

## Repro + Verification
### Environment
- OS: Ubuntu 24.04 (reported), macOS (dev/test)
- Runtime/container: npm global install + systemd --user (reported); pnpm + vitest (verified)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps
1. Ensure process umask is `0002`.
2. Start/upgrade OpenClaw so it creates `/tmp/openclaw` (or fallback tmp dir).
3. Observe gateway rejects the temp dir due to group-writable perms and restarts repeatedly.

### Expected
- Temp dir is created with strict perms and passes security checks; gateway starts normally.

### Actual
- Before: dir can be created as `0775` under umask `0002`, then rejected as unsafe.
- After: dir is chmod’d to `0700` after creation, preventing the unsafe-perms condition.

## Evidence
Attach at least one:
- [x] Failing test/log before + passing after

## Human Verification (required)
- Verified scenarios:
  - Unit tests for tmp-dir selection/creation pass, including a case simulating umask-widened perms and verifying `chmod(0700)` is called.
- Edge cases checked:
  - Both preferred `/tmp/openclaw` and fallback `os.tmpdir()/openclaw-<uid>` creation paths enforce `0700`.
- What you did **not** verify:
  - End-to-end Linux systemd crash-loop reproduction locally (relies on unit tests + reported behavior).

## Compatibility / Migration
- Backward compatible? (`Yes/No`) **Yes**
- Config/env changes? (`Yes/No`) **No**
- Migration needed? (`Yes/No`) **No**
- If yes, exact upgrade steps: **N/A**

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore:
  - `src/infra/tmp-openclaw-dir.ts`
  - `src/infra/tmp-openclaw-dir.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected errors on platforms where chmod is unavailable (shouldn’t apply in Node-supported environments, but worth watching CI).

## Risks and Mitigations
- Risk: On unusual filesystems/containers, `chmod` could fail even if `mkdir` succeeds, causing fallback/error paths.
- Mitigation: Keep behavior strict (security-sensitive); if chmod fails, existing validation will still reject unsafe dirs rather than silently proceed.