### PR TITLE
fix(logging): route subsystem logs to stderr when forceConsoleToStderr is set

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -240,8 +240,19 @@ function writeConsoleLine(level: LogLevel, line: string) {
     process.platform === "win32" && process.env.GITHUB_ACTIONS === "true"
       ? line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?").replace(/[\uD800-\uDFFF]/g, "?")
       : line;
+  // When forceConsoleToStderr is active (e.g. during `openclaw completion`),
+  // write directly to process.stderr so stdout stays clean for machine-
+  // consumed output like shell completion scripts.
+  if (loggingState.forceConsoleToStderr) {
+    try {
+      process.stderr.write(`${sanitized}\n`);
+    } catch {
+      // swallow EPIPE / EIO
+    }
+    return;
+  }
   const sink = loggingState.rawConsole ?? console;
-  if (loggingState.forceConsoleToStderr || level === "error" || level === "fatal") {
+  if (level === "error" || level === "fatal") {
     (sink.error ?? console.error)(sanitized);
   } else if (level === "warn") {
     (sink.warn ?? console.warn)(sanitized);


### PR DESCRIPTION
## Summary

- Fixes #22449 — `openclaw completion` outputs plugin logs to stdout, breaking `source <(openclaw completion --shell bash)`.
- Changes `writeConsoleLine` in the subsystem logger to write directly to `process.stderr` when `forceConsoleToStderr` is active, instead of routing through `sink.error` (raw `console.error`). This eliminates any possibility of stdout pollution during shell completion generation.
- Adds a test verifying all subsystem log levels (info, warn, error, debug) route to stderr with zero stdout output when `routeLogsToStderr()` is active.

## Test plan

- [x] Existing subsystem logger tests pass (5/5)
- [x] New `forceConsoleToStderr` test passes — verifies info/warn/error/debug all go to stderr with empty stdout
- [x] Broader logging + completion test suites pass (55 tests across 13 files)
- [x] Lint/format clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)