### PR TITLE
fix(discord): strip echoed inbound metadata from thread replies

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -58,7 +58,7 @@ describe("stripInboundMetadata", () => {
     expect(stripInboundMetadata(input)).toBe("Got it, thanks!");
   });
 
-  it("strips all six known sentinel types", () => {
+  it("strips all known fenced sentinel types", () => {
     const sentinels = [
       "Conversation info (untrusted metadata):",
       "Sender (untrusted metadata):",
@@ -71,6 +71,16 @@ describe("stripInboundMetadata", () => {
       const input = `${sentinel}\n\`\`\`json\n{"x": 1}\n\`\`\`\n\nUser message`;
       expect(stripInboundMetadata(input)).toBe("User message");
     }
+  });
+
+  it("strips unfenced [Thread starter - for context] block", () => {
+    const input = `[Thread starter - for context]\nSome thread starter text\n\nUser message`;
+    expect(stripInboundMetadata(input)).toBe("User message");
+  });
+
+  it("strips unfenced [Thread history - for context] block", () => {
+    const input = `[Thread history - for context]\nLine 1\nLine 2\n\nUser message`;
+    expect(stripInboundMetadata(input)).toBe("User message");
   });
 
   it("handles metadata block with no user text after it", () => {

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -2,6 +2,7 @@ import type { RequestClient } from "@buape/carbon";
 import { resolveAgentAvatar } from "../../agents/identity-avatar.js";
 import type { ChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import { loadConfig } from "../../config/config.js";
 import type { MarkdownTableMode, ReplyToMode } from "../../config/types.base.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
@@ -175,7 +176,7 @@ export async function deliverDiscordReply(params: {
   const persona = resolveBindingPersona(binding);
   for (const payload of params.replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-    const rawText = payload.text ?? "";
+    const rawText = stripInboundMetadata(payload.text ?? "");
     const tableMode = params.tableMode ?? "code";
     const text = convertMarkdownTables(rawText, tableMode);
     if (!text && mediaList.length === 0) {


### PR DESCRIPTION
## Summary

When the LLM echoes back injected context blocks in its response, internal metadata appears as visible text in Discord threads:
- `[Thread starter - for context]` + raw text
- `Conversation info (untrusted metadata):` JSON
- `Sender (untrusted metadata):` JSON

## Root Cause

Two issues:

1. `strip-inbound-meta.ts` sentinel list covered fenced blocks (`"Thread starter (untrusted, for context):"`) but not the unfenced bracket-style blocks (`"[Thread starter - for context]"`, `"[Thread history - for context]"`) injected by `get-reply-run.ts`.

2. Discord `reply-delivery.ts` never called `stripInboundMetadata()` before sending — so even recognized blocks leaked when the model echoed them.

## Changes

| File | Change |
|------|--------|
| `strip-inbound-meta.ts` | Add 2 unfenced sentinels + unfenced block parsing mode |
| `strip-inbound-meta.test.ts` | Add 2 test cases for unfenced bracket-style blocks |
| `reply-delivery.ts` | Call `stripInboundMetadata()` on reply text before sending |

## Testing

- `strip-inbound-meta.test.ts`: 14/14 pass (12 existing + 2 new)
- `reply-delivery.test.ts`: 8/8 pass
- Build passes (`pnpm build`)
- Lint passes (`pnpm lint`, 0 warnings, 0 errors)

Fixes #28170

lobster-biscuit