### PR TITLE
fix(mmr): add CJK character and bigram support to tokenize

### DIFF
--- a/src/memory/mmr.ts
+++ b/src/memory/mmr.ts
@@ -27,11 +27,23 @@ export const DEFAULT_MMR_CONFIG: MMRConfig = {
 
 /**
  * Tokenize text for Jaccard similarity computation.
- * Extracts alphanumeric tokens and normalizes to lowercase.
+ * Extracts alphanumeric tokens, CJK characters, and CJK bigrams.
  */
 export function tokenize(text: string): Set<string> {
-  const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
-  return new Set(tokens);
+  const lower = text.toLowerCase();
+  const ascii = lower.match(/[a-z0-9_]+/g) ?? [];
+
+  // Extract CJK characters (Chinese, Japanese kanji, Korean hanja)
+  // Unicode ranges: CJK Unified Ideographs (4E00-9FFF) and Extension A (3400-4DBF)
+  const cjkChars = Array.from(lower).filter((c) => /[\u4e00-\u9fff\u3400-\u4dbf]/.test(c));
+
+  // Generate bigrams from CJK characters for phrase-level similarity
+  const bigrams: string[] = [];
+  for (let i = 0; i < cjkChars.length - 1; i++) {
+    bigrams.push(cjkChars[i] + cjkChars[i + 1]);
+  }
+
+  return new Set([...ascii, ...bigrams, ...cjkChars]);
 }
 
 /**


### PR DESCRIPTION
## Summary

The `tokenize()` function in `src/memory/mmr.ts` only matched ASCII alphanumeric tokens (`/[a-z0-9_]+/`), which returned empty sets for pure CJK (Chinese/Japanese/Korean) text. This caused Jaccard similarity to always return 0 or 1 between CJK documents, making MMR diversity detection ineffective for CJK users.

## Fix

This fix adds:
- Individual CJK character extraction (unigrams) for broad matching
- CJK character bigrams for phrase-level similarity detection
- Preserves existing ASCII token extraction

Unicode ranges supported:
- CJK Unified Ideographs: \u4e00-\u9fff
- CJK Extension A: \u3400-\u4dbf

## Testing

All 25 existing MMR tests pass.

Fixes #28000
