### PR TITLE
fix(web-search): include Brave Search API signup URL in error messages

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -328,7 +328,7 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   }
   return {
     error: "missing_brave_api_key",
-    message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
+    message: `web_search needs a Brave Search API key (get one at https://brave.com/search/api/). Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
     docs: "https://docs.openclaw.ai/tools/web",
   };
 }

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -139,7 +139,7 @@ async function promptWebToolsConfig(
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "It requires a Brave Search API key (you can store it in the config or set BRAVE_API_KEY in the Gateway environment).",
+      "It requires a Brave Search API key (get one at https://brave.com/search/api/; you can store it in the config or set BRAVE_API_KEY in the Gateway environment).",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -448,7 +448,7 @@ export async function finalizeOnboardingWizard(
       : [
           "If you want your agent to be able to search the web, you’ll need an API key.",
           "",
-          "OpenClaw uses Brave Search for the `web_search` tool. Without a Brave Search API key, web search won’t work.",
+          "OpenClaw uses Brave Search for the `web_search` tool. Get an API key at https://brave.com/search/api/. Without a Brave Search API key, web search won’t work.",
           "",
           "Set it up interactively:",
           `- Run: ${formatCliCommand("openclaw configure --section web")}`,


### PR DESCRIPTION
## Summary
- Include the Brave Search API signup URL in the web-search error path so users can immediately find where to provision credentials.
- Keep the fix scoped to the existing single-commit branch (`2a1fde49e`) with no unrelated code changes.

## Testing
- Targeted validation for this slice was completed earlier for the affected web-search path.
- Full test suite currently has unrelated baseline failures in this repo.

Fixes #27796

## AI Assistance
- AI-assisted: this PR was prepared with Codex (GPT-5.3-codex).