### PR TITLE
Fix fallback chain crash when registry entry has no api field

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -324,4 +324,33 @@ describe("resolveModel", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-antigravity/some-model");
   });
+
+  it("falls back to openrouter default when registry entry has no api field (#28022)", () => {
+    // Simulate a registry entry that was discovered without an api field.
+    // Without the fix, model.api would be undefined and streamSimple would
+    // throw "No API provider registered for api: undefined".
+    mockDiscoveredModel({
+      provider: "openrouter",
+      modelId: "google/gemini-3.1-pro",
+      templateModel: {
+        id: "google/gemini-3.1-pro",
+        name: "google/gemini-3.1-pro",
+        provider: "openrouter",
+        // api intentionally omitted
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      },
+    });
+
+    const result = resolveModel("openrouter", "google/gemini-3.1-pro", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    expect(result.model?.api).toBe("openai-completions");
+    expect(result.model?.provider).toBe("openrouter");
+    expect(result.model?.id).toBe("google/gemini-3.1-pro");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -53,7 +53,10 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+  // Treat registry entries without an `api` field as not found so the
+  // fallback paths below can construct a complete model (fixes #28022).
+  const registryModel = modelRegistry.find(provider, modelId) as Model<Api> | null;
+  const model = registryModel?.api ? registryModel : null;
 
   if (!model) {
     const providers = cfg?.models?.providers ?? {};


### PR DESCRIPTION
When the model registry contains an entry without an `api` field (e.g. an OpenRouter model discovered without API metadata), the model was returned as-is with `api: undefined`. This caused `resolveApiProvider` to throw "No API provider registered for api: undefined".

Treat registry entries without an `api` field as incomplete so they fall through to the existing fallback paths, which correctly construct models with the appropriate API (e.g. `openai-completions` for OpenRouter).

Fixes #28022

## Summary

- **Problem:** `resolveModel()` returns registry entries even when they lack the required `api` field, causing `resolveApiProvider(undefined)` to crash.
- **Why it matters:** Breaks fallback chains entirely — when the primary model times out, the fallback model (e.g. `openrouter/google/gemini-3.1-pro`) crashes instead of serving the request.
- **What changed:** Registry entries without an `api` field are now treated as incomplete, falling through to the existing fallback paths that correctly construct models with proper API values.
- **What did NOT change:** Models found in the registry with a valid `api` field are still returned directly as before. All existing fallback logic is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #28022

## User-visible / Behavior Changes

Fallback chains using OpenRouter (or other providers with incomplete registry entries) now work correctly instead of crashing with "No API provider registered for api: undefined".

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Model/provider: `openrouter/google/gemini-3.1-pro` as fallback for `anthropic/claude-opus-4-5`

### Steps

1. Configure primary model as `anthropic/claude-opus-4-5` with fallback to `openrouter/google/gemini-3.1-pro`
2. Primary model times out (rate limit or overload)
3. Fallback chain activates

### Expected

Fallback model serves the request via OpenRouter.

### Actual

Crashes with `Error: No API provider registered for api: undefined`.

## Evidence

- [x] Failing test/log before + passing after

Added test `falls back to openrouter default when registry entry has no api field (#28022)` that:
1. Mocks a registry entry for `openrouter/google/gemini-3.1-pro` without an `api` field
2. Verifies `resolveModel()` returns a model with `api: "openai-completions"` via the OpenRouter fallback path

All 18 tests pass.

## Human Verification (required)

- Verified scenarios: Test covers the exact bug scenario from #28022
- Edge cases checked: Existing tests ensure models WITH `api` fields still resolve correctly from the registry
- What I did **not** verify: Live OpenRouter fallback (no access to the specific configuration described in the issue)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit
- The only changed line is: `const model = registryModel?.api ? registryModel : null;`

## Risks and Mitigations

- Risk: A provider intentionally registers models without `api` and relies on them being returned as-is.
  - Mitigation: Such models would already crash at `resolveApiProvider`. The fallback paths are strictly better — they set proper `api` values based on provider. All 18 existing tests pass unchanged.