### PR TITLE
fix(feishu): re-throw rate-limit errors from typing indicator to trip circuit breaker

### DIFF
--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isRateLimitError } from "./typing.js";
+
+describe("isRateLimitError", () => {
+  it("returns true for HTTP 429 status", () => {
+    const err = { response: { status: 429, data: {} } };
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  it("returns true for Feishu quota error code 99991403", () => {
+    const err = { response: { status: 200, data: { code: 99991403 } } };
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  it("returns false for non-rate-limit Feishu error codes", () => {
+    const err = { response: { status: 400, data: { code: 99991672 } } };
+    expect(isRateLimitError(err)).toBe(false);
+  });
+
+  it("returns false for a plain Error with no response", () => {
+    expect(isRateLimitError(new Error("network failure"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isRateLimitError(null)).toBe(false);
+  });
+
+  it("returns false for non-object values", () => {
+    expect(isRateLimitError("string error")).toBe(false);
+    expect(isRateLimitError(42)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+});

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -79,7 +79,7 @@ export async function removeTypingIndicator(params: {
       },
     });
   } catch (err) {
-    // Re-throw rate-limit / quota errors so the circuit breaker can trip (#28062).
+    // Re-throw rate-limit / quota errors so callers (onStopError) can observe them (#28062).
     if (isRateLimitError(err)) {
       throw err;
     }
@@ -90,9 +90,10 @@ export async function removeTypingIndicator(params: {
 
 /**
  * Detect Feishu rate-limit or quota-exceeded errors (HTTP 429 / error code 99991403).
- * These must propagate to the circuit breaker to stop the keepalive loop.
+ * These must propagate so the circuit breaker (for start) or error handlers (for stop)
+ * can observe them instead of being silently swallowed.
  */
-function isRateLimitError(err: unknown): boolean {
+export function isRateLimitError(err: unknown): boolean {
   if (typeof err !== "object" || err === null) {
     return false;
   }


### PR DESCRIPTION
`addTypingIndicator` and `removeTypingIndicator` caught all errors silently, preventing the circuit breaker from tripping on Feishu API rate-limit / quota errors. This caused the keepalive loop to retry indefinitely (~4,800 failed calls/hour).

Fixes #28062

## Summary

- **Problem:** Feishu typing indicator catch block swallows all errors including HTTP 429 and quota error `99991403`. The circuit breaker in `typing-start-guard.ts` relies on errors being thrown to count consecutive failures and trip — but it never sees them.
- **Why it matters:** After quota is hit, generates ~76,000+ failed API calls in 8 hours. Worsens quota exhaustion and floods logs.
- **What changed:** Rate-limit errors (HTTP 429 / Feishu code `99991403`) are now re-thrown so the circuit breaker can trip and stop the keepalive loop. Other non-critical errors (e.g. message deleted) remain silently handled.
- **What did NOT change:** No changes to the circuit breaker itself, the keepalive loop, or any other extension. Only the Feishu typing indicator error handling is affected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #28062

## User-visible / Behavior Changes

When Feishu API quota is exceeded, the typing indicator stops retrying after 2 consecutive failures (circuit breaker default) instead of retrying indefinitely.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Integration/channel: Feishu (Lark)

### Steps

1. Exhaust Feishu API monthly quota (or simulate 429 response)
2. Send a message that triggers agent reply with typing indicator
3. Observe keepalive loop behavior

### Expected

Circuit breaker trips after 2 consecutive failures, keepalive loop stops.

### Actual (before fix)

Keepalive loop retries every 3 seconds indefinitely, generating ~4,800 failed calls/hour.

## Evidence

- [x] Trace/log snippets

From the issue: 76,000+ total 429 errors accumulated in ~8 hours before manual intervention.

The fix ensures these errors propagate to the circuit breaker (`typing-start-guard.ts` line 41: `consecutiveFailures += 1`) which trips at `maxConsecutiveFailures: 2` and calls `keepaliveLoop.stop()`.

## Human Verification (required)

- Verified scenarios: Traced error flow from `addTypingIndicator` → `typing-start-guard.run()` → circuit breaker. Confirmed the guard expects thrown errors to count failures.
- Edge cases checked: Non-rate-limit errors (e.g. message deleted, network timeout) still silently handled. `removeTypingIndicator` gets the same treatment.
- What I did **not** verify: Live Feishu 429 reproduction (no Feishu API access).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this single commit
- The only behavioral change: rate-limit errors now throw instead of being swallowed

## Risks and Mitigations

- Risk: Some other caller of `addTypingIndicator` might not expect thrown errors.
  - Mitigation: All callers go through `createTypingCallbacks` → `typing-start-guard.run()`, which already has a try-catch that handles thrown errors (counting failures + optional rethrow). This is the intended contract.