### PR TITLE
fix(provider): add xai to reasoning tag provider list (#27533)

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -21,7 +21,8 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   if (
     normalized === "google" ||
     normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
+    normalized === "google-generative-ai" ||
+    normalized === "xai"
   ) {
     return true;
   }

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -79,6 +79,8 @@ describe("isReasoningTagProvider", () => {
     { name: "returns false for null", value: null, expected: false },
     { name: "returns false for undefined", value: undefined, expected: false },
     { name: "returns false for empty", value: "", expected: false },
+    { name: "returns true for xai (grok reasoning tags)", value: "xai", expected: true },
+    { name: "returns true for xai (case-insensitive)", value: "XAI", expected: true },
     { name: "returns false for anthropic", value: "anthropic", expected: false },
     { name: "returns false for openai", value: "openai", expected: false },
     { name: "returns false for openrouter", value: "openrouter", expected: false },


### PR DESCRIPTION
## Summary

- **Problem:** `xai/grok-4-1-fast-non-reasoning` outputs `<think>` tags as visible text to users.
- **Why it matters:** Users see raw reasoning tags instead of clean responses.
- **What changed:** Added `xai` to `isReasoningTagProvider()` so thinking tags are stripped for xAI models.
- **What did NOT change:** No other providers affected; xAI reasoning models benefit from the same tag enforcement as Google/Minimax.

Closes #27533

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27533

## User-visible / Behavior Changes

xAI/grok model responses no longer show raw `<think>...</think>` tags.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Windows / Linux
- Model/provider: xai/grok-4-1-fast-non-reasoning

### Steps

1. Set agent primary model to `xai/grok-4-1-fast-non-reasoning`
2. Send any message
3. Before: `<think>...` tags visible in response. After: tags stripped.

## Evidence

- [x] Failing test/log before + passing after

```
✓ src/utils/utils-misc.test.ts (23 tests)
Tests  79 passed (across 3 test files)
```

## Human Verification (required)

- Verified scenarios: `isReasoningTagProvider("xai")` returns true; case-insensitive `"XAI"` also returns true.
- Edge cases checked: existing providers (google, minimax, ollama) unaffected.
- What you did **not** verify: Live xAI API call (unit-level only).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert single-line change in `src/utils/provider-utils.ts`.

## Risks and Mitigations

None — additive change to an existing allowlist.
