### PR TITLE
fix: respect typingMode in signalToolStart

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -470,7 +470,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("does not start typing on tool-start in message mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -480,16 +480,40 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+    // In message mode, tool calls alone should NOT trigger typing.
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+  });
+
+  it("refreshes ttl on tool-start in message mode when already active", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "message",
+      isHeartbeat: false,
+    });
+
+    // Simulate typing already started by a prior text delta.
     (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
-    (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
-    (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
     await signaler.signalToolStart();
 
+    // Should refresh TTL but not restart the loop.
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts typing on tool-start in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).toHaveBeenCalled();
   });
 
   it("suppresses typing when disabled", async () => {


### PR DESCRIPTION
## Problem

`signalToolStart` unconditionally starts/refreshes the typing indicator whenever a tool begins executing, regardless of the configured `typingMode`. This causes channels like Telegram to show a continuous "typing..." indicator for minutes during long tool-call sequences (web searches, exec, etc.) even when `typingMode` is set to `message` or `thinking`.

The root cause is that `signalToolStart` only checks `disabled` (heartbeat / `never`), but does not check whether the mode permits typing to start on tool execution.

## Fix

`signalToolStart` now checks the resolved mode:

- **`message` / `thinking`**: only refreshes TTL if typing is already active (started by a prior text or reasoning delta); does **not** start typing on its own.
- **`instant`**: starts typing on first tool call (preserves existing behavior).
- **`never` / heartbeat**: no-op (unchanged).

## Changes

- `src/auto-reply/reply/typing-mode.ts`: Added mode guard in `signalToolStart`
- `src/auto-reply/reply/reply-utils.test.ts`: Updated and expanded tests to cover all three tool-start scenarios (message, instant, already-active)

All 30 existing tests pass.