### PR TITLE
fix(hooks): fire message:sent from inline channel delivery paths

### DIFF
--- a/src/hooks/emit-message-sent.test.ts
+++ b/src/hooks/emit-message-sent.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunMessageSent = vi.fn().mockResolvedValue(undefined);
+const mockHasHooks = vi.fn().mockReturnValue(false);
+const mockGetGlobalHookRunner = vi.fn().mockReturnValue(null);
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => mockGetGlobalHookRunner(),
+}));
+
+const mockTriggerInternalHook = vi.fn().mockResolvedValue(undefined);
+const mockCreateInternalHookEvent = vi.fn().mockReturnValue({ type: "message", action: "sent" });
+
+vi.mock("./internal-hooks.js", () => ({
+  triggerInternalHook: (...args: unknown[]) => mockTriggerInternalHook(...args),
+  createInternalHookEvent: (...args: unknown[]) => mockCreateInternalHookEvent(...args),
+}));
+
+import { emitMessageSentHook } from "./emit-message-sent.js";
+
+describe("emitMessageSentHook", () => {
+  const baseParams = {
+    to: "chat-123",
+    content: "Hello world",
+    success: true,
+    channelId: "telegram",
+    accountId: "acct-1",
+    sessionKey: "session-abc",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGlobalHookRunner.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("plugin hook", () => {
+    it("fires with correct args when hookRunner has hooks", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        { to: "chat-123", content: "Hello world", success: true },
+        { channelId: "telegram", accountId: "acct-1", conversationId: "chat-123" },
+      );
+    });
+
+    it("includes error field when success is false", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, success: false, error: "send failed" });
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        { to: "chat-123", content: "Hello world", success: false, error: "send failed" },
+        { channelId: "telegram", accountId: "acct-1", conversationId: "chat-123" },
+      );
+    });
+
+    it("does not fire when hookRunner is null (plugins not loaded)", () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when hookRunner.hasHooks returns false", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(false),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors from plugin hook (fire-and-forget)", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent.mockRejectedValue(new Error("plugin crash")),
+      });
+
+      // Should not throw
+      expect(() => emitMessageSentHook(baseParams)).not.toThrow();
+    });
+  });
+
+  describe("internal hook", () => {
+    it("fires with correct event shape when sessionKey is provided", () => {
+      emitMessageSentHook(baseParams);
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith("message", "sent", "session-abc", {
+        to: "chat-123",
+        content: "Hello world",
+        success: true,
+        channelId: "telegram",
+        accountId: "acct-1",
+        conversationId: "chat-123",
+        messageId: undefined,
+      });
+      expect(mockTriggerInternalHook).toHaveBeenCalled();
+    });
+
+    it("does not fire when sessionKey is undefined", () => {
+      emitMessageSentHook({ ...baseParams, sessionKey: undefined });
+
+      expect(mockCreateInternalHookEvent).not.toHaveBeenCalled();
+      expect(mockTriggerInternalHook).not.toHaveBeenCalled();
+    });
+
+    it("includes messageId when provided", () => {
+      emitMessageSentHook({ ...baseParams, messageId: "msg-42" });
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+        "message",
+        "sent",
+        "session-abc",
+        expect.objectContaining({ messageId: "msg-42" }),
+      );
+    });
+
+    it("includes error in context when success is false", () => {
+      emitMessageSentHook({ ...baseParams, success: false, error: "timeout" });
+
+      expect(mockCreateInternalHookEvent).toHaveBeenCalledWith(
+        "message",
+        "sent",
+        "session-abc",
+        expect.objectContaining({ success: false, error: "timeout" }),
+      );
+    });
+
+    it("swallows errors from internal hook (fire-and-forget)", () => {
+      mockTriggerInternalHook.mockRejectedValue(new Error("internal hook crash"));
+
+      expect(() => emitMessageSentHook(baseParams)).not.toThrow();
+    });
+  });
+
+  describe("independence", () => {
+    it("fires internal hook even when plugin hook is not available", () => {
+      mockGetGlobalHookRunner.mockReturnValue(null);
+
+      emitMessageSentHook(baseParams);
+
+      expect(mockRunMessageSent).not.toHaveBeenCalled();
+      expect(mockTriggerInternalHook).toHaveBeenCalled();
+    });
+
+    it("fires plugin hook even when sessionKey is missing (internal hook skipped)", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, sessionKey: undefined });
+
+      expect(mockRunMessageSent).toHaveBeenCalled();
+      expect(mockTriggerInternalHook).not.toHaveBeenCalled();
+    });
+
+    it("passes accountId as undefined when not provided", () => {
+      mockGetGlobalHookRunner.mockReturnValue({
+        hasHooks: mockHasHooks.mockReturnValue(true),
+        runMessageSent: mockRunMessageSent,
+      });
+
+      emitMessageSentHook({ ...baseParams, accountId: undefined });
+
+      expect(mockRunMessageSent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ accountId: undefined }),
+      );
+    });
+  });
+});

--- a/src/hooks/emit-message-sent.ts
+++ b/src/hooks/emit-message-sent.ts
@@ -1,0 +1,61 @@
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+/**
+ * Fire message:sent hooks (plugin + internal) for inline delivery paths.
+ *
+ * Mirrors the hook emission in src/infra/outbound/deliver.ts (emitMessageSent),
+ * extracted as a shared utility so channel-specific deliverReplies functions
+ * can fire hooks without routing through the centralized outbound path.
+ *
+ * Both hooks are fire-and-forget — errors are caught and swallowed.
+ */
+export function emitMessageSentHook(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: string;
+  channelId: string;
+  accountId?: string;
+  sessionKey?: string;
+}): void {
+  const { to, content, success, error, messageId, channelId, accountId, sessionKey } = params;
+
+  // Plugin hook
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to,
+          content,
+          success,
+          ...(error ? { error } : {}),
+        },
+        {
+          channelId,
+          accountId,
+          conversationId: to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  // Internal hook (requires sessionKey)
+  if (!sessionKey) {
+    return;
+  }
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", sessionKey, {
+      to,
+      content,
+      success,
+      ...(error ? { error } : {}),
+      channelId,
+      accountId,
+      conversationId: to,
+      messageId,
+    }),
+  ).catch(() => {});
+}

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -2,6 +2,7 @@ import { chunkTextWithMode, resolveChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
@@ -17,6 +18,7 @@ export async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
+  sessionKey?: string;
 }) {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
     params;
@@ -35,34 +37,62 @@ export async function deliverReplies(params: {
     if (!text && mediaList.length === 0) {
       continue;
     }
-    if (mediaList.length === 0) {
-      sentMessageCache?.remember(scope, { text });
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        const sent = await sendMessageIMessage(target, chunk, {
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+    const hookBase = {
+      to: target,
+      channelId: "imessage" as const,
+      accountId,
+      sessionKey: params.sessionKey,
+    };
+    try {
+      if (mediaList.length === 0) {
+        sentMessageCache?.remember(scope, { text });
+        for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+          const sent = await sendMessageIMessage(target, chunk, {
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+          emitMessageSentHook({
+            ...hookBase,
+            content: chunk,
+            success: true,
+            messageId: sent.messageId,
+          });
+        }
+      } else {
+        let first = true;
+        for (const url of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          const sent = await sendMessageIMessage(target, caption, {
+            mediaUrl: url,
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          sentMessageCache?.remember(scope, {
+            text: caption || undefined,
+            messageId: sent.messageId,
+          });
+          emitMessageSentHook({
+            ...hookBase,
+            content: caption || url,
+            success: true,
+            messageId: sent.messageId,
+          });
+        }
       }
-    } else {
-      let first = true;
-      for (const url of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        const sent = await sendMessageIMessage(target, caption, {
-          mediaUrl: url,
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, {
-          text: caption || undefined,
-          messageId: sent.messageId,
-        });
-      }
+    } catch (err) {
+      emitMessageSentHook({
+        ...hookBase,
+        content: text,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);
   }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -372,6 +372,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           maxBytes: mediaMaxBytes,
           textLimit,
           sentMessageCache,
+          sessionKey: ctxPayload.SessionKey ?? decision.route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -9,6 +9,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
+import { emitMessageSentHook } from "../hooks/emit-message-sent.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
@@ -288,6 +289,7 @@ async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   chunkMode: "length" | "newline";
+  sessionKey?: string;
 }) {
   const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
     params;
@@ -297,28 +299,46 @@ async function deliverReplies(params: {
     if (!text && mediaList.length === 0) {
       continue;
     }
-    if (mediaList.length === 0) {
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        await sendMessageSignal(target, chunk, {
-          baseUrl,
-          account,
-          maxBytes,
-          accountId,
-        });
+    const hookBase = {
+      to: target,
+      channelId: "signal" as const,
+      accountId,
+      sessionKey: params.sessionKey,
+    };
+    try {
+      if (mediaList.length === 0) {
+        for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+          await sendMessageSignal(target, chunk, {
+            baseUrl,
+            account,
+            maxBytes,
+            accountId,
+          });
+          emitMessageSentHook({ ...hookBase, content: chunk, success: true });
+        }
+      } else {
+        let first = true;
+        for (const url of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          await sendMessageSignal(target, caption, {
+            baseUrl,
+            account,
+            mediaUrl: url,
+            maxBytes,
+            accountId,
+          });
+          emitMessageSentHook({ ...hookBase, content: caption || url, success: true });
+        }
       }
-    } else {
-      let first = true;
-      for (const url of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        await sendMessageSignal(target, caption, {
-          baseUrl,
-          account,
-          mediaUrl: url,
-          maxBytes,
-          accountId,
-        });
-      }
+    } catch (err) {
+      emitMessageSentHook({
+        ...hookBase,
+        content: text,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
     }
     runtime.log?.(`delivered reply to ${target}`);
   }

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -236,6 +236,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+          sessionKey: route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -104,6 +104,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
+    sessionKey?: string;
   }) => Promise<void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -190,6 +190,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       textLimit: ctx.textLimit,
       replyThreadTs,
       replyToMode: ctx.replyToMode,
+      sessionKey: route.mainSessionKey,
     });
     replyPlan.markSent();
   };

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -190,7 +190,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       textLimit: ctx.textLimit,
       replyThreadTs,
       replyToMode: ctx.replyToMode,
-      sessionKey: route.mainSessionKey,
+      sessionKey: prepared.ctxPayload.SessionKey ?? route.mainSessionKey,
     });
     replyPlan.markSent();
   };

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -4,6 +4,7 @@ import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-refere
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack } from "../send.js";
@@ -17,6 +18,7 @@ export async function deliverReplies(params: {
   textLimit: number;
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
+  sessionKey?: string;
 }) {
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
@@ -29,28 +31,46 @@ export async function deliverReplies(params: {
       continue;
     }
 
-    if (mediaList.length === 0) {
-      const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-        continue;
-      }
-      await sendMessageSlack(params.target, trimmed, {
-        token: params.token,
-        threadTs,
-        accountId: params.accountId,
-      });
-    } else {
-      let first = true;
-      for (const mediaUrl of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        await sendMessageSlack(params.target, caption, {
+    const hookBase = {
+      to: params.target,
+      channelId: "slack" as const,
+      accountId: params.accountId,
+      sessionKey: params.sessionKey,
+    };
+    try {
+      if (mediaList.length === 0) {
+        const trimmed = text.trim();
+        if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+          continue;
+        }
+        await sendMessageSlack(params.target, trimmed, {
           token: params.token,
-          mediaUrl,
           threadTs,
           accountId: params.accountId,
         });
+        emitMessageSentHook({ ...hookBase, content: trimmed, success: true });
+      } else {
+        let first = true;
+        for (const mediaUrl of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          await sendMessageSlack(params.target, caption, {
+            token: params.token,
+            mediaUrl,
+            threadTs,
+            accountId: params.accountId,
+          });
+          emitMessageSentHook({ ...hookBase, content: caption || mediaUrl, success: true });
+        }
       }
+    } catch (err) {
+      emitMessageSentHook({
+        ...hookBase,
+        content: text,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
     }
     params.runtime.log?.(`delivered reply to ${params.target}`);
   }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -366,6 +366,7 @@ export const dispatchTelegramMessage = async ({
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
     sessionKey: ctxPayload.SessionKey,
+    accountId: route.accountId,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -365,6 +365,7 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    sessionKey: ctxPayload.SessionKey,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {


### PR DESCRIPTION
## Summary

- **Problem:** The `message:sent` hook (both plugin and internal) only fires from the centralized outbound delivery path (`src/infra/outbound/deliver.ts`). Conversational replies — the primary message flow — route through channel-specific inline `deliverReplies()` functions in Telegram, Signal, Slack, and iMessage that bypass this path entirely, so the hook never fires.
- **Why it matters:** Any integration relying on `message:sent` for conversation logging, analytics, or downstream processing silently misses all conversational replies. This was identified as a gap in #24968.
- **What changed:** A shared `emitMessageSentHook()` utility is added and wired into all four inline delivery paths. `sessionKey` is threaded from each channel's routing context to enable internal hook emission.
- **What did NOT change (scope boundary):** The centralized outbound delivery path is untouched. Hook semantics, payload shape, and fire-and-forget behavior are identical to the existing implementation. No new dependencies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24968

## User-visible / Behavior Changes

- `message:sent` plugin hooks now fire for conversational replies delivered via Telegram, Signal, Slack, and iMessage inline delivery paths (previously only fired for outbound messages routed through the centralized delivery path).
- Internal hooks (`message` / `sent` events) now fire for the same paths when a `sessionKey` is available.
- No config changes required. No new config options.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (hooks are existing internal event dispatch)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Node 22 slim container via Docker/Colima) and macOS (Darwin 25.3.0)
- Runtime/container: Node 22 (Docker container for E2E), pnpm/Bun (local for unit tests)
- Model/provider: Anthropic (Claude Opus 4.6, used for E2E Telegram test)
- Integration/channel: Telegram (E2E verified), Signal/Slack/iMessage (unit tested)
- Relevant config: Internal `message:sent` hook writing JSONL to `/tmp/message_sent.log`

### Steps

1. Register a `message:sent` internal hook that appends events to a log file
2. Start the gateway from this branch in a Docker container with only the test Telegram bot
3. Send a DM to the bot on Telegram and wait for a reply
4. Inspect the log file for `message:sent` events

### Expected

- `message:sent` hook fires for every outbound reply, with `to`, `content`, `success`, `channelId`, `accountId`, `messageId`, and `sessionKey` populated

### Actual (before fix)

- Hook only fires for messages routed through `src/infra/outbound/deliver.ts` (e.g., scheduled messages, broadcast). Conversational replies via inline `deliverReplies()` silently skip hook emission.

### Actual (after fix)

- Hook fires correctly. Example JSONL output from E2E test:

```json
{"timestamp":"2026-02-27T00:55:32.057Z","type":"message","action":"sent","to":"8323132901","content":"Hey. I just came online...","success":true,"channelId":"telegram","accountId":"e2etest","conversationId":"8323132901","messageId":"8","sessionKey":"agent:main:main"}
```

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Unit tests:** 13 tests for the shared `emitMessageSentHook()` utility covering:
- Plugin hook firing with correct args
- Error field inclusion on failure
- No-op when hookRunner is null or has no hooks
- Fire-and-forget error swallowing
- Internal hook firing with sessionKey
- Internal hook skipped when sessionKey is undefined
- messageId threading
- Independence of plugin and internal hooks

All 13 tests pass. Full test suite (`pnpm test`, 948 tests across 105 files) passes with no regressions.

**E2E test:** Gateway running from this branch inside a Docker container (Node 22 slim, Linux) with a dedicated Telegram bot (`@money_printed_bot`). An internal `message:sent` hook logged events to `/tmp/message_sent.log`. Sent a real DM, received a reply, and confirmed the hook fired with all expected fields (`to`, `content`, `success: true`, `channelId: "telegram"`, `accountId: "e2etest"`, `messageId: "8"`, `sessionKey: "agent:main:main"`).

## Human Verification (required)

- **Verified scenarios:** Build passes (`pnpm build`), type-check passes (`pnpm tsgo`), lint/format passes (`pnpm check`), all 13 new unit tests pass, full test suite passes with no regressions, live E2E Telegram test in Docker confirms hook emission on real conversational replies.
- **Edge cases checked:** Missing sessionKey (internal hook gracefully skipped), missing hookRunner (plugin hook gracefully skipped), hook errors (swallowed, never block delivery), partial delivery failure (hook fires per-message with correct success/error state), media send failures (Telegram: all media types wrapped in try/catch for `success: false` hooks), voice fallback path (hook fires on fallback text delivery and on rethrow).
- **What I did not verify:** Live E2E for Signal, Slack, and iMessage channels (only Telegram was tested live; the other three channels follow the same pattern and are covered by unit tests).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit. The hook calls are additive and fire-and-forget, so removing them restores exact previous behavior.
- Files/config to restore: No config changes to revert.
- Known bad symptoms reviewers should watch for: Unexpected errors logged from hook execution (though errors are caught and swallowed). Performance degradation if hooks do expensive synchronous work (unlikely — hooks are async).

## Risks and Mitigations

- Risk: Hook handlers that assume they only receive centralized-path messages may see unexpected volume.
  - Mitigation: Hook payload shape is identical to the existing centralized path. The documentation describes `message:sent` as firing "when an outbound message is successfully sent" — this fix makes reality match the contract.

---

## AI Transparency

This PR was AI-assisted using Claude Code (Opus 4.6). The approach was validated by comparing independent implementations from three LLMs (Claude, Gemini 2.5 Pro, GPT o3) in isolated git worktrees — all three converged on the same core solution. The shared helper pattern was chosen as the cleanest (DRY, single maintenance point).

### Discovery Story

I'm building a product on top of OpenClaw and needed bidirectional conversation logging via the `message:sent` hook. I discovered the hook wasn't firing for conversational replies — the primary message flow. Investigation confirmed this affects all four built-in channels with inline delivery paths (Telegram, Signal, Slack, iMessage) and that it was identified as a known gap in #24968.

### Review Feedback Addressed

All automated review comments from Codex and Greptile were addressed in the follow-up commit:

1. **Telegram `accountId` missing** (Codex P2): Added `accountId` to `deliverReplies` params and `hookBase`, threaded from `route.accountId` via `bot-message-dispatch.ts`.
2. **Telegram media failure hooks** (Codex P2 + Greptile): Wrapped all media send paths (GIF, image, video, audio, document, follow-up text) in try/catch to emit `success: false` hooks on failure, matching the text-only path. Voice rethrow paths also emit failure hooks.
3. **Slack thread-aware sessionKey** (Codex P2): Changed from `route.mainSessionKey` to `prepared.ctxPayload.SessionKey ?? route.mainSessionKey` so threaded replies use the correct per-conversation session key.

<details>
<summary>AI Prompt Used</summary>

```
Fix the message:sent hook gap in OpenClaw where conversational replies bypass hook emission.

Context: The message:sent hook (both plugin hooks via hookRunner.runMessageSent and internal hooks
via triggerInternalHook/createInternalHookEvent) only fires from the centralized outbound delivery
path in src/infra/outbound/deliver.ts. Four channels have inline deliverReplies() functions that
bypass this path: Telegram, Signal, Slack, and iMessage.

Reference implementation (src/infra/outbound/deliver.ts lines 448-510):
- Plugin hook: hookRunner.runMessageSent({to, content, success, error?}, {channelId, accountId, conversationId})
- Internal hook: triggerInternalHook(createInternalHookEvent("message", "sent", sessionKey, context))
- Both are fire-and-forget: void promise.catch(() => {})

Solution approach:
1. Create src/hooks/emit-message-sent.ts — shared utility that fires both hooks
2. Wire into all four inline delivery paths
3. Thread sessionKey from each channel's routing context

Files to modify:
- NEW: src/hooks/emit-message-sent.ts (shared helper)
- NEW: src/hooks/emit-message-sent.test.ts (comprehensive unit tests)
- src/telegram/bot/delivery.ts (add hook firing after each send, try/catch for all paths including media)
- src/telegram/bot-message-dispatch.ts (thread sessionKey + accountId via deliveryBaseOptions)
- src/signal/monitor.ts (add hook firing in deliverReplies)
- src/signal/monitor/event-handler.ts (thread sessionKey)
- src/signal/monitor/event-handler.types.ts (add sessionKey to type)
- src/slack/monitor/replies.ts (add hook firing)
- src/slack/monitor/message-handler/dispatch.ts (thread sessionKey, use thread-aware ctxPayload.SessionKey)
- src/imessage/monitor/deliver.ts (add hook firing)
- src/imessage/monitor/monitor-provider.ts (thread sessionKey)

Key constraints:
- Hooks must never block message delivery (fire-and-forget)
- Use void promise.catch(() => {}) pattern
- sessionKey is required for internal hooks but optional (gracefully skip if missing)
- Plugin hooks check hookRunner?.hasHooks("message_sent") before calling
- All send paths (text + media) must emit both success and failure hooks
- Include accountId in hook context for multi-account setups
- Follow existing code style (TypeScript ESM, tabs, Oxfmt formatting)
```

</details>

### Testing Level

- 13 unit tests for the shared utility (all pass)
- Full test suite passes (`pnpm test`, 948 tests across 105 files)
- Build (`pnpm build`), type-check (`pnpm tsgo`), lint/format (`pnpm check`) all pass
- CI: all checks green (Node + Bun on Linux, Node on Windows)
- **Live E2E: Telegram bot in Docker container (Node 22, Linux) confirmed hook fires on real conversational replies with all expected fields**

I confirm that I understand the contribution guidelines and that this submission complies with them.