### PR TITLE
fix(memory-lancedb): enable autoRecall by default for persistent memory

### DIFF
--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -72,10 +72,12 @@
         "type": "string"
       },
       "autoCapture": {
-        "type": "boolean"
+        "type": "boolean",
+        "default": false
       },
       "autoRecall": {
-        "type": "boolean"
+        "type": "boolean",
+        "default": true
       },
       "captureMaxChars": {
         "type": "number",


### PR DESCRIPTION
## Summary

fix(memory-lancedb): enable autoRecall by default for persistent memory (closes #25202)

**Diff:**  1 file changed, 4 insertions(+), 2 deletions(-)

Fixes #25202

🤖 Generated with [Claude Code](https://claude.com/claude-code)