### PR TITLE
fix(tui): wrap markdown link text with OSC 8 to prevent terminal autolink override

### DIFF
--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -1,6 +1,11 @@
 import type { Component, DefaultTextStyle, MarkdownTheme } from "@mariozechner/pi-tui";
 import { Markdown } from "@mariozechner/pi-tui";
-import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
+import {
+  type LinkTextMapping,
+  addOsc8Hyperlinks,
+  extractLinkTextMappings,
+  extractUrls,
+} from "../osc8-hyperlinks.js";
 
 /**
  * Wrapper around pi-tui's Markdown component that adds OSC 8 terminal
@@ -10,6 +15,7 @@ import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
 export class HyperlinkMarkdown implements Component {
   private inner: Markdown;
   private urls: string[];
+  private linkTexts: LinkTextMapping[];
 
   constructor(
     text: string,
@@ -20,15 +26,17 @@ export class HyperlinkMarkdown implements Component {
   ) {
     this.inner = new Markdown(text, paddingX, paddingY, theme, options);
     this.urls = extractUrls(text);
+    this.linkTexts = extractLinkTextMappings(text);
   }
 
   render(width: number): string[] {
-    return addOsc8Hyperlinks(this.inner.render(width), this.urls);
+    return addOsc8Hyperlinks(this.inner.render(width), this.urls, this.linkTexts);
   }
 
   setText(text: string): void {
     this.inner.setText(text);
     this.urls = extractUrls(text);
+    this.linkTexts = extractLinkTextMappings(text);
   }
 
   invalidate(): void {

--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -185,9 +185,7 @@ describe("extractLinkTextMappings", () => {
   it("extracts non-URL link text mappings", () => {
     const md = "[#16901](https://github.com/org/repo/issues/16901)";
     const mappings = extractLinkTextMappings(md);
-    expect(mappings).toEqual([
-      { text: "#16901", url: "https://github.com/org/repo/issues/16901" },
-    ]);
+    expect(mappings).toEqual([{ text: "#16901", url: "https://github.com/org/repo/issues/16901" }]);
   });
 
   it("skips links where text is a URL", () => {

--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { addOsc8Hyperlinks, extractUrls, wrapOsc8 } from "./osc8-hyperlinks.js";
+import {
+  addOsc8Hyperlinks,
+  extractLinkTextMappings,
+  extractUrls,
+  wrapOsc8,
+} from "./osc8-hyperlinks.js";
 
 describe("wrapOsc8", () => {
   it("wraps text with OSC 8 open and close sequences", () => {
@@ -147,5 +152,61 @@ describe("addOsc8Hyperlinks", () => {
       expect(line).toContain(`\x1b]8;;${fullUrl}\x07`);
       expect(line).toContain(`\x1b]8;;\x07`);
     }
+  });
+
+  it("wraps non-URL link text with OSC 8 when linkTexts provided", () => {
+    const url = "https://github.com/anthropics/claude-code/issues/16901";
+    // pi-tui renders [#16901](url) as "#16901 (url)"
+    const line = `#16901 (${url})`;
+    const linkTexts = [{ text: "#16901", url }];
+    const result = addOsc8Hyperlinks([line], [url], linkTexts);
+
+    // Both the link text and URL should be wrapped
+    expect(result[0]).toContain(`\x1b]8;;${url}\x07#16901\x1b]8;;\x07`);
+    expect(result[0]).toContain(`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
+  });
+
+  it("does not double-wrap link text that overlaps with URL ranges", () => {
+    const url = "https://example.com";
+    // Link text IS the URL — should not get a second wrapping
+    const line = `${url}`;
+    const linkTexts = [{ text: url, url }];
+    const result = addOsc8Hyperlinks([line], [url], linkTexts);
+
+    // Should have exactly one open and one close
+    const opens = result[0].split(`\x1b]8;;${url}\x07`).length - 1;
+    const closes = result[0].split("\x1b]8;;\x07").length - 1;
+    expect(opens).toBe(1);
+    expect(closes).toBe(1);
+  });
+});
+
+describe("extractLinkTextMappings", () => {
+  it("extracts non-URL link text mappings", () => {
+    const md = "[#16901](https://github.com/org/repo/issues/16901)";
+    const mappings = extractLinkTextMappings(md);
+    expect(mappings).toEqual([
+      { text: "#16901", url: "https://github.com/org/repo/issues/16901" },
+    ]);
+  });
+
+  it("skips links where text is a URL", () => {
+    const md = "[https://example.com](https://example.com)";
+    const mappings = extractLinkTextMappings(md);
+    expect(mappings).toEqual([]);
+  });
+
+  it("extracts multiple mappings", () => {
+    const md = "See [#100](https://a.com/100) and [docs](https://b.com/docs)";
+    const mappings = extractLinkTextMappings(md);
+    expect(mappings).toEqual([
+      { text: "#100", url: "https://a.com/100" },
+      { text: "docs", url: "https://b.com/docs" },
+    ]);
+  });
+
+  it("returns empty array for bare URLs", () => {
+    const mappings = extractLinkTextMappings("https://example.com");
+    expect(mappings).toEqual([]);
   });
 });

--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -169,7 +169,7 @@ describe("addOsc8Hyperlinks", () => {
   it("does not double-wrap link text that overlaps with URL ranges", () => {
     const url = "https://example.com";
     // Link text IS the URL — should not get a second wrapping
-    const line = `${url}`;
+    const line = url;
     const linkTexts = [{ text: url, url }];
     const result = addOsc8Hyperlinks([line], [url], linkTexts);
 

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -11,6 +11,32 @@ export function wrapOsc8(url: string, text: string): string {
   return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
 }
 
+export type LinkTextMapping = { text: string; url: string };
+
+/**
+ * Extract link-text-to-URL mappings for markdown links whose visible text
+ * is not itself a URL (e.g. `[#16901](https://github.com/…/issues/16901)`).
+ *
+ * These mappings are used to wrap the link text with OSC 8 so that terminal
+ * autolink features (which detect patterns like `#N`) do not override the
+ * explicit URL with one resolved from the current git remote.
+ */
+export function extractLinkTextMappings(markdown: string): LinkTextMapping[] {
+  const mappings: LinkTextMapping[] = [];
+  const mdLinkRe = /\[([^\]]+)\]\(\s*<?(https?:\/\/[^)\s>]+)>?(?:\s+["'][^"']*["'])?\s*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = mdLinkRe.exec(markdown)) !== null) {
+    const text = m[1];
+    const url = m[2];
+    // Only create a mapping when the link text is not a URL itself — URL text
+    // is already handled by the standard URL-range matching.
+    if (!/^https?:\/\//.test(text)) {
+      mappings.push({ text, url });
+    }
+  }
+  return mappings;
+}
+
 /**
  * Extract all unique URLs from raw markdown text.
  * Finds both bare URLs and markdown link hrefs [text](url).
@@ -209,14 +235,68 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
 }
 
 /**
+ * Find ranges in visible text that match link-text mappings (e.g. `#16901`).
+ * Avoids overlapping with existing URL ranges.
+ */
+function findLinkTextRanges(
+  visibleText: string,
+  mappings: LinkTextMapping[],
+  existingRanges: UrlRange[],
+): UrlRange[] {
+  if (mappings.length === 0) {
+    return [];
+  }
+
+  // Build a set of positions already covered by URL ranges.
+  const covered = new Set<number>();
+  for (const r of existingRanges) {
+    for (let p = r.start; p < r.end; p++) {
+      covered.add(p);
+    }
+  }
+
+  const ranges: UrlRange[] = [];
+  for (const { text, url } of mappings) {
+    let pos = 0;
+    while (pos < visibleText.length) {
+      const idx = visibleText.indexOf(text, pos);
+      if (idx < 0) {
+        break;
+      }
+      // Only add if none of the positions overlap with existing ranges.
+      let overlaps = false;
+      for (let p = idx; p < idx + text.length; p++) {
+        if (covered.has(p)) {
+          overlaps = true;
+          break;
+        }
+      }
+      if (!overlaps) {
+        ranges.push({ start: idx, end: idx + text.length, url });
+      }
+      pos = idx + text.length;
+    }
+  }
+  return ranges;
+}
+
+/**
  * Add OSC 8 hyperlinks to rendered lines using a pre-extracted URL list.
  *
  * For each line, finds URL-like substrings in the visible text, matches them
  * against known URLs, and wraps each fragment with OSC 8 escape sequences.
  * Handles URLs broken across multiple lines by pi-tui's word wrapping.
+ *
+ * When `linkTexts` is provided, non-URL link text (e.g. `#16901` from
+ * `[#16901](url)`) is also wrapped with OSC 8 pointing to the explicit URL.
+ * This prevents terminal autolink features from overriding the intended URL.
  */
-export function addOsc8Hyperlinks(lines: string[], urls: string[]): string[] {
-  if (urls.length === 0) {
+export function addOsc8Hyperlinks(
+  lines: string[],
+  urls: string[],
+  linkTexts?: LinkTextMapping[],
+): string[] {
+  if (urls.length === 0 && (!linkTexts || linkTexts.length === 0)) {
     return lines;
   }
 
@@ -226,6 +306,13 @@ export function addOsc8Hyperlinks(lines: string[], urls: string[]): string[] {
     const visible = stripAnsi(line);
     const result = findUrlRanges(visible, urls, pending);
     pending = result.pending;
-    return applyOsc8Ranges(line, result.ranges);
+
+    // Merge link-text ranges (non-overlapping with URL ranges).
+    const linkTextRanges = linkTexts
+      ? findLinkTextRanges(visible, linkTexts, result.ranges)
+      : [];
+    const allRanges = [...result.ranges, ...linkTextRanges];
+
+    return applyOsc8Ranges(line, allRanges);
   });
 }

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -308,9 +308,7 @@ export function addOsc8Hyperlinks(
     pending = result.pending;
 
     // Merge link-text ranges (non-overlapping with URL ranges).
-    const linkTextRanges = linkTexts
-      ? findLinkTextRanges(visible, linkTexts, result.ranges)
-      : [];
+    const linkTextRanges = linkTexts ? findLinkTextRanges(visible, linkTexts, result.ranges) : [];
     const allRanges = [...result.ranges, ...linkTextRanges];
 
     return applyOsc8Ranges(line, allRanges);


### PR DESCRIPTION
## Summary

Markdown links like `[#16901](https://github.com/anthropics/claude-code/issues/16901)` render with the correct URL in parentheses, but the link text (`#16901`) is not wrapped with an OSC 8 hyperlink. Terminals with autolink features (Ghostty, VS Code integrated terminal, Cursor) detect the `#N` pattern and resolve it against the current git remote, making the link point to the wrong repository.

This PR wraps the link text with an OSC 8 hyperlink pointing to the explicit URL from the markdown, giving it precedence over the terminal's autolink detection.

## Changes

- Added `extractLinkTextMappings()` to extract non-URL link text to URL pairs from raw markdown
- Added `findLinkTextRanges()` to locate link text spans in rendered output without overlapping existing URL ranges
- Extended `addOsc8Hyperlinks()` to accept optional link text mappings and apply OSC 8 to them
- Updated `HyperlinkMarkdown` component to extract and pass link text mappings
- Added 4 new tests covering link text wrapping, overlap avoidance, and extraction

## How it works

1. `extractLinkTextMappings("[#16901](url)")` returns `[{ text: "#16901", url: "..." }]`
2. After rendering, `findLinkTextRanges` locates `#16901` in the visible text (skipping positions already covered by URL ranges)
3. `applyOsc8Ranges` wraps both the link text and the URL with OSC 8 sequences

The terminal sees `#16901` already has an OSC 8 hyperlink and does not apply its own autolink.

## Test plan

- [x] All 25 existing + new tests pass (`npx vitest run src/tui/osc8-hyperlinks.test.ts`)
- [x] oxlint passes on modified files
- [ ] Manual test: render `[#16901](https://github.com/anthropics/claude-code/issues/16901)` in Ghostty/VS Code terminal and verify clicking `#16901` opens the correct URL

## Fixes

Fixes #29188