### PR TITLE
fix(plugins): allow hardlinked manifests for bundled/global (closes #28175)

### DIFF
--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -17,7 +17,7 @@ export function resolveBundledPluginSources(params: {
     if (candidate.origin !== "bundled") {
       continue;
     }
-    const manifest = loadPluginManifest(candidate.rootDir);
+    const manifest = loadPluginManifest(candidate.rootDir, { rejectHardlinks: false });
     if (!manifest.ok) {
       continue;
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -167,7 +167,9 @@ export function loadPluginManifestRegistry(params: {
   const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
-    const manifestRes = loadPluginManifest(candidate.rootDir);
+    const manifestRes = loadPluginManifest(candidate.rootDir, {
+      rejectHardlinks: candidate.origin !== "bundled" && candidate.origin !== "global",
+    });
     if (!manifestRes.ok) {
       diagnostics.push({
         level: "error",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -42,12 +42,16 @@ export function resolvePluginManifestPath(rootDir: string): string {
   return path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
 }
 
-export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
+export function loadPluginManifest(
+  rootDir: string,
+  options?: { rejectHardlinks?: boolean },
+): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: rootDir,
     boundaryLabel: "plugin root",
+    rejectHardlinks: options?.rejectHardlinks,
   });
   if (!opened.ok) {
     if (opened.reason === "path") {


### PR DESCRIPTION
## **Summary**

- Problem: pnpm add -g openclaw (notably on Windows) can install plugin files via hardlinks; plugin manifest loading then reports unsafe plugin manifest path and can break startup.
- Why it matters: A documented/expected install method fails on some platforms due to overly strict hardlink rejection for package-manager managed installs.
- What changed: loadPluginManifest accepts an option to control hardlink rejection; manifest-registry allows hardlinked manifests for bundled and global plugin origins while keeping workspace/config strict; add a regression test covering hardlinked bundled manifests.
- What did NOT change (scope boundary): Symlink escape protections remain; workspace/config origins still reject hardlinked manifests; no changes to plugin discovery paths or install behavior.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #28175
- Related #

## **User-visible / Behavior Changes**

- Bundled/global plugin manifests may now be hardlinked without being rejected as “unsafe”.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS (local verification; regression test constructs a hardlink on non-Windows platforms)
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A (unit-test coverage)

### **Steps**

1. Create a bundled plugin root directory.
2. Create openclaw.plugin.json as a hardlink (simulating package-manager hardlink layout).
3. Load the plugin manifest registry.

### **Expected**

- Bundled/global plugin manifests should load successfully and not emit unsafe plugin manifest path.

### **Actual**

- Before fix: hardlinked manifests are rejected as unsafe.

## **Evidence**

Attach at least one:

- [x]  Failing test/log before + passing after
    - Verification: manifest-registry.test.ts
- [ ]  Trace/log snippets
- [ ]  Screenshot/recording
- [ ]  Perf numbers (if relevant)

## **Human Verification (required)**

What you personally verified (not just CI), and how:

- Verified scenarios:
    - manifest-registry.test.ts
    - pnpm check
- Edge cases checked:
    - workspace/config plugin origins remain strict (hardlinks still rejected).
- What you did **not** verify:
    - Full end-to-end pnpm -g install and gateway startup on Windows.

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

- How to disable/revert this change quickly:
    - Revert this commit to restore previous hardlink rejection for bundled/global.
- Files/config to restore:
    - manifest.ts
    - manifest-registry.ts
- Known bad symptoms reviewers should watch for:
    - Unexpected plugin manifest loading differences for bundled/global in environments with unusual hardlink layouts.

## **Risks and Mitigations**

- Risk:
    - Allowing hardlinked manifests for bundled/global could theoretically read a hardlinked file with content not “originally created” inside the plugin directory.
- Mitigation:
    - Scope is limited to package-manager managed origins (bundled/global); user-controlled origins (workspace/config) remain strict; boundary path validation and symlink protections remain in place.