### PR TITLE
Feat/my changes

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+import os from "node:os";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -16,6 +18,40 @@ import {
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
 import type { defaultRuntime } from "../../runtime.js";
 
+/**
+ * Spawns `caffeinate -i` on macOS to prevent the system from idle-sleeping
+ * while the gateway is running. Returns a cleanup function that kills the
+ * caffeinate process when the gateway shuts down.
+ *
+ * macOS suspends TCP connections during sleep, which causes the Telegram
+ * long-polling loop to stall until the system wakes up. `caffeinate -i`
+ * prevents idle sleep without affecting display or user-initiated sleep.
+ */
+function spawnCaffeinate(): (() => void) | null {
+  if (os.platform() !== "darwin") {
+    return null;
+  }
+  try {
+    // -i: prevent idle sleep  -w <pid>: exit when the given process exits
+    const child = spawn("caffeinate", ["-i", "-w", String(process.pid)], {
+      detached: false,
+      stdio: "ignore",
+    });
+    child.unref();
+    gatewayLog.info("caffeinate started: system will not idle-sleep while gateway is running");
+    return () => {
+      try {
+        child.kill();
+      } catch {
+        // ignore cleanup errors
+      }
+    };
+  } catch {
+    gatewayLog.warn("caffeinate not available; system may sleep and interrupt Telegram polling");
+    return null;
+  }
+}
+
 const gatewayLog = createSubsystemLogger("gateway");
 
 type GatewayRunSignalAction = "stop" | "restart";
@@ -25,6 +61,7 @@ export async function runGatewayLoop(params: {
   runtime: typeof defaultRuntime;
   lockPort?: number;
 }) {
+  const stopCaffeinate = spawnCaffeinate();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
@@ -194,6 +231,7 @@ export async function runGatewayLoop(params: {
       });
     }
   } finally {
+    stopCaffeinate?.();
     await releaseLockIfHeld();
     cleanupSignals();
   }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -798,6 +798,28 @@ export async function runCapability(params: {
   if (shouldLogVerbose()) {
     logVerbose(`Media understanding ${formatDecisionSummary(decision)}`);
   }
+  if (capability === "image" && outputs.length === 0 && selected.length > 0) {
+    const allAttempts = attachmentDecisions.flatMap((a) => a.attempts);
+    const failedAttempts = allAttempts.filter(
+      (a) => a.outcome !== "skipped" && a.outcome !== "success",
+    );
+    if (failedAttempts.length > 0) {
+      const reasons = failedAttempts
+        .map((a) =>
+          a.type === "provider"
+            ? `${a.provider}/${a.model ?? "?"}: ${a.outcome}`
+            : `cli: ${a.outcome}`,
+        )
+        .join(", ");
+      console.warn(
+        `[media-understanding] image understanding failed for ${selected.length} attachment(s) — image(s) will not reach the model. Tried: ${reasons}`,
+      );
+    } else if (allAttempts.length === 0) {
+      console.warn(
+        `[media-understanding] no image understanding providers resolved — image(s) will not reach the model unless the primary model supports vision natively`,
+      );
+    }
+  }
   return {
     outputs,
     decision,

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -39,9 +39,9 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("keeps broad snippet matching disabled for send context", () => {
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
 
     const undiciSnippetErr = new Error("Undici: socket failure");

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -40,6 +40,13 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "timed out", // grammY getUpdates returns "timed out after X seconds" (not matched by "timeout")
 ];
 
+function isExplicitNetworkRequestFailureMessage(message: string): boolean {
+  if (!message) {
+    return false;
+  }
+  return message.includes("network request for") && message.includes("failed");
+}
+
 function normalizeCode(code?: string): string {
   return code?.trim().toUpperCase() ?? "";
 }
@@ -140,6 +147,11 @@ export function isRecoverableTelegramNetworkError(
 
     const message = formatErrorMessage(candidate).trim().toLowerCase();
     if (message && ALWAYS_RECOVERABLE_MESSAGES.has(message)) {
+      return true;
+    }
+    // Send context intentionally disables broad message snippet matching.
+    // Still treat explicit grammY network request failures as recoverable.
+    if (!allowMessageMatch && isExplicitNetworkRequestFailureMessage(message)) {
       return true;
     }
     if (allowMessageMatch && message) {


### PR DESCRIPTION
## Summary
- Problem: macOS idle sleep causes Telegram long-polling to disconnect; image understanding failures lack clear debug logs; Telegram message send偶发网络错误被判定为永久失败
- Why it matters: Telegram disconnection affects message delivery; debugging is difficult without logs; unnecessary message failures
- What changed: 1) Gateway spawns caffeinate to prevent macOS idle sleep 2) Image understanding failures now output detailed warning logs 3) Telegram network error detection is more lenient - explicit network request failures will retry
- What did NOT change: Core message handling logic, API contracts, config formats

## Change Type
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [x] Integrations (Telegram)
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes
- Gateway on macOS no longer causes system idle sleep
- Console warning logs appear when image understanding fails
- Telegram message send network errors now auto-retry

## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification
### Environment
- OS: macOS
- Runtime: Gateway
- Model: MiniMax M2.5

### Steps
1. Run Gateway on macOS
2. Wait for system to idle sleep
3. Observe Telegram remains connected

### Expected
- Telegram polling stays alive after system idles

### Actual
- Works as expected

## Compatibility
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
