### PR TITLE
Slack onboarding: improve token help note with manifest option

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -99,9 +99,9 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
   const manifest = buildSlackManifest(botName);
   await prompter.note(
     [
-      "1) Slack API → Create App → From scratch",
+      "1) Slack API → Create App → From scratch or From manifest (with the JSON below)",
       "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
-      "3) OAuth & Permissions → install app to workspace (xoxb- bot token)",
+      "3) Installed App to workspace to get the xoxb- bot token",
       "4) Enable Event Subscriptions (socket) for message events",
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -101,7 +101,7 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
     [
       "1) Slack API → Create App → From scratch or From manifest (with the JSON below)",
       "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
-      "3) Installed App to workspace to get the xoxb- bot token",
+      "3) Install App to workspace to get the xoxb- bot token",
       "4) Enable Event Subscriptions (socket) for message events",
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",


### PR DESCRIPTION
## Summary

- **Problem:** The Slack onboarding wizard's token-help note gave only a "From scratch" path and used a slightly ambiguous label for step 3.
- **Why it matters:** Users setting up Slack via the manifest path had no guidance in the wizard; they had to discover the "From manifest" option on their own.
- **What changed:** Updated two instruction strings in `noteSlackTokenHelp` — step 1 now mentions the "From manifest" option, and step 3 clarifies the install-to-workspace wording.
- **What did NOT change:** No logic, config schema, token handling, or runtime behavior was modified.


See this screenshot, there is a from manifest option which is much better than from scratch:

<img width="559" height="399" alt="Screenshot 2026-02-26 at 5 18 05 PM" src="https://github.com/user-attachments/assets/ac84ee65-0cd3-4974-afc0-8f4f1f3eb0fa" />

See this screenshot, install app is no longer under Auth & Permission session:

<img width="816" height="354" alt="Screenshot 2026-02-26 at 5 18 52 PM" src="https://github.com/user-attachments/assets/97c2c36d-fe65-49de-af90-be3fd40ded54" />


## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

The Slack onboarding wizard now shows "From scratch or From manifest (with the JSON below)" for step 1, and "Installed App to workspace to get the xoxb- bot token" for step 3.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw onboard` (or `openclaw channels configure --channel slack`)
2. Reach the token-setup step for a new Slack account
3. Observe the printed help note

### Expected

- Step 1 mentions both "From scratch" and "From manifest" options
- Step 3 reads "Installed App to workspace to get the xoxb- bot token"

### Actual

- (Before) Step 1 only mentioned "From scratch"; step 3 referenced "OAuth & Permissions" tab

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

(String-only change; no test change required.)

## Human Verification (required)

- **Verified scenarios:** Diff reviewed; strings match intended wording.
- **Edge cases checked:** No logic paths affected — text is inside a `prompter.note()` call only.
- **What you did not verify:** Full end-to-end Slack onboarding wizard run.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert 250218bbc`
- Files/config to restore: `src/channels/plugins/onboarding/slack.ts`
- Known bad symptoms: None expected; change is display-text only.

## Risks and Mitigations

None.