### PR TITLE
security(telegram): gate channel_post commands by explicit allowFrom

### DIFF
--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,7 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender/chat IDs only.",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -234,6 +234,147 @@ describe("registerTelegramNativeCommands (plugin auth)", () => {
     expect(executePluginCommand).not.toHaveBeenCalled();
   });
 
+  it("allows requireAuth plugin commands from channel_post when allowFrom includes the channel id", async () => {
+    const command = {
+      name: "plugin",
+      description: "Plugin command",
+      requireAuth: true,
+      handler: vi.fn(),
+    } as const;
+
+    getPluginCommandSpecs.mockReturnValue([{ name: "plugin", description: "Plugin command" }]);
+    matchPluginCommand.mockReturnValue({ command, args: undefined });
+    executePluginCommand.mockResolvedValue({ text: "ok" });
+
+    const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
+    const bot = {
+      api: {
+        setMyCommands: vi.fn().mockResolvedValue(undefined),
+        sendMessage: vi.fn(),
+      },
+      command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as const;
+
+    registerTelegramNativeCommands({
+      bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      cfg: {} as OpenClawConfig,
+      runtime: {} as unknown as RuntimeEnv,
+      accountId: "default",
+      telegramCfg: {} as TelegramAccountConfig,
+      allowFrom: ["-100123"],
+      groupAllowFrom: [],
+      replyToMode: "off",
+      textLimit: 4000,
+      useAccessGroups: false,
+      nativeEnabled: false,
+      nativeSkillsEnabled: false,
+      nativeDisabledExplicit: false,
+      resolveGroupPolicy: () =>
+        ({
+          allowlistEnabled: false,
+          allowed: true,
+        }) as ChannelGroupPolicy,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+      shouldSkipUpdate: () => false,
+      opts: { token: "token" },
+    });
+
+    await handlers.plugin?.({
+      channelPost: {
+        chat: { id: -100123, type: "channel" },
+        sender_chat: { id: -100123, type: "channel", title: "Ops" },
+        message_id: 42,
+        date: 123456,
+        text: "/plugin",
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAuthorizedSender: true,
+      }),
+    );
+    expect(bot.api.sendMessage).not.toHaveBeenCalledWith(
+      -100123,
+      "You are not authorized to use this command.",
+    );
+  });
+
+  it("allows requireAuth:false plugin commands from channel_post even when sender is unauthorized", async () => {
+    const command = {
+      name: "plugin",
+      description: "Plugin command",
+      requireAuth: false,
+      handler: vi.fn(),
+    } as const;
+
+    getPluginCommandSpecs.mockReturnValue([{ name: "plugin", description: "Plugin command" }]);
+    matchPluginCommand.mockReturnValue({ command, args: undefined });
+    executePluginCommand.mockResolvedValue({ text: "ok" });
+
+    const handlers: Record<string, (ctx: unknown) => Promise<void>> = {};
+    const bot = {
+      api: {
+        setMyCommands: vi.fn().mockResolvedValue(undefined),
+        sendMessage: vi.fn(),
+      },
+      command: (name: string, handler: (ctx: unknown) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as const;
+
+    registerTelegramNativeCommands({
+      bot: bot as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      cfg: {} as OpenClawConfig,
+      runtime: {} as unknown as RuntimeEnv,
+      accountId: "default",
+      telegramCfg: {} as TelegramAccountConfig,
+      allowFrom: [],
+      groupAllowFrom: [],
+      replyToMode: "off",
+      textLimit: 4000,
+      useAccessGroups: false,
+      nativeEnabled: false,
+      nativeSkillsEnabled: false,
+      nativeDisabledExplicit: false,
+      resolveGroupPolicy: () =>
+        ({
+          allowlistEnabled: false,
+          allowed: true,
+        }) as ChannelGroupPolicy,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: undefined,
+        topicConfig: undefined,
+      }),
+      shouldSkipUpdate: () => false,
+      opts: { token: "token" },
+    });
+
+    await handlers.plugin?.({
+      channelPost: {
+        chat: { id: -100123, type: "channel" },
+        sender_chat: { id: -100123, type: "channel", title: "Ops" },
+        message_id: 42,
+        date: 123456,
+        text: "/plugin",
+      },
+      match: "",
+    });
+
+    expect(executePluginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAuthorizedSender: false,
+      }),
+    );
+    expect(bot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("allows requireAuth plugin commands from channel_post only with explicit wildcard allowFrom", async () => {
     const command = {
       name: "plugin",

--- a/src/telegram/bot-native-commands.plugin-auth.test.ts
+++ b/src/telegram/bot-native-commands.plugin-auth.test.ts
@@ -15,7 +15,9 @@ vi.mock("../plugins/commands.js", () => ({
   executePluginCommand,
 }));
 
-const deliverReplies = vi.hoisted(() => vi.fn(async () => {}));
+const deliverReplies = vi.hoisted(() =>
+  vi.fn(async (): Promise<{ delivered: boolean }> => ({ delivered: true })),
+);
 vi.mock("./bot/delivery.js", () => ({ deliverReplies }));
 
 vi.mock("../pairing/pairing-store.js", () => ({


### PR DESCRIPTION
## Summary
- require explicit `allowFrom` authorization for Telegram `channel_post` native/plugin commands
- treat signed Telegram channel/chat IDs as valid allowlist entries so channel posts can still be authorized intentionally
- add regression coverage for authorized and unauthorized `channel_post` command paths

## Why This Fits The Project
From `VISION.md`:
> - Security and safe defaults
> - One PR = one issue/topic. Do not bundle multiple unrelated fixes/features.

From `CONTRIBUTING.md`:
> - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
> - Describe what & why

This is a focused Telegram command-authorization hardening change.

## What Changed
- unify native command auth so `channel_post` updates go through explicit allowlist checks
- resolve `sender_chat.id` for channel posts and accept signed numeric Telegram IDs in `allowFrom` / `groupAllowFrom`
- extend Telegram plugin-auth tests to cover channel-post allow/deny cases

## Testing
- `pnpm vitest run src/telegram/bot-native-commands.plugin-auth.test.ts src/channels/telegram/allow-from.test.ts`

## AI Transparency
- AI-assisted: yes
- Testing: fully tested for the changed path
- I reviewed the final diff and validated the branch against current `upstream/main`
