### PR TITLE
fix(gateway): surface HTTP upgrade rejection details on ws 1006 closes

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -10,12 +11,13 @@ const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const clearDevicePairingMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
 
-type WsEvent = "open" | "message" | "close" | "error";
+type WsEvent = "open" | "message" | "close" | "error" | "unexpected-response";
 type WsEventHandlers = {
   open: () => void;
   message: (data: string | Buffer) => void;
   close: (code: number, reason: Buffer) => void;
   error: (err: unknown) => void;
+  "unexpected-response": (request: unknown, response: EventEmitter) => void;
 };
 
 class MockWebSocket {
@@ -23,6 +25,7 @@ class MockWebSocket {
   private messageHandlers: WsEventHandlers["message"][] = [];
   private closeHandlers: WsEventHandlers["close"][] = [];
   private errorHandlers: WsEventHandlers["error"][] = [];
+  private unexpectedResponseHandlers: WsEventHandlers["unexpected-response"][] = [];
   readonly sent: string[] = [];
 
   constructor(_url: string, _options?: unknown) {
@@ -33,6 +36,7 @@ class MockWebSocket {
   on(event: "message", handler: WsEventHandlers["message"]): void;
   on(event: "close", handler: WsEventHandlers["close"]): void;
   on(event: "error", handler: WsEventHandlers["error"]): void;
+  on(event: "unexpected-response", handler: WsEventHandlers["unexpected-response"]): void;
   on(event: WsEvent, handler: WsEventHandlers[WsEvent]): void {
     switch (event) {
       case "open":
@@ -46,6 +50,9 @@ class MockWebSocket {
         return;
       case "error":
         this.errorHandlers.push(handler as WsEventHandlers["error"]);
+        return;
+      case "unexpected-response":
+        this.unexpectedResponseHandlers.push(handler as WsEventHandlers["unexpected-response"]);
         return;
       default:
         return;
@@ -74,6 +81,26 @@ class MockWebSocket {
     for (const handler of this.closeHandlers) {
       handler(code, Buffer.from(reason));
     }
+  }
+
+  emitUnexpectedResponse(params: {
+    statusCode?: number;
+    statusMessage?: string;
+    body?: string;
+  }): void {
+    const response = new EventEmitter() as EventEmitter & {
+      statusCode?: number;
+      statusMessage?: string;
+    };
+    response.statusCode = params.statusCode;
+    response.statusMessage = params.statusMessage;
+    for (const handler of this.unexpectedResponseHandlers) {
+      handler({}, response);
+    }
+    if (params.body !== undefined) {
+      response.emit("data", Buffer.from(params.body));
+    }
+    response.emit("end");
   }
 }
 
@@ -307,6 +334,35 @@ describe("GatewayClient close handling", () => {
     expect(clearDeviceAuthTokenMock).not.toHaveBeenCalled();
     expect(clearDevicePairingMock).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: signature invalid");
+    client.stop();
+  });
+
+  it("surfaces HTTP upgrade rejection details when close reason is empty", () => {
+    const onClose = vi.fn();
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onClose,
+      onConnectError,
+    });
+
+    client.start();
+    getLatestWs().emitUnexpectedResponse({
+      statusCode: 401,
+      statusMessage: "Unauthorized",
+      body: "Unauthorized",
+    });
+    getLatestWs().emitClose(1006, "");
+
+    expect(onConnectError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("HTTP 401 Unauthorized"),
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith(
+      1006,
+      expect.stringContaining("gateway upgrade rejected (HTTP 401 Unauthorized): Unauthorized"),
+    );
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { WebSocket, type ClientOptions, type CertMeta } from "ws";
 import {
@@ -96,6 +97,7 @@ export class GatewayClient {
   private lastTick: number | null = null;
   private tickIntervalMs = 30_000;
   private tickTimer: NodeJS.Timeout | null = null;
+  private upgradeRejectHint: string | null = null;
 
   constructor(opts: GatewayClientOptions) {
     this.opts = {
@@ -167,8 +169,46 @@ export class GatewayClient {
         // oxlint-disable-next-line typescript/no-explicit-any
       }) as any;
     }
+    this.upgradeRejectHint = null;
     this.ws = new WebSocket(url, wsOptions);
 
+    this.ws.on("unexpected-response", (_request, response) => {
+      const statusCode = response.statusCode;
+      const statusText = response.statusMessage?.trim();
+      let bufferedBytes = 0;
+      const bodyChunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer | string) => {
+        if (bufferedBytes >= 1024) {
+          return;
+        }
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const remaining = 1024 - bufferedBytes;
+        if (buf.length <= remaining) {
+          bodyChunks.push(buf);
+          bufferedBytes += buf.length;
+          return;
+        }
+        bodyChunks.push(buf.subarray(0, remaining));
+        bufferedBytes += remaining;
+      });
+      response.on("end", () => {
+        const bodyRaw = Buffer.concat(bodyChunks).toString("utf8");
+        const body = bodyRaw.replace(/\s+/g, " ").trim();
+        const bodySuffix = body ? `: ${body}` : "";
+        const statusSuffix = statusText ? ` ${statusText}` : "";
+        const hint =
+          typeof statusCode === "number"
+            ? `gateway upgrade rejected (HTTP ${statusCode}${statusSuffix})${bodySuffix}`
+            : `gateway upgrade rejected${bodySuffix}`;
+        this.upgradeRejectHint = hint;
+        this.opts.onConnectError?.(new Error(hint));
+      });
+      response.on("error", () => {
+        const hint = "gateway upgrade rejected (failed to read response body)";
+        this.upgradeRejectHint = hint;
+        this.opts.onConnectError?.(new Error(hint));
+      });
+    });
     this.ws.on("open", () => {
       if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
         const tlsError = this.validateTlsFingerprint();
@@ -182,7 +222,11 @@ export class GatewayClient {
     });
     this.ws.on("message", (data) => this.handleMessage(rawDataToString(data)));
     this.ws.on("close", (code, reason) => {
-      const reasonText = rawDataToString(reason);
+      let reasonText = rawDataToString(reason);
+      if (!reasonText && code === 1006 && this.upgradeRejectHint) {
+        reasonText = this.upgradeRejectHint;
+      }
+      this.upgradeRejectHint = null;
       this.ws = null;
       // Clear persisted device auth state only when device-token auth was active.
       // Shared token/password failures can return the same close reason but should


### PR DESCRIPTION
## Summary
- capture HTTP upgrade rejection details from websocket `unexpected-response` events in `GatewayClient`
- reuse that hint when websocket close code is `1006` with an empty close reason
- add regression coverage so clients surface actionable `HTTP <status>` errors instead of opaque `no close reason`

## Testing
- pnpm vitest src/gateway/client.test.ts

Closes #8227
