### PR TITLE
ci(windows): skip A2UI bundling in sharded test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,12 +425,12 @@ jobs:
             task: test
             shard_index: 1
             shard_count: 2
-            command: pnpm canvas:a2ui:bundle && pnpm test
+            command: pnpm test
           - runtime: node
             task: test
             shard_index: 2
             shard_count: 2
-            command: pnpm canvas:a2ui:bundle && pnpm test
+            command: pnpm test
           - runtime: node
             task: protocol
             shard_index: 0


### PR DESCRIPTION
## Summary
- Problem: Windows sharded test jobs have been unstable around the pre-test A2UI bundle step (`pnpm canvas:a2ui:bundle && pnpm test`), including timeout/hang behavior in shard 1.
- What changed: for `checks-windows` test shards only, run `pnpm test` directly instead of prepending `pnpm canvas:a2ui:bundle`.
- Scope boundary: Linux `checks` lanes keep the existing bundle step (`pnpm canvas:a2ui:bundle`) so bundle validation still runs in CI.

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #

## User-visible / Behavior Changes
- None (CI-only change)

## Security Impact
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: macOS (local verification)
- Runtime/container: Node 22 / pnpm 10

### Steps
1. Run `pnpm check`
2. Confirm workflow diff only changes Windows test matrix commands in `.github/workflows/ci.yml`

### Expected
- CI Windows shards no longer run the extra A2UI bundle pre-step; Linux lanes still do.

### Actual
- As expected.

## Evidence
- Prior Windows shard failures/timeouts:
  - https://github.com/openclaw/openclaw/actions/runs/22464259628
  - https://github.com/openclaw/openclaw/actions/runs/22464570892
- Local verification: `pnpm check` passed.

## Human Verification
- Verified scenarios:
  - Workflow matrix commands for `checks-windows` test shards are now `pnpm test`.
  - Linux `checks` matrix still runs `pnpm canvas:a2ui:bundle && ...`.
- Edge cases checked:
  - Other Windows lanes (`lint`, `protocol`) unchanged.
- What I did **not** verify:
  - I did not execute GitHub-hosted Windows runners locally.

## Compatibility / Migration
- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery
- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `.github/workflows/ci.yml`
- Known bad symptoms reviewers should watch for:
  - If A2UI bundle generation is unexpectedly required in Windows test shards, affected tests would fail in those lanes.

## Risks and Mitigations
- Risk: Windows-only A2UI bundle regressions may be less directly exercised in Windows test shards.
  - Mitigation: Linux CI lanes still run `pnpm canvas:a2ui:bundle` before tests.
