### PR TITLE
fix(web): handle 515 Stream Error during WhatsApp QR pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: extend the enclosing run deadline once while compaction is actively in flight, and abort the underlying SDK compaction on timeout/cancel so large-session compactions stop freezing mid-run. (#46889) Thanks @asyncjason.
 - Models/openai-completions: default non-native OpenAI-compatible providers to omit tool-definition `strict` fields unless users explicitly opt back in, so tool calling keeps working on providers that reject that option. (#45497) Thanks @sahancava.
 - WhatsApp/reconnect: restore the append recency filter in the extension inbox monitor and handle protobuf `Long` timestamps correctly, so fresh post-reconnect append messages are processed while stale history sync stays suppressed. (#42588) thanks @MonkeyLeeT.
+- WhatsApp/login: wait for pending creds writes before reopening after Baileys `515` pairing restarts in both QR login and `channels login` flows, and keep the restart coverage pinned to the real wrapped error shape plus per-account creds queues. (#27910) Thanks @asyncjason.
 
 ### Fixes
 

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -17,11 +17,13 @@ vi.mock("./session.js", () => {
   const getStatusCode = vi.fn(
     (err: unknown) =>
       (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-      (err as { status?: number })?.status,
+      (err as { status?: number })?.status ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode,
   );
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
+  const waitForCredsSaveQueue = vi.fn(async () => {});
   return {
     createWaSocket,
     waitForWaConnection,
@@ -30,6 +32,7 @@ vi.mock("./session.js", () => {
     webAuthExists,
     readWebSelfId,
     logoutWeb,
+    waitForCredsSaveQueue,
   };
 });
 

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
-import { createWaSocket, logoutWeb, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  logoutWeb,
+  waitForCredsSaveQueue,
+  waitForWaConnection,
+} from "./session.js";
 
 vi.mock("./session.js", () => {
   const createWaSocket = vi.fn(
@@ -42,6 +47,7 @@ vi.mock("./qr-image.js", () => ({
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const waitForCredsSaveQueueMock = vi.mocked(waitForCredsSaveQueue);
 const logoutWebMock = vi.mocked(logoutWeb);
 
 describe("login-qr", () => {
@@ -62,6 +68,8 @@ describe("login-qr", () => {
 
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledOnce();
+    expect(waitForCredsSaveQueueMock).toHaveBeenCalledWith(expect.any(String));
     expect(logoutWebMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -3,7 +3,7 @@ import { startWebLoginWithQr, waitForWebLogin } from "./login-qr.js";
 import {
   createWaSocket,
   logoutWeb,
-  waitForCredsSaveQueue,
+  waitForCredsSaveQueueWithTimeout,
   waitForWaConnection,
 } from "./session.js";
 
@@ -28,7 +28,7 @@ vi.mock("./session.js", () => {
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
-  const waitForCredsSaveQueue = vi.fn(async () => {});
+  const waitForCredsSaveQueueWithTimeout = vi.fn(async () => {});
   return {
     createWaSocket,
     waitForWaConnection,
@@ -37,7 +37,7 @@ vi.mock("./session.js", () => {
     webAuthExists,
     readWebSelfId,
     logoutWeb,
-    waitForCredsSaveQueue,
+    waitForCredsSaveQueueWithTimeout,
   };
 });
 
@@ -47,8 +47,13 @@ vi.mock("./qr-image.js", () => ({
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
-const waitForCredsSaveQueueMock = vi.mocked(waitForCredsSaveQueue);
+const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
 const logoutWebMock = vi.mocked(logoutWeb);
+
+async function flushTasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("login-qr", () => {
   beforeEach(() => {
@@ -56,20 +61,32 @@ describe("login-qr", () => {
   });
 
   it("restarts login once on status 515 and completes", async () => {
+    let releaseCredsFlush: (() => void) | undefined;
+    const credsFlushGate = new Promise<void>((resolve) => {
+      releaseCredsFlush = resolve;
+    });
     waitForWaConnectionMock
       // Baileys v7 wraps the error: { error: BoomError(515) }
       .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
       .mockResolvedValueOnce(undefined);
+    waitForCredsSaveQueueWithTimeoutMock.mockReturnValueOnce(credsFlushGate);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });
     expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
 
-    const result = await waitForWebLogin({ timeoutMs: 5000 });
+    const resultPromise = waitForWebLogin({ timeoutMs: 5000 });
+    await flushTasks();
+    await flushTasks();
+
+    expect(createWaSocketMock).toHaveBeenCalledTimes(1);
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledOnce();
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith(expect.any(String));
+
+    releaseCredsFlush?.();
+    const result = await resultPromise;
 
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
-    expect(waitForCredsSaveQueueMock).toHaveBeenCalledOnce();
-    expect(waitForCredsSaveQueueMock).toHaveBeenCalledWith(expect.any(String));
     expect(logoutWebMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -51,7 +51,8 @@ describe("login-qr", () => {
 
   it("restarts login once on status 515 and completes", async () => {
     waitForWaConnectionMock
-      .mockRejectedValueOnce({ output: { statusCode: 515 } })
+      // Baileys v7 wraps the error: { error: BoomError(515) }
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
       .mockResolvedValueOnce(undefined);
 
     const start = await startWebLoginWithQr({ timeoutMs: 5000 });

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -12,7 +12,7 @@ import {
   getStatusCode,
   logoutWeb,
   readWebSelfId,
-  waitForCredsSaveQueue,
+  waitForCredsSaveQueueWithTimeout,
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
@@ -89,14 +89,7 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); waiting for creds to save…"),
   );
   closeSocket(login.sock);
-  // Flush pending creds writes before reopening; bound to avoid hanging on stalled I/O.
-  let flushTimeout: ReturnType<typeof setTimeout> | undefined;
-  await Promise.race([
-    waitForCredsSaveQueue(login.authDir),
-    new Promise<void>((resolve) => {
-      flushTimeout = setTimeout(resolve, 15_000);
-    }),
-  ]).finally(() => clearTimeout(flushTimeout));
+  await waitForCredsSaveQueueWithTimeout(login.authDir);
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -89,9 +89,11 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); waiting for creds to save…"),
   );
   closeSocket(login.sock);
-  // Wait for this account's pending creds.update writes to flush to disk before
-  // creating a new socket — otherwise useMultiFileAuthState reads stale/empty creds.
-  await waitForCredsSaveQueue(login.authDir);
+  // Flush pending creds writes before reopening; bound to avoid hanging on stalled I/O.
+  await Promise.race([
+    waitForCredsSaveQueue(login.authDir),
+    new Promise<void>((resolve) => setTimeout(resolve, 15_000)),
+  ]);
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -90,10 +90,13 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
   );
   closeSocket(login.sock);
   // Flush pending creds writes before reopening; bound to avoid hanging on stalled I/O.
+  let flushTimeout: ReturnType<typeof setTimeout> | undefined;
   await Promise.race([
     waitForCredsSaveQueue(login.authDir),
-    new Promise<void>((resolve) => setTimeout(resolve, 15_000)),
-  ]);
+    new Promise<void>((resolve) => {
+      flushTimeout = setTimeout(resolve, 15_000);
+    }),
+  ]).finally(() => clearTimeout(flushTimeout));
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -89,9 +89,9 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); waiting for creds to save…"),
   );
   closeSocket(login.sock);
-  // Wait for any pending creds.update writes to flush to disk before creating
-  // a new socket — otherwise useMultiFileAuthState reads stale/empty creds.
-  await waitForCredsSaveQueue();
+  // Wait for this account's pending creds.update writes to flush to disk before
+  // creating a new socket — otherwise useMultiFileAuthState reads stale/empty creds.
+  await waitForCredsSaveQueue(login.authDir);
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/extensions/whatsapp/src/login.coverage.test.ts
+++ b/extensions/whatsapp/src/login.coverage.test.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import { DisconnectReason } from "@whiskeysockets/baileys";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loginWeb } from "./login.js";
-import { createWaSocket, formatError, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  formatError,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "./session.js";
 
 const rmMock = vi.spyOn(fs, "rm");
 
@@ -35,10 +40,19 @@ vi.mock("./session.js", () => {
   const createWaSocket = vi.fn(async () => (call++ === 0 ? sockA : sockB));
   const waitForWaConnection = vi.fn();
   const formatError = vi.fn((err: unknown) => `formatted:${String(err)}`);
+  const getStatusCode = vi.fn(
+    (err: unknown) =>
+      (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+      (err as { status?: number })?.status ??
+      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode,
+  );
+  const waitForCredsSaveQueueWithTimeout = vi.fn(async () => {});
   return {
     createWaSocket,
     waitForWaConnection,
     formatError,
+    getStatusCode,
+    waitForCredsSaveQueueWithTimeout,
     WA_WEB_AUTH_DIR: authDir,
     logoutWeb: vi.fn(async (params: { authDir?: string }) => {
       await fs.rm(params.authDir ?? authDir, {
@@ -52,7 +66,13 @@ vi.mock("./session.js", () => {
 
 const createWaSocketMock = vi.mocked(createWaSocket);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
+const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
 const formatErrorMock = vi.mocked(formatError);
+
+async function flushTasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("loginWeb coverage", () => {
   beforeEach(() => {
@@ -65,12 +85,25 @@ describe("loginWeb coverage", () => {
   });
 
   it("restarts once when WhatsApp requests code 515", async () => {
+    let releaseCredsFlush: (() => void) | undefined;
+    const credsFlushGate = new Promise<void>((resolve) => {
+      releaseCredsFlush = resolve;
+    });
     waitForWaConnectionMock
-      .mockRejectedValueOnce({ output: { statusCode: 515 } })
+      .mockRejectedValueOnce({ error: { output: { statusCode: 515 } } })
       .mockResolvedValueOnce(undefined);
+    waitForCredsSaveQueueWithTimeoutMock.mockReturnValueOnce(credsFlushGate);
 
     const runtime = { log: vi.fn(), error: vi.fn() } as never;
-    await loginWeb(false, waitForWaConnectionMock as never, runtime);
+    const pendingLogin = loginWeb(false, waitForWaConnectionMock as never, runtime);
+    await flushTasks();
+
+    expect(createWaSocketMock).toHaveBeenCalledTimes(1);
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledOnce();
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith(authDir);
+
+    releaseCredsFlush?.();
+    await pendingLogin;
 
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
     const firstSock = await createWaSocketMock.mock.results[0]?.value;

--- a/extensions/whatsapp/src/login.ts
+++ b/extensions/whatsapp/src/login.ts
@@ -5,7 +5,14 @@ import { danger, info, success } from "../../../src/globals.js";
 import { logInfo } from "../../../src/logger.js";
 import { defaultRuntime, type RuntimeEnv } from "../../../src/runtime.js";
 import { resolveWhatsAppAccount } from "./accounts.js";
-import { createWaSocket, formatError, logoutWeb, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  formatError,
+  getStatusCode,
+  logoutWeb,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "./session.js";
 
 export async function loginWeb(
   verbose: boolean,
@@ -24,20 +31,17 @@ export async function loginWeb(
     await wait(sock);
     console.log(success("✅ Linked! Credentials saved for future sends."));
   } catch (err) {
-    const code =
-      (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
-      (err as { output?: { statusCode?: number } })?.output?.statusCode;
+    const code = getStatusCode(err);
     if (code === 515) {
       console.log(
-        info(
-          "WhatsApp asked for a restart after pairing (code 515); creds are saved. Restarting connection once…",
-        ),
+        info("WhatsApp asked for a restart after pairing (code 515); waiting for creds to save…"),
       );
       try {
         sock.ws?.close();
       } catch {
         // ignore
       }
+      await waitForCredsSaveQueueWithTimeout(account.authDir);
       const retry = await createWaSocket(false, verbose, {
         authDir: account.authDir,
       });

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -204,6 +204,62 @@ describe("web session", () => {
     expect(inFlight).toBe(0);
   });
 
+  it("lets different authDir queues flush independently", async () => {
+    let inFlightA = 0;
+    let inFlightB = 0;
+    let releaseA: (() => void) | null = null;
+    let releaseB: (() => void) | null = null;
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const gateB = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+
+    const saveCredsA = vi.fn(async () => {
+      inFlightA += 1;
+      await gateA;
+      inFlightA -= 1;
+    });
+    const saveCredsB = vi.fn(async () => {
+      inFlightB += 1;
+      await gateB;
+      inFlightB -= 1;
+    });
+    useMultiFileAuthStateMock
+      .mockResolvedValueOnce({
+        state: { creds: {} as never, keys: {} as never },
+        saveCreds: saveCredsA,
+      })
+      .mockResolvedValueOnce({
+        state: { creds: {} as never, keys: {} as never },
+        saveCreds: saveCredsB,
+      });
+
+    await createWaSocket(false, false, { authDir: "/tmp/wa-a" });
+    const sockA = getLastSocket();
+    await createWaSocket(false, false, { authDir: "/tmp/wa-b" });
+    const sockB = getLastSocket();
+
+    sockA.ev.emit("creds.update", {});
+    sockB.ev.emit("creds.update", {});
+
+    await flushCredsUpdate();
+
+    expect(saveCredsA).toHaveBeenCalledTimes(1);
+    expect(saveCredsB).toHaveBeenCalledTimes(1);
+    expect(inFlightA).toBe(1);
+    expect(inFlightB).toBe(1);
+
+    (releaseA as (() => void) | null)?.();
+    (releaseB as (() => void) | null)?.();
+    await flushCredsUpdate();
+    await flushCredsUpdate();
+
+    expect(inFlightA).toBe(0);
+    expect(inFlightB).toBe(0);
+  });
+
   it("rotates creds backup when creds.json is valid JSON", async () => {
     const creds = mockCredsJsonSpies("{}");
     const backupSuffix = path.join(

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -186,8 +186,14 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 export function getStatusCode(err: unknown) {
   return (
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-    (err as { status?: number })?.status
+    (err as { status?: number })?.status ??
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode
   );
+}
+
+/** Await any pending credential saves. */
+export function waitForCredsSaveQueue(): Promise<void> {
+  return credsSaveQueue;
 }
 
 function safeStringify(value: unknown, limit = 800): string {

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -39,14 +39,15 @@ function enqueueSaveCreds(
   logger: ReturnType<typeof getChildLogger>,
 ): void {
   const prev = credsSaveQueues.get(authDir) ?? Promise.resolve();
-  credsSaveQueues.set(
-    authDir,
-    prev
-      .then(() => safeSaveCreds(authDir, saveCreds, logger))
-      .catch((err) => {
-        logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
-      }),
-  );
+  const next = prev
+    .then(() => safeSaveCreds(authDir, saveCreds, logger))
+    .catch((err) => {
+      logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
+    })
+    .finally(() => {
+      if (credsSaveQueues.get(authDir) === next) credsSaveQueues.delete(authDir);
+    });
+  credsSaveQueues.set(authDir, next);
 }
 
 async function safeSaveCreds(

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -33,6 +33,7 @@ export {
 
 // Per-authDir queues so multi-account creds saves don't block each other.
 const credsSaveQueues = new Map<string, Promise<void>>();
+const CREDS_SAVE_FLUSH_TIMEOUT_MS = 15_000;
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
@@ -203,6 +204,24 @@ export function waitForCredsSaveQueue(authDir?: string): Promise<void> {
     return credsSaveQueues.get(authDir) ?? Promise.resolve();
   }
   return Promise.all(credsSaveQueues.values()).then(() => {});
+}
+
+/** Await pending credential saves, but don't hang forever on stalled I/O. */
+export async function waitForCredsSaveQueueWithTimeout(
+  authDir: string,
+  timeoutMs = CREDS_SAVE_FLUSH_TIMEOUT_MS,
+): Promise<void> {
+  let flushTimeout: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    waitForCredsSaveQueue(authDir),
+    new Promise<void>((resolve) => {
+      flushTimeout = setTimeout(resolve, timeoutMs);
+    }),
+  ]).finally(() => {
+    if (flushTimeout) {
+      clearTimeout(flushTimeout);
+    }
+  });
 }
 
 function safeStringify(value: unknown, limit = 800): string {

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -31,17 +31,22 @@ export {
   webAuthExists,
 } from "./auth-store.js";
 
-let credsSaveQueue: Promise<void> = Promise.resolve();
+// Per-authDir queues so multi-account creds saves don't block each other.
+const credsSaveQueues = new Map<string, Promise<void>>();
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
   logger: ReturnType<typeof getChildLogger>,
 ): void {
-  credsSaveQueue = credsSaveQueue
-    .then(() => safeSaveCreds(authDir, saveCreds, logger))
-    .catch((err) => {
-      logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
-    });
+  const prev = credsSaveQueues.get(authDir) ?? Promise.resolve();
+  credsSaveQueues.set(
+    authDir,
+    prev
+      .then(() => safeSaveCreds(authDir, saveCreds, logger))
+      .catch((err) => {
+        logger.warn({ error: String(err) }, "WhatsApp creds save queue error");
+      }),
+  );
 }
 
 async function safeSaveCreds(
@@ -191,9 +196,12 @@ export function getStatusCode(err: unknown) {
   );
 }
 
-/** Await any pending credential saves. */
-export function waitForCredsSaveQueue(): Promise<void> {
-  return credsSaveQueue;
+/** Await pending credential saves — scoped to one authDir, or all if omitted. */
+export function waitForCredsSaveQueue(authDir?: string): Promise<void> {
+  if (authDir) {
+    return credsSaveQueues.get(authDir) ?? Promise.resolve();
+  }
+  return Promise.all(credsSaveQueues.values()).then(() => {});
 }
 
 function safeStringify(value: unknown, limit = 800): string {


### PR DESCRIPTION
## Summary

- **Problem**: `getStatusCode()` never unwrapped the `lastDisconnect` wrapper object (`{ error: BoomError, date }`), so `login.errorStatus` was always `undefined` and the 515 restart path in `restartLoginSocket` was dead code
- **Why it matters**: WhatsApp QR pairing fails 100% of the time on Baileys v7 because the 515 "restart required" signal is never detected, creds are never flushed, and the reconnect never happens
- **What changed**: (1) Added `err.error?.output?.statusCode` fallback to `getStatusCode()`, (2) exported `waitForCredsSaveQueue()` from session.ts, (3) `restartLoginSocket` now awaits creds flush before creating new socket
- **What did NOT change**: No changes to the pairing protocol, QR generation, or any other WhatsApp/Baileys flow — only the error unwrapping and restart path

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #33961

## User-visible / Behavior Changes

WhatsApp QR pairing now succeeds when Baileys sends the expected 515 "restart required" signal during the key exchange. Previously this always failed with "WhatsApp login failed: status=515 Unknown Stream Errored (restart required)".

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian Bookworm (Docker)
- Runtime: Node v22.22.0
- Baileys: @whiskeysockets/baileys v7.0.0-rc.9
- Channel: WhatsApp Web (Linked Devices)

### Steps

1. Configure WhatsApp channel in OpenClaw
2. Start QR login via gateway web.login.start
3. Scan QR code with WhatsApp on phone

### Expected

After 515, socket restarts with saved creds, connection completes, "Linked!" message returned.

### Actual (before fix)

getStatusCode({ error: BoomError(515), date }) returns undefined → 515 check never matches → restartLoginSocket never called → "WhatsApp login failed: status=515" → creds directory empty on disk.

## Evidence

- VM logs confirm NO "WhatsApp asked for a restart after pairing (code 515)" message ever appeared (proving restartLoginSocket was dead code)
- After fix: pairing completes successfully, creds.json contains valid me.id (authenticated JID)
- SSH inspection of VM showed empty creds directory after every failed 515 attempt pre-fix

## Human Verification

- Verified WhatsApp QR pairing end-to-end on live VM (Debian Bookworm, Docker, Node 22, Baileys 7.0.0-rc.9)
- Verified "Message Yourself" chat triggers AI response after successful pairing
- Verified creds.json contains valid me.id after pairing
- Edge case: restartAttempted flag prevents infinite restart loops (existing logic, unchanged)
- Did not verify: multi-account scenarios, group message flow post-pairing

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this commit — behavior returns to pre-fix (515 always fails, same as current main)
- No config or data changes to roll back

## Risks and Mitigations

- Risk: waitForCredsSaveQueue() could hang if credsSaveQueue promise never resolves
  - Mitigation: isLoginFresh() TTL check (3 min) in the outer waitForWebLogin loop will still time out and clean up

## Attribution

Code authored by Claude Code (Opus 4.6). Investigation, review, and testing by @asyncjason.