### PR TITLE
fix(config): add missing firecrawl and readability to web fetch Zod schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,55 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts tools.web.fetch.firecrawl config block (#27833)", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              enabled: true,
+              apiKey: "fc-test",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 172800000,
+              timeoutSeconds: 60,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts tools.web.fetch.readability config key", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            readability: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid firecrawl config keys (strict mode)", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              unknownKey: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -305,6 +305,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+const FirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -314,6 +326,8 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: FirecrawlSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Fixes #27833

The Zod validation schema for `tools.web.fetch` in `zod-schema.agent-runtime.ts` was missing two fields that are defined in the TypeScript type (`types.tools.ts`), config labels (`schema.labels.ts`), and help text (`schema.help.ts`):

- `firecrawl` — the entire Firecrawl fallback configuration block (6 fields)
- `readability` — boolean toggle for Readability content extraction

Because `ToolsWebFetchSchema` uses `.strict()`, any `openclaw.json` containing these documented keys was rejected:

```
Invalid config: tools.web.fetch: Unrecognized key: "firecrawl"
```

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.agent-runtime.ts` | Add `FirecrawlSchema` (enabled, apiKey, baseUrl, onlyMainContent, maxAgeMs, timeoutSeconds) and `readability` to `ToolsWebFetchSchema` |
| `src/config/config.schema-regressions.test.ts` | 3 regression tests: firecrawl block accepted, readability accepted, unknown firecrawl keys rejected |

## Verification

- Schema field types match `types.tools.ts` exactly
- `FirecrawlSchema` uses `.strict()` to prevent unknown keys leaking through
- All fields are `.optional()` — zero breaking changes for existing configs

## Checklist

- [x] AI-assisted — schema diff verified by manual type cross-reference
- [x] Regression tests included
- [x] No runtime behavior changes — config validation only