### PR TITLE
fix(zsh completion): initialize compinit before compdef

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -171,6 +171,23 @@ If you need custom runtime paths, use:
 
 See [Environment vars](/help/environment) for precedence and full details.
 
+## Shell completion (zsh)
+
+If you use dynamic zsh completion manually:
+
+```bash
+source <(openclaw completion --shell zsh)
+```
+
+OpenClaw now auto-initializes `compinit` when needed, so this works even if
+`compinit` wasn't initialized earlier in your `~/.zshrc`.
+
+For fastest startup and fewer shell hooks, prefer cached completion:
+
+```bash
+openclaw completion --install
+```
+
 ## Troubleshooting: `openclaw` not found
 
 <Accordion title="PATH diagnosis and fix">

--- a/docs/zh-CN/install/index.md
+++ b/docs/zh-CN/install/index.md
@@ -162,6 +162,22 @@ curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git
 - `OPENCLAW_NO_ONBOARD=1`
 - `SHARP_IGNORE_GLOBAL_LIBVIPS=0|1`（默认：`1`；避免 `sharp` 针对系统 libvips 构建）
 
+## Shell 补全（zsh）
+
+如果你手动使用 zsh 动态补全：
+
+```bash
+source <(openclaw completion --shell zsh)
+```
+
+OpenClaw 现在会在需要时自动初始化 `compinit`，即使你的 `~/.zshrc` 里还没提前初始化也不会报错。
+
+为了更快启动和更少 shell hook，推荐使用缓存补全：
+
+```bash
+openclaw completion --install
+```
+
 ## 故障排除：找不到 `openclaw`（PATH）
 
 快速诊断：

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const { getSubCliEntries, registerSubCliByName } = vi.hoisted(() => ({
   getSubCliEntries: vi.fn(() => []),
@@ -11,25 +11,14 @@ vi.mock("./program/register.subclis.js", () => ({
   registerSubCliByName,
 }));
 
-const { registerCompletionCli } = await import("./completion-cli.js");
+const { getCompletionScript } = await import("./completion-cli.js");
 
 describe("completion-cli", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("generates zsh completion that initializes compinit before compdef", async () => {
+  it("generates zsh completion that initializes compinit before compdef", () => {
     const program = new Command();
     program.name("openclaw");
-    registerCompletionCli(program);
 
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await program.parseAsync(["node", "openclaw", "completion", "--shell", "zsh"], {
-      from: "node",
-    });
-
-    const script = String(logSpy.mock.calls.at(0)?.[0] ?? "");
+    const script = getCompletionScript("zsh", program);
     const compinitIndex = script.indexOf("autoload -Uz compinit");
     const compdefIndex = script.indexOf("compdef _openclaw_root_completion openclaw");
 

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getSubCliEntries, registerSubCliByName } = vi.hoisted(() => ({
+  getSubCliEntries: vi.fn(() => []),
+  registerSubCliByName: vi.fn(async () => {}),
+}));
+
+vi.mock("./program/register.subclis.js", () => ({
+  getSubCliEntries,
+  registerSubCliByName,
+}));
+
+const { registerCompletionCli } = await import("./completion-cli.js");
+
+describe("completion-cli", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("generates zsh completion that initializes compinit before compdef", async () => {
+    const program = new Command();
+    program.name("openclaw");
+    registerCompletionCli(program);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await program.parseAsync(["node", "openclaw", "completion", "--shell", "zsh"], {
+      from: "node",
+    });
+
+    const script = String(logSpy.mock.calls.at(0)?.[0] ?? "");
+    const compinitIndex = script.indexOf("autoload -Uz compinit");
+    const compdefIndex = script.indexOf("compdef _openclaw_root_completion openclaw");
+
+    expect(script).toContain("if ! (( $+functions[compdef] )); then");
+    expect(compinitIndex).toBeGreaterThan(-1);
+    expect(compdefIndex).toBeGreaterThan(-1);
+    expect(compinitIndex).toBeLessThan(compdefIndex);
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -1,7 +1,7 @@
-import { Command, Option } from "commander";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Command, Option } from "commander";
 import { resolveStateDir } from "../config/paths.js";
 import { pathExists } from "../utils.js";
 import { getSubCliEntries, registerSubCliByName } from "./program/register.subclis.js";
@@ -60,7 +60,7 @@ export async function completionCacheExists(
   return pathExists(cachePath);
 }
 
-function getCompletionScript(shell: CompletionShell, program: Command): string {
+export function getCompletionScript(shell: CompletionShell, program: Command): string {
   if (shell === "zsh") {
     return generateZshCompletion(program);
   }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -352,6 +352,11 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
+if ! (( $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
+
 #compdef ${rootCmd}
 
 _${rootCmd}_root_completion() {


### PR DESCRIPTION
Closes #14289

## Problem
Sourcing zsh completion directly with `source <(openclaw completion --shell zsh)` could fail on shell startup with `command not found: compdef` when `compinit` had not run yet.

## Root Cause
The generated zsh completion script invoked `compdef` unconditionally, assuming completion internals were already initialized.

## Fix
Added a compatibility preamble to generated zsh completion output that checks for `compdef` and runs `autoload -Uz compinit` + `compinit` only when needed, then proceeds with completion registration.
Also added a regression test for this scenario and documented zsh completion initialization/recommended setup in install docs.

## Testing
- `pnpm exec vitest run src/cli/completion-cli.test.ts src/wizard/onboarding.completion.test.ts`
- Verified the new test asserts compinit bootstrap appears before `compdef` registration
