### PR TITLE
feat(telegram): add disableChatActions config to suppress typing indicators

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -137,6 +137,8 @@ export type TelegramAccountConfig = {
   webhookPort?: number;
   /** Per-action tool gating (default: true for all). */
   actions?: TelegramActionConfig;
+  /** Disable typing / record_voice chat action indicators entirely (default: false). */
+  disableChatActions?: boolean;
   /**
    * Controls which user reactions trigger notifications:
    * - "off" (default): ignore all reactions

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -215,6 +215,7 @@ export const TelegramAccountSchemaBase = z
     linkPreview: z.boolean().optional(),
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
+    disableChatActions: z.boolean().optional(),
   })
   .strict();
 

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -118,6 +118,8 @@ export type BuildTelegramMessageContextParams = {
   resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
   /** Global (per-account) handler for sendChatAction 401 backoff (#27092). */
   sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
+  /** When true, suppress all sendChatAction calls (typing/record_voice). */
+  disableChatActions?: boolean;
 };
 
 async function resolveStickerVisionSupport(params: {
@@ -159,6 +161,7 @@ export const buildTelegramMessageContext = async ({
   resolveGroupRequireMention,
   resolveTelegramGroupConfig,
   sendChatActionHandler,
+  disableChatActions,
 }: BuildTelegramMessageContextParams) => {
   const msg = primaryCtx.message;
   const chatId = msg.chat.id;
@@ -244,6 +247,9 @@ export const buildTelegramMessageContext = async ({
   );
 
   const sendTyping = async () => {
+    if (disableChatActions) {
+      return;
+    }
     await withTelegramApiErrorLogging({
       operation: "sendChatAction",
       fn: () =>
@@ -256,6 +262,9 @@ export const buildTelegramMessageContext = async ({
   };
 
   const sendRecordVoice = async () => {
+    if (disableChatActions) {
+      return;
+    }
     try {
       await withTelegramApiErrorLogging({
         operation: "sendChatAction",

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -72,6 +72,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       resolveGroupRequireMention,
       resolveTelegramGroupConfig,
       sendChatActionHandler,
+      disableChatActions: telegramCfg.disableChatActions,
     });
     if (!context) {
       return;


### PR DESCRIPTION
## Summary
- Add `disableChatActions` boolean to `TelegramAccountConfig` that suppresses all `sendChatAction` calls (typing, record_voice) when set to `true`
- Update Zod schema validation to accept the new field
- Wire config through `buildTelegramMessageContext` to the `sendTyping`/`sendRecordVoice` closures

## Usage

```json
{
  "channels": {
    "telegram": {
      "disableChatActions": true
    }
  }
}
```

Also works at the account level:
```json
{
  "channels": {
    "telegram": {
      "accounts": {
        "mybot": {
          "disableChatActions": true
        }
      }
    }
  }
}
```

## Test plan
- [ ] Set `disableChatActions: true` in telegram config
- [ ] Send a message — verify no typing indicator appears
- [ ] Set `disableChatActions: false` (or omit) — verify typing works normally
- [ ] Verify schema validation accepts the new field

Closes #27927

🤖 Generated with [Claude Code](https://claude.com/claude-code)