### PR TITLE
fix(ui): prevent tiny mobile chat input field

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -285,9 +285,10 @@
 
 /* Override .field textarea min-height (180px) from components.css */
 .chat-compose .chat-compose__field textarea {
+  flex: 1 1 auto;
   width: 100%;
   height: 40px;
-  min-height: 40px;
+  min-height: 48px;
   max-height: 150px;
   padding: 9px 12px;
   border-radius: 8px;
@@ -443,7 +444,7 @@
   border-color: rgba(16, 24, 40, 0.15);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .chat-session {
     min-width: 140px;
   }
@@ -458,16 +459,32 @@
     gap: 8px;
   }
 
-  /* Mobile: stack action buttons vertically */
+  /* Mobile: keep actions compact and allow wrapping when needed */
   .chat-compose__actions {
-    flex-direction: column;
+    flex-wrap: wrap;
     width: 100%;
     gap: 8px;
   }
 
-  /* Mobile: full-width buttons */
+  /* Mobile: buttons should not force textarea to collapse */
   .chat-compose .chat-compose__actions .btn {
-    width: 100%;
+    flex: 1 1 140px;
+    min-width: 0;
+    padding: 0 12px;
+  }
+
+  .chat-compose .chat-compose__actions .btn .btn-kbd {
+    display: none;
+  }
+
+  .chat-compose .chat-compose__field textarea {
+    min-height: 64px;
+    max-height: 45vh;
+  }
+
+  .chat-compose .chat-compose__field textarea::placeholder {
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .chat-controls {


### PR DESCRIPTION
Closes #28083

Problem
On mobile widths, the compose textarea and action buttons could compete for limited horizontal space, making the message input area feel too small and harder to use.

Root Cause
The compose controls shared a constrained flex row while the action buttons remained fixed-size. On narrow screens this allowed controls to crowd the textarea.

Fix
Adjusted mobile compose layout to prioritize textarea usability: increased textarea minimum height, allowed textarea to grow via flex, expanded mobile breakpoint to 768px, and made action buttons compact/wrappable instead of forcing tight layout pressure. Also hid the keyboard hint badge on mobile to reduce button width pressure.

Testing
- Ran: pnpm --dir /root/openclaw/workspace/repos/openclaw/ui exec vitest run src/ui/views/chat.test.ts --config vitest.config.ts (pass)
- Ran: pnpm --dir /root/openclaw/workspace/repos/openclaw/ui test (fails due pre-existing unrelated test failures in cron/navigation/i18n/focus-mode/open-external-url suites; not introduced by this change)
