### PR TITLE
fix(signal): don't drop valid group dataMessage when syncMessage exists

### DIFF
--- a/src/signal/monitor/event-handler.inbound-contract.test.ts
+++ b/src/signal/monitor/event-handler.inbound-contract.test.ts
@@ -113,6 +113,31 @@ describe("signal createSignalEventHandler inbound contract", () => {
     expect(context.OriginatingTo).toBe("+15550002222");
   });
 
+  it("processes dataMessage even when syncMessage envelope key is present", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        syncMessage: { sentMessage: { destination: "+15550003333" } },
+        dataMessage: {
+          message: "group hello",
+          attachments: [],
+          groupInfo: { groupId: "g-sync", groupName: "Sync Group" },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ChatType).toBe("group");
+    expect(capture.ctx?.GroupSubject).toBe("Sync Group");
+  });
+
   it("sends typing + read receipt for allowed DMs", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -418,9 +418,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     if (!envelope) {
       return;
     }
-    if (envelope.syncMessage) {
-      return;
-    }
 
     const sender = resolveSignalSender(envelope);
     if (!sender) {


### PR DESCRIPTION
﻿## Summary
Fixes #28322.

Signal group messages can be delivered with `syncMessage` present on the envelope while still carrying a valid inbound `dataMessage`. The current handler returned early on any `envelope.syncMessage`, which caused those group messages to be silently dropped.

## What changed
- Removed the unconditional early-return on `envelope.syncMessage`.
- Keep existing message parsing/filters so only valid inbound payloads continue to processing.

## Regression coverage
Added test in `event-handler.inbound-contract.test.ts`:
- envelope includes `syncMessage` and a valid group `dataMessage`
- verifies message is still processed and reaches dispatch context.

## Validation
- `pnpm test src/signal/monitor/event-handler.inbound-contract.test.ts` ✅

## Notes
This is intentionally minimal and targeted: it restores message handling for valid payloads that include `syncMessage` metadata while preserving existing gate checks.
