### PR TITLE
fix(agent): emit model.usage diagnostic event for CLI agent runs

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -823,7 +823,7 @@ export async function agentCommand(
       const cacheWrite = usage.cacheWrite ?? 0;
       const promptTokens = input + cacheRead + cacheWrite;
       const totalTokens = usage.total ?? promptTokens + output;
-      const providerUsed = fallbackProvider ?? provider;
+      const providerUsed = result.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
       const modelUsed = result.meta?.agentMeta?.model ?? fallbackModel ?? model;
       const costConfig = resolveModelCostConfig({
         provider: providerUsed,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -30,6 +30,7 @@ import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
+import { hasNonzeroUsage } from "../agents/usage.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import {
   formatThinkingLevels,
@@ -59,6 +60,7 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -67,6 +69,7 @@ import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
@@ -807,6 +810,45 @@ export async function agentCommand(
         fallbackProvider,
         fallbackModel,
         result,
+      });
+    }
+
+    // Emit model.usage diagnostic event for OTEL/metrics parity with the
+    // messaging-channel reply path (agent-runner.ts). Fixes #28133.
+    const usage = result.meta?.agentMeta?.usage;
+    if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
+      const input = usage.input ?? 0;
+      const output = usage.output ?? 0;
+      const cacheRead = usage.cacheRead ?? 0;
+      const cacheWrite = usage.cacheWrite ?? 0;
+      const promptTokens = input + cacheRead + cacheWrite;
+      const totalTokens = usage.total ?? promptTokens + output;
+      const providerUsed = fallbackProvider ?? provider;
+      const modelUsed = result.meta?.agentMeta?.model ?? fallbackModel ?? model;
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      emitDiagnosticEvent({
+        type: "model.usage",
+        sessionKey,
+        sessionId,
+        channel: opts.replyChannel ?? opts.channel ?? "cli",
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens,
+          total: totalTokens,
+        },
+        lastCallUsage: result.meta?.agentMeta?.lastCallUsage,
+        costUsd,
+        durationMs: Date.now() - startedAt,
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes #28133 — `openclaw agent` CLI runs did not emit `model.usage` diagnostic events, making them invisible to OTEL-based monitoring. Messaging channel runs (Telegram, WhatsApp, heartbeats) correctly emitted these events.

### Root Cause

The messaging channel path in `agent-runner.ts` calls `emitDiagnosticEvent({ type: "model.usage", ... })` after each run. The CLI agent path in `commands/agent.ts` only called `updateSessionStoreAfterAgentRun()` to persist usage to disk — no diagnostic event was emitted.

### Fix

Added `emitDiagnosticEvent()` call after `updateSessionStoreAfterAgentRun()` using the same pattern as the messaging path:
- Guard: `isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)`
- Compute token breakdown (input, output, cacheRead, cacheWrite, promptTokens, total)
- Resolve model cost config and estimate USD cost
- Emit with session/provider/model/channel context

### Changes

| File | Change |
|------|--------|
| `src/commands/agent.ts` | +3 imports, +32 lines diagnostic event emission |

### Validation

- Build: PASS
- Lint: 0 warnings, 0 errors
- Event shape matches `DiagnosticUsageEvent` type exactly
- Guarded by `isDiagnosticsEnabled()` — zero impact when diagnostics disabled

lobster-biscuit