### PR TITLE
fix(gateway): add Windows-compatible port detection using netstat fallback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
   "typescript.reportStyleChecksAsWarnings": false,
   "typescript.updateImportsOnFileMove.enabled": "always",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.experimental.useTsgo": true
+  "typescript.experimental.useTsgo": true,
+  "postman.settings.dotenv-detection-notification-visibility": false
 }

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -158,6 +158,28 @@ export function parseLsofOutput(output: string): PortProcess[] {
 }
 
 export function listPortListeners(port: number): PortProcess[] {
+  if (process.platform === "win32") {
+    try {
+      const out = execFileSync("netstat", ["-ano", "-p", "TCP"], { encoding: "utf-8" });
+      const lines = out.split(/\r?\n/).filter(Boolean);
+      const results: PortProcess[] = [];
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length >= 5 && parts[3] === "LISTENING" && parts[1].endsWith(`:${port}`)) {
+          const pid = Number.parseInt(parts[4], 10);
+          if (!Number.isNaN(pid) && pid > 0) {
+            if (!results.some(p => p.pid === pid)) {
+              results.push({ pid });
+            }
+          }
+        }
+      }
+      return results;
+    } catch (err: unknown) {
+      throw new Error(`netstat failed: ${String(err)}`, { cause: err });
+    }
+  }
+
   try {
     const lsof = resolveLsofCommandSync();
     const out = execFileSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFc"], {

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -165,11 +165,15 @@ export function listPortListeners(port: number): PortProcess[] {
       const results: PortProcess[] = [];
       for (const line of lines) {
         const parts = line.trim().split(/\s+/);
-        if (parts.length >= 5 && parts[3] === "LISTENING" && parts[1].endsWith(`:${port}`)) {
-          const pid = Number.parseInt(parts[4], 10);
-          if (!Number.isNaN(pid) && pid > 0) {
-            if (!results.some(p => p.pid === pid)) {
-              results.push({ pid });
+        if (parts.length >= 5 && parts[3] === "LISTENING") {
+          const localAddress = parts[1];
+          const addressPort = localAddress.split(":").pop();
+          if (addressPort === String(port)) {
+            const pid = Number.parseInt(parts[4], 10);
+            if (!Number.isNaN(pid) && pid > 0) {
+              if (!results.some((p) => p.pid === pid)) {
+                results.push({ pid });
+              }
             }
           }
         }


### PR DESCRIPTION
## Fix: Native Windows Support for Gateway Port Detection

### What does this PR do?
Resolves a fatal crash when launching the Gateway on native Windows via `pnpm gateway:watch` or the `--force` flag.

### Problem
`forceFreePort` and `listPortListeners` relied exclusively on `lsof` to identify processes listening on a target port. Since `lsof` is Unix-only, Windows users hit an `lsof not found` fatal error on startup, completely blocking native Windows development.

### Solution
Added a `process.platform === "win32"` branch in `src/cli/ports.ts`. On Windows, the CLI now invokes `netstat -ano -p TCP` to parse active TCP listeners and resolve the correct process IDs.

### Impact
- ✅ **Windows** — Gateway can now run natively without errors
- ✅ **macOS / Linux** — Unaffected; existing `lsof` logic is unchanged and runs behind a strict platform check

### Testing
- [ ] Verified `pnpm gateway:watch` runs successfully on Windows
- [ ] Verified no regression on macOS/Linux
