### PR TITLE
fix(logging): include provider/model context in agent error logs

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -241,7 +241,7 @@ function resolveImageFallbackCandidates(params: {
   return candidates;
 }
 
-function resolveFallbackCandidates(params: {
+export function resolveFallbackCandidates(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
   model: string;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -581,7 +581,7 @@ export async function runAgentTurnWithFallback(params: {
         // back to an alternate model first would not help. Instead we wait
         // and retry the complete primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Transient HTTP provider error before reply (provider=${fallbackProvider} model=${fallbackModel} error=${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
@@ -589,7 +589,9 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
 
-      defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+      defaultRuntime.error(
+        `Embedded agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+      );
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { resolveFallbackCandidates, runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   isCompactionFailureError,
@@ -574,6 +574,14 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
+      // Compute the full fallback chain for diagnostic logging so operators
+      // can see every provider/model that was (or would be) attempted.
+      const fallbackChainForLog = resolveFallbackCandidates(
+        resolveModelFallbackOptions(params.followupRun.run),
+      )
+        .map((c) => `${c.provider}/${c.model}`)
+        .join(" → ");
+
       if (isTransientHttp && !didRetryTransientHttpError) {
         didRetryTransientHttpError = true;
         // Retry the full runWithModelFallback() cycle — transient errors
@@ -581,7 +589,7 @@ export async function runAgentTurnWithFallback(params: {
         // back to an alternate model first would not help. Instead we wait
         // and retry the complete primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (provider=${fallbackProvider} model=${fallbackModel} error=${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Transient HTTP provider error before reply (chain=${fallbackChainForLog} error=${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
@@ -590,7 +598,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(
-        `Embedded agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+        `Embedded agent failed before reply (chain=${fallbackChainForLog}): ${message}`,
       );
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -22,6 +22,8 @@ vi.mock("../../agents/model-fallback.js", () => ({
     model: string;
     run: (provider: string, model: string) => Promise<unknown>;
   }) => runWithModelFallbackMock(params),
+  resolveFallbackCandidates: () => [],
+  resolveModelFallbackOptions: () => ({}),
 }));
 
 vi.mock("../../agents/pi-embedded.js", async () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -67,6 +67,8 @@ vi.mock("../../agents/model-fallback.js", () => ({
     model,
     attempts: [],
   }),
+  resolveFallbackCandidates: () => [],
+  resolveModelFallbackOptions: () => ({}),
 }));
 
 vi.mock("../../agents/pi-embedded.js", () => ({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -3,7 +3,7 @@ import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { resolveFallbackCandidates, runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
@@ -227,8 +227,21 @@ export function createFollowupRunner(params: {
         fallbackModel = fallbackResult.model;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        // Log the full fallback chain so operators can see every model that was attempted.
+        const fallbackChainForLog = resolveFallbackCandidates({
+          cfg: queued.run.config,
+          provider: queued.run.provider,
+          model: queued.run.model,
+          fallbacksOverride: resolveRunModelFallbacksOverride({
+            cfg: queued.run.config,
+            agentId: queued.run.agentId,
+            sessionKey: queued.run.sessionKey,
+          }),
+        })
+          .map((c) => `${c.provider}/${c.model}`)
+          .join(" → ");
         defaultRuntime.error?.(
-          `Followup agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+          `Followup agent failed before reply (chain=${fallbackChainForLog}): ${message}`,
         );
         return;
       }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -227,7 +227,9 @@ export function createFollowupRunner(params: {
         fallbackModel = fallbackResult.model;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
+        defaultRuntime.error?.(
+          `Followup agent failed before reply (provider=${fallbackProvider} model=${fallbackModel}): ${message}`,
+        );
         return;
       }
 

--- a/src/test-utils/model-fallback.mock.ts
+++ b/src/test-utils/model-fallback.mock.ts
@@ -9,3 +9,11 @@ export async function runWithModelFallback(params: {
     model: params.model,
   };
 }
+
+export function resolveFallbackCandidates() {
+  return [];
+}
+
+export function resolveModelFallbackOptions() {
+  return {};
+}


### PR DESCRIPTION
## Summary

fix(logging): include provider/model context in agent error logs (closes #25212)

**Diff:**  2 files changed, 7 insertions(+), 3 deletions(-)

Fixes #25212

🤖 Generated with [Claude Code](https://claude.com/claude-code)