### PR TITLE
fix: propagate provider headers to inline models and recognize custom Anthropic providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.anthropic-custom-provider.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.anthropic-custom-provider.test.ts
@@ -1,0 +1,88 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "../pi-embedded-runner.js";
+
+// Mock the logger to avoid noise in tests
+vi.mock("./logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("custom Anthropic provider beta headers", () => {
+  it("applies anthropicBeta for 'anthropic-1m' provider", () => {
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic-1m/claude-opus-4-6": {
+              params: {
+                anthropicBeta: "context-1m-2025-08-07",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic-1m", "claude-opus-4-6");
+
+    // streamFn should be wrapped (beta headers + cache retention wrappers)
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("applies anthropicBeta for 'anthropic-beta' provider", () => {
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic-beta/claude-opus-4-6": {
+              params: {
+                anthropicBeta: "interleaved-thinking-2025-05-14",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic-beta", "claude-opus-4-6");
+
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("applies cache retention default for custom anthropic- prefixed providers", () => {
+    const agent: { streamFn?: StreamFn } = {};
+
+    applyExtraParamsToAgent(agent, undefined, "anthropic-1m", "claude-opus-4-6");
+
+    // Should apply default "short" cache retention, same as canonical "anthropic" provider
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("does not apply anthropic betas for non-anthropic providers", () => {
+    // Verify that specifying anthropicBeta on a non-Anthropic provider does not
+    // crash or misbehave.  We don't check streamFn === undefined because other
+    // wrappers (e.g. extra-params) may still be applied for the provider.
+    const agent: { streamFn?: StreamFn } = {};
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4": {
+              params: {
+                anthropicBeta: "context-1m-2025-08-07",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Should not throw
+    expect(() => applyExtraParamsToAgent(agent, cfg, "openai", "gpt-4")).not.toThrow();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -67,7 +67,7 @@ function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
 ): CacheRetention | undefined {
-  const isAnthropicDirect = provider === "anthropic";
+  const isAnthropicDirect = isAnthropicDirectProvider(provider);
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
@@ -265,12 +265,26 @@ function parseHeaderList(value: unknown): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Returns true for providers that talk directly to the Anthropic Messages API.
+ * This covers the canonical "anthropic" provider and custom providers that use
+ * a prefixed name (e.g. "anthropic-1m", "anthropic-beta") to enable extended
+ * context windows or other beta features via provider-level headers.
+ */
+function isAnthropicDirectProvider(provider: string): boolean {
+  const normalized = provider.trim().toLowerCase();
+  return normalized === "anthropic" || normalized.startsWith("anthropic-");
+}
+
 function resolveAnthropicBetas(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
   modelId: string,
 ): string[] | undefined {
-  if (provider !== "anthropic") {
+  // Match the canonical "anthropic" provider as well as custom Anthropic
+  // providers that use a prefixed name (e.g. "anthropic-1m", "anthropic-beta").
+  // These providers use the same anthropic-messages API and need beta headers.
+  if (!isAnthropicDirectProvider(provider)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Problem

When using a custom Anthropic provider (e.g. `anthropic-1m`) with the `context-1m-2025-08-07` beta header to enable 1M token context windows, sessions exceeding 200K tokens fail with:

```
prompt is too long: 302957 tokens > 200000 maximum
```

This happens despite the model being correctly configured with `contextWindow: 1048576` and the appropriate beta header.

## Root Cause

A chain of three issues:

1. **Model registry loading fails silently for all custom providers** when any single provider has a validation error (e.g. ollama without `apiKey`). This causes the fallback path (`buildInlineProviderModels`) to be used.

2. **`buildInlineProviderModels()` drops provider-level `headers`** — it only copies `baseUrl` and `api` from the provider config to inline model entries. The `anthropic-beta: context-1m-2025-08-07` header is lost.

3. **`resolveAnthropicBetas()` only matches `provider === "anthropic"`** — custom Anthropic providers like `anthropic-1m` and `anthropic-beta` are excluded from beta header injection.

Without the `context-1m-2025-08-07` beta header, the Anthropic API enforces the standard 200K token limit, causing context overflow even though the model is configured for 1M tokens.

## Fix

- **`model.ts`**: `buildInlineProviderModels()` now merges provider-level `headers` into inline model entries (model-level headers take precedence via spread order)
- **`extra-params.ts`**: Added `isAnthropicDirectProvider()` helper that matches `"anthropic"` and any `"anthropic-*"` prefixed provider. Used in both `resolveAnthropicBetas()` and `resolveCacheRetention()`.

## Tests

- 3 new tests in `model.test.ts` for header propagation (provider headers, model override, no headers)
- 4 new tests in `extra-params.anthropic-custom-provider.test.ts` for custom Anthropic provider recognition
- All 181 existing tests in `pi-embedded-runner/` pass
- All 75 compaction + models-config tests pass
- TypeScript type check passes
- Lint/format passes

## Impact

Affects users who:
- Configure custom Anthropic providers with prefixed names (e.g. `anthropic-1m`, `anthropic-beta`)
- Use provider-level `headers` for beta features like extended context windows
- Have an unrelated provider (e.g. ollama) that causes model registry validation to fail

The fix ensures provider-level headers survive the inline model fallback path and that custom Anthropic providers receive the same beta header treatment as the canonical `anthropic` provider.
