### PR TITLE
fix(daemon): include WorkingDirectory in LaunchAgent plist

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { collectConfigServiceEnvVars } from "../config/env-vars.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildServiceEnvironment } from "../daemon/service-env.js";
@@ -71,7 +72,11 @@ export async function buildGatewayInstallPlan(params: {
   };
   Object.assign(environment, serviceEnvironment);
 
-  return { programArguments, workingDirectory, environment };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment };
 }
 
 export function gatewayInstallErrorHint(platform = process.platform): string {

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,4 +1,5 @@
 import { formatNodeServiceDescription } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
@@ -61,5 +62,9 @@ export async function buildNodeInstallPlan(params: {
     version: environment.OPENCLAW_SERVICE_VERSION,
   });
 
-  return { programArguments, workingDirectory, environment, description };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment, description };
 }


### PR DESCRIPTION
## Summary
Default WorkingDirectory to the OpenClaw state dir when program-args resolver does not provide one, so the gateway doesn't run with / as working directory.

Closes #25562

## Test plan
- [x] 2 new tests for default and explicit WorkingDirectory
- [x] All daemon tests pass