### PR TITLE
fix(macos): reuse remote gateway credentials for local loopback endpoints

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -97,26 +97,13 @@ actor GatewayEndpointStore {
             }
             return trimmed
         }
-        if isRemote {
-            if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let password = remote["password"] as? String
-            {
-                let pw = password.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !pw.isEmpty {
-                    return pw
-                }
-            }
-            return nil
-        }
-        if let gateway = root["gateway"] as? [String: Any],
-           let auth = gateway["auth"] as? [String: Any],
-           let password = auth["password"] as? String
+        if let configPassword = self.resolveConfigPassword(isRemote: isRemote, root: root),
+           !configPassword.isEmpty
         {
-            let pw = password.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !pw.isEmpty {
-                return pw
-            }
+            return configPassword
+        }
+        if isRemote {
+            return nil
         }
         if let password = launchdSnapshot?.password?.trimmingCharacters(in: .whitespacesAndNewlines),
            !password.isEmpty

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -143,6 +143,12 @@ actor GatewayEndpointStore {
         {
             return password.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+        if let gateway = root["gateway"] as? [String: Any],
+           let remote = gateway["remote"] as? [String: Any],
+           let password = remote["password"] as? String
+        {
+            return password.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         return nil
     }
 
@@ -200,6 +206,12 @@ actor GatewayEndpointStore {
         if let gateway = root["gateway"] as? [String: Any],
            let auth = gateway["auth"] as? [String: Any],
            let token = auth["token"] as? String
+        {
+            return token.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let gateway = root["gateway"] as? [String: Any],
+           let remote = gateway["remote"] as? [String: Any],
+           let token = remote["token"] as? String
         {
             return token.trimmingCharacters(in: .whitespacesAndNewlines)
         }

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -110,31 +110,38 @@ actor GatewayEndpointStore {
         {
             return password
         }
+        if let remotePassword = self.resolveRemoteConfigPassword(root: root), !remotePassword.isEmpty {
+            return remotePassword
+        }
         return nil
     }
 
     private static func resolveConfigPassword(isRemote: Bool, root: [String: Any]) -> String? {
         if isRemote {
-            if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let password = remote["password"] as? String
-            {
-                return password.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return nil
+            return self.resolveRemoteConfigPassword(root: root)
         }
 
         if let gateway = root["gateway"] as? [String: Any],
            let auth = gateway["auth"] as? [String: Any],
            let password = auth["password"] as? String
         {
-            return password.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
         }
+        return nil
+    }
+
+    private static func resolveRemoteConfigPassword(root: [String: Any]) -> String? {
         if let gateway = root["gateway"] as? [String: Any],
            let remote = gateway["remote"] as? [String: Any],
            let password = remote["password"] as? String
         {
-            return password.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
         }
         return nil
     }
@@ -175,32 +182,39 @@ actor GatewayEndpointStore {
         {
             return token
         }
+        if let remoteToken = self.resolveRemoteConfigToken(root: root), !remoteToken.isEmpty {
+            return remoteToken
+        }
 
         return nil
     }
 
     private static func resolveConfigToken(isRemote: Bool, root: [String: Any]) -> String? {
         if isRemote {
-            if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let token = remote["token"] as? String
-            {
-                return token.trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return nil
+            return self.resolveRemoteConfigToken(root: root)
         }
 
         if let gateway = root["gateway"] as? [String: Any],
            let auth = gateway["auth"] as? [String: Any],
            let token = auth["token"] as? String
         {
-            return token.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
         }
+        return nil
+    }
+
+    private static func resolveRemoteConfigToken(root: [String: Any]) -> String? {
         if let gateway = root["gateway"] as? [String: Any],
            let remote = gateway["remote"] as? [String: Any],
            let token = remote["token"] as? String
         {
-            return token.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
         }
         return nil
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -55,6 +55,21 @@ import Testing
         #expect(token == nil)
     }
 
+    @Test func resolveGatewayTokenFallsBackToRemoteTokenForLocalLoopbackMode() {
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "token": "remote-token"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
     @Test func resolveGatewayPasswordFallsBackToLaunchd() {
         let snapshot = LaunchAgentPlistSnapshot(
             programArguments: [],
@@ -72,6 +87,21 @@ import Testing
             env: [:],
             launchdSnapshot: snapshot)
         #expect(password == "launchd-pass")
+    }
+
+    @Test func resolveGatewayPasswordFallsBackToRemotePasswordForLocalLoopbackMode() {
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "password": "remote-pass"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(password == "remote-pass")
     }
 
     @Test func connectionModeResolverPrefersConfigModeOverDefaults() {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -70,6 +70,49 @@ import Testing
         #expect(token == "remote-token")
     }
 
+    @Test func resolveGatewayTokenPrefersLaunchdOverRemoteTokenInLocalMode() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: [],
+            environment: ["OPENCLAW_GATEWAY_TOKEN": "launchd-token"],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: nil,
+            bind: nil,
+            token: "launchd-token",
+            password: nil)
+
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "token": "remote-token"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: snapshot)
+        #expect(token == "launchd-token")
+    }
+
+    @Test func resolveGatewayTokenTreatsBlankAuthTokenAsMissingForRemoteFallback() {
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "token": "   "
+                    ],
+                    "remote": [
+                        "token": "remote-token"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(token == "remote-token")
+    }
+
     @Test func resolveGatewayPasswordFallsBackToLaunchd() {
         let snapshot = LaunchAgentPlistSnapshot(
             programArguments: [],
@@ -94,6 +137,49 @@ import Testing
             isRemote: false,
             root: [
                 "gateway": [
+                    "remote": [
+                        "password": "remote-pass"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: nil)
+        #expect(password == "remote-pass")
+    }
+
+    @Test func resolveGatewayPasswordPrefersLaunchdOverRemotePasswordInLocalMode() {
+        let snapshot = LaunchAgentPlistSnapshot(
+            programArguments: [],
+            environment: ["OPENCLAW_GATEWAY_PASSWORD": "launchd-pass"],
+            stdoutPath: nil,
+            stderrPath: nil,
+            port: nil,
+            bind: nil,
+            token: nil,
+            password: "launchd-pass")
+
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "remote": [
+                        "password": "remote-pass"
+                    ]
+                ]
+            ],
+            env: [:],
+            launchdSnapshot: snapshot)
+        #expect(password == "launchd-pass")
+    }
+
+    @Test func resolveGatewayPasswordTreatsBlankAuthPasswordAsMissingForRemoteFallback() {
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "password": "   "
+                    ],
                     "remote": [
                         "password": "remote-pass"
                     ]


### PR DESCRIPTION
## Summary
- fall back to `gateway.remote.token` / `gateway.remote.password` for macOS local-mode endpoint resolution when `gateway.auth.*` is unset
- add focused macOS endpoint-store tests covering the local fallback behavior

Fixes #27835

## Why This Fits The Project
`VISION.md`:
> Security and safe defaults

`VISION.md`:
> Setup reliability and first-run UX

`CONTRIBUTING.md`:
> Keep PRs focused (one thing per PR; do not mix unrelated concerns)

`CONTRIBUTING.md`:
> Describe what & why

This keeps the macOS companion app aligned with existing CLI credential resolution for loopback/docker gateway setups, which avoids a false "token not found" failure without widening auth behavior beyond already-supported config paths.

## Testing
- Added macOS endpoint-store tests for local fallback to `gateway.remote.token`
- Added macOS endpoint-store tests for local fallback to `gateway.remote.password`
- Attempted: `swift test --package-path apps/macos --filter GatewayEndpointStoreTests`
  - blocked waiting on Swift package artifact download (`Sparkle-for-Swift-Package-Manager.zip`) in this environment
