### PR TITLE
feat(discord): simplify status replacement and reduce emoji churn

### DIFF
--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -15,11 +15,6 @@ import { shouldAckReaction as shouldAckReactionGate } from "../../channels/ack-r
 import { logTypingFailure, logAckFailure } from "../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
-import {
-  createStatusReactionController,
-  DEFAULT_TIMING,
-  type StatusReactionAdapter,
-} from "../../channels/status-reactions.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
@@ -48,14 +43,18 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import {
+  createDiscordStatusReactionLifecycle,
+  resolveDiscordStatusReactionProjection,
+  type DiscordStatusReactionAdapter,
+} from "./status-reaction-lifecycle.js";
+import {
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+  waitForDiscordStatusReactionQueueTurn,
+} from "./status-reaction-queue.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import { sendTyping } from "./typing.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 export async function processDiscordMessage(ctx: DiscordMessagePreflightContext) {
   const {
@@ -104,13 +103,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     discordRestFetch,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
-  const forwardedMediaList = await resolveForwardedMediaList(
-    message,
-    mediaMaxBytes,
-    discordRestFetch,
-  );
-  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);
@@ -120,7 +112,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
-  const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -136,7 +127,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }),
     );
   const statusReactionsEnabled = shouldAckReaction();
-  const discordAdapter: StatusReactionAdapter = {
+  let statusQueueClaimed = false;
+  let queueTurnPromise: Promise<void> | null = null;
+  const discordAdapter: DiscordStatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: client.rest as never,
@@ -148,12 +141,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   };
-  const statusReactions = createStatusReactionController({
+  const statusReactions = createDiscordStatusReactionLifecycle({
     enabled: statusReactionsEnabled,
+    messageId: message.id,
     adapter: discordAdapter,
-    initialEmoji: ackReaction,
-    emojis: cfg.messages?.statusReactions?.emojis,
-    timing: cfg.messages?.statusReactions?.timing,
+    projection: resolveDiscordStatusReactionProjection(
+      cfg.messages?.statusReactions?.emojis,
+      ackReaction,
+    ),
     onError: (err) => {
       logAckFailure({
         log: logVerbose,
@@ -164,466 +159,465 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     },
   });
   if (statusReactionsEnabled) {
-    void statusReactions.setQueued();
-  }
-
-  const fromLabel = isDirectMessage
-    ? buildDirectLabel(author)
-    : buildGuildLabel({
-        guild: data.guild ?? undefined,
-        channelName: channelName ?? messageChannelId,
-        channelId: messageChannelId,
-      });
-  const senderLabel = sender.label;
-  const isForumParent =
-    threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
-  const forumParentSlug =
-    isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
-  const threadChannelId = threadChannel?.id;
-  const isForumStarter =
-    Boolean(threadChannelId && isForumParent && forumParentSlug) && message.id === threadChannelId;
-  const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
-  const groupChannel = isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
-  const groupSubject = isDirectMessage ? undefined : groupChannel;
-  const untrustedChannelMetadata = isGuildMessage
-    ? buildUntrustedChannelMetadata({
-        source: "discord",
-        label: "Discord channel topic",
-        entries: [channelInfo?.topic],
-      })
-    : undefined;
-  const senderName = sender.isPluralKit
-    ? (sender.name ?? author.username)
-    : (data.member?.nickname ?? author.globalName ?? author.username);
-  const senderUsername = sender.isPluralKit
-    ? (sender.tag ?? sender.name ?? author.username)
-    : author.username;
-  const senderTag = sender.tag;
-  const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
-  const groupSystemPrompt =
-    systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
-  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
-  });
-  const storePath = resolveStorePath(cfg.session?.store, {
-    agentId: route.agentId,
-  });
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const previousTimestamp = readSessionUpdatedAt({
-    storePath,
-    sessionKey: route.sessionKey,
-  });
-  let combinedBody = formatInboundEnvelope({
-    channel: "Discord",
-    from: fromLabel,
-    timestamp: resolveTimestampMs(message.timestamp),
-    body: text,
-    chatType: isDirectMessage ? "direct" : "channel",
-    senderLabel,
-    previousTimestamp,
-    envelope: envelopeOptions,
-  });
-  const shouldIncludeChannelHistory =
-    !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
-  if (shouldIncludeChannelHistory) {
-    combinedBody = buildPendingHistoryContextFromMap({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-      currentMessage: combinedBody,
-      formatEntry: (entry) =>
-        formatInboundEnvelope({
-          channel: "Discord",
-          from: fromLabel,
-          timestamp: entry.timestamp,
-          body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
-          chatType: "channel",
-          senderLabel: entry.sender,
-          envelope: envelopeOptions,
-        }),
-    });
-  }
-  const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
-  if (forumContextLine) {
-    combinedBody = `${combinedBody}\n${forumContextLine}`;
-  }
-
-  let threadStarterBody: string | undefined;
-  let threadLabel: string | undefined;
-  let parentSessionKey: string | undefined;
-  if (threadChannel) {
-    const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
-    if (includeThreadStarter) {
-      const starter = await resolveDiscordThreadStarter({
-        channel: threadChannel,
-        client,
-        parentId: threadParentId,
-        parentType: threadParentType,
-        resolveTimestampMs,
-      });
-      if (starter?.text) {
-        // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
-        threadStarterBody = starter.text;
-      }
-    }
-    const parentName = threadParentName ?? "parent";
-    threadLabel = threadName
-      ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
-      : `Discord thread #${normalizeDiscordSlug(parentName)}`;
-    if (threadParentId) {
-      parentSessionKey = buildAgentSessionKey({
-        agentId: route.agentId,
-        channel: route.channel,
-        peer: { kind: "channel", id: threadParentId },
-      });
+    const claim = claimDiscordStatusReactionQueue(messageChannelId, message.id);
+    statusQueueClaimed = true;
+    void statusReactions.enterWaiting(claim.hasPriorPendingWork);
+    if (claim.hasPriorPendingWork) {
+      queueTurnPromise = waitForDiscordStatusReactionQueueTurn(messageChannelId, message.id);
     }
   }
-  const mediaPayload = buildDiscordMediaPayload(mediaList);
-  const threadKeys = resolveThreadSessionKeys({
-    baseSessionKey,
-    threadId: threadChannel ? messageChannelId : undefined,
-    parentSessionKey,
-    useSuffix: false,
-  });
-  const replyPlan = await resolveDiscordAutoThreadReplyPlan({
-    client,
-    message,
-    messageChannelId,
-    isGuildMessage,
-    channelConfig,
-    threadChannel,
-    channelType: channelInfo?.type,
-    baseText: baseText ?? "",
-    combinedBody,
-    replyToMode,
-    agentId: route.agentId,
-    channel: route.channel,
-  });
-  const deliverTarget = replyPlan.deliverTarget;
-  const replyTarget = replyPlan.replyTarget;
-  const replyReference = replyPlan.replyReference;
-  const autoThreadContext = replyPlan.autoThreadContext;
-
-  const effectiveFrom = isDirectMessage
-    ? `discord:${author.id}`
-    : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
-  const effectiveTo = autoThreadContext?.To ?? replyTarget;
-  if (!effectiveTo) {
-    runtime.error?.(danger("discord: missing reply target"));
-    return;
-  }
-  // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
-  const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
-
-  const inboundHistory =
-    shouldIncludeChannelHistory && historyLimit > 0
-      ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
-      : undefined;
-
-  const ctxPayload = finalizeInboundContext({
-    Body: combinedBody,
-    BodyForAgent: baseText ?? text,
-    InboundHistory: inboundHistory,
-    RawBody: baseText,
-    CommandBody: baseText,
-    From: effectiveFrom,
-    To: effectiveTo,
-    SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
-    AccountId: route.accountId,
-    ChatType: isDirectMessage ? "direct" : "channel",
-    ConversationLabel: fromLabel,
-    SenderName: senderName,
-    SenderId: sender.id,
-    SenderUsername: senderUsername,
-    SenderTag: senderTag,
-    GroupSubject: groupSubject,
-    GroupChannel: groupChannel,
-    UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
-    GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
-    GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
-    OwnerAllowFrom: ownerAllowFrom,
-    Provider: "discord" as const,
-    Surface: "discord" as const,
-    WasMentioned: effectiveWasMentioned,
-    MessageSid: message.id,
-    ReplyToId: replyContext?.id,
-    ReplyToBody: replyContext?.body,
-    ReplyToSender: replyContext?.sender,
-    ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
-    MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
-    ThreadStarterBody: threadStarterBody,
-    ThreadLabel: threadLabel,
-    Timestamp: resolveTimestampMs(message.timestamp),
-    ...mediaPayload,
-    CommandAuthorized: commandAuthorized,
-    CommandSource: "text" as const,
-    // Originating channel for reply routing.
-    OriginatingChannel: "discord" as const,
-    OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
-  });
-  const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
-
-  await recordInboundSession({
-    storePath,
-    sessionKey: persistedSessionKey,
-    ctx: ctxPayload,
-    updateLastRoute: {
-      sessionKey: persistedSessionKey,
-      channel: "discord",
-      to: lastRouteTo,
-      accountId: route.accountId,
-    },
-    onRecordError: (err) => {
-      logVerbose(`discord: failed updating session meta: ${String(err)}`);
-    },
-  });
-
-  if (shouldLogVerbose()) {
-    const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
-    logVerbose(
-      `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
-    );
-  }
-
-  const typingChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-
-  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
-    cfg,
-    agentId: route.agentId,
-    channel: "discord",
-    accountId: route.accountId,
-  });
-  const tableMode = resolveMarkdownTableMode({
-    cfg,
-    channel: "discord",
-    accountId,
-  });
-  const chunkMode = resolveChunkMode(cfg, "discord", accountId);
-
-  const typingCallbacks = createTypingCallbacks({
-    start: () => sendTyping({ client, channelId: typingChannelId }),
-    onStartError: (err) => {
-      logTypingFailure({
-        log: logVerbose,
-        channel: "discord",
-        target: typingChannelId,
-        error: err,
-      });
-    },
-  });
-
-  // --- Discord draft stream (edit-based preview streaming) ---
-  const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
-  const draftMaxChars = Math.min(textLimit, 2000);
-  const accountBlockStreamingEnabled =
-    typeof discordConfig?.blockStreaming === "boolean"
-      ? discordConfig.blockStreaming
-      : cfg.agents?.defaults?.blockStreamingDefault === "on";
-  const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
-  const draftReplyToMessageId = () => replyReference.use();
-  const deliverChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-  const draftStream = canStreamDraft
-    ? createDiscordDraftStream({
-        rest: client.rest,
-        channelId: deliverChannelId,
-        maxChars: draftMaxChars,
-        replyToMessageId: draftReplyToMessageId,
-        minInitialChars: 30,
-        throttleMs: 1200,
-        log: logVerbose,
-        warn: logVerbose,
-      })
-    : undefined;
-  const draftChunking =
-    draftStream && discordStreamMode === "block"
-      ? resolveDiscordDraftStreamingChunking(cfg, accountId)
-      : undefined;
-  const shouldSplitPreviewMessages = discordStreamMode === "block";
-  const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
-  let lastPartialText = "";
-  let draftText = "";
-  let hasStreamedMessage = false;
-  let finalizedViaPreviewMessage = false;
-
-  const resolvePreviewFinalText = (text?: string) => {
-    if (typeof text !== "string") {
-      return undefined;
+  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
+  let statusLifecycleSettled = false;
+  const finalizeStatusReactions = async (succeeded: boolean): Promise<void> => {
+    if (!statusReactionsEnabled || statusLifecycleSettled) {
+      return;
     }
-    const formatted = convertMarkdownTables(text, tableMode);
-    const chunks = chunkDiscordTextWithMode(formatted, {
-      maxChars: draftMaxChars,
-      maxLines: discordConfig?.maxLinesPerMessage,
-      chunkMode,
-    });
-    if (!chunks.length && formatted) {
-      chunks.push(formatted);
-    }
-    if (chunks.length !== 1) {
-      return undefined;
-    }
-    const trimmed = chunks[0].trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
-    if (
-      currentPreviewText &&
-      currentPreviewText.startsWith(trimmed) &&
-      trimmed.length < currentPreviewText.length
-    ) {
-      return undefined;
-    }
-    return trimmed;
+    statusLifecycleSettled = true;
+    await statusReactions.complete(succeeded);
   };
 
-  const updateDraftFromPartial = (text?: string) => {
-    if (!draftStream || !text) {
-      return;
+  try {
+    await queueTurnPromise;
+    const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
+    const forwardedMediaList = await resolveForwardedMediaList(
+      message,
+      mediaMaxBytes,
+      discordRestFetch,
+    );
+    mediaList.push(...forwardedMediaList);
+
+    const fromLabel = isDirectMessage
+      ? buildDirectLabel(author)
+      : buildGuildLabel({
+          guild: data.guild ?? undefined,
+          channelName: channelName ?? messageChannelId,
+          channelId: messageChannelId,
+        });
+    const senderLabel = sender.label;
+    const isForumParent =
+      threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
+    const forumParentSlug =
+      isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+    const threadChannelId = threadChannel?.id;
+    const isForumStarter =
+      Boolean(threadChannelId && isForumParent && forumParentSlug) &&
+      message.id === threadChannelId;
+    const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
+    const groupChannel =
+      isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
+    const groupSubject = isDirectMessage ? undefined : groupChannel;
+    const untrustedChannelMetadata = isGuildMessage
+      ? buildUntrustedChannelMetadata({
+          source: "discord",
+          label: "Discord channel topic",
+          entries: [channelInfo?.topic],
+        })
+      : undefined;
+    const senderName = sender.isPluralKit
+      ? (sender.name ?? author.username)
+      : (data.member?.nickname ?? author.globalName ?? author.username);
+    const senderUsername = sender.isPluralKit
+      ? (sender.tag ?? sender.name ?? author.username)
+      : author.username;
+    const senderTag = sender.tag;
+    const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
+      (entry): entry is string => Boolean(entry),
+    );
+    const groupSystemPrompt =
+      systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+    const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
+      channelConfig,
+      guildInfo,
+      sender: { id: sender.id, name: sender.name, tag: sender.tag },
+      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+    });
+    const storePath = resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+    const previousTimestamp = readSessionUpdatedAt({
+      storePath,
+      sessionKey: route.sessionKey,
+    });
+    let combinedBody = formatInboundEnvelope({
+      channel: "Discord",
+      from: fromLabel,
+      timestamp: resolveTimestampMs(message.timestamp),
+      body: text,
+      chatType: isDirectMessage ? "direct" : "channel",
+      senderLabel,
+      previousTimestamp,
+      envelope: envelopeOptions,
+    });
+    const shouldIncludeChannelHistory =
+      !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
+    if (shouldIncludeChannelHistory) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: guildHistories,
+        historyKey: messageChannelId,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatInboundEnvelope({
+            channel: "Discord",
+            from: fromLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
+            chatType: "channel",
+            senderLabel: entry.sender,
+            envelope: envelopeOptions,
+          }),
+      });
     }
-    // Strip reasoning/thinking tags that may leak through the stream.
-    const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
-    // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
-    if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
-      return;
-    }
-    if (cleaned === lastPartialText) {
-      return;
-    }
-    hasStreamedMessage = true;
-    if (discordStreamMode === "partial") {
-      // Keep the longer preview to avoid visible punctuation flicker.
-      if (
-        lastPartialText &&
-        lastPartialText.startsWith(cleaned) &&
-        cleaned.length < lastPartialText.length
-      ) {
-        return;
-      }
-      lastPartialText = cleaned;
-      draftStream.update(cleaned);
-      return;
+    const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
+    if (forumContextLine) {
+      combinedBody = `${combinedBody}\n${forumContextLine}`;
     }
 
-    let delta = cleaned;
-    if (cleaned.startsWith(lastPartialText)) {
-      delta = cleaned.slice(lastPartialText.length);
-    } else {
-      // Streaming buffer reset (or non-monotonic stream). Start fresh.
-      draftChunker?.reset();
-      draftText = "";
+    let threadStarterBody: string | undefined;
+    let threadLabel: string | undefined;
+    let parentSessionKey: string | undefined;
+    if (threadChannel) {
+      const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
+      if (includeThreadStarter) {
+        const starter = await resolveDiscordThreadStarter({
+          channel: threadChannel,
+          client,
+          parentId: threadParentId,
+          parentType: threadParentType,
+          resolveTimestampMs,
+        });
+        if (starter?.text) {
+          // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
+          threadStarterBody = starter.text;
+        }
+      }
+      const parentName = threadParentName ?? "parent";
+      threadLabel = threadName
+        ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
+        : `Discord thread #${normalizeDiscordSlug(parentName)}`;
+      if (threadParentId) {
+        parentSessionKey = buildAgentSessionKey({
+          agentId: route.agentId,
+          channel: route.channel,
+          peer: { kind: "channel", id: threadParentId },
+        });
+      }
     }
-    lastPartialText = cleaned;
-    if (!delta) {
+    const mediaPayload = buildDiscordMediaPayload(mediaList);
+    const threadKeys = resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: threadChannel ? messageChannelId : undefined,
+      parentSessionKey,
+      useSuffix: false,
+    });
+    const replyPlan = await resolveDiscordAutoThreadReplyPlan({
+      client,
+      message,
+      messageChannelId,
+      isGuildMessage,
+      channelConfig,
+      threadChannel,
+      channelType: channelInfo?.type,
+      baseText: baseText ?? "",
+      combinedBody,
+      replyToMode,
+      agentId: route.agentId,
+      channel: route.channel,
+    });
+    const deliverTarget = replyPlan.deliverTarget;
+    const replyTarget = replyPlan.replyTarget;
+    const replyReference = replyPlan.replyReference;
+    const autoThreadContext = replyPlan.autoThreadContext;
+
+    const effectiveFrom = isDirectMessage
+      ? `discord:${author.id}`
+      : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
+    const effectiveTo = autoThreadContext?.To ?? replyTarget;
+    if (!effectiveTo) {
+      runtime.error?.(danger("discord: missing reply target"));
       return;
     }
-    if (!draftChunker) {
-      draftText = cleaned;
-      draftStream.update(draftText);
-      return;
-    }
-    draftChunker.append(delta);
-    draftChunker.drain({
-      force: false,
-      emit: (chunk) => {
-        draftText += chunk;
-        draftStream.update(draftText);
+    // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
+    const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
+
+    const inboundHistory =
+      shouldIncludeChannelHistory && historyLimit > 0
+        ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+          }))
+        : undefined;
+
+    const ctxPayload = finalizeInboundContext({
+      Body: combinedBody,
+      BodyForAgent: baseText ?? text,
+      InboundHistory: inboundHistory,
+      RawBody: baseText,
+      CommandBody: baseText,
+      From: effectiveFrom,
+      To: effectiveTo,
+      SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isDirectMessage ? "direct" : "channel",
+      ConversationLabel: fromLabel,
+      SenderName: senderName,
+      SenderId: sender.id,
+      SenderUsername: senderUsername,
+      SenderTag: senderTag,
+      GroupSubject: groupSubject,
+      GroupChannel: groupChannel,
+      UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
+      GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
+      GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
+      OwnerAllowFrom: ownerAllowFrom,
+      Provider: "discord" as const,
+      Surface: "discord" as const,
+      WasMentioned: effectiveWasMentioned,
+      MessageSid: message.id,
+      ReplyToId: replyContext?.id,
+      ReplyToBody: replyContext?.body,
+      ReplyToSender: replyContext?.sender,
+      ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
+      MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
+      ThreadStarterBody: threadStarterBody,
+      ThreadLabel: threadLabel,
+      Timestamp: resolveTimestampMs(message.timestamp),
+      ...mediaPayload,
+      CommandAuthorized: commandAuthorized,
+      CommandSource: "text" as const,
+      // Originating channel for reply routing.
+      OriginatingChannel: "discord" as const,
+      OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    });
+    const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+
+    await recordInboundSession({
+      storePath,
+      sessionKey: persistedSessionKey,
+      ctx: ctxPayload,
+      updateLastRoute: {
+        sessionKey: persistedSessionKey,
+        channel: "discord",
+        to: lastRouteTo,
+        accountId: route.accountId,
+      },
+      onRecordError: (err) => {
+        logVerbose(`discord: failed updating session meta: ${String(err)}`);
       },
     });
-  };
 
-  const flushDraft = async () => {
-    if (!draftStream) {
-      return;
+    if (shouldLogVerbose()) {
+      const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
+      logVerbose(
+        `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
+      );
     }
-    if (draftChunker?.hasBuffered()) {
-      draftChunker.drain({
-        force: true,
-        emit: (chunk) => {
-          draftText += chunk;
-        },
-      });
-      draftChunker.reset();
-      if (draftText) {
-        draftStream.update(draftText);
+
+    const typingChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+
+    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+      cfg,
+      agentId: route.agentId,
+      channel: "discord",
+      accountId: route.accountId,
+    });
+    const tableMode = resolveMarkdownTableMode({
+      cfg,
+      channel: "discord",
+      accountId,
+    });
+    const chunkMode = resolveChunkMode(cfg, "discord", accountId);
+
+    const typingCallbacks = createTypingCallbacks({
+      start: () => sendTyping({ client, channelId: typingChannelId }),
+      onStartError: (err) => {
+        logTypingFailure({
+          log: logVerbose,
+          channel: "discord",
+          target: typingChannelId,
+          error: err,
+        });
+      },
+    });
+
+    // --- Discord draft stream (edit-based preview streaming) ---
+    const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
+    const draftMaxChars = Math.min(textLimit, 2000);
+    const accountBlockStreamingEnabled =
+      typeof discordConfig?.blockStreaming === "boolean"
+        ? discordConfig.blockStreaming
+        : cfg.agents?.defaults?.blockStreamingDefault === "on";
+    const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
+    const draftReplyToMessageId = () => replyReference.use();
+    const deliverChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+    const draftStream = canStreamDraft
+      ? createDiscordDraftStream({
+          rest: client.rest,
+          channelId: deliverChannelId,
+          maxChars: draftMaxChars,
+          replyToMessageId: draftReplyToMessageId,
+          minInitialChars: 30,
+          throttleMs: 1200,
+          log: logVerbose,
+          warn: logVerbose,
+        })
+      : undefined;
+    const draftChunking =
+      draftStream && discordStreamMode === "block"
+        ? resolveDiscordDraftStreamingChunking(cfg, accountId)
+        : undefined;
+    const shouldSplitPreviewMessages = discordStreamMode === "block";
+    const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
+    let lastPartialText = "";
+    let draftText = "";
+    let hasStreamedMessage = false;
+    let finalizedViaPreviewMessage = false;
+
+    const resolvePreviewFinalText = (text?: string) => {
+      if (typeof text !== "string") {
+        return undefined;
       }
-    }
-    await draftStream.flush();
-  };
+      const formatted = convertMarkdownTables(text, tableMode);
+      const chunks = chunkDiscordTextWithMode(formatted, {
+        maxChars: draftMaxChars,
+        maxLines: discordConfig?.maxLinesPerMessage,
+        chunkMode,
+      });
+      if (!chunks.length && formatted) {
+        chunks.push(formatted);
+      }
+      if (chunks.length !== 1) {
+        return undefined;
+      }
+      const trimmed = chunks[0].trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
+      if (
+        currentPreviewText &&
+        currentPreviewText.startsWith(trimmed) &&
+        trimmed.length < currentPreviewText.length
+      ) {
+        return undefined;
+      }
+      return trimmed;
+    };
 
-  // When draft streaming is active, suppress block streaming to avoid double-streaming.
-  const disableBlockStreamingForDraft = draftStream ? true : undefined;
-
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    ...prefixOptions,
-    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    typingCallbacks,
-    deliver: async (payload: ReplyPayload, info) => {
-      const isFinal = info.kind === "final";
-      if (payload.isReasoning) {
-        // Reasoning/thinking payloads should not be delivered to Discord.
+    const updateDraftFromPartial = (text?: string) => {
+      if (!draftStream || !text) {
         return;
       }
-      if (draftStream && isFinal) {
-        await flushDraft();
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-        const finalText = payload.text;
-        const previewFinalText = resolvePreviewFinalText(finalText);
-        const previewMessageId = draftStream.messageId();
-
-        // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
-        const canFinalizeViaPreviewEdit =
-          !finalizedViaPreviewMessage &&
-          !hasMedia &&
-          typeof previewFinalText === "string" &&
-          typeof previewMessageId === "string" &&
-          !payload.isError;
-
-        if (canFinalizeViaPreviewEdit) {
-          await draftStream.stop();
-          try {
-            await editMessageDiscord(
-              deliverChannelId,
-              previewMessageId,
-              { content: previewFinalText },
-              { rest: client.rest },
-            );
-            finalizedViaPreviewMessage = true;
-            replyReference.markSent();
-            return;
-          } catch (err) {
-            logVerbose(
-              `discord: preview final edit failed; falling back to standard send (${String(err)})`,
-            );
-          }
+      // Strip reasoning/thinking tags that may leak through the stream.
+      const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
+      // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
+      if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
+        return;
+      }
+      if (cleaned === lastPartialText) {
+        return;
+      }
+      hasStreamedMessage = true;
+      if (discordStreamMode === "partial") {
+        // Keep the longer preview to avoid visible punctuation flicker.
+        if (
+          lastPartialText &&
+          lastPartialText.startsWith(cleaned) &&
+          cleaned.length < lastPartialText.length
+        ) {
+          return;
         }
+        lastPartialText = cleaned;
+        draftStream.update(cleaned);
+        return;
+      }
 
-        // Check if stop() flushed a message we can edit
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.stop();
-          const messageIdAfterStop = draftStream.messageId();
-          if (
-            typeof messageIdAfterStop === "string" &&
-            typeof previewFinalText === "string" &&
+      let delta = cleaned;
+      if (cleaned.startsWith(lastPartialText)) {
+        delta = cleaned.slice(lastPartialText.length);
+      } else {
+        // Streaming buffer reset (or non-monotonic stream). Start fresh.
+        draftChunker?.reset();
+        draftText = "";
+      }
+      lastPartialText = cleaned;
+      if (!delta) {
+        return;
+      }
+      if (!draftChunker) {
+        draftText = cleaned;
+        draftStream.update(draftText);
+        return;
+      }
+      draftChunker.append(delta);
+      draftChunker.drain({
+        force: false,
+        emit: (chunk) => {
+          draftText += chunk;
+          draftStream.update(draftText);
+        },
+      });
+    };
+
+    const flushDraft = async () => {
+      if (!draftStream) {
+        return;
+      }
+      if (draftChunker?.hasBuffered()) {
+        draftChunker.drain({
+          force: true,
+          emit: (chunk) => {
+            draftText += chunk;
+          },
+        });
+        draftChunker.reset();
+        if (draftText) {
+          draftStream.update(draftText);
+        }
+      }
+      await draftStream.flush();
+    };
+
+    // When draft streaming is active, suppress block streaming to avoid double-streaming.
+    const disableBlockStreamingForDraft = draftStream ? true : undefined;
+
+    const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      deliver: async (payload: ReplyPayload, info) => {
+        const isFinal = info.kind === "final";
+        if (payload.isReasoning) {
+          // Reasoning/thinking payloads should not be delivered to Discord.
+          return;
+        }
+        if (draftStream && isFinal) {
+          await flushDraft();
+          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const finalText = payload.text;
+          const previewFinalText = resolvePreviewFinalText(finalText);
+          const previewMessageId = draftStream.messageId();
+
+          // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
+          const canFinalizeViaPreviewEdit =
+            !finalizedViaPreviewMessage &&
             !hasMedia &&
-            !payload.isError
-          ) {
+            typeof previewFinalText === "string" &&
+            typeof previewMessageId === "string" &&
+            !payload.isError;
+
+          if (canFinalizeViaPreviewEdit) {
+            await draftStream.stop();
             try {
               await editMessageDiscord(
                 deliverChannelId,
-                messageIdAfterStop,
+                previewMessageId,
                 { content: previewFinalText },
                 { rest: client.rest },
               );
@@ -632,127 +626,157 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               return;
             } catch (err) {
               logVerbose(
-                `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                `discord: preview final edit failed; falling back to standard send (${String(err)})`,
               );
             }
           }
+
+          // Check if stop() flushed a message we can edit
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.stop();
+            const messageIdAfterStop = draftStream.messageId();
+            if (
+              typeof messageIdAfterStop === "string" &&
+              typeof previewFinalText === "string" &&
+              !hasMedia &&
+              !payload.isError
+            ) {
+              try {
+                await editMessageDiscord(
+                  deliverChannelId,
+                  messageIdAfterStop,
+                  { content: previewFinalText },
+                  { rest: client.rest },
+                );
+                finalizedViaPreviewMessage = true;
+                replyReference.markSent();
+                return;
+              } catch (err) {
+                logVerbose(
+                  `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                );
+              }
+            }
+          }
+
+          // Clear the preview and fall through to standard delivery
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.clear();
+          }
         }
 
-        // Clear the preview and fall through to standard delivery
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.clear();
-        }
-      }
-
-      const replyToId = replyReference.use();
-      await deliverDiscordReply({
-        replies: [payload],
-        target: deliverTarget,
-        token,
-        accountId,
-        rest: client.rest,
-        runtime,
-        replyToId,
-        replyToMode,
-        textLimit,
-        maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
-        tableMode,
-        chunkMode,
-        sessionKey: ctxPayload.SessionKey,
-        threadBindings,
-      });
-      replyReference.markSent();
-    },
-    onError: (err, info) => {
-      runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
-    },
-    onReplyStart: async () => {
-      await typingCallbacks.onReplyStart();
-      await statusReactions.setThinking();
-    },
-  });
-
-  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
-  let dispatchError = false;
-  try {
-    dispatchResult = await dispatchInboundMessage({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        skillFilter: channelConfig?.skills,
-        disableBlockStreaming:
-          disableBlockStreamingForDraft ??
-          (typeof discordConfig?.blockStreaming === "boolean"
-            ? !discordConfig.blockStreaming
-            : undefined),
-        onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
-        onAssistantMessageStart: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onReasoningEnd: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onModelSelected,
-        onReasoningStream: async () => {
-          await statusReactions.setThinking();
-        },
-        onToolStart: async (payload) => {
-          await statusReactions.setTool(payload.name);
-        },
+        const replyToId = replyReference.use();
+        await deliverDiscordReply({
+          replies: [payload],
+          target: deliverTarget,
+          token,
+          accountId,
+          rest: client.rest,
+          runtime,
+          replyToId,
+          replyToMode,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode,
+          sessionKey: ctxPayload.SessionKey,
+          threadBindings,
+        });
+        replyReference.markSent();
+      },
+      onError: (err, info) => {
+        runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
+      },
+      onReplyStart: async () => {
+        await typingCallbacks.onReplyStart();
+        void statusReactions.enterActive();
       },
     });
-  } catch (err) {
-    dispatchError = true;
-    throw err;
-  } finally {
-    try {
-      // Must stop() first to flush debounced content before clear() wipes state.
-      await draftStream?.stop();
-      if (!finalizedViaPreviewMessage) {
-        await draftStream?.clear();
-      }
-    } catch (err) {
-      // Draft cleanup should never keep typing alive.
-      logVerbose(`discord: draft cleanup failed: ${String(err)}`);
-    } finally {
-      markDispatchIdle();
-    }
-    if (statusReactionsEnabled) {
-      if (dispatchError) {
-        await statusReactions.setError();
-      } else {
-        await statusReactions.setDone();
-      }
-      if (removeAckAfterReply) {
-        void (async () => {
-          await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
-      }
-    }
-  }
 
-  if (!dispatchResult?.queuedFinal) {
+    let dispatchError = false;
+    try {
+      await statusReactions.enterActive();
+      dispatchResult = await dispatchInboundMessage({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            disableBlockStreamingForDraft ??
+            (typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined),
+          onPartialReply: draftStream
+            ? (payload) => updateDraftFromPartial(payload.text)
+            : undefined,
+          onAssistantMessageStart: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onReasoningEnd: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onModelSelected,
+          onReasoningStream: () => {
+            void statusReactions.enterActive();
+          },
+          onToolStart: (_payload) => {
+            void statusReactions.enterActive();
+          },
+        },
+      });
+    } catch (err) {
+      dispatchError = true;
+      throw err;
+    } finally {
+      try {
+        // Must stop() first to flush debounced content before clear() wipes state.
+        await draftStream?.stop();
+        if (!finalizedViaPreviewMessage) {
+          await draftStream?.clear();
+        }
+      } catch (err) {
+        // Draft cleanup should never keep typing alive.
+        logVerbose(`discord: draft cleanup failed: ${String(err)}`);
+      } finally {
+        markDispatchIdle();
+      }
+      await finalizeStatusReactions(!dispatchError);
+    }
+
+    if (!dispatchResult?.queuedFinal) {
+      if (isGuildMessage) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: guildHistories,
+          historyKey: messageChannelId,
+          limit: historyLimit,
+        });
+      }
+      return;
+    }
+    if (shouldLogVerbose()) {
+      const finalCount = dispatchResult.counts.final;
+      logVerbose(
+        `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+      );
+    }
     if (isGuildMessage) {
       clearHistoryEntriesIfEnabled({
         historyMap: guildHistories,
@@ -760,19 +784,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         limit: historyLimit,
       });
     }
-    return;
-  }
-  if (shouldLogVerbose()) {
-    const finalCount = dispatchResult.counts.final;
-    logVerbose(
-      `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
-    );
-  }
-  if (isGuildMessage) {
-    clearHistoryEntriesIfEnabled({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-    });
+  } finally {
+    if (statusQueueClaimed && !statusLifecycleSettled) {
+      await finalizeStatusReactions(false);
+    }
+    if (statusQueueClaimed) {
+      releaseDiscordStatusReactionQueue(messageChannelId, message.id);
+    }
   }
 }

--- a/src/discord/monitor/status-reaction-lifecycle.test.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  createDiscordStatusReactionLifecycle,
+  resolveDiscordStatusReactionProjection,
+} from "./status-reaction-lifecycle.js";
+
+describe("status-reaction-lifecycle", () => {
+  it("keeps waiting-fresh and waiting-backlog mutually exclusive per message", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const removeReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m1",
+      adapter: { setReaction, removeReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toContain("⏳");
+    expect(emojis).not.toContain("👀");
+  });
+
+  it("keeps waiting when active interruption fails", async () => {
+    let activeFailed = false;
+    const setReaction = vi.fn(async (emoji: string) => {
+      if (emoji === "🤔" && !activeFailed) {
+        activeFailed = true;
+        throw new Error("active failed");
+      }
+    });
+    const onError = vi.fn();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m2",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+      onError,
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toEqual(["👀", "🤔"]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps waiting until an active interruption is requested", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m3",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.complete(true);
+
+    expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["⏳"]);
+  });
+
+  it("records failed transition when active update fails", async () => {
+    __testing.resetTraceEntriesForTests();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m4",
+      adapter: {
+        setReaction: async (emoji: string) => {
+          if (emoji === "🤔") {
+            throw new Error("boom");
+          }
+        },
+      },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+
+    const failed = __testing
+      .getTraceEntriesForTests()
+      .filter((entry) => entry.messageId === "m4" && entry.stage === "failed")
+      .map((entry) => entry.state);
+    expect(failed).toContain("active");
+  });
+});
+
+it("requires a completed active transition before terminal transition", async () => {
+  __testing.resetTraceEntriesForTests();
+  const releaseActiveRef: { current?: () => void } = {};
+  const setReaction = vi.fn((emoji: string) => {
+    if (emoji === "🤔") {
+      return new Promise<void>((resolve) => {
+        releaseActiveRef.current = resolve;
+      });
+    }
+    return Promise.resolve();
+  });
+  const lifecycle = createDiscordStatusReactionLifecycle({
+    enabled: true,
+    messageId: "m5",
+    adapter: { setReaction },
+    projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+  });
+
+  await lifecycle.enterWaiting(false);
+  const activePromise = lifecycle.enterActive();
+  await Promise.resolve();
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
+
+  const blockedComplete = lifecycle.complete(true);
+  await Promise.resolve();
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
+
+  releaseActiveRef.current?.();
+  await activePromise;
+  await blockedComplete;
+  await lifecycle.complete(true);
+
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔", "✅"]);
+});

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -1,0 +1,333 @@
+import type { StatusReactionEmojis } from "../../channels/status-reactions.js";
+
+export type DiscordStatusLifecycleState =
+  | "idle"
+  | "waiting-fresh"
+  | "waiting-backlog"
+  | "active"
+  | "done"
+  | "error"
+  | "cleared";
+
+type DiscordStatusTraceStage = "queued" | "applied" | "ignored" | "failed";
+
+export type DiscordStatusTraceEntry = {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  at: number;
+};
+
+export type DiscordStatusReactionAdapter = {
+  setReaction: (emoji: string) => Promise<void>;
+  removeReaction?: (emoji: string) => Promise<void>;
+};
+
+export type DiscordStatusReactionProjection = {
+  waitingFresh: string;
+  waitingBacklog: string;
+  active: string;
+  done: string;
+  error: string;
+};
+
+export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection = {
+  waitingFresh: "👀",
+  waitingBacklog: "⏳",
+  active: "🤔",
+  done: "✅",
+  error: "❌",
+};
+
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+
+const MAX_TRACE_ENTRIES = 2000;
+const traceEntries: DiscordStatusTraceEntry[] = [];
+
+function pushTrace(entry: DiscordStatusTraceEntry): void {
+  traceEntries.push(entry);
+  if (traceEntries.length > MAX_TRACE_ENTRIES) {
+    traceEntries.splice(0, traceEntries.length - MAX_TRACE_ENTRIES);
+  }
+}
+
+function resolveEmojiForState(
+  state: DiscordStatusLifecycleState,
+  projection: DiscordStatusReactionProjection,
+): string | null {
+  switch (state) {
+    case "waiting-fresh":
+      return projection.waitingFresh;
+    case "waiting-backlog":
+      return projection.waitingBacklog;
+    case "active":
+      return projection.active;
+    case "done":
+      return projection.done;
+    case "error":
+      return projection.error;
+    default:
+      return null;
+  }
+}
+
+function isWaitingState(state: DiscordStatusLifecycleState): boolean {
+  return state === "waiting-fresh" || state === "waiting-backlog";
+}
+
+function canTransition(
+  from: DiscordStatusLifecycleState,
+  to: DiscordStatusLifecycleState,
+): boolean {
+  if (from === "idle") {
+    return isWaitingState(to) || to === "active";
+  }
+  if (isWaitingState(from)) {
+    return to === "active";
+  }
+  if (from === "active") {
+    return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
+  }
+  return false;
+}
+
+function canEnqueueTransition(params: {
+  state: DiscordStatusLifecycleState;
+  lastRequestedState: DiscordStatusLifecycleState | null;
+  nextState: DiscordStatusLifecycleState;
+}): boolean {
+  if (canTransition(params.state, params.nextState)) {
+    return true;
+  }
+  if (
+    isWaitingState(params.state) &&
+    params.lastRequestedState === "active" &&
+    (params.nextState === "done" || params.nextState === "error")
+  ) {
+    // Allow terminal transition to queue behind an in-flight active transition.
+    return true;
+  }
+  return false;
+}
+
+function trackTransition(params: {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}): void {
+  const entry: DiscordStatusTraceEntry = {
+    messageId: params.messageId,
+    state: params.state,
+    stage: params.stage,
+    emoji: params.emoji,
+    at: Date.now(),
+  };
+  pushTrace(entry);
+  params.onTrace?.(entry);
+}
+
+export function resolveDiscordStatusReactionProjection(
+  overrides?: StatusReactionEmojis,
+  waitingFreshFallback?: string,
+): DiscordStatusReactionProjection {
+  const normalizedWaitingFreshFallback = waitingFreshFallback?.trim() || undefined;
+  return {
+    waitingFresh:
+      overrides?.queued ??
+      normalizedWaitingFreshFallback ??
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh,
+    waitingBacklog: overrides?.stallSoft ?? DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    active: overrides?.thinking ?? DISCORD_STATUS_DEFAULT_PROJECTION.active,
+    done: overrides?.done ?? DISCORD_STATUS_DEFAULT_PROJECTION.done,
+    error: overrides?.error ?? DISCORD_STATUS_DEFAULT_PROJECTION.error,
+  };
+}
+
+export function createDiscordStatusReactionLifecycle(params: {
+  enabled: boolean;
+  messageId: string;
+  adapter: DiscordStatusReactionAdapter;
+  projection: DiscordStatusReactionProjection;
+  onError?: (err: unknown) => void;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}) {
+  const { enabled, messageId, adapter, projection, onError, onTrace } = params;
+  let state: DiscordStatusLifecycleState = "idle";
+  let lastRequestedState: DiscordStatusLifecycleState | null = null;
+  let currentEmoji: string | null = null;
+  let chain = Promise.resolve();
+  let clearTimer: NodeJS.Timeout | null = null;
+  const knownEmojis = new Set<string>([
+    projection.waitingFresh,
+    projection.waitingBacklog,
+    projection.active,
+    projection.done,
+    projection.error,
+  ]);
+
+  function transition(nextState: DiscordStatusLifecycleState): Promise<void> {
+    const nextEmoji = resolveEmojiForState(nextState, projection);
+    trackTransition({
+      messageId,
+      state: nextState,
+      stage: "queued",
+      emoji: nextEmoji,
+      onTrace,
+    });
+
+    if (!enabled) {
+      state = nextState;
+      return Promise.resolve();
+    }
+    if (nextState === state || nextState === lastRequestedState) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+    if (!canEnqueueTransition({ state, lastRequestedState, nextState })) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+
+    lastRequestedState = nextState;
+    chain = chain.then(async () => {
+      const fromState = state;
+      try {
+        if (!canTransition(fromState, nextState)) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: nextEmoji,
+            onTrace,
+          });
+          return;
+        }
+
+        if (nextState === "cleared") {
+          let hadFailure = false;
+          if (adapter.removeReaction) {
+            for (const emoji of knownEmojis) {
+              try {
+                await adapter.removeReaction(emoji);
+              } catch (err) {
+                hadFailure = true;
+                onError?.(err);
+              }
+            }
+          }
+
+          if (hadFailure) {
+            state = fromState;
+            trackTransition({
+              messageId,
+              state: nextState,
+              stage: "failed",
+              emoji: null,
+              onTrace,
+            });
+            return;
+          }
+
+          state = nextState;
+          currentEmoji = null;
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "applied",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        if (!nextEmoji) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        const previousEmoji = currentEmoji;
+        await adapter.setReaction(nextEmoji);
+        if (adapter.removeReaction && previousEmoji && previousEmoji !== nextEmoji) {
+          await adapter.removeReaction(previousEmoji);
+        }
+        state = nextState;
+        currentEmoji = nextEmoji;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "applied",
+          emoji: nextEmoji,
+          onTrace,
+        });
+      } catch (err) {
+        state = fromState;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "failed",
+          emoji: nextEmoji,
+          onTrace,
+        });
+        onError?.(err);
+      } finally {
+        if (lastRequestedState === nextState) {
+          lastRequestedState = null;
+        }
+      }
+    });
+    return chain;
+  }
+
+  return {
+    enterWaiting: (hasPriorPendingWork: boolean): Promise<void> =>
+      transition(hasPriorPendingWork ? "waiting-backlog" : "waiting-fresh"),
+    enterActive: (): Promise<void> => transition("active"),
+    complete: (succeeded: boolean): Promise<void> => transition(succeeded ? "done" : "error"),
+    clearAfterHold: (holdMs = DISCORD_STATUS_CLEAR_HOLD_MS): void => {
+      if (!enabled || clearTimer) {
+        return;
+      }
+      clearTimer = setTimeout(() => {
+        clearTimer = null;
+        void transition("cleared");
+      }, holdMs);
+    },
+  };
+}
+
+function resetTraceEntriesForTests(): void {
+  traceEntries.length = 0;
+}
+
+function getTraceEntriesForTests(): DiscordStatusTraceEntry[] {
+  return traceEntries.map((entry) => ({ ...entry }));
+}
+
+export const __testing = {
+  getTraceEntriesForTests,
+  resetTraceEntriesForTests,
+};

--- a/src/discord/monitor/status-reaction-queue.test.ts
+++ b/src/discord/monitor/status-reaction-queue.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __testing,
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+  waitForDiscordStatusReactionQueueTurn,
+} from "./status-reaction-queue.js";
+
+afterEach(() => {
+  __testing.resetQueueForTests();
+});
+
+describe("status-reaction-queue", () => {
+  it("marks only later messages in same channel as backlog", () => {
+    const first = claimDiscordStatusReactionQueue("c1", "m1");
+    const second = claimDiscordStatusReactionQueue("c1", "m2");
+
+    expect(first).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(second).toMatchObject({ hasPriorPendingWork: true, position: 1 });
+  });
+
+  it("isolates queue lanes by channel", () => {
+    const c1 = claimDiscordStatusReactionQueue("c1", "m1");
+    const c2 = claimDiscordStatusReactionQueue("c2", "m2");
+
+    expect(c1.hasPriorPendingWork).toBe(false);
+    expect(c2.hasPriorPendingWork).toBe(false);
+  });
+
+  it("waits until the message reaches the lane head", async () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+
+    let resolved = false;
+    const waitTurn = waitForDiscordStatusReactionQueueTurn("c1", "m2").then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseDiscordStatusReactionQueue("c1", "m1");
+    await waitTurn;
+    expect(resolved).toBe(true);
+  });
+
+  it("is idempotent for duplicate claims and cleans up on release", () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    const duplicate = claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+    releaseDiscordStatusReactionQueue("c1", "m1");
+
+    expect(duplicate).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(__testing.getQueueSnapshot()).toEqual({
+      size: 1,
+      lanes: [{ channelId: "c1", messageIds: ["m2"] }],
+    });
+  });
+});

--- a/src/discord/monitor/status-reaction-queue.ts
+++ b/src/discord/monitor/status-reaction-queue.ts
@@ -1,0 +1,164 @@
+type QueueLaneSnapshot = {
+  channelId: string;
+  messageIds: string[];
+};
+
+type QueueSnapshot = {
+  size: number;
+  lanes: QueueLaneSnapshot[];
+};
+
+const lanes = new Map<string, string[]>();
+const laneWaiters = new Map<string, Map<string, Set<() => void>>>();
+
+function normalizeChannelId(channelId: string): string {
+  return channelId.trim();
+}
+
+function normalizeMessageId(messageId: string): string {
+  return messageId.trim();
+}
+
+function resolveWaiters(channelId: string, messageId: string): void {
+  const channelWaiters = laneWaiters.get(channelId);
+  if (!channelWaiters) {
+    return;
+  }
+  const waiters = channelWaiters.get(messageId);
+  if (!waiters || waiters.size === 0) {
+    return;
+  }
+  channelWaiters.delete(messageId);
+  if (channelWaiters.size === 0) {
+    laneWaiters.delete(channelId);
+  }
+  for (const resolve of waiters) {
+    resolve();
+  }
+}
+
+function notifyHeadWaiters(channelId: string): void {
+  const lane = lanes.get(channelId);
+  if (!lane || lane.length === 0) {
+    return;
+  }
+  const head = lane[0];
+  if (!head) {
+    return;
+  }
+  resolveWaiters(channelId, head);
+}
+
+/**
+ * Claim a queue slot for a Discord message lifecycle within a channel lane.
+ * hasPriorPendingWork means this message is not first in that lane.
+ */
+export function claimDiscordStatusReactionQueue(
+  channelId: string,
+  messageId: string,
+): {
+  hasPriorPendingWork: boolean;
+  position: number;
+} {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return { hasPriorPendingWork: false, position: 0 };
+  }
+
+  const lane = lanes.get(laneKey) ?? [];
+  let position = lane.indexOf(normalizedMessageId);
+  if (position < 0) {
+    lane.push(normalizedMessageId);
+    position = lane.length - 1;
+  }
+  lanes.set(laneKey, lane);
+  if (position === 0) {
+    notifyHeadWaiters(laneKey);
+  }
+  return {
+    hasPriorPendingWork: position > 0,
+    position,
+  };
+}
+
+/**
+ * Wait until this claimed message reaches the head of its channel lane.
+ */
+export function waitForDiscordStatusReactionQueueTurn(
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return Promise.resolve();
+  }
+
+  const lane = lanes.get(laneKey);
+  if (!lane) {
+    return Promise.resolve();
+  }
+  const position = lane.indexOf(normalizedMessageId);
+  if (position <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let channelWaiters = laneWaiters.get(laneKey);
+    if (!channelWaiters) {
+      channelWaiters = new Map<string, Set<() => void>>();
+      laneWaiters.set(laneKey, channelWaiters);
+    }
+    let waiters = channelWaiters.get(normalizedMessageId);
+    if (!waiters) {
+      waiters = new Set<() => void>();
+      channelWaiters.set(normalizedMessageId, waiters);
+    }
+    waiters.add(resolve);
+  });
+}
+
+/**
+ * Release a previously claimed queue slot.
+ */
+export function releaseDiscordStatusReactionQueue(channelId: string, messageId: string): void {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return;
+  }
+  const lane = lanes.get(laneKey);
+  if (!lane) {
+    return;
+  }
+  const nextLane = lane.filter((entry) => entry !== normalizedMessageId);
+  resolveWaiters(laneKey, normalizedMessageId);
+  if (nextLane.length === 0) {
+    lanes.delete(laneKey);
+    laneWaiters.delete(laneKey);
+    return;
+  }
+  lanes.set(laneKey, nextLane);
+  notifyHeadWaiters(laneKey);
+}
+
+function getQueueSnapshot(): QueueSnapshot {
+  const laneEntries = Array.from(lanes.entries())
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([channelId, messageIds]) => ({ channelId, messageIds: [...messageIds] }));
+  return {
+    size: laneEntries.reduce((sum, lane) => sum + lane.messageIds.length, 0),
+    lanes: laneEntries,
+  };
+}
+
+function resetQueueForTests(): void {
+  lanes.clear();
+  laneWaiters.clear();
+}
+
+export const __testing = {
+  getQueueSnapshot,
+  resetQueueForTests,
+};


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord status reaction updates were noisy/inconsistent in queued and fast paths, and frequent emoji flips could generate repeated mobile push notifications.
- Why it matters: users need clear, low-noise visibility of waiting/active/finished states without notification spam while browsing other channels.
- What changed: implemented queue-aware lane handling + state-replacement lifecycle so transitions are explicit and ordered (`👀/⏳ -> 🤔 -> ✅/❌`), with waiting replaced only when active actually takes over.
- What did NOT change (scope boundary): no auth/model/provider contract changes, no cross-channel redesign, no migration of existing config schema.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #27856

## User-visible / Behavior Changes

- Fresh message path: `👀 -> 🤔 -> ✅/❌`
- Backlog message path: `⏳ -> 🤔 -> ✅/❌`
- State replacement rule: old state changes only when a new state cuts in.
- Waiting visibility rule: waiting remains visible until active takes over.
- Notification-noise goal: fewer unnecessary emoji flips to reduce Discord mobile push disturbance.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local + GitHub Actions matrix
- Runtime/container: OpenClaw gateway + Node/Vitest
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): `messages.inbound.byChannel.discord=3000` during merge-window checks

### Steps

1. Send message A that runs long enough to observe queue behavior.
2. While A is active, send message B in the same channel/thread.
3. Observe B status progression and terminal update.

### Expected

- B shows waiting first (`⏳` when backlog).
- B transitions to `🤔` before terminal `✅/❌`.
- No direct waiting -> terminal jump.

### Actual

- Targeted verification after changes follows waiting -> active -> terminal ordering.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing targeted suite:
- `src/discord/monitor/status-reaction-queue.test.ts`
- `src/discord/monitor/status-reaction-lifecycle.test.ts`
- `src/discord/monitor/message-handler.process.test.ts`
- `src/channels/status-reactions.test.ts`
- `src/discord/monitor/message-handler.preflight.test.ts`
- `src/discord/monitor/message-handler.inbound-contract.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: queue/backlog visibility, waiting->active->terminal order, and active-before-terminal enforcement.
- Edge cases checked: in-flight active + queued terminal request, lane turn waiting before dispatch, rapid short-message paths.
- What you did **not** verify: long-duration production-scale traffic behavior under sustained high load.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit range.
- Files/config to restore: `src/discord/monitor/status-reaction-*.ts`, `src/discord/monitor/message-handler.process.ts`.
- Known bad symptoms reviewers should watch for: waiting immediately jumping to terminal, missing active phase, or backlog not remaining visible.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: timing race between active and terminal requests in fast paths.
  - Mitigation: queue-aware lifecycle gating + transition validity recheck at apply time.
