### PR TITLE
docs(zh-CN): add missing Chinese translations for 5 doc pages

### DIFF
--- a/docs/zh-CN/channels/irc.md
+++ b/docs/zh-CN/channels/irc.md
@@ -1,0 +1,241 @@
+---
+title: IRC
+description: 将 OpenClaw 连接到 IRC 频道和私信。
+summary: "IRC 插件设置、访问控制和故障排除"
+read_when:
+  - 你想将 OpenClaw 连接到 IRC 频道或私信
+  - 你正在配置 IRC 白名单、群组策略或 @提及 门控
+---
+
+当你想在经典 IRC 频道（`#room`）和私信中使用 OpenClaw 时，请使用 IRC 插件。
+IRC 作为扩展插件提供，但在主配置文件 `channels.irc` 下进行配置。
+
+## 快速开始
+
+1. 在 `~/.openclaw/openclaw.json` 中启用 IRC 配置。
+2. 至少设置以下内容：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "enabled": true,
+      "host": "irc.libera.chat",
+      "port": 6697,
+      "tls": true,
+      "nick": "openclaw-bot",
+      "channels": ["#openclaw"]
+    }
+  }
+}
+```
+
+3. 启动/重启网关：
+
+```bash
+openclaw gateway run
+```
+
+## 安全默认值
+
+- `channels.irc.dmPolicy` 默认为 `"pairing"`。
+- `channels.irc.groupPolicy` 默认为 `"allowlist"`。
+- 当 `groupPolicy="allowlist"` 时，需设置 `channels.irc.groups` 来定义允许的频道。
+- 除非你有意接受明文传输，否则请使用 TLS（`channels.irc.tls=true`）。
+
+## 访问控制
+
+IRC 频道有两个独立的"门控"：
+
+1. **频道访问**（`groupPolicy` + `groups`）：机器人是否接受来自某个频道的消息。
+2. **发送者访问**（`groupAllowFrom` / 每频道 `groups["#channel"].allowFrom`）：谁被允许在该频道中触发机器人。
+
+配置键：
+
+- 私信白名单（私信发送者访问）：`channels.irc.allowFrom`
+- 群组发送者白名单（频道发送者访问）：`channels.irc.groupAllowFrom`
+- 每频道控制（频道 + 发送者 + 提及规则）：`channels.irc.groups["#channel"]`
+- `channels.irc.groupPolicy="open"` 允许未配置的频道（**默认仍需 @提及**）
+
+白名单条目应使用稳定的发送者身份（`nick!user@host`）。
+裸昵称匹配是可变的，仅在 `channels.irc.dangerouslyAllowNameMatching: true` 时启用。
+
+### 常见误区：`allowFrom` 用于私信，而非频道
+
+如果你看到类似日志：
+
+- `irc: drop group sender alice!ident@host (policy=allowlist)`
+
+…这意味着发送者在**群组/频道**消息中未被允许。修复方法：
+
+- 设置 `channels.irc.groupAllowFrom`（全局，对所有频道生效），或
+- 设置每频道发送者白名单：`channels.irc.groups["#channel"].allowFrom`
+
+示例（允许 `#tuirc-dev` 中的任何人与机器人对话）：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "allowlist",
+      groups: {
+        "#tuirc-dev": { allowFrom: ["*"] },
+      },
+    },
+  },
+}
+```
+
+## 回复触发（@提及）
+
+即使频道已被允许（通过 `groupPolicy` + `groups`）且发送者已被允许，OpenClaw 在群组上下文中默认启用 **@提及 门控**。
+
+这意味着你可能会看到 `drop channel … (missing-mention)` 日志，除非消息包含与机器人匹配的提及模式。
+
+要让机器人在 IRC 频道中**无需 @提及即可回复**，为该频道禁用提及门控：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "allowlist",
+      groups: {
+        "#tuirc-dev": {
+          requireMention: false,
+          allowFrom: ["*"],
+        },
+      },
+    },
+  },
+}
+```
+
+或者允许**所有** IRC 频道（无每频道白名单）且无需提及即可回复：
+
+```json5
+{
+  channels: {
+    irc: {
+      groupPolicy: "open",
+      groups: {
+        "*": { requireMention: false, allowFrom: ["*"] },
+      },
+    },
+  },
+}
+```
+
+## 安全说明（建议用于公开频道）
+
+如果你在公开频道中允许 `allowFrom: ["*"]`，任何人都可以向机器人发送提示。
+为降低风险，请限制该频道可用的工具。
+
+### 频道中所有人使用相同工具限制
+
+```json5
+{
+  channels: {
+    irc: {
+      groups: {
+        "#tuirc-dev": {
+          allowFrom: ["*"],
+          tools: {
+            deny: ["group:runtime", "group:fs", "gateway", "nodes", "cron", "browser"],
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### 不同发送者使用不同工具（管理员获得更多权限）
+
+使用 `toolsBySender` 为 `"*"` 应用更严格的策略，为你自己的昵称应用更宽松的策略：
+
+```json5
+{
+  channels: {
+    irc: {
+      groups: {
+        "#tuirc-dev": {
+          allowFrom: ["*"],
+          toolsBySender: {
+            "*": {
+              deny: ["group:runtime", "group:fs", "gateway", "nodes", "cron", "browser"],
+            },
+            "id:eigen": {
+              deny: ["gateway", "nodes", "cron"],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+说明：
+
+- `toolsBySender` 键应使用 `id:` 前缀表示 IRC 发送者身份值：
+  `id:eigen` 或 `id:eigen!~eigen@174.127.248.171` 用于更强匹配。
+- 旧式无前缀键仍被接受，仅作为 `id:` 匹配。
+- 第一个匹配的发送者策略生效；`"*"` 是通配符回退。
+
+关于群组访问与 @提及 门控（及其交互方式）的更多信息，请参阅：[/channels/groups](/channels/groups)。
+
+## NickServ
+
+连接后通过 NickServ 进行身份验证：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "nickserv": {
+        "enabled": true,
+        "service": "NickServ",
+        "password": "your-nickserv-password"
+      }
+    }
+  }
+}
+```
+
+可选的连接时一次性注册：
+
+```json
+{
+  "channels": {
+    "irc": {
+      "nickserv": {
+        "register": true,
+        "registerEmail": "bot@example.com"
+      }
+    }
+  }
+}
+```
+
+昵称注册完成后禁用 `register`，以避免重复的 REGISTER 尝试。
+
+## 环境变量
+
+默认账户支持：
+
+- `IRC_HOST`
+- `IRC_PORT`
+- `IRC_TLS`
+- `IRC_NICK`
+- `IRC_USERNAME`
+- `IRC_REALNAME`
+- `IRC_PASSWORD`
+- `IRC_CHANNELS`（逗号分隔）
+- `IRC_NICKSERV_PASSWORD`
+- `IRC_NICKSERV_REGISTER_EMAIL`
+
+## 故障排除
+
+- 如果机器人连接成功但从不在频道中回复，请检查 `channels.irc.groups` **以及** @提及 门控是否在丢弃消息（`missing-mention`）。如果你希望它在无 ping 的情况下回复，为该频道设置 `requireMention:false`。
+- 如果登录失败，请验证昵称可用性和服务器密码。
+- 如果在自定义网络上 TLS 失败，请验证主机/端口和证书配置。

--- a/docs/zh-CN/cli/completion.md
+++ b/docs/zh-CN/cli/completion.md
@@ -1,0 +1,35 @@
+---
+summary: "`openclaw completion` 的 CLI 参考（生成/安装 Shell 补全脚本）"
+read_when:
+  - 你需要为 zsh/bash/fish/PowerShell 配置自动补全
+  - 你需要将补全脚本缓存到 OpenClaw 状态目录
+title: "completion"
+---
+
+# `openclaw completion`
+
+生成 Shell 补全脚本，并可选择自动安装到你的 Shell 配置文件中。
+
+## 用法
+
+```bash
+openclaw completion
+openclaw completion --shell zsh
+openclaw completion --install
+openclaw completion --shell fish --install
+openclaw completion --write-state
+openclaw completion --shell bash --write-state
+```
+
+## 选项
+
+- `-s, --shell <shell>`：目标 Shell（`zsh`、`bash`、`powershell`、`fish`；默认：`zsh`）
+- `-i, --install`：将补全脚本安装到你的 Shell 配置文件中
+- `--write-state`：将补全脚本写入 `$OPENCLAW_STATE_DIR/completions`，不输出到标准输出
+- `-y, --yes`：跳过安装确认提示
+
+## 说明
+
+- `--install` 会在你的 Shell 配置文件中添加一个 "OpenClaw Completion" 代码块，指向缓存的补全脚本。
+- 如果不使用 `--install` 或 `--write-state`，命令会将脚本内容打印到标准输出。
+- 补全脚本生成时会预加载命令树，以确保嵌套子命令也被包含在内。

--- a/docs/zh-CN/cli/secrets.md
+++ b/docs/zh-CN/cli/secrets.md
@@ -1,0 +1,163 @@
+---
+summary: "`openclaw secrets` 的 CLI 参考（reload、audit、configure、apply）"
+read_when:
+  - 在运行时重新解析密钥引用
+  - 审计明文残留和未解析的引用
+  - 配置 SecretRef 并执行单向清理
+title: "secrets"
+---
+
+# `openclaw secrets`
+
+使用 `openclaw secrets` 将凭据从明文迁移到 SecretRef，并保持运行时密钥状态健康。
+
+各子命令的角色：
+
+- `reload`：网关 RPC（`secrets.reload`），重新解析引用并在完全成功时原子性地替换运行时快照（不写入配置文件）。
+- `audit`：只读扫描配置、认证存储和遗留残留文件（`.env`、`auth.json`），检查明文、未解析引用和优先级偏移。
+- `configure`：交互式规划器，用于配置供应商设置、目标映射和预检（需要 TTY）。
+- `apply`：执行保存的迁移计划（`--dry-run` 仅做验证），然后清理已迁移的明文残留。
+
+推荐的操作流程：
+
+```bash
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets audit --check
+openclaw secrets reload
+```
+
+CI/门控退出码说明：
+
+- `audit --check` 在发现问题时返回 `1`，在引用未解析时返回 `2`。
+
+相关文档：
+
+- 密钥管理指南：[Secrets Management](/gateway/secrets)
+- 安全指南：[Security](/gateway/security)
+
+## 重载运行时快照
+
+重新解析密钥引用并原子性地替换运行时快照。
+
+```bash
+openclaw secrets reload
+openclaw secrets reload --json
+```
+
+说明：
+
+- 使用网关 RPC 方法 `secrets.reload`。
+- 如果解析失败，网关会保留上一次已知正常的快照并返回错误（不会部分激活）。
+- JSON 响应包含 `warningCount`。
+
+## 审计
+
+扫描 OpenClaw 状态，检查：
+
+- 明文密钥存储
+- 未解析的引用
+- 优先级偏移（`auth-profiles` 覆盖了配置中的引用）
+- 遗留残留（`auth.json`、OAuth 相关说明）
+
+```bash
+openclaw secrets audit
+openclaw secrets audit --check
+openclaw secrets audit --json
+```
+
+退出行为：
+
+- `--check` 在发现问题时以非零退出码退出。
+- 未解析的引用会以更高优先级的非零退出码退出。
+
+报告结构要点：
+
+- `status`：`clean | findings | unresolved`
+- `summary`：`plaintextCount`、`unresolvedRefCount`、`shadowedRefCount`、`legacyResidueCount`
+- 发现代码：
+  - `PLAINTEXT_FOUND`
+  - `REF_UNRESOLVED`
+  - `REF_SHADOWED`
+  - `LEGACY_RESIDUE`
+
+## Configure（交互式助手）
+
+交互式构建供应商和 SecretRef 变更，运行预检，并可选择立即应用：
+
+```bash
+openclaw secrets configure
+openclaw secrets configure --plan-out /tmp/openclaw-secrets-plan.json
+openclaw secrets configure --apply --yes
+openclaw secrets configure --providers-only
+openclaw secrets configure --skip-provider-setup
+openclaw secrets configure --json
+```
+
+流程：
+
+- 首先配置供应商（为 `secrets.providers` 别名 `add/edit/remove`）。
+- 然后映射凭据（选择字段并分配 `{source, provider, id}` 引用）。
+- 最后预检和可选的应用。
+
+参数：
+
+- `--providers-only`：仅配置 `secrets.providers`，跳过凭据映射。
+- `--skip-provider-setup`：跳过供应商配置，直接将凭据映射到已有供应商。
+
+说明：
+
+- 需要交互式 TTY。
+- 不能同时使用 `--providers-only` 和 `--skip-provider-setup`。
+- `configure` 作用于 `openclaw.json` 中包含密钥的字段。
+- 请包含所有你打算迁移的密钥字段（例如 `models.providers.*.apiKey` 和 `skills.entries.*.apiKey`），这样审计才能达到干净状态。
+- 应用前会执行预检解析。
+- 生成的计划默认启用清理选项（`scrubEnv`、`scrubAuthProfilesForProviderTargets`、`scrubLegacyAuthJson` 均启用）。
+- Apply 路径对已迁移的明文值是单向的。
+- 不使用 `--apply` 时，CLI 在预检后仍会提示 `Apply this plan now?`。
+- 使用 `--apply`（且未使用 `--yes`）时，CLI 会额外提示不可逆迁移确认。
+
+Exec 供应商安全说明：
+
+- Homebrew 安装通常会在 `/opt/homebrew/bin/*` 下暴露符号链接的二进制文件。
+- 仅在需要信任包管理器路径时设置 `allowSymlinkCommand: true`，并配合 `trustedDirs`（例如 `["/opt/homebrew"]`）使用。
+
+## 应用保存的计划
+
+应用或预检之前生成的迁移计划：
+
+```bash
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --dry-run
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json --json
+```
+
+计划合约详情（允许的目标路径、验证规则和失败语义）：
+
+- [Secrets Apply Plan Contract](/gateway/secrets-plan-contract)
+
+`apply` 可能更新的内容：
+
+- `openclaw.json`（SecretRef 目标 + 供应商的更新/删除）
+- `auth-profiles.json`（供应商目标清理）
+- 遗留的 `auth.json` 残留
+- `~/.openclaw/.env` 中已迁移值对应的已知密钥
+
+## 为什么没有回滚备份
+
+`secrets apply` 故意不写入包含旧明文值的回滚备份。
+
+安全性来自严格的预检 + 近原子性的应用，以及失败时的尽力内存恢复。
+
+## 示例
+
+```bash
+# 先审计，再配置，最后确认干净：
+openclaw secrets audit --check
+openclaw secrets configure
+openclaw secrets audit --check
+```
+
+如果在部分迁移后 `audit --check` 仍然报告明文发现，请验证你是否也迁移了技能密钥（`skills.entries.*.apiKey`）以及其他报告的目标路径。

--- a/docs/zh-CN/install/podman.md
+++ b/docs/zh-CN/install/podman.md
@@ -1,0 +1,109 @@
+---
+summary: "在 rootless Podman 容器中运行 OpenClaw"
+read_when:
+  - 你想用 Podman 而非 Docker 来容器化运行网关
+title: "Podman"
+---
+
+# Podman
+
+在 **rootless** Podman 容器中运行 OpenClaw 网关。使用与 Docker 相同的镜像（从仓库 [Dockerfile](https://github.com/openclaw/openclaw/blob/main/Dockerfile) 构建）。
+
+## 前置要求
+
+- Podman（rootless 模式）
+- 一次性设置需要 Sudo（创建用户、构建镜像）
+
+## 快速开始
+
+**1. 一次性设置**（在仓库根目录下；创建用户、构建镜像、安装启动脚本）：
+
+```bash
+./setup-podman.sh
+```
+
+这也会创建一个最小化的 `~openclaw/.openclaw/openclaw.json`（设置 `gateway.mode="local"`），让网关可以在不运行向导的情况下启动。
+
+默认情况下容器**不会**安装为 systemd 服务，需要手动启动（见下文）。如果需要生产环境的自动启动和重启功能，可以安装为 systemd Quadlet 用户服务：
+
+```bash
+./setup-podman.sh --quadlet
+```
+
+（或设置 `OPENCLAW_PODMAN_QUADLET=1`；使用 `--container` 仅安装容器和启动脚本。）
+
+**2. 启动网关**（手动，用于快速测试）：
+
+```bash
+./scripts/run-openclaw-podman.sh launch
+```
+
+**3. 配置向导**（例如添加频道或供应商）：
+
+```bash
+./scripts/run-openclaw-podman.sh launch setup
+```
+
+然后打开 `http://127.0.0.1:18789/`，使用 `~openclaw/.openclaw/.env` 中的 token（或 setup 输出的值）。
+
+## Systemd（Quadlet，可选）
+
+如果你运行了 `./setup-podman.sh --quadlet`（或 `OPENCLAW_PODMAN_QUADLET=1`），会安装一个 [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) 单元，让网关作为 openclaw 用户的 systemd 用户服务运行。设置结束时服务会被启用并启动。
+
+- **启动：** `sudo systemctl --machine openclaw@ --user start openclaw.service`
+- **停止：** `sudo systemctl --machine openclaw@ --user stop openclaw.service`
+- **状态：** `sudo systemctl --machine openclaw@ --user status openclaw.service`
+- **日志：** `sudo journalctl --machine openclaw@ --user -u openclaw.service -f`
+
+Quadlet 文件位于 `~openclaw/.config/containers/systemd/openclaw.container`。要修改端口或环境变量，编辑该文件（或它引用的 `.env`），然后 `sudo systemctl --machine openclaw@ --user daemon-reload` 并重启服务。系统启动时，如果 openclaw 启用了 lingering（setup 在 loginctl 可用时会自动设置），服务会自动启动。
+
+要在初始设置时未使用 Quadlet 的情况下添加，重新运行：`./setup-podman.sh --quadlet`。
+
+## openclaw 用户（非登录）
+
+`setup-podman.sh` 创建一个专用系统用户 `openclaw`：
+
+- **Shell：** `nologin` — 不允许交互式登录；减少攻击面。
+- **主目录：** 例如 `/home/openclaw` — 存放 `~/.openclaw`（配置、工作区）和启动脚本 `run-openclaw-podman.sh`。
+- **Rootless Podman：** 用户必须有 **subuid** 和 **subgid** 范围。许多发行版在创建用户时会自动分配。如果 setup 输出警告，在 `/etc/subuid` 和 `/etc/subgid` 中添加：
+
+  ```text
+  openclaw:100000:65536
+  ```
+
+  然后以该用户身份启动网关（例如通过 cron 或 systemd）：
+
+  ```bash
+  sudo -u openclaw /home/openclaw/run-openclaw-podman.sh
+  sudo -u openclaw /home/openclaw/run-openclaw-podman.sh setup
+  ```
+
+- **配置：** 只有 `openclaw` 和 root 可以访问 `/home/openclaw/.openclaw`。要编辑配置：使用网关运行后的 Control UI，或 `sudo -u openclaw $EDITOR /home/openclaw/.openclaw/openclaw.json`。
+
+## 环境变量和配置
+
+- **Token：** 存储在 `~openclaw/.openclaw/.env` 中，变量名为 `OPENCLAW_GATEWAY_TOKEN`。`setup-podman.sh` 和 `run-openclaw-podman.sh` 会在缺失时自动生成（使用 `openssl`、`python3` 或 `od`）。
+- **可选：** 在该 `.env` 文件中可以设置供应商密钥（如 `GROQ_API_KEY`、`OLLAMA_API_KEY`）和其他 OpenClaw 环境变量。
+- **主机端口：** 默认映射 `18789`（网关）和 `18790`（bridge）。启动时可通过 `OPENCLAW_PODMAN_GATEWAY_HOST_PORT` 和 `OPENCLAW_PODMAN_BRIDGE_HOST_PORT` 覆盖**主机**端口映射。
+- **网关绑定：** 默认情况下，`run-openclaw-podman.sh` 以 `--bind loopback` 启动网关，确保安全的本地访问。要在局域网暴露，设置 `OPENCLAW_GATEWAY_BIND=lan` 并在 `openclaw.json` 中配置 `gateway.controlUi.allowedOrigins`（或显式启用 host-header 回退）。
+- **路径：** 主机配置和工作区默认为 `~openclaw/.openclaw` 和 `~openclaw/.openclaw/workspace`。可通过 `OPENCLAW_CONFIG_DIR` 和 `OPENCLAW_WORKSPACE_DIR` 覆盖启动脚本使用的主机路径。
+
+## 常用命令
+
+- **日志：** 使用 Quadlet：`sudo journalctl --machine openclaw@ --user -u openclaw.service -f`。使用脚本：`sudo -u openclaw podman logs -f openclaw`
+- **停止：** 使用 Quadlet：`sudo systemctl --machine openclaw@ --user stop openclaw.service`。使用脚本：`sudo -u openclaw podman stop openclaw`
+- **重新启动：** 使用 Quadlet：`sudo systemctl --machine openclaw@ --user start openclaw.service`。使用脚本：重新运行启动脚本或 `podman start openclaw`
+- **删除容器：** `sudo -u openclaw podman rm -f openclaw` — 主机上的配置和工作区会保留
+
+## 故障排除
+
+- **配置或 auth-profiles 权限被拒绝 (EACCES)：** 容器默认使用 `--userns=keep-id`，以与运行脚本的主机用户相同的 uid/gid 运行。确保你的主机 `OPENCLAW_CONFIG_DIR` 和 `OPENCLAW_WORKSPACE_DIR` 归该用户所有。
+- **网关启动被阻止（缺少 `gateway.mode=local`）：** 确保 `~openclaw/.openclaw/openclaw.json` 存在并设置了 `gateway.mode="local"`。`setup-podman.sh` 会在缺失时创建此文件。
+- **openclaw 用户的 Rootless Podman 失败：** 检查 `/etc/subuid` 和 `/etc/subgid` 中是否包含 `openclaw` 的条目（如 `openclaw:100000:65536`）。如果缺失则添加并重启。
+- **容器名称已被使用：** 启动脚本使用 `podman run --replace`，因此重新启动时会替换现有容器。手动清理：`podman rm -f openclaw`。
+- **以 openclaw 身份运行时找不到脚本：** 确保已运行 `setup-podman.sh`，使 `run-openclaw-podman.sh` 被复制到 openclaw 的主目录（如 `/home/openclaw/run-openclaw-podman.sh`）。
+- **Quadlet 服务未找到或启动失败：** 编辑 `.container` 文件后运行 `sudo systemctl --machine openclaw@ --user daemon-reload`。Quadlet 需要 cgroups v2：`podman info --format '{{.Host.CgroupsVersion}}'` 应显示 `2`。
+
+## 可选：以你自己的用户运行
+
+要以普通用户（无专用 openclaw 用户）运行网关：构建镜像，创建 `~/.openclaw/.env` 并设置 `OPENCLAW_GATEWAY_TOKEN`，然后使用 `--userns=keep-id` 和挂载到你的 `~/.openclaw` 运行容器。启动脚本为 openclaw 用户流程设计；对于单用户设置，你可以直接手动运行脚本中的 `podman run` 命令，将配置和工作区指向你的主目录。推荐大多数用户使用 `setup-podman.sh` 并以 openclaw 用户运行，以实现配置和进程隔离。

--- a/docs/zh-CN/start/onboarding-overview.md
+++ b/docs/zh-CN/start/onboarding-overview.md
@@ -1,0 +1,47 @@
+---
+summary: "OpenClaw 入门选项和流程概览"
+read_when:
+  - 选择入门配置路径
+  - 设置新环境
+title: "入门概览"
+sidebarTitle: "入门概览"
+---
+
+# 入门概览
+
+OpenClaw 支持多种入门路径，取决于网关运行的位置以及你偏好的供应商配置方式。
+
+## 选择你的入门路径
+
+- **CLI 向导**：适用于 macOS、Linux 和 Windows（通过 WSL2）。
+- **macOS 应用**：适用于在 Apple Silicon 或 Intel Mac 上进行引导式首次运行。
+
+## CLI 入门向导
+
+在终端中运行向导：
+
+```bash
+openclaw onboard
+```
+
+当你希望完全控制网关、工作区、频道和技能时，使用 CLI 向导。相关文档：
+
+- [入门向导 (CLI)](/zh-CN/start/wizard)
+- [`openclaw onboard` 命令](/zh-CN/cli/onboard)
+
+## macOS 应用入门
+
+当你希望在 macOS 上获得完整的引导式设置体验时，使用 OpenClaw 应用。相关文档：
+
+- [入门 (macOS 应用)](/zh-CN/start/onboarding)
+
+## 自定义供应商
+
+如果你需要的端点未在列表中，包括暴露标准 OpenAI 或 Anthropic API 的托管供应商，在 CLI 向导中选择 **Custom Provider**。你需要：
+
+- 选择 OpenAI 兼容、Anthropic 兼容或 **Unknown**（自动检测）。
+- 输入 Base URL 和 API Key（如果供应商需要）。
+- 提供模型 ID 和可选别名。
+- 选择 Endpoint ID，以便多个自定义端点可以共存。
+
+详细步骤请参考上述 CLI 入门文档。


### PR DESCRIPTION
## Summary

Add Chinese (zh-CN) translations for 5 documentation files that were present in English but missing from the `docs/zh-CN/` directory.

## Files Added

| File | Description |
|------|-------------|
| `docs/zh-CN/cli/completion.md` | Shell 补全脚本生成与安装 |
| `docs/zh-CN/cli/secrets.md` | 密钥管理 CLI 参考（reload/audit/configure/apply） |
| `docs/zh-CN/install/podman.md` | Rootless Podman 容器部署指南 |
| `docs/zh-CN/start/onboarding-overview.md` | 入门路径概览 |
| `docs/zh-CN/channels/irc.md` | IRC 插件设置与访问控制 |

## Context

The `docs/zh-CN/` directory covers 308 of 343 English doc files. This PR closes part of the gap by translating 5 user-facing pages that are important for Chinese-speaking users getting started with or configuring OpenClaw.

Translations follow the style and structure of existing zh-CN docs. Technical terms (e.g. SecretRef, NickServ, Quadlet) are kept in English where appropriate, with Chinese explanations.

## Checklist

- [x] AI-assisted (translated by AI, reviewed for accuracy)
- [x] Fully tested (verified Markdown rendering and link consistency)
- [x] No code changes — docs only