### PR TITLE
fix(cli): redirect doctor note output to stderr when --json is active

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -90,6 +90,14 @@ These are the standard files OpenClaw expects inside the workspace:
   - Optional tiny checklist for heartbeat runs.
   - Keep it short to avoid token burn.
 
+- `WORKFLOW_AUTO.md`
+  - Post-compaction recovery checklist.
+  - Lists the files the agent should re-read after context compaction so
+    operating protocols are restored.
+  - Checked by the [post-compaction audit](/concepts/compaction#post-compaction-audit).
+    If the agent does not read this file after a compaction, a warning is
+    injected into the session.
+
 - `BOOT.md`
   - Optional startup checklist executed on gateway restart when internal hooks are enabled.
   - Keep it short; use the message tool for outbound sends.

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -91,11 +91,11 @@ These are the standard files OpenClaw expects inside the workspace:
   - Keep it short to avoid token burn.
 
 - `WORKFLOW_AUTO.md`
-  - Post-compaction recovery checklist.
+  - Optional post-compaction recovery checklist.
   - Lists the files the agent should re-read after context compaction so
     operating protocols are restored.
-  - Checked by the [post-compaction audit](/concepts/compaction#post-compaction-audit).
-    If the agent does not read this file after a compaction, a warning is
+  - Checked by the [post-compaction audit](/concepts/compaction#post-compaction-audit)
+    after auto-compaction. If the agent does not read this file, a warning is
     injected into the session.
 
 - `BOOT.md`

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -69,10 +69,12 @@ See [OpenAI provider](/providers/openai) for model params and overrides.
 
 ## Post-compaction audit
 
-After every compaction (auto or manual), OpenClaw runs a **post-compaction
-audit** that checks whether the agent re-read a set of required startup files.
-If any are missing, a warning is injected into the session so the agent can
-recover.
+After auto-compaction, OpenClaw runs a **post-compaction audit** that checks
+whether the agent re-read a set of required startup files. If any are missing,
+a warning is injected into the session so the agent can recover.
+
+The audit currently fires after **auto-compaction only**. Manual `/compact`
+does not trigger the audit.
 
 The default required files are:
 
@@ -102,11 +104,10 @@ Resume the conversation naturally without announcing the reset.
 ```
 
 Place this file in the root of your [agent workspace](/concepts/agent-workspace).
-`openclaw setup` will create a default if one does not exist.
 
 ### How the audit works
 
-1. Compaction completes (auto or `/compact`).
+1. Auto-compaction completes.
 2. OpenClaw injects the "Session Startup" and "Red Lines" sections from
    `AGENTS.md` as a post-compaction context reminder.
 3. On the **next agent turn**, the audit reads the session history and checks
@@ -122,12 +123,6 @@ Place this file in the root of your [agent workspace](/concepts/agent-workspace)
 
 The audit is **one-shot per compaction** (it fires once, then resets) and
 **best-effort** (failures are silently ignored).
-
-### Customizing the required files
-
-The default list is defined in `post-compaction-audit.ts`. You can override it
-by passing a custom `requiredReads` array in your agent configuration. Both
-literal file names and regular expressions are supported.
 
 ## Tips
 

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -67,6 +67,68 @@ compaction and can run alongside it.
 
 See [OpenAI provider](/providers/openai) for model params and overrides.
 
+## Post-compaction audit
+
+After every compaction (auto or manual), OpenClaw runs a **post-compaction
+audit** that checks whether the agent re-read a set of required startup files.
+If any are missing, a warning is injected into the session so the agent can
+recover.
+
+The default required files are:
+
+- `WORKFLOW_AUTO.md` (literal match)
+- `memory/YYYY-MM-DD.md` (pattern match for any daily memory file)
+
+### What is WORKFLOW_AUTO.md
+
+`WORKFLOW_AUTO.md` is a workspace file that tells the agent **which files to
+re-read after a context reset**. Because compaction replaces the full
+conversation with a summary, the agent loses any instructions it loaded at the
+start of the session. `WORKFLOW_AUTO.md` acts as a recovery checklist.
+
+A typical `WORKFLOW_AUTO.md` looks like:
+
+```md
+# Post-Compaction Recovery
+
+After context compaction, read these files in order:
+
+1. SOUL.md
+2. USER.md
+3. memory/YYYY-MM-DD.md (today + yesterday)
+4. HEARTBEAT.md
+
+Resume the conversation naturally without announcing the reset.
+```
+
+Place this file in the root of your [agent workspace](/concepts/agent-workspace).
+`openclaw setup` will create a default if one does not exist.
+
+### How the audit works
+
+1. Compaction completes (auto or `/compact`).
+2. OpenClaw injects the "Session Startup" and "Red Lines" sections from
+   `AGENTS.md` as a post-compaction context reminder.
+3. On the **next agent turn**, the audit reads the session history and checks
+   which files the agent accessed via the Read tool.
+4. Any required file that was not read triggers a warning:
+
+   ```
+   Post-Compaction Audit: The following required startup files were not
+   read after context reset:
+     - WORKFLOW_AUTO.md
+   Please read them now using the Read tool before continuing.
+   ```
+
+The audit is **one-shot per compaction** (it fires once, then resets) and
+**best-effort** (failures are silently ignored).
+
+### Customizing the required files
+
+The default list is defined in `post-compaction-audit.ts`. You can override it
+by passing a custom `requiredReads` array in your agent configuration. Both
+literal file names and regular expressions are supported.
+
 ## Tips
 
 - Use `/compact` when sessions feel stale or context is bloated.


### PR DESCRIPTION
## Summary

Fixes #25132

When using `--json` with CLI commands (e.g. `openclaw nodes status --json`), doctor migration notes ("Doctor changes", "Unknown config keys") were printed to stdout before the JSON output, breaking JSON parsing.

The `note()` function (wrapping `@clack/prompts` `note`) now detects `--json` on `process.argv` and redirects output to `stderr` instead of `stdout`, keeping stdout as valid JSON.

- Modified `src/terminal/note.ts` to pass `{ output: process.stderr }` to `@clack/prompts` when `--json` is detected
- Added `src/terminal/note.test.ts` with tests for the stderr redirect behavior

## Test plan

- [x] `pnpm test -- --run src/terminal/note.test.ts` passes (3 tests)
- [x] `pnpm test -- --run src/cli/program/config-guard.test.ts src/commands/doctor-config-flow.test.ts` passes (22 tests)
- [x] `pnpm check` passes (lint + format + typecheck)
- [ ] Manual: `openclaw nodes status --json` should produce valid JSON on stdout (doctor warnings go to stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)