### PR TITLE
feat: add agent:beforeRun and agent:afterRun lifecycle hook events

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -10,6 +10,7 @@ import {
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../../hooks/internal-hooks.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -987,6 +988,15 @@ export async function runEmbeddedAttempt(
       try {
         const promptStartedAt = Date.now();
 
+        // Fire agent:beforeRun internal hook before processing begins
+        void triggerInternalHook(
+          createInternalHookEvent("agent", "beforeRun", params.sessionKey ?? "", {
+            sessionKey: params.sessionKey ?? "",
+            messageProvider: params.messageProvider ?? undefined,
+            timestamp: new Date().toISOString(),
+          }),
+        );
+
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
@@ -1251,6 +1261,19 @@ export async function runEmbeddedAttempt(
               log.warn(`agent_end hook failed: ${err}`);
             });
         }
+
+        // Fire agent:afterRun internal hook after the agent completes
+        const totalResponseLength = assistantTexts.reduce((sum, t) => sum + t.length, 0);
+        void triggerInternalHook(
+          createInternalHookEvent("agent", "afterRun", params.sessionKey ?? "", {
+            sessionKey: params.sessionKey ?? "",
+            responseLength: totalResponseLength,
+            timestamp: new Date().toISOString(),
+            success: !aborted && !promptError,
+            error: promptError ? describeUnknownError(promptError) : undefined,
+            durationMs: Date.now() - promptStartedAt,
+          }),
+        );
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {

--- a/src/hooks/bundled/agent-run-logger/HOOK.md
+++ b/src/hooks/bundled/agent-run-logger/HOOK.md
@@ -1,0 +1,25 @@
+---
+name: agent-run-logger
+description: Logs agent run start and end times to a local file for auditing and debugging.
+events:
+  - agent:beforeRun
+  - agent:afterRun
+---
+
+# Agent Run Logger
+
+Appends a line to `~/.openclaw/logs/agent-runs.log` for every agent run.
+
+**Before run:**
+
+```
+2026-02-26T21:00:00.000Z START sessionKey=agent:main:main
+```
+
+**After run:**
+
+```
+2026-02-26T21:00:05.123Z END   sessionKey=agent:main:main duration=5123ms length=420
+```
+
+Useful for auditing activity, spotting stuck runs, and measuring response times.

--- a/src/hooks/bundled/agent-run-logger/handler.ts
+++ b/src/hooks/bundled/agent-run-logger/handler.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  AgentBeforeRunHookEvent,
+  AgentAfterRunHookEvent,
+  HookHandler,
+} from "../../internal-hooks.js";
+
+const logPath = path.join(os.homedir(), ".openclaw", "logs", "agent-runs.log");
+
+function appendLog(line: string): void {
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, line + "\n", "utf8");
+  } catch {
+    // best-effort — never crash the agent
+  }
+}
+
+export const handler: HookHandler<AgentBeforeRunHookEvent | AgentAfterRunHookEvent> = (event) => {
+  if (event.type === "agent:beforeRun") {
+    appendLog(`${event.timestamp} START sessionKey=${event.sessionKey}`);
+  } else if (event.type === "agent:afterRun") {
+    appendLog(
+      `${event.timestamp} END   sessionKey=${event.sessionKey} duration=${event.durationMs}ms length=${event.responseLength}`,
+    );
+  }
+};

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -93,6 +93,46 @@ export type MessageSentHookEvent = InternalHookEvent & {
   context: MessageSentHookContext;
 };
 
+// ============================================================================
+// Agent Lifecycle Hook Events
+// ============================================================================
+
+export type AgentBeforeRunHookContext = {
+  /** The session key for this agent run */
+  sessionKey: string;
+  /** The channel or provider that triggered this run (e.g., "telegram", "web") */
+  messageProvider?: string;
+  /** ISO timestamp when the run started */
+  timestamp: string;
+};
+
+export type AgentBeforeRunHookEvent = InternalHookEvent & {
+  type: "agent";
+  action: "beforeRun";
+  context: AgentBeforeRunHookContext;
+};
+
+export type AgentAfterRunHookContext = {
+  /** The session key for this agent run */
+  sessionKey: string;
+  /** Total character length of assistant response texts */
+  responseLength: number;
+  /** ISO timestamp when the run completed */
+  timestamp: string;
+  /** Whether the run completed successfully */
+  success: boolean;
+  /** Error description if the run failed */
+  error?: string;
+  /** Duration of the run in milliseconds */
+  durationMs: number;
+};
+
+export type AgentAfterRunHookEvent = InternalHookEvent & {
+  type: "agent";
+  action: "afterRun";
+  context: AgentAfterRunHookContext;
+};
+
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */
   type: InternalHookEventType;
@@ -280,5 +320,31 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
     typeof context.to === "string" &&
     typeof context.channelId === "string" &&
     typeof context.success === "boolean"
+  );
+}
+
+export function isAgentBeforeRunEvent(event: InternalHookEvent): event is AgentBeforeRunHookEvent {
+  if (event.type !== "agent" || event.action !== "beforeRun") {
+    return false;
+  }
+  const context = event.context as Partial<AgentBeforeRunHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.sessionKey === "string" && typeof context.timestamp === "string";
+}
+
+export function isAgentAfterRunEvent(event: InternalHookEvent): event is AgentAfterRunHookEvent {
+  if (event.type !== "agent" || event.action !== "afterRun") {
+    return false;
+  }
+  const context = event.context as Partial<AgentAfterRunHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return (
+    typeof context.sessionKey === "string" &&
+    typeof context.responseLength === "number" &&
+    typeof context.timestamp === "string"
   );
 }


### PR DESCRIPTION
## Summary

Adds `agent:beforeRun` and `agent:afterRun` lifecycle hook events, giving users a standard way to hook into the agent execution pipeline before and after each model call.

## Change Type
- [x] Feature

## Scope
`src/agents/pi-embedded-runner/run/attempt.ts`, `src/hooks/internal-hooks.ts`

## User-visible / Behavior Changes
Two new hook events available in `workspace/hooks/`:
- `agent:beforeRun` — fires before the model is called, with `{ sessionKey, messageType, timestamp }`
- `agent:afterRun` — fires after the agent replies, with `{ sessionKey, durationMs, responseLength, timestamp }`

Includes a bundled `agent-run-logger` hook that appends run start/end timestamps to `~/.openclaw/logs/agent-runs.log` — useful for auditing, debugging stuck runs, and measuring response times.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No

## Compatibility / Migration
- Backward compatible? Yes — no config changes, no migration needed

## Failure Recovery
- Hook failures are caught, logged, and never affect agent runs

## Risks and Mitigations
- Hook execution is async with timeout; slow hooks are logged and skipped
