### PR TITLE
fix(telegram): prevent chat lock when media download hangs

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchRemoteMedia } from "./fetch.js";
+import { MediaFetchError, fetchRemoteMedia } from "./fetch.js";
 
 function makeStream(chunks: Uint8Array[]) {
   return new ReadableStream<Uint8Array>({
@@ -52,6 +52,32 @@ describe("fetchRemoteMedia", () => {
         lookupFn,
       }),
     ).rejects.toThrow("exceeds maxBytes");
+  });
+
+  it("normalizes body-read failures as MediaFetchError(fetch_failed)", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = async () => {
+      const res = new Response("ok", { status: 200 });
+      vi.spyOn(res, "arrayBuffer").mockRejectedValueOnce(new Error("AbortError: timed out"));
+      return res;
+    };
+
+    let captured: unknown;
+    try {
+      await fetchRemoteMedia({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn,
+      });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(MediaFetchError);
+    expect((captured as MediaFetchError).code).toBe("fetch_failed");
+    expect(String(captured)).toContain("AbortError");
   });
 
   it("blocks private IP literals before fetching", async () => {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -31,6 +31,7 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
+  timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
 };
@@ -87,6 +88,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     filePathHint,
     maxBytes,
     maxRedirects,
+    timeoutMs,
     ssrfPolicy,
     lookupFn,
   } = options;
@@ -100,6 +102,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       fetchImpl,
       init: requestInit,
       maxRedirects,
+      timeoutMs,
       policy: ssrfPolicy,
       lookupFn,
     });

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -143,15 +143,26 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       }
     }
 
-    const buffer = maxBytes
-      ? await readResponseWithLimit(res, maxBytes, {
-          onOverflow: ({ maxBytes, res }) =>
-            new MediaFetchError(
-              "max_bytes",
-              `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
-            ),
-        })
-      : Buffer.from(await res.arrayBuffer());
+    let buffer: Buffer;
+    try {
+      buffer = maxBytes
+        ? await readResponseWithLimit(res, maxBytes, {
+            onOverflow: ({ maxBytes, res }) =>
+              new MediaFetchError(
+                "max_bytes",
+                `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
+              ),
+          })
+        : Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      if (err instanceof MediaFetchError) {
+        throw err;
+      }
+      throw new MediaFetchError(
+        "fetch_failed",
+        `Failed to fetch media from ${url}: ${String(err)}`,
+      );
+    }
     let fileNameFromUrl: string | undefined;
     try {
       const parsed = new URL(finalUrl);

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -167,14 +167,20 @@ export const registerTelegramHandlers = ({
     ...(params.date != null ? { date: params.date } : {}),
   });
   const buildSyntheticContext = (
-    ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
+    ctx: Pick<TelegramContext, "me"> & { getFile?: unknown; api?: unknown },
     message: Message,
   ): TelegramContext => {
     const getFile =
       typeof ctx.getFile === "function"
         ? (ctx.getFile as TelegramContext["getFile"]).bind(ctx as object)
         : async () => ({});
-    return { message, me: ctx.me, getFile };
+    const api =
+      typeof ctx.api === "object" &&
+      ctx.api !== null &&
+      typeof (ctx.api as { getFile?: unknown }).getFile === "function"
+        ? (ctx.api as TelegramContext["api"])
+        : undefined;
+    return { message, me: ctx.me, getFile, api };
   };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -33,6 +33,7 @@ const BOT_TOKEN = "tok123";
 function makeCtx(
   mediaField: "voice" | "audio" | "photo" | "video",
   getFile: TelegramContext["getFile"],
+  api?: TelegramContext["api"],
 ): TelegramContext {
   const msg: Record<string, unknown> = {
     message_id: 1,
@@ -60,6 +61,7 @@ function makeCtx(
       username: "bot",
     } as unknown as TelegramContext["me"],
     getFile,
+    api,
   };
 }
 
@@ -154,6 +156,44 @@ describe("resolveMedia getFile retry", () => {
     const result = await promise;
 
     expect(getFile).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
+  it("aborts timed-out api.getFile calls before retrying", async () => {
+    const apiGetFile = vi
+      .fn()
+      .mockImplementationOnce((_fileId: string, signal?: AbortSignal) => {
+        return new Promise<{ file_path?: string }>((_, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+      })
+      .mockResolvedValueOnce({ file_path: "voice/file_0.oga" });
+
+    const getFile = vi.fn().mockResolvedValue({ file_path: "unused.oga" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(
+      makeCtx("voice", getFile, { getFile: apiGetFile }),
+      MAX_MEDIA_BYTES,
+      BOT_TOKEN,
+    );
+    await vi.advanceTimersByTimeAsync(15_001);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(apiGetFile).toHaveBeenCalledTimes(2);
+    expect(getFile).not.toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
     );

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -349,7 +349,12 @@ export async function resolveMedia(
     }
 
     try {
-      const file = await ctx.getFile();
+      const file = await getTelegramFileWithTimeout(
+        ctx,
+        sticker.file_id,
+        TELEGRAM_GET_FILE_TIMEOUT_MS,
+        "telegram:getFile",
+      );
       if (!file.file_path) {
         logVerbose("telegram: getFile returned no file_path for sticker");
         return null;
@@ -423,7 +428,13 @@ export async function resolveMedia(
   let file: { file_path?: string };
   try {
     file = await retryAsync(
-      () => withTimeout(() => ctx.getFile(), TELEGRAM_GET_FILE_TIMEOUT_MS, "telegram:getFile"),
+      () =>
+        getTelegramFileWithTimeout(
+          ctx,
+          m.file_id,
+          TELEGRAM_GET_FILE_TIMEOUT_MS,
+          "telegram:getFile",
+        ),
       {
         attempts: 3,
         minDelayMs: 1000,
@@ -462,18 +473,40 @@ export async function resolveMedia(
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }
 
-async function withTimeout<T>(run: () => Promise<T>, timeoutMs: number, label: string): Promise<T> {
+async function getTelegramFileWithTimeout(
+  ctx: TelegramContext,
+  fileId: string,
+  timeoutMs: number,
+  label: string,
+): Promise<{ file_path?: string }> {
+  const normalizedTimeoutMs = Math.max(1, timeoutMs);
+
+  if (ctx.api && typeof ctx.api.getFile === "function") {
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, normalizedTimeoutMs);
+
+    try {
+      return await ctx.api.getFile(fileId, controller.signal);
+    } catch (err) {
+      if (controller.signal.aborted) {
+        throw new Error(`${label} timed out after ${normalizedTimeoutMs}ms`, { cause: err });
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      run(),
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(
-          () => {
-            reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-          },
-          Math.max(1, timeoutMs),
-        );
+      ctx.getFile(),
+      new Promise<{ file_path?: string }>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${normalizedTimeoutMs}ms`));
+        }, normalizedTimeoutMs);
       }),
     ]);
   } finally {

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -13,7 +13,7 @@ export type TelegramContext = {
   me?: UserFromGetMe;
   getFile: () => Promise<{ file_path?: string }>;
   api?: {
-    getFile: (fileId: string, signal?: AbortSignal) => Promise<{ file_path?: string }>;
+    getFile: (fileId: string, signal?: unknown) => Promise<{ file_path?: string }>;
   };
 };
 

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -12,6 +12,9 @@ export type TelegramContext = {
   message: Message;
   me?: UserFromGetMe;
   getFile: () => Promise<{ file_path?: string }>;
+  api?: {
+    getFile: (fileId: string, signal?: AbortSignal) => Promise<{ file_path?: string }>;
+  };
 };
 
 /** Telegram sticker metadata for context enrichment and caching. */


### PR DESCRIPTION
## Summary
- add explicit timeouts around Telegram inbound media retrieval
- bound `ctx.getFile()` with a retryable timeout so a hung Bot API call cannot hold `sequentialize(chatId)` forever
- pass a timeout into `fetchRemoteMedia` and apply it to Telegram file downloads
- add regression coverage for the hanging `getFile` path

Fixes #27984

## Testing
- pnpm test src/telegram/bot/delivery.resolve-media-retry.test.ts
- pnpm check
- pnpm check:docs
- pnpm protocol:check
