### PR TITLE
fix: add null guards to usage sort comparators

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -638,7 +638,9 @@ export const usageHandlers: GatewayRequestHandlers = {
                 totals: emptyTotals(),
               } as SessionModelUsage);
             modelExisting.count += entry.count;
-            mergeTotals(modelExisting.totals, entry.totals);
+            if (entry.totals) {
+              mergeTotals(modelExisting.totals, entry.totals);
+            }
             byModelMap.set(modelKey, modelExisting);
 
             const providerKey = entry.provider ?? "unknown";
@@ -651,7 +653,9 @@ export const usageHandlers: GatewayRequestHandlers = {
                 totals: emptyTotals(),
               } as SessionModelUsage);
             providerExisting.count += entry.count;
-            mergeTotals(providerExisting.totals, entry.totals);
+            if (entry.totals) {
+              mergeTotals(providerExisting.totals, entry.totals);
+            }
             byProviderMap.set(providerKey, providerExisting);
           }
         }

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -769,22 +769,22 @@ export const usageHandlers: GatewayRequestHandlers = {
           .toSorted((a, b) => b.count - a.count),
       },
       byModel: Array.from(byModelMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       }),
       byProvider: Array.from(byProviderMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       }),
       byAgent: Array.from(byAgentMap.entries())
         .map(([id, totals]) => ({ agentId: id, totals }))
-        .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+        .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
       ...tail,
     };
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -707,11 +707,11 @@ export async function loadSessionCostSummary(params: {
 
   const modelUsage = modelUsageMap.size
     ? Array.from(modelUsageMap.values()).toSorted((a, b) => {
-        const costDiff = b.totals.totalCost - a.totals.totalCost;
+        const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
         if (costDiff !== 0) {
           return costDiff;
         }
-        return b.totals.totalTokens - a.totals.totalTokens;
+        return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       })
     : undefined;
 


### PR DESCRIPTION
## Problem

When a session has no usage data (e.g. sessions that error early or have no tool calls), the `totals` object can be undefined. The sort comparators in `byModel`, `byProvider`, and `byAgent` accessed `totals.totalCost` and `totals.totalTokens` directly, causing:

```
Cannot read properties of undefined (reading 'totalTokens')
```

This crash cascades into a context overflow in active sessions, requiring a full session recovery.

## Fix

Added optional chaining (`?.`) and nullish coalescing (`?? 0`) to all three sort comparators in `usage.ts` and `session-cost-usage.ts`.

## Files Changed

- `src/gateway/server-methods/usage.ts` — byModel, byProvider, byAgent comparators
- `src/infra/session-cost-usage.ts` — modelUsage comparator

Minimal, defensive change with no behavioral impact when data is present.