### PR TITLE
fix(telegram): warn on allowlist-empty group message drop

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -555,8 +555,11 @@ export const registerTelegramHandlers = ({
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
-        logVerbose(
-          "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
+        // Warn (not verbose) so users notice when allowlist has no allowFrom entries (#27552).
+        logger.warn(
+          { chatId, title: chatTitle, reason: "allowlist-empty" },
+          "Blocked group message: groupPolicy is 'allowlist' but no allowFrom entries are configured. " +
+            'Add allowFrom: ["*"] to allow all senders, or specify allowed user IDs.',
         );
         return true;
       }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -473,6 +473,9 @@ export const registerTelegramHandlers = ({
         senderUsername,
       }));
 
+  // Rate-limit the allowlist-empty warning to once per chat ID to avoid log flooding (#27552).
+  const warnedAllowlistEmptyChatIds = new Set<string | number>();
+
   const shouldSkipGroupMessage = (params: {
     isGroup: boolean;
     chatId: string | number;
@@ -555,12 +558,15 @@ export const registerTelegramHandlers = ({
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
-        // Warn (not verbose) so users notice when allowlist has no allowFrom entries (#27552).
-        logger.warn(
-          { chatId, title: chatTitle, reason: "allowlist-empty" },
-          "Blocked group message: groupPolicy is 'allowlist' but no allowFrom entries are configured. " +
-            'Add allowFrom: ["*"] to allow all senders, or specify allowed user IDs.',
-        );
+        // Warn once per chat ID to avoid log flooding on high-traffic groups (#27552).
+        if (!warnedAllowlistEmptyChatIds.has(chatId)) {
+          warnedAllowlistEmptyChatIds.add(chatId);
+          logger.warn(
+            { chatId, title: chatTitle, reason: "allowlist-empty" },
+            "Blocked group message: groupPolicy is 'allowlist' but no allowFrom entries are configured. " +
+              'Add allowFrom: ["*"] to allow all senders, or specify allowed user IDs.',
+          );
+        }
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-unauthorized") {

--- a/src/telegram/group-access.group-policy.test.ts
+++ b/src/telegram/group-access.group-policy.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { resolveTelegramRuntimeGroupPolicy } from "./group-access.js";
+import type { NormalizedAllowFrom } from "./bot-access.js";
+import {
+  evaluateTelegramGroupPolicyAccess,
+  resolveTelegramRuntimeGroupPolicy,
+} from "./group-access.js";
+
+function allow(entries: string[], hasWildcard = false): NormalizedAllowFrom {
+  return {
+    entries,
+    hasWildcard,
+    hasEntries: entries.length > 0 || hasWildcard,
+    invalidEntries: [],
+  };
+}
 
 describe("resolveTelegramRuntimeGroupPolicy", () => {
   it("fails closed when channels.telegram is missing and no defaults are set", () => {
@@ -25,5 +38,77 @@ describe("resolveTelegramRuntimeGroupPolicy", () => {
     });
     expect(resolved.groupPolicy).toBe("allowlist");
     expect(resolved.providerMissingFallbackApplied).toBe(true);
+  });
+});
+
+describe("evaluateTelegramGroupPolicyAccess", () => {
+  const baseParams = {
+    isGroup: true,
+    chatId: -1001234567890,
+    cfg: { channels: { telegram: {} } },
+    telegramCfg: { groupPolicy: "allowlist" as const },
+    effectiveGroupAllow: allow([]),
+    senderId: "12345",
+    senderUsername: "tester",
+    resolveGroupPolicy: () => ({ allowlistEnabled: false, allowed: true }),
+    enforcePolicy: true,
+    useTopicAndGroupOverrides: false,
+    enforceAllowlistAuthorization: true,
+    allowEmptyAllowlistEntries: false,
+    requireSenderForAllowlistAuthorization: true,
+    checkChatAllowlist: false,
+  };
+
+  it("returns group-policy-allowlist-empty when allowFrom is undefined/empty", () => {
+    const result = evaluateTelegramGroupPolicyAccess(baseParams);
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-empty",
+      groupPolicy: "allowlist",
+    });
+  });
+
+  it("allows message when allowEmptyAllowlistEntries is true (e.g. native commands)", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      ...baseParams,
+      allowEmptyAllowlistEntries: true,
+      effectiveGroupAllow: allow([]),
+    });
+
+    // Empty allowlist + allowEmptyAllowlistEntries=true => isSenderAllowed defaults to allow.
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("allows message when wildcard is present in allowFrom", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      ...baseParams,
+      effectiveGroupAllow: allow([], true),
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("allows message when sender is in allowFrom list", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      ...baseParams,
+      effectiveGroupAllow: allow(["12345"]),
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
+
+  it("blocks unauthorized sender even when allowFrom has entries", () => {
+    const result = evaluateTelegramGroupPolicyAccess({
+      ...baseParams,
+      senderId: "99999",
+      effectiveGroupAllow: allow(["12345"]),
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: "group-policy-allowlist-unauthorized",
+      groupPolicy: "allowlist",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #27552.

- Upgraded the `group-policy-allowlist-empty` rejection log in `shouldSkipGroupMessage` from `logVerbose` (debug-level, invisible to most users) to `logger.warn` with structured metadata (`chatId`, `title`, `reason`) and an actionable message explaining how to fix the config.
- Added unit tests for `evaluateTelegramGroupPolicyAccess` covering the allowlist-empty, wildcard, authorized/unauthorized sender, and `allowEmptyAllowlistEntries` scenarios.

When `groupPolicy: "allowlist"` is configured without an `allowFrom` field, the gateway now emits a WARN-level log:

> Blocked group message: groupPolicy is 'allowlist' but no allowFrom entries are configured. Add allowFrom: ["*"] to allow all senders, or specify allowed user IDs.

## Test plan

- [x] `pnpm test -- --run src/telegram/group-access.group-policy.test.ts` (8 tests pass)
- [x] `pnpm test -- --run src/telegram/group-access.base-access.test.ts` (3 tests pass)
- [x] `pnpm test -- --run src/telegram/bot.test.ts` (37 tests pass)
- [x] Formatting check via `pnpm format`