### PR TITLE
fix(agents): replace generic error with friendly message on Anthropic refusal

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,13 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  it("returns a friendly message for refusal/sensitive stop reasons", () => {
+    const msg = makeAssistantError("An unknown error occurred");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("content policy restrictions");
+    expect(result).not.toBe("An unknown error occurred");
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -486,6 +486,16 @@ export function formatAssistantErrorText(
     }
   }
 
+  // The PI SDK's Anthropic provider maps refusal/sensitive stop_reason to
+  // stopReason="error" and throws a generic "An unknown error occurred".
+  // Replace with a friendlier message that guides the user.
+  if (raw === "An unknown error occurred") {
+    return (
+      "The model could not complete this request. " +
+      "This may be due to content policy restrictions. Try rephrasing your message."
+    );
+  }
+
   if (isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +


### PR DESCRIPTION
## Summary
- Detect the generic "An unknown error occurred" error message from the PI SDK (thrown when Anthropic returns `stop_reason: "refusal"` or `"sensitive"`)
- Replace with a user-friendly message explaining content policy restrictions and suggesting to rephrase
- Add test coverage for the new error detection

## Context

When Anthropic's safety filters flag a message, the API returns `stop_reason: "refusal"` or `"sensitive"`. The PI SDK maps these to `stopReason: "error"` and throws `"An unknown error occurred"`, which gets forwarded to the user as the bot's reply. This is confusing and unhelpful.

Closes #27975

## Test plan
- [ ] Verify refusal responses now show "content policy restrictions" message instead of "An unknown error occurred"
- [ ] Run `pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
- [ ] Verify other error types (context overflow, rate limit, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)