### PR TITLE
fix(status): honor persisted session think/verbose/reasoning levels

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -139,6 +139,26 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Runtime: docker/all");
   });
 
+  it("falls back to persisted session levels when no inline overrides are provided", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: {
+        sessionId: "persisted-levels",
+        updatedAt: 0,
+        thinkingLevel: "low",
+        verboseLevel: "on",
+        reasoningLevel: "low",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(text).toContain("Think: low");
+    expect(text).toContain("verbose");
+    expect(text).toContain("Reasoning: low");
+  });
+
   it("shows verbose/elevated labels only when enabled", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -468,9 +468,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel =
+    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+  const verboseLevel =
+    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??


### PR DESCRIPTION
## Summary
- make `/status` fall back to `sessionEntry` persisted levels when no inline directive is present
- keep existing precedence of inline overrides over session values
- add a regression test covering persisted `thinkingLevel`, `verboseLevel`, and `reasoningLevel`

## Why
Issue #28041 reports `/status` showing `Think: off` right after `/think low` because status was only checking inline resolution + agent defaults.

## Testing
- `pnpm vitest src/auto-reply/status.test.ts --run` *(blocked locally: missing package `ipaddr.js` in this environment before tests start)*