### PR TITLE
security(config): fail closed on invalid config

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -350,7 +350,7 @@ export async function getHealthSnapshot(params?: {
   probe?: boolean;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
-  const cfg = loadConfig();
+  const cfg = loadConfig({ allowInvalid: true });
   const { defaultAgentId, ordered } = resolveAgentOrder(cfg);
   const channelBindings = buildChannelAccountBindings(cfg);
   const sessionCache = new Map<string, HealthSummary["sessions"]>();
@@ -526,7 +526,7 @@ export async function healthCommand(
   opts: { json?: boolean; timeoutMs?: number; verbose?: boolean; config?: OpenClawConfig },
   runtime: RuntimeEnv,
 ) {
-  const cfg = opts.config ?? loadConfig();
+  const cfg = opts.config ?? loadConfig({ allowInvalid: true });
   // Always query the running gateway; do not open a direct Baileys socket here.
   const summary = await withProgress(
     {

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -75,7 +75,7 @@ export async function scanStatus(
     },
     async (progress) => {
       progress.setLabel("Loading config…");
-      const cfg = loadConfig();
+      const cfg = loadConfig({ allowInvalid: true });
       const osSummary = resolveOsSummary();
       progress.tick();
 

--- a/src/config/io.invalid-config.test.ts
+++ b/src/config/io.invalid-config.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot, loadConfig } from "./config.js";
+import { withTempHome } from "./test-helpers.js";
+
+describe("loadConfig invalid config handling", () => {
+  afterEach(() => {
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("throws instead of silently falling back to empty defaults on invalid config", async () => {
+    await withTempHome(async (home) => {
+      const configPath = `${home}/.openclaw/openclaw.json`;
+      await fs.mkdir(`${home}/.openclaw`, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          tools: { sessions: { visibility: "all" } },
+          skills: { "nano-banana-pro": { env: { GEMINI_API_KEY: "test" } } },
+        }),
+        "utf-8",
+      );
+
+      expect(() => loadConfig()).toThrow(/Invalid config/);
+    });
+  });
+
+  it("does not cache an empty fallback after an invalid-config failure", async () => {
+    await withTempHome(async (home) => {
+      const configDir = `${home}/.openclaw`;
+      const configPath = `${configDir}/openclaw.json`;
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          gateway: { port: 19001 },
+          skills: { "nano-banana-pro": { env: { GEMINI_API_KEY: "test" } } },
+        }),
+        "utf-8",
+      );
+
+      expect(() => loadConfig()).toThrow(/Invalid config/);
+
+      clearConfigCache();
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          gateway: { port: 19002 },
+        }),
+        "utf-8",
+      );
+
+      expect(loadConfig().gateway?.port).toBe(19002);
+    });
+  });
+});

--- a/src/config/io.invalid-config.test.ts
+++ b/src/config/io.invalid-config.test.ts
@@ -54,4 +54,25 @@ describe("loadConfig invalid config handling", () => {
       expect(loadConfig().gateway?.port).toBe(19002);
     });
   });
+
+  it("keeps throwing on repeated reads until the invalid config is fixed", async () => {
+    await withTempHome(async (home) => {
+      const configDir = `${home}/.openclaw`;
+      const configPath = `${configDir}/openclaw.json`;
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          skills: { "nano-banana-pro": { env: { GEMINI_API_KEY: "test" } } },
+        }),
+        "utf-8",
+      );
+
+      expect(() => loadConfig()).toThrow(/Invalid config/);
+
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      expect(() => loadConfig()).toThrow(/Invalid config/);
+    });
+  });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -810,7 +810,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const error = err as { code?: string };
       if (error?.code === "INVALID_CONFIG") {
-        return {};
+        throw err;
       }
       deps.logger.error(`Failed to read config at ${configPath}`, err);
       return {};


### PR DESCRIPTION
## Summary

- Problem: `loadConfig()` already detects `INVALID_CONFIG`, but then catches that error and silently falls back to `{}`.
- Why it matters: one invalid key can drop the entire runtime back to implicit defaults, including security-related config, without failing closed.
- What changed: `loadConfig()` now rethrows `INVALID_CONFIG` instead of returning an empty config, and adds regression tests covering both the throw path and cache behavior after the failure.
- What did NOT change (scope boundary): this PR does not introduce partial/lenient config parsing; it only removes the unsafe empty-config fallback.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28140
- Related #28175

## User-visible / Behavior Changes

Invalid config now fails closed instead of silently loading an empty/default config.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): config loading
- Relevant config (redacted): invalid `skills.nano-banana-pro` key used to trigger schema failure

### Steps

1. Write an invalid `openclaw.json` with an unrecognized key.
2. Call `loadConfig()`.
3. Fix the config file and call `loadConfig()` again.

### Expected

- Invalid config throws.
- A later valid config load succeeds and is not polluted by an empty fallback cache entry.

### Actual

- Before this change, invalid config returned `{}` and could fall back to unsafe defaults.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added targeted tests for invalid-config throw behavior and for the post-failure cache path; `pnpm vitest run src/config/io.invalid-config.test.ts` passes.
- Edge cases checked: missing config file behavior is unchanged; only `INVALID_CONFIG` is rethrown.
- What you did **not** verify: full workspace-wide `pnpm check` is still blocked by pre-existing missing OTEL exporter modules in `extensions/diagnostics-otel/src/service.ts`.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Yes
- If breaking: added/updated `openclaw doctor` upgrade warning/check? (`Yes/No/N/A`) N/A
- If yes, exact upgrade steps:
  - Fix the invalid config key/value reported in the startup error.
  - Re-run the command or restart the gateway.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c286ae5ccc`
- Files/config to restore: `src/config/io.ts`
- Known bad symptoms reviewers should watch for: automation that was implicitly relying on the old unsafe fallback will now stop on invalid config and surface the error.

## Risks and Mitigations

- Risk: invalid configs that previously limped along on defaults will now fail immediately.
  - Mitigation: that is the intended fail-closed posture, and the error path already includes the validation details operators need to fix the file.

## Fit With Repo Guidance

- `VISION.md`: "Security and safe defaults" and "Bug fixes and stability" apply directly here.
- `VISION.md`: "One PR = one issue/topic. Do not bundle multiple unrelated fixes/features."
- `CONTRIBUTING.md`: "Keep PRs focused (one thing per PR; do not mix unrelated concerns)"
- `CONTRIBUTING.md`: "Describe what & why"
