### PR TITLE
fix(cli): wait for process exit before restarting gateway on Windows

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -11,8 +11,8 @@ describe("restart-helper", () => {
   const originalPlatform = process.platform;
   const originalGetUid = process.getuid;
 
-  async function prepareAndReadScript(env: Record<string, string>) {
-    const scriptPath = await prepareRestartScript(env);
+  async function prepareAndReadScript(env: Record<string, string>, gatewayPort = 18789) {
+    const scriptPath = await prepareRestartScript(env, gatewayPort);
     expect(scriptPath).toBeTruthy();
     const content = await fs.readFile(scriptPath!, "utf-8");
     return { scriptPath: scriptPath!, content };
@@ -143,18 +143,21 @@ describe("restart-helper", () => {
       await cleanupScript(scriptPath);
     });
 
-    it("uses OPENCLAW_GATEWAY_PORT for port polling on Windows", async () => {
+    it("uses passed gateway port for port polling on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
+      const customPort = 9999;
 
-      const { scriptPath, content } = await prepareAndReadScript({
-        OPENCLAW_PROFILE: "default",
-        OPENCLAW_GATEWAY_PORT: "19000",
-      });
-      expect(content).toContain('netstat -ano | findstr /R /C:":19000 .*LISTENING" >nul');
-      expect(content).toContain(
-        'for /f "tokens=5" %%P in (\'netstat -ano ^| findstr /R /C:":19000 .*LISTENING"\') do (',
+      const { scriptPath, content } = await prepareAndReadScript(
+        {
+          OPENCLAW_PROFILE: "default",
+        },
+        customPort,
       );
-      expectWindowsRestartWaitOrdering(content, 19000);
+      expect(content).toContain(`netstat -ano | findstr /R /C:":${customPort} .*LISTENING" >nul`);
+      expect(content).toContain(
+        `for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${customPort} .*LISTENING"') do (`,
+      );
+      expectWindowsRestartWaitOrdering(content, customPort);
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -22,12 +22,12 @@ describe("restart-helper", () => {
     await fs.unlink(scriptPath);
   }
 
-  function expectWindowsRestartWaitOrdering(content: string) {
+  function expectWindowsRestartWaitOrdering(content: string, port = 18789) {
     const endCommand = 'schtasks /End /TN "';
     const pollAttemptsInit = "set /a attempts=0";
     const pollLabel = ":wait_for_port_release";
     const pollAttemptIncrement = "set /a attempts+=1";
-    const pollNetstatCheck = 'netstat -ano | findstr /R /C:":18789 .*LISTENING" >nul';
+    const pollNetstatCheck = `netstat -ano | findstr /R /C:":${port} .*LISTENING" >nul`;
     const forceKillLabel = ":force_kill_listener";
     const forceKillCommand = "taskkill /F /PID %%P >nul 2>&1";
     const portReleasedLabel = ":port_released";
@@ -140,6 +140,21 @@ describe("restart-helper", () => {
       expect(content).toContain('schtasks /End /TN "OpenClaw Gateway (custom)"');
       expect(content).toContain('schtasks /Run /TN "OpenClaw Gateway (custom)"');
       expectWindowsRestartWaitOrdering(content);
+      await cleanupScript(scriptPath);
+    });
+
+    it("uses OPENCLAW_GATEWAY_PORT for port polling on Windows", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        OPENCLAW_PROFILE: "default",
+        OPENCLAW_GATEWAY_PORT: "19000",
+      });
+      expect(content).toContain('netstat -ano | findstr /R /C:":19000 .*LISTENING" >nul');
+      expect(content).toContain(
+        'for /f "tokens=5" %%P in (\'netstat -ano ^| findstr /R /C:":19000 .*LISTENING"\') do (',
+      );
+      expectWindowsRestartWaitOrdering(content, 19000);
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -24,15 +24,35 @@ describe("restart-helper", () => {
 
   function expectWindowsRestartWaitOrdering(content: string) {
     const endCommand = 'schtasks /End /TN "';
-    const waitCommand = "timeout /t 3 /nobreak >nul";
+    const pollAttemptsInit = "set /a attempts=0";
+    const pollLabel = ":wait_for_port_release";
+    const pollAttemptIncrement = "set /a attempts+=1";
+    const pollNetstatCheck = 'netstat -ano | findstr /R /C:":18789 .*LISTENING" >nul';
+    const forceKillLabel = ":force_kill_listener";
+    const forceKillCommand = "taskkill /F /PID %%P >nul 2>&1";
+    const portReleasedLabel = ":port_released";
     const runCommand = 'schtasks /Run /TN "';
     const endIndex = content.indexOf(endCommand);
-    const waitIndex = content.indexOf(waitCommand, endIndex);
-    const runIndex = content.indexOf(runCommand, waitIndex);
+    const attemptsInitIndex = content.indexOf(pollAttemptsInit, endIndex);
+    const pollLabelIndex = content.indexOf(pollLabel, attemptsInitIndex);
+    const pollAttemptIncrementIndex = content.indexOf(pollAttemptIncrement, pollLabelIndex);
+    const pollNetstatCheckIndex = content.indexOf(pollNetstatCheck, pollAttemptIncrementIndex);
+    const forceKillLabelIndex = content.indexOf(forceKillLabel, pollNetstatCheckIndex);
+    const forceKillCommandIndex = content.indexOf(forceKillCommand, forceKillLabelIndex);
+    const portReleasedLabelIndex = content.indexOf(portReleasedLabel, forceKillCommandIndex);
+    const runIndex = content.indexOf(runCommand, portReleasedLabelIndex);
 
     expect(endIndex).toBeGreaterThanOrEqual(0);
-    expect(waitIndex).toBeGreaterThan(endIndex);
-    expect(runIndex).toBeGreaterThan(waitIndex);
+    expect(attemptsInitIndex).toBeGreaterThan(endIndex);
+    expect(pollLabelIndex).toBeGreaterThan(attemptsInitIndex);
+    expect(pollAttemptIncrementIndex).toBeGreaterThan(pollLabelIndex);
+    expect(pollNetstatCheckIndex).toBeGreaterThan(pollAttemptIncrementIndex);
+    expect(forceKillLabelIndex).toBeGreaterThan(pollNetstatCheckIndex);
+    expect(forceKillCommandIndex).toBeGreaterThan(forceKillLabelIndex);
+    expect(portReleasedLabelIndex).toBeGreaterThan(forceKillCommandIndex);
+    expect(runIndex).toBeGreaterThan(portReleasedLabelIndex);
+
+    expect(content).not.toContain("timeout /t 3 /nobreak >nul");
   }
 
   beforeEach(() => {

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -101,6 +101,8 @@ REM Standalone restart script — survives parent process termination.
 REM Wait briefly to ensure file locks are released after update.
 timeout /t 2 /nobreak >nul
 schtasks /End /TN "${taskName}"
+REM Wait for the ended gateway process to release bound ports before rerun.
+timeout /t 3 /nobreak >nul
 schtasks /Run /TN "${taskName}"
 REM Self-cleanup
 del "%~f0"

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -56,6 +56,7 @@ function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
  */
 export async function prepareRestartScript(
   env: NodeJS.ProcessEnv = process.env,
+  gatewayPort: number = DEFAULT_GATEWAY_PORT,
 ): Promise<string | null> {
   const tmpDir = os.tmpdir();
   const timestamp = Date.now();
@@ -96,8 +97,8 @@ rm -f "$0"
       if (!isBatchSafe(taskName)) {
         return null;
       }
-      const envPort = Number(env.OPENCLAW_GATEWAY_PORT?.trim());
-      const port = Number.isFinite(envPort) && envPort > 0 ? envPort : DEFAULT_GATEWAY_PORT;
+      const port =
+        Number.isFinite(gatewayPort) && gatewayPort > 0 ? gatewayPort : DEFAULT_GATEWAY_PORT;
       filename = `openclaw-restart-${timestamp}.bat`;
       scriptContent = `@echo off
 REM Standalone restart script — survives parent process termination.

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -101,8 +101,21 @@ REM Standalone restart script — survives parent process termination.
 REM Wait briefly to ensure file locks are released after update.
 timeout /t 2 /nobreak >nul
 schtasks /End /TN "${taskName}"
-REM Wait for the ended gateway process to release bound ports before rerun.
-timeout /t 3 /nobreak >nul
+REM Poll for gateway port release before rerun; force-kill listener if stuck.
+set /a attempts=0
+:wait_for_port_release
+set /a attempts+=1
+netstat -ano | findstr /R /C:":18789 .*LISTENING" >nul
+if errorlevel 1 goto port_released
+if %attempts% GEQ 10 goto force_kill_listener
+timeout /t 1 /nobreak >nul
+goto wait_for_port_release
+:force_kill_listener
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":18789 .*LISTENING"') do (
+  taskkill /F /PID %%P >nul 2>&1
+  goto port_released
+)
+:port_released
 schtasks /Run /TN "${taskName}"
 REM Self-cleanup
 del "%~f0"

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { DEFAULT_GATEWAY_PORT } from "../../config/paths.js";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
@@ -95,6 +96,8 @@ rm -f "$0"
       if (!isBatchSafe(taskName)) {
         return null;
       }
+      const envPort = Number(env.OPENCLAW_GATEWAY_PORT?.trim());
+      const port = Number.isFinite(envPort) && envPort > 0 ? envPort : DEFAULT_GATEWAY_PORT;
       filename = `openclaw-restart-${timestamp}.bat`;
       scriptContent = `@echo off
 REM Standalone restart script — survives parent process termination.
@@ -105,13 +108,13 @@ REM Poll for gateway port release before rerun; force-kill listener if stuck.
 set /a attempts=0
 :wait_for_port_release
 set /a attempts+=1
-netstat -ano | findstr /R /C:":18789 .*LISTENING" >nul
+netstat -ano | findstr /R /C:":${port} .*LISTENING" >nul
 if errorlevel 1 goto port_released
 if %attempts% GEQ 10 goto force_kill_listener
 timeout /t 1 /nobreak >nul
 goto wait_for_port_release
 :force_kill_listener
-for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":18789 .*LISTENING"') do (
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${port} .*LISTENING"') do (
   taskkill /F /PID %%P >nul 2>&1
   goto port_released
 )

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -818,11 +818,15 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   let restartScriptPath: string | null = null;
   let refreshGatewayServiceEnv = false;
+  const gatewayPort = resolveGatewayPort(
+    configSnapshot.valid ? configSnapshot.config : undefined,
+    process.env,
+  );
   if (shouldRestart) {
     try {
       const loaded = await resolveGatewayService().isLoaded({ env: process.env });
       if (loaded) {
-        restartScriptPath = await prepareRestartScript(process.env);
+        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
         refreshGatewayServiceEnv = true;
       }
     } catch {
@@ -903,7 +907,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     result,
     opts,
     refreshServiceEnv: refreshGatewayServiceEnv,
-    gatewayPort: resolveGatewayPort(configSnapshot.valid ? configSnapshot.config : undefined),
+    gatewayPort,
     restartScriptPath,
   });
 


### PR DESCRIPTION
Fixes #27802

## What this changes
- Ensure the CLI waits for the existing gateway process to fully exit before starting a new gateway process on Windows.

## Windows maintainer verification
Please verify on a Windows machine:
1. Start the gateway and confirm it is running.
2. Trigger a restart flow from the CLI.
3. Confirm the previous gateway process has exited before the new process starts.
4. Repeat restart quickly multiple times and confirm no duplicate/stale gateway processes remain.
5. Run the related Windows test path and confirm it passes.

## AI-assisted disclosure
This pull request was prepared with AI assistance for drafting and command execution; all changes were reviewed before submission.