### PR TITLE
fix(handlers): suppress internal 'terminated' and 'aborted' error markers from user-facing replies

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,16 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  it("suppresses internal 'terminated' error marker", () => {
+    const msg = makeAssistantError("terminated");
+    expect(formatAssistantErrorText(msg)).toBeUndefined();
+  });
+
+  it("suppresses internal 'aborted' error marker", () => {
+    const msg = makeAssistantError("aborted");
+    expect(formatAssistantErrorText(msg)).toBeUndefined();
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -472,6 +472,13 @@ export function formatAssistantErrorText(
     return "LLM request failed with an unknown error.";
   }
 
+  // Suppress internal error markers that should never reach users
+  // "terminated" is a transient internal state (e.g., aborted runs) that may
+  // temporarily set errorMessage but doesn't represent a user-facing error.
+  if (raw === "terminated" || raw === "aborted") {
+    return undefined;
+  }
+
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);


### PR DESCRIPTION
## Summary

Internal error markers like `terminated` and `aborted` are transient states that may temporarily set `errorMessage` during agent runs but should never be shown to users. These markers represent internal lifecycle states (e.g., aborted runs, temporary interruptions) rather than actual user-facing errors.

## Problem

As reported in #28051, users on Telegram and TUI/webchat were seeing the literal text "terminated" appear in chat during normal conversation flows. The logs showed:

```
embedded run agent end ... isError=true error=terminated
then later completes with:
embedded run done ... aborted=false
```

The run would ultimately succeed, but the internal error marker "terminated" leaked into user-visible output.

## Root Cause

The `formatAssistantErrorText` function in `pi-embedded-helpers/errors.ts` would return the raw error message when it didn't match any known error pattern. The internal markers "terminated" and "aborted" weren't being filtered out.

## Solution

Added explicit checks in `formatAssistantErrorText` to suppress internal error markers:
- If `errorMessage` is exactly "terminated" or "aborted", return `undefined`
- This prevents these internal lifecycle markers from reaching user-facing output

## Testing

Added test cases to verify:
- `formatAssistantErrorText` returns `undefined` for "terminated" error
- `formatAssistantErrorText` returns `undefined` for "aborted" error

All existing tests pass.

Fixes #28051

🤖 Generated with [Claude Code](https://claude.com/claude-code)