### PR TITLE
fix(secrets): respect timeoutMs config for exec provider no-output timeout fallback

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -516,9 +516,18 @@ async function resolveExecRefs(params: {
   }
 
   const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
+  // When noOutputTimeoutMs is not explicitly configured, fall back to the
+  // resolved timeoutMs so the no-output watchdog never fires earlier than the
+  // overall timeout the user requested.  This prevents a situation where a user
+  // sets timeoutMs: 10_000 but the provider is killed after only 2 000 ms of
+  // silence (the previous hard-coded default).
+  const noOutputFallback =
+    params.providerConfig.noOutputTimeoutMs == null && params.providerConfig.timeoutMs != null
+      ? timeoutMs
+      : DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS;
   const noOutputTimeoutMs = normalizePositiveInt(
     params.providerConfig.noOutputTimeoutMs,
-    DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,
+    noOutputFallback,
   );
   const maxOutputBytes = normalizePositiveInt(
     params.providerConfig.maxOutputBytes,


### PR DESCRIPTION
### Problem

Fixes #28161

When a user configures `timeoutMs` on an exec secret provider (e.g. `secrets.providers.onepassword.timeoutMs: 10000`) but does **not** explicitly set `noOutputTimeoutMs`, the no-output watchdog still fires at the hard-coded 2 000 ms default. This causes exec providers that need a few seconds of startup time — such as the 1Password CLI with service-account authentication — to be killed before they produce any output, even though the user explicitly allowed a longer window.

**Error observed by the reporter:**
```
[ws] ⇄ res ✗ secrets.reload 3432ms errorCode=UNAVAILABLE
errorMessage=Error: Exec provider "onepassword" produced no output for 2000ms.
```

### Root Cause

In `resolveExecRefs` (`src/secrets/resolve.ts`), `timeoutMs` and `noOutputTimeoutMs` are derived independently:

```ts
const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
const noOutputTimeoutMs = normalizePositiveInt(
  params.providerConfig.noOutputTimeoutMs,
  DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,  // always 2_000
);
```

When only `timeoutMs` is set, `noOutputTimeoutMs` silently falls back to `DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS` (2 000 ms), which can be far shorter than the configured overall timeout. The two values never interact.

### Fix

When `noOutputTimeoutMs` is **not** explicitly configured, fall back to the resolved `timeoutMs` (if the user set it) instead of the hard-coded 2 000 ms default. This ensures the no-output watchdog never fires earlier than the overall timeout the user requested. When both values are explicitly set, both are honoured as-is — no existing behaviour changes.

```ts
const noOutputFallback =
  params.providerConfig.noOutputTimeoutMs == null && params.providerConfig.timeoutMs != null
    ? timeoutMs
    : DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS;
const noOutputTimeoutMs = normalizePositiveInt(
  params.providerConfig.noOutputTimeoutMs,
  noOutputFallback,
);
```

### Changes

| File | Change |
|------|--------|
| `src/secrets/resolve.ts` | Derive `noOutputTimeoutMs` fallback from `timeoutMs` when not explicitly configured |
| `src/secrets/resolve.test.ts` | Add test: exec provider with 2.5 s delayed output succeeds when `timeoutMs: 5000` and `noOutputTimeoutMs` is omitted |

### Behaviour Matrix

| `timeoutMs` | `noOutputTimeoutMs` | Effective no-output timeout | Change? |
|-------------|--------------------|-----------------------------|---------|
| omitted | omitted | 2 000 ms (default) | No |
| 10 000 | omitted | **10 000 ms** (was 2 000) | **Yes** |
| omitted | 3 000 | 3 000 ms | No |
| 10 000 | 3 000 | 3 000 ms | No |

### Test Plan

- New unit test creates a slow exec script (2.5 s delay before output) and verifies it resolves successfully with `timeoutMs: 5000` and no explicit `noOutputTimeoutMs`.
- Under the old code this test would fail with `produced no output for 2000ms`.