### PR TITLE
fix(secrets): default exec noOutputTimeoutMs to timeoutMs (closes #28161)

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -516,9 +516,14 @@ async function resolveExecRefs(params: {
   }
 
   const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_EXEC_TIMEOUT_MS);
+  const defaultNoOutputTimeoutMs =
+    params.providerConfig.noOutputTimeoutMs === undefined &&
+    typeof params.providerConfig.timeoutMs === "number"
+      ? timeoutMs
+      : DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS;
   const noOutputTimeoutMs = normalizePositiveInt(
     params.providerConfig.noOutputTimeoutMs,
-    DEFAULT_EXEC_NO_OUTPUT_TIMEOUT_MS,
+    defaultNoOutputTimeoutMs,
   );
   const maxOutputBytes = normalizePositiveInt(
     params.providerConfig.maxOutputBytes,


### PR DESCRIPTION
## **Summary**

- Problem: Exec-based secrets providers can hit a hardcoded 2000ms “no output” timeout even when secrets.providers.<name>.timeoutMs is configured higher, causing secrets.reload failures.
- Why it matters: Slow exec providers (e.g. 1Password CLI service account) can be killed prematurely, making gateway startup and reload unreliable.
- What changed: In resolve.ts, when timeoutMs is set and noOutputTimeoutMs is unset, default noOutputTimeoutMs to timeoutMs; add a regression test in resolve.test.ts.
- What did NOT change (scope boundary): If noOutputTimeoutMs is explicitly configured, behavior is unchanged; timeoutMs still caps total execution time; no gateway runtime/handler logic was changed.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #28161
- Related #

## **User-visible / Behavior Changes**

- For exec secrets providers: if secrets.providers.<name>.timeoutMs is set and noOutputTimeoutMs is not set, the default “no-output timeout” now follows timeoutMs (instead of defaulting to 2000ms).

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS (local verification)
- Runtime/container: Node + pnpm (repo standard toolchain)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A (unit-test coverage)

### **Steps**

1. Configure an exec secrets provider with timeoutMs set (e.g. 10000) and noOutputTimeoutMs unset.
2. Have the exec resolver produce its first stdout after >2000ms.
3. Resolve a SecretRef / trigger secrets resolution (secrets.reload path relies on the same resolver).

### **Expected**

- Should not fail with “produced no output for 2000ms”; should allow waiting up to the configured timeoutMs.

### **Actual**

- Before fix: fails with “produced no output for 2000ms”.

## **Evidence**

Attach at least one:

- [x]  Failing test/log before + passing after
    - Verification: resolve.test.ts (new regression case)
- [ ]  Trace/log snippets
- [ ]  Screenshot/recording
- [ ]  Perf numbers (if relevant)

## **Human Verification (required)**

What you personally verified (not just CI), and how:

- Verified scenarios:
    - resolve.test.ts
    - pnpm check
- Edge cases checked:
    - Explicit noOutputTimeoutMs continues to take precedence (no behavior change when set).
- What you did **not** verify:
    - End-to-end gateway startup with a real 1Password service account in a production-like environment.

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

- How to disable/revert this change quickly:
    - Revert this commit; or explicitly set secrets.providers.<name>.noOutputTimeoutMs to restore a more aggressive no-output timeout.
- Files/config to restore:
    - resolve.ts
- Known bad symptoms reviewers should watch for:
    - Hung exec providers may take longer to fail by default (still bounded by timeoutMs).

## **Risks and Mitigations**

- Risk:
    - Default no-output timeout increases when timeoutMs is set, delaying failure for “no-output” hangs.
- Mitigation:
    - Total runtime is still bounded by timeoutMs; users can explicitly configure noOutputTimeoutMs if they need earlier failure.