### PR TITLE
fix(bluebubbles): accept attachment-only messages with empty text (#28066)

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -3370,4 +3370,92 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
   });
+
+  describe("attachment-only messages", () => {
+    it("accepts attachment-only messages with no text", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: null,
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-attachment-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+          attachments: [
+            {
+              guid: "att-guid-1",
+              mimeType: "image/jpeg",
+              transferName: "photo.jpg",
+              totalBytes: 50000,
+            },
+          ],
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    });
+
+    it("accepts flat webhook payload with attachments", async () => {
+      const account = createMockAccount({ dmPolicy: "open" });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        guid: "msg-flat-1",
+        handle: { address: "+15551234567" },
+        isGroup: false,
+        isFromMe: false,
+        chatGuid: "iMessage;-;+15551234567",
+        date: Date.now(),
+        attachments: [
+          {
+            guid: "att-guid-2",
+            mimeType: "image/png",
+            transferName: "screenshot.png",
+            totalBytes: 120000,
+          },
+        ],
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(200);
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: Attachment-only messages (images, files with no text caption) sent via iMessage/BlueBubbles are rejected with "unable to parse message payload" because `extractMessagePayload` fails when the webhook uses a flat payload structure and `normalizeWebhookMessage` cannot resolve the sender when `handle` is null.
- Why it matters: Users sending images without text captions via iMessage get silently dropped — the agent never receives the image.
- What changed:
  - `extractMessagePayload` now falls back to the payload root when it contains recognizable message keys (`guid`, `handle`, `senderId`, or non-empty `attachments`).
  - Added `chatIdentifier` as a sender fallback for DM chats where `handle` is missing.
- What did NOT change: The existing data/message wrapper extraction logic is untouched; the fallback only activates when all standard paths fail.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Channel: BlueBubbles

## Linked Issue/PR

- Closes #28066

## User-visible / Behavior Changes

Attachment-only messages from iMessage/BlueBubbles are now accepted and forwarded to the agent instead of being rejected with a 400 error.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx vitest run extensions/bluebubbles/src/monitor.test.ts` — 70/70 passed (2 new tests)
- [x] `npx oxfmt --check` — clean

## Human Verification (required)

- Verified scenarios: null-text webhook with attachments accepted; flat payload (no data wrapper) with attachments accepted; existing text+attachment payloads unaffected
- What you did **not** verify: Live BlueBubbles server attachment webhook payloads

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; attachment-only messages return to being rejected (existing behavior)

## Risks and Mitigations

The `looksLikeMessagePayload` fallback only activates when standard extraction paths all fail, minimizing risk to existing behavior.