### PR TITLE
CLI/Skills: prevent Claude interactive permission hangs by default

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -159,10 +159,10 @@ gh pr comment <PR#> --body "<review content>"
 
 ```bash
 # With PTY for proper terminal output
-bash pty:true workdir:~/project command:"claude 'Your task'"
+bash pty:true workdir:~/project command:"claude --dangerously-skip-permissions 'Your task'"
 
 # Background
-bash pty:true workdir:~/project background:true command:"claude 'Your task'"
+bash pty:true workdir:~/project background:true command:"claude --dangerously-skip-permissions 'Your task'"
 ```
 
 ---

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -34,3 +34,34 @@ describe("resolveCliBackendConfig reliability merge", () => {
     expect(resolved?.config.reliability?.watchdog?.fresh?.noOutputTimeoutRatio).toBe(0.8);
   });
 });
+
+describe("resolveCliBackendConfig claude-cli defaults", () => {
+  it("includes --dangerously-skip-permissions in fresh and resume args", () => {
+    const resolved = resolveCliBackendConfig("claude-cli");
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.args).toContain("--dangerously-skip-permissions");
+    expect(resolved?.config.resumeArgs).toContain("--dangerously-skip-permissions");
+  });
+
+  it("retains default claude safety args when only command is overridden", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "/usr/local/bin/claude",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.command).toBe("/usr/local/bin/claude");
+    expect(resolved?.config.args).toContain("--dangerously-skip-permissions");
+    expect(resolved?.config.resumeArgs).toContain("--dangerously-skip-permissions");
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Claude Code tasks launched via coding-agent examples could block on interactive permission prompts and appear to hang silently.
- Why it matters: users see long silent delays/timeouts with no actionable feedback when stdin is waiting for approval.
- What changed: added regression tests that lock `claude-cli` defaults to include `--dangerously-skip-permissions` (fresh + resume + command-only override); updated coding-agent Claude examples to include the same flag.
- What did NOT change (scope boundary): no PTY stdin-block detection, no new heartbeat/status streaming behavior, and no runtime supervisor logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28261
- Related #28261

## User-visible / Behavior Changes

- Claude commands in `skills/coding-agent/SKILL.md` now include `--dangerously-skip-permissions` in both foreground and background examples.
- Added tests guarding `claude-cli` backend defaults to keep non-interactive args present.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (repo dev environment)
- Runtime/container: Node + pnpm
- Model/provider: `claude-cli`
- Integration/channel (if any): coding-agent skill docs / CLI backend config
- Relevant config (redacted): default `agents.defaults.cliBackends["claude-cli"]`

### Steps

1. Run Claude Code via coding-agent workflows where interactive approval may be requested.
2. Observe prompt blocking behavior when permissions are not bypassed.
3. Verify backend defaults/examples include `--dangerously-skip-permissions` so runs are non-interactive by default.

### Expected

- Claude CLI invocations for this path are non-interactive by default and do not block waiting for permission input.

### Actual

- Before: examples could omit the flag and block on stdin.
- After: examples + guarded defaults align on non-interactive behavior.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification output:

```text
RUN  v4.0.18 /home/tsb/Code/openclaw
✓ src/agents/cli-backends.test.ts (3 tests)
Test Files  1 passed (1)
Tests  3 passed (3)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm vitest run src/agents/cli-backends.test.ts` and confirmed all tests pass (including new assertions for `--dangerously-skip-permissions`).
- Edge cases checked: command-only `claude-cli` override still retains default args; resume args retain the flag.
- What you did **not** verify: end-to-end Slack runtime reproduction in this PR; PTY blocked-stdin detection/forwarding is intentionally out of scope.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/cli-backends.test.ts`, `skills/coding-agent/SKILL.md`.
- Known bad symptoms reviewers should watch for: none expected beyond docs/test drift.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: docs and runtime defaults could drift again.
  - Mitigation: new unit tests enforce default claude args and resume args include the flag.
