### PR TITLE
fix: merge consecutive assistant messages in validateAnthropicTurns

### DIFF
--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -97,11 +97,18 @@ export function mergeConsecutiveUserTurns(
 /**
  * Validates and fixes conversation turn sequences for Anthropic API.
  * Anthropic requires strict alternating user→assistant pattern.
- * Merges consecutive user messages together.
+ * Merges consecutive assistant messages first (so tool_result immediately
+ * follows the assistant turn containing the tool_use), then merges
+ * consecutive user messages.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
-  return validateTurnsWithConsecutiveMerge({
+  const assistantMerged = validateTurnsWithConsecutiveMerge({
     messages,
+    role: "assistant",
+    merge: mergeConsecutiveAssistantTurns,
+  });
+  return validateTurnsWithConsecutiveMerge({
+    messages: assistantMerged,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });


### PR DESCRIPTION
## Summary

- Fixes a bug where consecutive assistant messages (text reply + tool_use) cause `tool_use ids were found without tool_result blocks` errors with the Anthropic API
- Adds a first pass to `validateAnthropicTurns` that merges consecutive assistant messages using the existing `mergeConsecutiveAssistantTurns` helper (same as `validateGeminiTurns` already does)
- Adds test coverage for the text + tool_use merge scenario

## Test plan

- [x] Existing tests updated to reflect new merging behavior
- [x] New test case: assistant text + tool_use merged so tool_result immediately follows
- [ ] Run `pnpm test` to verify all tests pass

Closes #27889

🤖 Generated with [Claude Code](https://claude.com/claude-code)