### PR TITLE
Add firecrawl and readability fields to web fetch schema validator

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -305,6 +305,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().url().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -314,6 +326,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.web-fetch-firecrawl.test.ts
+++ b/src/config/zod-schema.web-fetch-firecrawl.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ToolsWebFetchSchema } from "./zod-schema.agent-runtime.js";
+
+describe("ToolsWebFetchSchema firecrawl", () => {
+  it("accepts a valid firecrawl config block", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: {
+        enabled: true,
+        apiKey: "fc-test",
+        baseUrl: "https://api.firecrawl.dev",
+        onlyMainContent: true,
+        maxAgeMs: 172800000,
+        timeoutSeconds: 60,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts firecrawl with only apiKey", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: { apiKey: "fc-test" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects firecrawl with unknown keys", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      firecrawl: { apiKey: "fc-test", unknownField: true },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts readability boolean", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      readability: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts fetch config without firecrawl", () => {
+    const result = ToolsWebFetchSchema.safeParse({
+      enabled: true,
+      maxChars: 50000,
+      timeoutSeconds: 30,
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
The Zod schema for `tools.web.fetch` used `.strict()` but was missing the `firecrawl` object and `readability` boolean that are already defined in the TypeScript types (`types.tools.ts`) and referenced in the docs. This caused `openclaw doctor` to reject valid firecrawl configuration blocks with an "Unrecognized key" error.

**Changes:**
- Add `ToolsWebFetchFirecrawlSchema` as a nested strict object with all six documented fields (`enabled`, `apiKey`, `baseUrl`, `onlyMainContent`, `maxAgeMs`, `timeoutSeconds`)
- Add `readability` as an optional boolean to `ToolsWebFetchSchema`
- Add test coverage for firecrawl validation (accepts valid configs, rejects unknown keys)

Closes #27833