### PR TITLE
config: skip empty string in raw redaction to avoid corrupting snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Slack/app manifest: set `bot_user.always_online` to `true` in the onboarding and example Slack app manifest so the Slack app appears ready to respond.
 - Gateway/websocket auth: refresh auth on new websocket connects after secrets reload so rotated gateway tokens take effect immediately without requiring a restart. (#60323) Thanks @mappel-nv.
 - Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
+- Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 
 ## 2026.4.2
 
@@ -170,7 +171,6 @@ Docs: https://docs.openclaw.ai
 - Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
 - TUI/chat: keep pending local sends visible and reconciled across history reloads, make busy/error recovery clearer through fallback and terminal-error paths, and reclaim transcript width for long links and paths. (#59800) Thanks @vincentkoc.
 - Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
-- Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 
 ## 2026.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ Docs: https://docs.openclaw.ai
 - Exec/node hosts: stop forwarding the gateway workspace cwd to remote node exec when no workdir was explicitly requested, so cross-platform node approvals fall back to the node default cwd instead of failing with `SYSTEM_RUN_DENIED`. (#58977) Thanks @Starhappysh.
 - TUI/chat: keep pending local sends visible and reconciled across history reloads, make busy/error recovery clearer through fallback and terminal-error paths, and reclaim transcript width for long links and paths. (#59800) Thanks @vincentkoc.
 - Exec approvals/channels: decouple initiating-surface approval availability from native delivery enablement so Telegram, Slack, and Discord still expose approvals when approvers exist and native target routing is configured separately. (#59776) Thanks @joelnishanth.
+- Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 
 ## 2026.4.1
 

--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED_SENTINEL } from "./redact-snapshot.js";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("ignores empty string replacement tokens", () => {
+    const raw = '{ "gateway": { "auth": { "token": "" } }, "other": "" }';
+
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: [""],
+      redactedSentinel: REDACTED_SENTINEL,
+    });
+
+    expect(result).toBe(raw);
+  });
+
+  it("redacts non-empty values while preserving blank strings", () => {
+    const raw = '{ "token": "", "secret": "abc123", "other": "" }';
+
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", "abc123"],
+      redactedSentinel: REDACTED_SENTINEL,
+    });
+
+    expect(result).toContain('"token": ""');
+    expect(result).toContain('"other": ""');
+    expect(result).not.toContain("abc123");
+    expect(result).toContain(REDACTED_SENTINEL);
+  });
+
+  it("replaces longest values first for overlapping matches", () => {
+    const raw = '{ "token": "abcd", "prefix": "ab" }';
+
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["ab", "abcd", "abcd"],
+      redactedSentinel: REDACTED_SENTINEL,
+    });
+
+    expect(result).toBe(`{ "token": "${REDACTED_SENTINEL}", "prefix": "${REDACTED_SENTINEL}" }`);
+  });
+});

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,11 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // Empty string is not a valid replacement token here: replaceAll("", x)
+  // matches every character boundary and corrupts the whole raw snapshot.
+  const values = [...new Set(params.sensitiveValues)]
+    .filter((value) => value !== "")
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -545,6 +545,19 @@ describe("redactConfigSnapshot", () => {
     expect(restored).toEqual(snapshot.config);
   });
 
+  it("does not mangle raw when a sensitive field value is empty string", () => {
+    const config = {
+      gateway: { auth: { token: "" } },
+      other: "",
+    };
+    const raw = '{ "gateway": { "auth": { "token": "" } }, "other": "" }';
+    const snapshot = makeSnapshot(config, raw);
+    const result = redactConfigSnapshot(snapshot);
+    expect(result.config.gateway?.auth?.token).toBe(REDACTED_SENTINEL);
+    expect(result.raw).toBe(raw);
+    expect((result.raw ?? "").split(REDACTED_SENTINEL).length).toBe(1);
+  });
+
   it("redacts parsed and resolved objects", () => {
     const snapshot = makeSnapshot({
       channels: { discord: { token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.FgH" } },


### PR DESCRIPTION
## Summary

- **Problem:** When loading config in Settings → All Settings, if any **encrypted/sensitive field has an empty string value**, `redactRawText` runs `replaceAll("", REDACTED_SENTINEL)` on the raw string. In JavaScript an empty string matches every character boundary, so the entire raw is filled with `__OPENCLAW_REDACTED__` and the All Settings raw view is corrupted.
- **Why it matters:** Users who leave tokens/apiKeys blank (value `""`) should still see and edit the rest of the config; otherwise All Settings is unusable.
- **What changed:** In `redactRawText`, the list from `collectSensitiveValues` is **filtered to drop empty strings** before running `replaceAll` on the raw. Sensitive empty strings in the object tree are still redacted to the sentinel by `redactObject`; only raw-text replacement no longer uses `""`.
- **What did NOT change (scope boundary):** Only raw redaction logic was changed; no changes to `redactObject`, `restoreRedactedValues`, schema, API, or other modules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- **Before:** When any sensitive field (e.g. `gateway.auth.token`) was an empty string, the raw in Settings → All Settings was replaced entirely with `__OPENCLAW_REDACTED__`, so it could not be read or edited.
- **After:** When sensitive fields are empty strings, the raw is left unchanged; in the object view those fields still show the sentinel. Behavior is consistent and the raw is no longer corrupted.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (non-empty sensitive values are still redacted; empty strings do not expose secrets)
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any **Yes**, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any (e.g. Linux / macOS)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config (redacted): Any OpenClaw config with a sensitive path set to `""` (e.g. `gateway.auth.token: ""`).

### Steps

1. Set at least one sensitive field to `""` in `openclaw.json` (e.g. `gateway.auth.token: ""`).
2. Open Web UI → Settings → All Settings (or equivalent flow that loads the config snapshot with raw).
3. Inspect the raw text area.

### Expected

- Raw content matches the file and is **not** replaced entirely by `__OPENCLAW_REDACTED__`; that sensitive key still shows as the sentinel in the object view.

### Actual (before fix)

- Raw was fully replaced with the sentinel and unusable.

## Evidence

- [x] Failing test/log before + passing after  
  New test: `does not mangle raw when a sensitive field value is empty string` in `src/config/redact-snapshot.test.ts`, asserting that when a sensitive field is `""`, `result.raw` is unchanged and does not contain extra sentinels.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Ran `pnpm test -- src/config/redact-snapshot.test.ts` locally (including the new case); confirmed `redactRawText` only replaces non-empty sensitive values in the raw.
- **Edge cases checked:** Config and raw with both a sensitive `""` and a non-sensitive `""`; raw is not corrupted and non-empty sensitive values are still redacted.
- **What you did not verify:** Did not run a full Web UI deploy and click through All Settings end-to-end (relied on unit tests and code review).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit or restore the previous `redactRawText` logic in `src/config/redact-snapshot.ts` (remove the empty-string filter).
- Files/config to restore: `src/config/redact-snapshot.ts` (and optionally `redact-snapshot.test.ts` if removing the new test).
- Known bad symptoms reviewers should watch for: If we ever filter out values other than `""`, sensitive content could leak in the raw; current change only excludes `""` and is consistent with the intended design.

## Risks and Mitigations

- **Risk:** If in the future we filter out more than the empty string, some sensitive values might not be redacted in the raw.  
  **Mitigation:** Only values strictly equal to `""` are filtered, and the comment in code explains why we do not run `replaceAll` on empty string.