### PR TITLE
test(discord): add proxy-aware attachment download coverage

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -314,6 +314,77 @@ describe("resolveMediaList", () => {
     });
   });
 
+  it("downloads direct attachments", async () => {
+    const attachment = {
+      id: "att-direct",
+      url: "https://cdn.discordapp.com/attachments/1/photo.png",
+      filename: "photo.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/photo.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledWith({
+      url: attachment.url,
+      filePathHint: attachment.filename,
+      maxBytes: 512,
+      fetchImpl: undefined,
+    });
+    expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
+    expect(result).toEqual([
+      {
+        path: "/tmp/photo.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+  });
+
+  it("forwards fetchImpl to direct attachment downloads (proxy support)", async () => {
+    const proxyFetch = vi.fn() as unknown as typeof fetch;
+    const attachment = {
+      id: "att-proxy-direct",
+      url: "https://cdn.discordapp.com/attachments/1/proxy-photo.png",
+      filename: "proxy-photo.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/proxy-photo.png",
+      contentType: "image/png",
+    });
+
+    await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+      proxyFetch,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ fetchImpl: proxyFetch }),
+    );
+  });
+
   it("forwards fetchImpl to sticker downloads", async () => {
     const proxyFetch = vi.fn() as unknown as typeof fetch;
     const sticker = {


### PR DESCRIPTION
## Summary

Closes #22575

The underlying fix for threading `fetchImpl` through Discord's inbound attachment/sticker download path was already landed in 97e56cb73 ("fix(discord): land proxy/media/reaction/model-picker regressions"). However, the `resolveMediaList` test suite only covered sticker downloads and forwarded attachment downloads -- direct (non-forwarded) attachment downloads had no test coverage.

This PR adds the missing tests:

- **"downloads direct attachments"** -- verifies `resolveMediaList` downloads a direct CDN attachment via `fetchRemoteMedia` and returns the expected media info
- **"forwards fetchImpl to direct attachment downloads (proxy support)"** -- verifies the proxy `fetchImpl` is threaded through to `fetchRemoteMedia` for direct attachments, which is the exact scenario reported in #22575

## Test plan

- [x] `pnpm test src/discord/monitor/message-utils.test.ts` passes (22 tests, 0 failures)
- [x] New tests exercise the exact call chain described in the issue: `resolveMediaList` -> `appendResolvedMediaFromAttachments` -> `fetchRemoteMedia({ fetchImpl })`