### PR TITLE
feat(feishu): add sendAudioFeishu for native voice message UI

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -21,6 +21,7 @@ export {
   uploadFileFeishu,
   sendImageFeishu,
   sendFileFeishu,
+  sendAudioFeishu,
   sendMediaFeishu,
 } from "./src/media.js";
 export { probeFeishu } from "./src/probe.js";

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -36,7 +36,12 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-import { downloadImageFeishu, downloadMessageResourceFeishu, sendMediaFeishu } from "./media.js";
+import {
+  downloadImageFeishu,
+  downloadMessageResourceFeishu,
+  sendMediaFeishu,
+  sendAudioFeishu,
+} from "./media.js";
 
 function expectPathIsolatedToTmpRoot(pathValue: string, key: string): void {
   expect(pathValue).not.toContain(key);
@@ -146,6 +151,50 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ msg_type: "media" }),
+      }),
+    );
+  });
+
+  it("uses msg_type=audio for opus when useAudioType is true", async () => {
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio"),
+      fileName: "voice.opus",
+      useAudioType: true,
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_type: "opus" }),
+      }),
+    );
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
+  it("uses msg_type=media for mp3 files (not affected by useAudioType)", async () => {
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio"),
+      fileName: "music.mp3",
+      useAudioType: true,
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_type: "stream" }),
+      }),
+    );
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
   });
@@ -275,5 +324,108 @@ describe("sendMediaFeishu msg_type routing", () => {
     ).rejects.toThrow("invalid file_key");
 
     expect(messageResourceGetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendAudioFeishu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    resolveFeishuAccountMock.mockReturnValue({
+      configured: true,
+      accountId: "main",
+      config: {},
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+    });
+
+    normalizeFeishuTargetMock.mockReturnValue("ou_target");
+    resolveReceiveIdTypeMock.mockReturnValue("open_id");
+
+    createFeishuClientMock.mockReturnValue({
+      im: {
+        message: {
+          create: messageCreateMock,
+          reply: messageReplyMock,
+        },
+      },
+    });
+
+    messageCreateMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "msg_audio_1", chat_id: "chat_1" },
+    });
+
+    messageReplyMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "reply_audio_1", chat_id: "chat_1" },
+    });
+  });
+
+  it("sends audio message with msg_type=audio", async () => {
+    const result = await sendAudioFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      fileKey: "file_audio_key",
+    });
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { receive_id_type: "open_id" },
+        data: expect.objectContaining({
+          msg_type: "audio",
+          content: JSON.stringify({ file_key: "file_audio_key" }),
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      messageId: "msg_audio_1",
+      chatId: "ou_target",
+    });
+  });
+
+  it("sends audio message with duration", async () => {
+    await sendAudioFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      fileKey: "file_audio_key",
+      duration: 5234.67,
+    });
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          msg_type: "audio",
+          content: JSON.stringify({ file_key: "file_audio_key", duration: 5234 }),
+        }),
+      }),
+    );
+  });
+
+  it("sends audio reply with msg_type=audio", async () => {
+    const result = await sendAudioFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      fileKey: "file_audio_key",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(messageReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { message_id: "om_parent" },
+        data: expect.objectContaining({
+          msg_type: "audio",
+          content: JSON.stringify({ file_key: "file_audio_key" }),
+        }),
+      }),
+    );
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      messageId: "reply_audio_1",
+      chatId: "ou_target",
+    });
   });
 });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -300,6 +300,53 @@ export async function sendImageFeishu(params: {
 }
 
 /**
+ * Send an audio message using a file_key
+ * Audio messages use msg_type="audio" for native voice message UI in Feishu
+ */
+export async function sendAudioFeishu(params: {
+  cfg: ClawdbotConfig;
+  to: string;
+  fileKey: string;
+  duration?: number;
+  replyToMessageId?: string;
+  accountId?: string;
+}): Promise<SendMediaResult> {
+  const { cfg, to, fileKey, duration, replyToMessageId, accountId } = params;
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
+    cfg,
+    to,
+    accountId,
+  });
+  const content = JSON.stringify({
+    file_key: fileKey,
+    ...(duration !== undefined && { duration: Math.floor(duration) }),
+  });
+
+  if (replyToMessageId) {
+    const response = await client.im.message.reply({
+      path: { message_id: replyToMessageId },
+      data: {
+        content,
+        msg_type: "audio",
+      },
+    });
+    assertFeishuMessageApiSuccess(response, "Feishu audio reply failed");
+    return toFeishuSendResult(response, receiveId);
+  }
+
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      content,
+      msg_type: "audio",
+    },
+  });
+  assertFeishuMessageApiSuccess(response, "Feishu audio send failed");
+  return toFeishuSendResult(response, receiveId);
+}
+
+/**
  * Send a file message using a file_key
  */
 export async function sendFileFeishu(params: {
@@ -386,8 +433,11 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
+  /** When true, send audio files as msg_type="audio" for native voice message UI */
+  useAudioType?: boolean;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId, useAudioType } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -427,6 +477,19 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
+
+    // Use native audio message type if requested and file is audio
+    const isAudio = fileType === "opus";
+    if (useAudioType && isAudio) {
+      return sendAudioFeishu({
+        cfg,
+        to,
+        fileKey,
+        replyToMessageId,
+        accountId,
+      });
+    }
+
     // Feishu requires msg_type "media" for audio/video, "file" for documents
     const isMedia = fileType === "mp4" || fileType === "opus";
     return sendFileFeishu({


### PR DESCRIPTION
## Summary

Adds support for sending Feishu native audio/voice messages using `msg_type="audio"` instead of `msg_type="media"`.

## Changes

- **New function `sendAudioFeishu`**: Sends audio messages with `msg_type="audio"` for native voice message UI in Feishu
- **Enhanced `sendMediaFeishu`**: Added `useAudioType` parameter to optionally send opus files as audio messages
- **Export update**: Exported `sendAudioFeishu` in `extensions/feishu/index.ts`

## Implementation Details

### `sendAudioFeishu` function
- Sends messages with `msg_type="audio"` (native voice message type)
- Supports optional `duration` parameter for audio length (in milliseconds)
- Supports reply functionality via `replyToMessageId`
- Compatible with Feishu's audio message API requirements

### `sendMediaFeishu` enhancement
- Added `useAudioType` boolean parameter (default: `false`)
- When `useAudioType=true` and file is `.opus`/`.ogg`, uses `sendAudioFeishu`
- Maintains backward compatibility (default behavior unchanged)
- Only affects opus audio files; mp4/other formats continue using `msg_type="media"`

## Differences: `audio` vs `media` message types

| Feature | `msg_type="audio"` | `msg_type="media"` |
|---------|-------------------|-------------------|
| UI Display | Native voice message UI (waveform) | Generic media player |
| Supported formats | opus/ogg | opus/ogg, mp4 |
| Duration field | Optional | Not used |
| Use case | TTS voice responses | General audio/video files |

## Test Coverage

Added comprehensive test cases:
- ✅ Send audio message with `msg_type="audio"`
- ✅ Send audio message with duration parameter
- ✅ Send audio reply message
- ✅ `sendMediaFeishu` with `useAudioType=true` routes to audio type
- ✅ `sendMediaFeishu` without `useAudioType` maintains default behavior
- ✅ Non-opus files are not affected by `useAudioType`

## Testing

```bash
pnpm test extensions/feishu/
pnpm check
```

All tests passing ✅

## Related Issues

This enables better TTS voice message support in Feishu, allowing voice responses to display with native voice message UI rather than generic media attachments.

## Checklist

- [x] Added new functionality with tests
- [x] All existing tests pass
- [x] Lint and format checks pass
- [x] Backward compatible (no breaking changes)
- [x] Export added to public API


Made with [Cursor](https://cursor.com)