### PR TITLE
fix(config): add firecrawl and readability to ToolsWebFetchSchema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -314,6 +314,18 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.firecrawl.test.ts
+++ b/src/config/zod-schema.firecrawl.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { ToolsWebFetchSchema } from "./zod-schema.agent-runtime.js";
+
+describe("ToolsWebFetchSchema – firecrawl block", () => {
+  it("accepts a valid firecrawl config", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: {
+        apiKey: "fc-test",
+        baseUrl: "https://api.firecrawl.dev",
+        onlyMainContent: true,
+        maxAgeMs: 172800000,
+        timeoutSeconds: 60,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts firecrawl with only enabled flag", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: { enabled: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts readability boolean", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      readability: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown keys inside firecrawl", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: { unknownKey: true },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts full fetch config with firecrawl", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      enabled: true,
+      maxChars: 50000,
+      timeoutSeconds: 30,
+      readability: true,
+      firecrawl: {
+        enabled: true,
+        apiKey: "fc-xxx",
+        baseUrl: "https://custom.firecrawl.dev",
+        onlyMainContent: false,
+        maxAgeMs: 86400000,
+        timeoutSeconds: 45,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #27833.

The Zod validation schema for `tools.web.fetch` (`ToolsWebFetchSchema`) uses `.strict()` but was missing two properties that are defined in `types.tools.ts`, documented in `schema.help.ts` / `schema.labels.ts`, and actively used in existing tests:

- `readability` (boolean) — controls Readability extraction
- `firecrawl` (object) — Firecrawl fallback configuration with `enabled`, `apiKey`, `baseUrl`, `onlyMainContent`, `maxAgeMs`, `timeoutSeconds`

This causes `openclaw doctor` to reject any config containing these keys as "unrecognized".

## Changes

- `src/config/zod-schema.agent-runtime.ts`: Add `readability` and `firecrawl` sub-object to `ToolsWebFetchSchema`. The `apiKey` field is registered as `sensitive` following the existing pattern.
- `src/config/zod-schema.firecrawl.test.ts`: 5 test cases covering valid configs, partial configs, strict-mode rejection of unknown keys, and full combined config.

## Test Results

```
✓ src/config/zod-schema.firecrawl.test.ts (5 tests) 12ms
✓ src/agents/tools/web-fetch.ssrf.test.ts (5 tests)
✓ src/agents/tools/web-tools.fetch.test.ts (14 tests)
```

All 24 related tests pass. TypeScript compiles clean (`tsc --noEmit` exit 0).