### PR TITLE
fix(discord): prevent interaction listener from blocking gateway event queue

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -18,7 +18,11 @@ import {
   sanitizeDiscordThreadName,
   shouldEmitDiscordReactionNotification,
 } from "./monitor.js";
-import { DiscordMessageListener, DiscordReactionListener } from "./monitor/listeners.js";
+import {
+  DiscordInteractionListener,
+  DiscordMessageListener,
+  DiscordReactionListener,
+} from "./monitor/listeners.js";
 
 const readAllowFromStoreMock = vi.hoisted(() => vi.fn());
 
@@ -207,6 +211,72 @@ describe("DiscordMessageListener", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("DiscordInteractionListener", () => {
+  function createDeferred() {
+    let resolve: (() => void) | null = null;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    return {
+      promise,
+      resolve: () => {
+        if (typeof resolve === "function") {
+          (resolve as () => void)();
+        }
+      },
+    };
+  }
+
+  it("fires interaction handler without blocking (fire-and-forget)", async () => {
+    let handlerCalled = false;
+    const deferred = createDeferred();
+    const mockClient = {
+      handleInteraction: vi.fn(async () => {
+        await deferred.promise;
+        handlerCalled = true;
+      }),
+    } as unknown as import("@buape/carbon").Client;
+
+    const listener = new DiscordInteractionListener();
+
+    // handle() should return immediately
+    await listener.handle({} as never, mockClient);
+
+    // handleInteraction should be invoked but not yet resolved
+    // oxlint-disable-next-line typescript-eslint/unbound-method
+    expect(mockClient.handleInteraction).toHaveBeenCalledOnce();
+    expect(handlerCalled).toBe(false);
+
+    // Release
+    deferred.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handlerCalled).toBe(true);
+  });
+
+  it("logs interaction handler failures", async () => {
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>;
+
+    const mockClient = {
+      handleInteraction: vi.fn(async () => {
+        throw new Error("interaction boom");
+      }),
+    } as unknown as import("@buape/carbon").Client;
+
+    const listener = new DiscordInteractionListener(logger);
+    await listener.handle({} as never, mockClient);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("discord interaction handler failed"),
+    );
   });
 });
 

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -36,7 +36,11 @@ export function createDiscordGatewayPlugin(params: {
   const options = {
     reconnect: { maxAttempts: 50 },
     intents,
-    autoInteractions: true,
+    // Disable Carbon's default InteractionEventListener so we can replace it
+    // with DiscordInteractionListener (fire-and-forget) in provider.ts.
+    // The default listener blocks the gateway event queue with `await`,
+    // causing Discord "Unknown interaction" (10062) errors.
+    autoInteractions: false,
   };
 
   if (!proxy) {

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -1,6 +1,8 @@
 import {
   ChannelType,
   type Client,
+  InteractionCreateListener,
+  ListenerEvent,
   MessageCreateListener,
   MessageReactionAddListener,
   MessageReactionRemoveListener,
@@ -151,6 +153,43 @@ export class DiscordMessageListener extends MessageCreateListener {
         },
       }),
     );
+  }
+}
+
+/**
+ * Non-blocking wrapper around Carbon's InteractionEventListener.
+ *
+ * The upstream InteractionEventListener awaits `client.handleInteraction()`,
+ * which blocks the gateway event queue for the entire duration of the
+ * interaction handling (slash commands, button clicks, modals, etc.).
+ * Discord requires an initial response within 3 seconds; any processing
+ * that exceeds that window causes an "Unknown interaction" (10062) error,
+ * shown to the user as "This application did not respond".
+ *
+ * By using fire-and-forget (`void`) the interaction is dispatched without
+ * blocking subsequent gateway events, matching the fix applied to
+ * DiscordMessageListener above.
+ */
+export class DiscordInteractionListener extends InteractionCreateListener {
+  type = ListenerEvent.InteractionCreate;
+  private logger?: Logger;
+
+  constructor(logger?: Logger) {
+    super();
+    this.logger = logger;
+  }
+
+  async handle(data: Parameters<InteractionCreateListener["handle"]>[0], client: Client) {
+    void runDiscordListenerWithSlowLog({
+      logger: this.logger,
+      listener: this.constructor.name,
+      event: this.type,
+      run: () => client.handleInteraction(data, {}),
+      onError: (err) => {
+        const logger = this.logger ?? discordEventQueueLog;
+        logger.error(danger(`discord interaction handler failed: ${String(err)}`));
+      },
+    });
   }
 }
 

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -59,6 +59,7 @@ import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-app
 import { attachEarlyGatewayErrorGuard } from "./gateway-error-guard.js";
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import {
+  DiscordInteractionListener,
   DiscordMessageListener,
   DiscordPresenceListener,
   DiscordReactionListener,
@@ -565,6 +566,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       client.listeners,
       new DiscordMessageListener(messageHandler, logger, trackInboundEvent),
     );
+
+    // Replace Carbon's default InteractionEventListener with our non-blocking
+    // version. The default listener awaits the full interaction handling chain,
+    // which blocks the gateway event queue and causes Discord "Unknown
+    // interaction" (10062) errors when processing exceeds 3 seconds.
+    registerDiscordListener(client.listeners, new DiscordInteractionListener(logger));
+
     const reactionListenerOptions = {
       cfg,
       accountId: account.accountId,


### PR DESCRIPTION
## Problem

Two listeners in the Discord gateway pipeline block the event queue by awaiting long-running handlers:

1. **`DiscordMessageListener.handle()`** — awaits message processing (including LLM calls)
2. **`InteractionEventListener.handle()`** (from `@buape/carbon`) — awaits `client.handleInteraction()`

Discord requires interaction responses within 3 seconds. When handler processing exceeds this window, the interaction token expires and Discord returns `Unknown interaction` (error code 10062), shown to the user as *"This application did not respond"*.

The message listener blocking was reported in #9238. The interaction listener has the same root cause but was not addressed.

## Changes

- **`DiscordMessageListener`**: change `await` → `void` (fire-and-forget)
- **Add `DiscordInteractionListener`**: non-blocking replacement for Carbon's `InteractionEventListener`, using the same fire-and-forget pattern with slow-log instrumentation
- **`gateway-plugin.ts`**: set `autoInteractions: false` to prevent Carbon from registering its blocking `InteractionEventListener`
- **`provider.ts`**: register `DiscordInteractionListener`
- Update existing tests for fire-and-forget behavior
- Add tests for `DiscordInteractionListener`

## Before/After

| | Before | After |
|---|---|---|
| Message handling | Blocks event queue ~15-60s | Fire-and-forget |
| Interaction handling | Blocks event queue ~15s → `Unknown interaction` | Fire-and-forget |
| Error logging | N/A for interactions | ✅ Logged via slow-listener instrumentation |

Supersedes #23857 (rebased on latest main with both fixes combined).

Fixes #9238