### PR TITLE
fix(reply): prevent cross-run duplicate resend after message tool sends

### DIFF
--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -7,7 +7,15 @@ const require = createRequire(import.meta.url);
 let tsCache;
 
 function getTypeScript() {
-  tsCache ??= require("typescript");
+  if (!tsCache) {
+    try {
+      tsCache = require("typescript");
+    } catch {
+      // Some lightweight CI jobs intentionally do not install full JS deps.
+      // AST helpers should fail lazily only when invoked.
+      throw new Error("typescript dependency is required for AST guard helpers but is not installed");
+    }
+  }
   return tsCache;
 }
 
@@ -121,26 +129,26 @@ export function toLine(sourceFile, node) {
 }
 
 export function getPropertyNameText(name) {
-  const ts = getTypeScript();
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+  const tsApi = getTypeScript();
+  if (tsApi.isIdentifier(name) || tsApi.isStringLiteral(name) || tsApi.isNumericLiteral(name)) {
     return name.text;
   }
   return null;
 }
 
 export function unwrapExpression(expression) {
-  const ts = getTypeScript();
+  const tsApi = getTypeScript();
   let current = expression;
   while (true) {
-    if (ts.isParenthesizedExpression(current)) {
+    if (tsApi.isParenthesizedExpression(current)) {
       current = current.expression;
       continue;
     }
-    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+    if (tsApi.isAsExpression(current) || tsApi.isTypeAssertionExpression(current)) {
       current = current.expression;
       continue;
     }
-    if (ts.isNonNullExpression(current)) {
+    if (tsApi.isNonNullExpression(current)) {
       current = current.expression;
       continue;
     }

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -13,7 +13,9 @@ function getTypeScript() {
     } catch {
       // Some lightweight CI jobs intentionally do not install full JS deps.
       // AST helpers should fail lazily only when invoked.
-      throw new Error("typescript dependency is required for AST guard helpers but is not installed");
+      throw new Error(
+        "typescript dependency is required for AST guard helpers but is not installed",
+      );
     }
   }
   return tsCache;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -57,6 +57,8 @@ import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-r
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
+const RECENT_MESSAGING_TOOL_DEDUPE_WINDOW_MS = 2 * 60 * 1000;
+
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 export async function runReplyAgent(params: {
@@ -413,6 +415,54 @@ export async function runReplyAgent(params: {
     }
 
     const payloadArray = runResult.payloads ?? [];
+
+    const sentTexts = runResult.messagingToolSentTexts ?? [];
+    const sentMediaUrls = runResult.messagingToolSentMediaUrls ?? [];
+    const sentTargets = runResult.messagingToolSentTargets ?? [];
+    const sessionDedupeEntry = activeSessionEntry;
+    if (sessionDedupeEntry) {
+      const now = Date.now();
+      if (sentTexts.length || sentMediaUrls.length || sentTargets.length) {
+        sessionDedupeEntry.lastMessagingToolSessionId = followupRun.run.sessionId;
+        sessionDedupeEntry.lastMessagingToolSentAt = now;
+        sessionDedupeEntry.lastMessagingToolSentTexts = sentTexts;
+        sessionDedupeEntry.lastMessagingToolSentMediaUrls = sentMediaUrls;
+        sessionDedupeEntry.lastMessagingToolSentTargets = sentTargets;
+      } else if (
+        typeof sessionDedupeEntry.lastMessagingToolSentAt === "number" &&
+        now - sessionDedupeEntry.lastMessagingToolSentAt > RECENT_MESSAGING_TOOL_DEDUPE_WINDOW_MS
+      ) {
+        delete sessionDedupeEntry.lastMessagingToolSessionId;
+        delete sessionDedupeEntry.lastMessagingToolSentAt;
+        delete sessionDedupeEntry.lastMessagingToolSentTexts;
+        delete sessionDedupeEntry.lastMessagingToolSentMediaUrls;
+        delete sessionDedupeEntry.lastMessagingToolSentTargets;
+      }
+      if (sessionKey && activeSessionStore) {
+        activeSessionStore[sessionKey] = sessionDedupeEntry;
+      }
+      if (sessionKey && storePath) {
+        try {
+          await updateSessionStoreEntry({
+            storePath,
+            sessionKey,
+            update: async () => ({
+              lastMessagingToolSessionId: sessionDedupeEntry.lastMessagingToolSessionId,
+              lastMessagingToolSentAt: sessionDedupeEntry.lastMessagingToolSentAt,
+              lastMessagingToolSentTexts: sessionDedupeEntry.lastMessagingToolSentTexts,
+              lastMessagingToolSentMediaUrls: sessionDedupeEntry.lastMessagingToolSentMediaUrls,
+              lastMessagingToolSentTargets: sessionDedupeEntry.lastMessagingToolSentTargets,
+            }),
+          });
+        } catch (error) {
+          console.warn(
+            "Failed to persist messaging-tool dedupe state for session",
+            sessionKey,
+            error,
+          );
+        }
+      }
+    }
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { MessagingToolSend } from "../../agents/pi-embedded-runner.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
@@ -73,6 +74,16 @@ export type SessionEntry = {
   lastHeartbeatText?: string;
   /** Timestamp (ms) when lastHeartbeatText was delivered. */
   lastHeartbeatSentAt?: number;
+  /** Timestamp (ms) for the most recent message-tool send fingerprint (cross-run dedupe). */
+  lastMessagingToolSentAt?: number;
+  /** Session id that produced the most recent message-tool dedupe fingerprint. */
+  lastMessagingToolSessionId?: string;
+  /** Recently sent message-tool text payloads for short-window cross-run dedupe. */
+  lastMessagingToolSentTexts?: string[];
+  /** Recently sent message-tool media urls for short-window cross-run dedupe. */
+  lastMessagingToolSentMediaUrls?: string[];
+  /** Recently sent message-tool routing targets for short-window cross-run dedupe. */
+  lastMessagingToolSentTargets?: MessagingToolSend[];
   sessionId: string;
   updatedAt: number;
   sessionFile?: string;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -182,7 +182,7 @@ describe("gateway server chat", () => {
           finish();
           return;
         }
-          opts?.abortSignal?.addEventListener("abort", finish, { once: true });
+        opts?.abortSignal?.addEventListener("abort", finish, { once: true });
       });
       return undefined;
     });


### PR DESCRIPTION
Fixes #28151

## Summary
This PR fixes duplicate outbound messages that can occur across consecutive runs when:
1) a run sends via the `message` tool and returns `NO_REPLY`, and then
2) a system-triggered followup run (for example exec-completed notification handling) executes shortly after.

## What was broken
Deduplication for message-tool sends was effectively run-local.

- During a given run, dedupe used:
  - `runResult.messagingToolSentTexts`
  - `runResult.messagingToolSentMediaUrls`
  - `runResult.messagingToolSentTargets`
- A subsequent followup run did not have access to the previous run's sent-message fingerprint.

This made it possible for the next run to re-deliver content that had just been sent by the previous run.

## Root cause (code-level)
Cross-run dedupe state was missing from session metadata and followup dedupe only looked at current-run values.

## Changes
### 1) Persist short-window dedupe state in session metadata
File: `src/config/sessions/types.ts`

Added optional fields on `SessionEntry`:
- `lastMessagingToolSessionId?: string`
- `lastMessagingToolSentAt?: number`
- `lastMessagingToolSentTexts?: string[]`
- `lastMessagingToolSentMediaUrls?: string[]`
- `lastMessagingToolSentTargets?: MessagingToolSend[]`

### 2) Write/update dedupe state from `agent-runner`
File: `src/auto-reply/reply/agent-runner.ts`

- Persist `messagingToolSent*` into session state after each run.
- Persist `lastMessagingToolSessionId` alongside timestamp.
- Add expiry cleanup for stale dedupe state (2-minute window).
- Wrap session-store persistence in `try/catch` so dedupe-state write failures do not block normal replies.
- On `resetSession(...)`, clear dedupe fields to avoid stale carry-over into a fresh session.

### 3) Consume dedupe state in `followup-runner` with safety scoping
File: `src/auto-reply/reply/followup-runner.ts`

- For followup runs, use session-level dedupe only when all are true:
  - within dedupe window,
  - `lastMessagingToolSessionId === queued.run.sessionId`,
  - recent target matches current followup target.
- Keep target-based suppression scoped to current-run `messagingToolSentTargets`.
- Use session-level text/media dedupe only when target-match criteria are satisfied.

This avoids both:
- duplicate re-delivery across runs,
- accidental suppression of valid replies to different targets/sessions.

### 4) Regression tests
File: `src/auto-reply/reply/followup-runner.test.ts`

Added/updated tests:
- `suppresses replies using recent session-level messaging-tool dedupe state`
- `does not use session-level text dedupe when recent target does not match`
- `does not use session-level dedupe from a previous session id`

## Scope
- Reply dedupe behavior only.
- No channel plugin behavior changes.
- No changes to normal message-tool delivery semantics.

## Local validation
- `pnpm vitest run src/auto-reply/reply/followup-runner.test.ts`
- `pnpm vitest run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
