### PR TITLE
fix(macos): accept openclaw-gateway process title in PortGuardian

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -110,7 +110,7 @@ struct LowCoverageHelperTests {
         _ = PresenceReporter._testPrimaryIPv4Address()
     }
 
-    @Test func portGuardianParsesListenersAndBuildsReports() {
+    @Test func portGuardianParsesListenersAndBuildsReports() async {
         let output = """
         p123
         cnode
@@ -138,6 +138,14 @@ struct LowCoverageHelperTests {
 
         let emptyReport = PortGuardian._testBuildReport(port: 18789, mode: .local, listeners: [])
         #expect(emptyReport.summary.contains("Nothing is listening"))
+
+        let expectedCurrent = await PortGuardian._testIsExpectedLocal(
+            listener: (pid: 10, command: "openclaw-gateway", fullCommand: "openclaw-gateway", user: "me"))
+        #expect(expectedCurrent)
+
+        let expectedLegacy = await PortGuardian._testIsExpectedLocal(
+            listener: (pid: 11, command: "openclaw", fullCommand: "openclaw-gateway-daemon", user: "me"))
+        #expect(expectedLegacy)
     }
 
     @Test @MainActor func canvasSchemeHandlerResolvesFilesAndErrors() throws {


### PR DESCRIPTION
﻿## Summary
Fixes #28363.

On macOS, `PortGuardian.isExpected()` in local mode only accepted `gateway-daemon` process titles. Current gateway launches often use `openclaw-gateway` (set by CLI preaction process title), which caused legitimate gateway processes to be misclassified and terminated.

## Changes
- Accept `openclaw-gateway` in `PortGuardian.isExpected()` local-mode checks.
- Keep legacy support for `gateway-daemon` titles.
- Add a regression test helper and assertions in `LowCoverageHelperTests` to validate both current and legacy titles are treated as expected.

## Why this is safe
- Scope is limited to local-mode expected-process detection.
- It only broadens the allow condition to include the current canonical process title.
- Existing behavior for legacy `gateway-daemon` remains unchanged.
