### PR TITLE
fix(sessions): use agentId instead of storePath for transcriptPath resolution

### DIFF
--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -84,7 +83,6 @@ export function createSessionsListTool(opts?: {
       });
 
       const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
-      const storePath = typeof list?.path === "string" ? list.path : undefined;
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const visibilityGuard = await createSessionVisibilityGuard({
         action: "list",
@@ -154,15 +152,16 @@ export function createSessionsListTool(opts?: {
         const sessionFileRaw = (entry as { sessionFile?: unknown }).sessionFile;
         const sessionFile = typeof sessionFileRaw === "string" ? sessionFileRaw : undefined;
         let transcriptPath: string | undefined;
-        if (sessionId && storePath) {
+        if (sessionId) {
           try {
+            const agentId = resolveAgentIdFromSessionKey(key);
+            // Use only agentId so resolveSessionFilePath uses resolveAgentSessionsDir(agentId),
+            // i.e. <stateDir>/agents/<agentId>/sessions/. Do not use path.dirname(storePath)
+            // because gateway may return a workspace store path, yielding wrong transcript paths.
             transcriptPath = resolveSessionFilePath(
               sessionId,
               sessionFile ? { sessionFile } : undefined,
-              {
-                agentId: resolveAgentIdFromSessionKey(key),
-                sessionsDir: path.dirname(storePath),
-              },
+              { agentId },
             );
           } catch {
             transcriptPath = undefined;


### PR DESCRIPTION
## Summary

- Fix `sessions_list` tool returning incorrect `transcriptPath` that pointed to workspace directory instead of agent state directory
- Remove dependency on `storePath` from gateway response; now consistently use `resolveAgentSessionsDir(agentId)` via `agentId` option

## Root Cause

`resolveSessionFilePath` was called with `sessionsDir: path.dirname(storePath)`, where `storePath` could be a workspace path (e.g. `~/.openclaw/workspace/sessions.json`). This caused `transcriptPath` to resolve to `~/.openclaw/workspace/<session-id>.jsonl` instead of the correct `~/.openclaw/agents/<agentId>/sessions/<session-id>.jsonl`.

## Fix

Pass only `{ agentId }` to `resolveSessionFilePath`, allowing it to internally call `resolveAgentSessionsDir(agentId)` for the canonical sessions directory.

Fixes #28379

Made with [Cursor](https://cursor.com)