### PR TITLE
fix(csp): allow Google Fonts in Control UI CSP header

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -7,6 +7,12 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+  });
+
+  it("allows Google Fonts for style and font loading", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,15 +1,18 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
   // (UI uses a lot of inline style attributes in templates).
+  // Google Fonts (fonts.googleapis.com for stylesheets, fonts.gstatic.com for
+  // font files) are allowed because the Control UI loads Space Grotesk and
+  // JetBrains Mono from the Google Fonts CDN.
   return [
     "default-src 'self'",
     "base-uri 'none'",
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary

- Add `https://fonts.googleapis.com` to the `style-src` CSP directive so the Control UI can load the Google Fonts stylesheet (Space Grotesk + JetBrains Mono)
- Add `https://fonts.gstatic.com` to the `font-src` CSP directive so the browser can fetch the actual font files
- Add test coverage for the new Google Fonts CSP allowances

Fixes #23050

## Test plan

- [x] `control-ui-csp.test.ts` passes (2 tests, including new Google Fonts test)
- [x] `control-ui.http.test.ts` passes (12 tests, existing security header assertions still hold)
- [ ] Manual: open dashboard at `http://127.0.0.1:18789/?token=<token>`, verify no CSP violations in console, verify hamburger menu works, verify Space Grotesk / JetBrains Mono fonts load