### PR TITLE
fix(gateway): preserve pairing state for local reconnect recovery

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -251,7 +251,10 @@ describe("GatewayClient close handling", () => {
     );
 
     expect(clearDeviceAuthTokenMock).toHaveBeenCalledWith({ deviceId: "dev-1", role: "operator" });
-    expect(clearDevicePairingMock).toHaveBeenCalledWith("dev-1");
+    expect(clearDevicePairingMock).not.toHaveBeenCalled();
+    expect(logDebugMock).toHaveBeenCalledWith(
+      expect.stringContaining("preserving paired device entry"),
+    );
     expect(onClose).toHaveBeenCalledWith(
       1008,
       "unauthorized: DEVICE token mismatch (rotate/reissue device token)",
@@ -275,24 +278,6 @@ describe("GatewayClient close handling", () => {
       expect.stringContaining("failed clearing stale device-auth token"),
     );
     expect(clearDevicePairingMock).not.toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: device token mismatch");
-    client.stop();
-  });
-
-  it("does not break close flow when pairing clear rejects", async () => {
-    clearDevicePairingMock.mockRejectedValue(new Error("pairing store unavailable"));
-    const onClose = vi.fn();
-    const client = createClientWithIdentity("dev-3", onClose);
-
-    client.start();
-    expect(() => {
-      getLatestWs().emitClose(1008, "unauthorized: device token mismatch");
-    }).not.toThrow();
-
-    await Promise.resolve();
-    expect(logDebugMock).toHaveBeenCalledWith(
-      expect.stringContaining("failed clearing stale device pairing"),
-    );
     expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: device token mismatch");
     client.stop();
   });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -11,7 +11,6 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
-import { clearDevicePairing } from "../infra/device-pairing.js";
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { rawDataToString } from "../infra/ws.js";
 import { logDebug, logError } from "../logger.js";
@@ -198,9 +197,9 @@ export class GatewayClient {
         const role = this.opts.role ?? "operator";
         try {
           clearDeviceAuthToken({ deviceId, role });
-          void clearDevicePairing(deviceId).catch((err) => {
-            logDebug(`failed clearing stale device pairing for device ${deviceId}: ${String(err)}`);
-          });
+          logDebug(
+            `preserving paired device entry for device ${deviceId} after token mismatch; clearing local device-auth token only`,
+          );
           logDebug(`cleared stale device-auth token for device ${deviceId}`);
         } catch (err) {
           logDebug(


### PR DESCRIPTION
## Summary
- preserve paired device entries when a client hits `device token mismatch`
- clear only local cached device token so the next connect can recover with a fresh token
- normalize legacy `devices/paired.json` array format to object-map on load
- add regression tests for both behaviors

## Why
`pairing required` loops can persist when local recovery clears pairing state or when legacy `paired.json` format prevents approvals from persisting correctly.

## Testing
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/client.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/infra/device-pairing.test.ts`

Fixes #22445
Refs #23498
