### PR TITLE
feat(config): add compaction.auditReads to disable post-compaction audit warnings

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -49,6 +49,13 @@ import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-repl
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
+import {
+  auditPostCompactionReads,
+  extractReadPaths,
+  formatAuditWarning,
+  pendingPostCompactionAudits,
+  readSessionMessages,
+} from "./post-compaction-audit.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
@@ -678,6 +685,8 @@ export async function runReplyAgent(params: {
           .catch(() => {
             // Silent failure — post-compaction context is best-effort
           });
+        // Mark this session as pending a post-compaction read audit on the next turn
+        pendingPostCompactionAudits.set(sessionKey, true);
       }
 
       if (verboseEnabled) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -89,6 +89,8 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
+  /** Whether to run the post-compaction read audit (default: true). */
+  compactionAuditReads?: boolean;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -115,6 +117,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    compactionAuditReads = true,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -688,6 +691,26 @@ export async function runReplyAgent(params: {
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
+
+    // Post-compaction read audit (Layer 3) — skipped when compaction.auditReads is false
+    if (sessionKey && compactionAuditReads && pendingPostCompactionAudits.get(sessionKey)) {
+      pendingPostCompactionAudits.delete(sessionKey); // Delete FIRST — one-shot only
+      try {
+        const sessionFile = activeSessionEntry?.sessionFile;
+        if (sessionFile) {
+          const messages = readSessionMessages(sessionFile);
+          const readPaths = extractReadPaths(messages);
+          const workspaceDir = process.cwd();
+          const audit = auditPostCompactionReads(readPaths, workspaceDir);
+          if (!audit.passed) {
+            enqueueSystemEvent(formatAuditWarning(audit.missingPatterns), { sessionKey });
+          }
+        }
+      } catch {
+        // Silent failure — audit is best-effort
+      }
+    }
+
 
     return finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -692,22 +692,26 @@ export async function runReplyAgent(params: {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
 
-    // Post-compaction read audit (Layer 3) — skipped when compaction.auditReads is false
-    if (sessionKey && compactionAuditReads && pendingPostCompactionAudits.get(sessionKey)) {
-      pendingPostCompactionAudits.delete(sessionKey); // Delete FIRST — one-shot only
-      try {
-        const sessionFile = activeSessionEntry?.sessionFile;
-        if (sessionFile) {
-          const messages = readSessionMessages(sessionFile);
-          const readPaths = extractReadPaths(messages);
-          const workspaceDir = process.cwd();
-          const audit = auditPostCompactionReads(readPaths, workspaceDir);
-          if (!audit.passed) {
-            enqueueSystemEvent(formatAuditWarning(audit.missingPatterns), { sessionKey });
+    // Post-compaction read audit (Layer 3)
+    // Always clear the pending flag to avoid stale map entries; only run the
+    // actual audit when compaction.auditReads is enabled.
+    if (sessionKey && pendingPostCompactionAudits.get(sessionKey)) {
+      pendingPostCompactionAudits.delete(sessionKey);
+      if (compactionAuditReads) {
+        try {
+          const sessionFile = activeSessionEntry?.sessionFile;
+          if (sessionFile) {
+            const messages = readSessionMessages(sessionFile);
+            const readPaths = extractReadPaths(messages);
+            const workspaceDir = process.cwd();
+            const audit = auditPostCompactionReads(readPaths, workspaceDir);
+            if (!audit.passed) {
+              enqueueSystemEvent(formatAuditWarning(audit.missingPatterns), { sessionKey });
+            }
           }
+        } catch {
+          // Silent failure — audit is best-effort
         }
-      } catch {
-        // Silent failure — audit is best-effort
       }
     }
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -542,5 +542,6 @@ export async function runPreparedReply(
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    compactionAuditReads: agentCfg?.compaction?.auditReads,
   });
 }

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+
+/**
+ * Tracks sessions that have undergone compaction and are pending a
+ * post-compaction read audit on the next agent turn.
+ * Keyed by sessionKey; value is true when audit is pending.
+ */
+export const pendingPostCompactionAudits = new Map<string, boolean>();
+
+/**
+ * Required startup file patterns to verify after compaction.
+ * Each entry is a substring (case-insensitive) that should appear in
+ * at least one file path read by the agent after compaction.
+ */
+const REQUIRED_READ_PATTERNS = ["WORKFLOW_AUTO.md", "MEMORY.md"];
+
+/**
+ * Reads raw session messages from a JSONL session file.
+ * Returns an array of parsed message objects (assistant/user/tool).
+ */
+export function readSessionMessages(sessionFile: string): unknown[] {
+  try {
+    const lines = fs.readFileSync(sessionFile, "utf-8").split(/\r?\n/);
+    const messages: unknown[] = [];
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        // Session JSONL entries have a "message" field for message records
+        if (parsed?.message) {
+          messages.push(parsed.message);
+        }
+      } catch {
+        // Ignore malformed lines
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extracts file paths that were read by the agent from a set of session messages.
+ * Looks for tool_use blocks with name "read" and extracts the path/file_path input.
+ */
+export function extractReadPaths(messages: unknown[]): string[] {
+  const paths: string[] = [];
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const msg = message as Record<string, unknown>;
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    const content = msg.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const b = block as Record<string, unknown>;
+      if (b.type !== "tool_use") {
+        continue;
+      }
+      // Tool name may have surrounding whitespace in some model outputs
+      const name = typeof b.name === "string" ? b.name.trim() : "";
+      if (name !== "read") {
+        continue;
+      }
+      const input = b.input;
+      if (!input || typeof input !== "object") {
+        continue;
+      }
+      const inp = input as Record<string, unknown>;
+      // Read tool accepts "path" or "file_path" as the path key
+      const filePath = inp.path ?? inp.file_path;
+      if (typeof filePath === "string" && filePath) {
+        paths.push(filePath);
+      }
+    }
+  }
+  return paths;
+}
+
+/**
+ * Audits whether the agent read the required startup files after compaction.
+ * Returns passed=true if all required patterns were covered, or false with
+ * the list of missing pattern names.
+ */
+export function auditPostCompactionReads(
+  readPaths: string[],
+  _workspaceDir: string,
+): { passed: boolean; missingPatterns: string[] } {
+  const missingPatterns: string[] = [];
+  for (const pattern of REQUIRED_READ_PATTERNS) {
+    const found = readPaths.some((p) => p.toLowerCase().includes(pattern.toLowerCase()));
+    if (!found) {
+      missingPatterns.push(pattern);
+    }
+  }
+  return { passed: missingPatterns.length === 0, missingPatterns };
+}
+
+/**
+ * Formats a warning message for missing post-compaction reads.
+ */
+export function formatAuditWarning(missingPatterns: string[]): string {
+  const list = missingPatterns.map((p) => `- ${p}`).join("\n");
+  return (
+    "[Post-compaction audit warning]\n\n" +
+    "The agent did not read the following required startup files after context compaction:\n\n" +
+    list +
+    "\n\nPlease read these files now to restore required context before responding."
+  );
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -83,4 +83,40 @@ describe("config compaction settings", () => {
       },
     );
   });
+
+  it("preserves auditReads: false", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              auditReads: false,
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.auditReads).toBe(false);
+      },
+    );
+  });
+
+  it("defaults auditReads to undefined (treated as true)", async () => {
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokensFloor: 9000,
+            },
+          },
+        },
+      },
+      async () => {
+        const cfg = loadConfig();
+        expect(cfg.agents?.defaults?.compaction?.auditReads).toBeUndefined();
+      },
+    );
+  });
 });

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -375,6 +375,7 @@ const TARGET_KEYS = [
   "agents.defaults.compaction.memoryFlush.softThresholdTokens",
   "agents.defaults.compaction.memoryFlush.prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt",
+  "agents.defaults.compaction.auditReads",
 ] as const;
 
 const ENUM_EXPECTATIONS: Record<string, string[]> = {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -955,6 +955,8 @@ export const FIELD_HELP: Record<string, string> = {
     "User-prompt template used for the pre-compaction memory flush turn when generating memory candidates. Use this only when you need custom extraction instructions beyond the default memory flush behavior.",
   "agents.defaults.compaction.memoryFlush.systemPrompt":
     "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
+  "agents.defaults.compaction.auditReads":
+    "Enable post-compaction audit that checks whether the agent read required startup files (WORKFLOW_AUTO.md, daily memory) after context compaction (default: true). Disable when extensions manage their own post-compaction context restoration.",
   "agents.defaults.embeddedPi":
     "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in OpenClaw sessions.",
   "agents.defaults.embeddedPi.projectSettingsPolicy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -429,6 +429,7 @@ export const FIELD_LABELS: Record<string, string> = {
     "Compaction Memory Flush Transcript Size Threshold",
   "agents.defaults.compaction.memoryFlush.prompt": "Compaction Memory Flush Prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt": "Compaction Memory Flush System Prompt",
+  "agents.defaults.compaction.auditReads": "Compaction Audit Reads",
   "agents.defaults.embeddedPi": "Embedded Pi",
   "agents.defaults.embeddedPi.projectSettingsPolicy": "Embedded Pi Project Settings Policy",
   "agents.defaults.heartbeat.directPolicy": "Heartbeat Direct Policy",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -306,6 +306,8 @@ export type AgentCompactionConfig = {
   identifierInstructions?: string;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Enable post-compaction read audit warnings (default: true). */
+  auditReads?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -112,6 +112,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        auditReads: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Closes #23643

- Adds `agents.defaults.compaction.auditReads` config option (boolean, default: `true`) to control the post-compaction read audit that checks whether the agent read required startup files after context compaction
- When set to `false`, the system message warning about unread `WORKFLOW_AUTO.md` / daily memory files is suppressed, which is useful when extensions (e.g. R-Memory) manage their own post-compaction context restoration

### Config example

```yaml
agents:
  defaults:
    compaction:
      auditReads: false
```

### Files changed

- `src/config/types.agent-defaults.ts` — add `auditReads?: boolean` to `AgentCompactionConfig`
- `src/config/zod-schema.agent-defaults.ts` — add `auditReads` to compaction zod schema
- `src/config/schema.labels.ts` — add label for the new config key
- `src/config/schema.help.ts` — add help text for the new config key
- `src/config/schema.help.quality.test.ts` — register key in TARGET_KEYS
- `src/auto-reply/reply/agent-runner.ts` — accept `compactionAuditReads` param and skip audit when false
- `src/auto-reply/reply/get-reply-run.ts` — pass `agentCfg.compaction.auditReads` to agent runner
- `src/config/config.compaction-settings.test.ts` — test config parsing for `auditReads`

## Test plan

- [x] `pnpm vitest run src/config/config.compaction-settings.test.ts` — passes (including 2 new tests)
- [x] `pnpm vitest run src/config/schema.help.quality.test.ts` — passes
- [x] `pnpm vitest run src/auto-reply/reply/post-compaction-audit.test.ts` — passes
- [x] `pnpm vitest run src/config/schema.test.ts` — passes
- [x] TypeScript compiles cleanly for all modified files
- [x] Formatting passes (`oxfmt --check`)