### PR TITLE
fix(typing): stop keepalive loop immediately on markRunComplete

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -189,6 +189,11 @@ export function createTypingController(params: {
 
   const markRunComplete = () => {
     runComplete = true;
+    // Stop the keepalive loop immediately so no further sendChatAction
+    // calls can reach the channel. The guard blocks triggers, but the
+    // setInterval still fires; stopping it avoids a window where a
+    // late tick could slip through on slow event loops.
+    typingLoop.stop();
     maybeStopOnIdle();
     if (!sealed && !dispatchIdle) {
       dispatchIdleTimer = setTimeout(() => {

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -90,9 +90,10 @@ export function createTypingController(params: {
       clearTimeout(typingTtlTimer);
     }
     typingTtlTimer = setTimeout(() => {
-      if (!typingLoop.isRunning()) {
-        return;
-      }
+      // Always clean up when TTL fires, even if the loop was stopped
+      // externally (e.g., by a WebSocket disconnect/reconnect). Skipping
+      // cleanup here left the controller unsealed, so late events or
+      // reconnects could restart typing indefinitely (#27926).
       log?.(`typing TTL reached (${formatTypingTtl(typingTtlMs)}); stopping typing indicator`);
       cleanup();
     }, typingTtlMs);


### PR DESCRIPTION
## Summary

- Stops the typing keepalive `setInterval` immediately when `markRunComplete` is called, instead of relying on the start guard to block triggers
- On slow event loops, a late tick could slip through the guard and send one more `sendChatAction` call, extending the channel typing indicator
- This complements the existing TTL safety net and 10s grace timer fixes

## Test plan

- [x] Verified `typingLoop.stop()` is idempotent (safe to call multiple times)
- [ ] Run `pnpm test` to verify existing typing tests pass
- [ ] Manual: send message to Discord agent, verify typing stops immediately after reply

Closes #27926

🤖 Generated with [Claude Code](https://claude.com/claude-code)