### PR TITLE
fix(onboarding): always prompt for OpenRouter API key replacement

### DIFF
--- a/src/commands/auth-choice.apply-helpers.test.ts
+++ b/src/commands/auth-choice.apply-helpers.test.ts
@@ -229,6 +229,36 @@ describe("ensureApiKeyFromEnvOrPrompt", () => {
     expect(text).not.toHaveBeenCalled();
   });
 
+  it("never includes API key preview in env confirmation prompt", async () => {
+    process.env.MINIMAX_API_KEY = "sk-minimax-secret-value";
+    delete process.env.MINIMAX_OAUTH_TOKEN;
+
+    const { confirm, text } = createPromptSpies({
+      confirmResult: true,
+      textResult: "prompt-key",
+    });
+    const setCredential = vi.fn(async () => undefined);
+
+    await ensureMinimaxApiKey({
+      confirm,
+      text,
+      setCredential,
+    });
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Use existing MINIMAX_API_KEY (env: MINIMAX_API_KEY)?",
+      }),
+    );
+    const confirmCall = (
+      confirm.mock.calls as unknown as Array<[{ message?: string }] | undefined>
+    )[0];
+    const confirmMessage = String(confirmCall?.[0]?.message ?? "");
+    expect(confirmMessage).not.toContain("sk-minimax-secret-value");
+    expect(confirmMessage).not.toContain("sk-m");
+    expect(confirmMessage).not.toContain("alue");
+  });
+
   it("falls back to prompt when env is declined", async () => {
     const { result, setCredential, text } = await runEnsureMinimaxApiKeyFlow({
       confirmResult: false,

--- a/src/commands/auth-choice.apply-helpers.ts
+++ b/src/commands/auth-choice.apply-helpers.ts
@@ -9,7 +9,6 @@ import {
 } from "../secrets/ref-contract.js";
 import { resolveSecretRefString } from "../secrets/resolve.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { formatApiKeyPreview } from "./auth-choice.api-key.js";
 import type { ApplyAuthChoiceParams } from "./auth-choice.apply.js";
 import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 import type { SecretInputMode } from "./onboard-types.js";
@@ -510,7 +509,7 @@ export async function ensureApiKeyFromEnvOrPrompt(params: {
 
   if (envKey && selectedMode === "plaintext") {
     const useExisting = await params.prompter.confirm({
-      message: `Use existing ${params.envLabel} (${envKey.source}, ${formatApiKeyPreview(envKey.apiKey)})?`,
+      message: `Use existing ${params.envLabel} (${envKey.source})?`,
       initialValue: true,
     });
     if (useExisting) {

--- a/src/commands/auth-choice.apply.openrouter.test.ts
+++ b/src/commands/auth-choice.apply.openrouter.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyAuthChoiceOpenRouter } from "./auth-choice.apply.openrouter.js";
+import { setOpenrouterApiKey } from "./onboard-auth.js";
+import {
+  createAuthTestLifecycle,
+  createExitThrowingRuntime,
+  createWizardPrompter,
+  readAuthProfilesForAgent,
+  setupAuthTestEnv,
+} from "./test-wizard-helpers.js";
+
+describe("applyAuthChoiceOpenRouter", () => {
+  const lifecycle = createAuthTestLifecycle([
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_AGENT_DIR",
+    "PI_CODING_AGENT_DIR",
+    "OPENROUTER_API_KEY",
+  ]);
+
+  async function setupTempState() {
+    const env = await setupAuthTestEnv("openclaw-openrouter-");
+    lifecycle.setStateDir(env.stateDir);
+    return env.agentDir;
+  }
+
+  afterEach(async () => {
+    await lifecycle.cleanup();
+  });
+
+  it("prompts for API key even when an OpenRouter key already exists", async () => {
+    const agentDir = await setupTempState();
+    await setOpenrouterApiKey("old-openrouter-key", agentDir);
+
+    const confirm = vi.fn(async () => true);
+    const text = vi.fn(async () => "new-openrouter-key");
+    const prompter = createWizardPrompter({ confirm, text }, { defaultSelect: "plaintext" });
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoiceOpenRouter({
+      authChoice: "openrouter-api-key",
+      config: {
+        auth: {
+          profiles: {
+            "openrouter:legacy": {
+              provider: "openrouter",
+              mode: "oauth",
+            },
+          },
+        },
+      },
+      prompter,
+      runtime,
+      setDefaultModel: true,
+    });
+
+    expect(result.config.auth?.profiles?.["openrouter:default"]).toMatchObject({
+      provider: "openrouter",
+      mode: "api_key",
+    });
+    expect(text).toHaveBeenCalledTimes(1);
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, { key?: string }>;
+    }>(agentDir);
+    expect(parsed.profiles?.["openrouter:default"]?.key).toBe("new-openrouter-key");
+  });
+});

--- a/src/commands/auth-choice.apply.openrouter.ts
+++ b/src/commands/auth-choice.apply.openrouter.ts
@@ -1,4 +1,3 @@
-import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../agents/auth-profiles.js";
 import { normalizeApiKeyInput, validateApiKeyInput } from "./auth-choice.api-key.js";
 import {
   createAuthChoiceAgentModelNoter,
@@ -22,59 +21,29 @@ export async function applyAuthChoiceOpenRouter(
   let agentModelOverride: string | undefined;
   const noteAgentModel = createAuthChoiceAgentModelNoter(params);
   const requestedSecretInputMode = normalizeSecretInputModeInput(params.opts?.secretInputMode);
-
-  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
-  const profileOrder = resolveAuthProfileOrder({
-    cfg: nextConfig,
-    store,
+  await ensureApiKeyFromOptionEnvOrPrompt({
+    token: params.opts?.token,
+    tokenProvider: params.opts?.tokenProvider,
+    secretInputMode: requestedSecretInputMode,
+    config: nextConfig,
+    expectedProviders: ["openrouter"],
     provider: "openrouter",
+    envLabel: "OPENROUTER_API_KEY",
+    promptMessage: "Enter OpenRouter API key",
+    normalize: normalizeApiKeyInput,
+    validate: validateApiKeyInput,
+    prompter: params.prompter,
+    setCredential: async (apiKey, mode) =>
+      setOpenrouterApiKey(apiKey, params.agentDir, { secretInputMode: mode }),
   });
-  const existingProfileId = profileOrder.find((profileId) => Boolean(store.profiles[profileId]));
-  const existingCred = existingProfileId ? store.profiles[existingProfileId] : undefined;
-  let profileId = "openrouter:default";
-  let mode: "api_key" | "oauth" | "token" = "api_key";
-  let hasCredential = false;
 
-  if (existingProfileId && existingCred?.type) {
-    profileId = existingProfileId;
-    mode =
-      existingCred.type === "oauth" ? "oauth" : existingCred.type === "token" ? "token" : "api_key";
-    hasCredential = true;
-  }
-
-  if (!hasCredential && params.opts?.token && params.opts?.tokenProvider === "openrouter") {
-    await setOpenrouterApiKey(normalizeApiKeyInput(params.opts.token), params.agentDir, {
-      secretInputMode: requestedSecretInputMode,
-    });
-    hasCredential = true;
-  }
-
-  if (!hasCredential) {
-    await ensureApiKeyFromOptionEnvOrPrompt({
-      token: params.opts?.token,
-      tokenProvider: params.opts?.tokenProvider,
-      secretInputMode: requestedSecretInputMode,
-      config: nextConfig,
-      expectedProviders: ["openrouter"],
-      provider: "openrouter",
-      envLabel: "OPENROUTER_API_KEY",
-      promptMessage: "Enter OpenRouter API key",
-      normalize: normalizeApiKeyInput,
-      validate: validateApiKeyInput,
-      prompter: params.prompter,
-      setCredential: async (apiKey, mode) =>
-        setOpenrouterApiKey(apiKey, params.agentDir, { secretInputMode: mode }),
-    });
-    hasCredential = true;
-  }
-
-  if (hasCredential) {
-    nextConfig = applyAuthProfileConfig(nextConfig, {
-      profileId,
-      provider: "openrouter",
-      mode,
-    });
-  }
+  // OpenRouter API key onboarding always writes `openrouter:default` credentials.
+  // Keep config pointer in sync even if legacy oauth/token profiles exist.
+  nextConfig = applyAuthProfileConfig(nextConfig, {
+    profileId: "openrouter:default",
+    provider: "openrouter",
+    mode: "api_key",
+  });
 
   const applied = await applyDefaultModelChoice({
     config: nextConfig,


### PR DESCRIPTION
## Summary
- remove the OpenRouter credential short-circuit in API-key onboarding so choosing "OpenRouter API key" always runs key input flow
- always point config auth profile to `openrouter:default` in `api_key` mode to match where credentials are written
- add regression coverage for the existing-key replacement path

## Testing
- pnpm vitest src/commands/auth-choice.apply.openrouter.test.ts

Closes #8983
