### PR TITLE
fix: update tests after removing WORKFLOW_AUTO.md from post-compaction audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -14,7 +14,7 @@ describe("extractReadPaths", () => {
           {
             type: "tool_use",
             name: "read",
-            input: { file_path: "WORKFLOW_AUTO.md" },
+            input: { file_path: "AGENTS.md" },
           },
         ],
       },
@@ -31,7 +31,7 @@ describe("extractReadPaths", () => {
     ];
 
     const paths = extractReadPaths(messages);
-    expect(paths).toEqual(["WORKFLOW_AUTO.md", "memory/2026-02-16.md"]);
+    expect(paths).toEqual(["AGENTS.md", "memory/2026-02-16.md"]);
   });
 
   it("handles path parameter (alternative to file_path)", () => {
@@ -78,7 +78,7 @@ describe("extractReadPaths", () => {
           {
             type: "tool_use",
             name: "exec",
-            input: { command: "cat WORKFLOW_AUTO.md" },
+            input: { command: "cat AGENTS.md" },
           },
         ],
       },
@@ -110,7 +110,8 @@ describe("auditPostCompactionReads", () => {
   const workspaceDir = "/Users/test/workspace";
 
   it("passes when all required files are read", () => {
-    const readPaths = ["WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    // WORKFLOW_AUTO.md is no longer required (removed per issue #27697)
+    const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -121,30 +122,31 @@ describe("auditPostCompactionReads", () => {
     const result = auditPostCompactionReads([], workspaceDir);
 
     expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
-  });
-
-  it("reports only missing files", () => {
-    const readPaths = ["WORKFLOW_AUTO.md"];
-    const result = auditPostCompactionReads(readPaths, workspaceDir);
-
-    expect(result.passed).toBe(false);
+    // WORKFLOW_AUTO.md is no longer a required read (removed per issue #27697)
     expect(result.missingPatterns).not.toContain("WORKFLOW_AUTO.md");
     expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
   });
 
-  it("matches RegExp patterns against relative paths", () => {
+  it("reports only missing files", () => {
+    // Providing only the memory file satisfies all requirements
     const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
-    expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.length).toBe(1);
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
+  });
+
+  it("matches RegExp patterns against relative paths", () => {
+    // memory pattern matches daily memory files via RegExp
+    const readPaths = ["memory/2026-02-16.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
   });
 
   it("normalizes relative paths when matching", () => {
-    const readPaths = ["./WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const readPaths = ["./memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -152,10 +154,7 @@ describe("auditPostCompactionReads", () => {
   });
 
   it("normalizes absolute paths when matching", () => {
-    const readPaths = [
-      "/Users/test/workspace/WORKFLOW_AUTO.md",
-      "/Users/test/workspace/memory/2026-02-16.md",
-    ];
+    const readPaths = ["/Users/test/workspace/memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -174,24 +173,23 @@ describe("auditPostCompactionReads", () => {
 
 describe("formatAuditWarning", () => {
   it("formats warning message with missing patterns", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
+    const missingPatterns = ["memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
     const message = formatAuditWarning(missingPatterns);
 
     expect(message).toContain("⚠️ Post-Compaction Audit");
-    expect(message).toContain("WORKFLOW_AUTO.md");
     expect(message).toContain("memory");
     expect(message).toContain("Please read them now");
   });
 
   it("formats single missing pattern", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md"];
+    const missingPatterns = ["memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
     const message = formatAuditWarning(missingPatterns);
 
-    expect(message).toContain("WORKFLOW_AUTO.md");
-    // Check that the missing patterns list only contains WORKFLOW_AUTO.md
+    expect(message).toContain("memory");
+    // Check that the missing patterns list only contains one entry
     const lines = message.split("\n");
     const patternLines = lines.filter((l) => l.trim().startsWith("- "));
     expect(patternLines).toHaveLength(1);
-    expect(patternLines[0]).toContain("WORKFLOW_AUTO.md");
+    expect(patternLines[0]).toContain("memory");
   });
 });

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 
 // Default required files — constants, extensible to config later
+// Note: WORKFLOW_AUTO.md removed from DEFAULT_REQUIRED_READS to prevent
+// prompt injection attack vector (see issue #27697)
 const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
   /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
 ];
 


### PR DESCRIPTION
## Summary

This PR fixes the failing CI tests introduced by PR #27721, which removed `WORKFLOW_AUTO.md` from the post-compaction audit's default required reads.

## Background

- Issue #27697 reported that `WORKFLOW_AUTO.md` in the post-compaction audit represents a prompt injection attack vector
- PR #27721 fixed the security issue by removing `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` in `post-compaction-audit.ts`
- However, the existing tests in `post-compaction-audit.test.ts` still referenced `WORKFLOW_AUTO.md` as an expected required file, causing CI to fail

## Changes

- Removed assertion expecting `WORKFLOW_AUTO.md` in `missingPatterns` (previously lines 124 and 142)
- Updated `"passes when all required files are read"` test to only include the memory file (now the only default requirement)
- Rewrote `"matches RegExp patterns against relative paths"` test to verify memory regex still matches correctly
- Updated `"normalizes relative paths"` test to use `./memory/...` path to test normalization with `./` prefix
- Updated `"normalizes absolute paths"` test to remove the now-unnecessary WORKFLOW_AUTO.md absolute path
- Updated `formatAuditWarning` tests to use memory pattern instead of WORKFLOW_AUTO.md

## Testing

All 15 tests pass after this change:
```
✓ src/auto-reply/reply/post-compaction-audit.test.ts (15 tests) 3ms
```

## Related

- Intended to be merged after / together with #27721
- Addresses CI failures caused by the security fix in #27721
- Security issue: #27697