### PR TITLE
Agents: fix session cwd for CLI sandboxes

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { prepareSessionManagerForRun } from "./session-manager-init.js";
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("prepareSessionManagerForRun", () => {
+  it("stamps header.cwd for existing transcript files without assistant messages", async () => {
+    const dir = makeTempDir("openclaw-session-init-");
+    const sessionFile = path.join(dir, "sess.jsonl");
+
+    fs.writeFileSync(
+      sessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: "old-session-id",
+        timestamp: new Date().toISOString(),
+        cwd: "/",
+      })}\n`,
+      "utf-8",
+    );
+
+    const sm = SessionManager.open(sessionFile) as unknown as { fileEntries: Array<unknown> };
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "new-session-id",
+      cwd: "/tmp/workspace",
+    });
+
+    const header = sm.fileEntries.find(
+      (entry): entry is { type: "session"; id?: string; cwd?: string } =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as { type?: unknown }).type === "session",
+    );
+    expect(header?.id).toBe("new-session-id");
+    expect(header?.cwd).toBe("/tmp/workspace");
+    expect(fs.readFileSync(sessionFile, "utf-8")).toBe("");
+  });
+
+  it("stamps header.cwd when the transcript file does not exist yet", async () => {
+    const sm = SessionManager.inMemory() as unknown as { fileEntries: Array<unknown> };
+    await prepareSessionManagerForRun({
+      sessionManager: sm,
+      sessionFile: "/dev/null",
+      hadSessionFile: false,
+      sessionId: "sess-1",
+      cwd: "/tmp/workspace",
+    });
+
+    const header = sm.fileEntries.find(
+      (entry): entry is { type: "session"; id?: string; cwd?: string } =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as { type?: unknown }).type === "session",
+    );
+    expect(header?.id).toBe("sess-1");
+    expect(header?.cwd).toBe("/tmp/workspace");
+  });
+});

--- a/src/agents/pi-embedded-runner/session-manager-init.test.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.test.ts
@@ -26,7 +26,10 @@ describe("prepareSessionManagerForRun", () => {
       "utf-8",
     );
 
-    const sm = SessionManager.open(sessionFile) as unknown as { fileEntries: Array<unknown> };
+    const sm = SessionManager.open(sessionFile) as unknown as {
+      fileEntries: Array<unknown>;
+      sessionId: string;
+    };
     await prepareSessionManagerForRun({
       sessionManager: sm,
       sessionFile,
@@ -43,11 +46,15 @@ describe("prepareSessionManagerForRun", () => {
     );
     expect(header?.id).toBe("new-session-id");
     expect(header?.cwd).toBe("/tmp/workspace");
+    expect(sm.sessionId).toBe("new-session-id");
     expect(fs.readFileSync(sessionFile, "utf-8")).toBe("");
   });
 
   it("stamps header.cwd when the transcript file does not exist yet", async () => {
-    const sm = SessionManager.inMemory() as unknown as { fileEntries: Array<unknown> };
+    const sm = SessionManager.inMemory() as unknown as {
+      fileEntries: Array<unknown>;
+      sessionId: string;
+    };
     await prepareSessionManagerForRun({
       sessionManager: sm,
       sessionFile: "/dev/null",
@@ -64,5 +71,6 @@ describe("prepareSessionManagerForRun", () => {
     );
     expect(header?.id).toBe("sess-1");
     expect(header?.cwd).toBe("/tmp/workspace");
+    expect(sm.sessionId).toBe("sess-1");
   });
 });

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -42,6 +42,11 @@ export async function prepareSessionManagerForRun(params: {
   }
 
   if (params.hadSessionFile && header && !hasAssistant) {
+    // Ensure existing transcript headers inherit the effective workspace cwd.
+    // Without this, launchd/system daemons frequently write cwd="/" and downstream
+    // sandboxes interpret the session as rooted at "/".
+    header.id = params.sessionId;
+    header.cwd = params.cwd;
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fs.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -47,6 +47,7 @@ export async function prepareSessionManagerForRun(params: {
     // sandboxes interpret the session as rooted at "/".
     header.id = params.sessionId;
     header.cwd = params.cwd;
+    sm.sessionId = params.sessionId;
     // Reset file so the first assistant flush includes header+user+assistant in order.
     await fs.writeFile(params.sessionFile, "", "utf-8");
     sm.fileEntries = [header];


### PR DESCRIPTION
## Summary

- Problem: Some sessions end up with `cwd=/` in the transcript header, which can cause Claude Code sandbox rules to block workspace file operations.
- Why it matters: A bad `cwd` effectively breaks write/edit tooling for otherwise-allowed workspaces.
- What changed: When a transcript file already exists but has no assistant messages yet, `prepareSessionManagerForRun` now stamps the session header `id` and `cwd` from the resolved workspace before the first flush.
- What did NOT change (scope boundary): No sandbox policy changes; this only adjusts session transcript header initialization.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #27627

## User-visible / Behavior Changes

- Claude Code sessions created from pre-existing transcripts no longer inherit `cwd=/`; they use the resolved workspace cwd.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Create a session transcript file containing only a `type:"session"` header with `cwd:"/"`.
2. Start a run in a configured agent workspace.

### Expected

- Session header `cwd` reflects the configured workspace.

### Actual

- Prior to this change, header `cwd` could remain `/`.

## Evidence

- `pnpm test src/agents/pi-embedded-runner/session-manager-init.test.ts`
- `pnpm build`
- `pnpm check`

## Human Verification (required)

- Verified scenarios: added and ran a unit test covering existing transcript files without assistant messages.
- Edge cases checked: in-memory session path.
- What you did not verify: end-to-end gateway run with Claude Code sandbox.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Revert commit `f072bcc28`.

## Risks and Mitigations

- Risk: None identified; change is limited to initializing header metadata.
  - Mitigation: Regression test included.

AI-assisted: Yes
Testing: `pnpm build`, `pnpm check`, targeted `pnpm test`.
