### PR TITLE
fix(typing): skip typing indicator for isolated cron sessions

### DIFF
--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -334,5 +334,79 @@ describe("createTypingCallbacks", () => {
         vi.useRealTimers();
       }
     });
+
+    it("skips typing for isolated cron sessions", async () => {
+      const start = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+
+      // Isolated cron session key pattern
+      const cronSessionKey = "agent:default:cron:daily-report:run:abc123";
+
+      const callbacks = createTypingCallbacks({
+        start,
+        stop,
+        onStartError,
+        sessionKey: cronSessionKey,
+      });
+
+      // onReplyStart should not call start for isolated cron
+      await callbacks.onReplyStart();
+      expect(start).not.toHaveBeenCalled();
+
+      // onIdle should not call stop
+      callbacks.onIdle?.();
+      expect(stop).not.toHaveBeenCalled();
+
+      // onCleanup should not call stop
+      callbacks.onCleanup?.();
+      expect(stop).not.toHaveBeenCalled();
+    });
+
+    it("allows typing for regular user sessions", async () => {
+      const start = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+
+      // Regular user DM session
+      const userSessionKey = "agent:default:telegram:dm:123456789";
+
+      const callbacks = createTypingCallbacks({
+        start,
+        stop,
+        onStartError,
+        sessionKey: userSessionKey,
+      });
+
+      // onReplyStart should call start for regular user session
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      // onIdle should call stop
+      callbacks.onIdle?.();
+      await flushMicrotasks();
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows typing for main cron sessions (non-isolated)", async () => {
+      const start = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+
+      // Main cron session (not isolated, no :run: in key)
+      // Format: agent:<agentId>:cron:<jobId>
+      const mainCronSessionKey = "agent:main:cron:daily-report";
+
+      const callbacks = createTypingCallbacks({
+        start,
+        stop,
+        onStartError,
+        sessionKey: mainCronSessionKey,
+      });
+
+      // onReplyStart should call start for main cron session
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -421,6 +421,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         error: err,
       });
     },
+    sessionKey: ctxPayload.SessionKey,
   });
 
   // --- Discord draft stream (edit-based preview streaming) ---

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -220,6 +220,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           error: err,
         });
       },
+      sessionKey: ctxPayload.SessionKey,
     });
 
     const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -147,6 +147,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         error: err,
       });
     },
+    sessionKey: route.sessionKey,
   });
 
   const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -428,6 +428,7 @@ export const dispatchTelegramMessage = async ({
         error: err,
       });
     },
+    sessionKey: ctxPayload.SessionKey,
   });
 
   try {


### PR DESCRIPTION
## Summary

- **Problem:** Isolated cron sessions with `delivery: "none"` incorrectly send typing indicators to user DMs, causing phantom "typing..." episodes throughout the day from background jobs.
- **Why it matters:** Users see "typing..." indicators from cron jobs that shouldn't show any activity, creating confusion and appearing like unauthorized access.
- **What changed:** Added `sessionKey` parameter to `createTypingCallbacks()` to detect isolated cron sessions (pattern: `:cron:` + `:run:`) and skip typing entirely for these sessions.
- **What did NOT change:** No changes to typing behavior for regular user sessions or main cron sessions. TTL safety mechanism remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration (typing lifecycle)
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Telegram, Discord, Slack, Signal)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #27902

## User-visible / Behavior Changes

**Before:**
- Isolated cron jobs with `delivery: { "mode": "none" }` showed "typing..." indicator in user DM
- ~50+ phantom typing episodes per day with typical cron configurations

**After:**
- Isolated cron sessions no longer send typing indicators
- Background jobs run silently as expected
- Regular user sessions unchanged

## Security Impact (required)
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime/container: Node.js 22+
- Integration/channel: Telegram (also affects Discord, Slack, Signal)
- Relevant config:
  
json
{
    "cron": {
      "jobs": [
        {
          "id": "test-job",
          "sessionTarget": "isolated",
          "delivery": { "mode": "none" },
          "cron": "/30 * * *",
          "message": "Background task"
        }
      ]
    }
  }
  
### Steps
  
1. Configure isolated cron job with `delivery: { "mode": "none" }`
2. Wait for cron job to execute
3. Observe user DM (before fix: typing appears; after fix: no typing)

### Expected

- Isolated cron with `mode: "none"` should not show typing indicator

### Actual

- ✅ Isolated cron jobs no longer show phantom typing
- ✅ Regular user sessions still show typing normally
- ✅ Main cron sessions (non-isolated) still show typing
  
## Evidence

- [x] Failing test/log before + passing after
  - Added 3 new tests for cron session detection
  - All 17 tests pass (14 existing + 3 new)
  - Test: "skips typing for isolated cron sessions" validates the fix
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

**Verified scenarios:**
- Isolated cron sessions (`:cron:` + `:run:` pattern) skip typing
- Regular user sessions work normally
  
- Main cron sessions (non-isolated) still show typing
- All 4 channels (Telegram, Discord, Slack, Signal) updated consistently

**Edge cases checked:**
- Session key patterns correctly detected
- No-op callbacks don't leak resources
- Existing typing behavior unaffected for non-cron sessions

**What did NOT verify:**
- Actual production API behavior (tested via unit tests)
- Long-running cron job scenarios beyond test coverage

## Compatibility / Migration

- Backward compatible? (`Yes`)
  
- Config/env changes? (`No`)
- Migration needed? (`No`)

Existing code without `sessionKey` works normally - cron detection only activates when session key is provided.

## Failure Recovery (if this breaks)

- **How to disable:** Revert session key check in `typing.ts`
- **Files to restore:** `src/channels/typing.ts` and `src/channels/typing.test.ts`
- **Bad symptoms:** 
  - All typing skipped → check session key pattern matching
  - No change in behavior → verify sessionKey is passed from channels

## Risks and Mitigations
  
**Risk:** Session key pattern might have false positives
- **Mitigation:** Pattern (`:cron:` + `:run:`) is specific to isolated cron session keys. User sessions and main cron sessions use different patterns. Tests verify all three cases.

**Risk:** Breaking change for users expecting typing from cron jobs
- **Mitigation:** This is the intended behavior - isolated cron with `delivery: "none"` should never have shown typing. Users who need typing can use `sessionTarget: "main"` or configure delivery mode appropriately.

---
