### PR TITLE
fix(ollama): fall back to reasoning field when content is empty (#27806)

### DIFF
--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -47,7 +47,7 @@ export function coerceImageAssistantText(params: {
   if (errorMessage) {
     throw new Error(`Image model failed (${params.provider}/${params.model}): ${errorMessage}`);
   }
-  const text = extractAssistantText(params.message);
+  const text = extractAssistantText(params.message, { fallbackToThinking: false });
   if (text.trim()) {
     return text.trim();
   }


### PR DESCRIPTION
## Summary

- **Problem:** Ollama reasoning models (e.g. `glm-4.7-flash`, `Qwen3`) put their answer in the `reasoning` field instead of `content`, leaving all text blocks empty. `extractAssistantText` only reads text blocks, so the response is silently dropped — the bot never replies.
- **Why it matters:** Every message sent to an Ollama reasoning model returns nothing.
- **What changed:** `extractAssistantText` falls back to thinking blocks when text is empty. Callers that must not surface thinking (e.g. image tool) pass `{ fallbackToThinking: false }` to opt out.
- **What did NOT change:** When text blocks have content, the existing code path is unchanged.

Closes #27806

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27806
- Related #27911

## User-visible / Behavior Changes

Users on Ollama reasoning models now get responses instead of silence.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11
- Model/provider: Ollama `glm-4.7-flash`

### Steps

1. Configure OpenClaw with an Ollama reasoning model
2. Send any message
3. Before: silent empty response. After: reply returned from thinking content.

### Expected

Bot replies with the model's answer.

### Actual (before fix)

Empty response — silently dropped.

## Evidence

- [x] Failing test/log before + passing after

```
✓ src/agents/pi-embedded-utils.test.ts (34 tests)
✓ src/agents/tools/image-tool.test.ts   (26 tests)
Tests  60 passed
```

## Human Verification (required)

- Verified scenarios: 5 new unit test paths (4 fallback cases + image-tool opt-out); all 55 pre-existing tests pass.
- Edge cases checked: whitespace-only text, multiple thinking blocks, mixed text+thinking (text wins), empty message, image tool strict mode.
- What you did **not** verify: Live end-to-end channel flow (unit-level only).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert changes to `src/agents/pi-embedded-utils.ts` and `src/agents/tools/image-tool.helpers.ts`.

## Risks and Mitigations

- Risk: A model using thinking purely for internal CoT would now surface that content to users.
  - Mitigation: Callers with strict text-only requirements use `{ fallbackToThinking: false }`.
