### PR TITLE
fix(bluebubbles): fix voicenote functionality

### DIFF
--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -372,6 +372,79 @@ describe("sendBlueBubblesAttachment", () => {
     expect(bodyText).toContain('name="isAudioMessage"');
     expect(bodyText).toContain("true");
     expect(bodyText).toContain('filename="voice.mp3"');
+    expect(bodyText).toContain('name="attachment"');
+  });
+
+  it("retries with alternate multipart file field names when first key is rejected", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: () => Promise.resolve("missing attachment field"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ messageId: "msg-retry" })),
+      });
+
+    await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const firstBody = decodeBody(mockFetch.mock.calls[0][1]?.body as Uint8Array);
+    const secondBody = decodeBody(mockFetch.mock.calls[1][1]?.body as Uint8Array);
+    expect(firstBody).toContain('name="attachment"');
+    expect(secondBody).toContain('name="attachments"');
+  });
+
+  it("retries alternate field when 200 response does not persist voice flag", async () => {
+    mockFetch
+      // First POST attempt succeeds but message not persisted as voice
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ messageId: "msg-not-voice" })),
+      })
+      // Verification GET for first message
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { isAudioMessage: false } }),
+      })
+      // Second POST attempt
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ messageId: "msg-voice" })),
+      })
+      // Verification GET for second message
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { isAudioMessage: true } }),
+      });
+
+    const result = await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    expect(result.messageId).toBe("msg-voice");
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    const firstPostBody = decodeBody(mockFetch.mock.calls[0][1]?.body as Uint8Array);
+    const secondPostBody = decodeBody(mockFetch.mock.calls[2][1]?.body as Uint8Array);
+    expect(firstPostBody).toContain('name="attachment"');
+    expect(secondPostBody).toContain('name="attachments"');
   });
 
   it("normalizes mp3 filenames for voice memos", async () => {

--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -385,6 +385,11 @@ describe("sendBlueBubblesAttachment", () => {
       .mockResolvedValueOnce({
         ok: true,
         text: () => Promise.resolve(JSON.stringify({ messageId: "msg-retry" })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { isAudioMessage: true } }),
       });
 
     await sendBlueBubblesAttachment({
@@ -396,7 +401,7 @@ describe("sendBlueBubblesAttachment", () => {
       opts: { serverUrl: "http://localhost:1234", password: "test" },
     });
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
     const firstBody = decodeBody(mockFetch.mock.calls[0][1]?.body as Uint8Array);
     const secondBody = decodeBody(mockFetch.mock.calls[1][1]?.body as Uint8Array);
     expect(firstBody).toContain('name="attachment"');
@@ -445,6 +450,35 @@ describe("sendBlueBubblesAttachment", () => {
     const secondPostBody = decodeBody(mockFetch.mock.calls[2][1]?.body as Uint8Array);
     expect(firstPostBody).toContain('name="attachment"');
     expect(secondPostBody).toContain('name="attachments"');
+  });
+
+  it("does not retry on verification failures or non-ok verify responses", async () => {
+    mockFetch
+      // POST success
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ messageId: "msg-verify-unavailable" })),
+      })
+      // Verification endpoint unavailable / non-ok
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ message: "not found" }),
+      });
+
+    const result = await sendBlueBubblesAttachment({
+      to: "chat_guid:iMessage;-;+15551234567",
+      buffer: new Uint8Array([1, 2, 3]),
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      asVoice: true,
+      opts: { serverUrl: "http://localhost:1234", password: "test" },
+    });
+
+    expect(result.messageId).toBe("msg-verify-unavailable");
+    // One POST + one verify GET, no re-upload attempts.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("normalizes mp3 filenames for voice memos", async () => {

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -198,85 +198,125 @@ export async function sendBlueBubblesAttachment(params: {
     password,
   });
 
-  // Build FormData with the attachment
-  const boundary = `----BlueBubblesFormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
-  const parts: Uint8Array[] = [];
-  const encoder = new TextEncoder();
-
-  // Helper to add a form field
-  const addField = (name: string, value: string) => {
-    parts.push(encoder.encode(`--${boundary}\r\n`));
-    parts.push(encoder.encode(`Content-Disposition: form-data; name="${name}"\r\n\r\n`));
-    parts.push(encoder.encode(`${value}\r\n`));
-  };
-
-  // Helper to add a file field
-  const addFile = (name: string, fileBuffer: Uint8Array, fileName: string, mimeType?: string) => {
-    parts.push(encoder.encode(`--${boundary}\r\n`));
-    parts.push(
-      encoder.encode(`Content-Disposition: form-data; name="${name}"; filename="${fileName}"\r\n`),
-    );
-    parts.push(encoder.encode(`Content-Type: ${mimeType ?? "application/octet-stream"}\r\n\r\n`));
-    parts.push(fileBuffer);
-    parts.push(encoder.encode("\r\n"));
-  };
-
-  // Add required fields
-  addFile("attachment", buffer, filename, contentType);
-  addField("chatGuid", chatGuid);
-  addField("name", filename);
-  addField("tempGuid", `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`);
-  if (privateApiEnabled) {
-    addField("method", "private-api");
-  }
-
-  // Add isAudioMessage flag for voice memos
-  if (isAudioMessage) {
-    addField("isAudioMessage", "true");
-  }
-
   const trimmedReplyTo = replyToMessageGuid?.trim();
-  if (trimmedReplyTo && privateApiEnabled) {
-    addField("selectedMessageGuid", trimmedReplyTo);
-    addField("partIndex", typeof replyToPartIndex === "number" ? String(replyToPartIndex) : "0");
-  } else if (trimmedReplyTo && privateApiStatus === null) {
+  if (trimmedReplyTo && privateApiStatus === null) {
     warnBlueBubbles(
       "Private API status unknown; sending attachment without reply threading metadata. Run a status probe to restore private-api reply features.",
     );
   }
 
-  // Add optional caption
-  if (caption) {
-    addField("message", caption);
-    addField("text", caption);
-    addField("caption", caption);
+  const buildMultipartParts = (fileFieldName: string) => {
+    const boundary = `----BlueBubblesFormBoundary${crypto.randomUUID().replace(/-/g, "")}`;
+    const parts: Uint8Array[] = [];
+    const encoder = new TextEncoder();
+
+    const addField = (name: string, value: string) => {
+      parts.push(encoder.encode(`--${boundary}\r\n`));
+      parts.push(encoder.encode(`Content-Disposition: form-data; name="${name}"\r\n\r\n`));
+      parts.push(encoder.encode(`${value}\r\n`));
+    };
+
+    const addFile = (name: string, fileBuffer: Uint8Array, fileName: string, mimeType?: string) => {
+      parts.push(encoder.encode(`--${boundary}\r\n`));
+      parts.push(
+        encoder.encode(`Content-Disposition: form-data; name="${name}"; filename="${fileName}"\r\n`),
+      );
+      parts.push(encoder.encode(`Content-Type: ${mimeType ?? "application/octet-stream"}\r\n\r\n`));
+      parts.push(fileBuffer);
+      parts.push(encoder.encode("\r\n"));
+    };
+
+    addFile(fileFieldName, buffer, filename, contentType);
+    addField("chatGuid", chatGuid);
+    addField("name", filename);
+    addField("tempGuid", `temp-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`);
+    if (privateApiEnabled) {
+      addField("method", "private-api");
+    }
+    if (isAudioMessage) {
+      addField("isAudioMessage", "true");
+    }
+    if (trimmedReplyTo && privateApiEnabled) {
+      addField("selectedMessageGuid", trimmedReplyTo);
+      addField("partIndex", typeof replyToPartIndex === "number" ? String(replyToPartIndex) : "0");
+    }
+    if (caption) {
+      addField("message", caption);
+      addField("text", caption);
+      addField("caption", caption);
+    }
+
+    parts.push(encoder.encode(`--${boundary}--\r\n`));
+    return { boundary, parts };
+  };
+
+  const candidateFileFields = ["attachment", "attachments", "file"];
+  let lastStatus = 0;
+  let lastErrorText = "";
+
+  for (let i = 0; i < candidateFileFields.length; i += 1) {
+    const fieldName = candidateFileFields[i];
+    const { boundary, parts } = buildMultipartParts(fieldName);
+    const res = await postMultipartFormData({
+      url,
+      boundary,
+      parts,
+      timeoutMs: opts.timeoutMs ?? 60_000,
+    });
+
+    const responseBody = await res.text();
+    if (res.ok) {
+      let messageId = "ok";
+      if (responseBody) {
+        try {
+          const parsed = JSON.parse(responseBody) as unknown;
+          messageId = extractBlueBubblesMessageId(parsed);
+        } catch {
+          messageId = "ok";
+        }
+      }
+
+      // Some BlueBubbles variants may return 200 even when the chosen multipart
+      // file field is ignored. For voice notes, verify persistence and continue
+      // fallback attempts unless the message is actually stored as audio.
+      if (isAudioMessage && messageId !== "ok") {
+        try {
+          const verifyUrl = buildBlueBubblesApiUrl({
+            baseUrl,
+            path: `/api/v1/message/${encodeURIComponent(messageId)}`,
+            password,
+          });
+          const verifyRes = await blueBubblesFetchWithTimeout(
+            verifyUrl,
+            { method: "GET" },
+            opts.timeoutMs,
+          );
+          const verifyJson = (await verifyRes.json().catch(() => null)) as
+            | { data?: { isAudioMessage?: boolean } }
+            | null;
+          const persistedAsVoice = verifyJson?.data?.isAudioMessage === true;
+          if (!persistedAsVoice) {
+            const isLastAttempt = i === candidateFileFields.length - 1;
+            if (!isLastAttempt) {
+              continue;
+            }
+          }
+        } catch {
+          // If verification fails, keep backward-compatible behavior.
+        }
+      }
+
+      return { messageId };
+    }
+
+    lastStatus = res.status;
+    lastErrorText = responseBody || "unknown";
+    const isLastAttempt = i === candidateFileFields.length - 1;
+    const shouldRetryWithAlternateField = !isLastAttempt && [400, 404, 415, 422].includes(res.status);
+    if (!shouldRetryWithAlternateField) {
+      break;
+    }
   }
 
-  // Close the multipart body
-  parts.push(encoder.encode(`--${boundary}--\r\n`));
-
-  const res = await postMultipartFormData({
-    url,
-    boundary,
-    parts,
-    timeoutMs: opts.timeoutMs ?? 60_000, // longer timeout for file uploads
-  });
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    throw new Error(
-      `BlueBubbles attachment send failed (${res.status}): ${errorText || "unknown"}`,
-    );
-  }
-
-  const responseBody = await res.text();
-  if (!responseBody) {
-    return { messageId: "ok" };
-  }
-  try {
-    const parsed = JSON.parse(responseBody) as unknown;
-    return { messageId: extractBlueBubblesMessageId(parsed) };
-  } catch {
-    return { messageId: "ok" };
-  }
+  throw new Error(`BlueBubbles attachment send failed (${lastStatus}): ${lastErrorText || "unknown"}`);
 }

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -291,14 +291,16 @@ export async function sendBlueBubblesAttachment(params: {
             { method: "GET" },
             opts.timeoutMs,
           );
-          const verifyJson = (await verifyRes.json().catch(() => null)) as
-            | { data?: { isAudioMessage?: boolean } }
-            | null;
-          const persistedAsVoice = verifyJson?.data?.isAudioMessage === true;
-          if (!persistedAsVoice) {
-            const isLastAttempt = i === candidateFileFields.length - 1;
-            if (!isLastAttempt) {
-              continue;
+          if (verifyRes.ok) {
+            const verifyJson = (await verifyRes.json().catch(() => null)) as
+              | { data?: { isAudioMessage?: boolean } }
+              | null;
+            const explicitlyNotVoice = verifyJson?.data?.isAudioMessage === false;
+            if (explicitlyNotVoice) {
+              const isLastAttempt = i === candidateFileFields.length - 1;
+              if (!isLastAttempt) {
+                continue;
+              }
             }
           }
         } catch {


### PR DESCRIPTION
## Summary
Fixes BlueBubbles voice-note delivery regressions where uploads were accepted but persisted without attachment metadata (no waveform inline playback), due to multipart file field-name variance across server/helper combos.

## Changes
- In `sendBlueBubblesAttachment`, start with multipart file key `attachment`.
- If the server rejects with common client-side validation statuses (`400/404/415/422`), retry with alternate keys:
  - `attachments`
  - `file`
- Keep existing `isAudioMessage=true` behavior unchanged.
- For voice notes, after a successful send response, verify persisted message state via `/api/v1/message/{id}`:
  - if `isAudioMessage` is not true, continue fallback attempts with alternate file keys.
- Add tests for:
  - standard voice upload payload (`attachment` key)
  - fallback retry behavior on rejected first key
  - fallback retry behavior when first attempt returns 200 but does not persist voice flag

## Why
Some BlueBubbles installations appear to require a different multipart file field key than the current one.

Retrying alternates only on likely field-rejection responses avoids tripling every upload payload while still improving compatibility. The additional voice-persistence check handles server variants that return 200 while silently dropping/ignoring audio metadata.

## Testing
- Validated locally in a live environment where voice notes previously arrived as plain messages.
- After patch: BlueBubbles API returns `isAudioMessage: true` and the message renders as an inline waveform voice note on iMessage.

(Unable to run full repo tests in this environment because project dev dependencies are not installed.)
