### PR TITLE
fix(security): reject placeholder secrets in config.apply/config.patch writes

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   REDACTED_SENTINEL,
   redactConfigSnapshot,
+  rejectPlaceholderSecrets,
   restoreRedactedValues as restoreRedactedValues_orig,
 } from "./redact-snapshot.js";
 import { __test__ } from "./schema.hints.js";
@@ -1093,6 +1094,166 @@ describe("restoreRedactedValues", () => {
     const result = restoreRedactedValues(incoming, original, hints) as typeof incoming;
     expect(result.channels.slack.accounts[0].botToken).toBe("original-token-first-account");
     expect(result.channels.slack.accounts[1].botToken).toBe("user-provided-new-token-value");
+  });
+});
+
+describe("rejectPlaceholderSecrets", () => {
+  // Helper: wrap a placeholder value at a known-sensitive path (ends in "token")
+  function configWithSensitiveValue(value: string) {
+    return { channels: { slack: { botToken: value } } };
+  }
+
+  describe("pattern matching", () => {
+    const placeholders = [
+      ["__OPENCLAW_REDACTED__", "redaction sentinel"],
+      ["REDACTED", "bare REDACTED"],
+      ["xoxb-REDACTED", "Slack-prefixed REDACTED"],
+      ["xapp-REDACTED", "xapp-prefixed REDACTED"],
+      ["REPLACE_ME", "bare REPLACE_ME"],
+      ["xoxb-REPLACE_ME", "Slack-prefixed REPLACE_ME"],
+      ["your-token", "your-token placeholder"],
+      ["your-password", "your-password placeholder"],
+      ["your-api-key", "your-api-key placeholder"],
+      ["paste-your-key", "paste-your-key placeholder"],
+      ["paste-your-token", "paste-your-token placeholder"],
+      ["sk-xxx", "sk-xxx dummy key"],
+      ["sk-xxxx", "sk-xxxx dummy key"],
+      ["<token>", "angle-bracket placeholder"],
+      ["<api-key>", "angle-bracket api-key placeholder"],
+      ["TODO", "TODO sentinel"],
+      ["CHANGEME", "CHANGEME sentinel"],
+      ["FIXME", "FIXME sentinel"],
+      ["test-token", "test-prefixed placeholder"],
+      ["example-password", "example-prefixed placeholder"],
+    ] as const;
+
+    for (const [value, label] of placeholders) {
+      it(`rejects placeholder: ${label} (${value})`, () => {
+        const result = rejectPlaceholderSecrets(configWithSensitiveValue(value));
+        expect(result.ok).toBe(false);
+        expect(result.humanReadableMessage).toContain("channels.slack.botToken");
+      });
+    }
+  });
+
+  describe("false positive checks", () => {
+    const realValues = [
+      ["sk-proj-abcdef1234567890", "real OpenAI key"],
+      ["xoxb-1234567890123-1234567890123-AbCdEf", "real Slack token"],
+      ["your-workspace", "non-secret your- suffix"],
+      ["my-actual-password-123", "real password value"],
+      ["ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "real GitHub token"],
+    ] as const;
+
+    for (const [value, label] of realValues) {
+      it(`allows real value: ${label} (${value})`, () => {
+        const result = rejectPlaceholderSecrets(configWithSensitiveValue(value));
+        expect(result.ok).toBe(true);
+      });
+    }
+  });
+
+  describe("findPlaceholderSecretPath traversal", () => {
+    it("returns correct path for top-level sensitive key with placeholder", () => {
+      const result = rejectPlaceholderSecrets({ token: "REDACTED" });
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain('"token"');
+    });
+
+    it("returns correct path for nested sensitive key", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { botToken: "REDACTED" } },
+      });
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("channels.slack.botToken");
+    });
+
+    it("returns correct path for array items at sensitive paths", () => {
+      // "token[]" matches isSensitivePath because "token" ends with "token"
+      const result = rejectPlaceholderSecrets({
+        token: ["REDACTED"],
+      });
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("token[]");
+    });
+
+    it("returns null for non-sensitive paths", () => {
+      // "displayName" doesn't match any sensitive pattern
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { displayName: "your-bot" } },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("respects sensitive:false hints override", () => {
+      const hints: ConfigUiHints = {
+        "channels.slack.botToken": { sensitive: false },
+      };
+      // Even though "botToken" would match the sensitive pattern,
+      // the hint says it's not sensitive
+      const result = rejectPlaceholderSecrets(
+        { channels: { slack: { botToken: "REDACTED" } } },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("integration", () => {
+    it("returns { ok: true } for clean config", () => {
+      const result = rejectPlaceholderSecrets({
+        gateway: { auth: { token: "real-production-token-value" } },
+        channels: { slack: { botToken: "xoxb-real-slack-token-1234" } },
+        models: { providers: { openai: { apiKey: "sk-proj-real-key-here" } } },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("returns { ok: false } with humanReadableMessage containing offending path", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { botToken: "xoxb-REPLACE_ME" } },
+      });
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toBeDefined();
+      expect(result.humanReadableMessage).toContain("channels.slack.botToken");
+    });
+
+    it("works with ConfigUiHints marking custom paths as sensitive", () => {
+      const hints: ConfigUiHints = {
+        "custom.mySecret": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets({ custom: { mySecret: "CHANGEME" } }, hints);
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("custom.mySecret");
+    });
+
+    it("works without ConfigUiHints", () => {
+      const result = rejectPlaceholderSecrets({
+        gateway: { auth: { password: "FIXME" } },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("handles empty strings at sensitive paths", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { botToken: "" } },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("handles null values at sensitive paths", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { botToken: null } },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("handles numeric values at sensitive paths", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: { slack: { botToken: 12345 } },
+      });
+      expect(result.ok).toBe(true);
+    });
   });
 });
 

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -1446,6 +1446,49 @@ describe("rejectPlaceholderSecrets", () => {
     });
   });
 
+  describe("P1: wildcardVariants depth bound prevents DoS", () => {
+    it("does not hang on deeply nested config payloads (>20 segments)", () => {
+      // Build a config object with 30 levels of nesting, ending in a sensitive key.
+      // Without the depth bound in wildcardVariants, this would generate 2^30
+      // (~1 billion) combinations and stall the event loop.
+      const keys = Array.from({ length: 30 }, (_, i) => `level${i}`);
+      let obj: Record<string, unknown> = { token: "REPLACE_ME" };
+      for (let i = keys.length - 1; i >= 0; i--) {
+        obj = { [keys[i]]: obj };
+      }
+
+      const hints: ConfigUiHints = {
+        [`${keys.join(".")}.token`]: { sensitive: true },
+      };
+
+      // Should complete promptly (well under 1 second) instead of hanging
+      const start = performance.now();
+      const result = rejectPlaceholderSecrets(obj, hints);
+      const elapsed = performance.now() - start;
+
+      // The placeholder should still be detected even with the fallback
+      // linear variant strategy
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("token");
+      // Sanity: must complete in reasonable time (< 2s); without the fix
+      // this would take minutes/hours
+      expect(elapsed).toBeLessThan(2000);
+    });
+
+    it("still generates full 2^n variants for shallow paths", () => {
+      // Paths with <= 12 segments should still get the full enumeration
+      const hints: ConfigUiHints = {
+        "a.*.c.*.token": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        { a: { x: { c: { y: { token: "REDACTED" } } } } },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("token");
+    });
+  });
+
   describe("P2: sensitive:false hints override parent and pattern sensitivity", () => {
     it("allows placeholder at path marked sensitive:false even if pattern matches", () => {
       const hints: ConfigUiHints = {

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -1255,6 +1255,242 @@ describe("rejectPlaceholderSecrets", () => {
       expect(result.ok).toBe(true);
     });
   });
+
+  describe("P1: propagate sensitivity into nested object values", () => {
+    it("rejects placeholder inside a sensitive object (serviceAccount)", () => {
+      // channels.googlechat.serviceAccount is a sensitive whole-object path.
+      // Nested keys like private_key don't themselves match isSensitivePath,
+      // but they should still be checked because the parent is sensitive.
+      const result = rejectPlaceholderSecrets({
+        channels: {
+          googlechat: {
+            serviceAccount: {
+              type: "service_account",
+              project_id: "my-project",
+              private_key: "REDACTED",
+            },
+          },
+        },
+      });
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("private_key");
+    });
+
+    it("rejects placeholder deeply nested inside a sensitive object", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: {
+          googlechat: {
+            serviceAccount: {
+              nested: { deep: { value: "REPLACE_ME" } },
+            },
+          },
+        },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("allows real values inside a sensitive object", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: {
+          googlechat: {
+            serviceAccount: {
+              type: "service_account",
+              project_id: "my-project",
+              private_key: "-----BEGIN RSA PRIVATE KEY-----\nreal-key-data\n-----END RSA PRIVATE KEY-----",
+            },
+          },
+        },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects placeholder in serviceAccountRef nested values", () => {
+      const result = rejectPlaceholderSecrets({
+        channels: {
+          googlechat: {
+            serviceAccountRef: {
+              credential: "CHANGEME",
+            },
+          },
+        },
+      });
+      expect(result.ok).toBe(false);
+    });
+
+    it("propagates sensitivity via hint-marked sensitive objects", () => {
+      const hints: ConfigUiHints = {
+        "custom.credentials": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        {
+          custom: {
+            credentials: {
+              username: "admin",
+              password: "FIXME",
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("password");
+    });
+  });
+
+  describe("P1: apply ConfigUiHints when scanning arrays", () => {
+    it("rejects placeholder in array marked sensitive by hints", () => {
+      const hints: ConfigUiHints = {
+        "custom.secretList[]": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        { custom: { secretList: ["REDACTED"] } },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it("allows real values in array marked sensitive by hints", () => {
+      const hints: ConfigUiHints = {
+        "custom.secretList[]": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        { custom: { secretList: ["real-secret-value-123"] } },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects placeholder in array where parent path hint is sensitive", () => {
+      const hints: ConfigUiHints = {
+        "custom.secretList": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        { custom: { secretList: ["CHANGEME"] } },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("P1: match wildcard-sensitive hints for intermediate record keys", () => {
+    it("rejects placeholder at plugins.entries.*.apiKey via wildcard hint", () => {
+      const hints: ConfigUiHints = {
+        "plugins.entries.*.apiKey": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        {
+          plugins: {
+            entries: {
+              "voice-call": { apiKey: "REDACTED" },
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("apiKey");
+    });
+
+    it("allows real values at wildcard-sensitive hint paths", () => {
+      const hints: ConfigUiHints = {
+        "plugins.entries.*.apiKey": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        {
+          plugins: {
+            entries: {
+              "voice-call": { apiKey: "sk-proj-real-key-abc123" },
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("rejects placeholder at skills.entries.*.apiKey via wildcard hint", () => {
+      const hints: ConfigUiHints = {
+        "skills.entries.*.apiKey": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        {
+          skills: {
+            entries: {
+              "my-skill": { apiKey: "your-api-key" },
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects placeholder at deeply nested wildcard path", () => {
+      const hints: ConfigUiHints = {
+        "plugins.entries.*.config.twilio.authToken": { sensitive: true },
+      };
+      const result = rejectPlaceholderSecrets(
+        {
+          plugins: {
+            entries: {
+              "voice-call": {
+                config: { twilio: { authToken: "REPLACE_ME" } },
+              },
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(false);
+      expect(result.humanReadableMessage).toContain("authToken");
+    });
+  });
+
+  describe("P2: sensitive:false hints override parent and pattern sensitivity", () => {
+    it("allows placeholder at path marked sensitive:false even if pattern matches", () => {
+      const hints: ConfigUiHints = {
+        "channels.slack.botToken": { sensitive: false },
+      };
+      const result = rejectPlaceholderSecrets(
+        { channels: { slack: { botToken: "REDACTED" } } },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("allows placeholder at path marked sensitive:false via wildcard hint", () => {
+      const hints: ConfigUiHints = {
+        "custom.*.token": { sensitive: false },
+      };
+      const result = rejectPlaceholderSecrets(
+        { custom: { myService: { token: "REDACTED" } } },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("sensitive:false overrides parent sensitivity propagation", () => {
+      const hints: ConfigUiHints = {
+        "channels.googlechat.serviceAccount": { sensitive: true },
+        "channels.googlechat.serviceAccount.type": { sensitive: false },
+      };
+      // type is explicitly non-sensitive even though parent is sensitive
+      const result = rejectPlaceholderSecrets(
+        {
+          channels: {
+            googlechat: {
+              serviceAccount: {
+                type: "CHANGEME",
+                private_key: "real-key-value",
+              },
+            },
+          },
+        },
+        hints,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
 });
 
 describe("realredactConfigSnapshot_real", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -423,11 +423,18 @@ const PLACEHOLDER_SECRET_PATTERNS: RegExp[] = [
   // REPLACE_ME variants (xoxb-REPLACE_ME, xapp-REPLACE_ME, plain REPLACE_ME)
   /^(?:[a-z]+-)*REPLACE_ME$/i,
   // Docs/template placeholders: your-token, your-password, your-api-key, your-secret, etc.
-  /^your-[a-z][\w-]*$/i,
+  // Tightened to known secret suffixes to avoid false positives on e.g. "your-workspace"
+  /^your-(token|password|api[_-]?key|secret|credential|auth|bot[_-]?token)[\w-]*$/i,
   // paste-your-* variants (paste-your-key, paste-your-token)
   /^paste-your-[a-z][\w-]*$/i,
   // sk-xxx / sk-yyy style dummy keys used in documentation
   /^sk-x{2,}$/i,
+  // Angle-bracket placeholders common in docs (e.g. <token>, <api-key>)
+  /^<[a-z][\w-]*>$/i,
+  // Common sentinel values
+  /^(?:TODO|CHANGEME|FIXME)$/,
+  // Test/example/dummy prefixed placeholders (e.g. test-token, example-password)
+  /^(?:test|example|sample|dummy|fake)-(?:token|password|api[_-]?key|secret|credential|auth)[\w-]*$/i,
 ];
 
 function isPlaceholderSecretValue(value: string): boolean {
@@ -467,7 +474,9 @@ function findPlaceholderSecretPath(
     // Determine whether this path is sensitive via hints (preferred) or pattern guessing
     const hintSensitive =
       hints && (hints[path]?.sensitive === true || hints[wildcardPath]?.sensitive === true);
-    const guessSensitive = !hintSensitive && isSensitivePath(path);
+    const hintExplicitlyNonSensitive =
+      hints && (hints[path]?.sensitive === false || hints[wildcardPath]?.sensitive === false);
+    const guessSensitive = !hintSensitive && !hintExplicitlyNonSensitive && isSensitivePath(path);
     const sensitive = hintSensitive || guessSensitive;
     if (sensitive && typeof value === "string" && isPlaceholderSecretValue(value)) {
       return path;

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -409,6 +409,102 @@ export type RedactionResult = {
 };
 
 /**
+ * Patterns that indicate an obvious placeholder/example secret value.
+ * Matched case-insensitively against string values at sensitive config paths.
+ *
+ * Covers the most common forms seen in documentation examples and redacted
+ * template payloads (e.g. xoxb-REDACTED, xapp-REPLACE_ME, your-token-here).
+ */
+const PLACEHOLDER_SECRET_PATTERNS: RegExp[] = [
+  // OpenClaw redaction sentinel (shouldn't remain after restoreRedactedValues, but guard anyway)
+  /^__OPENCLAW_REDACTED__$/,
+  // Bare REDACTED or with common Slack-style prefix (xoxb-REDACTED, xapp-REDACTED, etc.)
+  /^(?:[a-z]+-)*REDACTED$/i,
+  // REPLACE_ME variants (xoxb-REPLACE_ME, xapp-REPLACE_ME, plain REPLACE_ME)
+  /^(?:[a-z]+-)*REPLACE_ME$/i,
+  // Docs/template placeholders: your-token, your-password, your-api-key, your-secret, etc.
+  /^your-[a-z][\w-]*$/i,
+  // paste-your-* variants (paste-your-key, paste-your-token)
+  /^paste-your-[a-z][\w-]*$/i,
+  // sk-xxx / sk-yyy style dummy keys used in documentation
+  /^sk-x{2,}$/i,
+];
+
+function isPlaceholderSecretValue(value: string): boolean {
+  const trimmed = value.trim();
+  return PLACEHOLDER_SECRET_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/**
+ * Deep-walk `config` and collect the first sensitive path that contains an
+ * obvious placeholder secret value (e.g. "REDACTED", "your-token", etc.).
+ * Returns `null` when no placeholder is found.
+ */
+function findPlaceholderSecretPath(
+  obj: unknown,
+  prefix: string,
+  hints: ConfigUiHints | undefined,
+): string | null {
+  if (obj === null || obj === undefined || typeof obj !== "object") {
+    return null;
+  }
+  if (Array.isArray(obj)) {
+    const path = `${prefix}[]`;
+    for (const item of obj) {
+      if (typeof item === "string" && isSensitivePath(path) && isPlaceholderSecretValue(item)) {
+        return path;
+      }
+      const nested = findPlaceholderSecretPath(item, path, hints);
+      if (nested) {
+        return nested;
+      }
+    }
+    return null;
+  }
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const wildcardPath = prefix ? `${prefix}.*` : "*";
+    // Determine whether this path is sensitive via hints (preferred) or pattern guessing
+    const hintSensitive =
+      hints && (hints[path]?.sensitive === true || hints[wildcardPath]?.sensitive === true);
+    const guessSensitive = !hintSensitive && isSensitivePath(path);
+    const sensitive = hintSensitive || guessSensitive;
+    if (sensitive && typeof value === "string" && isPlaceholderSecretValue(value)) {
+      return path;
+    }
+    const nested = findPlaceholderSecretPath(value, path, hints);
+    if (nested) {
+      return nested;
+    }
+  }
+  return null;
+}
+
+/**
+ * Guard called by config.apply and config.patch before writing to disk.
+ *
+ * Returns `{ ok: false, humanReadableMessage }` if any sensitive config path
+ * contains an obvious placeholder value (e.g. "REDACTED", "your-token",
+ * "xoxb-REPLACE_ME"). This prevents redacted template payloads from silently
+ * overwriting real production credentials.
+ *
+ * Returns `{ ok: true }` when no placeholder is detected.
+ */
+export function rejectPlaceholderSecrets(
+  config: unknown,
+  hints?: ConfigUiHints,
+): Pick<RedactionResult, "ok" | "humanReadableMessage"> {
+  const badPath = findPlaceholderSecretPath(config, "", hints);
+  if (badPath) {
+    return {
+      ok: false,
+      humanReadableMessage: `Placeholder secret detected at "${badPath}": use a real value, an env-var reference like \${ENV_VAR}, or retain the existing value via config.patch`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
  * Deep-walk `incoming` and replace any {@link REDACTED_SENTINEL} values
  * (on sensitive paths) with the corresponding value from `original`.
  *

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -443,25 +443,103 @@ function isPlaceholderSecretValue(value: string): boolean {
 }
 
 /**
+ * Generate all wildcard-expanded variants of a dotted config path.
+ * For "a.b.c" returns ["a.b.c", "a.b.*", "a.*.c", "*.b.c", "a.*.*", "*.b.*", "*.*.c", "*.*.*"].
+ * For single-segment paths, returns [path, "*"].
+ * Used to match hints like "plugins.entries.*.apiKey" when the concrete path
+ * is "plugins.entries.voice-call.apiKey".
+ */
+function wildcardVariants(path: string): string[] {
+  const parts = path.split(".");
+  if (parts.length <= 1) {
+    return [path];
+  }
+  // Generate 2^n combinations (each segment can be itself or "*")
+  const count = 1 << parts.length;
+  const variants: string[] = [];
+  for (let mask = 0; mask < count; mask++) {
+    const segments: string[] = [];
+    for (let i = 0; i < parts.length; i++) {
+      segments.push(mask & (1 << i) ? "*" : parts[i]);
+    }
+    variants.push(segments.join("."));
+  }
+  return variants;
+}
+
+/**
+ * Check if any wildcard variant of the path is marked sensitive in hints.
+ * Returns true if any variant has sensitive === true.
+ */
+function isHintSensitive(hints: ConfigUiHints | undefined, path: string): boolean {
+  if (!hints) return false;
+  for (const variant of wildcardVariants(path)) {
+    if (hints[variant]?.sensitive === true) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if any wildcard variant of the path is explicitly non-sensitive in hints.
+ * Returns true if any variant has sensitive === false.
+ */
+function isHintExplicitlyNonSensitive(hints: ConfigUiHints | undefined, path: string): boolean {
+  if (!hints) return false;
+  for (const variant of wildcardVariants(path)) {
+    if (hints[variant]?.sensitive === false) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if any wildcard variant of the array-suffixed path is sensitive in hints.
+ * Needed for "customArray[]" style paths from ConfigUiHints.
+ */
+function isArrayPathHintSensitive(hints: ConfigUiHints | undefined, arrayPath: string): boolean {
+  if (!hints) return false;
+  // arrayPath looks like "foo.bar[]"; check both "foo.bar[]" and wildcard variants
+  // Also check the base path without "[]" since hints may mark the parent
+  const basePath = arrayPath.endsWith("[]") ? arrayPath.slice(0, -2) : arrayPath;
+  for (const variant of wildcardVariants(arrayPath)) {
+    if (hints[variant]?.sensitive === true) return true;
+  }
+  for (const variant of wildcardVariants(basePath)) {
+    if (hints[variant]?.sensitive === true) return true;
+  }
+  return false;
+}
+
+/**
  * Deep-walk `config` and collect the first sensitive path that contains an
  * obvious placeholder secret value (e.g. "REDACTED", "your-token", etc.).
  * Returns `null` when no placeholder is found.
+ *
+ * @param parentSensitive When true, the parent node was determined to be
+ *   sensitive (e.g. a serviceAccount object). All leaf strings inside inherit
+ *   that sensitivity without needing their own path match.
  */
 function findPlaceholderSecretPath(
   obj: unknown,
   prefix: string,
   hints: ConfigUiHints | undefined,
+  parentSensitive = false,
 ): string | null {
   if (obj === null || obj === undefined || typeof obj !== "object") {
     return null;
   }
   if (Array.isArray(obj)) {
     const path = `${prefix}[]`;
+    // Check sensitivity via hints (including wildcard variants) and pattern guessing.
+    // Explicit sensitive:false overrides parent propagation and pattern guessing.
+    const hintSens = isArrayPathHintSensitive(hints, path);
+    const hintNonSens = isHintExplicitlyNonSensitive(hints, path);
+    const guessSens = !hintSens && !hintNonSens && isSensitivePath(path);
+    const arraySensitive = hintNonSens ? false : parentSensitive || hintSens || guessSens;
     for (const item of obj) {
-      if (typeof item === "string" && isSensitivePath(path) && isPlaceholderSecretValue(item)) {
+      if (typeof item === "string" && arraySensitive && isPlaceholderSecretValue(item)) {
         return path;
       }
-      const nested = findPlaceholderSecretPath(item, path, hints);
+      const nested = findPlaceholderSecretPath(item, path, hints, arraySensitive);
       if (nested) {
         return nested;
       }
@@ -470,18 +548,28 @@ function findPlaceholderSecretPath(
   }
   for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    const wildcardPath = prefix ? `${prefix}.*` : "*";
-    // Determine whether this path is sensitive via hints (preferred) or pattern guessing
-    const hintSensitive =
-      hints && (hints[path]?.sensitive === true || hints[wildcardPath]?.sensitive === true);
-    const hintExplicitlyNonSensitive =
-      hints && (hints[path]?.sensitive === false || hints[wildcardPath]?.sensitive === false);
-    const guessSensitive = !hintSensitive && !hintExplicitlyNonSensitive && isSensitivePath(path);
-    const sensitive = hintSensitive || guessSensitive;
+    // Determine whether this path is sensitive via hints (with wildcard matching) or pattern guessing.
+    const hintSens = isHintSensitive(hints, path);
+    const hintNonSens = isHintExplicitlyNonSensitive(hints, path);
+    // Explicit sensitive:false in hints overrides both parent propagation and pattern guessing.
+    const guessSens = !hintSens && !hintNonSens && isSensitivePath(path);
+    const sensitive = hintNonSens ? false : parentSensitive || hintSens || guessSens;
+
     if (sensitive && typeof value === "string" && isPlaceholderSecretValue(value)) {
       return path;
     }
-    const nested = findPlaceholderSecretPath(value, path, hints);
+    // Propagate sensitivity into children: if this node is a sensitive object
+    // (e.g. serviceAccount), all nested strings inherit sensitivity.
+    const childSensitive =
+      sensitive && typeof value === "object" && value !== null && !Array.isArray(value)
+        ? isWholeObjectSensitivePath(path) || hintSens
+        : false;
+    const nested = findPlaceholderSecretPath(
+      value,
+      path,
+      hints,
+      parentSensitive || childSensitive,
+    );
     if (nested) {
       return nested;
     }

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -443,17 +443,48 @@ function isPlaceholderSecretValue(value: string): boolean {
 }
 
 /**
+ * Maximum number of path segments for which we enumerate all 2^n wildcard
+ * combinations.  Beyond this threshold the function falls back to a linear
+ * set of variants (exact path + single-segment wildcards) to prevent
+ * exponential CPU usage on deeply nested payloads.  12 segments -> 4 096
+ * variants, which is a comfortable upper bound for real-world config shapes.
+ */
+const WILDCARD_MAX_SEGMENTS = 12;
+
+/**
  * Generate all wildcard-expanded variants of a dotted config path.
  * For "a.b.c" returns ["a.b.c", "a.b.*", "a.*.c", "*.b.c", "a.*.*", "*.b.*", "*.*.c", "*.*.*"].
  * For single-segment paths, returns [path, "*"].
  * Used to match hints like "plugins.entries.*.apiKey" when the concrete path
  * is "plugins.entries.voice-call.apiKey".
+ *
+ * When the number of segments exceeds {@link WILDCARD_MAX_SEGMENTS} the full
+ * 2^n enumeration is skipped to avoid exponential blowup (a path with 30
+ * segments would otherwise produce >1 billion variants).  Instead the
+ * function returns the exact path plus one variant per segment with that
+ * segment replaced by "*", which still matches all single-wildcard hint
+ * patterns used in practice.
  */
 function wildcardVariants(path: string): string[] {
   const parts = path.split(".");
   if (parts.length <= 1) {
     return [path];
   }
+
+  // For paths with many segments, fall back to a linear set of variants
+  // instead of the full 2^n enumeration to prevent CPU-bound stalls.
+  if (parts.length > WILDCARD_MAX_SEGMENTS) {
+    const variants: string[] = [path];
+    for (let i = 0; i < parts.length; i++) {
+      const segments = parts.slice();
+      segments[i] = "*";
+      variants.push(segments.join("."));
+    }
+    // Also include the all-wildcards variant
+    variants.push(parts.map(() => "*").join("."));
+    return variants;
+  }
+
   // Generate 2^n combinations (each segment can be itself or "*")
   const count = 1 << parts.length;
   const variants: string[] = [];

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -341,26 +341,32 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const merged = applyMergePatch(snapshot.config, parsedRes.parsed, {
-      mergeObjectArraysById: true,
-    });
     const schemaPatch = loadSchemaWithPlugins();
-    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
-    if (!restoredMerge.ok) {
+    // Restore redacted sentinels in the patch *before* merging, so we can
+    // check only the fields the caller is actually changing for placeholders.
+    // This avoids false positives from existing placeholder-like values in
+    // untouched parts of the config (P2: config.patch scope).
+    const restoredPatch = restoreRedactedValues(
+      parsedRes.parsed,
+      snapshot.config,
+      schemaPatch.uiHints,
+    );
+    if (!restoredPatch.ok) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          restoredMerge.humanReadableMessage ?? "invalid config",
+          restoredPatch.humanReadableMessage ?? "invalid config",
         ),
       );
       return;
     }
     // Guard: reject obvious placeholder/example secrets before writing to disk.
-    // This prevents redacted template payloads from silently overwriting real credentials.
+    // Only check the patch input (not the entire merged config) so existing
+    // placeholder-like values in untouched fields don't cause spurious errors.
     const placeholderCheckPatch = rejectPlaceholderSecrets(
-      restoredMerge.result,
+      restoredPatch.result,
       schemaPatch.uiHints,
     );
     if (!placeholderCheckPatch.ok) {
@@ -370,6 +376,21 @@ export const configHandlers: GatewayRequestHandlers = {
         errorShape(
           ErrorCodes.INVALID_REQUEST,
           placeholderCheckPatch.humanReadableMessage ?? "placeholder secret in config",
+        ),
+      );
+      return;
+    }
+    const merged = applyMergePatch(snapshot.config, restoredPatch.result as Record<string, unknown>, {
+      mergeObjectArraysById: true,
+    });
+    const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
+    if (!restoredMerge.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          restoredMerge.humanReadableMessage ?? "invalid config",
         ),
       );
       return;


### PR DESCRIPTION
Closes #21573

Reject obvious placeholder/example secrets in sensitive config paths before writing to disk, preventing redacted template payloads from silently overwriting real credentials.