### PR TITLE
fix(telegram): suppress NO_REPLY before API call to prevent flash

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -1,5 +1,6 @@
 import { type Bot, GrammyError, InputFile } from "grammy";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
@@ -108,6 +109,13 @@ export async function deliverReplies(params: {
         continue;
       }
       runtime.error?.(danger("reply missing text/media"));
+      continue;
+    }
+    // Suppress NO_REPLY before the Telegram API call to prevent the
+    // send-then-delete flash visible to users in group chats (#27959).
+    const trimmedText = reply.text?.trim() ?? "";
+    if (isSilentReplyText(trimmedText) && !hasMedia) {
+      logVerbose("telegram send: suppressed NO_REPLY token before API call");
       continue;
     }
     const replyToId = replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);


### PR DESCRIPTION
## Summary
- Intercept `NO_REPLY` responses **before** calling the Telegram Bot API, preventing the send-then-delete flash
- Add `isSilentReplyText` check in `deliverReplies()` mirroring the existing Slack suppression (`src/slack/send.ts:235`)
- NO_REPLY payloads without media are now skipped entirely — no message is ever published or deleted

## Root Cause
Previously, `NO_REPLY` was detected only in the normalize-reply pipeline or cleanup phase, **after** a Telegram preview/message had already been sent. Users would see a brief message flash before deletion, especially noticeable in group chats.

## Test plan
- [ ] Send a message that triggers NO_REPLY in a Telegram group chat
- [ ] Verify no message flash appears (no send + delete cycle)
- [ ] Verify normal replies still work correctly
- [ ] Verify NO_REPLY with media still delivers the media (only text suppression)

Closes #27959

🤖 Generated with [Claude Code](https://claude.com/claude-code)