### PR TITLE
security(gateway): reject oversized pre-auth websocket frames

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -30,6 +30,16 @@ export const getHandshakeTimeoutMs = () => {
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };
+export const DEFAULT_MAX_PREAUTH_FRAME_BYTES = 64 * 1024;
+export const getMaxPreAuthFrameBytes = () => {
+  if (process.env.VITEST && process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES) {
+    const parsed = Number(process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_MAX_PREAUTH_FRAME_BYTES;
+};
 export const TICK_INTERVAL_MS = 30_000;
 export const HEALTH_REFRESH_INTERVAL_MS = 60_000;
 export const DEDUPE_TTL_MS = 5 * 60_000;

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -590,6 +590,35 @@ describe("gateway server auth/connect", () => {
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     });
 
+    test("rejects oversized pre-auth frames before handshake parsing", async () => {
+      const prevMaxPreAuth = process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES;
+      process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES = "512";
+      try {
+        const ws = await openWs(port);
+        const closeInfoPromise = new Promise<{ code: number; reason: string }>((resolve) => {
+          ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+        });
+        const oversizedFrame = JSON.stringify({
+          type: "req",
+          id: "oversized-preauth",
+          method: "health",
+          padding: "x".repeat(4096),
+        });
+        expect(Buffer.byteLength(oversizedFrame, "utf8")).toBeGreaterThan(512);
+        ws.send(oversizedFrame);
+
+        const closeInfo = await closeInfoPromise;
+        expect(closeInfo.code).toBe(1009);
+        expect(closeInfo.reason).toContain("pre-auth frame too large");
+      } finally {
+        if (prevMaxPreAuth === undefined) {
+          delete process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES;
+        } else {
+          process.env.OPENCLAW_TEST_MAX_PREAUTH_FRAME_BYTES = prevMaxPreAuth;
+        }
+      }
+    });
+
     test("requires nonce for device auth", async () => {
       const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
         headers: { host: "example.com" },

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -61,7 +61,12 @@ import {
   validateRequestFrame,
 } from "../../protocol/index.js";
 import { parseGatewayRole } from "../../role-policy.js";
-import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
+import {
+  getMaxPreAuthFrameBytes,
+  MAX_BUFFERED_BYTES,
+  MAX_PAYLOAD_BYTES,
+  TICK_INTERVAL_MS,
+} from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import { formatError } from "../../server-utils.js";
@@ -206,6 +211,34 @@ function resolvePinnedClientMetadata(params: {
   };
 }
 
+function rawDataByteLength(data: WebSocket.RawData): number {
+  if (typeof data === "string") {
+    return Buffer.byteLength(data, "utf8");
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (Array.isArray(data)) {
+    let total = 0;
+    for (const chunk of data) {
+      if (Buffer.isBuffer(chunk)) {
+        total += chunk.byteLength;
+        continue;
+      }
+      if (chunk instanceof ArrayBuffer) {
+        total += chunk.byteLength;
+        continue;
+      }
+      total += Buffer.byteLength(String(chunk), "utf8");
+    }
+    return total;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data), "utf8");
+}
+
 export function attachGatewayWsMessageHandler(params: {
   socket: WebSocket;
   upgradeReq: IncomingMessage;
@@ -334,6 +367,23 @@ export function attachGatewayWsMessageHandler(params: {
   socket.on("message", async (data) => {
     if (isClosed()) {
       return;
+    }
+    const preAuthClient = getClient();
+    if (!preAuthClient) {
+      const preAuthFrameBytes = rawDataByteLength(data);
+      const maxPreAuthFrameBytes = getMaxPreAuthFrameBytes();
+      if (preAuthFrameBytes > maxPreAuthFrameBytes) {
+        setHandshakeState("failed");
+        setCloseCause("preauth-frame-too-large", {
+          preAuthFrameBytes,
+          maxPreAuthFrameBytes,
+        });
+        logWsControl.warn(
+          `pre-auth frame too large conn=${connId} remote=${remoteAddr ?? "?"} bytes=${preAuthFrameBytes} limit=${maxPreAuthFrameBytes}`,
+        );
+        close(1009, "pre-auth frame too large");
+        return;
+      }
     }
     const text = rawDataToString(data);
     try {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -221,15 +221,7 @@ function rawDataByteLength(data: WebSocket.RawData): number {
   if (Array.isArray(data)) {
     let total = 0;
     for (const chunk of data) {
-      if (Buffer.isBuffer(chunk)) {
-        total += chunk.byteLength;
-        continue;
-      }
-      if (chunk instanceof ArrayBuffer) {
-        total += chunk.byteLength;
-        continue;
-      }
-      total += Buffer.byteLength(String(chunk), "utf8");
+      total += chunk.byteLength;
     }
     return total;
   }


### PR DESCRIPTION
## Summary
- reject oversized websocket frames before the gateway parses unauthenticated handshake payloads
- close those connections with a clear websocket payload-too-large signal
- add regression coverage for oversized pre-auth frames

## Why This Fits The Project
From `VISION.md`:
> - Security and safe defaults
> - One PR = one issue/topic. Do not bundle multiple unrelated fixes/features.

From `CONTRIBUTING.md`:
> - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
> - Describe what & why

This keeps the change on one gateway boundary hardening issue and documents the security rationale directly.

## What Changed
- add a max-size guard for frames received before websocket auth completes
- close oversized pre-auth frames with code `1009` instead of letting handshake parsing work on arbitrarily large payloads
- cover the failure path in `server.auth.test.ts`

## Testing
- `pnpm vitest run src/gateway/server.auth.test.ts`

## AI Transparency
- AI-assisted: yes
- Testing: fully tested for the changed path
- I reviewed the final diff and validated the branch against current `upstream/main`
