### PR TITLE
fix: pass hasGroupAllowFrom to resolveChannelGroupPolicy in Telegram and iMessage

### DIFF
--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -123,6 +123,7 @@ export function resolveIMessageInboundDecision(params: {
         channel: "imessage",
         accountId: params.accountId,
         groupId: groupIdCandidate,
+        hasGroupAllowFrom: params.groupAllowFrom.length > 0,
       })
     : {
         allowlistEnabled: false,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -296,12 +296,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const mediaMaxBytes = (opts.mediaMaxMb ?? telegramCfg.mediaMaxMb ?? 5) * 1024 * 1024;
   const logger = getChildLogger({ module: "telegram-auto-reply" });
   const streamMode = resolveTelegramStreamMode(telegramCfg);
+  const hasGroupAllowFrom = Array.isArray(groupAllowFrom) && groupAllowFrom.length > 0;
   const resolveGroupPolicy = (chatId: string | number) =>
     resolveChannelGroupPolicy({
       cfg,
       channel: "telegram",
       accountId: account.accountId,
       groupId: String(chatId),
+      hasGroupAllowFrom,
     });
   const resolveGroupActivation = (params: {
     chatId: string | number;


### PR DESCRIPTION
## Summary

- Problem: When `groupPolicy: "allowlist"` is configured with `groupAllowFrom` but without explicit `groups:` entries, all inbound group messages are silently dropped in Telegram and iMessage channels.
- Why it matters: Users configuring `groupAllowFrom` expect sender-level filtering to work across any group — the allowlist should gate by sender, not require every group ID to be enumerated.
- What changed: Pass `hasGroupAllowFrom` flag to `resolveChannelGroupPolicy` in both Telegram (`bot.ts`) and iMessage (`inbound-processing.ts`) call sites. This activates the existing `senderFilterBypass` logic that was already implemented but never reached.
- What did NOT change: The WhatsApp handler already passed this flag correctly. The `resolveChannelGroupPolicy` function and `senderFilterBypass` logic are untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Channel: Telegram
- [x] Channel: iMessage

## Linked Issue/PR

- Closes #28307

## User-visible / Behavior Changes

With `groupPolicy: "allowlist"` and `groupAllowFrom` configured (but no `groups:` block), group messages from allowed senders are now accepted instead of silently dropped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — sender-level access control (`groupAllowFrom`) still enforced

## Evidence

- [x] `npx vitest run src/config/group-policy.test.ts` — 13/13 passed (pre-existing `senderFilterBypass` tests)
- [x] `npx vitest run src/imessage/monitor/inbound-processing.test.ts` — 4/4 passed
- [x] `npx oxfmt --check` — clean

## Human Verification (required)

- Verified scenarios: `groupPolicy: "allowlist"` + `groupAllowFrom: ["@alice"]` + no `groups:` config → messages from @alice in any group accepted; messages from unlisted senders still rejected
- What you did **not** verify: Live Telegram/iMessage group with this configuration

## Compatibility / Migration

- Backward compatible? Yes — existing configs with explicit `groups:` entries are unaffected
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit; group messages without explicit `groups:` entries return to being dropped (existing behavior)

## Risks and Mitigations

The `senderFilterBypass` only activates when `groupPolicy === "allowlist"` AND `hasGroupAllowFrom === true` AND `hasGroups === false`. It does not bypass sender-level checks — those are enforced separately by `evaluateTelegramGroupPolicyAccess`.