### PR TITLE
Android: add live integration capability tests and canvas refresh hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Android/Nodes: add Android `device` capability plus `device.status` and `device.info` node commands, including runtime handler wiring and protocol/registry coverage for device status/info payloads. (#27664) Thanks @obviyus.
 - Android/Nodes: add `notifications.list` support on Android nodes and expose `nodes notifications_list` in agent tooling for listing active device notifications. (#27344) thanks @obviyus.
 - Android/Nodes: add `camera.list`, `device.permissions`, `device.health`, and `notifications.actions` (`open`/`dismiss`/`reply`) on Android nodes, plus first-class node-tool actions for the new device/notification commands. (#28260) Thanks @obviyus.
+- Android/Gateway capability refresh: add live Android capability integration coverage and node canvas capability refresh wiring, plus runtime hardening for A2UI readiness retries, scoped canvas URL normalization, debug diagnostics JSON, and JavaScript MIME delivery. (#28388) Thanks @obviyus.
 - Docs/Contributing: add Nimrod Gutman to the maintainer roster in `CONTRIBUTING.md`. (#27840) Thanks @ngutman.
 
 ### Fixes

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -141,6 +141,7 @@ class NodeRuntime(context: Context) {
     locationEnabled = { locationMode.value != LocationMode.Off },
     smsAvailable = { sms.canSendSms() },
     debugBuild = { BuildConfig.DEBUG },
+    refreshNodeCanvasCapability = { nodeSession.refreshNodeCanvasCapability() },
     onCanvasA2uiPush = {
       _canvasA2uiHydrated.value = true
       _canvasRehydratePending.value = false

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -173,6 +173,43 @@ class GatewaySession(
     throw IllegalStateException("${err?.code ?: "UNAVAILABLE"}: ${err?.message ?: "request failed"}")
   }
 
+  suspend fun refreshNodeCanvasCapability(timeoutMs: Long = 8_000): Boolean {
+    val conn = currentConnection ?: return false
+    val response =
+      try {
+        conn.request("node.canvas.capability.refresh", params = null, timeoutMs = timeoutMs)
+      } catch (err: Throwable) {
+        Log.w("OpenClawGateway", "node.canvas.capability.refresh failed: ${err.message ?: err::class.java.simpleName}")
+        return false
+      }
+    if (!response.ok) {
+      val err = response.error
+      Log.w(
+        "OpenClawGateway",
+        "node.canvas.capability.refresh rejected: ${err?.code ?: "UNAVAILABLE"}: ${err?.message ?: "request failed"}",
+      )
+      return false
+    }
+    val payloadObj = response.payloadJson?.let(::parseJsonOrNull)?.asObjectOrNull()
+    val refreshedCapability = payloadObj?.get("canvasCapability").asStringOrNull()?.trim().orEmpty()
+    if (refreshedCapability.isEmpty()) {
+      Log.w("OpenClawGateway", "node.canvas.capability.refresh missing canvasCapability")
+      return false
+    }
+    val scopedCanvasHostUrl = canvasHostUrl?.trim().orEmpty()
+    if (scopedCanvasHostUrl.isEmpty()) {
+      Log.w("OpenClawGateway", "node.canvas.capability.refresh missing local canvasHostUrl")
+      return false
+    }
+    val refreshedUrl = replaceCanvasCapabilityInScopedHostUrl(scopedCanvasHostUrl, refreshedCapability)
+    if (refreshedUrl == null) {
+      Log.w("OpenClawGateway", "node.canvas.capability.refresh unable to rewrite scoped canvas URL")
+      return false
+    }
+    canvasHostUrl = refreshedUrl
+    return true
+  }
+
   private data class RpcResponse(val id: String, val ok: Boolean, val payloadJson: String?, val error: ErrorShape?)
 
   private inner class Connection(
@@ -695,6 +732,19 @@ private fun parseJsonOrNull(payload: String): JsonElement? {
   } catch (_: Throwable) {
     null
   }
+}
+
+private fun replaceCanvasCapabilityInScopedHostUrl(
+  scopedUrl: String,
+  capability: String,
+): String? {
+  val marker = "/__openclaw__/cap/"
+  val markerStart = scopedUrl.indexOf(marker)
+  if (markerStart < 0) return null
+  val capabilityStart = markerStart + marker.length
+  val capabilityEnd = scopedUrl.indexOf("/", capabilityStart)
+  if (capabilityEnd <= capabilityStart) return null
+  return scopedUrl.substring(0, capabilityStart) + capability + scopedUrl.substring(capabilityEnd)
 }
 
 internal fun resolveInvokeResultAckTimeoutMs(invokeTimeoutMs: Long?): Long {

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -734,7 +734,7 @@ private fun parseJsonOrNull(payload: String): JsonElement? {
   }
 }
 
-private fun replaceCanvasCapabilityInScopedHostUrl(
+internal fun replaceCanvasCapabilityInScopedHostUrl(
   scopedUrl: String,
   capability: String,
 ): String? {
@@ -742,7 +742,10 @@ private fun replaceCanvasCapabilityInScopedHostUrl(
   val markerStart = scopedUrl.indexOf(marker)
   if (markerStart < 0) return null
   val capabilityStart = markerStart + marker.length
-  val capabilityEnd = scopedUrl.indexOf("/", capabilityStart)
+  val slashEnd = scopedUrl.indexOf("/", capabilityStart).takeIf { it >= 0 }
+  val queryEnd = scopedUrl.indexOf("?", capabilityStart).takeIf { it >= 0 }
+  val fragmentEnd = scopedUrl.indexOf("#", capabilityStart).takeIf { it >= 0 }
+  val capabilityEnd = listOfNotNull(slashEnd, queryEnd, fragmentEnd).minOrNull() ?: scopedUrl.length
   if (capabilityEnd <= capabilityStart) return null
   return scopedUrl.substring(0, capabilityStart) + capability + scopedUrl.substring(capabilityEnd)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DebugHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DebugHandler.kt
@@ -62,7 +62,8 @@ class DebugHandler(
         results.add("Signature.Ed25519: FAILED - ${e.javaClass.simpleName}: ${e.message}")
       }
 
-      return GatewaySession.InvokeResult.ok("""{"diagnostics":"${results.joinToString("\\n").replace("\"", "\\\"")}"}"""")
+      val diagnostics = results.joinToString("\n")
+      return GatewaySession.InvokeResult.ok("""{"diagnostics":${JsonPrimitive(diagnostics)}}""")
     } catch (e: Throwable) {
       return GatewaySession.InvokeResult.error(code = "ED25519_TEST_FAILED", message = "${e.javaClass.simpleName}: ${e.message}\n${e.stackTraceToString().take(500)}")
     }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -26,6 +26,7 @@ class InvokeDispatcher(
   private val locationEnabled: () -> Boolean,
   private val smsAvailable: () -> Boolean,
   private val debugBuild: () -> Boolean,
+  private val refreshNodeCanvasCapability: suspend () -> Boolean,
   private val onCanvasA2uiPush: () -> Unit,
   private val onCanvasA2uiReset: () -> Unit,
 ) {
@@ -149,16 +150,28 @@ class InvokeDispatcher(
   private suspend fun withReadyA2ui(
     block: suspend () -> GatewaySession.InvokeResult,
   ): GatewaySession.InvokeResult {
-    val a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
+    var a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
       ?: return GatewaySession.InvokeResult.error(
         code = "A2UI_HOST_NOT_CONFIGURED",
         message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
       )
-    val ready = a2uiHandler.ensureA2uiReady(a2uiUrl)
-    if (!ready) {
+    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
+      if (!refreshNodeCanvasCapability()) {
+        return GatewaySession.InvokeResult.error(
+          code = "A2UI_HOST_UNAVAILABLE",
+          message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
+        )
+      }
+      a2uiUrl = a2uiHandler.resolveA2uiHostUrl()
+        ?: return GatewaySession.InvokeResult.error(
+          code = "A2UI_HOST_NOT_CONFIGURED",
+          message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
+        )
+    }
+    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
       return GatewaySession.InvokeResult.error(
         code = "A2UI_HOST_UNAVAILABLE",
-        message = "A2UI host not reachable",
+        message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
       )
     }
     return block()

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/InvokeDispatcher.kt
@@ -155,7 +155,8 @@ class InvokeDispatcher(
         code = "A2UI_HOST_NOT_CONFIGURED",
         message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
       )
-    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
+    val readyOnFirstCheck = a2uiHandler.ensureA2uiReady(a2uiUrl)
+    if (!readyOnFirstCheck) {
       if (!refreshNodeCanvasCapability()) {
         return GatewaySession.InvokeResult.error(
           code = "A2UI_HOST_UNAVAILABLE",
@@ -167,12 +168,12 @@ class InvokeDispatcher(
           code = "A2UI_HOST_NOT_CONFIGURED",
           message = "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
         )
-    }
-    if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
-      return GatewaySession.InvokeResult.error(
-        code = "A2UI_HOST_UNAVAILABLE",
-        message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
-      )
+      if (!a2uiHandler.ensureA2uiReady(a2uiUrl)) {
+        return GatewaySession.InvokeResult.error(
+          code = "A2UI_HOST_UNAVAILABLE",
+          message = "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
+        )
+      }
     }
     return block()
   }

--- a/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewaySessionInvokeTimeoutTest.kt
@@ -22,4 +22,26 @@ class GatewaySessionInvokeTimeoutTest {
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(121_000L))
     assertEquals(120_000L, resolveInvokeResultAckTimeoutMs(Long.MAX_VALUE))
   }
+
+  @Test
+  fun replaceCanvasCapabilityInScopedHostUrl_rewritesTerminalCapabilitySegment() {
+    assertEquals(
+      "http://127.0.0.1:18789/__openclaw__/cap/new-token",
+      replaceCanvasCapabilityInScopedHostUrl(
+        "http://127.0.0.1:18789/__openclaw__/cap/old-token",
+        "new-token",
+      ),
+    )
+  }
+
+  @Test
+  fun replaceCanvasCapabilityInScopedHostUrl_rewritesWhenQueryAndFragmentPresent() {
+    assertEquals(
+      "http://127.0.0.1:18789/__openclaw__/cap/new-token?a=1#frag",
+      replaceCanvasCapabilityInScopedHostUrl(
+        "http://127.0.0.1:18789/__openclaw__/cap/old-token?a=1#frag",
+        "new-token",
+      ),
+    )
+  }
 }

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -101,6 +101,23 @@ Use this decision table:
 - Touching gateway networking / WS protocol / pairing: add `pnpm test:e2e`
 - Debugging “my bot is down” / provider-specific failures / tool calling: run a narrowed `pnpm test:live`
 
+## Live: Android node capability sweep
+
+- Test: `src/gateway/android-node.capabilities.live.test.ts`
+- Script: `pnpm android:test:integration`
+- Goal: invoke **every command currently advertised** by a connected Android node and assert command contract behavior.
+- Scope:
+  - Preconditioned/manual setup (the suite does not install/run/pair the app).
+  - Command-by-command gateway `node.invoke` validation for the selected Android node.
+- Required pre-setup:
+  - Android app already connected + paired to the gateway.
+  - App kept in foreground.
+  - Permissions/capture consent granted for capabilities you expect to pass.
+- Optional target overrides:
+  - `OPENCLAW_ANDROID_NODE_ID` or `OPENCLAW_ANDROID_NODE_NAME`.
+  - `OPENCLAW_ANDROID_GATEWAY_URL` / `OPENCLAW_ANDROID_GATEWAY_TOKEN` / `OPENCLAW_ANDROID_GATEWAY_PASSWORD`.
+- Full Android setup details: [Android App](/platforms/android)
+
 ## Live: model smoke (profile keys)
 
 Live tests are split into two layers so we can isolate failures:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "android:install": "cd apps/android && ./gradlew :app:installDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
+    "android:test:integration": "OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_ANDROID_NODE=1 vitest run --config vitest.live.config.ts src/gateway/android-node.capabilities.live.test.ts",
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",

--- a/src/gateway/android-node.capabilities.live.test.ts
+++ b/src/gateway/android-node.capabilities.live.test.ts
@@ -1,0 +1,532 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { loadConfig } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { parseNodeList, parsePairingList } from "../shared/node-list-parse.js";
+import type { NodeListNode } from "../shared/node-list-types.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { buildGatewayConnectionDetails } from "./call.js";
+import { GatewayClient } from "./client.js";
+import { resolveGatewayCredentialsFromConfig } from "./credentials.js";
+
+const LIVE = isTruthyEnvValue(process.env.LIVE) || isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST);
+const LIVE_ANDROID_NODE = isTruthyEnvValue(process.env.OPENCLAW_LIVE_ANDROID_NODE);
+const describeLive = LIVE && LIVE_ANDROID_NODE ? describe : describe.skip;
+const SKIPPED_INTERACTIVE_COMMANDS = new Set<string>(["screen.record"]);
+
+type CommandOutcome = "success" | "error";
+
+type CommandContext = {
+  notifications: Array<Record<string, unknown>>;
+};
+
+type CommandProfile = {
+  buildParams: (ctx: CommandContext) => Record<string, unknown>;
+  timeoutMs?: number;
+  outcome: CommandOutcome;
+  allowedErrorCodes?: string[];
+  onSuccess?: (payload: unknown, ctx: CommandContext) => void;
+};
+
+type CommandResult = {
+  command: string;
+  ok: boolean;
+  payload?: unknown;
+  errorCode?: string;
+  errorMessage?: string;
+  durationMs: number;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+}
+
+function parseErrorCode(message: string): string {
+  const trimmed = message.trim();
+  const idx = trimmed.indexOf(":");
+  const head = (idx >= 0 ? trimmed.slice(0, idx) : trimmed).trim();
+  if (/^[A-Z0-9_]+$/.test(head)) {
+    return head;
+  }
+  return "UNKNOWN";
+}
+
+function assertObjectPayload(command: string, payload: unknown): Record<string, unknown> {
+  const obj = asRecord(payload);
+  expect(Object.keys(obj).length, `${command} payload must be a JSON object`).toBeGreaterThan(0);
+  return obj;
+}
+
+const COMMAND_PROFILES: Record<string, CommandProfile> = {
+  "canvas.present": {
+    buildParams: () => ({ url: "about:blank" }),
+    timeoutMs: 20_000,
+    outcome: "success",
+  },
+  "canvas.hide": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+  },
+  "canvas.navigate": {
+    buildParams: () => ({ url: "about:blank" }),
+    timeoutMs: 20_000,
+    outcome: "success",
+  },
+  "canvas.eval": {
+    buildParams: () => ({ javaScript: "1 + 1" }),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("canvas.eval", payload);
+      expect(obj.result).toBeDefined();
+    },
+  },
+  "canvas.snapshot": {
+    buildParams: () => ({ format: "jpeg", maxWidth: 320, quality: 0.6 }),
+    timeoutMs: 30_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("canvas.snapshot", payload);
+      expect(readString(obj.format)).not.toBeNull();
+      expect(readString(obj.base64)).not.toBeNull();
+    },
+  },
+  "canvas.a2ui.push": {
+    buildParams: () => ({ jsonl: '{"beginRendering":{}}\n' }),
+    timeoutMs: 30_000,
+    outcome: "success",
+  },
+  "canvas.a2ui.pushJSONL": {
+    buildParams: () => ({ jsonl: '{"beginRendering":{}}\n' }),
+    timeoutMs: 30_000,
+    outcome: "success",
+  },
+  "canvas.a2ui.reset": {
+    buildParams: () => ({}),
+    timeoutMs: 30_000,
+    outcome: "success",
+  },
+  "screen.record": {
+    buildParams: () => ({ durationMs: 1500, fps: 8, includeAudio: false }),
+    timeoutMs: 60_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("screen.record", payload);
+      expect(readString(obj.base64)).not.toBeNull();
+    },
+  },
+  "camera.list": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("camera.list", payload);
+      expect(Array.isArray(obj.devices)).toBe(true);
+    },
+  },
+  "camera.snap": {
+    buildParams: () => ({ facing: "front", maxWidth: 640, quality: 0.6, format: "jpg" }),
+    timeoutMs: 60_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("camera.snap", payload);
+      expect(readString(obj.base64)).not.toBeNull();
+    },
+  },
+  "camera.clip": {
+    buildParams: () => ({ facing: "front", durationMs: 1500, includeAudio: false, format: "mp4" }),
+    timeoutMs: 90_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("camera.clip", payload);
+      expect(readString(obj.base64)).not.toBeNull();
+    },
+  },
+  "location.get": {
+    buildParams: () => ({ timeoutMs: 5000, desiredAccuracy: "balanced" }),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      assertObjectPayload("location.get", payload);
+    },
+  },
+  "device.status": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      assertObjectPayload("device.status", payload);
+    },
+  },
+  "device.info": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("device.info", payload);
+      expect(readString(obj.systemName)).not.toBeNull();
+      expect(readString(obj.systemVersion)).not.toBeNull();
+    },
+  },
+  "device.permissions": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("device.permissions", payload);
+      expect(asRecord(obj.permissions)).toBeTruthy();
+    },
+  },
+  "device.health": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("device.health", payload);
+      expect(asRecord(obj.memory)).toBeTruthy();
+    },
+  },
+  "notifications.list": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload, ctx) => {
+      const obj = assertObjectPayload("notifications.list", payload);
+      const notifications = Array.isArray(obj.notifications) ? obj.notifications : [];
+      ctx.notifications = notifications.map((entry) => asRecord(entry));
+    },
+  },
+  "notifications.actions": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "error",
+    allowedErrorCodes: ["INVALID_REQUEST"],
+  },
+  "sms.send": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "error",
+    allowedErrorCodes: ["INVALID_REQUEST"],
+  },
+  "debug.logs": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("debug.logs", payload);
+      expect(readString(obj.logs)).not.toBeNull();
+    },
+  },
+  "debug.ed25519": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "success",
+    onSuccess: (payload) => {
+      const obj = assertObjectPayload("debug.ed25519", payload);
+      expect(readString(obj.diagnostics)).not.toBeNull();
+    },
+  },
+  "app.update": {
+    buildParams: () => ({}),
+    timeoutMs: 20_000,
+    outcome: "error",
+    allowedErrorCodes: ["INVALID_REQUEST"],
+  },
+};
+
+function resolveGatewayConnection() {
+  const cfg = loadConfig();
+  const urlOverride = readString(process.env.OPENCLAW_ANDROID_GATEWAY_URL);
+  const details = buildGatewayConnectionDetails({
+    config: cfg,
+    ...(urlOverride ? { url: urlOverride } : {}),
+  });
+  const tokenOverride = readString(process.env.OPENCLAW_ANDROID_GATEWAY_TOKEN);
+  const passwordOverride = readString(process.env.OPENCLAW_ANDROID_GATEWAY_PASSWORD);
+  const creds = resolveGatewayCredentialsFromConfig({
+    cfg,
+    explicitAuth: {
+      ...(tokenOverride ? { token: tokenOverride } : {}),
+      ...(passwordOverride ? { password: passwordOverride } : {}),
+    },
+  });
+  return {
+    url: details.url,
+    token: creds.token,
+    password: creds.password,
+  };
+}
+
+async function connectGatewayClient(params: {
+  url: string;
+  token?: string;
+  password?: string;
+}): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    const stop = (err?: Error, client?: GatewayClient) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(client as GatewayClient);
+    };
+
+    const client = new GatewayClient({
+      url: params.url,
+      token: params.token,
+      password: params.password,
+      connectDelayMs: 0,
+      clientName: GATEWAY_CLIENT_NAMES.TEST,
+      clientDisplayName: "android-live-test",
+      clientVersion: "dev",
+      platform: "test",
+      mode: GATEWAY_CLIENT_MODES.TEST,
+      onHelloOk: () => stop(undefined, client),
+      onConnectError: (err) => stop(err),
+      onClose: (code, reason) =>
+        stop(new Error(`gateway closed during connect (${code}): ${reason}`)),
+    });
+
+    const timer = setTimeout(() => stop(new Error("gateway connect timeout")), 10_000);
+    timer.unref();
+    client.start();
+  });
+}
+
+function isAndroidNode(node: NodeListNode): boolean {
+  const platform = readString(node.platform)?.toLowerCase();
+  if (platform === "android") {
+    return true;
+  }
+  const displayName = readString(node.displayName)?.toLowerCase();
+  return displayName?.includes("android") === true;
+}
+
+function selectTargetNode(nodes: NodeListNode[]): NodeListNode {
+  const nodeIdOverride = readString(process.env.OPENCLAW_ANDROID_NODE_ID);
+  if (nodeIdOverride) {
+    const match = nodes.find((node) => node.nodeId === nodeIdOverride);
+    if (!match) {
+      throw new Error(`OPENCLAW_ANDROID_NODE_ID not found in node.list: ${nodeIdOverride}`);
+    }
+    return match;
+  }
+
+  const nodeNameOverride = readString(process.env.OPENCLAW_ANDROID_NODE_NAME)?.toLowerCase();
+  if (nodeNameOverride) {
+    const match = nodes.find(
+      (node) => readString(node.displayName)?.toLowerCase() === nodeNameOverride,
+    );
+    if (!match) {
+      throw new Error(`OPENCLAW_ANDROID_NODE_NAME not found in node.list: ${nodeNameOverride}`);
+    }
+    return match;
+  }
+
+  const androidNodes = nodes.filter(isAndroidNode);
+  if (androidNodes.length === 0) {
+    throw new Error("no Android node found in node.list");
+  }
+
+  return androidNodes.slice().toSorted((a, b) => {
+    const aMs = typeof a.connectedAtMs === "number" ? a.connectedAtMs : 0;
+    const bMs = typeof b.connectedAtMs === "number" ? b.connectedAtMs : 0;
+    return bMs - aMs;
+  })[0];
+}
+
+async function invokeNodeCommand(params: {
+  client: GatewayClient;
+  nodeId: string;
+  command: string;
+  profile: CommandProfile;
+  ctx: CommandContext;
+}): Promise<CommandResult> {
+  const startedAt = Date.now();
+  const timeoutMs = params.profile.timeoutMs ?? 20_000;
+  const invokeParams = {
+    nodeId: params.nodeId,
+    command: params.command,
+    params: params.profile.buildParams(params.ctx),
+    timeoutMs,
+    idempotencyKey: randomUUID(),
+  };
+
+  try {
+    const raw = await params.client.request("node.invoke", invokeParams);
+    const payload = asRecord(raw).payload;
+    return {
+      command: params.command,
+      ok: true,
+      payload,
+      durationMs: Math.max(1, Date.now() - startedAt),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      command: params.command,
+      ok: false,
+      errorCode: parseErrorCode(message),
+      errorMessage: message,
+      durationMs: Math.max(1, Date.now() - startedAt),
+    };
+  }
+}
+
+function evaluateCommandResult(params: {
+  result: CommandResult;
+  profile: CommandProfile;
+  ctx: CommandContext;
+}): string | null {
+  const { result, profile, ctx } = params;
+
+  if (result.ok) {
+    if (profile.outcome === "error") {
+      return `expected error, got success`;
+    }
+    try {
+      profile.onSuccess?.(result.payload, ctx);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  const code = result.errorCode ?? "UNKNOWN";
+  if (profile.outcome === "success") {
+    return `expected success, got ${code}: ${result.errorMessage ?? "unknown error"}`;
+  }
+  const allowed = new Set(profile.allowedErrorCodes ?? []);
+  if (allowed.has(code)) {
+    return null;
+  }
+  return `unexpected error ${code}: ${result.errorMessage ?? "unknown error"}`;
+}
+
+describeLive("android node capability integration (preconditioned)", () => {
+  let client: GatewayClient | null = null;
+  let nodeId = "";
+  let commandsToRun: string[] = [];
+  const ctx: CommandContext = { notifications: [] };
+  const results = new Map<string, CommandResult>();
+
+  beforeAll(async () => {
+    const { url, token, password } = resolveGatewayConnection();
+    client = await connectGatewayClient({ url, token, password });
+
+    const listRaw = await client.request("node.list", {});
+    const nodes = parseNodeList(listRaw);
+    expect(nodes.length, "node.list returned no nodes").toBeGreaterThan(0);
+
+    const target = selectTargetNode(nodes);
+    nodeId = target.nodeId;
+
+    if (!target.connected || !target.paired) {
+      const pairingRaw = await client.request("node.pair.list", {});
+      const pairing = parsePairingList(pairingRaw);
+      const pendingForNode = pairing.pending.filter((entry) => entry.nodeId === nodeId);
+      const pendingHint =
+        pendingForNode.length > 0
+          ? `pending request(s): ${pendingForNode.map((entry) => entry.requestId).join(", ")}`
+          : "no pending request for selected node";
+      throw new Error(
+        [
+          `selected node is not ready (nodeId=${nodeId}, connected=${String(target.connected)}, paired=${String(target.paired)})`,
+          pendingHint,
+          "precondition: open app, keep foreground, ensure pairing approved (`openclaw nodes pending` / `openclaw nodes approve <requestId>`)",
+        ].join("\n"),
+      );
+    }
+
+    const describeRaw = await client.request("node.describe", { nodeId });
+    const describeObj = asRecord(describeRaw);
+    const commands = readStringArray(describeObj.commands);
+    expect(commands.length, "node.describe advertised no commands").toBeGreaterThan(0);
+    commandsToRun = commands.filter((command) => !SKIPPED_INTERACTIVE_COMMANDS.has(command));
+    expect(
+      commandsToRun.length,
+      "node.describe advertised only interactive commands (nothing runnable in CI/dev integration mode)",
+    ).toBeGreaterThan(0);
+
+    const missingProfiles = commandsToRun.filter((command) => !COMMAND_PROFILES[command]);
+    if (missingProfiles.length > 0) {
+      throw new Error(
+        `unmapped advertised commands: ${missingProfiles.join(", ")} (update COMMAND_PROFILES before running this suite)`,
+      );
+    }
+  }, 60_000);
+
+  afterAll(() => {
+    client?.stop();
+    client = null;
+  });
+
+  const profiledCommands = Object.keys(COMMAND_PROFILES).toSorted();
+  for (const command of profiledCommands) {
+    const profile = COMMAND_PROFILES[command];
+    const timeout = Math.max(20_000, profile.timeoutMs ?? 20_000) + 15_000;
+    it(`command: ${command}`, { timeout }, async () => {
+      if (!client) {
+        throw new Error("gateway client not connected");
+      }
+      if (!commandsToRun.includes(command)) {
+        return;
+      }
+      const result = await invokeNodeCommand({ client, nodeId, command, profile, ctx });
+      results.set(command, result);
+      const issue = evaluateCommandResult({ result, profile, ctx });
+      if (!issue) {
+        return;
+      }
+      const status = result.ok ? "ok" : `err:${result.errorCode ?? "UNKNOWN"}`;
+      throw new Error(
+        [
+          `${command}: ${issue}`,
+          "summary:",
+          `${result.command} -> ${status} (${result.durationMs}ms)`,
+        ].join("\n"),
+      );
+    });
+  }
+
+  it("covers every advertised non-interactive command", () => {
+    const missingRuns = commandsToRun.filter((command) => !results.has(command));
+    if (missingRuns.length === 0) {
+      return;
+    }
+    const summary = [...results.values()]
+      .map((entry) => {
+        const status = entry.ok ? "ok" : `err:${entry.errorCode ?? "UNKNOWN"}`;
+        return `${entry.command} -> ${status} (${entry.durationMs}ms)`;
+      })
+      .join("\n");
+    throw new Error(
+      [
+        `advertised commands missing execution (${missingRuns.length}/${commandsToRun.length})`,
+        ...missingRuns,
+        "summary:",
+        summary,
+      ].join("\n"),
+    );
+  });
+});

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -19,7 +19,12 @@ export const CLI_DEFAULT_OPERATOR_SCOPES: OperatorScope[] = [
   PAIRING_SCOPE,
 ];
 
-const NODE_ROLE_METHODS = new Set(["node.invoke.result", "node.event", "skills.bins"]);
+const NODE_ROLE_METHODS = new Set([
+  "node.invoke.result",
+  "node.event",
+  "node.canvas.capability.refresh",
+  "skills.bins",
+]);
 
 const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
   [APPROVALS_SCOPE]: [

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -77,6 +77,7 @@ const BASE_METHODS = [
   "node.invoke",
   "node.invoke.result",
   "node.event",
+  "node.canvas.capability.refresh",
   "cron.list",
   "cron.status",
   "cron.add",

--- a/src/gateway/server-methods/nodes.canvas-capability-refresh.test.ts
+++ b/src/gateway/server-methods/nodes.canvas-capability-refresh.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../protocol/index.js";
+import { nodeHandlers } from "./nodes.js";
+
+describe("node.canvas.capability.refresh", () => {
+  it("rotates the caller canvas capability and returns a fresh scoped URL", async () => {
+    const respond = vi.fn();
+    const client = {
+      connect: { role: "node", client: { id: "node-1" } },
+      canvasHostUrl: "http://127.0.0.1:18789",
+      canvasCapability: "old-token",
+      canvasCapabilityExpiresAtMs: Date.now() - 1,
+    };
+
+    await nodeHandlers["node.canvas.capability.refresh"]({
+      req: { type: "req", id: "req-1", method: "node.canvas.capability.refresh" },
+      params: {},
+      respond,
+      context: {} as never,
+      client: client as never,
+      isWebchatConnect: () => false,
+    });
+
+    const call = respond.mock.calls[0] as
+      | [
+          boolean,
+          {
+            canvasCapability?: string;
+            canvasHostUrl?: string;
+            canvasCapabilityExpiresAtMs?: number;
+          },
+        ]
+      | undefined;
+    expect(call?.[0]).toBe(true);
+    const payload = call?.[1] ?? {};
+    expect(typeof payload.canvasCapability).toBe("string");
+    expect(payload.canvasCapability).not.toBe("old-token");
+    expect(payload.canvasHostUrl).toContain("/__openclaw__/cap/");
+    expect(typeof payload.canvasCapabilityExpiresAtMs).toBe("number");
+    expect(payload.canvasCapabilityExpiresAtMs).toBeGreaterThan(Date.now());
+    expect(client.canvasCapability).toBe(payload.canvasCapability);
+    expect(client.canvasCapabilityExpiresAtMs).toBe(payload.canvasCapabilityExpiresAtMs);
+  });
+
+  it("returns unavailable when the caller session has no base canvas URL", async () => {
+    const respond = vi.fn();
+
+    await nodeHandlers["node.canvas.capability.refresh"]({
+      req: { type: "req", id: "req-2", method: "node.canvas.capability.refresh" },
+      params: {},
+      respond,
+      context: {} as never,
+      client: { connect: { role: "node", client: { id: "node-1" } } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    const call = respond.mock.calls[0] as
+      | [boolean, unknown, { code?: number; message?: string }]
+      | undefined;
+    expect(call?.[0]).toBe(false);
+    expect(call?.[2]?.code).toBe(ErrorCodes.UNAVAILABLE);
+  });
+});

--- a/src/gateway/server-methods/nodes.helpers.ts
+++ b/src/gateway/server-methods/nodes.helpers.ts
@@ -59,20 +59,22 @@ export function respondUnavailableOnNodeInvokeError<T extends { ok: boolean; err
   if (res.ok) {
     return true;
   }
-  const message =
-    res.error && typeof res.error === "object" && "message" in res.error
-      ? (res.error as { message?: unknown }).message
+  const nodeError =
+    res.error && typeof res.error === "object"
+      ? (res.error as { code?: unknown; message?: unknown })
       : null;
+  const nodeCode = typeof nodeError?.code === "string" ? nodeError.code.trim() : "";
+  const nodeMessage =
+    typeof nodeError?.message === "string" && nodeError.message.trim().length > 0
+      ? nodeError.message.trim()
+      : "node invoke failed";
+  const message = nodeCode ? `${nodeCode}: ${nodeMessage}` : nodeMessage;
   respond(
     false,
     undefined,
-    errorShape(
-      ErrorCodes.UNAVAILABLE,
-      typeof message === "string" ? message : "node invoke failed",
-      {
-        details: { nodeError: res.error ?? null },
-      },
-    ),
+    errorShape(ErrorCodes.UNAVAILABLE, message, {
+      details: { nodeError: res.error ?? null },
+    }),
   );
   return false;
 }

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -14,6 +14,11 @@ import {
   sendApnsAlert,
   sendApnsBackgroundWake,
 } from "../../infra/push-apns.js";
+import {
+  buildCanvasScopedHostUrl,
+  CANVAS_CAPABILITY_TTL_MS,
+  mintCanvasCapabilityToken,
+} from "../canvas-capability.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import { sanitizeNodeInvokeParamsForForwarding } from "../node-invoke-sanitize.js";
 import {
@@ -557,6 +562,51 @@ export const nodeHandlers: GatewayRequestHandlers = {
         undefined,
       );
     });
+  },
+  "node.canvas.capability.refresh": async ({ params, respond, client }) => {
+    if (!validateNodeListParams(params)) {
+      respondInvalidParams({
+        respond,
+        method: "node.canvas.capability.refresh",
+        validator: validateNodeListParams,
+      });
+      return;
+    }
+    const baseCanvasHostUrl = client?.canvasHostUrl?.trim() ?? "";
+    if (!baseCanvasHostUrl) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "canvas host unavailable for this node session"),
+      );
+      return;
+    }
+
+    const canvasCapability = mintCanvasCapabilityToken();
+    const canvasCapabilityExpiresAtMs = Date.now() + CANVAS_CAPABILITY_TTL_MS;
+    const scopedCanvasHostUrl = buildCanvasScopedHostUrl(baseCanvasHostUrl, canvasCapability);
+    if (!scopedCanvasHostUrl) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, "failed to mint scoped canvas host URL"),
+      );
+      return;
+    }
+
+    if (client) {
+      client.canvasCapability = canvasCapability;
+      client.canvasCapabilityExpiresAtMs = canvasCapabilityExpiresAtMs;
+    }
+    respond(
+      true,
+      {
+        canvasCapability,
+        canvasCapabilityExpiresAtMs,
+        canvasHostUrl: scopedCanvasHostUrl,
+      },
+      undefined,
+    );
   },
   "node.invoke": async ({ params, respond, context, client, req }) => {
     if (!validateNodeInvokeParams(params)) {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -18,6 +18,9 @@ export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
   clientIp?: string;
+  canvasHostUrl?: string;
+  canvasCapability?: string;
+  canvasCapabilityExpiresAtMs?: number;
 };
 
 export type RespondFn = (

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1016,6 +1016,7 @@ export function attachGatewayWsMessageHandler(params: {
           connId,
           presenceKey,
           clientIp: reportedClientIp,
+          canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,
         };

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -7,6 +7,7 @@ export type GatewayWsClient = {
   connId: string;
   presenceKey?: string;
   clientIp?: string;
+  canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
 };

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -60,6 +60,13 @@ describe("mime detection", () => {
     });
     expect(mime).toBe("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   });
+
+  it("uses extension mapping for JavaScript assets", async () => {
+    const mime = await detectMime({
+      filePath: "/tmp/a2ui.bundle.js",
+    });
+    expect(mime).toBe("text/javascript");
+  });
 });
 
 describe("extensionForMime", () => {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -38,6 +38,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ...Object.fromEntries(Object.entries(EXT_BY_MIME).map(([mime, ext]) => [ext, mime])),
   // Additional extension aliases
   ".jpeg": "image/jpeg",
+  ".js": "text/javascript",
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Summary
- add a preconditioned live Android integration suite that executes every advertised non-interactive node capability (with `screen.record` intentionally skipped)
- document Android integration-test preconditions, pairing expectations, and common failure fixes in `apps/android/README.md`
- harden canvas/A2UI behavior by retrying once after `node.canvas.capability.refresh`, and fix `debug.ed25519` response JSON formatting
- fix canvas asset serving by mapping `.js` to `text/javascript`, with MIME regression coverage

## Validation
- `pnpm test -- src/media/mime.test.ts src/gateway/server-methods/nodes.canvas-capability-refresh.test.ts`
- `pnpm android:test:integration` (validated locally during this branch work; 24/24 passing)
