### PR TITLE
PR: Feishu Plugin - Auto-grant document permissions to requesting user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Discord/Thread bindings: replace fixed TTL lifecycle with inactivity (`idleHours`, default 24h) plus optional hard `maxAgeHours` lifecycle controls, and add `/session idle` + `/session max-age` commands for focused thread-bound sessions. (#27845) Thanks @osolmaz.
 - Android/Nodes: add `camera.list`, `device.permissions`, `device.health`, and `notifications.actions` (`open`/`dismiss`/`reply`) on Android nodes, plus first-class node-tool actions for the new device/notification commands. (#28260) Thanks @obviyus.
 - Android/Gateway capability refresh: add live Android capability integration coverage and node canvas capability refresh wiring, plus runtime hardening for A2UI readiness retries, scoped canvas URL normalization, debug diagnostics JSON, and JavaScript MIME delivery. (#28388) Thanks @obviyus.
+- Feishu/Doc permissions: support optional owner permission grant fields on `feishu_doc` create and report permission metadata only when the grant call succeeds, with regression coverage for success/failure/omitted-owner paths. (#28295) Thanks @zhoulongchao77.
 
 ### Fixes
 

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -21,6 +21,14 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    owner_open_id: Type.Optional(
+      Type.String({ description: "Open ID of the user to grant ownership permission" }),
+    ),
+    owner_perm_type: Type.Optional(
+      Type.Union([Type.Literal("view"), Type.Literal("edit"), Type.Literal("full_access")], {
+        description: "Permission type (default: full_access)",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -21,9 +21,11 @@ import { registerFeishuDocTools } from "./docx.js";
 
 describe("feishu_doc image fetch hardening", () => {
   const convertMock = vi.hoisted(() => vi.fn());
+  const documentCreateMock = vi.hoisted(() => vi.fn());
   const blockListMock = vi.hoisted(() => vi.fn());
   const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
   const driveUploadAllMock = vi.hoisted(() => vi.fn());
+  const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
   const blockPatchMock = vi.hoisted(() => vi.fn());
   const scopeListMock = vi.hoisted(() => vi.fn());
 
@@ -34,6 +36,7 @@ describe("feishu_doc image fetch hardening", () => {
       docx: {
         document: {
           convert: convertMock,
+          create: documentCreateMock,
         },
         documentBlock: {
           list: blockListMock,
@@ -46,6 +49,9 @@ describe("feishu_doc image fetch hardening", () => {
       drive: {
         media: {
           uploadAll: driveUploadAllMock,
+        },
+        permissionMember: {
+          create: permissionMemberCreateMock,
         },
       },
       application: {
@@ -78,6 +84,11 @@ describe("feishu_doc image fetch hardening", () => {
     });
 
     driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    documentCreateMock.mockResolvedValue({
+      code: 0,
+      data: { document: { document_id: "doc_created", title: "Created Doc" } },
+    });
+    permissionMemberCreateMock.mockResolvedValue({ code: 0 });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
   });
@@ -120,5 +131,108 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("reports owner permission details when grant succeeds", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      owner_open_id: "ou_123",
+      owner_perm_type: "edit",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBe(true);
+    expect(result.details.owner_open_id).toBe("ou_123");
+    expect(result.details.owner_perm_type).toBe("edit");
+  });
+
+  it("does not report owner permission details when grant fails", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    permissionMemberCreateMock.mockRejectedValueOnce(new Error("permission denied"));
+
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      owner_open_id: "ou_123",
+      owner_perm_type: "edit",
+    });
+
+    expect(permissionMemberCreateMock).toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBeUndefined();
+    expect(result.details.owner_open_id).toBeUndefined();
+    expect(result.details.owner_perm_type).toBeUndefined();
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("skips permission grant when owner_open_id is omitted", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+    });
+
+    expect(permissionMemberCreateMock).not.toHaveBeenCalled();
+    expect(result.details.owner_permission_added).toBeUndefined();
   });
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -271,7 +271,13 @@ async function readDoc(client: Lark.Client, docToken: string) {
   };
 }
 
-async function createDoc(client: Lark.Client, title: string, folderToken?: string) {
+async function createDoc(
+  client: Lark.Client,
+  title: string,
+  folderToken?: string,
+  ownerOpenId?: string,
+  ownerPermType: "view" | "edit" | "full_access" = "full_access",
+) {
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
   });
@@ -279,10 +285,34 @@ async function createDoc(client: Lark.Client, title: string, folderToken?: strin
     throw new Error(res.msg);
   }
   const doc = res.data?.document;
+  const docToken = doc?.document_id;
+
+  // Auto add owner permission if ownerOpenId is provided
+  if (docToken && ownerOpenId) {
+    try {
+      await client.drive.permissionMember.create({
+        path: { token: docToken },
+        params: { type: "docx", need_notification: false },
+        data: {
+          member_type: "openid",
+          member_id: ownerOpenId,
+          perm: ownerPermType,
+        },
+      });
+    } catch (err) {
+      console.warn("Failed to add owner permission (non-critical):", err);
+    }
+  }
+
   return {
-    document_id: doc?.document_id,
+    document_id: docToken,
     title: doc?.title,
-    url: `https://feishu.cn/docx/${doc?.document_id}`,
+    url: `https://feishu.cn/docx/${docToken}`,
+    ...(ownerOpenId && {
+      owner_permission_added: true,
+      owner_open_id: ownerOpenId,
+      owner_perm_type: ownerPermType,
+    }),
   };
 }
 
@@ -512,7 +542,15 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     ),
                   );
                 case "create":
-                  return json(await createDoc(client, p.title, p.folder_token));
+                  return json(
+                    await createDoc(
+                      client,
+                      p.title,
+                      p.folder_token,
+                      (p as any).owner_open_id,
+                      (p as any).owner_perm_type,
+                    ),
+                  );
                 case "list_blocks":
                   return json(await listBlocks(client, p.doc_token));
                 case "get_block":

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -286,6 +286,7 @@ async function createDoc(
   }
   const doc = res.data?.document;
   const docToken = doc?.document_id;
+  let ownerPermissionAdded = false;
 
   // Auto add owner permission if ownerOpenId is provided
   if (docToken && ownerOpenId) {
@@ -299,6 +300,7 @@ async function createDoc(
           perm: ownerPermType,
         },
       });
+      ownerPermissionAdded = true;
     } catch (err) {
       console.warn("Failed to add owner permission (non-critical):", err);
     }
@@ -308,11 +310,12 @@ async function createDoc(
     document_id: docToken,
     title: doc?.title,
     url: `https://feishu.cn/docx/${docToken}`,
-    ...(ownerOpenId && {
-      owner_permission_added: true,
-      owner_open_id: ownerOpenId,
-      owner_perm_type: ownerPermType,
-    }),
+    ...(ownerOpenId &&
+      ownerPermissionAdded && {
+        owner_permission_added: true,
+        owner_open_id: ownerOpenId,
+        owner_perm_type: ownerPermType,
+      }),
   };
 }
 
@@ -547,8 +550,8 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       client,
                       p.title,
                       p.folder_token,
-                      (p as any).owner_open_id,
-                      (p as any).owner_perm_type,
+                      p.owner_open_id,
+                      p.owner_perm_type,
                     ),
                   );
                 case "list_blocks":


### PR DESCRIPTION
# PR: Feishu Plugin - Auto-grant document permissions to requesting user

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: When a user asks OpenClaw to create a Feishu document via the feishu_doc tool, the document is created but only the bot account has access. The requesting user has no permissions to edit the document.
- **Why it matters**: This creates a poor user experience — users expect to be able to edit documents they ask the bot to create for them. It requires manual permission setup in Feishu every time.
- **What changed**: Added optional parameters `owner_open_id` and `owner_perm_type` to the `create` action in `feishu_doc` tool. The `createDoc` function now automatically calls `drive.permissionMember.create` to grant full_access permission to the specified user when document is created.
- **What did NOT change (scope boundary)**: 
  - No changes to existing tool behavior when new parameters are not provided (backward compatible)
  - No changes to other feishu_doc actions (read, write, append, etc.)
  - No changes to feishu_perm tool itself

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

**New features**:

- `feishu_doc` tool's `create` action now accepts optional parameters:
  - `owner_open_id` (string): Open ID of user to grant permissions
  - `owner_perm_type` (string): Permission type - "view", "edit", or "full_access" (default: "full_access")
- When `owner_open_id` is provided, the document will automatically grant that user full_access permission upon creation
- The response now includes:
  - `owner_permission_added` (boolean): whether permission was successfully added
  - `owner_open_id` (string): the user ID that received permission
  - `owner_perm_type` (string): the permission type granted

**Backward compatible**: Yes - existing calls to `create` action continue to work exactly as before.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
  - Adds ability to grant permissions on newly created Feishu documents
  - **Mitigation**: Permissions are only granted to explicitly specified users via the `owner_open_id` parameter, and only when that parameter is provided. No permissions are granted by default.
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
  - Adds one additional API call to `drive.permissionMember.create` when owner_open_id is provided
  - **Mitigation**: This is the official Feishu API for permission management, follows the same authentication pattern as other Feishu calls
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS / Linux / Windows

- Runtime/container: Node.js 18+

- Model/provider: Any (feishu plugin is independent)

- Integration/channel: Feishu

- Relevant config:

  ```yaml
  channels:
    feishu:
      tools:
        doc: true
  ```

### Steps

1. Configure Feishu plugin with valid credentials
2. Call `feishu_doc` with action: "create" without new parameters - verify document creation still works
3. Call `feishu_doc` with action: "create", title: "Test", owner_open_id: "ou_xxx", owner_perm_type: "full_access"
4. Open the document URL in Feishu
5. Verify the user with open_id "ou_xxx" has full_access permission

### Expected

- Document is created successfully
- When owner_open_id is provided, that user automatically has edit/full_access permission
- When owner_open_id is NOT provided, behavior is unchanged from before

### Actual

- ✅ Document creation works
- ✅ Permission is automatically granted when owner_open_id is provided
- ✅ Backward compatibility maintained

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording (available in the blog post linked below)
- [ ] Perf numbers (if relevant)

**Evidence from testing**:

```json
{
  "document_id": "xxx",
  "title": "Test Document",
  "url": "https://feishu.cn/docx/xxx",
  "owner_permission_added": true,
  "owner_open_id": "ou_xxx",
  "owner_perm_type": "full_access"
}
```

Full testing details and screenshots: https://blog.csdn.net/m0_46360532/article/details/158426139

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios**:
  - Document creation without new parameters (backward compatibility)
  - Document creation with owner_open_id (permission auto-granted)
  - Different permission types (view/edit/full_access)
  - Multiple documents created in sequence

- **Edge cases checked**:
  - Invalid open_id provided (graceful error handling)
  - Feishu API failure (permission failure doesn't block document creation)
  - Folder token provided with owner_open_id (both work together)

- **What you did NOT verify**:
  - Wiki pages (out of scope, focused on docx documents)
  - Other Feishu document types (sheet, slide, etc. - out of scope)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

**If yes, exact upgrade steps**: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert changes to `docx.ts` and `doc-schema.ts`
  - Or simply don't use the new parameters (old behavior preserved)

- Files/config to restore:
  - `extensions/feishu/src/docx.ts`
  - `extensions/feishu/src/doc-schema.ts`

- Known bad symptoms reviewers should watch for:
  - Document creation fails when new parameters are provided
  - Permission API calls cause errors that block document creation
  - Existing document creation breaks (backward compatibility broken)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed.

- **Risk**: Permission API calls could fail and block document creation
  - **Mitigation**: Wrapped permission call in try/catch, permission failure is non-critical and only logged as warning, document creation succeeds regardless

- **Risk**: Backward compatibility could break
  - **Mitigation**: New parameters are optional, existing calls work unchanged, tested thoroughly before submission

- **Risk**: Unintended permissions could be granted
  - **Mitigation**: Permissions only granted when explicitly requested via owner_open_id parameter, no default permissions granted, parameter is optional

---

**Related Blog Post**: https://blog.csdn.net/m0_46360532/article/details/158426139