### PR TITLE
fix(discord): suppress NO_REPLY sentinel in draft previews

### DIFF
--- a/src/discord/monitor/message-handler.preview-silent.test.ts
+++ b/src/discord/monitor/message-handler.preview-silent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldSuppressDiscordDraftPreviewText } from "./message-handler.process.js";
+
+describe("shouldSuppressDiscordDraftPreviewText", () => {
+  it("suppresses exact NO_REPLY", () => {
+    expect(shouldSuppressDiscordDraftPreviewText("NO_REPLY")).toBe(true);
+    expect(shouldSuppressDiscordDraftPreviewText("  NO_REPLY  ")).toBe(true);
+  });
+
+  it("suppresses partial sentinel prefixes (streaming leakage)", () => {
+    expect(shouldSuppressDiscordDraftPreviewText("NO_")).toBe(true);
+    expect(shouldSuppressDiscordDraftPreviewText("NO_RE")).toBe(true);
+    expect(shouldSuppressDiscordDraftPreviewText("NO_REP")).toBe(true);
+  });
+
+  it("does not suppress normal text", () => {
+    expect(shouldSuppressDiscordDraftPreviewText("No worries")).toBe(false);
+    expect(shouldSuppressDiscordDraftPreviewText("This is not a NO_REPLY situation")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Problem

Discord draft-stream preview can post partial model output into the channel/thread and later edit/delete it during finalize. When the model emits the silent token `NO_REPLY` (or partial streaming fragments like `NO_`, `NO_RE`), that sentinel can briefly appear to users and then disappear — looks like a “ghost message”.



### AI-assisted contribution

This PR was **AI-assisted** (OpenClaw agent + LLM) for drafting/iteration, with human review.

**Testing:** lightly tested  
- Unit tests added/updated and run locally (vitest unit tests).

**What it does (author understands the change):**  
Suppresses the `NO_REPLY` sentinel token (and partial streaming prefixes like `NO_`, `NO_RE`, etc.) from appearing in draft preview streaming. This prevents “ghost” preview text that briefly appears and is then deleted/overwritten.

**Prompts/logs:** not included (happy to provide additional context if helpful).

### Fix

- Suppress `NO_REPLY` and its streaming prefix fragments before calling `draftStream.update(...)`.
- Adds small unit coverage for the suppression helper.

### Related

- Slack fix: https://github.com/openclaw/openclaw/pull/28279
- Telegram fix: https://github.com/openclaw/openclaw/pull/28289