### PR TITLE
fix: use effective model resolver in resolveAgentModelPrimary

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -185,7 +185,7 @@ export function resolveAgentEffectiveModelPrimary(
 
 // Backward-compatible alias. Prefer explicit/effective helpers at new call sites.
 export function resolveAgentModelPrimary(cfg: OpenClawConfig, agentId: string): string | undefined {
-  return resolveAgentExplicitModelPrimary(cfg, agentId);
+  return resolveAgentEffectiveModelPrimary(cfg, agentId);
 }
 
 export function resolveAgentModelFallbacksOverride(


### PR DESCRIPTION
## Bug
The backward-compatible alias `resolveAgentModelPrimary` was calling `resolveAgentExplicitModelPrimary`, which only checks local agent configuration and ignores global defaults.

## Fix
Retarget the alias to `resolveAgentEffectiveModelPrimary`, which properly merges local settings with global defaults via nullish coalescing.

## Impact
Prevents authentication failures when users set global default models without explicit agent-level overrides.