### PR TITLE
ci: reduce test parallelism to prevent OOM errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,9 @@ jobs:
         run: |
           # `pnpm test` runs `scripts/test-parallel.mjs`, which spawns multiple Node processes.
           # Default heap limits have been too low on Linux CI (V8 OOM near 4GB).
-          echo "OPENCLAW_TEST_WORKERS=2" >> "$GITHUB_ENV"
-          echo "OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=6144" >> "$GITHUB_ENV"
+          # Reduced workers to 1 and increased memory to 8192 to prevent OOM errors.
+          echo "OPENCLAW_TEST_WORKERS=1" >> "$GITHUB_ENV"
+          echo "OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=8192" >> "$GITHUB_ENV"
 
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         if: matrix.runtime != 'bun' || github.event_name != 'push'


### PR DESCRIPTION
## Summary

This PR reduces test parallelism and increases memory allocation to prevent JavaScript heap out of memory errors in CI.

## Changes

- `OPENCLAW_TEST_WORKERS`: 2 → 1 (reduce parallel test workers)
- `OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB`: 6144 → 8192 (increase Node.js heap size)

## Problem

CI runs have been failing with:
```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

This affects multiple PRs including documentation and test-only changes that shouldn't cause memory issues.

## Solution

By reducing workers from 2 to 1, we serialize test execution which reduces memory pressure. Increasing heap size from 6GB to 8GB provides additional headroom.

## Trade-offs

- **Pros**: More stable CI, fewer false negatives
- **Cons**: Slightly longer test runs (acceptable for reliability)

## Testing

This change should allow previously failing PRs to pass CI, including:
- #27006 (Chinese abort triggers)
- #27046 (Italian/French/Spanish abort triggers)
- And other PRs with OOM failures