### PR TITLE
fix(control-ui): save form edits via minimal config.patch merge diff

### DIFF
--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { JsonSchema } from "../../views/config-form.shared.ts";
 import { coerceFormValues } from "./form-coerce.ts";
-import { cloneConfigObject, serializeConfigForm, setPathValue } from "./form-utils.ts";
+import {
+  buildMergePatch,
+  cloneConfigObject,
+  serializeConfigForm,
+  setPathValue,
+} from "./form-utils.ts";
 
 /**
  * Minimal model provider schema matching the Zod-generated JSON Schema for
@@ -467,5 +472,34 @@ describe("coerceFormValues", () => {
     const form = { flag: "true" };
     const coerced = coerceFormValues(form, schema) as Record<string, unknown>;
     expect(coerced.flag).toBe(true);
+  });
+});
+
+describe("buildMergePatch", () => {
+  it("returns only changed nested keys", () => {
+    const base = { update: { channel: "stable", checkOnStart: true } };
+    const next = { update: { channel: "stable", checkOnStart: false } };
+
+    expect(buildMergePatch(base, next)).toEqual({
+      update: { checkOnStart: false },
+    });
+  });
+
+  it("uses null for removed keys", () => {
+    const base = { update: { channel: "stable", checkOnStart: true } };
+    const next = { update: { checkOnStart: true } };
+
+    expect(buildMergePatch(base, next)).toEqual({
+      update: { channel: null },
+    });
+  });
+
+  it("replaces arrays as whole values", () => {
+    const base = { channels: { telegram: { allowFrom: ["1", "2"] } } };
+    const next = { channels: { telegram: { allowFrom: ["1", "2", "3"] } } };
+
+    expect(buildMergePatch(base, next)).toEqual({
+      channels: { telegram: { allowFrom: ["1", "2", "3"] } },
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary
Fixes #28339.

Control UI form-mode saves currently send the entire config via `config.set` after form serialization. In practice this can surface unrelated validation failures when only one field changed (for example toggling `update.checkOnStart`).

This PR switches form-mode save behavior to send a **minimal RFC7396 merge patch** via `config.patch` based on the diff between original and edited form state.

## What changed
- Added `buildMergePatch(base, next)` utility for nested object diffing:
  - emits only changed keys
  - emits `null` for removed keys
  - replaces arrays atomically (RFC7396 semantics)
- Updated `saveConfig()` in UI controller:
  - in form mode, compute coerced next config and send minimal patch through `config.patch`
  - keep raw mode behavior unchanged (`config.set`)

## Why this fixes the issue
Toggling a single field (like `update.checkOnStart`) now patches only that path, instead of rewriting the full config payload, which avoids unrelated validation churn during save.

## Tests
- Added `buildMergePatch` tests:
  - nested boolean change
  - key deletion -> `null`
  - array replacement semantics

Note: Full UI test run in this local environment requires Playwright browser binaries (`pnpm exec playwright install`).
