### PR TITLE
fix(memory): add retry with backoff to Gemini embedding calls

### DIFF
--- a/src/memory/embeddings-gemini.test.ts
+++ b/src/memory/embeddings-gemini.test.ts
@@ -144,11 +144,13 @@ describe("createGeminiEmbeddingProvider retry behavior", () => {
     });
 
     const { provider } = await getProvider();
-    try {
-      await provider.embedQuery("test");
-    } catch (err) {
-      expect((err as Error).message).toContain("429");
-      expect((err as { status: number }).status).toBe(429);
-    }
+    const err: Error & { status?: number } = await provider
+      .embedQuery("test")
+      .then(() => {
+        throw new Error("expected embedQuery to reject");
+      })
+      .catch((e: Error) => e);
+    expect(err.message).toContain("429");
+    expect(err.status).toBe(429);
   });
 });

--- a/src/memory/embeddings-gemini.test.ts
+++ b/src/memory/embeddings-gemini.test.ts
@@ -135,15 +135,13 @@ describe("createGeminiEmbeddingProvider retry behavior", () => {
     retryAsyncMock.mockImplementation(async (run: () => Promise<unknown>) => await run());
 
     // Mock withRemoteHttpResponse to call onResponse with a non-ok response
-    wrhrMock.mockImplementation(
-      async (opts: { onResponse: (res: unknown) => Promise<unknown> }) => {
-        return await opts.onResponse({
-          ok: false,
-          status: 429,
-          text: async () => "rate limited",
-        });
-      },
-    );
+    wrhrMock.mockImplementation(async (opts) => {
+      return await opts.onResponse({
+        ok: false,
+        status: 429,
+        text: async () => "rate limited",
+      } as unknown as Response);
+    });
 
     const { provider } = await getProvider();
     try {

--- a/src/memory/embeddings-gemini.test.ts
+++ b/src/memory/embeddings-gemini.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { retryAsync } from "../infra/retry.js";
+
+vi.mock("../infra/retry.js", () => ({
+  retryAsync: vi.fn(async (run: () => Promise<unknown>) => await run()),
+}));
+
+vi.mock("../agents/api-key-rotation.js", () => ({
+  collectProviderApiKeysForExecution: () => ["test-key"],
+  executeWithApiKeyRotation: vi.fn(async (opts: { execute: (key: string) => Promise<unknown> }) => {
+    return await opts.execute("test-key");
+  }),
+}));
+
+vi.mock("../agents/model-auth.js", () => ({
+  requireApiKey: (k: string) => k,
+  resolveApiKeyForProvider: async () => "test-key",
+}));
+
+vi.mock("../infra/gemini-auth.js", () => ({
+  parseGeminiAuth: () => ({ headers: { "x-goog-api-key": "test-key" } }),
+}));
+
+vi.mock("./embeddings-debug.js", () => ({
+  debugEmbeddingsLog: () => {},
+}));
+
+vi.mock("./remote-http.js", () => ({
+  buildRemoteBaseUrlPolicy: () => undefined,
+  withRemoteHttpResponse: vi.fn(),
+}));
+
+describe("createGeminiEmbeddingProvider retry behavior", () => {
+  const retryAsyncMock = vi.mocked(retryAsync);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-setup retryAsync to execute the function (passthrough) by default
+    retryAsyncMock.mockImplementation(async (run: () => Promise<unknown>) => await run());
+  });
+
+  async function getProvider() {
+    const { createGeminiEmbeddingProvider } = await import("./embeddings-gemini.js");
+    return await createGeminiEmbeddingProvider({
+      model: "gemini-embedding-001",
+      config: {},
+    } as never);
+  }
+
+  it("configures retryAsync with correct options for embedQuery", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    const wrhrMock = vi.mocked(withRemoteHttpResponse);
+    wrhrMock.mockResolvedValueOnce({ embedding: { values: [0.1, 0.2] } });
+
+    const { provider } = await getProvider();
+    await provider.embedQuery("hello");
+
+    expect(retryAsyncMock).toHaveBeenCalledTimes(1);
+    const retryOptions = retryAsyncMock.mock.calls[0]?.[1] as {
+      attempts: number;
+      minDelayMs: number;
+      maxDelayMs: number;
+      jitter: number;
+      shouldRetry: (err: unknown) => boolean;
+    };
+    expect(retryOptions.attempts).toBe(3);
+    expect(retryOptions.minDelayMs).toBe(300);
+    expect(retryOptions.maxDelayMs).toBe(2000);
+    expect(retryOptions.jitter).toBe(0.2);
+  });
+
+  it("retries on 429 rate limit errors", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    vi.mocked(withRemoteHttpResponse).mockResolvedValueOnce({ embedding: { values: [0.1] } });
+
+    const { provider } = await getProvider();
+    await provider.embedQuery("test");
+
+    const opts = retryAsyncMock.mock.calls[0]?.[1] as {
+      shouldRetry: (err: unknown) => boolean;
+    };
+    expect(opts.shouldRetry({ status: 429 })).toBe(true);
+  });
+
+  it("retries on 5xx server errors", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    vi.mocked(withRemoteHttpResponse).mockResolvedValueOnce({ embedding: { values: [0.1] } });
+
+    const { provider } = await getProvider();
+    await provider.embedQuery("test");
+
+    const opts = retryAsyncMock.mock.calls[0]?.[1] as {
+      shouldRetry: (err: unknown) => boolean;
+    };
+    expect(opts.shouldRetry({ status: 500 })).toBe(true);
+    expect(opts.shouldRetry({ status: 502 })).toBe(true);
+    expect(opts.shouldRetry({ status: 503 })).toBe(true);
+  });
+
+  it("does not retry on 4xx client errors (except 429)", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    vi.mocked(withRemoteHttpResponse).mockResolvedValueOnce({ embedding: { values: [0.1] } });
+
+    const { provider } = await getProvider();
+    await provider.embedQuery("test");
+
+    const opts = retryAsyncMock.mock.calls[0]?.[1] as {
+      shouldRetry: (err: unknown) => boolean;
+    };
+    expect(opts.shouldRetry({ status: 400 })).toBe(false);
+    expect(opts.shouldRetry({ status: 401 })).toBe(false);
+    expect(opts.shouldRetry({ status: 403 })).toBe(false);
+    expect(opts.shouldRetry({ status: 404 })).toBe(false);
+  });
+
+  it("retries on network errors (no status code)", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    vi.mocked(withRemoteHttpResponse).mockResolvedValueOnce({ embedding: { values: [0.1] } });
+
+    const { provider } = await getProvider();
+    await provider.embedQuery("test");
+
+    const opts = retryAsyncMock.mock.calls[0]?.[1] as {
+      shouldRetry: (err: unknown) => boolean;
+    };
+    // Network errors have no status — shouldRetry returns false (only retries known server errors)
+    expect(opts.shouldRetry(new Error("fetch failed"))).toBe(false);
+  });
+
+  it("attaches status code to error for retry detection", async () => {
+    const { withRemoteHttpResponse } = await import("./remote-http.js");
+    const wrhrMock = vi.mocked(withRemoteHttpResponse);
+
+    // Make retryAsync actually call the function so we can test error shaping
+    retryAsyncMock.mockImplementation(async (run: () => Promise<unknown>) => await run());
+
+    // Mock withRemoteHttpResponse to call onResponse with a non-ok response
+    wrhrMock.mockImplementation(
+      async (opts: { onResponse: (res: unknown) => Promise<unknown> }) => {
+        return await opts.onResponse({
+          ok: false,
+          status: 429,
+          text: async () => "rate limited",
+        });
+      },
+    );
+
+    const { provider } = await getProvider();
+    try {
+      await provider.embedQuery("test");
+    } catch (err) {
+      expect((err as Error).message).toContain("429");
+      expect((err as { status: number }).status).toBe(429);
+    }
+  });
+});

--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -5,6 +5,7 @@ import {
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { parseGeminiAuth } from "../infra/gemini-auth.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { retryAsync } from "../infra/retry.js";
 import { debugEmbeddingsLog } from "./embeddings-debug.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy, withRemoteHttpResponse } from "./remote-http.js";
@@ -76,26 +77,41 @@ export async function createGeminiEmbeddingProvider(
       ...authHeaders.headers,
       ...client.headers,
     };
-    const payload = await withRemoteHttpResponse({
-      url: endpoint,
-      ssrfPolicy: client.ssrfPolicy,
-      init: {
-        method: "POST",
-        headers,
-        body: JSON.stringify(body),
+    return await retryAsync(
+      async () => {
+        return await withRemoteHttpResponse({
+          url: endpoint,
+          ssrfPolicy: client.ssrfPolicy,
+          init: {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+          },
+          onResponse: async (res) => {
+            if (!res.ok) {
+              const text = await res.text();
+              const err = new Error(`gemini embeddings failed: ${res.status} ${text}`);
+              (err as Error & { status: number }).status = res.status;
+              throw err;
+            }
+            return (await res.json()) as {
+              embedding?: { values?: number[] };
+              embeddings?: Array<{ values?: number[] }>;
+            };
+          },
+        });
       },
-      onResponse: async (res) => {
-        if (!res.ok) {
-          const text = await res.text();
-          throw new Error(`gemini embeddings failed: ${res.status} ${text}`);
-        }
-        return (await res.json()) as {
-          embedding?: { values?: number[] };
-          embeddings?: Array<{ values?: number[] }>;
-        };
+      {
+        attempts: 3,
+        minDelayMs: 300,
+        maxDelayMs: 2000,
+        jitter: 0.2,
+        shouldRetry: (err) => {
+          const status = (err as { status?: number }).status;
+          return status === 429 || (typeof status === "number" && status >= 500);
+        },
       },
-    });
-    return payload;
+    );
   };
 
   const embedQuery = async (text: string): Promise<number[]> => {


### PR DESCRIPTION
## Summary

- **Problem:** Gemini `embedQuery` and `embedBatch` functions make raw `fetch()` calls with zero retry logic. Rate limit 429s or transient 5xx errors crash immediately. OpenAI and Voyage embedding paths already use `retryAsync`/`postJsonWithRetry` — Gemini is the only provider missing retry.
- **Why it matters:** On the Gemini free tier (100 req/min), even moderate corpus indexing triggers rate limits. Without retry+backoff, the entire embedding job fails on the first 429.
- **What changed:** Wrapped `fetchWithGeminiAuth` with `retryAsync()` — 3 attempts, exponential backoff (300ms → 2s), 0.2 jitter. Retries on 429 and 5xx. HTTP status attached to error objects for retry classification.
- **What did NOT change (scope boundary):** No changes to batch embedding path, API key rotation, or any other provider's code.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #15738

## User-visible / Behavior Changes

- Gemini embedding calls now automatically retry on rate limits (429) and server errors (5xx) instead of failing immediately.
- No config changes required. Retry parameters match existing OpenAI/Voyage behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same calls, just retried on failure)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- Any OS with Node 22+
- Gemini embedding provider (free tier most likely to hit rate limits)

### Steps

1. Configure memory embeddings with Gemini provider
2. Index a corpus large enough to trigger rate limits (~50+ chunks)
3. Run `openclaw memory index`

### Expected

- Embedding calls retry on 429 with backoff and eventually succeed

### Actual (before fix)

- First 429 response crashes the embedding job with `gemini embeddings failed: 429`

## Evidence

- [x] Failing test/log before + passing after

Unit tests verify:
- Retry config (3 attempts, 300ms–2s, 0.2 jitter)
- `shouldRetry` returns `true` for 429, 500, 502, 503
- `shouldRetry` returns `false` for 400, 401, 403, 404
- HTTP status is attached to error objects for retry detection

## Human Verification (required)

- Verified scenarios: Unit tests for retry configuration and error classification
- Edge cases checked: 4xx non-429 errors are NOT retried; network errors without status codes
- What you did **not** verify: Live Gemini API calls under rate limit conditions

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/memory/embeddings-gemini.ts`
- Known bad symptoms reviewers should watch for: Embedding calls taking longer to fail (due to retries) on persistent errors

## Risks and Mitigations

- Risk: Retry delays slow down non-recoverable errors
  - Mitigation: Only retries 429/5xx (not 4xx client errors), max 3 attempts with 2s cap

---

AI-assisted (Claude). Code reviewed and understood by contributor.