### PR TITLE
fix(secrets): default exec no-output timeout to timeoutMs

### DIFF
--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -112,6 +112,44 @@ describe("secret ref resolver", () => {
     expect(value).toBe("value:openai/api-key");
   });
 
+  it("uses timeoutMs as the default no-output timeout for exec providers", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secrets-resolve-exec-delay-"));
+    cleanupRoots.push(root);
+    const scriptPath = path.join(root, "resolver-delay.mjs");
+    await writeSecureFile(
+      scriptPath,
+      [
+        "#!/usr/bin/env node",
+        "setTimeout(() => {",
+        "  process.stdout.write(JSON.stringify({ protocolVersion: 1, values: { delayed: 'ok' } }));",
+        "}, 2200);",
+      ].join("\n"),
+      0o700,
+    );
+
+    const value = await resolveSecretRefString(
+      { source: "exec", provider: "execmain", id: "delayed" },
+      {
+        config: {
+          secrets: {
+            providers: {
+              execmain: {
+                source: "exec",
+                command: scriptPath,
+                passEnv: ["PATH"],
+                timeoutMs: 5000,
+              },
+            },
+          },
+        },
+      },
+    );
+    expect(value).toBe("ok");
+  });
+
   it("supports non-JSON single-value exec output when jsonOnly is false", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -27,7 +27,6 @@ const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const DEFAULT_FILE_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FILE_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
-const DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS = 2_000;
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
@@ -518,7 +517,7 @@ async function resolveExecRefs(params: {
   const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
   const noOutputTimeoutMs = normalizePositiveInt(
     params.providerConfig.noOutputTimeoutMs,
-    DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,
+    timeoutMs,
   );
   const maxOutputBytes = normalizePositiveInt(
     params.providerConfig.maxOutputBytes,


### PR DESCRIPTION
## Summary

- Problem: exec secret providers respect `timeoutMs`, but when `noOutputTimeoutMs` is omitted they still fall back to a hardcoded `2000ms` no-output watchdog.
- Why it matters: quiet-but-valid providers (for example 1Password service-account flows) can be killed early during `secrets.reload` even though the configured `timeoutMs` is higher.
- What changed: exec secret providers now default `noOutputTimeoutMs` to the resolved `timeoutMs`, and add a regression test covering a delayed-but-successful provider.
- What did NOT change (scope boundary): explicit `noOutputTimeoutMs` config still wins; this PR only changes the default when that field is omitted.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28161
- Related #28140

## User-visible / Behavior Changes

Exec-based secret providers no longer get killed by the default `2000ms` no-output watchdog when only `timeoutMs` is configured.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): secrets.reload / exec secret provider
- Relevant config (redacted): `secrets.providers.execmain.timeoutMs = 5000`

### Steps

1. Configure an exec secret provider with `timeoutMs` but no `noOutputTimeoutMs`.
2. Make the provider stay quiet for >2s before printing a valid protocol response.
3. Resolve a secret through that provider.

### Expected

- The provider succeeds as long as it responds before `timeoutMs`.

### Actual

- Before this change, it could fail early with `produced no output for 2000ms`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added a delayed exec-provider regression test and ran `pnpm vitest run src/secrets/resolve.test.ts` successfully.
- Edge cases checked: explicit `noOutputTimeoutMs` remains supported because the code still uses that field when present.
- What you did **not** verify: full workspace-wide `pnpm check` is still blocked by pre-existing missing OTEL exporter modules in `extensions/diagnostics-otel/src/service.ts`.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If breaking: added/updated `openclaw doctor` upgrade warning/check? (`Yes/No/N/A`) N/A
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d0de192c43`
- Files/config to restore: `src/secrets/resolve.ts`
- Known bad symptoms reviewers should watch for: longer quiet periods before the exec provider emits output will now be allowed up to `timeoutMs` when no explicit no-output watchdog is configured.

## Risks and Mitigations

- Risk: some operators may have implicitly relied on the old 2s quiet-output cutoff.
  - Mitigation: explicit `noOutputTimeoutMs` remains available for strict watchdog behavior; this change only fixes the surprising default.

## Fit With Repo Guidance

- `VISION.md`: "Security and safe defaults" and "Bug fixes and stability" apply here because secrets resolution should respect configured timeouts instead of failing on an unrelated hardcoded default.
- `VISION.md`: "One PR = one issue/topic. Do not bundle multiple unrelated fixes/features."
- `CONTRIBUTING.md`: "Keep PRs focused (one thing per PR; do not mix unrelated concerns)"
- `CONTRIBUTING.md`: "Describe what & why"
