### PR TITLE
fix(slack): suppress NO_REPLY sentinel in draft previews

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.preview-silent.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.preview-silent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldSuppressSlackDraftPreviewText } from "./dispatch.js";
+
+describe("shouldSuppressSlackDraftPreviewText", () => {
+  it("suppresses exact NO_REPLY", () => {
+    expect(shouldSuppressSlackDraftPreviewText("NO_REPLY")).toBe(true);
+    expect(shouldSuppressSlackDraftPreviewText("  NO_REPLY  ")).toBe(true);
+  });
+
+  it("suppresses partial sentinel prefixes (streaming leakage)", () => {
+    expect(shouldSuppressSlackDraftPreviewText("NO_")).toBe(true);
+    expect(shouldSuppressSlackDraftPreviewText("NO_RE")).toBe(true);
+    expect(shouldSuppressSlackDraftPreviewText("NO_REP")).toBe(true);
+  });
+
+  it("does not suppress normal text", () => {
+    expect(shouldSuppressSlackDraftPreviewText("No worries")).toBe(false);
+    expect(shouldSuppressSlackDraftPreviewText("This is not a NO_REPLY situation")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Problem
Slack draft-stream preview (used for partial/non-native streaming) posts partial model output into the channel/thread and later deletes/edits it. When the model emits the silent token `NO_REPLY` (or partial streaming fragments like `NO_`, `NO_RE`), that sentinel text can briefly appear to users and then disappear — looks like a “ghost message”.



### AI-assisted contribution

This PR was **AI-assisted** (OpenClaw agent + LLM) for drafting/iteration, with human review.

**Testing:** lightly tested  
- Unit tests added/updated and run locally (vitest unit tests).

**What it does (author understands the change):**  
Suppresses the `NO_REPLY` sentinel token (and partial streaming prefixes like `NO_`, `NO_RE`, etc.) from appearing in draft preview streaming. This prevents “ghost” preview text that briefly appears and is then deleted/overwritten.

**Prompts/logs:** not included (happy to provide additional context if helpful).

### Fix
- Suppress silent-token text **and its streaming prefix fragments** before sending any draft preview updates.
- Adds small unit coverage for the suppression helper.

### Notes
This does not affect normal Slack sends; it only gates the draft preview stream inside `dispatchPreparedSlackMessage`.

Repro: use Slack + message tool send, then have agent return `NO_REPLY` as its final assistant output (or stream partials starting with `NO_`).

### Related

- Discord fix: https://github.com/openclaw/openclaw/pull/28287
- Telegram fix: https://github.com/openclaw/openclaw/pull/28289
