### PR TITLE
fix(control-ui): parse backtick-wrapped avatar paths from IDENTITY.md

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -16,6 +16,12 @@ describe("parseIdentityMarkdown", () => {
     expect(parsed).toEqual({});
   });
 
+  it("parses avatar path wrapped in markdown backticks", () => {
+    const content = "\n- **Avatar:** `avatars/avatar.png`\n";
+    const parsed = parseIdentityMarkdown(content);
+    expect(parsed.avatar).toBe("avatars/avatar.png");
+  });
+
   it("parses explicit identity values", () => {
     const content = `
 - **Name:** Samantha

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -45,10 +45,13 @@ export function parseIdentityMarkdown(content: string): AgentIdentityFile {
       continue;
     }
     const label = cleaned.slice(0, colonIndex).replace(/[*_]/g, "").trim().toLowerCase();
-    const value = cleaned
+    let value = cleaned
       .slice(colonIndex + 1)
       .replace(/^[*_]+|[*_]+$/g, "")
       .trim();
+    if (value.startsWith("`") && value.endsWith("`")) {
+      value = value.slice(1, -1).trim();
+    }
     if (!value) {
       continue;
     }


### PR DESCRIPTION
Fixes #28042

## Summary
This PR fixes Control UI avatar 404s when `IDENTITY.md` uses markdown backticks around the avatar path.

## What was broken
`parseIdentityMarkdown()` accepted markdown labels (e.g. `- **Avatar:** ...`) but did not normalize backtick-wrapped values.

Example that failed:

```md
- **Avatar:** `avatars/avatar.png`
```

The parser stored the value including backticks, so avatar resolution looked for a literal path containing backtick characters and returned `kind: none`, causing `/avatar/main` to return 404.

## Root cause
- File: `src/agents/identity-file.ts`
- Function: `parseIdentityMarkdown`
- Behavior: Value cleanup removed `*`/`_` markdown wrappers but not `` ` `` wrappers.

## Changes
1. Normalize avatar/identity field values wrapped in markdown backticks by stripping outer backticks.
2. Add regression test in `src/agents/identity-file.test.ts`:
   - `parses avatar path wrapped in markdown backticks`

## Scope
- Parsing-only fix in identity markdown ingestion.
- No route or HTTP handler behavior changes.

## Local verification
- Ran: `pnpm vitest run src/agents/identity-file.test.ts`
- Result: all tests passed.
