### PR TITLE
fix(cron): condition requireExplicitMessageTarget on resolved delivery

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -466,7 +466,10 @@ export async function runCronIsolatedAgentTurn(params: {
           verboseLevel: resolvedVerboseLevel,
           timeoutMs,
           runId: cronSession.sessionEntry.sessionId,
-          requireExplicitMessageTarget: true,
+          // Only enforce an explicit message target when the cron delivery target
+          // was successfully resolved. When resolution fails the agent should not
+          // be blocked by a target it cannot satisfy (#27898).
+          requireExplicitMessageTarget: deliveryRequested && resolvedDelivery.ok,
           disableMessageTool: deliveryRequested,
           abortSignal,
         });


### PR DESCRIPTION
## Summary

- Fixes "Action send requires a target" errors when a cron job's delivery target resolution fails
- `requireExplicitMessageTarget` was unconditionally set to `true` for all cron isolated agent runs
- Now conditioned on `deliveryRequested && resolvedDelivery.ok` so the agent isn't blocked by a target that was never resolved

## Root Cause

In `src/cron/isolated-agent/run.ts:469`, the `requireExplicitMessageTarget` flag was hardcoded to `true`. When `resolveDeliveryTarget()` returns `{ ok: false }` (e.g. missing session history, no configured channel), the embedded PI agent still enforced the explicit target requirement on its message tool, producing the "Action send requires a target" error.

## Fix

Condition the flag on both `deliveryRequested` (delivery was actually requested in the cron job payload) AND `resolvedDelivery.ok` (the target was successfully resolved). When either condition is false, the agent can use messaging tools without the explicit target constraint.

## Test plan

- [ ] Verify cron jobs with valid delivery targets still enforce explicit message targets
- [ ] Verify cron jobs without configured delivery (or failed resolution) no longer produce "send requires a target" errors
- [ ] Verify `disableMessageTool` is still correctly set based on `deliveryRequested`

Fixes #27898

🤖 Generated with [Claude Code](https://claude.com/claude-code)