### PR TITLE
feat(qq): implement QQ Bot API v2 channel plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -73,6 +73,11 @@
           - "src/slack/**"
           - "extensions/slack/**"
           - "docs/channels/slack.md"
+"channel: qq":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/qq/**"
+          - "docs/channels/qq.md"
 "channel: telegram":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/qq/index.ts
+++ b/extensions/qq/index.ts
@@ -1,0 +1,17 @@
+import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { qqPlugin } from "./src/channel.js";
+import { setQQRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "qq",
+  name: "QQ",
+  description: "QQ channel plugin (Bot API v2, WebSocket)",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setQQRuntime(api.runtime);
+    api.registerChannel({ plugin: qqPlugin as ChannelPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/qq/openclaw.plugin.json
+++ b/extensions/qq/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "qq",
+  "channels": ["qq"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/qq/package.json
+++ b/extensions/qq/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/qq",
+  "version": "2026.2.26",
+  "private": true,
+  "description": "OpenClaw QQ channel plugin (Bot API v2)",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/qq/src/api.ts
+++ b/extensions/qq/src/api.ts
@@ -1,0 +1,102 @@
+import { getQQAccessToken } from "./token.js";
+import type { QQSendMessageParams, QQSendResult } from "./types.js";
+
+const QQ_API_BASE = "https://api.sgroup.qq.com";
+
+async function qqRequest<T>(params: {
+  appId: string;
+  clientSecret: string;
+  method: string;
+  path: string;
+  body?: unknown;
+  signal?: AbortSignal;
+}): Promise<T> {
+  const token = await getQQAccessToken(params.appId, params.clientSecret);
+  const res = await fetch(`${QQ_API_BASE}${params.path}`, {
+    method: params.method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `QQBot ${token}`,
+      "X-Union-Appid": params.appId,
+    },
+    body: params.body ? JSON.stringify(params.body) : undefined,
+    signal: params.signal,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`QQ API ${params.method} ${params.path} failed: ${res.status} ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+/** Send C2C (single chat) message */
+export async function sendQQC2CMessage(params: {
+  appId: string;
+  clientSecret: string;
+  openid: string;
+  msg: QQSendMessageParams;
+  signal?: AbortSignal;
+}): Promise<QQSendResult> {
+  return qqRequest<QQSendResult>({
+    appId: params.appId,
+    clientSecret: params.clientSecret,
+    method: "POST",
+    path: `/v2/users/${encodeURIComponent(params.openid)}/messages`,
+    body: params.msg,
+    signal: params.signal,
+  });
+}
+
+/** Send group message */
+export async function sendQQGroupMessage(params: {
+  appId: string;
+  clientSecret: string;
+  groupOpenid: string;
+  msg: QQSendMessageParams;
+  signal?: AbortSignal;
+}): Promise<QQSendResult> {
+  return qqRequest<QQSendResult>({
+    appId: params.appId,
+    clientSecret: params.clientSecret,
+    method: "POST",
+    path: `/v2/groups/${encodeURIComponent(params.groupOpenid)}/messages`,
+    body: params.msg,
+    signal: params.signal,
+  });
+}
+
+/** Probe bot info */
+export async function probeQQBot(params: {
+  appId: string;
+  clientSecret: string;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; username?: string; id?: string }> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      params.timeoutMs ?? 5000,
+    );
+    try {
+      const token = await getQQAccessToken(params.appId, params.clientSecret);
+      const res = await fetch(`${QQ_API_BASE}/users/@me`, {
+        headers: {
+          Authorization: `QQBot ${token}`,
+          "X-Union-Appid": params.appId,
+        },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        return { ok: false };
+      }
+      const data = (await res.json()) as { id?: string; username?: string };
+      return { ok: true, id: data.id, username: data.username };
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return { ok: false };
+  }
+}

--- a/extensions/qq/src/channel.ts
+++ b/extensions/qq/src/channel.ts
@@ -1,0 +1,295 @@
+import type {
+  ChannelPlugin,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildChannelConfigSchema,
+} from "openclaw/plugin-sdk";
+import type { QQBotConfig, QQInboundMessage } from "./types.js";
+import { sendQQText, buildQQSessionKey, buildQQFrom, stripQQMention } from "./dispatch.js";
+import { monitorQQProvider } from "./monitor.js";
+import { probeQQBot } from "./api.js";
+import { getQQRuntime } from "./runtime.js";
+import { QQConfigSchema } from "./config-schema.js";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function listQQAccountIds(cfg: OpenClawConfig): string[] {
+  const qq = (cfg as Record<string, unknown>).channels as Record<string, unknown> | undefined;
+  const section = qq?.qq as Record<string, unknown> | undefined;
+  if (!section) return [];
+  const accounts = section.accounts as Record<string, unknown> | undefined;
+  const ids = accounts ? Object.keys(accounts) : [];
+  // Always include default if top-level config exists
+  if (!ids.includes(DEFAULT_ACCOUNT_ID)) {
+    ids.unshift(DEFAULT_ACCOUNT_ID);
+  }
+  return ids;
+}
+
+function resolveQQAccount(cfg: OpenClawConfig, accountId: string): QQBotConfig & { accountId: string } {
+  const channels = (cfg as Record<string, unknown>).channels as Record<string, unknown> | undefined;
+  const section = channels?.qq as Record<string, unknown> | undefined;
+  if (!section) {
+    return { accountId, appId: "", clientSecret: "" };
+  }
+  const accounts = section.accounts as Record<string, Record<string, unknown>> | undefined;
+  const accountCfg: Record<string, unknown> =
+    accountId !== DEFAULT_ACCOUNT_ID && accounts?.[accountId]
+      ? { ...section, ...accounts[accountId] }
+      : section;
+
+  return {
+    accountId,
+    appId: String(accountCfg.appId ?? accountCfg.app_id ?? ""),
+    clientSecret: String(accountCfg.clientSecret ?? accountCfg.client_secret ?? ""),
+    webhookPath: accountCfg.webhookPath as string | undefined,
+    webhookPort: accountCfg.webhookPort as number | undefined,
+    allowFrom: accountCfg.allowFrom as string[] | undefined,
+    dmPolicy: accountCfg.dmPolicy as QQBotConfig["dmPolicy"] | undefined,
+    name: accountCfg.name as string | undefined,
+    enabled: accountCfg.enabled as boolean | undefined,
+  };
+}
+
+// ── channel plugin ────────────────────────────────────────────────────────────
+
+export const qqPlugin: ChannelPlugin = {
+  id: "qq",
+  meta: {
+    id: "qq",
+    label: "QQ",
+    selectionLabel: "QQ (Bot API v2)",
+    detailLabel: "QQ Bot",
+    docsPath: "/channels/qq",
+    docsLabel: "qq",
+    blurb: "QQ official bot API v2 with webhook support.",
+    systemImage: "message",
+  },
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    reactions: false,
+    threads: false,
+    media: false,
+    polls: false,
+    nativeCommands: false,
+    blockStreaming: false,
+  },
+  reload: { configPrefixes: ["channels.qq"] },
+  configSchema: buildChannelConfigSchema(QQConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listQQAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveQQAccount(cfg, accountId),
+    defaultAccountId: (cfg) => {
+      const ids = listQQAccountIds(cfg);
+      return ids[0] ?? DEFAULT_ACCOUNT_ID;
+    },
+    isConfigured: (account) => {
+      const a = account as QQBotConfig;
+      return Boolean(a.appId?.trim()) && Boolean(a.clientSecret?.trim());
+    },
+    unconfiguredReason: (account) => {
+      const a = account as QQBotConfig;
+      if (!a.appId?.trim()) return "channels.qq.appId is required";
+      if (!a.clientSecret?.trim()) return "channels.qq.clientSecret is required";
+      return "not configured";
+    },
+    describeAccount: (account) => {
+      const a = account as QQBotConfig & { accountId: string };
+      return {
+        accountId: a.accountId,
+        name: a.name,
+        enabled: a.enabled,
+        configured: Boolean(a.appId?.trim()) && Boolean(a.clientSecret?.trim()),
+      };
+    },
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const account = resolveQQAccount(cfg, accountId);
+      return (account.allowFrom ?? []).map(String);
+    },
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom.map((e) => String(e).trim()).filter(Boolean),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      const a = account as QQBotConfig;
+      return {
+        policy: a.dmPolicy ?? "open",
+        allowFrom: a.allowFrom ?? [],
+        policyPath: "channels.qq.dmPolicy",
+        allowFromPath: "channels.qq.",
+        approveHint: "Add the user openid to channels.qq.allowFrom",
+        normalizeEntry: (raw: string) => raw,
+      };
+    },
+    collectWarnings: () => [],
+  },
+  messaging: {
+    normalizeTarget: (target) => ({ target: String(target).trim() }),
+    targetResolver: {
+      looksLikeId: (raw) => /^[a-zA-Z0-9_-]{10,}$/.test(raw),
+      hint: "<openid or group_openid>",
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => {
+      // Simple chunker: split on newlines respecting limit
+      const chunks: string[] = [];
+      let current = "";
+      for (const line of text.split("\n")) {
+        if (current.length + line.length + 1 > limit && current) {
+          chunks.push(current);
+          current = line;
+        } else {
+          current = current ? `${current}\n${line}` : line;
+        }
+      }
+      if (current) chunks.push(current);
+      return chunks;
+    },
+    chunkerMode: "plain",
+    textChunkLimit: 4000,
+    sendText: async ({ to, text, accountId, replyToId }) => {
+      const runtime = getQQRuntime();
+      const cfg = runtime.config.loadConfig();
+      const account = resolveQQAccount(cfg, accountId ?? DEFAULT_ACCOUNT_ID);
+      // Determine chat type from target format: "group:<openid>" or plain openid for c2c
+      const chatType = to.startsWith("group:") ? "group" : "c2c";
+      const openid = to.startsWith("group:") ? to.slice(6) : to;
+      const result = await sendQQText({
+        config: account,
+        to: openid,
+        chatType,
+        text,
+        replyToMsgId: replyToId ?? undefined,
+      });
+      return { channel: "qq", id: result.id };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildChannelSummary: ({ snapshot }) => {
+      if (!snapshot) return "QQ: not configured";
+      if (snapshot.running) return `QQ: running (${snapshot.accountId})`;
+      if (snapshot.lastError) return `QQ: error — ${snapshot.lastError}`;
+      return "QQ: stopped";
+    },
+    probeAccount: async ({ account, timeoutMs }) => {
+      const a = account as QQBotConfig;
+      return probeQQBot({ appId: a.appId, clientSecret: a.clientSecret, timeoutMs });
+    },
+    buildAccountSnapshot: ({ account, runtime }) => {
+      const a = account as QQBotConfig & { accountId: string };
+      return {
+        accountId: a.accountId,
+        name: a.name,
+        enabled: a.enabled,
+        configured: Boolean(a.appId?.trim()) && Boolean(a.clientSecret?.trim()),
+        running: runtime?.running ?? false,
+        lastStartAt: runtime?.lastStartAt ?? null,
+        lastStopAt: runtime?.lastStopAt ?? null,
+        lastError: runtime?.lastError ?? null,
+      };
+    },
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account as QQBotConfig & { accountId: string };
+      ctx.log?.info?.(`[${account.accountId}] starting QQ webhook provider`);
+
+      const onMessage = async (msg: QQInboundMessage) => {
+        await handleInboundQQMessage({
+          msg,
+          account,
+          cfg: ctx.cfg,
+          log: ctx.log,
+        });
+      };
+
+      return monitorQQProvider({
+        config: account,
+        accountId: account.accountId,
+        onMessage,
+        abortSignal: ctx.abortSignal,
+        log: ctx.log,
+      });
+    },
+  },
+};
+
+// ── inbound message handler ───────────────────────────────────────────────────
+
+async function handleInboundQQMessage(params: {
+  msg: QQInboundMessage;
+  account: QQBotConfig & { accountId: string };
+  cfg: OpenClawConfig;
+  log?: { info?: (s: string) => void; error?: (s: string) => void };
+}): Promise<void> {
+  const { msg, account, cfg, log } = params;
+
+  const content = stripQQMention(msg.content);
+  if (!content) return;
+
+  const from = buildQQFrom(msg);
+  const sessionKey = buildQQSessionKey({
+    accountId: account.accountId,
+    chatType: msg.chatType,
+    openid: msg.openid,
+  });
+
+  log?.info?.(`[${account.accountId}] inbound ${msg.chatType} from ${msg.senderOpenid}: ${content.slice(0, 80)}`);
+
+  try {
+    const runtime = getQQRuntime();
+
+    // Build MsgContext (same pattern as Telegram/Discord channel plugins)
+    const ctx = {
+      Body: content,
+      CommandBody: content,
+      BodyForCommands: content,
+      From: from,
+      To: msg.chatType === "group" ? `group:${msg.openid}` : msg.senderOpenid,
+      SessionKey: sessionKey,
+      MessageSid: msg.msgId,
+      AccountId: account.accountId,
+      // Surface/Provider are used by dispatchReplyFromConfig to resolve the channel
+      Surface: "qq",
+      Provider: "qq",
+      Channel: "qq" as const,
+      ChatType: msg.chatType === "group" ? ("group" as const) : ("direct" as const),
+    };
+
+    // Build a reply dispatcher that sends back to QQ.
+    // dispatcherOptions must have a `deliver(payload, info)` function —
+    // payload.text contains the reply text.
+    const dispatcherOptions = {
+      deliver: async (payload: { text?: string }, _info: unknown) => {
+        const text = payload?.text;
+        if (!text) return;
+        await sendQQText({
+          config: account,
+          to: msg.chatType === "group" ? msg.openid : msg.senderOpenid,
+          chatType: msg.chatType,
+          text,
+          replyToMsgId: msg.msgId,
+        });
+      },
+    };
+
+    await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+      ctx,
+      cfg,
+      dispatcherOptions,
+    });
+  } catch (err) {
+    log?.error?.(`[${account.accountId}] dispatch error: ${String(err)}`);
+  }
+}

--- a/extensions/qq/src/channel.ts
+++ b/extensions/qq/src/channel.ts
@@ -272,6 +272,10 @@ async function handleInboundQQMessage(params: {
       Provider: "qq",
       Channel: "qq" as const,
       ChatType: msg.chatType === "group" ? ("group" as const) : ("direct" as const),
+      // SenderId enables allowlist/owner matching for group chats
+      SenderId: msg.senderOpenid,
+      // CommandAuthorized allows /new, /reset and other commands to work
+      CommandAuthorized: true,
     };
 
     // Build a reply dispatcher that sends back to QQ.

--- a/extensions/qq/src/channel.ts
+++ b/extensions/qq/src/channel.ts
@@ -135,10 +135,17 @@ export const qqPlugin: ChannelPlugin = {
   outbound: {
     deliveryMode: "direct",
     chunker: (text, limit) => {
-      // Simple chunker: split on newlines respecting limit
       const chunks: string[] = [];
       let current = "";
       for (const line of text.split("\n")) {
+        // If a single line exceeds limit, split it by character
+        if (line.length > limit) {
+          if (current) { chunks.push(current); current = ""; }
+          for (let i = 0; i < line.length; i += limit) {
+            chunks.push(line.slice(i, i + limit));
+          }
+          continue;
+        }
         if (current.length + line.length + 1 > limit && current) {
           chunks.push(current);
           current = line;

--- a/extensions/qq/src/config-schema.ts
+++ b/extensions/qq/src/config-schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const QQAccountSchema = z
+  .object({
+    appId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    webhookPath: z.string().optional(),
+    webhookPort: z.number().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional(),
+  })
+  .strict();
+
+export const QQConfigSchema = z
+  .object({
+    appId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    webhookPath: z.string().optional(),
+    webhookPort: z.number().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional(),
+    accounts: z.record(z.string(), QQAccountSchema.optional()).optional(),
+  })
+  .strict();
+
+export type QQConfig = z.infer<typeof QQConfigSchema>;

--- a/extensions/qq/src/dispatch.ts
+++ b/extensions/qq/src/dispatch.ts
@@ -1,0 +1,95 @@
+import type { QQBotConfig, QQInboundMessage } from "./types.js";
+import { sendQQC2CMessage, sendQQGroupMessage } from "./api.js";
+
+// Seq counter per msgId to avoid duplicate passive replies
+const seqMap = new Map<string, number>();
+
+function nextSeq(msgId: string): number {
+  const seq = (seqMap.get(msgId) ?? 0) + 1;
+  seqMap.set(msgId, seq);
+  // Cleanup old entries
+  if (seqMap.size > 500) {
+    const first = seqMap.keys().next().value;
+    if (first) seqMap.delete(first);
+  }
+  return seq;
+}
+
+export type QQSendTextParams = {
+  config: QQBotConfig;
+  to: string;
+  chatType: "c2c" | "group";
+  text: string;
+  replyToMsgId?: string;
+  signal?: AbortSignal;
+};
+
+/**
+ * Send a text message to QQ (C2C or group).
+ * Uses passive reply (msg_id) when replyToMsgId is provided.
+ */
+export async function sendQQText(params: QQSendTextParams): Promise<{ id: string }> {
+  const { config, to, chatType, text, replyToMsgId, signal } = params;
+  const msgSeq = replyToMsgId ? nextSeq(replyToMsgId) : undefined;
+
+  if (chatType === "c2c") {
+    const result = await sendQQC2CMessage({
+      appId: config.appId,
+      clientSecret: config.clientSecret,
+      openid: to,
+      msg: {
+        content: text,
+        msg_type: 0,
+        msg_id: replyToMsgId,
+        msg_seq: msgSeq,
+      },
+      signal,
+    });
+    return { id: result.id };
+  }
+
+  const result = await sendQQGroupMessage({
+    appId: config.appId,
+    clientSecret: config.clientSecret,
+    groupOpenid: to,
+    msg: {
+      content: text,
+      msg_type: 0,
+      msg_id: replyToMsgId,
+      msg_seq: msgSeq,
+    },
+    signal,
+  });
+  return { id: result.id };
+}
+
+/**
+ * Build the session key for a QQ conversation.
+ * Format: qq:<accountId>:<chatType>:<openid>
+ */
+export function buildQQSessionKey(params: {
+  accountId: string;
+  chatType: "c2c" | "group";
+  openid: string;
+}): string {
+  return `qq:${params.accountId}:${params.chatType}:${params.openid}`;
+}
+
+/**
+ * Build the From field for a QQ message context.
+ */
+export function buildQQFrom(msg: QQInboundMessage): string {
+  if (msg.chatType === "c2c") {
+    return `qq:${msg.senderOpenid}`;
+  }
+  // group: use group_openid as the "from" channel, sender as sub-id
+  return `qq-group:${msg.openid}:${msg.senderOpenid}`;
+}
+
+/**
+ * Strip @bot mention from group messages.
+ * QQ group messages to bot start with <@!botId> or similar.
+ */
+export function stripQQMention(content: string): string {
+  return content.replace(/^<@!?\w+>\s*/, "").trim();
+}

--- a/extensions/qq/src/monitor.ts
+++ b/extensions/qq/src/monitor.ts
@@ -1,0 +1,209 @@
+import WebSocket from "ws";
+import type { QQBotConfig, QQC2CMessageEvent, QQGroupMessageEvent, QQInboundMessage } from "./types.js";
+import { getQQAccessToken } from "./token.js";
+
+export type QQMessageHandler = (msg: QQInboundMessage) => Promise<void>;
+
+export type MonitorQQOptions = {
+  config: QQBotConfig;
+  accountId: string;
+  onMessage: QQMessageHandler;
+  abortSignal?: AbortSignal;
+  log?: { info?: (msg: string) => void; error?: (msg: string) => void; debug?: (msg: string) => void };
+};
+
+const BACKOFF_INITIAL_MS = 5_000;
+const BACKOFF_MAX_MS = 5 * 60_000;
+const BACKOFF_FACTOR = 2;
+
+// QQ WebSocket intents: GROUP_AT_MESSAGE_CREATE (1<<25) + C2C_MESSAGE_CREATE (1<<9)
+const INTENTS = (1 << 25) | (1 << 9);
+
+async function getGatewayUrl(config: QQBotConfig): Promise<string> {
+  const token = await getQQAccessToken(config.appId, config.clientSecret);
+  const res = await fetch("https://api.sgroup.qq.com/gateway/bot", {
+    headers: { Authorization: `QQBot ${token}` },
+  });
+  if (!res.ok) throw new Error(`gateway/bot returned ${res.status}`);
+  const data = await res.json() as { url: string };
+  if (!data.url) throw new Error("gateway/bot: missing url");
+  return data.url;
+}
+
+export async function monitorQQProvider(opts: MonitorQQOptions): Promise<void> {
+  const { config, accountId, onMessage, abortSignal, log } = opts;
+
+  let stopped = false;
+  let reconnectDelay = BACKOFF_INITIAL_MS;
+
+  abortSignal?.addEventListener("abort", () => { stopped = true; }, { once: true });
+
+  while (!stopped) {
+    try {
+      await runWebSocketSession({ config, accountId, onMessage, log, abortSignal,
+        onConnected: () => { reconnectDelay = BACKOFF_INITIAL_MS; },
+      });
+    } catch (err) {
+      if (stopped) break;
+      log?.error?.(`[${accountId}] WS session error: ${String(err)}, retrying in ${reconnectDelay / 1000}s`);
+    }
+
+    if (stopped) break;
+
+    await sleep(reconnectDelay, abortSignal);
+    reconnectDelay = Math.min(reconnectDelay * BACKOFF_FACTOR, BACKOFF_MAX_MS);
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => { clearTimeout(timer); resolve(); }, { once: true });
+  });
+}
+
+async function runWebSocketSession(opts: {
+  config: QQBotConfig;
+  accountId: string;
+  onMessage: QQMessageHandler;
+  log?: MonitorQQOptions["log"];
+  abortSignal?: AbortSignal;
+  onConnected: () => void;
+}): Promise<void> {
+  const { config, accountId, onMessage, log, abortSignal, onConnected } = opts;
+
+  const gatewayUrl = await getGatewayUrl(config);
+  log?.info?.(`[${accountId}] connecting to QQ WebSocket: ${gatewayUrl}`);
+
+  return new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(gatewayUrl);
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let seq: number | null = null;
+    let identified = false;
+
+    const cleanup = () => {
+      if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+    };
+
+    const close = (err?: Error) => {
+      cleanup();
+      ws.terminate();
+      if (err) reject(err);
+      else resolve();
+    };
+
+    abortSignal?.addEventListener("abort", () => close(), { once: true });
+
+    ws.on("open", () => {
+      log?.info?.(`[${accountId}] QQ WebSocket connected`);
+    });
+
+    ws.on("message", async (raw: Buffer) => {
+      let payload: { op: number; t?: string; d?: unknown; s?: number };
+      try { payload = JSON.parse(raw.toString()); } catch { return; }
+
+      const { op, t, d, s } = payload;
+      if (s != null) seq = s;
+
+      // op=10: Hello — start heartbeat + identify
+      if (op === 10) {
+        const hello = d as { heartbeat_interval: number };
+        heartbeatTimer = setInterval(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ op: 1, d: seq }));
+          }
+        }, hello.heartbeat_interval);
+
+        if (!identified) {
+          identified = true;
+          const token = await getQQAccessToken(config.appId, config.clientSecret).catch(() => "");
+          ws.send(JSON.stringify({
+            op: 2,
+            d: {
+              token: `QQBot ${token}`,
+              intents: INTENTS,
+              shard: [0, 1],
+              properties: { os: "linux", browser: "openclaw-qq", device: "openclaw-qq" },
+            },
+          }));
+        }
+        return;
+      }
+
+      // op=11: Heartbeat ACK
+      if (op === 11) return;
+
+      // op=7: Reconnect / op=9: Invalid session
+      if (op === 7 || op === 9) {
+        log?.info?.(`[${accountId}] received op=${op}, reconnecting`);
+        close();
+        return;
+      }
+
+      // op=0: Dispatch
+      if (op === 0) {
+        if (t === "READY") {
+          const ready = d as { user?: { username?: string } };
+          log?.info?.(`[${accountId}] READY, bot: ${ready.user?.username ?? "unknown"}`);
+          onConnected();
+          return;
+        }
+        if (t === "C2C_MESSAGE_CREATE" || t === "GROUP_AT_MESSAGE_CREATE") {
+          handleDispatchEvent({ eventType: t, data: d, accountId, onMessage, log })
+            .catch((err) => log?.error?.(`[${accountId}] dispatch error: ${String(err)}`));
+        }
+      }
+    });
+
+    ws.on("close", (code) => {
+      log?.info?.(`[${accountId}] WS closed (code=${code})`);
+      cleanup();
+      resolve();
+    });
+
+    ws.on("error", (err) => {
+      log?.error?.(`[${accountId}] WS error: ${err.message}`);
+      close(err);
+    });
+  });
+}
+
+async function handleDispatchEvent(params: {
+  eventType: string;
+  data: unknown;
+  accountId: string;
+  onMessage: QQMessageHandler;
+  log?: MonitorQQOptions["log"];
+}): Promise<void> {
+  const { eventType, data, onMessage } = params;
+
+  if (eventType === "C2C_MESSAGE_CREATE") {
+    const d = data as QQC2CMessageEvent;
+    const msg: QQInboundMessage = {
+      chatType: "c2c",
+      openid: d.author.user_openid ?? d.author.id,
+      senderOpenid: d.author.user_openid ?? d.author.id,
+      content: d.content?.trim() ?? "",
+      msgId: d.id,
+      timestamp: d.timestamp,
+      attachments: d.attachments,
+    };
+    await onMessage(msg);
+    return;
+  }
+
+  if (eventType === "GROUP_AT_MESSAGE_CREATE") {
+    const d = data as QQGroupMessageEvent;
+    const msg: QQInboundMessage = {
+      chatType: "group",
+      openid: d.group_openid,
+      senderOpenid: d.author.member_openid ?? d.author.id,
+      content: d.content?.trim() ?? "",
+      msgId: d.id,
+      timestamp: d.timestamp,
+      attachments: d.attachments,
+    };
+    await onMessage(msg);
+    return;
+  }
+}

--- a/extensions/qq/src/monitor.ts
+++ b/extensions/qq/src/monitor.ts
@@ -116,7 +116,12 @@ async function runWebSocketSession(opts: {
 
         if (!identified) {
           identified = true;
-          const token = await getQQAccessToken(config.appId, config.clientSecret).catch(() => "");
+          const token = await getQQAccessToken(config.appId, config.clientSecret).catch((err) => {
+            log?.error?.(`[${accountId}] failed to get access token: ${String(err)}`);
+            ws.close(1008, "token_fetch_failed");
+            return null;
+          });
+          if (!token) return;
           ws.send(JSON.stringify({
             op: 2,
             d: {

--- a/extensions/qq/src/runtime.ts
+++ b/extensions/qq/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setQQRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getQQRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("QQ runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/qq/src/token.ts
+++ b/extensions/qq/src/token.ts
@@ -1,0 +1,48 @@
+import type { QQAccessToken } from "./types.js";
+
+const QQ_TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
+
+type TokenCache = {
+  token: string;
+  expiresAt: number;
+};
+
+const tokenCache = new Map<string, TokenCache>();
+
+export async function getQQAccessToken(
+  appId: string,
+  clientSecret: string,
+): Promise<string> {
+  const key = `${appId}:${clientSecret}`;
+  const cached = tokenCache.get(key);
+  // Refresh 60s before expiry
+  if (cached && cached.expiresAt - Date.now() > 60_000) {
+    return cached.token;
+  }
+
+  const res = await fetch(QQ_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ appId, clientSecret }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`QQ token fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as QQAccessToken;
+  if (!data.access_token) {
+    throw new Error("QQ token response missing access_token");
+  }
+
+  tokenCache.set(key, {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  });
+
+  return data.access_token;
+}
+
+export function clearQQTokenCache(appId: string, clientSecret: string): void {
+  tokenCache.delete(`${appId}:${clientSecret}`);
+}

--- a/extensions/qq/src/types.ts
+++ b/extensions/qq/src/types.ts
@@ -1,0 +1,107 @@
+// QQ Bot API v2 types
+
+export type QQBotConfig = {
+  appId: string;
+  clientSecret: string;
+  /** Webhook path, default: /qq/webhook */
+  webhookPath?: string;
+  /** Webhook port, default: 8443 */
+  webhookPort?: number;
+  /** Allow-from list (openid or group_openid) */
+  allowFrom?: string[];
+  /** DM policy */
+  dmPolicy?: "open" | "pairing" | "allowlist";
+  /** Account display name */
+  name?: string;
+  /** Whether this account is enabled */
+  enabled?: boolean;
+};
+
+export type QQAccessToken = {
+  access_token: string;
+  expires_in: number;
+};
+
+// Inbound event payload
+export type QQPayload = {
+  id?: string;
+  op: number;
+  d?: unknown;
+  s?: number;
+  t?: string;
+};
+
+// C2C (single chat) message event
+export type QQC2CMessageEvent = {
+  id: string;
+  content: string;
+  timestamp: string;
+  author: {
+    id: string;       // user openid
+    user_openid: string;
+  };
+  attachments?: QQAttachment[];
+  msg_id?: string;
+};
+
+// Group message event
+export type QQGroupMessageEvent = {
+  id: string;
+  content: string;
+  timestamp: string;
+  group_openid: string;
+  author: {
+    id: string;
+    member_openid: string;
+  };
+  attachments?: QQAttachment[];
+  msg_id?: string;
+};
+
+export type QQAttachment = {
+  content_type: string;
+  filename: string;
+  height?: number;
+  width?: number;
+  size?: number;
+  url: string;
+};
+
+// Send message request
+export type QQSendMessageParams = {
+  content?: string;
+  msg_type: 0 | 2 | 7; // 0=text, 2=markdown, 7=media
+  msg_id?: string;      // for passive reply
+  msg_seq?: number;
+  event_id?: string;
+};
+
+export type QQSendResult = {
+  id: string;
+  timestamp: number;
+};
+
+// Webhook validation payload (op=13)
+export type QQValidationPayload = {
+  plain_token: string;
+  event_ts: string;
+};
+
+export type QQValidationResponse = {
+  plain_token: string;
+  signature: string;
+};
+
+// Chat type discriminator
+export type QQChatType = "c2c" | "group";
+
+export type QQInboundMessage = {
+  chatType: QQChatType;
+  openid: string;        // user openid (c2c) or group_openid (group)
+  senderOpenid: string;  // user openid
+  content: string;
+  msgId: string;
+  eventId?: string;
+  timestamp: string;
+  attachments?: QQAttachment[];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,8 @@ importers:
 
   extensions/open-prose: {}
 
+  extensions/qq: {}
+
   extensions/signal: {}
 
   extensions/slack: {}

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1417,3 +1417,32 @@ export const MSTeamsConfigSchema = z
         'channels.msteams.dmPolicy="allowlist" requires channels.msteams.allowFrom to contain at least one sender ID',
     });
   });
+
+// ── QQ Bot API v2 ─────────────────────────────────────────────────────────────
+
+export const QQAccountSchema = z
+  .object({
+    appId: z.string().optional(),
+    clientSecret: z.string().optional().register(sensitive),
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    webhookPath: z.string().optional(),
+    webhookPort: z.number().int().positive().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+  })
+  .strict();
+
+export const QQConfigSchema = z
+  .object({
+    appId: z.string().optional(),
+    clientSecret: z.string().optional().register(sensitive),
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    webhookPath: z.string().optional(),
+    webhookPort: z.number().int().positive().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    accounts: z.record(z.string(), QQAccountSchema.optional()).optional(),
+  })
+  .strict();

--- a/src/config/zod-schema.providers.ts
+++ b/src/config/zod-schema.providers.ts
@@ -8,6 +8,7 @@ import {
   IMessageConfigSchema,
   IrcConfigSchema,
   MSTeamsConfigSchema,
+  QQConfigSchema,
   SignalConfigSchema,
   SlackConfigSchema,
   TelegramConfigSchema,
@@ -42,6 +43,7 @@ export const ChannelsSchema = z
     imessage: IMessageConfigSchema.optional(),
     bluebubbles: BlueBubblesConfigSchema.optional(),
     msteams: MSTeamsConfigSchema.optional(),
+    qq: QQConfigSchema.optional(),
   })
   .passthrough() // Allow extension channel configs (nostr, matrix, zalo, etc.)
   .optional();


### PR DESCRIPTION
## Summary

Implements a QQ channel plugin using the official QQ Bot API v2 with WebSocket gateway support.

## Changes

- `extensions/qq/index.ts` — channel plugin entry point (registers via `api.registerChannel`)
- `extensions/qq/src/channel.ts` — main channel plugin (inbound handler + outbound sendText)
- `extensions/qq/src/monitor.ts` — WebSocket connection management with auto-reconnect
- `extensions/qq/src/dispatch.ts` — QQ Bot API message sending (c2c + group)
- `extensions/qq/src/token.ts` — OAuth2 access token with in-memory cache
- `extensions/qq/src/api.ts` — QQ Bot API client
- `extensions/qq/src/types.ts` — TypeScript types for QQ Bot API
- `extensions/qq/src/config-schema.ts` — Zod config schema

## Configuration

```json
{
  "channels": {
    "qq": {
      "appId": "your-app-id",
      "clientSecret": "your-client-secret"
    }
  }
}