### PR TITLE
fix(secrets): avoid re-materializing plaintext apiKey in agent models.json

### DIFF
--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -123,13 +123,23 @@ describe("models-config", () => {
 
   it("prefers runtime source config so SecretRef is not re-materialized to plaintext", async () => {
     await withTempHome(async () => {
+      const modelDef = {
+        id: "kimi-k2.5",
+        name: "Kimi K2.5",
+        reasoning: false,
+        input: ["text"] as Array<"text" | "image">,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      };
+
       const runtimeResolved: OpenClawConfig = {
         models: {
           providers: {
             moonshot: {
               baseUrl: "https://api.moonshot.cn/v1",
               apiKey: "sk-live-plaintext-should-not-persist",
-              models: [{ id: "kimi-k2.5" }],
+              models: [modelDef],
             },
           },
         },
@@ -139,8 +149,8 @@ describe("models-config", () => {
           providers: {
             moonshot: {
               baseUrl: "https://api.moonshot.cn/v1",
-              apiKey: { source: "env", id: "KIMI_API_KEY" },
-              models: [{ id: "kimi-k2.5" }],
+              apiKey: { source: "env", provider: "default", id: "KIMI_API_KEY" },
+              models: [modelDef],
             },
           },
         },
@@ -155,7 +165,11 @@ describe("models-config", () => {
           providers: Record<string, { apiKey?: unknown }>;
         };
 
-        expect(parsed.providers.moonshot?.apiKey).toEqual({ source: "env", id: "KIMI_API_KEY" });
+        expect(parsed.providers.moonshot?.apiKey).toEqual({
+          source: "env",
+          provider: "default",
+          id: "KIMI_API_KEY",
+        });
       } finally {
         clearRuntimeConfigSnapshot();
       }

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import {
   CUSTOM_PROXY_MODELS_CONFIG,
@@ -113,6 +118,47 @@ describe("models-config", () => {
         expectedApiKeyRef: "SYNTHETIC_API_KEY",
         expectedModelIds: ["hf:MiniMaxAI/MiniMax-M2.1"],
       });
+    });
+  });
+
+  it("prefers runtime source config so SecretRef is not re-materialized to plaintext", async () => {
+    await withTempHome(async () => {
+      const runtimeResolved: OpenClawConfig = {
+        models: {
+          providers: {
+            moonshot: {
+              baseUrl: "https://api.moonshot.cn/v1",
+              apiKey: "sk-live-plaintext-should-not-persist",
+              models: [{ id: "kimi-k2.5" }],
+            },
+          },
+        },
+      };
+      const runtimeSource: OpenClawConfig = {
+        models: {
+          providers: {
+            moonshot: {
+              baseUrl: "https://api.moonshot.cn/v1",
+              apiKey: { source: "env", id: "KIMI_API_KEY" },
+              models: [{ id: "kimi-k2.5" }],
+            },
+          },
+        },
+      };
+
+      setRuntimeConfigSnapshot(runtimeResolved, runtimeSource);
+      try {
+        await ensureOpenClawModelsJson();
+        const modelPath = path.join(resolveOpenClawAgentDir(), "models.json");
+        const raw = await fs.readFile(modelPath, "utf8");
+        const parsed = JSON.parse(raw) as {
+          providers: Record<string, { apiKey?: unknown }>;
+        };
+
+        expect(parsed.providers.moonshot?.apiKey).toEqual({ source: "env", id: "KIMI_API_KEY" });
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
     });
   });
 });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -116,10 +116,7 @@ export async function ensureOpenClawModelsJson(
   // with plaintext apiKey values. Prefer the source snapshot (with SecretRef inputs)
   // when available so models.json does not persist resolved secrets to disk.
   const sourceCfg = getRuntimeConfigSourceSnapshot();
-  const explicitProviders = (sourceCfg?.models?.providers ?? cfg.models?.providers ?? {}) as Record<
-    string,
-    ProviderConfig
-  >;
+  const explicitProviders = sourceCfg?.models?.providers ?? cfg.models?.providers ?? {};
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { type OpenClawConfig, loadConfig } from "../config/config.js";
+import {
+  type OpenClawConfig,
+  getRuntimeConfigSourceSnapshot,
+  loadConfig,
+} from "../config/config.js";
 import { isRecord } from "../utils.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import {
@@ -108,7 +112,14 @@ export async function ensureOpenClawModelsJson(
   const cfg = config ?? loadConfig();
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
 
-  const explicitProviders = cfg.models?.providers ?? {};
+  // When runtime secrets are resolved, loadConfig() may return a materialized snapshot
+  // with plaintext apiKey values. Prefer the source snapshot (with SecretRef inputs)
+  // when available so models.json does not persist resolved secrets to disk.
+  const sourceCfg = getRuntimeConfigSourceSnapshot();
+  const explicitProviders = (sourceCfg?.models?.providers ?? cfg.models?.providers ?? {}) as Record<
+    string,
+    ProviderConfig
+  >;
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,6 +3,7 @@ export {
   clearRuntimeConfigSnapshot,
   createConfigIO,
   getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
   loadConfig,
   parseConfigJson5,
   readConfigFileSnapshot,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1346,6 +1346,10 @@ export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
   return runtimeConfigSnapshot;
 }
 
+export function getRuntimeConfigSourceSnapshot(): OpenClawConfig | null {
+  return runtimeConfigSourceSnapshot;
+}
+
 export function loadConfig(): OpenClawConfig {
   if (runtimeConfigSnapshot) {
     return runtimeConfigSnapshot;


### PR DESCRIPTION
﻿## Summary
Fixes #28359.

When runtime secrets are active, `loadConfig()` may return a resolved runtime snapshot with plaintext provider keys. `ensureOpenClawModelsJson()` used that snapshot directly, which could persist plaintext API keys into `~/.openclaw/agents/*/agent/models.json`.

## What changed
- Added `getRuntimeConfigSourceSnapshot()` export from config IO.
- Updated `ensureOpenClawModelsJson()` to prefer the **runtime source snapshot** (pre-resolution config) when choosing explicit model providers.
  - Falls back to regular config when source snapshot is unavailable.
- Added regression test:
  - sets a runtime resolved config containing plaintext `apiKey`
  - sets runtime source config containing `SecretRef`
  - verifies generated `models.json` keeps the SecretRef and does not persist plaintext.

## Why this is safe
- Behavior only changes when a runtime source snapshot exists.
- Existing merge/normalize flows remain unchanged.
- It narrows secret exposure on disk while preserving provider config semantics.

## Validation
- Ran: `pnpm test src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- Result: pass (5 tests)
