### PR TITLE
fix(secrets): make noOutputTimeoutMs default to timeoutMs

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -27,7 +27,6 @@ const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const DEFAULT_FILE_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FILE_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
-const DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS = 2_000;
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
@@ -518,7 +517,7 @@ async function resolveExecRefs(params: {
   const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
   const noOutputTimeoutMs = normalizePositiveInt(
     params.providerConfig.noOutputTimeoutMs,
-    DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,
+    timeoutMs, // Default to the total timeout when not explicitly configured
   );
   const maxOutputBytes = normalizePositiveInt(
     params.providerConfig.maxOutputBytes,


### PR DESCRIPTION
## Summary

Fixes #28161

The `secrets.reload` WebSocket handler was ignoring the configured `timeoutMs` value and using a hardcoded 2000ms default for `noOutputTimeoutMs`. This caused gateway startup failures when exec providers (like 1Password CLI) took longer than 2 seconds to produce output.

## Changes

- Changed `noOutputTimeoutMs` to default to `timeoutMs` when not explicitly configured
- Removed unused `DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS` constant
- Added regression test to verify the fix

## Test Plan

- [x] Added regression test: "uses timeoutMs as default for noOutputTimeoutMs when not explicitly set"
- [x] All existing secrets tests pass (31 tests)
- [x] Build passes

## Behavior Change

**Before:**
- User sets `timeoutMs: 10000` 
- `noOutputTimeoutMs` defaulted to hardcoded 2000ms
- Exec provider fails after 2 seconds with "produced no output for 2000ms"

**After:**
- User sets `timeoutMs: 10000`
- `noOutputTimeoutMs` defaults to 10000ms (same as `timeoutMs`)
- Exec provider allowed up to 10 seconds to produce output

Users can still explicitly set `noOutputTimeoutMs` to override this default.