### PR TITLE
security(gateway): cap pending pre-auth websocket handshakes

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -30,6 +30,16 @@ export const getHandshakeTimeoutMs = () => {
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
+export const DEFAULT_MAX_PENDING_HANDSHAKES = 64;
+export const getMaxPendingHandshakes = () => {
+  if (process.env.VITEST && process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES) {
+    const parsed = Number(process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+  }
+  return DEFAULT_MAX_PENDING_HANDSHAKES;
+};
 export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -357,6 +357,35 @@ describe("gateway server auth/connect", () => {
       }
     });
 
+    test("rejects excess concurrent pending handshakes", async () => {
+      vi.useRealTimers();
+      const prevPendingLimit = process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES;
+      process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES = "2";
+      const sockets: WebSocket[] = [];
+      try {
+        const first = await openWs(port);
+        sockets.push(first);
+        const second = await openWs(port);
+        sockets.push(second);
+        const third = await openWs(port);
+        sockets.push(third);
+
+        const thirdClosed = await waitForWsClose(third, 1000);
+        expect(thirdClosed).toBe(true);
+        expect(first.readyState).toBe(WebSocket.OPEN);
+        expect(second.readyState).toBe(WebSocket.OPEN);
+      } finally {
+        for (const ws of sockets) {
+          ws.close();
+        }
+        if (prevPendingLimit === undefined) {
+          delete process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES;
+        } else {
+          process.env.OPENCLAW_TEST_MAX_PENDING_HANDSHAKES = prevPendingLimit;
+        }
+      }
+    });
+
     test("connect (req) handshake returns hello-ok payload", async () => {
       const { CONFIG_PATH, STATE_DIR } = await import("../config/config.js");
       const ws = await openWs(port);

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -9,7 +9,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { isLoopbackAddress } from "../net.js";
-import { getHandshakeTimeoutMs } from "../server-constants.js";
+import { getHandshakeTimeoutMs, getMaxPendingHandshakes } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
@@ -103,7 +103,23 @@ export function attachGatewayWsConnectionHandler(params: {
     buildRequestContext,
   } = params;
 
+  const pendingHandshakes = new Set<WebSocket>();
+
   wss.on("connection", (socket, upgradeReq) => {
+    const maxPendingHandshakes = getMaxPendingHandshakes();
+    if (pendingHandshakes.size >= maxPendingHandshakes) {
+      logWsControl.warn(
+        `rejecting websocket before auth: pending handshake limit reached (${maxPendingHandshakes})`,
+      );
+      try {
+        socket.close(1013, "too many pending handshakes");
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    pendingHandshakes.add(socket);
+
     let client: GatewayWsClient | null = null;
     let closed = false;
     const openedAt = Date.now();
@@ -196,6 +212,7 @@ export function attachGatewayWsConnectionHandler(params: {
       );
 
     socket.once("close", (code, reason) => {
+      pendingHandshakes.delete(socket);
       const durationMs = Date.now() - openedAt;
       const logForwardedFor = sanitizeLogValue(forwardedFor);
       const logOrigin = sanitizeLogValue(requestOrigin);
@@ -297,6 +314,9 @@ export function attachGatewayWsConnectionHandler(params: {
       },
       setHandshakeState: (next) => {
         handshakeState = next;
+        if (next !== "pending") {
+          pendingHandshakes.delete(socket);
+        }
       },
       setCloseCause,
       setLastFrameMeta,


### PR DESCRIPTION
## Summary
- cap concurrent unauthenticated websocket handshakes before they enter the full auth flow
- close excess pending handshakes early instead of allowing unbounded handshake slot growth
- add regression coverage for the pending-handshake saturation case

## Why This Fits The Project
From `VISION.md`:
> - Security and safe defaults
> - One PR = one issue/topic. Do not bundle multiple unrelated fixes/features.

From `CONTRIBUTING.md`:
> - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
> - Describe what & why

This is a single-purpose gateway hardening change for a specific pre-auth resource exhaustion path.

## What Changed
- add a `MAX_PENDING_HANDSHAKES` guard for websocket connections that have opened but not completed auth
- reject additional pending handshakes once the cap is reached
- cover the rejection behavior in `server.auth.test.ts`

## Testing
- `pnpm vitest run src/gateway/server.auth.test.ts`

## AI Transparency
- AI-assisted: yes
- Testing: fully tested for the changed path
- I reviewed the final diff and validated the branch against current `upstream/main`
