### PR TITLE
fix: --profile flag silently ignored when OPENCLAW_* env vars are inherited

### DIFF
--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -109,18 +109,14 @@ export function applyCliProfileEnv(params: {
     return;
   }
 
-  // Convenience only: fill defaults, never override explicit env values.
+  // Always override STATE_DIR and CONFIG_PATH when --profile is explicitly provided,
+  // so inherited env vars from a running default gateway don't silently win (#28236).
   env.OPENCLAW_PROFILE = profile;
+  const stateDir = resolveProfileStateDir(profile, env, homedir);
+  env.OPENCLAW_STATE_DIR = stateDir;
+  env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
 
-  const stateDir = env.OPENCLAW_STATE_DIR?.trim() || resolveProfileStateDir(profile, env, homedir);
-  if (!env.OPENCLAW_STATE_DIR?.trim()) {
-    env.OPENCLAW_STATE_DIR = stateDir;
-  }
-
-  if (!env.OPENCLAW_CONFIG_PATH?.trim()) {
-    env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
-  }
-
+  // GATEWAY_PORT is dev-only and intentionally not overridden when explicitly set.
   if (profile === "dev" && !env.OPENCLAW_GATEWAY_PORT?.trim()) {
     env.OPENCLAW_GATEWAY_PORT = "19001";
   }


### PR DESCRIPTION
When a shell already has `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` set (e.g. inherited from a running default gateway), the `--profile` flag was silently ignored — the conditional guards in `applyCliProfileEnv` let the inherited values win, causing the wrong state directory to be used during `gateway install`.

Removed the conditional guards so `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` are always overridden when `--profile` is explicitly provided. `OPENCLAW_GATEWAY_PORT` keeps its conditional guard since that's intentional dev-only behaviour. Updated the relevant test and added a new test to confirm the port preservation.

Fixes #28236