### PR TITLE
fix(daemon): fix backslash escape in systemd env parser

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import { buildSystemdUnit, parseSystemdEnvAssignment } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -22,5 +22,19 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+});
+
+describe("parseSystemdEnvAssignment", () => {
+  it("unquotes simple assignment", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar"')).toEqual({ key: "FOO", value: "bar" });
+  });
+
+  it("handles backslash-escaped quotes in values", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar\\"baz"')).toEqual({ key: "FOO", value: 'bar"baz' });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseSystemdEnvAssignment("")).toBeNull();
   });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -96,7 +96,7 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
         escapeNext = false;
         continue;
       }
-      if (ch === "\\\\") {
+      if (ch === "\\") {
         escapeNext = true;
         continue;
       }


### PR DESCRIPTION
## Summary
Fix broken backslash escape in `parseSystemdEnvAssignment()` — the comparison `ch === "\\\\"" ` compiled to a 2-char string but `ch` from `for..of` is always 1 char, so the condition never matched.

## Test plan
- [x] Added tests for parseSystemdEnvAssignment
- [x] Verified fix via xxd byte inspection