### PR TITLE
feat: add memory-aoms plugin for AOMS HTTP memory backend

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -13,6 +13,9 @@ source of truth; the model only "remembers" what gets written to disk.
 
 Memory search tools are provided by the active memory plugin (default:
 `memory-core`). Disable memory plugins with `plugins.slots.memory = "none"`.
+For AOMS HTTP memory backends, switch to `plugins.slots.memory = "memory-aoms"`
+and configure `plugins.entries.memory-aoms.config.baseUrl` (defaults to
+`http://localhost:9100`).
 
 ## Memory files (Markdown)
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -44,6 +44,7 @@ Looking for third-party listings? See [Community plugins](/plugins/community).
 - Microsoft Teams is plugin-only as of 2026.1.15; install `@openclaw/msteams` if you use Teams.
 - Memory (Core) — bundled memory search plugin (enabled by default via `plugins.slots.memory`)
 - Memory (LanceDB) — bundled long-term memory plugin (auto-recall/capture; set `plugins.slots.memory = "memory-lancedb"`)
+- Memory (AOMS) — bundled HTTP memory backend plugin (`memory_search`, `memory_write`, `memory_weight`; set `plugins.slots.memory = "memory-aoms"`)
 - [Voice Call](/plugins/voice-call) — `@openclaw/voice-call`
 - [Zalo Personal](/plugins/zalouser) — `@openclaw/zalouser`
 - [Matrix](/channels/matrix) — `@openclaw/matrix`

--- a/extensions/memory-aoms/config.ts
+++ b/extensions/memory-aoms/config.ts
@@ -1,0 +1,97 @@
+export type AomsMemoryConfig = {
+  baseUrl: string;
+  timeoutMs: number;
+  apiKey?: string;
+};
+
+export const DEFAULT_AOMS_BASE_URL = "http://localhost:9100";
+export const DEFAULT_AOMS_TIMEOUT_MS = 10_000;
+
+const ALLOWED_CONFIG_KEYS = ["baseUrl", "timeoutMs", "apiKey"] as const;
+
+function assertAllowedKeys(value: Record<string, unknown>, allowed: readonly string[], label: string) {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length === 0) {
+    return;
+  }
+  throw new Error(`${label} has unknown keys: ${unknown.join(", ")}`);
+}
+
+function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const envValue = process.env[envVar];
+    if (!envValue) {
+      throw new Error(`Environment variable ${envVar} is not set`);
+    }
+    return envValue;
+  });
+}
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("baseUrl is required");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error("baseUrl must be a valid URL");
+  }
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export const aomsMemoryConfigSchema = {
+  parse(value: unknown): AomsMemoryConfig {
+    if (value === undefined) {
+      return {
+        baseUrl: DEFAULT_AOMS_BASE_URL,
+        timeoutMs: DEFAULT_AOMS_TIMEOUT_MS,
+      };
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("memory-aoms config must be an object");
+    }
+    const cfg = value as Record<string, unknown>;
+    assertAllowedKeys(cfg, ALLOWED_CONFIG_KEYS, "memory-aoms config");
+
+    const baseUrl =
+      typeof cfg.baseUrl === "string" ? normalizeBaseUrl(cfg.baseUrl) : DEFAULT_AOMS_BASE_URL;
+
+    const timeoutRaw = cfg.timeoutMs;
+    const timeoutMs =
+      typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw)
+        ? Math.trunc(timeoutRaw)
+        : DEFAULT_AOMS_TIMEOUT_MS;
+    if (timeoutMs < 500 || timeoutMs > 120_000) {
+      throw new Error("timeoutMs must be between 500 and 120000");
+    }
+
+    const apiKeyRaw = typeof cfg.apiKey === "string" ? cfg.apiKey.trim() : "";
+    const apiKey = apiKeyRaw ? resolveEnvVars(apiKeyRaw) : undefined;
+
+    return {
+      baseUrl,
+      timeoutMs,
+      apiKey,
+    };
+  },
+  uiHints: {
+    baseUrl: {
+      label: "AOMS Base URL",
+      placeholder: DEFAULT_AOMS_BASE_URL,
+      help: "Base URL for the AOMS HTTP API.",
+    },
+    timeoutMs: {
+      label: "Request Timeout (ms)",
+      placeholder: String(DEFAULT_AOMS_TIMEOUT_MS),
+      advanced: true,
+    },
+    apiKey: {
+      label: "AOMS API Key",
+      sensitive: true,
+      help: "Optional bearer token (or use ${AOMS_API_KEY}).",
+      advanced: true,
+    },
+  },
+};

--- a/extensions/memory-aoms/config.ts
+++ b/extensions/memory-aoms/config.ts
@@ -9,7 +9,11 @@ export const DEFAULT_AOMS_TIMEOUT_MS = 10_000;
 
 const ALLOWED_CONFIG_KEYS = ["baseUrl", "timeoutMs", "apiKey"] as const;
 
-function assertAllowedKeys(value: Record<string, unknown>, allowed: readonly string[], label: string) {
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+) {
   const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
   if (unknown.length === 0) {
     return;

--- a/extensions/memory-aoms/index.ts
+++ b/extensions/memory-aoms/index.ts
@@ -16,15 +16,13 @@ function jsonResult(payload: unknown) {
   };
 }
 
-async function postJson(
-  params: {
-    baseUrl: string;
-    path: string;
-    timeoutMs: number;
-    apiKey?: string;
-    body: Record<string, unknown>;
-  },
-): Promise<AomsToolResult> {
+async function postJson(params: {
+  baseUrl: string;
+  path: string;
+  timeoutMs: number;
+  apiKey?: string;
+  body: Record<string, unknown>;
+}): Promise<AomsToolResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
   try {
@@ -42,11 +40,13 @@ async function postJson(
     });
 
     let parsed: unknown = null;
-    try {
-      parsed = await response.json();
-    } catch {
-      const text = await response.text();
-      parsed = text ? { text } : null;
+    const text = await response.text();
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = { text };
+      }
     }
 
     if (!response.ok) {

--- a/extensions/memory-aoms/index.ts
+++ b/extensions/memory-aoms/index.ts
@@ -1,0 +1,174 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { aomsMemoryConfigSchema } from "./config.js";
+
+type AomsToolResult = {
+  ok: boolean;
+  status?: number;
+  data?: unknown;
+  error?: string;
+};
+
+function jsonResult(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+async function postJson(
+  params: {
+    baseUrl: string;
+    path: string;
+    timeoutMs: number;
+    apiKey?: string;
+    body: Record<string, unknown>;
+  },
+): Promise<AomsToolResult> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
+  try {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (params.apiKey) {
+      headers.authorization = `Bearer ${params.apiKey}`;
+    }
+    const response = await fetch(`${params.baseUrl}${params.path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(params.body),
+      signal: controller.signal,
+    });
+
+    let parsed: unknown = null;
+    try {
+      parsed = await response.json();
+    } catch {
+      const text = await response.text();
+      parsed = text ? { text } : null;
+    }
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        data: parsed,
+        error: `AOMS request failed (${response.status})`,
+      };
+    }
+
+    return {
+      ok: true,
+      status: response.status,
+      data: parsed,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const MemorySearchSchema = Type.Object({
+  query: Type.String({ description: "Query text to search" }),
+  maxResults: Type.Optional(Type.Number({ description: "Optional max results" })),
+  minScore: Type.Optional(Type.Number({ description: "Optional score threshold" })),
+});
+
+const MemoryWriteSchema = Type.Object({
+  tier: Type.String({ description: "AOMS memory tier, used as /memory/{tier}" }),
+  text: Type.String({ description: "Memory content to write" }),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+const MemoryWeightSchema = Type.Object({
+  id: Type.String({ description: "Memory item id" }),
+  weight: Type.Number({ description: "Target weight value" }),
+  tier: Type.Optional(Type.String({ description: "Optional tier hint" })),
+});
+
+const memoryAomsPlugin = {
+  id: "memory-aoms",
+  name: "Memory (AOMS)",
+  description: "AOMS HTTP-backed memory plugin",
+  kind: "memory",
+  configSchema: aomsMemoryConfigSchema,
+  register(api: OpenClawPluginApi) {
+    const cfg = aomsMemoryConfigSchema.parse(api.pluginConfig);
+    api.logger.info(`memory-aoms: configured (${cfg.baseUrl})`);
+
+    api.registerTool(
+      {
+        name: "memory_search",
+        label: "Memory Search (AOMS)",
+        description: "Search memory entries via AOMS /memory/search.",
+        parameters: MemorySearchSchema,
+        async execute(_toolCallId, params) {
+          const body = params as Record<string, unknown>;
+          const result = await postJson({
+            baseUrl: cfg.baseUrl,
+            path: "/memory/search",
+            timeoutMs: cfg.timeoutMs,
+            apiKey: cfg.apiKey,
+            body,
+          });
+          return jsonResult(result);
+        },
+      },
+      { name: "memory_search" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_write",
+        label: "Memory Write (AOMS)",
+        description: "Write memory entries via AOMS /memory/{tier}.",
+        parameters: MemoryWriteSchema,
+        async execute(_toolCallId, params) {
+          const raw = params as Record<string, unknown>;
+          const tier = typeof raw.tier === "string" ? raw.tier.trim() : "";
+          if (!tier) {
+            return jsonResult({ ok: false, error: "tier required" });
+          }
+          const { tier: _tier, ...body } = raw;
+          const result = await postJson({
+            baseUrl: cfg.baseUrl,
+            path: `/memory/${encodeURIComponent(tier)}`,
+            timeoutMs: cfg.timeoutMs,
+            apiKey: cfg.apiKey,
+            body,
+          });
+          return jsonResult(result);
+        },
+      },
+      { name: "memory_write" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_weight",
+        label: "Memory Weight (AOMS)",
+        description: "Adjust memory weight via AOMS /memory/weight.",
+        parameters: MemoryWeightSchema,
+        async execute(_toolCallId, params) {
+          const body = params as Record<string, unknown>;
+          const result = await postJson({
+            baseUrl: cfg.baseUrl,
+            path: "/memory/weight",
+            timeoutMs: cfg.timeoutMs,
+            apiKey: cfg.apiKey,
+            body,
+          });
+          return jsonResult(result);
+        },
+      },
+      { name: "memory_weight" },
+    );
+  },
+};
+
+export default memoryAomsPlugin;

--- a/extensions/memory-aoms/openclaw.plugin.json
+++ b/extensions/memory-aoms/openclaw.plugin.json
@@ -1,0 +1,31 @@
+{
+  "id": "memory-aoms",
+  "kind": "memory",
+  "uiHints": {
+    "baseUrl": {
+      "label": "AOMS Base URL",
+      "placeholder": "http://localhost:9100",
+      "help": "Base URL for the AOMS HTTP API."
+    },
+    "timeoutMs": {
+      "label": "Request Timeout (ms)",
+      "placeholder": "10000",
+      "advanced": true
+    },
+    "apiKey": {
+      "label": "AOMS API Key",
+      "sensitive": true,
+      "help": "Optional bearer token (or use ${AOMS_API_KEY}).",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": { "type": "string" },
+      "timeoutMs": { "type": "number", "minimum": 500, "maximum": 120000 },
+      "apiKey": { "type": "string" }
+    }
+  }
+}

--- a/extensions/memory-aoms/package.json
+++ b/extensions/memory-aoms/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@openclaw/memory-aoms",
+  "version": "2026.2.26",
+  "private": true,
+  "description": "OpenClaw AOMS HTTP memory backend plugin",
+  "type": "module",
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
+}

--- a/extensions/memory-aoms/package.json
+++ b/extensions/memory-aoms/package.json
@@ -11,6 +11,8 @@
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,15 @@ importers:
 
   extensions/mattermost: {}
 
+  extensions/memory-aoms:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      openclaw:
+        specifier: '>=2026.1.26'
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+
   extensions/memory-core:
     dependencies:
       openclaw:
@@ -971,15 +980,6 @@ packages:
 
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
-
-  '@google/genai@1.42.0':
-    resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@google/genai@1.43.0':
     resolution: {integrity: sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==}
@@ -6558,17 +6558,6 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.43.0':
     dependencies:
       google-auth-library: 10.6.1
@@ -6916,7 +6905,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6942,7 +6931,7 @@ snapshots:
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.43.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -6989,9 +6978,9 @@ snapshots:
   '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
+      '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11


### PR DESCRIPTION
## Summary

This PR adds a minimal, compile-ready memory backend plugin that connects OpenClaw to AOMS (Always-On Memory Service).

### New Plugin: `@openclaw/memory-aoms`

- **Plugin ID:** `memory-aoms` (`kind: "memory"`)
- **Default endpoint:** `http://localhost:9100`

### Tools Registered

| Tool | Endpoint | Description |
|------|----------|-------------|
| `memory_search` | POST /memory/search | Search across memory tiers |
| `memory_write` | POST /memory/{tier} | Write to episodic/semantic/procedural |
| `memory_weight` | POST /memory/weight | Adjust entry weights |

### Configuration

```json5
plugins: {
  slots: {
    memory: "memory-aoms",
  },
  entries: {
    "memory-aoms": {
      enabled: true,
      config: {
        baseUrl: "http://localhost:9100",
        timeoutMs: 10000,
        // apiKey: "\${AOMS_API_KEY}" // optional
      },
    },
  },
}
```

### Config Fields

- `baseUrl` (string, default `http://localhost:9100`)
- `timeoutMs` (number, default `10000`)
- `apiKey` (string, optional bearer token)

### About AOMS

AOMS is a 4-tier cognitive memory service for AI agents:
- **Episodic:** Past experiences
- **Semantic:** Facts and relations
- **Procedural:** Learned skills
- **Progressive Loading (L0/L1/L2):** 95% token reduction

GitHub: https://github.com/dhawalc/cortex-mem

### Notes

- Minimal scope: no SDK changes, no secret material
- Tool responses return JSON payloads directly from AOMS