### PR TITLE
fix: stop leaking API key snippets in /models command output

### DIFF
--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -45,10 +45,12 @@ describe("resolveModelAuthLabel", () => {
       sessionEntry: { authProfileOverride: "github-copilot:default" } as never,
     });
 
-    expect(label).toContain("token ref(env:GITHUB_TOKEN)");
+    expect(label).toContain("token");
+    expect(label).toContain("ref(env:GITHUB_TOKEN)");
+    expect(label).not.toMatch(/[A-Za-z0-9]{6,}\.\.\./);
   });
 
-  it("masks short api-key profile values", () => {
+  it("does not leak api-key value in label", () => {
     const shortSecret = "abc123";
     ensureAuthProfileStoreMock.mockReturnValue({
       version: 1,
@@ -70,7 +72,7 @@ describe("resolveModelAuthLabel", () => {
     });
 
     expect(label).toContain("api-key");
-    expect(label).toContain("...");
     expect(label).not.toContain(shortSecret);
+    expect(label).not.toContain("...");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: The `/models` command in Telegram displays partial API key snippets (prefix…suffix) for API-key authenticated providers, leaking key structure and partial content in chat channels.
- Why it matters: Even masked key fragments reveal key format and partial values, which is unnecessary information exposure in a chat UI visible to other group members.
- What changed: Removed masked key value display from `resolveModelAuthLabel` — API-key and token labels now show only auth type and source metadata (profile label, env var name, secret ref, or "models.json").
- What did NOT change: CLI `models list` command retains `maskApiKey` display in terminal output (local context, acceptable).

**Before:** `Models (google · 🔑 api-key REDACTED…REDACTED (env: GEMINI_API_KEY))`
**After:** `Models (google · 🔑 api-key (env: GEMINI_API_KEY))`

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Agent runtime

## Linked Issue/PR

- Closes #28311

## User-visible / Behavior Changes

API key providers in `/models` output no longer show masked key fragments. Labels are cleaner and consistent with OAuth provider display style.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — key snippets removed from chat-facing labels
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] `npx vitest run src/agents/model-auth-label.test.ts` — 2/2 passed (updated to assert key absence)
- [x] `npx oxfmt --check` — clean

## Human Verification (required)

- Verified scenarios: API-key profiles produce clean labels; token profiles with refs show ref source without key value; env-sourced keys show env var name only
- What you did **not** verify: Live Telegram bot `/models` command output

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; key snippets return to being displayed (existing behavior)

## Risks and Mitigations

The `formatCredentialSource` helper only returns ref metadata when available; otherwise returns undefined. No risk of losing auth type information.