### PR TITLE
fix(process): handle EPIPE on child stdin write

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -56,6 +56,51 @@ describe("runCommandWithTimeout", () => {
     expect(result.code).not.toBe(0);
   });
 
+  it("resets no output timer when command keeps emitting output", async () => {
+    const result = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        [
+          'process.stdout.write(".");',
+          "let count = 0;",
+          'const ticker = setInterval(() => { process.stdout.write(".");',
+          "count += 1;",
+          "if (count === 6) {",
+          "clearInterval(ticker);",
+          "process.exit(0);",
+          "}",
+          "}, 200);",
+        ].join(" "),
+      ],
+      {
+        timeoutMs: 7_000,
+        // Keep a generous idle budget; CI event-loop stalls can exceed 450ms.
+        noOutputTimeoutMs: 900,
+      },
+    );
+
+    expect(result.signal).toBeNull();
+    expect(result.code ?? 0).toBe(0);
+    expect(result.termination).toBe("exit");
+    expect(result.noOutputTimedOut).toBe(false);
+    expect(result.stdout.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("does not throw when child closes stdin early (EPIPE)", async () => {
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", "process.stdin.destroy(); process.exit(0)"],
+      {
+        timeoutMs: 5_000,
+        input: "some data that will trigger EPIPE",
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.termination).toBe("exit");
+  });
+
+
   it("reports global timeout termination when overall timeout elapses", async () => {
     const result = await runCommandWithTimeout(
       [process.execPath, "-e", "setTimeout(() => {}, 10)"],

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -286,6 +286,9 @@ export async function runCommandWithTimeout(
     armNoOutputTimer();
 
     if (hasInput && child.stdin) {
+      child.stdin.on("error", () => {
+        // Ignore stdin errors (EPIPE when child closes stdin early)
+      });
       child.stdin.write(input ?? "");
       child.stdin.end();
     }

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -69,6 +69,9 @@ export async function createChildAdapter(params: {
 
   const child = spawned.child as ChildProcessWithoutNullStreams;
   if (child.stdin) {
+    child.stdin.on("error", () => {
+      // Ignore stdin errors (EPIPE when child closes stdin early)
+    });
     if (params.input !== undefined) {
       child.stdin.write(params.input);
       child.stdin.end();


### PR DESCRIPTION
## Summary

- Add `stdin.on("error")` listener in `runCommandWithTimeout` (`src/process/exec.ts`) to prevent uncaught EPIPE exceptions when a child process closes stdin before the parent finishes writing
- Apply the same fix to `createChildAdapter` (`src/process/supervisor/adapters/child.ts`) which has the same unguarded stdin write pattern
- Add a regression test that verifies EPIPE does not crash the process

## Context

When a child process exits or closes its stdin before the parent finishes `child.stdin.write()`, Node emits an EPIPE error on the stdin stream. Without an `"error"` listener, this becomes an uncaught exception that crashes `openclaw-gateway`.

EPIPE on stdin is expected behavior (e.g. `echo "hello" | head -1`) — the child's `close` event still fires normally and resolves the promise, so stdin errors can be safely ignored.

## Test plan

- [x] `pnpm check` — lint/format passes
- [x] `pnpm test -- src/process/exec.test.ts` — all 7 tests pass (including new EPIPE test)
- [x] `pnpm build` — TypeScript compilation succeeds