### PR TITLE
fix(security): enforce allowlist on message tool outbound sends

### DIFF
--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1050,3 +1050,135 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.params.accountId).toBe("account-b");
   });
 });
+
+describe("runMessageAction outbound allowlist enforcement", () => {
+  // WhatsApp config with a restricted allowFrom — only +15551111111 is allowed.
+  const restrictedConfig = {
+    channels: {
+      whatsapp: {
+        allowFrom: ["+15551111111"],
+      },
+    },
+  } as OpenClawConfig;
+
+  // WhatsApp config with wildcard — all targets allowed.
+  const wildcardConfig = {
+    channels: {
+      whatsapp: {
+        allowFrom: ["*"],
+      },
+    },
+  } as OpenClawConfig;
+
+  // WhatsApp config with empty allowFrom — open access (no restriction).
+  const openConfig = {
+    channels: {
+      whatsapp: {},
+    },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    installChannelRuntimes({ includeTelegram: false });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: whatsappPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("blocks send to a target not in the allowFrom list", async () => {
+    await expect(
+      runDrySend({
+        cfg: restrictedConfig,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("allows send to a target that is in the allowFrom list", async () => {
+    const result = await runDrySend({
+      cfg: restrictedConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15551111111",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when allowFrom contains wildcard", async () => {
+    const result = await runDrySend({
+      cfg: wildcardConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15559999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when allowFrom is empty (open access)", async () => {
+    const result = await runDrySend({
+      cfg: openConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15559999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows group JID targets regardless of allowlist", async () => {
+    const result = await runDrySend({
+      cfg: restrictedConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "120363123456789@g.us",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("blocks poll to a target not in the allowFrom list", async () => {
+    await expect(
+      runDryAction({
+        cfg: restrictedConfig,
+        action: "send" as const,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("provides clear error message for blocked targets", async () => {
+    await expect(
+      runDrySend({
+        cfg: restrictedConfig,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/allowFrom/);
+  });
+});

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -23,6 +23,7 @@ import {
   type GatewayClientName,
 } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
+import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
@@ -89,6 +90,80 @@ function resolveAndApplyOutboundThreadId(
     params.threadId = resolved;
   }
   return resolved ?? undefined;
+}
+
+// Actions that deliver content to an explicit target and should be gated by the
+// channel's outbound allowlist.  Read-only or management actions (react, delete,
+// search, etc.) are excluded intentionally.
+// Note: "broadcast" is not listed because handleBroadcastAction returns early
+// and recurses into runMessageAction with action="send" per target — each
+// individual send is checked there.
+const ALLOWLIST_GUARDED_ACTIONS = new Set<ChannelMessageActionName>([
+  "send",
+  "poll",
+  "reply",
+  "sendWithEffect",
+  "sendAttachment",
+  "thread-create",
+  "thread-reply",
+  "sticker",
+]);
+
+/**
+ * Enforce the channel's outbound allowlist on the resolved target.
+ *
+ * Uses the same plugin allowFrom + resolveTarget mechanism that the
+ * CLI/heartbeat delivery path uses (via `resolveOutboundTarget`), so the
+ * behaviour stays consistent across all send surfaces.
+ */
+function enforceOutboundAllowlist(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+  to: string;
+  accountId?: string | null;
+}): void {
+  if (!ALLOWLIST_GUARDED_ACTIONS.has(params.action)) {
+    return;
+  }
+
+  const plugin = resolveOutboundChannelPlugin({
+    channel: params.channel,
+    cfg: params.cfg,
+  });
+  if (!plugin) {
+    return;
+  }
+
+  const resolveAllowFrom = plugin.config.resolveAllowFrom;
+  const resolveTarget = plugin.outbound?.resolveTarget;
+  if (!resolveAllowFrom || !resolveTarget) {
+    // Channel has no allowlist enforcement capability — nothing to check.
+    return;
+  }
+
+  const allowFromRaw = resolveAllowFrom({
+    cfg: params.cfg,
+    accountId: params.accountId ?? undefined,
+  });
+  if (!allowFromRaw || allowFromRaw.length === 0) {
+    // No allowlist configured — open access.
+    return;
+  }
+
+  const allowFrom = allowFromRaw.map((entry) => String(entry));
+  const result = resolveTarget({
+    cfg: params.cfg,
+    to: params.to,
+    allowFrom,
+    accountId: params.accountId ?? undefined,
+    mode: "explicit",
+  });
+  if (!result.ok) {
+    throw new Error(
+      `Target not in allowlist. The message tool cannot send to "${params.to}" on ${params.channel} because it is not in the configured allowFrom list.`,
+    );
+  }
 }
 
 export type RunMessageActionParams = {
@@ -803,6 +878,20 @@ export async function runMessageAction(
     toolContext: input.toolContext,
     cfg,
   });
+
+  // Enforce outbound allowlist: reject sends to targets not in the configured
+  // allowFrom list for the channel.  Uses the resolved `to` from params
+  // (already written by resolveActionTarget / applyTargetToParams above).
+  const outboundTo = typeof params.to === "string" ? params.to.trim() : "";
+  if (outboundTo) {
+    enforceOutboundAllowlist({
+      cfg,
+      channel,
+      action,
+      to: outboundTo,
+      accountId,
+    });
+  }
 
   const gateway = resolveGateway(input);
 


### PR DESCRIPTION
## Summary

fix(security): enforce allowlist on message tool outbound sends (closes #24203)

**Diff:**  2 files changed, 221 insertions(+)

Fixes #24203

🤖 Generated with [Claude Code](https://claude.com/claude-code)