### PR TITLE
feat(pairing): support configurable pairing code TTL via OPENCLAW_PAIRING_TTL_MINUTES

### DIFF
--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -12,7 +12,18 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
 const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-const PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
+
+function resolvePairingTtlMs(): number {
+  const envMinutes = process.env.OPENCLAW_PAIRING_TTL_MINUTES;
+  if (envMinutes) {
+    const parsed = Number(envMinutes);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed * 60 * 1000;
+    }
+  }
+  return DEFAULT_PAIRING_PENDING_TTL_MS;
+}
 const PAIRING_PENDING_MAX = 3;
 const PAIRING_STORE_LOCK_OPTIONS = {
   retries: {
@@ -156,7 +167,7 @@ function isExpired(entry: PairingRequest, nowMs: number): boolean {
   if (!createdAt) {
     return true;
   }
-  return nowMs - createdAt > PAIRING_PENDING_TTL_MS;
+  return nowMs - createdAt > resolvePairingTtlMs();
 }
 
 function pruneExpiredRequests(reqs: PairingRequest[], nowMs: number) {


### PR DESCRIPTION
## Summary
- Adds `OPENCLAW_PAIRING_TTL_MINUTES` environment variable to override the
  default 1-hour pairing code expiry.
- The default behavior is unchanged (60 minutes). Operators can set e.g.
  `OPENCLAW_PAIRING_TTL_MINUTES=5` for a shorter window or
  `OPENCLAW_PAIRING_TTL_MINUTES=1440` for 24 hours.

Fixes #27949

## Test plan
- [ ] Set `OPENCLAW_PAIRING_TTL_MINUTES=2`, generate a pairing code, verify it expires after 2 minutes
- [ ] Without the env var, verify default 1-hour TTL behavior is preserved
- [ ] Invalid values (negative, non-numeric) fall back to the 1-hour default

🤖 Generated with [Claude Code](https://claude.com/claude-code)