### PR TITLE
fix: clean stale content-hashed dist files on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "openclaw": "node scripts/run-node.mjs",
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
+    "postinstall": "node scripts/cleanup-dist-hashes.mjs",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",

--- a/scripts/cleanup-dist-hashes.mjs
+++ b/scripts/cleanup-dist-hashes.mjs
@@ -1,0 +1,111 @@
+/**
+ * Cleanup script for stale content-hashed dist files.
+ *
+ * When OpenClaw is updated via npm global install, old content-hashed
+ * files may remain in the dist/ folder, causing import errors like:
+ * "Cannot find module '/.../openclaw/dist/tool-loop-detection-Ck6LbMx_.js'"
+ *
+ * This script removes stale .js files from dist/ that are not part of the current build.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DIST_DIR = path.join(__dirname, "dist");
+
+// Get all .js files in dist/
+function getJsFiles(dir) {
+  const files = [];
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
+
+  for (const file of fs.readdirSync(dir)) {
+    if (file.endsWith(".js")) {
+      files.push(path.join(dir, file));
+    }
+  }
+  return files;
+}
+
+// Get all files that should exist based on the build
+// We'll check which files are referenced in the built JS files
+function getReferencedFiles() {
+  const referenced = new Set();
+  const jsFiles = getJsFiles(DIST_DIR);
+
+  for (const file of jsFiles) {
+    try {
+      const content = fs.readFileSync(file, "utf-8");
+      // Match import statements like: import x from './file-HASH.js'
+      const matches = content.matchAll(/from\s+['"](\.[^'"]+\.js)['"]/g);
+      for (const match of matches) {
+        const relativePath = match[1];
+        // Resolve relative to the current file
+        const resolvedPath = path.resolve(path.dirname(file), relativePath);
+        referenced.add(resolvedPath);
+      }
+
+      // Also match dynamic imports
+      const dynamicMatches = content.matchAll(/import\(['"]([^'"]+\.js)['"]\)/g);
+      for (const match of dynamicMatches) {
+        const relativePath = match[1];
+        const resolvedPath = path.resolve(path.dirname(file), relativePath);
+        referenced.add(resolvedPath);
+      }
+    } catch {
+      // Ignore read errors
+    }
+  }
+
+  return referenced;
+}
+
+function cleanup() {
+  console.log("Running dist cleanup...");
+
+  const jsFiles = getJsFiles(DIST_DIR);
+  const referencedFiles = getReferencedFiles();
+
+  let removedCount = 0;
+
+  for (const file of jsFiles) {
+    // Keep files that are referenced by other files in dist/
+    // This preserves the current build's files
+    if (referencedFiles.has(file)) {
+      continue;
+    }
+
+    // Also keep index.js and plugin-sdk entry points
+    const fileName = path.basename(file);
+    if (
+      fileName === "index.js" ||
+      fileName.startsWith("plugin-sdk") ||
+      fileName === "openclaw.mjs"
+    ) {
+      continue;
+    }
+
+    // Remove stale files
+    try {
+      fs.unlinkSync(file);
+      console.log(`Removed stale file: ${fileName}`);
+      removedCount++;
+    } catch (err) {
+      console.error(`Failed to remove ${file}: ${err.message}`);
+    }
+  }
+
+  if (removedCount > 0) {
+    console.log(`Cleanup complete. Removed ${removedCount} stale file(s).`);
+  } else {
+    console.log("No stale files to remove.");
+  }
+}
+
+// Only run if executed directly
+cleanup();


### PR DESCRIPTION
When OpenClaw is updated via npm global install, old content-hashed
files may remain in the dist/ folder, causing import errors like:
'Cannot find module .../dist/tool-loop-detection-Ck6LbMx_.js'

This adds a postinstall script that removes stale .js files from dist/
that are not part of the current build's import graph.

Fixes #28074