### PR TITLE
fix(chat): preserve newlines in user messages across page refresh

### DIFF
--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { buildHistoryContextFromEntries } from "../auto-reply/reply/history.js";
-import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { buildAgentMessageFromConversationEntries } from "./agent-prompt.js";
 
 describe("gateway agent prompt", () => {
@@ -31,7 +30,7 @@ describe("gateway agent prompt", () => {
           },
         },
       ]),
-    ).toBe("hi there");
+    ).toBe("hi\nthere");
   });
 
   it("uses history context when there is history", () => {
@@ -87,11 +86,22 @@ describe("gateway agent prompt", () => {
     ] as const;
 
     const expected = buildHistoryContextFromEntries({
-      entries: entries.map((e) => e.entry),
-      currentMessage: "User: next step",
-      formatEntry: (e) => `${e.sender}: ${extractTextFromChatContent(e.body) ?? ""}`,
+      entries: [
+        { sender: "Assistant", body: "prev" },
+        { sender: "User", body: "next\nstep" },
+      ],
+      currentMessage: "User: next\nstep",
+      formatEntry: (e) => `${e.sender}: ${e.body}`,
     });
 
     expect(buildAgentMessageFromConversationEntries([...entries])).toBe(expected);
+  });
+
+  it("preserves newline semantics instead of collapsing multiline body to spaces", () => {
+    expect(
+      buildAgentMessageFromConversationEntries([
+        { role: "user", entry: { sender: "User", body: "line 1\nline 2" } },
+      ]),
+    ).toBe("line 1\nline 2");
   });
 });

--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -104,4 +104,11 @@ describe("gateway agent prompt", () => {
       ]),
     ).toBe("line 1\nline 2");
   });
+
+  it("preserves leading indentation inside multiline body text", () => {
+    const body = "def foo():\n    return bar";
+    expect(
+      buildAgentMessageFromConversationEntries([{ role: "user", entry: { sender: "User", body } }]),
+    ).toBe(body);
+  });
 });

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -12,13 +12,7 @@ export type ConversationEntry = {
  * [object Object] if used directly in a template literal.
  */
 function normalizePromptBodyText(text: string): string {
-  return text
-    .replaceAll("\r\n", "\n")
-    .replaceAll("\r", "\n")
-    .split("\n")
-    .map((line) => line.replace(/[ \t\f\v]+/g, " ").trim())
-    .join("\n")
-    .trim();
+  return text.replaceAll("\r\n", "\n").replaceAll("\r", "\n").trim();
 }
 
 function safeBody(body: unknown): string {

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -11,11 +11,26 @@ export type ConversationEntry = {
  * (e.g. [{type:"text", text:"hello"}]) that would serialize as
  * [object Object] if used directly in a template literal.
  */
+function normalizePromptBodyText(text: string): string {
+  return text
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t\f\v]+/g, " ").trim())
+    .join("\n")
+    .trim();
+}
+
 function safeBody(body: unknown): string {
   if (typeof body === "string") {
-    return body;
+    return normalizePromptBodyText(body);
   }
-  return extractTextFromChatContent(body) ?? "";
+  return (
+    extractTextFromChatContent(body, {
+      joinWith: "\n",
+      normalizeText: normalizePromptBodyText,
+    }) ?? ""
+  );
 }
 
 export function buildAgentMessageFromConversationEntries(entries: ConversationEntry[]): string {


### PR DESCRIPTION
Fixes #27809

## Root cause
- User message text is normalized through `safeBody` in `src/gateway/agent-prompt.ts`, which used the default whitespace-collapsing path and converted multiline newlines into single spaces before prompt assembly.

## Fix
- Preserve multiline newlines for user message content in the backend prompt-normalization path in `src/gateway/agent-prompt.ts`.
- Keep empty-content safety checks intact while avoiding newline collapse for non-empty user text.

## Regression tests
- Updated `src/gateway/agent-prompt.test.ts` to assert multiline user text remains newline-preserving in generated prompt payloads.
- Added coverage in `src/gateway/server.chat.gateway-server-chat-b.test.ts` for newline-preservation behavior and normalization expectations.

## Tested commands
- `pnpm vitest run src/gateway/agent-prompt.test.ts --reporter=verbose`
- `pnpm vitest run src/gateway/server.chat.gateway-server-chat-b.test.ts --reporter=verbose`

## AI-assisted disclosure
- AI-assisted: investigation and patch drafting were performed with Codex/Sisyphus and then validated via targeted tests.