### PR TITLE
fix(memory): read Gemini batch state from metadata.state

### DIFF
--- a/src/memory/batch-gemini.test.ts
+++ b/src/memory/batch-gemini.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGeminiBatchState } from "./batch-gemini.js";
+
+describe("normalizeGeminiBatchState", () => {
+  it("strips BATCH_STATE_ prefix", () => {
+    expect(normalizeGeminiBatchState("BATCH_STATE_SUCCEEDED")).toBe("SUCCEEDED");
+    expect(normalizeGeminiBatchState("BATCH_STATE_FAILED")).toBe("FAILED");
+    expect(normalizeGeminiBatchState("BATCH_STATE_CANCELLED")).toBe("CANCELLED");
+    expect(normalizeGeminiBatchState("BATCH_STATE_RUNNING")).toBe("RUNNING");
+  });
+
+  it("strips JOB_STATE_ prefix", () => {
+    expect(normalizeGeminiBatchState("JOB_STATE_SUCCEEDED")).toBe("SUCCEEDED");
+    expect(normalizeGeminiBatchState("JOB_STATE_FAILED")).toBe("FAILED");
+    expect(normalizeGeminiBatchState("JOB_STATE_RUNNING")).toBe("RUNNING");
+  });
+
+  it("returns unprefixed values unchanged", () => {
+    expect(normalizeGeminiBatchState("SUCCEEDED")).toBe("SUCCEEDED");
+    expect(normalizeGeminiBatchState("FAILED")).toBe("FAILED");
+    expect(normalizeGeminiBatchState("COMPLETED")).toBe("COMPLETED");
+    expect(normalizeGeminiBatchState("DONE")).toBe("DONE");
+    expect(normalizeGeminiBatchState("RUNNING")).toBe("RUNNING");
+    expect(normalizeGeminiBatchState("UNKNOWN")).toBe("UNKNOWN");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeGeminiBatchState("")).toBe("");
+  });
+
+  it("does not strip unrelated prefixes", () => {
+    expect(normalizeGeminiBatchState("TASK_STATE_SUCCEEDED")).toBe("TASK_STATE_SUCCEEDED");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `waitForGeminiBatch()` reads `status.state` but the Gemini REST API returns batch state under `status.metadata.state`. The code always sees `UNKNOWN` and polls forever, making the async Batch API non-functional.
- **Why it matters:** The batch API lets Gemini handle embeddings server-side in a single async job — no concurrent request storm. Without this fix, users hit rate limits instantly on the free tier (100 req/min).
- **What changed:** Read `metadata.state` first with fallback to `state` for backward compat; add `normalizeGeminiBatchState()` to strip `BATCH_STATE_`/`JOB_STATE_` enum prefixes; fix file download URL from `:download` suffix to `?alt=media` query param.
- **What did NOT change (scope boundary):** No changes to batch submission, file upload, output parsing, or any other provider's embedding code.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #15738

## User-visible / Behavior Changes

- Gemini async batch embeddings (`remote.batch.enabled: true`) now complete successfully instead of polling forever.
- No config changes required.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same endpoints, fixed URL format)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Any OS with Node 22+
- Gemini embedding provider with `remote.batch.enabled: true`

### Steps

1. Configure memory embeddings with Gemini provider and `remote.batch.enabled: true`
2. Run `openclaw memory index --force`
3. Observe batch status polling

### Expected

- Batch completes and embeddings are stored

### Actual (before fix)

- `waitForGeminiBatch()` sees state as `UNKNOWN` forever, times out

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Unit tests added for `normalizeGeminiBatchState()` covering all enum variants (prefixed and unprefixed).

## Human Verification (required)

- Verified scenarios: Unit tests for state normalization with `BATCH_STATE_`, `JOB_STATE_`, and unprefixed values
- Edge cases checked: Empty string, unrelated prefixes (`TASK_STATE_`), backward-compat with legacy `status.state`
- What you did **not** verify: Live Gemini batch API call (requires API key + quota)

## Compatibility / Migration

- Backward compatible? `Yes` — falls back to `status.state` if `metadata.state` is absent
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/memory/batch-gemini.ts`
- Known bad symptoms reviewers should watch for: Batch status polling stuck on `UNKNOWN`

## Risks and Mitigations

- Risk: The Gemini API response shape varies between API versions
  - Mitigation: Dual read path (`metadata.state` → `state`) ensures both old and new shapes work

---

AI-assisted (Claude). Code reviewed and understood by contributor.