### PR TITLE
fix(line): avoid cosmetic token WARN in status summary

### DIFF
--- a/extensions/line/src/channel.status-issues.test.ts
+++ b/extensions/line/src/channel.status-issues.test.ts
@@ -1,0 +1,37 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk";
+import { describe, expect, it } from "vitest";
+import { linePlugin } from "./channel.js";
+
+describe("linePlugin status.collectStatusIssues", () => {
+  it("warns when token/secret are missing and account is not configured", () => {
+    const collect = linePlugin.status!.collectStatusIssues!;
+    const issues = collect([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: false,
+        hasChannelAccessToken: false,
+        hasChannelSecret: false,
+      } as unknown as ChannelAccountSnapshot,
+    ]);
+
+    expect(issues.map((i) => i.message)).toContain("LINE channel access token not configured");
+    expect(issues.map((i) => i.message)).toContain("LINE channel secret not configured");
+  });
+
+  it("does not warn when snapshot is configured (cosmetic status fix)", () => {
+    const collect = linePlugin.status!.collectStatusIssues!;
+    const issues = collect([
+      {
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        // simulate drift / redaction
+        hasChannelAccessToken: false,
+        hasChannelSecret: false,
+      } as unknown as ChannelAccountSnapshot,
+    ]);
+
+    expect(issues).toEqual([]);
+  });
+});

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -574,10 +574,25 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
       lastError: null,
     },
     collectStatusIssues: (accounts) => {
+      // NOTE: `collectStatusIssues()` receives **account snapshots** (output of
+      // `status.buildAccountSnapshot()`), not raw resolved accounts.
+      // Snapshots intentionally do not include secrets (token/secret strings),
+      // so status issues must rely on boolean indicators.
       const issues: ChannelStatusIssue[] = [];
       for (const account of accounts) {
         const accountId = account.accountId ?? DEFAULT_ACCOUNT_ID;
-        if (!account.channelAccessToken?.trim()) {
+
+        // If the snapshot builder already marked the account as configured,
+        // do not emit cosmetic missing-token/secret issues.
+        if (account.configured) {
+          continue;
+        }
+
+        const hasToken = Boolean(
+          (account as { hasChannelAccessToken?: boolean }).hasChannelAccessToken,
+        );
+        const hasSecret = Boolean((account as { hasChannelSecret?: boolean }).hasChannelSecret);
+        if (!hasToken) {
           issues.push({
             channel: "line",
             accountId,
@@ -585,7 +600,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             message: "LINE channel access token not configured",
           });
         }
-        if (!account.channelSecret?.trim()) {
+        if (!hasSecret) {
           issues.push({
             channel: "line",
             accountId,
@@ -608,6 +623,9 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
         name: account.name,
         enabled: account.enabled,
         configured,
+        // Avoid leaking secrets in snapshots; keep booleans for status issues.
+        hasChannelAccessToken: Boolean(account.channelAccessToken?.trim()),
+        hasChannelSecret: Boolean(account.channelSecret?.trim()),
         tokenSource: account.tokenSource,
         running: runtime?.running ?? false,
         lastStartAt: runtime?.lastStartAt ?? null,


### PR DESCRIPTION
This addresses a cosmetic issue where `openclaw status` could show LINE as WARN ("channel access token not configured") even when credentials are provided via tokenFile/secretFile and the account is configured.

Key changes:
- LINE `collectStatusIssues()` now relies on snapshot booleans (`hasChannelAccessToken` / `hasChannelSecret`) instead of secret strings.
- `buildAccountSnapshot()` exports those booleans without leaking secrets.
- Adds a small unit test for the configured/no-warn behavior.

Motivation: keep runtime-only hosts on stable releases without confusing WARNs in `openclaw status`.
