### PR TITLE
feat: add provider billing reset countdown to error messages

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -2,11 +2,14 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { FailoverReason } from "./types.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
+import { formatResetCountdown } from "../provider-reset-times.js";
 
 export function formatBillingErrorMessage(provider?: string): string {
   const providerName = provider?.trim();
   if (providerName) {
-    return `⚠️ ${providerName} returned a billing error — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
+    const countdown = formatResetCountdown(providerName);
+    const resetHint = countdown ? ` (${countdown})` : "";
+    return `⚠️ ${providerName} returned a billing error${resetHint} — your API key has run out of credits or has an insufficient balance. Check your ${providerName} billing dashboard and top up or switch to a different API key.`;
   }
   return "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.";
 }

--- a/src/agents/provider-reset-times.test.ts
+++ b/src/agents/provider-reset-times.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  getResetSchedule,
+  msUntilReset,
+  formatResetCountdown,
+} from "./provider-reset-times.js";
+
+describe("provider-reset-times", () => {
+  describe("getResetSchedule", () => {
+    it("returns daily schedule for Venice", () => {
+      const schedule = getResetSchedule("venice");
+      expect(schedule).toEqual({ kind: "daily", utcHour: 0 });
+    });
+
+    it("returns daily schedule for Venice (case-insensitive)", () => {
+      expect(getResetSchedule("Venice")).toEqual({ kind: "daily", utcHour: 0 });
+      expect(getResetSchedule("VENICE")).toEqual({ kind: "daily", utcHour: 0 });
+      expect(getResetSchedule("venice.ai")).toEqual({ kind: "daily", utcHour: 0 });
+    });
+
+    it("returns monthly schedule for OpenAI", () => {
+      expect(getResetSchedule("openai")).toEqual({ kind: "monthly", dayOfMonth: 1, utcHour: 0 });
+    });
+
+    it("returns monthly schedule for Anthropic", () => {
+      expect(getResetSchedule("anthropic")).toEqual({ kind: "monthly", dayOfMonth: 1, utcHour: 0 });
+    });
+
+    it("returns none for Morpheus (free beta)", () => {
+      expect(getResetSchedule("mor-gateway")).toEqual({ kind: "none" });
+      expect(getResetSchedule("morpheus")).toEqual({ kind: "none" });
+    });
+
+    it("returns none for unknown providers", () => {
+      expect(getResetSchedule("some-random-provider")).toEqual({ kind: "none" });
+    });
+  });
+
+  describe("msUntilReset", () => {
+    it("returns null for unknown providers", () => {
+      expect(msUntilReset("unknown", Date.now())).toBeNull();
+    });
+
+    it("returns null for providers with no schedule", () => {
+      expect(msUntilReset("mor-gateway", Date.now())).toBeNull();
+    });
+
+    it("calculates time until midnight UTC for Venice", () => {
+      // 2026-02-27 18:00:00 UTC = 6 hours before midnight
+      const now = Date.UTC(2026, 1, 27, 18, 0, 0);
+      const ms = msUntilReset("venice", now);
+      expect(ms).toBe(6 * 60 * 60 * 1000); // 6 hours
+    });
+
+    it("calculates correctly when just past midnight UTC", () => {
+      // 2026-02-27 00:01:00 UTC = just past midnight, ~24h until next reset
+      const now = Date.UTC(2026, 1, 27, 0, 1, 0);
+      const ms = msUntilReset("venice", now);
+      // Should be ~23h 59m
+      expect(ms).toBeGreaterThan(23 * 60 * 60 * 1000);
+      expect(ms).toBeLessThan(24 * 60 * 60 * 1000);
+    });
+
+    it("calculates monthly reset for OpenAI", () => {
+      // 2026-02-15 12:00:00 UTC = mid-month, should reset on March 1
+      const now = Date.UTC(2026, 1, 15, 12, 0, 0);
+      const ms = msUntilReset("openai", now);
+      const expectedReset = Date.UTC(2026, 2, 1, 0, 0, 0); // March 1
+      expect(ms).toBe(expectedReset - now);
+    });
+
+    it("wraps to next month when past the reset day", () => {
+      // 2026-02-02 00:00:00 UTC = just past the 1st
+      const now = Date.UTC(2026, 1, 2, 0, 0, 0);
+      const ms = msUntilReset("openai", now);
+      const expectedReset = Date.UTC(2026, 2, 1, 0, 0, 0); // March 1
+      expect(ms).toBe(expectedReset - now);
+    });
+  });
+
+  describe("formatResetCountdown", () => {
+    it("returns null for unknown providers", () => {
+      expect(formatResetCountdown("unknown")).toBeNull();
+    });
+
+    it("formats hours and minutes for Venice", () => {
+      // 6 hours before midnight UTC
+      const now = Date.UTC(2026, 1, 27, 18, 0, 0);
+      expect(formatResetCountdown("venice", now)).toBe("resets in 6h 0m");
+    });
+
+    it("formats minutes only when under an hour", () => {
+      // 30 minutes before midnight UTC
+      const now = Date.UTC(2026, 1, 27, 23, 30, 0);
+      expect(formatResetCountdown("venice", now)).toBe("resets in 30m");
+    });
+
+    it("formats days for long waits", () => {
+      // Feb 2 — 27 days until March 1 reset
+      const now = Date.UTC(2026, 1, 2, 0, 0, 0);
+      const result = formatResetCountdown("openai", now);
+      expect(result).toMatch(/resets in \d+d \d+h/);
+    });
+  });
+});

--- a/src/agents/provider-reset-times.ts
+++ b/src/agents/provider-reset-times.ts
@@ -1,0 +1,100 @@
+/**
+ * Provider billing reset schedules.
+ *
+ * When a billing error occurs, knowing *when* the quota resets lets the user
+ * (and the agent) decide whether to wait vs. switch providers.
+ *
+ * Exported helpers are pure functions (Date.now injected for testability).
+ */
+
+export type ResetSchedule =
+  | { kind: "daily"; utcHour: number } // resets every day at this UTC hour
+  | { kind: "monthly"; dayOfMonth: number; utcHour: number } // resets on day N each month
+  | { kind: "none" }; // unknown / pay-as-you-go / free beta
+
+/**
+ * Known provider reset schedules.
+ * Keys are normalised provider ids (lowercase, trimmed).
+ */
+const PROVIDER_RESET_SCHEDULES: Record<string, ResetSchedule> = {
+  venice: { kind: "daily", utcHour: 0 }, // midnight UTC
+  "venice.ai": { kind: "daily", utcHour: 0 },
+  openai: { kind: "monthly", dayOfMonth: 1, utcHour: 0 },
+  anthropic: { kind: "monthly", dayOfMonth: 1, utcHour: 0 },
+  copilot: { kind: "monthly", dayOfMonth: 1, utcHour: 0 },
+  "github-copilot": { kind: "monthly", dayOfMonth: 1, utcHour: 0 },
+  "mor-gateway": { kind: "none" }, // free beta / staked MOR
+  morpheus: { kind: "none" },
+};
+
+function normalizeId(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+export function getResetSchedule(provider: string): ResetSchedule {
+  return PROVIDER_RESET_SCHEDULES[normalizeId(provider)] ?? { kind: "none" };
+}
+
+/**
+ * Calculate milliseconds until the next billing reset for a provider.
+ * Returns `null` when the schedule is unknown.
+ */
+export function msUntilReset(provider: string, now: number = Date.now()): number | null {
+  const schedule = getResetSchedule(provider);
+  if (schedule.kind === "none") {
+    return null;
+  }
+
+  const nowDate = new Date(now);
+
+  if (schedule.kind === "daily") {
+    const resetToday = new Date(nowDate);
+    resetToday.setUTCHours(schedule.utcHour, 0, 0, 0);
+    if (resetToday.getTime() <= now) {
+      resetToday.setUTCDate(resetToday.getUTCDate() + 1);
+    }
+    return resetToday.getTime() - now;
+  }
+
+  if (schedule.kind === "monthly") {
+    const resetThisMonth = new Date(
+      Date.UTC(
+        nowDate.getUTCFullYear(),
+        nowDate.getUTCMonth(),
+        schedule.dayOfMonth,
+        schedule.utcHour,
+      ),
+    );
+    if (resetThisMonth.getTime() <= now) {
+      // next month
+      resetThisMonth.setUTCMonth(resetThisMonth.getUTCMonth() + 1);
+    }
+    return resetThisMonth.getTime() - now;
+  }
+
+  return null;
+}
+
+/**
+ * Human-readable "resets in Xh Ym" string, or `null` if unknown.
+ */
+export function formatResetCountdown(provider: string, now: number = Date.now()): string | null {
+  const ms = msUntilReset(provider, now);
+  if (ms === null) {
+    return null;
+  }
+
+  const totalMinutes = Math.ceil(ms / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+    return `resets in ${days}d ${remainingHours}h`;
+  }
+  if (hours > 0) {
+    return `resets in ${hours}h ${minutes}m`;
+  }
+  return `resets in ${minutes}m`;
+}


### PR DESCRIPTION
## Summary

When a billing error occurs (e.g. Venice DIEM exhausted), the error message now includes a countdown showing when the provider's quota resets. This helps users decide whether to wait or switch providers.

**Before:**
> ⚠️ Venice returned a billing error — your API key has run out of credits or has an insufficient balance.

**After:**
> ⚠️ Venice returned a billing error (resets in 4h 23m) — your API key has run out of credits or has an insufficient balance.

## Changes

- **New file: `src/agents/provider-reset-times.ts`** (100 lines)
  - Pure function module with known provider reset schedules
  - Venice: daily at midnight UTC
  - OpenAI / Anthropic / Copilot: monthly on the 1st
  - Morpheus: none (free beta / staked MOR)
  - Unknown providers gracefully return `null` (no change to message)
  - All functions accept `now` parameter for testability

- **Modified: `src/agents/pi-embedded-helpers/errors.ts`** (+4/-1)
  - `formatBillingErrorMessage()` appends reset countdown when provider has a known schedule
  - Falls back to original message for unknown providers

- **New file: `src/agents/provider-reset-times.test.ts`** (16 tests)
  - Covers daily/monthly/none schedules
  - Edge cases: just past midnight, month rollover, unknown providers
  - Formatting: hours+minutes, minutes-only, days for long waits

## Test Results

All 260 existing tests pass (50 files), plus 16 new tests. Zero regressions.

## Design Decisions

- **Hardcoded schedules** rather than config-driven — keeps it simple and zero-config. Can be extended to read from `openclaw.json` later if needed.
- **Graceful degradation** — unknown providers get the original message unchanged.
- **No config schema changes** — zero risk of breaking existing installations.