### PR TITLE
feat(web-fetch): add ssrfPolicy config for fake-IP proxy environments

### DIFF
--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -492,6 +492,25 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** Maximum response body size in bytes before truncation. */
+      maxResponseBytes?: number;
+      /**
+       * SSRF policy overrides for web fetch requests.
+       * By default, web_fetch blocks private/internal/special-use IP addresses.
+       * Users behind TUN-mode proxies (Surge, Clash, etc.) that use fake-IP DNS
+       * (198.18.0.0/15) need to allow the RFC 2544 benchmark range.
+       */
+      ssrfPolicy?: {
+        /** Allow private/internal network addresses (default: false). Use with caution. */
+        dangerouslyAllowPrivateNetwork?: boolean;
+        /**
+         * Allow RFC 2544 benchmark range (198.18.0.0/15) (default: false).
+         * Enable this if your proxy uses fake-IP mode (Surge Enhanced Mode,
+         * Clash fake-ip, Shadowrocket, etc.) where all DNS queries resolve
+         * to addresses in this range.
+         */
+        allowRfc2544BenchmarkRange?: boolean;
+      };
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;


### PR DESCRIPTION
## Summary

Add `tools.web.fetch.ssrfPolicy` config option so `web_fetch` works in fake-IP proxy environments (Surge Enhanced Mode, Clash fake-ip, Shadowrocket, etc.).

Closes #28271
Related: #27223, #27597, #26847, #24454

## Problem

In TUN-mode proxy environments, all DNS queries resolve to addresses in the `198.18.0.0/15` (RFC 2544 benchmark) range. The SSRF guard in `web_fetch` blocks these as special-use IPs, making `web_fetch` completely non-functional.

The browser tool already has `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: true` by default, but `web_fetch` has no equivalent config path.

## Changes

**`src/config/types.tools.ts`**
- Add `ssrfPolicy` type to the `fetch` config with two options:
  - `dangerouslyAllowPrivateNetwork` (default: false)
  - `allowRfc2544BenchmarkRange` (default: false)

**`src/agents/tools/web-fetch.ts`**
- Add `resolveFetchSsrfPolicy()` to safely read and validate the config
- Add `ssrfPolicy` to `WebFetchRuntimeParams`
- Pass policy to `fetchWithWebToolsNetworkGuard()` in `runWebFetch()`
- Wire it up in `createWebFetchTool()`

No changes needed in `web-guarded-fetch.ts` — it already forwards `policy` via the `GuardedFetchOptions` spread to `fetchWithSsrFGuard()`.

## Config Example

```json5
{
  tools: {
    web: {
      fetch: {
        ssrfPolicy: {
          // Only unblock 198.18.0.0/15 (non-routable, never on public internet)
          allowRfc2544BenchmarkRange: true
        }
      }
    }
  }
}
```

## Security

- Both options default to `false` — secure by default
- `allowRfc2544BenchmarkRange` only unblocks `198.18.0.0/15`, a non-routable range
- All other private/internal/special-use ranges remain blocked
- The underlying SSRF guard code already implements these checks; this PR only adds a config path

## Testing

- [x] `tsc --noEmit` passes with zero errors
- [x] `ssrf.test.ts` — 9/9 tests pass
- [x] AI-assisted (OpenClaw + Claude Opus), fully understood and reviewed

## Who Benefits

Users running Surge, Clash, Shadowrocket, Quantumult X, Stash, or similar tools in fake-IP/TUN mode 