### PR TITLE
fix(telegram): add timeouts to getFile() and file download to prevent sequentializer deadlock

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -31,6 +31,9 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
+  /** Abort the download after this many milliseconds. Prevents indefinite hangs
+   *  when the remote server stalls mid-transfer (e.g. large Telegram file downloads). */
+  timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
 };
@@ -87,6 +90,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     filePathHint,
     maxBytes,
     maxRedirects,
+    timeoutMs,
     ssrfPolicy,
     lookupFn,
   } = options;
@@ -100,6 +104,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       fetchImpl,
       init: requestInit,
       maxRedirects,
+      timeoutMs,
       policy: ssrfPolicy,
       lookupFn,
     });


### PR DESCRIPTION
Fixes #27984

## Problem

Files between 5–20 MB (within Telegram's 20 MB Bot API limit) cause a **silent, permanent deadlock**: `sequentialize(chatId)` holds its slot forever because neither `ctx.getFile()` nor the subsequent file download has a timeout.

```
# Symptoms (reporter confirmed):
# - Send 5–20 MB file → no log output, no error, complete silence
# - All subsequent messages (including /reset) blocked forever
# - Only a gateway restart recovers the chat
# - Threshold confirmed: 4.59 MB works, 5.10 MB hangs
```

## Root Cause

**`fetchRemoteMedia()` has no download timeout.** `fetchWithSsrFGuard()` already supports `timeoutMs`, but `FetchMediaOptions` never exposed it, so every caller (including Telegram file downloads) used an unbounded fetch.

**`ctx.getFile()` has no call timeout.** The `retryAsync` wrapper retries *after* a rejection but cannot interrupt a hanging promise — if Telegram's Bot API stalls, each of the 3 attempts also hangs indefinitely.

## Fix

| Location | Change |
|---|---|
| `src/media/fetch.ts` | Add `timeoutMs?: number` to `FetchMediaOptions`; plumb it to `fetchWithSsrFGuard` |
| `src/telegram/bot/delivery.ts` | Apply `TELEGRAM_MEDIA_FETCH_TIMEOUT_MS = 60 s` to every `downloadAndSaveTelegramFile()` call |
| `src/telegram/bot/delivery.ts` | Wrap both `ctx.getFile()` call sites with `withGetFileTimeout(TELEGRAM_GETFILE_TIMEOUT_MS = 15 s)` |

After the fix:
- A stalled download rejects after ≤ 60 s → sequentializer slot released
- A stalled `getFile()` rejects after ≤ 15 s → retry cycle unblocked  
- The message is still delivered to the agent with a `<media:document>` placeholder (existing error-handling path)
- Files under 5 MB (fast downloads) are completely unaffected

## Tests

All 24 existing Telegram delivery tests pass (`pnpm vitest run src/telegram/bot/delivery`).