### PR TITLE
fix(typing): always clean up on TTL expiry regardless of loop state

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -90,9 +90,10 @@ export function createTypingController(params: {
       clearTimeout(typingTtlTimer);
     }
     typingTtlTimer = setTimeout(() => {
-      if (!typingLoop.isRunning()) {
-        return;
-      }
+      // Always clean up when TTL fires, even if the loop was stopped
+      // externally (e.g., by a WebSocket disconnect/reconnect). Skipping
+      // cleanup here left the controller unsealed, so late events or
+      // reconnects could restart typing indefinitely (#27926).
       log?.(`typing TTL reached (${formatTypingTtl(typingTtlMs)}); stopping typing indicator`);
       cleanup();
     }, typingTtlMs);


### PR DESCRIPTION
## Summary
- Remove the `typingLoop.isRunning()` guard from the TTL timeout handler so cleanup fires unconditionally
- This prevents typing indicators from persisting indefinitely after Discord WebSocket disconnects/reconnects

## Root Cause
The typing TTL timer (2-minute safety net) checked `if (!typingLoop.isRunning()) return;` before cleaning up. If the keepalive loop was stopped externally (e.g., by a Discord WebSocket disconnect with codes 1005/1006) without sealing the controller, the TTL would fire but skip cleanup. The controller remained unsealed, so late events or WebSocket reconnects could restart the typing loop indefinitely.

## Test plan
- [ ] Send a message via Discord, verify typing stops after agent completes reply
- [ ] Simulate long-running agent (>2 min); verify TTL cleanup fires and typing stops
- [ ] Verify typing still works normally for regular replies

Closes #27926

🤖 Generated with [Claude Code](https://claude.com/claude-code)