### PR TITLE
fix(infra): clamp heartbeat setTimeout delay to prevent 32-bit overflow loop [AI]

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -167,6 +167,24 @@ describe("resolveHeartbeatIntervalMs", () => {
       ),
     ).toBe(5 * 60_000);
   });
+
+  it("clamps intervals exceeding the 32-bit setTimeout limit (~24.8 days)", () => {
+    // 999h = 3,596,400,000 ms > 2^31-1; Node.js wraps overflow to ~1 ms causing
+    // an infinite re-arm loop — must be clamped to MAX_SAFE_TIMEOUT_MS.
+    const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: { every: "999h" } } },
+      }),
+    ).toBe(MAX_SAFE_TIMEOUT_MS);
+
+    // Exactly at the boundary: should NOT be clamped
+    expect(
+      resolveHeartbeatIntervalMs({
+        agents: { defaults: { heartbeat: { every: "35791m" } } },
+      }),
+    ).toBe(35791 * 60_000); // 2,147,460,000 ms < MAX_SAFE_TIMEOUT_MS
+  });
 });
 
 describe("resolveHeartbeatPrompt", () => {


### PR DESCRIPTION
## Summary

- Problem: `startHeartbeatRunner` passes `delay = Math.max(0, nextDue - now)` directly to `setTimeout` with no upper-bound check. When `heartbeat.every` is set to a value > ~24.8 days (e.g. `"999h"` = 3,596,400,000 ms), Node.js silently coerces the delay to its signed 32-bit integer overflow result (~1 ms), causing a tight re-arm loop that floods logs with `TimeoutOverflowWarning` indefinitely.
- Why it matters: Any user who configures a long `heartbeat.every` interval hits an infinite CPU/log-spam loop until the gateway is restarted.
- What changed: `resolveHeartbeatIntervalMs` now clamps the returned value to `MAX_SAFE_TIMEOUT_MS` (2^31-1) and emits a `log.warn` so operators know the interval was capped. `scheduleNext` also applies the same clamp defensively on the computed `delay`.
- What did NOT change: Normal intervals (<24.8 days), existing scheduling logic, config schema, or any other code path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #28405

## User-visible / Behavior Changes

Users who set `heartbeat.every` to a value exceeding ~24.8 days will see a `[gateway/heartbeat] warn: heartbeat: interval exceeds 32-bit timeout limit; clamping to ~24.8 days` log entry, and the heartbeat will fire at most every 24.8 days instead of spinning in a tight loop.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (affects any Node.js platform)
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel: any
- Relevant config (redacted): `heartbeat.every: "999h"`

### Steps

1. Set `agents.defaults.heartbeat.every: "999h"` in `openclaw.json`
2. Start the gateway
3. Observe `TimeoutOverflowWarning: 3596400000 does not fit into a 32-bit signed integer` repeating every ~1 ms in logs

### Expected

- One warning in the log that the interval was clamped, then the heartbeat fires at most every 24.8 days.

### Actual (before fix)

- Infinite `TimeoutOverflowWarning` spam; heartbeat re-arms every ~1 ms in a tight loop.

## Evidence

- [x] Failing test/log before + passing after: `heartbeat-runner.returns-default-unset.test.ts` and `heartbeat-runner.scheduler.test.ts` both contain new regression tests that pass with the fix.

## Human Verification (required)

- Verified scenarios: new unit tests cover the exact `"999h"` overflow value and the boundary just below the limit; scheduler test confirms no firing within 24 h for a `"999h"` config.
- Edge cases checked: value at boundary (35791m = 2,147,460,000 ms < limit) passes through unchanged; value exactly at MAX_SAFE_TIMEOUT_MS is not clamped.
- What you did **not** verify: live gateway restart with a real long-interval config.

## Compatibility / Migration

- Backward compatible? Yes — only intervals >24.8 days are affected; all normal configs are unchanged.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three-line change in `resolveHeartbeatIntervalMs` and remove the `Math.min` in `scheduleNext`.
- Files/config to restore: `src/infra/heartbeat-runner.ts` only.
- Known bad symptoms reviewers should watch for: none expected; the clamp is a no-op for all reasonable intervals.

## Risks and Mitigations

- Risk: A user who intentionally wanted a >24.8 day heartbeat interval will be silently capped.
  - Mitigation: A log warning is emitted explaining the cap; Node.js does not support longer single-shot timers natively and the previous behaviour was a runaway loop, so this is strictly an improvement.

---
_AI-assisted (Claude). Lightly tested: new unit tests pass; build and lint clean; not tested against a live gateway instance._