### PR TITLE
fix(config): accept bluebubbles allowPrivateNetwork setting

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -75,6 +75,34 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.bluebubbles.allowPrivateNetwork", () => {
+    const res = validateConfigObject({
+      channels: {
+        bluebubbles: {
+          allowPrivateNetwork: true,
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts channels.bluebubbles.accounts.*.allowPrivateNetwork", () => {
+    const res = validateConfigObject({
+      channels: {
+        bluebubbles: {
+          accounts: {
+            default: {
+              allowPrivateNetwork: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects unsafe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1277,6 +1277,7 @@ export const BlueBubblesAccountSchemaBase = z
     mediaMaxMb: z.number().int().positive().optional(),
     mediaLocalRoots: z.array(z.string()).optional(),
     sendReadReceipts: z.boolean().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     groups: z.record(z.string(), BlueBubblesGroupConfigSchema.optional()).optional(),


### PR DESCRIPTION
Fixes #28068

## Summary
- add `allowPrivateNetwork` to `BlueBubblesAccountSchemaBase`
- restore support for both top-level and per-account BlueBubbles config keys
- add regression tests to ensure both paths validate

## Validation
- pnpm check
- pnpm check:docs
- pnpm protocol:check
- pnpm vitest run src/config/config.schema-regressions.test.ts
