### PR TITLE
fix(ui): preserve string values in anyOf[string, number] to prevent Discord snowflake ID precision loss

### DIFF
--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -452,4 +452,24 @@ describe("coerceFormValues", () => {
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
     expect(coerced.flag).toBe(true);
   });
+
+  it("preserves large integer-like string in anyOf[string, number] — Discord snowflake IDs must not lose precision", () => {
+    const discordIdSchema: JsonSchema = {
+      anyOf: [{ type: "string" }, { type: "number" }],
+    };
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        users: {
+          type: "array",
+          items: discordIdSchema,
+        },
+      },
+    };
+    // These snowflake IDs exceed Number.MAX_SAFE_INTEGER and must survive the round-trip as strings
+    const snowflakeIds = ["823475887319941131", "648702641379082240", "648871246523662342"];
+    const form = { users: snowflakeIds };
+    const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
+    expect(coerced.users).toEqual(snowflakeIds);
+  });
 });


### PR DESCRIPTION
Fixes #27775.

When a config has Discord guild user allowlists with snowflake IDs stored as strings, saving any change through the web UI always fails with `INVALID_REQUEST: invalid config`. The bug is in `coerceFormValues` in `form-coerce.ts`.

Discord snowflake IDs like `"823475887319941131"` look like numbers, so when the schema is `anyOf: [string, number]` (which is how `DiscordIdSchema` compiles to JSON Schema), the coercion loop calls `Number("823475887319941131")` and gets back `823475887319941100` — a different value that fails schema validation. This corrupts every save, even when only changing an unrelated field like `logging.level`.

The fix is straightforward: skip number coercion when the anyOf union already includes a string variant. If the value is already a valid string and the schema accepts strings, leave it alone. Boolean coercion (`"true"`/`"false"`) is still applied even when a string variant exists, since that represents an unambiguous type change.

Added a regression test that covers the snowflake ID case directly.