### PR TITLE
fix(models): honor explicit minimax-portal apiKey over oauth placeholder

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -244,6 +244,58 @@ describe("models-config", () => {
     });
   });
 
+  it("does not preserve stale minimax oauth placeholder apiKey in merge mode", async () => {
+    await withTempHome(async () => {
+      const agentDir = resolveOpenClawAgentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify(
+          {
+            providers: {
+              "minimax-portal": {
+                apiKey: "minimax-oauth",
+                api: "openai-completions",
+                models: [{ id: "stale-model", name: "Stale", input: ["text"] }],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            "minimax-portal": {
+              apiKey: "MINIMAX_REAL_KEY",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string }>;
+      }>();
+      expect(parsed.providers["minimax-portal"]?.apiKey).toBe("MINIMAX_REAL_KEY");
+    });
+  });
+
   it("refreshes stale explicit moonshot model capabilities from implicit catalog", async () => {
     await withTempHome(async () => {
       const prevKey = process.env.MOONSHOT_API_KEY;

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -272,6 +272,7 @@ describe("models-config", () => {
           providers: {
             "minimax-portal": {
               apiKey: "MINIMAX_REAL_KEY",
+              baseUrl: "https://api.minimax.io/v1",
               api: "openai-completions",
               models: [
                 {

--- a/src/agents/models-config.providers.minimax-portal.test.ts
+++ b/src/agents/models-config.providers.minimax-portal.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("minimax-portal implicit provider", () => {
+  it("does not inject oauth placeholder when explicit minimax-portal apiKey is configured", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-minimax-portal-"));
+    try {
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "minimax-portal:default": {
+                type: "oauth",
+                provider: "minimax-portal",
+                access: "oauth-token",
+                refresh: "refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          "minimax-portal": {
+            apiKey: "real-api-key",
+          } as never,
+        },
+      });
+
+      expect(providers).toBeDefined();
+      expect(providers?.["minimax-portal"]?.apiKey).toBeUndefined();
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps oauth-backed implicit provider when explicit minimax-portal apiKey is absent", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-minimax-portal-"));
+    try {
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "minimax-portal:default": {
+                type: "oauth",
+                provider: "minimax-portal",
+                access: "oauth-token",
+                refresh: "refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers).toBeDefined();
+      expect(providers?.["minimax-portal"]?.apiKey).toBe("minimax-oauth");
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/models-config.providers.minimax-portal.test.ts
+++ b/src/agents/models-config.providers.minimax-portal.test.ts
@@ -40,6 +40,8 @@ describe("minimax-portal implicit provider", () => {
       });
 
       expect(providers).toBeDefined();
+      expect(providers?.["minimax-portal"]).toBeDefined();
+      expect(providers?.["minimax-portal"]?.models?.length).toBeGreaterThan(0);
       expect(providers?.["minimax-portal"]?.apiKey).toBeUndefined();
     } finally {
       fs.rmSync(agentDir, { recursive: true, force: true });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -842,6 +842,10 @@ export function buildKilocodeProvider(): ProviderConfig {
   };
 }
 
+function hasConfiguredApiKey(provider?: ProviderConfig): boolean {
+  return typeof provider?.apiKey === "string" && provider.apiKey.trim().length > 0;
+}
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
   explicitProviders?: Record<string, ProviderConfig> | null;
@@ -859,7 +863,10 @@ export async function resolveImplicitProviders(params: {
   }
 
   const minimaxOauthProfile = listProfilesForProvider(authStore, "minimax-portal");
-  if (minimaxOauthProfile.length > 0) {
+  if (
+    minimaxOauthProfile.length > 0 &&
+    !hasConfiguredApiKey(params.explicitProviders?.["minimax-portal"])
+  ) {
     providers["minimax-portal"] = {
       ...buildMinimaxPortalProvider(),
       apiKey: MINIMAX_OAUTH_PLACEHOLDER,

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -863,13 +863,12 @@ export async function resolveImplicitProviders(params: {
   }
 
   const minimaxOauthProfile = listProfilesForProvider(authStore, "minimax-portal");
-  if (
-    minimaxOauthProfile.length > 0 &&
-    !hasConfiguredApiKey(params.explicitProviders?.["minimax-portal"])
-  ) {
+  if (minimaxOauthProfile.length > 0) {
     providers["minimax-portal"] = {
       ...buildMinimaxPortalProvider(),
-      apiKey: MINIMAX_OAUTH_PLACEHOLDER,
+      ...(hasConfiguredApiKey(params.explicitProviders?.["minimax-portal"])
+        ? {}
+        : { apiKey: MINIMAX_OAUTH_PLACEHOLDER }),
     };
   }
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -155,7 +155,12 @@ export async function ensureOpenClawModelsJson(
           | undefined;
         if (existing) {
           const preserved: Record<string, unknown> = {};
-          if (typeof existing.apiKey === "string" && existing.apiKey) {
+          const existingApiKey =
+            typeof existing.apiKey === "string" ? existing.apiKey.trim() : "";
+          const keepExistingApiKey =
+            existingApiKey.length > 0 &&
+            !(key === "minimax-portal" && existingApiKey === "minimax-oauth");
+          if (keepExistingApiKey) {
             preserved.apiKey = existing.apiKey;
           }
           if (typeof existing.baseUrl === "string" && existing.baseUrl) {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -155,8 +155,7 @@ export async function ensureOpenClawModelsJson(
           | undefined;
         if (existing) {
           const preserved: Record<string, unknown> = {};
-          const existingApiKey =
-            typeof existing.apiKey === "string" ? existing.apiKey.trim() : "";
+          const existingApiKey = typeof existing.apiKey === "string" ? existing.apiKey.trim() : "";
           const keepExistingApiKey =
             existingApiKey.length > 0 &&
             !(key === "minimax-portal" && existingApiKey === "minimax-oauth");


### PR DESCRIPTION
Fixes #28290

## Summary
When a stale `minimax-portal` OAuth profile exists, implicit provider resolution always injected the OAuth placeholder key. This could shadow a user-configured `models.providers.minimax-portal.apiKey` after disabling the OAuth plugin.

This change skips implicit OAuth placeholder injection for `minimax-portal` when an explicit non-empty apiKey is configured.

## Validation
- `pnpm test -- src/agents/models-config.providers.minimax-portal.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`
