### PR TITLE
fix(secrets): honor exec no-output timeout fallback to provider timeout

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -27,7 +27,6 @@ const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const DEFAULT_FILE_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FILE_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
-const DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS = 2_000;
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
@@ -518,7 +517,7 @@ async function resolveExecRefs(params: {
   const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
   const noOutputTimeoutMs = normalizePositiveInt(
     params.providerConfig.noOutputTimeoutMs,
-    DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,
+    timeoutMs,
   );
   const maxOutputBytes = normalizePositiveInt(
     params.providerConfig.maxOutputBytes,


### PR DESCRIPTION
Closes #28161

## Problem
`secrets.reload` could fail for exec providers that emit output after startup delay, because the no-output watchdog fired at 2000ms even when provider `timeoutMs` was configured higher.

## Root Cause
Exec secret resolution defaulted `noOutputTimeoutMs` to a hardcoded 2000ms instead of deriving it from the resolved provider timeout budget.

## Fix
When `noOutputTimeoutMs` is not explicitly set, fallback now uses the resolved `timeoutMs` value for the same provider call path. Added regression tests for delayed (>2s) exec startup with configured and default timeout scenarios.

## Testing
- `npm test -- src/secrets/resolve.test.ts src/gateway/server-methods/secrets.test.ts`
