### PR TITLE
fix(browser): make Chrome extension relay reachable from Docker host

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -152,10 +152,12 @@ describe("chrome extension relay server", () => {
       "OPENCLAW_GATEWAY_TOKEN",
       "OPENCLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS",
       "OPENCLAW_EXTENSION_RELAY_COMMAND_RECONNECT_WAIT_MS",
+      "OPENCLAW_EXTENSION_RELAY_BIND_HOST",
     ]);
     process.env.OPENCLAW_GATEWAY_TOKEN = TEST_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_EXTENSION_RELAY_RECONNECT_GRACE_MS;
     delete process.env.OPENCLAW_EXTENSION_RELAY_COMMAND_RECONNECT_WAIT_MS;
+    delete process.env.OPENCLAW_EXTENSION_RELAY_BIND_HOST;
   });
 
   afterEach(async () => {
@@ -176,6 +178,18 @@ describe("chrome extension relay server", () => {
     await waitForOpen(ext);
     return { port, ext };
   }
+
+  it("uses configured bind host when OPENCLAW_EXTENSION_RELAY_BIND_HOST is set", async () => {
+    const port = await getFreePort();
+    cdpUrl = `http://127.0.0.1:${port}`;
+    process.env.OPENCLAW_EXTENSION_RELAY_BIND_HOST = "0.0.0.0";
+
+    const relay = await ensureChromeExtensionRelayServer({ cdpUrl });
+    expect(relay.host).toBe("0.0.0.0");
+
+    const status = await fetch(`${cdpUrl}/extension/status`);
+    expect(status.status).toBe(200);
+  });
 
   it("advertises CDP WS only when extension is connected", async () => {
     const port = await getFreePort();


### PR DESCRIPTION
Fixes #27924

## Summary
- bind the extension relay server to `0.0.0.0` when running inside Docker so host-mapped port `18792` is reachable
- keep default loopback binding outside Docker
- keep strict loopback websocket source checks unless relay is explicitly bound to a non-loopback host
- add test coverage for bind-host override (`OPENCLAW_EXTENSION_RELAY_BIND_HOST`)

## Validation
- `pnpm test -- src/browser/extension-relay.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`