### PR TITLE
fix(agents): drop thinking blocks for Anthropic API to prevent rejection

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -632,7 +632,7 @@ describe("sanitizeSessionHistory", () => {
     expect(types).not.toContain("thinking");
   });
 
-  it("does not drop thinking blocks for non-copilot providers", async () => {
+  it("drops thinking blocks for anthropic providers", async () => {
     setNonGoogleModelApi();
 
     const messages = makeThinkingAndTextAssistantMessages();
@@ -642,6 +642,24 @@ describe("sanitizeSessionHistory", () => {
       modelApi: "anthropic-messages",
       provider: "anthropic",
       modelId: "claude-opus-4-6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+    });
+
+    const types = getAssistantContentTypes(result);
+    expect(types).not.toContain("thinking");
+  });
+
+  it("does not drop thinking blocks for non-copilot non-anthropic providers", async () => {
+    setNonGoogleModelApi();
+
+    const messages = makeThinkingAndTextAssistantMessages();
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "openrouter",
+      modelId: "some-model",
       sessionManager: makeMockSessionManager(),
       sessionId: TEST_SESSION_ID,
     });


### PR DESCRIPTION
## Summary
- The Anthropic API rejects requests when `thinking`/`redacted_thinking` blocks in the latest assistant message have been modified from their original form. Subtle round-trip changes during session sanitization (e.g. `sanitizeSurrogates()` on thinking text, field renaming from `thinkingSignature` to `signature` in the pi-ai provider) can trigger this validation error:
  ```
  LLM request rejected: messages.X.content.Y: thinking or redacted_thinking blocks
  in the latest assistant message cannot be modified.
  ```
- Enables `dropThinkingBlocks` for Anthropic providers in the transcript policy, matching the existing behavior for GitHub Copilot Claude. The Anthropic API explicitly allows removing all thinking blocks from previous turns, and this also saves context window tokens.
- Updates tests to expect thinking blocks to be dropped for Anthropic and adds a separate test for non-Anthropic non-Copilot providers.

## Test plan
- [x] Existing `transcript-policy` tests pass
- [x] Existing `thinking.test.ts` tests pass
- [x] Updated `sanitize-session-history` test to expect Anthropic thinking block drops
- [x] Added test confirming non-Copilot non-Anthropic providers still preserve thinking blocks
- [ ] Verify Anthropic conversations no longer produce "thinking blocks cannot be modified" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)