### PR TITLE
fix(daemon): self-heal launchd restart when kickstart cannot find service

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -20,6 +20,7 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   kickstartError: "",
   kickstartFailuresRemaining: 0,
+  kickstartErrorOnce: false,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -77,9 +78,17 @@ vi.mock("./exec-file.js", () => ({
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
     }
-    if (call[0] === "kickstart" && state.kickstartError && state.kickstartFailuresRemaining > 0) {
-      state.kickstartFailuresRemaining -= 1;
-      return { stdout: "", stderr: state.kickstartError, code: 1 };
+    if (call[0] === "kickstart" && state.kickstartError) {
+      if (state.kickstartFailuresRemaining > 0) {
+        state.kickstartFailuresRemaining -= 1;
+        return { stdout: "", stderr: state.kickstartError, code: 1 };
+      }
+      if (state.kickstartErrorOnce) {
+        const stderr = state.kickstartError;
+        state.kickstartError = "";
+        state.kickstartErrorOnce = false;
+        return { stdout: "", stderr, code: 1 };
+      }
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -154,6 +163,7 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
+  state.kickstartErrorOnce = false;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -434,6 +444,37 @@ describe("launchd install", () => {
       waitForPid: process.pid,
     });
     expect(state.launchctlCalls).toEqual([]);
+  });
+
+  it("repairs missing service when kickstart reports it is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.kickstartError =
+      'Could not find service "ai.openclaw.gateway" in domain for user gui: 501';
+    state.kickstartErrorOnce = true;
+
+    await restartLaunchAgent({ env, stdout: new PassThrough() });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const firstKickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+    );
+    const repairBootstrapIndex = state.launchctlCalls.findIndex(
+      (c, idx) =>
+        idx > firstKickstartIndex && c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+    );
+    const repairKickstartIndex = state.launchctlCalls.findIndex(
+      (c, idx) =>
+        idx > firstKickstartIndex &&
+        c[0] === "kickstart" &&
+        c[1] === "-k" &&
+        c[2] === `${domain}/${label}`,
+    );
+
+    expect(firstKickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(repairBootstrapIndex).toBeGreaterThan(firstKickstartIndex);
+    expect(repairKickstartIndex).toBeGreaterThan(repairBootstrapIndex);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {


### PR DESCRIPTION
## Summary
- detect launchctl kickstart "service not found" errors during Restarted systemd service: openclaw-gateway.service
- automatically run a bootstrap + kickstart repair cycle before failing
- add regression coverage for the kickstart-501 missing-service path

Fixes #28147

## Validation
- pnpm exec vitest run src/daemon/launchd.test.ts
- pnpm check
- pnpm check:docs
- pnpm protocol:check