### PR TITLE
ci: add root Dockerfile CLI smoke gate to install-smoke

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Install pnpm deps (minimal)
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: Run root Dockerfile CLI smoke
+        run: |
+          docker build -t openclaw-dockerfile-smoke:local -f Dockerfile .
+          docker run --rm --entrypoint sh openclaw-dockerfile-smoke:local -lc 'which openclaw && openclaw --version'
+
       - name: Run installer docker tests
         env:
           CLAWDBOT_INSTALL_URL: https://openclaw.ai/install.sh


### PR DESCRIPTION
## Summary

- Problem: PR CI did not validate the repository root `Dockerfile` path used by production Docker builds.
- Why it matters: regressions in root image CLI availability can merge without pre-merge detection.
- What changed: added a root Dockerfile smoke step in `install-smoke` that runs `docker build` + `which openclaw && openclaw --version`.
- What did NOT change (scope boundary): installer smoke Dockerfiles/tests and runtime code paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #17151

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: GitHub Actions Ubuntu runner
- Runtime/container: Docker

### Steps

1. Trigger `install-smoke` workflow.
2. Observe new step: `Run root Dockerfile CLI smoke`.
3. Confirm it builds the root Dockerfile and executes `which openclaw && openclaw --version` successfully.

### Expected

- The workflow fails pre-merge if `openclaw` is not executable in the root image.

### Actual

- The workflow includes and executes the new guard step before installer smoke tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected workflow diff and rebased on latest `main`; confirmed step command content.
- Edge cases checked: n/a
- What you did **not** verify: did not run Docker locally in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `.github/workflows/install-smoke.yml`
- Known bad symptoms reviewers should watch for: `install-smoke` failing in `Run root Dockerfile CLI smoke`.

## Risks and Mitigations

- Risk: extra CI duration from one additional Docker build/run.
  - Mitigation: narrow smoke command (`which` + `--version`) and run in existing Docker-enabled workflow.
