### PR TITLE
fix: include mediaUrls in WebSocket chat events for TTS/media delivery

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import { splitMediaFromOutput } from "../media/parse.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
@@ -338,16 +339,22 @@ export function createAgentEventHandler({
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
+      // Extract MEDIA: tokens so WS clients can fetch audio/images.
+      const mediaSplit = splitMediaFromOutput(text);
+      const cleanText = mediaSplit.text?.trim() ?? "";
+      const mediaUrls = mediaSplit.mediaUrls ?? [];
+
       const payload = {
         runId: clientRunId,
         sessionKey,
         seq,
         state: "final" as const,
         message:
-          text && !shouldSuppressSilent
+          (cleanText || mediaUrls.length > 0) && !shouldSuppressSilent
             ? {
                 role: "assistant",
-                content: [{ type: "text", text }],
+                content: cleanText ? [{ type: "text", text: cleanText }] : [],
+                ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
                 timestamp: Date.now(),
               }
             : undefined,
@@ -405,13 +412,22 @@ export function createAgentEventHandler({
     const last = agentRunSeq.get(evt.runId) ?? 0;
     const isToolEvent = evt.stream === "tool";
     const toolVerbose = isToolEvent ? resolveToolVerboseLevel(evt.runId, sessionKey) : "off";
-    // Build tool payload: strip result/partialResult unless verbose=full
+    // Build tool payload: strip result/partialResult unless verbose=full,
+    // but preserve mediaUrls extracted from MEDIA: tokens in tool results
+    // so WS clients can fetch audio/image assets.
     const toolPayload =
       isToolEvent && toolVerbose !== "full"
         ? (() => {
             const data = evt.data ? { ...evt.data } : {};
+            // Extract media URLs from result before stripping
+            const resultText = typeof data.result === "string" ? data.result : undefined;
+            const mediaParsed = resultText ? splitMediaFromOutput(resultText) : undefined;
+            const mediaUrls = mediaParsed?.mediaUrls;
             delete data.result;
             delete data.partialResult;
+            if (mediaUrls && mediaUrls.length > 0) {
+              data.mediaUrls = mediaUrls;
+            }
             return sessionKey
               ? { ...eventForClients, sessionKey, data }
               : { ...eventForClients, data };


### PR DESCRIPTION
## Problem

When an agent uses tools that produce `MEDIA:` tokens (e.g. the `tts` tool with Hume), WebSocket clients (iOS apps, web UI) have no way to receive the generated media files. Channel-based surfaces (Telegram, Discord, WhatsApp) go through `parseReplyDirectives()` → `splitMediaFromOutput()` → `sendMedia()`, but the WS `chat` event path only calls `stripInlineDirectiveTagsForDisplay()` — which handles `[[audio_as_voice]]` and `[[reply_to:...]]` tags but not `MEDIA:` tokens.

This means TTS-generated audio files sit on the server with no path to reach WS-connected clients, and raw `MEDIA:/tmp/...` tokens leak as visible text in the chat.

## Fix

Two changes in `server-chat.ts`:

1. **Chat final events**: Run `splitMediaFromOutput()` on the buffered assistant text. Use the cleaned text for the content block and include extracted URLs as `message.mediaUrls`.
2. **Tool events**: Extract `MEDIA:` URLs from tool results before stripping `data.result` (in non-verbose mode) and include them as `data.mediaUrls`.

WS clients can now detect `mediaUrls` in either tool events or chat final events and fetch/play the assets.

## Notes

- **Delta events are not affected.** During streaming, raw `MEDIA:` tokens may appear briefly in delta text. The cleanup happens on the final event. This is intentional — running `splitMediaFromOutput` on every throttled delta would be wasteful, and clients should prefer the final event's text for display.
- **Local file paths**: `splitMediaFromOutput` can return local paths (e.g. `/tmp/tts-fAJy8C/voice.opus`). Channel surfaces can access these directly, but WS clients cannot. Should the server proxy local media for WS clients, or is that a separate concern?
- **Schema**: `ChatEventSchema` types `message` as `Type.Optional(Type.Unknown())`, so adding `mediaUrls` is backward compatible.

## Context

- Discovered while building [Claudio](https://github.com/bdecrem/claudio), an iOS client that connects via WebSocket
- The existing `splitMediaFromOutput` parser is reused — no new parsing logic
- Related: #28177

## Testing

- Verified `splitMediaFromOutput` correctly extracts `MEDIA:` tokens from TTS tool results
- WS clients receiving tool events with `tool-events` capability will see `data.mediaUrls`
- Chat final events include `message.mediaUrls` when assistant text contains media tokens