### PR TITLE
fix(providers): extend sanitizeToolsForGoogle to cover google-generative-ai

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -712,6 +712,8 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    /** Per-agent stream params (e.g. cacheRetention, temperature). */
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary

fix(providers): extend sanitizeToolsForGoogle to cover google-generative-ai provider (closes #20197)

**Diff:**  2 files changed, 21 insertions(+), 3 deletions(-)

Fixes #20197

🤖 Generated with [Claude Code](https://claude.com/claude-code)