### PR TITLE
fix(telegram): suppress NO_REPLY sentinel in draft previews

### DIFF
--- a/src/telegram/bot-message-dispatch.preview-silent.test.ts
+++ b/src/telegram/bot-message-dispatch.preview-silent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldSuppressTelegramDraftPreviewText } from "./bot-message-dispatch.js";
+
+describe("shouldSuppressTelegramDraftPreviewText", () => {
+  it("suppresses exact NO_REPLY", () => {
+    expect(shouldSuppressTelegramDraftPreviewText("NO_REPLY")).toBe(true);
+    expect(shouldSuppressTelegramDraftPreviewText("  NO_REPLY  ")).toBe(true);
+  });
+
+  it("suppresses partial sentinel prefixes (streaming leakage)", () => {
+    expect(shouldSuppressTelegramDraftPreviewText("NO_")).toBe(true);
+    expect(shouldSuppressTelegramDraftPreviewText("NO_RE")).toBe(true);
+    expect(shouldSuppressTelegramDraftPreviewText("NO_REP")).toBe(true);
+  });
+
+  it("does not suppress normal text", () => {
+    expect(shouldSuppressTelegramDraftPreviewText("No worries")).toBe(false);
+    expect(shouldSuppressTelegramDraftPreviewText("This is not a NO_REPLY situation")).toBe(false);
+  });
+});

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -43,6 +43,8 @@ import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
 } from "./reasoning-lane-coordinator.js";
+import { editMessageTelegram } from "./send.js";
+import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 export function shouldSuppressTelegramDraftPreviewText(
   text: string,
@@ -51,8 +53,6 @@ export function shouldSuppressTelegramDraftPreviewText(
   const trimmed = text.trim();
   return isSilentReplyText(trimmed, silentToken) || isSilentReplyPrefixText(trimmed, silentToken);
 }
-import { editMessageTelegram } from "./send.js";
-import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 


### PR DESCRIPTION
### Problem

Telegram draft-stream preview can post partial model output into the chat/thread and later edit/delete it during finalize. When the model emits the silent token `NO_REPLY` (or partial streaming fragments like `NO_`, `NO_RE`), that sentinel can briefly appear to users and then disappear — looks like a “ghost message”.



### AI-assisted contribution

This PR was **AI-assisted** (OpenClaw agent + LLM) for drafting/iteration, with human review.

**Testing:** lightly tested  
- Unit tests added/updated and run locally (vitest unit tests).

**What it does (author understands the change):**  
Suppresses the `NO_REPLY` sentinel token (and partial streaming prefixes like `NO_`, `NO_RE`, etc.) from appearing in draft preview streaming. This prevents “ghost” preview text that briefly appears and is then deleted/overwritten.

**Prompts/logs:** not included (happy to provide additional context if helpful).

### Fix

- Suppress `NO_REPLY` and its streaming prefix fragments before calling `laneStream.update(...)`.
- Adds small unit coverage for the suppression helper.

### Related

- Slack fix: https://github.com/openclaw/openclaw/pull/28279
- Discord fix: https://github.com/openclaw/openclaw/pull/28287