### PR TITLE
docs: fix heading formatting, broken links, and stale redirects

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -12,7 +12,7 @@ Manage chat channel accounts and their runtime status on the Gateway.
 
 Related docs:
 
-- Channel guides: [Channels](/channels/index)
+- Channel guides: [Channels](/channels)
 - Gateway configuration: [Configuration](/gateway/configuration)
 
 ## Common commands

--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -9,7 +9,7 @@ title: "Presence"
 
 # Presence
 
-OpenClaw “presence” is a lightweight, best‑effort view of:
+OpenClaw “presence” is a lightweight, best-effort view of:
 
 - the **Gateway** itself, and
 - **clients connected to the Gateway** (mac app, WebChat, CLI, etc.)
@@ -22,8 +22,8 @@ provide quick operator visibility.
 Presence entries are structured objects with fields like:
 
 - `instanceId` (optional but strongly recommended): stable client identity (usually `connect.client.instanceId`)
-- `host`: human‑friendly host name
-- `ip`: best‑effort IP address
+- `host`: human-friendly host name
+- `ip`: best-effort IP address
 - `version`: client version string
 - `deviceFamily` / `modelIdentifier`: hardware hints
 - `mode`: `ui`, `webchat`, `cli`, `backend`, `probe`, `test`, `node`, ...
@@ -45,9 +45,9 @@ even before any clients connect.
 Every WS client begins with a `connect` request. On successful handshake the
 Gateway upserts a presence entry for that connection.
 
-#### Why one‑off CLI commands don’t show up
+#### Why one-off CLI commands don’t show up
 
-The CLI often connects for short, one‑off commands. To avoid spamming the
+The CLI often connects for short, one-off commands. To avoid spamming the
 Instances list, `client.mode === "cli"` is **not** turned into a presence entry.
 
 ### 3) `system-event` beacons
@@ -62,11 +62,11 @@ upserts a presence entry for that node (same flow as other WS clients).
 
 ## Merge + dedupe rules (why `instanceId` matters)
 
-Presence entries are stored in a single in‑memory map:
+Presence entries are stored in a single in-memory map:
 
 - Entries are keyed by a **presence key**.
 - The best key is a stable `instanceId` (from `connect.client.instanceId`) that survives restarts.
-- Keys are case‑insensitive.
+- Keys are case-insensitive.
 
 If a client reconnects without a stable `instanceId`, it may show up as a
 **duplicate** row.
@@ -83,7 +83,7 @@ This keeps the list fresh and avoids unbounded memory growth.
 ## Remote/tunnel caveat (loopback IPs)
 
 When a client connects over an SSH tunnel / local port forward, the Gateway may
-see the remote address as `127.0.0.1`. To avoid overwriting a good client‑reported
+see the remote address as `127.0.0.1`. To avoid overwriting a good client-reported
 IP, loopback remote addresses are ignored.
 
 ## Consumers
@@ -99,4 +99,4 @@ indicator (Active/Idle/Stale) based on the age of the last update.
 - If you see duplicates:
   - confirm clients send a stable `client.instanceId` in the handshake
   - confirm periodic beacons use the same `instanceId`
-  - check whether the connection‑derived entry is missing `instanceId` (duplicates are expected)
+  - check whether the connection-derived entry is missing `instanceId` (duplicates are expected)

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -25,7 +25,7 @@ This page explains hardening **within that model**. It does not claim hostile mu
 
 ## Quick check: `openclaw security audit`
 
-See also: [Formal Verification (Security Models)](/security/formal-verification/)
+See also: [Formal Verification (Security Models)](/security/formal-verification)
 
 Run this regularly (especially after changing config or exposing network surfaces):
 
@@ -486,7 +486,7 @@ Treat the snippet above as **secure DM mode**:
 
 If you run multiple accounts on the same channel, use `per-account-channel-peer` instead. If the same person contacts you on multiple channels, use `session.identityLinks` to collapse those DM sessions into one canonical identity. See [Session Management](/concepts/session) and [Configuration](/gateway/configuration).
 
-## Allowlists (DM + groups) — terminology
+## Allowlists (DM + groups) - terminology
 
 OpenClaw has two separate “who can trigger me?” layers:
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -210,7 +210,7 @@ Common signatures:
 Related:
 
 - [/nodes/troubleshooting](/nodes/troubleshooting)
-- [/nodes/index](/nodes/index)
+- [Nodes](/nodes)
 - [/tools/exec-approvals](/tools/exec-approvals)
 
 ## Browser tool fails

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ The Gateway is the single source of truth for sessions, routing, and channel con
   </Step>
 </Steps>
 
-Need the full install and dev setup? See [Quick start](/start/quickstart).
+Need the full install and dev setup? See [Quick start](/start/getting-started).
 
 ## Dashboard
 

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -67,7 +67,7 @@ Those live under `$OPENCLAW_STATE_DIR`.
 
 ## Migration steps (recommended)
 
-### Step 0 — Make a backup (old machine)
+### Step 0 - Make a backup (old machine)
 
 On the **old** machine, stop the gateway first so files aren’t changing mid-copy:
 
@@ -87,7 +87,7 @@ tar -czf openclaw-workspace.tgz .openclaw/workspace
 
 If you have multiple profiles/state dirs (e.g. `~/.openclaw-main`, `~/.openclaw-work`), archive each.
 
-### Step 1 — Install OpenClaw on the new machine
+### Step 1 - Install OpenClaw on the new machine
 
 On the **new** machine, install the CLI (and Node if needed):
 
@@ -95,7 +95,7 @@ On the **new** machine, install the CLI (and Node if needed):
 
 At this stage, it’s OK if onboarding creates a fresh `~/.openclaw/` — you will overwrite it in the next step.
 
-### Step 2 — Copy the state dir + workspace to the new machine
+### Step 2 - Copy the state dir + workspace to the new machine
 
 Copy **both**:
 
@@ -113,7 +113,7 @@ After copying, ensure:
 - Hidden directories were included (e.g. `.openclaw/`)
 - File ownership is correct for the user running the gateway
 
-### Step 3 — Run Doctor (migrations + service repair)
+### Step 3 - Run Doctor (migrations + service repair)
 
 On the **new** machine:
 

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -5,7 +5,7 @@ read_when:
 title: "Audio and Voice Notes"
 ---
 
-# Audio / Voice Notes — 2026-01-17
+# Audio / Voice Notes - 2026-01-17
 
 ## What works
 

--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -5,7 +5,7 @@ read_when:
 title: "Image and Media Support"
 ---
 
-# Image & Media Support — 2025-12-05
+# Image & Media Support - 2025-12-05
 
 The WhatsApp channel runs via **Baileys Web**. This document captures the current media handling rules for send, gateway, and agent replies.
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -6,7 +6,7 @@ read_when:
 title: "Media Understanding"
 ---
 
-# Media Understanding (Inbound) — 2026-01-17
+# Media Understanding (Inbound) - 2026-01-17
 
 OpenClaw can **summarize inbound media** (image/audio/video) before the reply pipeline runs. It auto‑detects when local tools or provider keys are available, and can be disabled or customized. If understanding is off, models still receive the original files/URLs as usual.
 

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -107,7 +107,7 @@ If still stuck:
 
 Related:
 
-- [/nodes/index](/nodes/index)
+- [Nodes](/nodes)
 - [/nodes/camera](/nodes/camera)
 - [/nodes/location-command](/nodes/location-command)
 - [/tools/exec-approvals](/tools/exec-approvals)

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -37,7 +37,7 @@ MiniMax highlights these improvements in M2.1:
 
 ## Choose a setup
 
-### MiniMax OAuth (Coding Plan) — recommended
+### MiniMax OAuth (Coding Plan) - recommended
 
 **Best for:** quick setup with MiniMax Coding Plan via OAuth, no API key required.
 

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -125,7 +125,7 @@ openclaw models list | grep venice
 
 ## Available Models (25 Total)
 
-### Private Models (15) — Fully Private, No Logging
+### Private Models (15) - Fully Private, No Logging
 
 | Model ID                         | Name                    | Context (tokens) | Features                |
 | -------------------------------- | ----------------------- | ---------------- | ----------------------- |
@@ -145,7 +145,7 @@ openclaw models list | grep venice
 | `openai-gpt-oss-120b`            | OpenAI GPT OSS 120B     | 131k             | General                 |
 | `zai-org-glm-4.7`                | GLM 4.7                 | 202k             | Reasoning, multilingual |
 
-### Anonymized Models (10) — Via Venice Proxy
+### Anonymized Models (10) - Via Venice Proxy
 
 | Model ID                 | Original          | Context (tokens) | Features          |
 | ------------------------ | ----------------- | ---------------- | ----------------- |

--- a/docs/refactor/plugin-sdk.md
+++ b/docs/refactor/plugin-sdk.md
@@ -211,4 +211,4 @@ Notes:
 - New connector templates depend only on SDK + runtime.
 - External plugins can be developed and updated without core source access.
 
-Related docs: [Plugins](/tools/plugin), [Channels](/channels/index), [Configuration](/gateway/configuration).
+Related docs: [Plugins](/tools/plugin), [Channels](/channels), [Configuration](/gateway/configuration).

--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -6,7 +6,7 @@ read_when:
   - Enabling or auditing default skills
 ---
 
-# AGENTS.md — OpenClaw Personal Assistant (default)
+# AGENTS.md - OpenClaw Personal Assistant (default)
 
 ## First run (recommended)
 

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -17,7 +17,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 
 - [Index](/)
 - [Getting Started](/start/getting-started)
-- [Quick start](/start/quickstart)
+- [Quick start](/start/getting-started)
 - [Onboarding](/start/onboarding)
 - [Wizard](/start/wizard)
 - [Setup](/start/setup)

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -115,12 +115,12 @@ If you see `!`:
 
 ## Remote Gateway (use a node host)
 
-### Local Gateway (same machine as Chrome) — usually **no extra steps**
+### Local Gateway (same machine as Chrome) - usually **no extra steps**
 
 If the Gateway runs on the same machine as Chrome, it starts the browser control service on loopback
 and auto-starts the relay server. The extension talks to the local relay; the CLI/tool calls go to the Gateway.
 
-### Remote Gateway (Gateway runs elsewhere) — **run a node host**
+### Remote Gateway (Gateway runs elsewhere) - **run a node host**
 
 If your Gateway runs on another machine, start a node host on the machine that runs Chrome.
 The Gateway will proxy browser actions to that node; the extension + relay stay local to the browser machine.


### PR DESCRIPTION
## Summary
- Replace em dashes with hyphens in 14 headings across 9 files (breaks Mintlify anchor links)
- Replace non-breaking hyphens (U+2011) with ASCII hyphens
- Remove /index suffix from 4 internal doc links per Mintlify convention
- Remove trailing slash and fix 2 stale redirect links

## Test plan
- [x] All heading formatting issues fixed
- [x] All link targets verified to exist