### PR TITLE
fix(config): accept memorySearch chunking.strategy

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -607,6 +607,7 @@ export const MemorySearchSchema = z
       .optional(),
     chunking: z
       .object({
+        strategy: z.union([z.literal("token"), z.literal("section")]).optional(),
         tokens: z.number().int().positive().optional(),
         overlap: z.number().int().nonnegative().optional(),
       })

--- a/src/config/zod-schema.memory-search.test.ts
+++ b/src/config/zod-schema.memory-search.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("OpenClawSchema memorySearch chunking strategy", () => {
+  it("accepts valid chunking.strategy values", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        agents: {
+          defaults: {
+            memorySearch: {
+              chunking: {
+                strategy: "section",
+                tokens: 800,
+                overlap: 120,
+              },
+            },
+          },
+          list: [{ id: "main" }],
+        },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      OpenClawSchema.parse({
+        agents: {
+          defaults: {
+            memorySearch: {
+              chunking: {
+                strategy: "token",
+              },
+            },
+          },
+          list: [{ id: "main" }],
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid chunking.strategy values", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        agents: {
+          defaults: {
+            memorySearch: {
+              chunking: {
+                strategy: "invalid",
+              },
+            },
+          },
+          list: [{ id: "main" }],
+        },
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: `memorySearch.chunking.strategy` was exposed by the config types, but runtime validation still rejected it.
- Why it matters: users trying to enable section-aware chunking would hit `invalid config` even though the field already existed in the type surface.
- What changed: added `chunking.strategy` to the runtime Zod schema and added a focused regression test for accepted and rejected values.
- What did NOT change (scope boundary): this does not change chunking defaults, indexing behavior, or any memory retrieval logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28127
- Related #

## User-visible / Behavior Changes

`agents.defaults.memorySearch.chunking.strategy` and agent-level equivalents now validate correctly for `token` and `section`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local pnpm test run
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.memorySearch.chunking.strategy: "section"`

### Steps

1. Add `memorySearch.chunking.strategy` to config.
2. Validate config through the runtime schema.
3. Run `pnpm test -- src/config/zod-schema.memory-search.test.ts`.

### Expected

- `token` and `section` are accepted.
- Invalid values are still rejected.

### Actual

- The targeted regression test passes after the schema update.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove `chunking.strategy` from config
- Files/config to restore: `src/config/zod-schema.agent-runtime.ts`
- Known bad symptoms reviewers should watch for: unexpected validation behavior around `memorySearch.chunking`

## Risks and Mitigations

- Risk: adjacent config fields could still have similar schema drift elsewhere.
  - Mitigation: this PR stays narrowly scoped and adds a regression test for this field.