### PR TITLE
test: fix extension authz assertions for account-scoped pairing APIs

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -239,7 +239,10 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    expect(mockReadAllowFromStore).toHaveBeenCalledWith("feishu");
+    expect(mockReadAllowFromStore).toHaveBeenCalledWith({
+      accountId: "default",
+      channel: "feishu",
+    });
     expect(mockResolveCommandAuthorizedFromAuthorizers).not.toHaveBeenCalled();
     expect(mockFinalizeInboundContext).toHaveBeenCalledTimes(1);
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
@@ -277,6 +280,7 @@ describe("handleFeishuMessage command authorization", () => {
     await dispatchMessage({ cfg, event });
 
     expect(mockUpsertPairingRequest).toHaveBeenCalledWith({
+      accountId: "default",
       channel: "feishu",
       id: "ou-unapproved",
       meta: { name: undefined },

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -90,7 +90,7 @@ describe("msteams monitor handler authz", () => {
       sendActivity: vi.fn(async () => undefined),
     } as unknown as Parameters<typeof handler>[0]);
 
-    expect(readAllowFromStore).toHaveBeenCalledWith("msteams");
+    expect(readAllowFromStore).toHaveBeenCalledWith({ accountId: "default", channel: "msteams" });
     expect(conversationStore.upsert).not.toHaveBeenCalled();
   });
 });

--- a/extensions/nextcloud-talk/src/inbound.authz.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.authz.test.ts
@@ -75,7 +75,10 @@ describe("nextcloud-talk inbound authz", () => {
       } as unknown as RuntimeEnv,
     });
 
-    expect(readAllowFromStore).toHaveBeenCalledWith("nextcloud-talk");
+    expect(readAllowFromStore).toHaveBeenCalledWith({
+      accountId: "default",
+      channel: "nextcloud-talk",
+    });
     expect(buildMentionRegexes).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Commit bce643a0b (`refactor(security): enforce account-scoped pairing APIs`) changed `readAllowFromStore` and `upsertPairingRequest` to take `{ accountId, channel }` objects instead of plain channel strings, but 4 extension test assertions were not updated.
- Why it matters: CI fails on every PR that merges with main (feishu ×2, msteams ×1, nextcloud-talk ×1), masking real regressions.
- What changed: 4 test assertion lines updated to match the new account-scoped signatures.
- What did NOT change: No production code, no behavior, no types.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: upstream commit bce643a0b
- Related: #27922 (sibling fix for outbound session assertions)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.3.1 (arm64)
- Runtime/container: Node 22.17.0, vitest
- Model/provider: N/A
- Integration/channel: feishu, msteams, nextcloud-talk
- Relevant config: default

### Steps

1. `git checkout upstream/main`
2. `npx vitest run extensions/feishu/src/bot.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/nextcloud-talk/src/inbound.authz.test.ts`
3. Observe 4 failures (channel string vs object mismatch)
4. Apply this PR
5. Re-run same tests

### Expected

All tests pass.

### Actual

Before: 4 failures. After: 11/11 pass across 3 test files.

## Evidence

- [x] Failing test/log before + passing after

Before (on upstream/main):
```
FAIL extensions/feishu/src/bot.test.ts
  × allows paired DMs through
    Expected: "feishu"
    Received: {"accountId": "default", "channel": "feishu"}
  × creates pairing request and drops unauthorized DMs
    Expected: ObjectContaining {"channel": "feishu", "id": "ou-unapproved"}
    Received: {"accountId": "default", "channel": "feishu", "id": "ou-unapproved"}
FAIL extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
    Expected: "msteams"
    Received: {"accountId": "default", "channel": "msteams"}
FAIL extensions/nextcloud-talk/src/inbound.authz.test.ts
    Expected: "nextcloud-talk"
    Received: {"accountId": "default", "channel": "nextcloud-talk"}
```

After:
```
✓ extensions/nextcloud-talk/src/inbound.authz.test.ts (1 test) 3ms
✓ extensions/feishu/src/bot.test.ts (9 tests) 19ms
✓ extensions/msteams/src/monitor-handler/message-handler.authz.test.ts (1 test) 4ms
Test Files  3 passed (3)
Tests  11 passed (11)
```

## Human Verification (required)

- Verified scenarios: Ran all 3 extension test files locally, confirmed 11/11 pass. Cross-checked that failures match upstream/main CI.
- Edge cases checked: `grep -rn` confirmed no other old-shape `readAllowFromStore("...")`  assertions exist anywhere in repo.
- What you did **not** verify: Windows CI (pre-existing failures unrelated to this change).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert <sha>` — single commit, test-only.
- Files/config to restore: `extensions/feishu/src/bot.test.ts`, `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`, `extensions/nextcloud-talk/src/inbound.authz.test.ts`
- Known bad symptoms: N/A (test-only change)

## Risks and Mitigations

None — test assertions only, matching already-shipped production code.