### PR TITLE
fix(line): add CommandAuthorized to inbound context (#26996)

### DIFF
--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -7,6 +7,8 @@ import type {
   LeaveEvent,
   PostbackEvent,
 } from "@line/bot-sdk";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -113,10 +115,15 @@ async function sendLinePairingReply(params: {
   }
 }
 
+type LineAccessDecision = {
+  allowed: boolean;
+  commandAuthorized: boolean;
+};
+
 async function shouldProcessLineEvent(
   event: MessageEvent | PostbackEvent,
   context: LineHandlerContext,
-): Promise<boolean> {
+): Promise<LineAccessDecision> {
   const { cfg, account } = context;
   const { userId, groupId, roomId, isGroup } = getLineSourceInfo(event.source);
   const senderId = userId ?? "";
@@ -159,45 +166,59 @@ async function shouldProcessLineEvent(
     log: (message) => logVerbose(message),
   });
 
+  const denied = { allowed: false, commandAuthorized: false };
+
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       logVerbose(`Blocked line group ${groupId ?? roomId ?? "unknown"} (group disabled)`);
-      return false;
+      return denied;
     }
     if (typeof groupAllowOverride !== "undefined") {
       if (!senderId) {
         logVerbose("Blocked line group message (group allowFrom override, no sender ID)");
-        return false;
+        return denied;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group sender ${senderId} (group allowFrom override)`);
-        return false;
+        return denied;
       }
     }
     if (groupPolicy === "disabled") {
       logVerbose("Blocked line group message (groupPolicy: disabled)");
-      return false;
+      return denied;
     }
     if (groupPolicy === "allowlist") {
       if (!senderId) {
         logVerbose("Blocked line group message (no sender ID, groupPolicy: allowlist)");
-        return false;
+        return denied;
       }
       if (!effectiveGroupAllow.hasEntries) {
         logVerbose("Blocked line group message (groupPolicy: allowlist, no groupAllowFrom)");
-        return false;
+        return denied;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group message from ${senderId} (groupPolicy: allowlist)`);
-        return false;
+        return denied;
       }
     }
-    return true;
+
+    // Resolve command authorization using the same pattern as Telegram/Discord/Slack.
+    const allowForCommands = effectiveGroupAllow;
+    const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
+    const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+    const rawText = resolveEventRawText(event);
+    const commandGate = resolveControlCommandGate({
+      useAccessGroups,
+      authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
+      allowTextCommands: true,
+      hasControlCommand: hasControlCommand(rawText, cfg),
+    });
+    return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
   }
 
   if (dmPolicy === "disabled") {
     logVerbose("Blocked line sender (dmPolicy: disabled)");
-    return false;
+    return denied;
   }
 
   const dmAllowed = dmPolicy === "open" || isSenderAllowed({ allow: effectiveDmAllow, senderId });
@@ -205,7 +226,7 @@ async function shouldProcessLineEvent(
     if (dmPolicy === "pairing") {
       if (!senderId) {
         logVerbose("Blocked line sender (dmPolicy: pairing, no sender ID)");
-        return false;
+        return denied;
       }
       await sendLinePairingReply({
         senderId,
@@ -215,17 +236,44 @@ async function shouldProcessLineEvent(
     } else {
       logVerbose(`Blocked line sender ${senderId || "unknown"} (dmPolicy: ${dmPolicy})`);
     }
-    return false;
+    return denied;
   }
 
-  return true;
+  // Resolve command authorization for DMs.
+  const allowForCommands = effectiveDmAllow;
+  const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const rawText = resolveEventRawText(event);
+  const commandGate = resolveControlCommandGate({
+    useAccessGroups,
+    authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
+    allowTextCommands: true,
+    hasControlCommand: hasControlCommand(rawText, cfg),
+  });
+  return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
+}
+
+/** Extract raw text from a LINE message or postback event for command detection. */
+function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
+  if (event.type === "message") {
+    const msg = event.message;
+    if (msg.type === "text") {
+      return msg.text;
+    }
+    return "";
+  }
+  if (event.type === "postback") {
+    return event.postback?.data?.trim() ?? "";
+  }
+  return "";
 }
 
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
 
-  if (!(await shouldProcessLineEvent(event, context))) {
+  const decision = await shouldProcessLineEvent(event, context);
+  if (!decision.allowed) {
     return;
   }
 
@@ -255,6 +303,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     allMedia,
     cfg,
     account,
+    commandAuthorized: decision.commandAuthorized,
   });
 
   if (!messageContext) {
@@ -298,7 +347,8 @@ async function handlePostbackEvent(
   const data = event.postback.data;
   logVerbose(`line: received postback: ${data}`);
 
-  if (!(await shouldProcessLineEvent(event, context))) {
+  const decision = await shouldProcessLineEvent(event, context);
+  if (!decision.allowed) {
     return;
   }
 
@@ -306,6 +356,7 @@ async function handlePostbackEvent(
     event,
     cfg: context.cfg,
     account: context.account,
+    commandAuthorized: decision.commandAuthorized,
   });
   if (!postbackContext) {
     return;

--- a/src/line/bot-message-context.test.ts
+++ b/src/line/bot-message-context.test.ts
@@ -75,6 +75,7 @@ describe("buildLineMessageContext", () => {
       allMedia: [],
       cfg,
       account,
+      commandAuthorized: true,
     });
     expect(context).not.toBeNull();
     if (!context) {
@@ -92,6 +93,7 @@ describe("buildLineMessageContext", () => {
       event,
       cfg,
       account,
+      commandAuthorized: true,
     });
 
     expect(context?.ctxPayload.OriginatingTo).toBe("line:group:group-2");
@@ -105,9 +107,51 @@ describe("buildLineMessageContext", () => {
       event,
       cfg,
       account,
+      commandAuthorized: true,
     });
 
     expect(context?.ctxPayload.OriginatingTo).toBe("line:room:room-1");
     expect(context?.ctxPayload.To).toBe("line:room:room-1");
+  });
+
+  it("sets CommandAuthorized=true when authorized", async () => {
+    const event = createMessageEvent({ type: "user", userId: "user-auth" });
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.CommandAuthorized).toBe(true);
+  });
+
+  it("sets CommandAuthorized=false when not authorized", async () => {
+    const event = createMessageEvent({ type: "user", userId: "user-noauth" });
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: false,
+    });
+
+    expect(context?.ctxPayload.CommandAuthorized).toBe(false);
+  });
+
+  it("sets CommandAuthorized on postback context", async () => {
+    const event = createPostbackEvent({ type: "user", userId: "user-pb" });
+
+    const context = await buildLinePostbackContext({
+      event,
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.CommandAuthorized).toBe(true);
   });
 });

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -22,6 +22,7 @@ interface BuildLineMessageContextParams {
   allMedia: MediaRef[];
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
+  commandAuthorized: boolean;
 }
 
 export type LineSourceInfo = {
@@ -215,6 +216,7 @@ async function finalizeLineInboundContext(params: {
   rawBody: string;
   timestamp: number;
   messageSid: string;
+  commandAuthorized: boolean;
   media: {
     firstPath: string | undefined;
     firstContentType?: string;
@@ -286,6 +288,7 @@ async function finalizeLineInboundContext(params: {
     MediaUrls: params.media.paths,
     MediaTypes: params.media.types,
     ...params.locationContext,
+    CommandAuthorized: params.commandAuthorized,
     OriginatingChannel: "line" as const,
     OriginatingTo: originatingTo,
   });
@@ -342,7 +345,7 @@ async function finalizeLineInboundContext(params: {
 }
 
 export async function buildLineMessageContext(params: BuildLineMessageContextParams) {
-  const { event, allMedia, cfg, account } = params;
+  const { event, allMedia, cfg, account, commandAuthorized } = params;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = resolveLineInboundRoute({
@@ -388,6 +391,7 @@ export async function buildLineMessageContext(params: BuildLineMessageContextPar
     rawBody,
     timestamp,
     messageSid: messageId,
+    commandAuthorized,
     media: {
       firstPath: allMedia[0]?.path,
       firstContentType: allMedia[0]?.contentType,
@@ -418,8 +422,9 @@ export async function buildLinePostbackContext(params: {
   event: PostbackEvent;
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
+  commandAuthorized: boolean;
 }) {
-  const { event, cfg, account } = params;
+  const { event, cfg, account, commandAuthorized } = params;
 
   const source = event.source;
   const { userId, groupId, roomId, isGroup, peerId, route } = resolveLineInboundRoute({
@@ -451,6 +456,7 @@ export async function buildLinePostbackContext(params: {
     rawBody,
     timestamp,
     messageSid,
+    commandAuthorized,
     media: {
       firstPath: "",
       firstContentType: undefined,


### PR DESCRIPTION
## Summary

- Fix LINE channel silently rejecting all slash commands (`/new`, `/model`, `/status`, etc.) by adding missing `CommandAuthorized` field to the inbound context
- LINE was the only channel that did not compute or pass `CommandAuthorized` via `resolveControlCommandGate()`, causing `finalizeInboundContext` to coerce it from `undefined` to `false`, which silently blocked all commands

## Details

The root cause was in `src/line/bot-message-context.ts` where the `finalizeInboundContext()` call did not include a `CommandAuthorized` field. In `inbound-context.ts`, the normalization `normalized.CommandAuthorized = normalized.CommandAuthorized === true` turns `undefined` into `false`, which then causes `resolveCommandAuthorization` to deny all commands.

The fix:
- `src/line/bot-handlers.ts`: `shouldProcessLineEvent()` now returns a `LineAccessDecision` object with both `allowed` and `commandAuthorized` fields (previously returned just `boolean`). It computes `commandAuthorized` via `resolveControlCommandGate()` using the same pattern as Telegram, Discord, Slack, and other channels.
- `src/line/bot-message-context.ts`: `buildLineMessageContext()`, `buildLinePostbackContext()`, and `finalizeLineInboundContext()` now accept and thread through the `commandAuthorized` parameter, including it in the `finalizeInboundContext()` payload.
- `src/line/bot-message-context.test.ts`: Added tests verifying `CommandAuthorized` is correctly set to `true` and `false` for both message and postback contexts.

Closes #26996

## Test plan

- [x] All 18 LINE test files pass (116 tests total)
- [x] `pnpm check` (format + lint + typecheck) passes
- [ ] Manual: Send `/new` via LINE DM with `dmPolicy: "pairing"` and no `commands.allowFrom` configured -- command should now be processed instead of silently ignored