### PR TITLE
fix(cron): only require explicit message target when delivery is requested

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -466,7 +466,7 @@ export async function runCronIsolatedAgentTurn(params: {
           verboseLevel: resolvedVerboseLevel,
           timeoutMs,
           runId: cronSession.sessionEntry.sessionId,
-          requireExplicitMessageTarget: true,
+          requireExplicitMessageTarget: deliveryRequested,
           disableMessageTool: deliveryRequested,
           abortSignal,
         });


### PR DESCRIPTION
## Summary
- `requireExplicitMessageTarget` was unconditionally set to `true` for
  all cron isolated sessions. When a cron job has no `delivery` field
  (and no `payload.to`), `deliveryRequested` is `false` yet the message
  tool still demanded an explicit target, causing the error:
  *"Action send requires a target"*.
- Gate the flag on `deliveryRequested` so cron jobs without delivery
  configuration can still use the message tool freely.

Fixes #27898

## Test plan
- [ ] Create cron job without `delivery` field, verify message tool works
- [ ] Create cron job with `delivery: { mode: "announce", to: "..." }`, verify explicit target is still required
- [ ] Existing cron delivery tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)