### PR TITLE
Telegram: fix group messages silently dropped with groupPolicy allowlist + groupAllowFrom but no groups config

### DIFF
--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -757,6 +757,46 @@ describe("createTelegramBot", () => {
       expectedReplyCount: 0,
     },
     {
+      // Regression: groupPolicy="allowlist" + allowFrom but NO groups config must still allow
+      // in-allowlist senders (sender-level filtering is sufficient; the chat-allowlist
+      // check must activate senderFilterBypass when groupAllowFrom is present).
+      name: "allows group messages from authorized senders when groupPolicy='allowlist' + allowFrom but no groups config",
+      config: {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            allowFrom: ["123456789"],
+          },
+        },
+      },
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 123456789, username: "testuser" },
+        text: "@openclaw_bot hello",
+        date: 1736380800,
+      },
+      expectedReplyCount: 1,
+    },
+    {
+      // Regression: same as above but using the dedicated groupAllowFrom field.
+      name: "allows group messages from authorized senders when groupPolicy='allowlist' + groupAllowFrom but no groups config",
+      config: {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["123456789"],
+          },
+        },
+      },
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 123456789, username: "testuser" },
+        text: "@openclaw_bot hello",
+        date: 1736380800,
+      },
+      expectedReplyCount: 1,
+    },
+    {
       name: "allows group messages from senders in allowFrom (by ID) when groupPolicy is 'allowlist'",
       config: {
         channels: {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -302,6 +302,12 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       channel: "telegram",
       accountId: account.accountId,
       groupId: String(chatId),
+      // Forward whether a groupAllowFrom list exists so resolveChannelGroupPolicy can
+      // activate the senderFilterBypass path: groupPolicy="allowlist" + groupAllowFrom
+      // but no explicit per-group `groups` config should let every chat through — the
+      // sender-level allowlist check in evaluateTelegramGroupPolicyAccess already gates
+      // individual senders, so blocking the chat here would incorrectly drop all messages.
+      hasGroupAllowFrom: Array.isArray(groupAllowFrom) && groupAllowFrom.length > 0,
     });
   const resolveGroupActivation = (params: {
     chatId: string | number;


### PR DESCRIPTION
Fixes #28307

## What

Pass `hasGroupAllowFrom` in the `resolveGroupPolicy` closure in `src/telegram/bot.ts` so that `resolveChannelGroupPolicy` can activate the `senderFilterBypass` path when `groupPolicy: "allowlist"` is set with `groupAllowFrom` but no explicit per-group `groups:` entries.

## Why

`resolveChannelGroupPolicy` already contains the correct logic for this case:

```typescript
const senderFilterBypass =
  groupPolicy === "allowlist" && !hasGroups && Boolean(params.hasGroupAllowFrom);
const allowed =
  groupPolicy === "disabled"
    ? false
    : !allowlistEnabled || allowAll || Boolean(groupConfig) || senderFilterBypass;
```

But the closure in `bot.ts` never forwarded `hasGroupAllowFrom`, so `senderFilterBypass` was always `false`. The result: when a user configured `groupPolicy: "allowlist"` + `groupAllowFrom` without any `groups:` block, every inbound group message was silently dropped — even from allowlisted senders.

## Changes

- `src/telegram/bot.ts`: forward `hasGroupAllowFrom` in the `resolveGroupPolicy` closure
- `src/telegram/bot.create-telegram-bot.test.ts`: two regression tests covering `allowFrom` and `groupAllowFrom` without explicit `groups:` config

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test -- src/telegram/bot.create-telegram-bot.test.ts` — 45/45 passed ✅

AI-assisted. Fix manually reviewed; regression tests written and verified locally.

## 🤖 AI-Assisted PR

- [x] AI-assisted (Augment Agent / Claude Sonnet 4.6)
- [x] Degree of testing: **fully tested** — regression tests written and passing, build and lint clean
- [x] Fix manually reviewed and understood — one missing parameter in an existing closure; the `senderFilterBypass` logic in `group-policy.ts` was already correct and just needed to be wired up
- [ ] Prompt/session logs available on request
