### PR TITLE
fix(daemon): forward NODE_EXTRA_CA_CERTS + NODE_USE_SYSTEM_CA

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -329,6 +329,31 @@ describe("buildServiceEnvironment", () => {
     expect(env.http_proxy).toBe("http://proxy.local:7890");
     expect(env.all_proxy).toBe("socks5://proxy.local:1080");
   });
+
+  it("forwards NODE_USE_SYSTEM_CA for launchd/systemd runtime when set", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_USE_SYSTEM_CA: " 1 ",
+      },
+      port: 18789,
+    });
+
+    expect(env.NODE_USE_SYSTEM_CA).toBe("1");
+  });
+
+  it("omits NODE_USE_SYSTEM_CA for launchd/systemd runtime when not set", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+      },
+      port: 18789,
+      platform: "linux",
+    });
+
+    expect(env.NODE_USE_SYSTEM_CA).toBeUndefined();
+  });
+
   it("defaults NODE_EXTRA_CA_CERTS to system cert bundle on macOS", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user" },
@@ -375,6 +400,27 @@ describe("buildNodeServiceEnvironment", () => {
 
     expect(env.HTTPS_PROXY).toBe("https://proxy.local:7890");
     expect(env.no_proxy).toBe("localhost,127.0.0.1");
+  });
+
+  it("forwards NODE_USE_SYSTEM_CA for node services when set", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        NODE_USE_SYSTEM_CA: " true ",
+      },
+    });
+
+    expect(env.NODE_USE_SYSTEM_CA).toBe("true");
+  });
+
+  it("omits NODE_USE_SYSTEM_CA for node services when not set", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+      },
+    });
+
+    expect(env.NODE_USE_SYSTEM_CA).toBeUndefined();
   });
 
   it("forwards TMPDIR for node services", () => {


### PR DESCRIPTION
### Problem

The gateway daemon builds a whitelist of host environment variables to forward into the launchd plist / systemd unit environment (see `buildServiceEnvironment()` and `buildNodeServiceEnvironment()` in `src/daemon/service-env.ts`). Today we forward `HOME`, `TMPDIR`, `PATH`, proxy vars, and `OPENCLAW_*`, but we *don't* forward Node's standard TLS/CA environment variables:

- `NODE_EXTRA_CA_CERTS`
- `NODE_USE_SYSTEM_CA` (Node 22+)

As a result, in enterprise environments that rely on additional trust roots (internal CAs, TLS inspection, etc.), the daemon can fail with TLS verification errors because the supervised service doesn't see these env vars.

### Fix

- Add `SERVICE_TLS_ENV_KEYS` + `readServiceTlsEnvironment()` (mirrors the existing proxy forwarding pattern).
- Spread TLS env forwarding into both `buildServiceEnvironment()` (gateway) and `buildNodeServiceEnvironment()` (node).
- Keep the existing macOS default for `NODE_EXTRA_CA_CERTS` (`/etc/ssl/cert.pem`) when not explicitly set, since launchd services don't inherit shell env and Node may not find the system bundle.

### Tests

Add unit cases ensuring TLS env vars are forwarded when set and omitted when not set.

Verification: `pnpm vitest run --config vitest.unit.config.ts src/daemon/service-env.test.ts`