### PR TITLE
(fix) make chromium entry point become version agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       mkdir -p /home/node/.cache/ms-playwright && \
       PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      ln -sf /home/node/.cache/ms-playwright/chromium-*/chrome-linux64/chrome /home/node/chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright /home/node/chromium && \
+      ln -sf /home/node/.cache/ms-playwright/chromium-*/chrome-linux64/chrome /home/node/chrome && \
+      chown -R node:node /home/node/.cache/ms-playwright /home/node/chrome && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       mkdir -p /home/node/.cache/ms-playwright && \
       PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node /home/node/.cache/ms-playwright && \
+      ln -sf /home/node/.cache/ms-playwright/chromium-*/chrome-linux64/chrome /home/node/chromium && \
+      chown -R node:node /home/node/.cache/ms-playwright /home/node/chromium && \
       apt-get clean && \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
Currently, we have to get chrome by  path like `/home/node/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome`
but when its version may be  upgraded after a new build (> 12.08), the  absolute path will change.
so a softlink is a better way.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes # NA
- Related #

