### PR TITLE
feat: add tool call parameters to spans

### DIFF
--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -147,6 +147,18 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   pairedToolName?: string;
 };
 
+export type DiagnosticToolCallEvent = DiagnosticBaseEvent & {
+  type: "tool.call";
+  sessionKey?: string;
+  sessionId?: string;
+  toolName: string;
+  toolCallId?: string;
+  params?: Record<string, unknown>;
+  durationMs?: number;
+  outcome?: "success" | "error";
+  error?: string;
+};
+
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
   | DiagnosticWebhookReceivedEvent
@@ -160,7 +172,8 @@ export type DiagnosticEventPayload =
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent
   | DiagnosticHeartbeatEvent
-  | DiagnosticToolLoopEvent;
+  | DiagnosticToolLoopEvent
+  | DiagnosticToolCallEvent;
 
 export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
   ? Event extends DiagnosticEventPayload

--- a/src/logging/diagnostic-tool-call.test.ts
+++ b/src/logging/diagnostic-tool-call.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticToolCallEvent,
+} from "../infra/diagnostic-events.js";
+import { resetDiagnosticSessionStateForTest } from "./diagnostic-session-state.js";
+import { logToolCall, logToolCallCompleted } from "./diagnostic.js";
+
+describe("logToolCall diagnostic events", () => {
+  beforeEach(() => {
+    resetDiagnosticSessionStateForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  it("emits tool.call event with tool name and parameters", async () => {
+    const emitted: DiagnosticToolCallEvent[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type === "tool.call") {
+        emitted.push(evt);
+      }
+    });
+
+    logToolCall({
+      sessionKey: "test-session",
+      sessionId: "sess-123",
+      toolName: "read",
+      toolCallId: "call-1",
+      params: { path: "/tmp/file.txt", limit: 100 },
+    });
+
+    stop();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: "tool.call",
+      sessionKey: "test-session",
+      sessionId: "sess-123",
+      toolName: "read",
+      toolCallId: "call-1",
+      params: { path: "/tmp/file.txt", limit: 100 },
+    });
+  });
+
+  it("emits tool.call event without params when not provided", async () => {
+    const emitted: DiagnosticToolCallEvent[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type === "tool.call") {
+        emitted.push(evt);
+      }
+    });
+
+    logToolCall({
+      sessionKey: "test-session",
+      toolName: "browser",
+      toolCallId: "call-2",
+    });
+
+    stop();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: "tool.call",
+      toolName: "browser",
+      toolCallId: "call-2",
+    });
+    expect(emitted[0]?.params).toBeUndefined();
+  });
+
+  it("emits tool.call.completed event with duration and outcome", async () => {
+    const emitted: DiagnosticToolCallEvent[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type === "tool.call") {
+        emitted.push(evt);
+      }
+    });
+
+    logToolCallCompleted({
+      sessionKey: "test-session",
+      sessionId: "sess-123",
+      toolName: "exec",
+      toolCallId: "call-3",
+      durationMs: 150,
+      outcome: "success",
+    });
+
+    stop();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: "tool.call",
+      toolName: "exec",
+      toolCallId: "call-3",
+      durationMs: 150,
+      outcome: "success",
+    });
+  });
+
+  it("emits tool.call.completed event with error details", async () => {
+    const emitted: DiagnosticToolCallEvent[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type === "tool.call") {
+        emitted.push(evt);
+      }
+    });
+
+    logToolCallCompleted({
+      sessionKey: "test-session",
+      toolName: "write",
+      toolCallId: "call-4",
+      durationMs: 50,
+      outcome: "error",
+      error: "Permission denied",
+    });
+
+    stop();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      type: "tool.call",
+      toolName: "write",
+      toolCallId: "call-4",
+      durationMs: 50,
+      outcome: "error",
+      error: "Permission denied",
+    });
+  });
+
+  it("truncates large params to prevent excessive memory usage", async () => {
+    const emitted: DiagnosticToolCallEvent[] = [];
+    const stop = onDiagnosticEvent((evt) => {
+      if (evt.type === "tool.call") {
+        emitted.push(evt);
+      }
+    });
+
+    const largeContent = "x".repeat(10000);
+    logToolCall({
+      sessionKey: "test-session",
+      toolName: "write",
+      toolCallId: "call-5",
+      params: { content: largeContent },
+    });
+
+    stop();
+
+    expect(emitted).toHaveLength(1);
+    // Params should be stringified and truncated if too large
+    const paramsStr = JSON.stringify(emitted[0]?.params);
+    expect(paramsStr.length).toBeLessThanOrEqual(2048);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds tool call parameters to OpenTelemetry spans for better observability of tool execution.

## Changes

### New Diagnostic Event Type
- Added `DiagnosticToolCallEvent` type with:
  - Tool name and call ID
  - Tool parameters (truncated to prevent memory issues)
  - Duration in milliseconds
  - Outcome (success/error)
  - Error message for failed calls

### Diagnostic Logging
- Added `logToolCall()` function to emit events when a tool is called
- Added `logToolCallCompleted()` function to emit events when a tool finishes
- Parameters are truncated to 2000 chars to prevent memory issues

### OpenTelemetry Integration
- Added `openclaw.tool.calls` counter metric
- Added `openclaw.tool.duration_ms` histogram metric
- Creates spans with tool parameters as attributes:
  - `openclaw.toolName`: Name of the tool
  - `openclaw.toolCallId`: Unique call identifier
  - `openclaw.tool.params`: JSON-serialized parameters (truncated to 2048 chars)
  - `openclaw.tool.durationMs`: Execution time
  - `openclaw.tool.outcome`: success/error
  - `openclaw.tool.error`: Error message (redacted for sensitive data)

### Testing
- Added comprehensive tests for the diagnostic logging functions
- Tests verify event emission, parameter truncation, and error handling

## Related Ticket
Implements: add tool call parameters to spans