### PR TITLE
doctor: validate memorySearch provider against models.providers

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -219,7 +219,54 @@ describe("noteMemorySearchHealth", () => {
     expect(message).not.toContain("openclaw auth add --provider");
   });
 
-  it("warns in auto mode when no local modelPath and no API keys are configured", async () => {
+  it("mentions missing models.providers.google when gemini provider has no API key and no provider block", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "gemini",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("models.providers.google");
+    expect(message).toContain('Add a "google" entry to models.providers');
+  });
+
+  it("mentions missing models.providers.openai when openai provider has no API key and no provider block", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("models.providers.openai");
+  });
+
+  it("does not mention missing provider block when models.providers entry exists", async () => {
+    const cfgWithProvider = {
+      models: { providers: { google: { baseUrl: "https://example.com", models: [] } } },
+    } as unknown as OpenClawConfig;
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "gemini",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfgWithProvider);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).not.toContain("models.providers.google section is not configured");
+    expect(message).not.toContain('Add a "google" entry');
+  });
+
+  it("uses model configure hint in auto mode when no provider credentials are found", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "auto",
       local: {},

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -95,19 +95,30 @@ export async function noteMemorySearchHealth(
     }
     const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
     const envVar = providerEnvVar(resolved.provider);
+    const providerConfigKey = embeddingProviderToConfigKey(resolved.provider);
+    const hasProviderBlock = Boolean(cfg.models?.providers?.[providerConfigKey]);
     note(
       [
         `Memory search provider is set to "${resolved.provider}" but no API key was found.`,
         `Semantic recall will not work without a valid API key.`,
+        // Surface the models.providers dependency when the provider block is missing.
+        !hasProviderBlock
+          ? `The models.providers.${providerConfigKey} section is not configured in openclaw.json.`
+          : null,
         gatewayProbeWarning ? gatewayProbeWarning : null,
         "",
         "Fix (pick one):",
         `- Set ${envVar} in your environment`,
+        !hasProviderBlock
+          ? `- Add a "${providerConfigKey}" entry to models.providers in openclaw.json with your API key`
+          : null,
         `- Configure credentials: ${formatCliCommand("openclaw configure --section model")}`,
         `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
         "",
         `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
-      ].join("\n"),
+      ]
+        .filter((line) => line !== null)
+        .join("\n"),
       "Memory search",
     );
     return;
@@ -211,6 +222,17 @@ function providerEnvVar(provider: string): string {
     default:
       return `${provider.toUpperCase()}_API_KEY`;
   }
+}
+
+/**
+ * Map a memorySearch embedding provider name to the corresponding
+ * models.providers config key. "gemini" -> "google"; others are 1:1.
+ */
+function embeddingProviderToConfigKey(provider: string): string {
+  if (provider === "gemini") {
+    return "google";
+  }
+  return provider;
 }
 
 function buildGatewayProbeWarning(

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -226,6 +226,11 @@ export async function createEmbeddingProvider(
     return { ...primary, requestedProvider };
   } catch (primaryErr) {
     const reason = formatPrimaryError(primaryErr, requestedProvider);
+    // When a missing API key is the root cause, append a hint about the
+    // models.providers config dependency so users know where to look.
+    const reasonWithHint = isMissingApiKeyError(primaryErr)
+      ? appendProviderConfigHint(reason, requestedProvider, options.config)
+      : reason;
     if (fallback && fallback !== "none" && fallback !== requestedProvider) {
       try {
         const fallbackResult = await createProvider(fallback);
@@ -233,19 +238,19 @@ export async function createEmbeddingProvider(
           ...fallbackResult,
           requestedProvider,
           fallbackFrom: requestedProvider,
-          fallbackReason: reason,
+          fallbackReason: reasonWithHint,
         };
       } catch (fallbackErr) {
         // Both primary and fallback failed - check if it's auth-related
         const fallbackReason = formatErrorMessage(fallbackErr);
-        const combinedReason = `${reason}\n\nFallback to ${fallback} failed: ${fallbackReason}`;
+        const combinedReason = `${reasonWithHint}\n\nFallback to ${fallback} failed: ${fallbackReason}`;
         if (isMissingApiKeyError(primaryErr) && isMissingApiKeyError(fallbackErr)) {
           // Both failed due to missing API keys - return null for FTS-only mode
           return {
             provider: null,
             requestedProvider,
             fallbackFrom: requestedProvider,
-            fallbackReason: reason,
+            fallbackReason: reasonWithHint,
             providerUnavailableReason: combinedReason,
           };
         }
@@ -260,7 +265,7 @@ export async function createEmbeddingProvider(
       return {
         provider: null,
         requestedProvider,
-        providerUnavailableReason: reason,
+        providerUnavailableReason: reasonWithHint,
       };
     }
     const wrapped = new Error(reason) as Error & { cause?: unknown };
@@ -303,4 +308,49 @@ function formatLocalSetupError(err: unknown): string {
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+/**
+ * Map embedding provider id to the key used in models.providers config.
+ * "gemini" -> "google"; others are 1:1.
+ */
+function embeddingProviderConfigKey(provider: string): string {
+  return provider === "gemini" ? "google" : provider;
+}
+
+/**
+ * When a missing API key error occurs for an explicit provider, check whether
+ * the models.providers block is absent and append a targeted hint so users
+ * understand the config dependency.
+ */
+function appendProviderConfigHint(
+  reason: string,
+  provider: EmbeddingProviderId,
+  config: OpenClawConfig,
+): string {
+  const configKey = embeddingProviderConfigKey(provider);
+  const hasProviderBlock = Boolean(config.models?.providers?.[configKey]);
+  if (hasProviderBlock) {
+    return reason;
+  }
+  return [
+    reason,
+    `Hint: memorySearch provider "${provider}" requires a matching models.providers.${configKey} entry in openclaw.json (with apiKey), or a ${providerEnvVarName(provider)} environment variable.`,
+    `Run "openclaw doctor" for detailed guidance.`,
+  ].join("\n");
+}
+
+function providerEnvVarName(provider: string): string {
+  switch (provider) {
+    case "openai":
+      return "OPENAI_API_KEY";
+    case "gemini":
+      return "GEMINI_API_KEY";
+    case "voyage":
+      return "VOYAGE_API_KEY";
+    case "mistral":
+      return "MISTRAL_API_KEY";
+    default:
+      return `${provider.toUpperCase()}_API_KEY`;
+  }
 }


### PR DESCRIPTION
## Summary

Closes #25206

- When `memorySearch.provider` references a remote provider (e.g. `gemini`) and no API key is found, the `openclaw doctor` check now detects whether `models.providers.<key>` is also missing and surfaces an actionable hint explaining the config dependency.
- The runtime embedding provider creation (`embeddings.ts`) now appends a targeted hint to the error message when a missing API key error occurs and the corresponding `models.providers` block is absent, pointing users to `openclaw doctor` for guidance.
- Added 5 new tests covering the new validation paths (3 in doctor, 2 in embeddings).

## Details

The core problem: `memorySearch.provider: "gemini"` implicitly requires either a `GEMINI_API_KEY` env var, an auth profile, or a `models.providers.google` block with an API key. When none of these exist, the previous error said "no API key was found" without explaining that `models.providers.google` is one of the resolution sources.

**Doctor check (`doctor-memory-search.ts`):**
- Maps embedding provider names to config keys (`gemini` -> `google`)
- Checks if `cfg.models.providers[key]` exists
- When missing, adds two lines: a diagnostic ("models.providers.google is not configured") and a fix suggestion ("Add a google entry to models.providers")

**Runtime hint (`embeddings.ts`):**
- When `createEmbeddingProvider` encounters a missing API key for an explicit provider, checks the config for the provider block
- Appends a hint mentioning the specific `models.providers.<key>` entry and the relevant env var
- Suggests running `openclaw doctor` for full guidance

## Test plan

- [x] All 12 doctor-memory-search tests pass (3 new)
- [x] All 20 embeddings tests pass (2 new)
- [x] `pnpm check` (lint + format) passes
- [x] New tests verify: gemini without provider block shows hint, openai without provider block shows hint, existing provider block suppresses the hint, runtime error includes hint, runtime error with provider block omits hint

Generated with [Claude Code](https://claude.com/claude-code)