### PR TITLE
fix(openresponses): sanitize call_id for OpenAI Responses API

### DIFF
--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -8,6 +8,15 @@
 
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Sanitize an ID for the OpenAI Responses API which requires IDs to contain
+ * only letters, numbers, underscores, or dashes (`[A-Za-z0-9_-]`).
+ * Replace any disallowed character (e.g. pipe `|`) with an underscore.
+ */
+function sanitizeResponsesId(id: string): string {
+  return id.replace(/[^A-Za-z0-9_-]/g, "_");
+}
 import type { ClientToolDefinition } from "../agents/pi-embedded-runner/run/params.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
@@ -485,7 +494,7 @@ export async function handleOpenResponsesHttpRequest(
             {
               type: "function_call",
               id: functionCallItemId,
-              call_id: functionCall.id,
+              call_id: sanitizeResponsesId(functionCall.id),
               name: functionCall.name,
               arguments: functionCall.arguments,
             },
@@ -754,7 +763,7 @@ export async function handleOpenResponsesHttpRequest(
           const functionCallItem = {
             type: "function_call" as const,
             id: functionCallItemId,
-            call_id: functionCall.id,
+            call_id: sanitizeResponsesId(functionCall.id),
             name: functionCall.name,
             arguments: functionCall.arguments,
           };


### PR DESCRIPTION
## Summary
- Add `sanitizeResponsesId()` to replace characters outside `[A-Za-z0-9_-]` with underscores before sending `call_id` to the OpenAI Responses API
- Applied to both non-streaming (line 488) and streaming (line 757) code paths in `openresponses-http.ts`

## Root Cause
Internal tool call IDs can contain pipe characters (e.g. `call_xxx|fc_yyy`) which are disallowed by the OpenAI Responses API `input[].id` validation (`[A-Za-z0-9_-]` only). This caused 400 errors when using the `openai-codex` provider:

```
Invalid 'input[223].id': '...'. Expected an ID that contains letters, numbers, underscores, or dashes.
```

## Test plan
- [ ] Use `openai-codex` provider with tool-calling agent
- [ ] Verify tool call IDs with special characters are sanitized
- [ ] Verify tool results are correctly matched back to sanitized IDs

Closes #27961

🤖 Generated with [Claude Code](https://claude.com/claude-code)