### PR TITLE
fix(gateway): add --password-file and --token-file to avoid ps exposure

### DIFF
--- a/src/cli/gateway-cli/call.ts
+++ b/src/cli/gateway-cli/call.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { readSecretFromFile } from "../../acp/secret-file.js";
 import { callGateway } from "../../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { withProgress } from "../progress.js";
@@ -6,7 +7,9 @@ import { withProgress } from "../progress.js";
 export type GatewayRpcOpts = {
   url?: string;
   token?: string;
+  tokenFile?: string;
   password?: string;
+  passwordFile?: string;
   timeout?: string;
   expectFinal?: boolean;
   json?: boolean;
@@ -16,13 +19,35 @@ export const gatewayCallOpts = (cmd: Command) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
+    .option("--token-file <path>", "Read gateway token from file (avoids ps exposure)")
     .option("--password <password>", "Gateway password (password auth)")
+    .option("--password-file <path>", "Read gateway password from file (avoids ps exposure)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--expect-final", "Wait for final response (agent)", false)
     .option("--json", "Output JSON", false);
 
-export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, params?: unknown) =>
-  withProgress(
+function resolveCallSecret(
+  direct: string | undefined,
+  filePath: string | undefined,
+  directFlag: string,
+  fileFlag: string,
+  label: string,
+): string | undefined {
+  const d = direct?.trim();
+  const f = filePath?.trim();
+  if (d && f) {
+    throw new Error(`Use either ${directFlag} or ${fileFlag} for ${label}.`);
+  }
+  if (f) {
+    return readSecretFromFile(f, label);
+  }
+  return d || undefined;
+}
+
+export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, params?: unknown) => {
+  const token = resolveCallSecret(opts.token, opts.tokenFile, "--token", "--token-file", "Gateway token");
+  const password = resolveCallSecret(opts.password, opts.passwordFile, "--password", "--password-file", "Gateway password");
+  return withProgress(
     {
       label: `Gateway ${method}`,
       indeterminate: true,
@@ -31,8 +56,8 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
     async () =>
       await callGateway({
         url: opts.url,
-        token: opts.token,
-        password: opts.password,
+        token,
+        password,
         method,
         params,
         expectFinal: Boolean(opts.expectFinal),
@@ -41,3 +66,4 @@ export const callGatewayCli = async (method: string, opts: GatewayRpcOpts, param
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),
   );
+};


### PR DESCRIPTION
## Summary
- Add `--password-file` and `--token-file` options to `gateway run` and `gateway call` commands, following the existing ACP CLI pattern (`src/cli/acp-cli.ts`)
- Emit a warning when `--password` or `--token` are passed directly on the CLI, since they are visible in `ps aux` output
- Reuse the existing `readSecretFromFile()` utility from `src/acp/secret-file.ts`

## Context

Gateway passwords passed via `--password <secret>` appear in plaintext in process argument lists visible to all users on the host (`ps aux`, `/proc/[pid]/cmdline`). The environment variable (`OPENCLAW_GATEWAY_PASSWORD`) and config file alternatives already exist but the CLI lacked the file-based option that the ACP CLI already supports.

Closes #27948

## Test plan
- [ ] Verify `openclaw gateway run --password-file /path/to/secret` reads password from file
- [ ] Verify `openclaw gateway run --password mysecret` emits a warning
- [ ] Verify `--password` and `--password-file` together produces an error
- [ ] Verify `gateway call` subcommands support `--token-file` and `--password-file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)