### PR TITLE
fix: truncate oversized tool names to prevent API rejection

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -19,6 +19,7 @@ import {
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
   sanitizeToolCallInputs,
+  sanitizeToolNameLengths,
   stripToolResultDetails,
   sanitizeToolUseResultPairing,
 } from "../session-transcript-repair.js";
@@ -447,7 +448,8 @@ export async function sanitizeSessionHistory(params: {
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
-  const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  const sanitizedNames = sanitizeToolNameLengths(repairedTools);
+  const sanitizedToolResults = stripToolResultDetails(sanitizedNames);
   const sanitizedCompactionUsage =
     stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults);
 

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { sanitizeToolNameLengths } from "../session-transcript-repair.js";
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 // Keep a conservative input budget to absorb tokenizer variance and provider framing overhead.
@@ -321,13 +322,15 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
+    // Truncate oversized tool names before hitting the API (Anthropic rejects >200 chars).
+    const sanitized = sanitizeToolNameLengths(contextMessages);
     enforceToolResultContextBudgetInPlace({
-      messages: contextMessages,
+      messages: sanitized,
       contextBudgetChars,
       maxSingleToolResultChars,
     });
 
-    return contextMessages;
+    return sanitized;
   }) as GuardableTransformContext;
 
   return () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   sanitizeToolCallInputs,
+  sanitizeToolNameLengths,
   sanitizeToolUseResultPairing,
   repairToolUseResultPairing,
 } from "./session-transcript-repair.js";
@@ -313,5 +314,127 @@ describe("sanitizeToolCallInputs", () => {
       ? assistant.content.map((block) => (block as { type?: unknown }).type)
       : [];
     expect(types).toEqual(["text", "toolUse"]);
+  });
+});
+
+describe("sanitizeToolNameLengths", () => {
+  it("returns original messages when all tool names are within limit", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "toolCall", id: "1", name: "read", arguments: {} }] },
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages); // same reference = no changes
+  });
+
+  it("truncates toolResult.toolName exceeding 200 chars", () => {
+    const longName = "x".repeat(930);
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: longName,
+        content: [{ type: "text", text: "Tool not found" }],
+        isError: true,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).not.toBe(messages);
+    const toolResult = result[0] as { toolName: string };
+    expect(toolResult.toolName).toHaveLength(200);
+    expect(toolResult.toolName).toBe("x".repeat(200));
+  });
+
+  it("truncates assistant toolCall block name exceeding 200 chars", () => {
+    const longName = "a".repeat(300);
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me run this" },
+          { type: "toolCall", id: "1", name: longName, arguments: {} },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).not.toBe(messages);
+    const assistant = result[0] as { content: Array<{ name?: string }> };
+    expect(assistant.content[1].name).toHaveLength(200);
+  });
+
+  it("truncates both assistant and toolResult names consistently", () => {
+    const longName = "tool_" + "z".repeat(250);
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c1", name: longName, arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "c1",
+        toolName: longName,
+        content: [{ type: "text", text: "error" }],
+        isError: true,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    const assistantName = (result[0] as { content: Array<{ name?: string }> }).content[0].name;
+    const toolResultName = (result[1] as { toolName: string }).toolName;
+    expect(assistantName).toBe(toolResultName);
+    expect(assistantName).toHaveLength(200);
+  });
+
+  it("does not modify toolResult with toolName exactly 200 chars", () => {
+    const exactName = "b".repeat(200);
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "1",
+        toolName: exactName,
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages); // no mutation
+  });
+
+  it("handles toolUse and functionCall block types", () => {
+    const longName = "c".repeat(201);
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "1", name: longName, input: {} },
+          { type: "functionCall", id: "2", name: longName, arguments: {} },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = sanitizeToolNameLengths(messages);
+    const blocks = (result[0] as { content: Array<{ name?: string }> }).content;
+    expect(blocks[0].name).toHaveLength(200);
+    expect(blocks[1].name).toHaveLength(200);
+  });
+
+  it("passes through non-object messages unchanged", () => {
+    const messages = [null, undefined, "text"] as unknown as AgentMessage[];
+    const result = sanitizeToolNameLengths(messages);
+    expect(result).toBe(messages);
   });
 });


### PR DESCRIPTION
## Summary
When an LLM hallucinates a long tool name, it gets stored in session history and causes Anthropic API rejection (200 char limit). Add sanitization in the transformContext pipeline.

Closes #25484

## Test plan
- [x] 7 unit tests for tool name sanitization
- [x] All existing tests pass