### PR TITLE
fix(telegram): status reaction shows error emoji when block streaming delivers content

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -658,7 +658,7 @@ export const dispatchTelegramMessage = async ({
     sentFallback = result.delivered;
   }
 
-  const hasFinalResponse = queuedFinal || sentFallback;
+  const hasFinalResponse = queuedFinal || sentFallback || deliverySummary.delivered;
 
   if (statusReactionController && !hasFinalResponse) {
     void statusReactionController.setError().catch((err) => {


### PR DESCRIPTION
## Problem

When block streaming is enabled on Telegram and successfully delivers all content, the status reaction always ends with the error emoji (😱) instead of done (👍), even though the reply was delivered successfully.

## Root Cause

When block streaming succeeds end-to-end, the final reply payloads are intentionally dropped in `buildReplyPayloads()` (via `shouldDropFinalPayloads`) because they're duplicates of what was already streamed to the user. This means `replyPayloads` is empty, so `getReplyFromConfig` returns no final replies, and `queuedFinal` stays `false`.

The `hasFinalResponse` check at the end of the Telegram dispatch only considers:
- `queuedFinal` — set by `dispatcher.sendFinalReply()`
- `sentFallback` — set by the empty-response fallback path

Neither is `true` when block streaming handled delivery, even though `deliveryState.markDelivered()` was correctly called during block/lane streaming.

## Fix

Include `deliverySummary.delivered` in the `hasFinalResponse` check:

```diff
- const hasFinalResponse = queuedFinal || sentFallback;
+ const hasFinalResponse = queuedFinal || sentFallback || deliverySummary.delivered;
```

`deliverySummary.delivered` is already tracked by `deliveryState.markDelivered()` calls in both `sendPayload` and `deliverLaneText`, so this correctly reflects that content reached the user via streaming.

## Impact

One-line fix. Only affects the status reaction lifecycle — no change to message delivery, streaming, or any other Telegram behavior.

Fixes #27857