### PR TITLE
runner: sanitize invalid UTF-16 surrogates in prompts/history

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -488,6 +488,14 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
     expect(classifyFailoverReason("string should match pattern")).toBe("format");
+    expect(
+      classifyFailoverReason(
+        "request body is not valid JSON: no low surrogate in string: line 1 column 123",
+      ),
+    ).toBe("format");
+    expect(classifyFailoverReason("invalid request payload: lone surrogate in string")).toBe(
+      "format",
+    );
     expect(classifyFailoverReason("bad request")).toBeNull();
     expect(
       classifyFailoverReason(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -683,6 +683,9 @@ const ERROR_PATTERNS = {
     "tool_use_id",
     "messages.1.content.1.tool_use.id",
     "invalid request format",
+    "request body is not valid json",
+    "no low surrogate",
+    "lone surrogate",
     /tool call id was.*must be/i,
   ],
 } as const;

--- a/src/agents/pi-embedded-runner/unicode-safety.test.ts
+++ b/src/agents/pi-embedded-runner/unicode-safety.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUnpairedSurrogates,
+  repairInvalidUtf16Surrogates,
+  sanitizeUnknownStringsDeep,
+  sanitizeUnpairedSurrogatesWithStats,
+} from "./unicode-safety.js";
+
+describe("unicode-safety", () => {
+  it("leaves valid surrogate pairs unchanged", () => {
+    const value = "emoji 😀 ok";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.value).toBe(value);
+    expect(result.replacements).toBe(0);
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("replaces lone high surrogate", () => {
+    const value = "broken \ud83d tail";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.replacements).toBe(1);
+    expect(result.value).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("replaces lone low surrogate", () => {
+    const value = "broken \udc00 tail";
+    const result = sanitizeUnpairedSurrogatesWithStats(value);
+    expect(result.replacements).toBe(1);
+    expect(result.value).toContain("\uFFFD");
+    expect(hasUnpairedSurrogates(result.value)).toBe(false);
+  });
+
+  it("repairs nested objects and arrays", () => {
+    const data = {
+      text: "x\ud83d",
+      nested: [{ note: "y\udc00" }],
+    };
+    const result = sanitizeUnknownStringsDeep(data);
+    expect(result.replacements).toBe(2);
+    expect(result.value.text).toContain("\uFFFD");
+    expect(result.value.nested[0]?.note).toContain("\uFFFD");
+  });
+
+  it("exports repairInvalidUtf16Surrogates helper", () => {
+    expect(repairInvalidUtf16Surrogates("ok 😀")).toBe("ok 😀");
+    expect(repairInvalidUtf16Surrogates("bad \udc00")).toContain("\uFFFD");
+  });
+});

--- a/src/agents/pi-embedded-runner/unicode-safety.ts
+++ b/src/agents/pi-embedded-runner/unicode-safety.ts
@@ -1,0 +1,187 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+const HIGH_SURROGATE_MIN = 0xd800;
+const HIGH_SURROGATE_MAX = 0xdbff;
+const LOW_SURROGATE_MIN = 0xdc00;
+const LOW_SURROGATE_MAX = 0xdfff;
+const REPLACEMENT_CHAR = "\uFFFD";
+
+type StringSanitizeResult = {
+  value: string;
+  replacements: number;
+};
+
+type DeepSanitizeResult<T> = {
+  value: T;
+  replacements: number;
+  changed: boolean;
+};
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= HIGH_SURROGATE_MIN && codeUnit <= HIGH_SURROGATE_MAX;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= LOW_SURROGATE_MIN && codeUnit <= LOW_SURROGATE_MAX;
+}
+
+function sanitizeStringInternal(input: string): StringSanitizeResult {
+  if (!input) {
+    return { value: input, replacements: 0 };
+  }
+
+  const parts: string[] = [];
+  let replacements = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const current = input.charCodeAt(i);
+    if (isHighSurrogate(current)) {
+      if (i + 1 < input.length) {
+        const next = input.charCodeAt(i + 1);
+        if (isLowSurrogate(next)) {
+          parts.push(input[i], input[i + 1]);
+          i += 1;
+          continue;
+        }
+      }
+      replacements += 1;
+      parts.push(REPLACEMENT_CHAR);
+      continue;
+    }
+    if (isLowSurrogate(current)) {
+      replacements += 1;
+      parts.push(REPLACEMENT_CHAR);
+      continue;
+    }
+    parts.push(input[i]);
+  }
+
+  if (replacements === 0) {
+    return { value: input, replacements: 0 };
+  }
+  return { value: parts.join(""), replacements };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function sanitizeUnknownStringsDeepInternal(
+  value: unknown,
+  seen: WeakSet<object>,
+): DeepSanitizeResult<unknown> {
+  if (typeof value === "string") {
+    const sanitized = sanitizeStringInternal(value);
+    return {
+      value: sanitized.value,
+      replacements: sanitized.replacements,
+      changed: sanitized.replacements > 0,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    let replacements = 0;
+    let changed = false;
+    let out: unknown[] | undefined;
+    for (let i = 0; i < value.length; i++) {
+      const next = sanitizeUnknownStringsDeepInternal(value[i], seen);
+      replacements += next.replacements;
+      if (next.changed) {
+        changed = true;
+        if (!out) {
+          out = value.slice();
+        }
+        out[i] = next.value;
+      }
+    }
+    return {
+      value: changed ? (out as unknown) : value,
+      replacements,
+      changed,
+    };
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) {
+      return { value, replacements: 0, changed: false };
+    }
+    seen.add(value);
+
+    let replacements = 0;
+    let changed = false;
+    let out: Record<string, unknown> | undefined;
+    for (const [key, child] of Object.entries(value)) {
+      const next = sanitizeUnknownStringsDeepInternal(child, seen);
+      replacements += next.replacements;
+      if (next.changed) {
+        changed = true;
+        if (!out) {
+          out = { ...value };
+        }
+        out[key] = next.value;
+      }
+    }
+    return {
+      value: changed ? (out as unknown) : value,
+      replacements,
+      changed,
+    };
+  }
+
+  return { value, replacements: 0, changed: false };
+}
+
+export function hasUnpairedSurrogates(input: string): boolean {
+  if (!input) {
+    return false;
+  }
+  for (let i = 0; i < input.length; i++) {
+    const current = input.charCodeAt(i);
+    if (isHighSurrogate(current)) {
+      if (i + 1 >= input.length) {
+        return true;
+      }
+      const next = input.charCodeAt(i + 1);
+      if (!isLowSurrogate(next)) {
+        return true;
+      }
+      i += 1;
+      continue;
+    }
+    if (isLowSurrogate(current)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function repairInvalidUtf16Surrogates(text: string): string {
+  return sanitizeStringInternal(text).value;
+}
+
+export function sanitizeUnpairedSurrogatesWithStats(input: string): StringSanitizeResult {
+  return sanitizeStringInternal(input);
+}
+
+export function sanitizeUnknownStringsDeep<T>(value: T): { value: T; replacements: number } {
+  const result = sanitizeUnknownStringsDeepInternal(value, new WeakSet<object>());
+  return {
+    value: result.value as T,
+    replacements: result.replacements,
+  };
+}
+
+export function sanitizeAgentMessagesUnicode(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  replacementCount: number;
+} {
+  const result = sanitizeUnknownStringsDeep(messages);
+  return {
+    messages: result.value,
+    replacementCount: result.replacements,
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: invalid UTF-16 surrogate sequences in prompt/session history can trigger provider-side malformed JSON failures (for example `no low surrogate in string`).
- Why it matters: one poisoned turn can cause repeated request failures across subsequent runs.
- What changed: added deterministic surrogate repair for prompt text and session-history message text; expanded format-error classification for surrogate-malformed JSON signatures.
- What did NOT change: no usage/quota preflight behavior; no model fallback policy changes; no public API contract changes.
- AI-assisted disclosure: implementation was AI-assisted, then manually reviewed and manually verified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #21557
- Supersedes closed #21560 (stale/conflicting against current main)

## User-visible / Behavior Changes

- Prompt/history strings with invalid lone surrogates are repaired before provider request serialization.
- Valid surrogate pairs remain unchanged.
- Surrogate-related malformed JSON provider errors are classified as `format` (failover classification path).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm 10
- Model/provider: provider-agnostic runner tests
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config

### Steps

1. Run with prompt/session strings containing lone high/low surrogate code units.
2. Verify sanitization path repairs invalid units but preserves valid surrogate pairs.
3. Verify failover classification for malformed JSON surrogate signatures.

### Expected

- Requests no longer fail due to lone surrogate JSON encoding problems.
- Valid emoji surrogate pairs remain unchanged.
- Classification maps those malformed JSON signatures to `format`.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `corepack pnpm vitest run src/agents/pi-embedded-runner/unicode-safety.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - `corepack pnpm oxlint --type-aware src/agents/pi-embedded-runner/unicode-safety.ts src/agents/pi-embedded-runner/google.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-runner/unicode-safety.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - `corepack pnpm tsgo`
- Edge cases checked:
  - lone high surrogate repaired
  - lone low surrogate repaired
  - valid surrogate pairs unchanged
  - malformed JSON surrogate errors classified as `format`
- What you did **not** verify:
  - full end-to-end live provider runs with real quota exhaustion conditions

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f0ac9b6`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/unicode-safety.ts`
  - `src/agents/pi-embedded-runner/google.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected replacement characters in text that previously had only valid surrogate pairs

## Risks and Mitigations

- Risk:
  - Over-sanitization could alter intentionally malformed text payloads.
  - Mitigation:
    - sanitization only replaces invalid unpaired surrogate code units; valid surrogate pairs are preserved and covered by tests.
