### PR TITLE
fix(gateway): handle LLM API failures without crashing (fixes #23441)

### DIFF
--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -835,7 +835,9 @@ export async function handleOpenResponsesHttpRequest(
         });
       }
     }
-  })();
+  })().catch((err) => {
+    logWarn(`openresponses: streaming response unhandled: ${String(err)}`);
+  });
 
   return true;
 }

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -129,5 +129,23 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         expect.stringContaining("This operation was aborted"),
       );
     });
+
+    it("does not exit on LLM/API client errors (403, 404, unauthorized)", () => {
+      const llmApiCases = [
+        Object.assign(new Error("Model not permitted"), { statusCode: 403 }),
+        Object.assign(new Error("Not found"), { statusCode: 404 }),
+        new Error("Request failed with status code 403"),
+        new Error("Unauthorized: missing scope for model"),
+      ];
+
+      for (const err of llmApiCases) {
+        expectExitCodeFromUnhandled(err, []);
+      }
+
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(consoleWarnSpy.mock.calls.some((c) => String(c[0]).includes("LLM/API error"))).toBe(
+        true,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
When the LLM API call fails (e.g., 403/404 model permission), an Unhandled Promise Rejection could crash the gateway and cause infinite restart loops.

## Changes
- **unhandled-rejections**: Treat LLM/API client errors (403, 404, unauthorized, etc.) as non-fatal: log and keep gateway alive; export `isLlmOrApiClientError` for callers.
- **chat.send**: On dispatch failure, show fallback `[System Error: Model API failed]` when the error is an LLM/API error.
- **openai-http**: Non-stream and stream paths return/show `[System Error: Model API failed]` for LLM/API errors; add `.catch()` on streaming IIFE to avoid unhandled rejection.
- **openresponses-http**: Add `.catch()` on streaming IIFE.
- **Tests**: Add fatal-detection test for LLM/API errors (no exit, warning logged).

Fixes #23441

Made with [Cursor](https://cursor.com)