### PR TITLE
fix: extract full text from Slack blocks for bot messages

### DIFF
--- a/src/slack/blocks-fallback.ts
+++ b/src/slack/blocks-fallback.ts
@@ -1,0 +1,124 @@
+import type { Block, KnownBlock } from "@slack/web-api";
+import type { SlackBlock } from "./types.js";
+
+type PlainTextObject = { text?: string };
+
+type SlackBlockWithFields = {
+  type?: string;
+  text?: PlainTextObject & { type?: string };
+  title?: PlainTextObject;
+  alt_text?: string;
+  elements?: Array<{ text?: string; type?: string }>;
+};
+
+function cleanCandidate(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readSectionText(block: SlackBlockWithFields): string | undefined {
+  return cleanCandidate(block.text?.text);
+}
+
+function readHeaderText(block: SlackBlockWithFields): string | undefined {
+  return cleanCandidate(block.text?.text);
+}
+
+function readImageText(block: SlackBlockWithFields): string | undefined {
+  return cleanCandidate(block.alt_text) ?? cleanCandidate(block.title?.text);
+}
+
+function readVideoText(block: SlackBlockWithFields): string | undefined {
+  return cleanCandidate(block.title?.text) ?? cleanCandidate(block.alt_text);
+}
+
+function readContextText(block: SlackBlockWithFields): string | undefined {
+  if (!Array.isArray(block.elements)) {
+    return undefined;
+  }
+  const textParts = block.elements
+    .map((element) => cleanCandidate(element.text))
+    .filter((value): value is string => Boolean(value));
+  return textParts.length > 0 ? textParts.join(" ") : undefined;
+}
+
+export function extractFullTextFromBlocks(blocks: SlackBlock[]): string | undefined {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    switch (block.type) {
+      case "section":
+      case "header": {
+        const text = block.text?.text?.replace(/\s+/g, " ").trim();
+        if (text) {
+          parts.push(text);
+        }
+        break;
+      }
+      case "context": {
+        if (Array.isArray(block.elements)) {
+          const contextParts = block.elements
+            .map((el) => el.text?.replace(/\s+/g, " ").trim())
+            .filter(Boolean);
+          if (contextParts.length > 0) {
+            parts.push(contextParts.join(" "));
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+export function buildSlackBlocksFallbackText(blocks: (Block | KnownBlock)[]): string {
+  const parts: string[] = [];
+  for (const raw of blocks) {
+    const block = raw as SlackBlockWithFields;
+    switch (block.type) {
+      case "header": {
+        const text = readHeaderText(block);
+        if (text) {
+          parts.push(text);
+        }
+        break;
+      }
+      case "section": {
+        const text = readSectionText(block);
+        if (text) {
+          parts.push(text);
+        }
+        break;
+      }
+      case "image": {
+        const text = readImageText(block);
+        parts.push(text ?? "Shared an image");
+        break;
+      }
+      case "video": {
+        const text = readVideoText(block);
+        parts.push(text ?? "Shared a video");
+        break;
+      }
+      case "file": {
+        parts.push("Shared a file");
+        break;
+      }
+      case "context": {
+        const text = readContextText(block);
+        if (text) {
+          parts.push(text);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n") : "Shared a Block Kit message";
+}

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -1,16 +1,10 @@
 import type { WebClient as SlackWebClient } from "@slack/web-api";
+import { normalizeHostname } from "../../infra/net/hostname.js";
 import type { FetchLike } from "../../media/fetch.js";
-import type { SlackFile } from "../types.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
-
-function normalizeHostname(hostname: string): string {
-  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-  if (normalized.startsWith("[") && normalized.endsWith("]")) {
-    return normalized.slice(1, -1);
-  }
-  return normalized;
-}
+import type { SlackAttachment, SlackBlock, SlackFile } from "../types.js";
+import { extractFullTextFromBlocks } from "../blocks-fallback.js";
 
 function isSlackHostname(hostname: string): boolean {
   const normalized = normalizeHostname(hostname);
@@ -115,52 +109,211 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
   return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
+/**
+ * Slack voice messages (audio clips, huddle recordings) carry a `subtype` of
+ * `"slack_audio"` but are served with a `video/*` MIME type (e.g. `video/mp4`,
+ * `video/webm`).  Override the primary type to `audio/` so the
+ * media-understanding pipeline routes them to transcription.
+ */
+function resolveSlackMediaMimetype(
+  file: SlackFile,
+  fetchedContentType?: string,
+): string | undefined {
+  const mime = fetchedContentType ?? file.mimetype;
+  if (file.subtype === "slack_audio" && mime?.startsWith("video/")) {
+    return mime.replace("video/", "audio/");
+  }
+  return mime;
+}
+
+export type SlackMediaResult = {
+  path: string;
+  contentType?: string;
+  placeholder: string;
+};
+
+export const MAX_SLACK_MEDIA_FILES = 8;
+const MAX_SLACK_MEDIA_CONCURRENCY = 3;
+const MAX_SLACK_FORWARDED_ATTACHMENTS = 8;
+
+function isForwardedSlackAttachment(attachment: SlackAttachment): boolean {
+  // Narrow this parser to Slack's explicit "shared/forwarded" attachment payloads.
+  return attachment.is_share === true;
+}
+
+function resolveForwardedAttachmentImageUrl(attachment: SlackAttachment): string | null {
+  const rawUrl = attachment.image_url?.trim();
+  if (!rawUrl) {
+    return null;
+  }
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "https:" || !isSlackHostname(parsed.hostname)) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+  const results: R[] = [];
+  results.length = items.length;
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const idx = nextIndex++;
+        if (idx >= items.length) {
+          return;
+        }
+        results[idx] = await fn(items[idx]);
+      }
+    }),
+  );
+  return results;
+}
+
+/**
+ * Downloads all files attached to a Slack message and returns them as an array.
+ * Returns `null` when no files could be downloaded.
+ */
 export async function resolveSlackMedia(params: {
   files?: SlackFile[];
   token: string;
   maxBytes: number;
-}): Promise<{
-  path: string;
-  contentType?: string;
-  placeholder: string;
-} | null> {
+}): Promise<SlackMediaResult[] | null> {
   const files = params.files ?? [];
-  for (const file of files) {
-    const url = file.url_private_download ?? file.url_private;
-    if (!url) {
-      continue;
+  const limitedFiles =
+    files.length > MAX_SLACK_MEDIA_FILES ? files.slice(0, MAX_SLACK_MEDIA_FILES) : files;
+
+  const resolved = await mapLimit<SlackFile, SlackMediaResult | null>(
+    limitedFiles,
+    MAX_SLACK_MEDIA_CONCURRENCY,
+    async (file) => {
+      const url = file.url_private_download ?? file.url_private;
+      if (!url) {
+        return null;
+      }
+      try {
+        // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
+        // handles size limits internally. Provide a fetcher that uses auth once, then lets
+        // the redirect chain continue without credentials.
+        const fetchImpl = createSlackMediaFetch(params.token);
+        const fetched = await fetchRemoteMedia({
+          url,
+          fetchImpl,
+          filePathHint: file.name,
+          maxBytes: params.maxBytes,
+        });
+        if (fetched.buffer.byteLength > params.maxBytes) {
+          return null;
+        }
+        const effectiveMime = resolveSlackMediaMimetype(file, fetched.contentType);
+        const saved = await saveMediaBuffer(
+          fetched.buffer,
+          effectiveMime,
+          "inbound",
+          params.maxBytes,
+        );
+        const label = fetched.fileName ?? file.name;
+        const contentType = effectiveMime ?? saved.contentType;
+        return {
+          path: saved.path,
+          ...(contentType ? { contentType } : {}),
+          placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
+        };
+      } catch {
+        return null;
+      }
+    },
+  );
+
+  const results = resolved.filter((entry): entry is SlackMediaResult => Boolean(entry));
+  return results.length > 0 ? results : null;
+}
+
+/** Extracts text and media from forwarded-message attachments. Returns null when empty. */
+export async function resolveSlackAttachmentContent(params: {
+  attachments?: SlackAttachment[];
+  token: string;
+  maxBytes: number;
+}): Promise<{ text: string; media: SlackMediaResult[] } | null> {
+  const attachments = params.attachments;
+  if (!attachments || attachments.length === 0) {
+    return null;
+  }
+
+  const forwardedAttachments = attachments
+    .filter((attachment) => isForwardedSlackAttachment(attachment))
+    .slice(0, MAX_SLACK_FORWARDED_ATTACHMENTS);
+  if (forwardedAttachments.length === 0) {
+    return null;
+  }
+
+  const textBlocks: string[] = [];
+  const allMedia: SlackMediaResult[] = [];
+
+  for (const att of forwardedAttachments) {
+    const text = att.text?.trim() || att.fallback?.trim();
+    if (text) {
+      const author = att.author_name;
+      const heading = author ? `[Forwarded message from ${author}]` : "[Forwarded message]";
+      textBlocks.push(`${heading}\n${text}`);
     }
-    try {
-      // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
-      // handles size limits internally. Provide a fetcher that uses auth once, then lets
-      // the redirect chain continue without credentials.
-      const fetchImpl = createSlackMediaFetch(params.token);
-      const fetched = await fetchRemoteMedia({
-        url,
-        fetchImpl,
-        filePathHint: file.name,
+
+    const imageUrl = resolveForwardedAttachmentImageUrl(att);
+    if (imageUrl) {
+      try {
+        const fetched = await fetchRemoteMedia({
+          url: imageUrl,
+          maxBytes: params.maxBytes,
+        });
+        if (fetched.buffer.byteLength <= params.maxBytes) {
+          const saved = await saveMediaBuffer(
+            fetched.buffer,
+            fetched.contentType,
+            "inbound",
+            params.maxBytes,
+          );
+          const label = fetched.fileName ?? "forwarded image";
+          allMedia.push({
+            path: saved.path,
+            contentType: fetched.contentType ?? saved.contentType,
+            placeholder: `[Forwarded image: ${label}]`,
+          });
+        }
+      } catch {
+        // Skip images that fail to download
+      }
+    }
+
+    if (att.files && att.files.length > 0) {
+      const fileMedia = await resolveSlackMedia({
+        files: att.files,
+        token: params.token,
         maxBytes: params.maxBytes,
       });
-      if (fetched.buffer.byteLength > params.maxBytes) {
-        continue;
+      if (fileMedia) {
+        allMedia.push(...fileMedia);
       }
-      const saved = await saveMediaBuffer(
-        fetched.buffer,
-        fetched.contentType ?? file.mimetype,
-        "inbound",
-        params.maxBytes,
-      );
-      const label = fetched.fileName ?? file.name;
-      return {
-        path: saved.path,
-        contentType: saved.contentType,
-        placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
-      };
-    } catch {
-      // Ignore download failures and fall through to the next file.
     }
   }
-  return null;
+
+  const combinedText = textBlocks.join("\n\n");
+  if (!combinedText && allMedia.length === 0) {
+    return null;
+  }
+  return { text: combinedText, media: allMedia };
 }
 
 export type SlackThreadStarter = {
@@ -170,17 +323,49 @@ export type SlackThreadStarter = {
   files?: SlackFile[];
 };
 
-const THREAD_STARTER_CACHE = new Map<string, SlackThreadStarter>();
+type SlackThreadStarterCacheEntry = {
+  value: SlackThreadStarter;
+  cachedAt: number;
+};
+
+const THREAD_STARTER_CACHE = new Map<string, SlackThreadStarterCacheEntry>();
+const THREAD_STARTER_CACHE_TTL_MS = 6 * 60 * 60_000;
+const THREAD_STARTER_CACHE_MAX = 2000;
+
+function evictThreadStarterCache(): void {
+  const now = Date.now();
+  for (const [cacheKey, entry] of THREAD_STARTER_CACHE.entries()) {
+    if (now - entry.cachedAt > THREAD_STARTER_CACHE_TTL_MS) {
+      THREAD_STARTER_CACHE.delete(cacheKey);
+    }
+  }
+  if (THREAD_STARTER_CACHE.size <= THREAD_STARTER_CACHE_MAX) {
+    return;
+  }
+  const excess = THREAD_STARTER_CACHE.size - THREAD_STARTER_CACHE_MAX;
+  let removed = 0;
+  for (const cacheKey of THREAD_STARTER_CACHE.keys()) {
+    THREAD_STARTER_CACHE.delete(cacheKey);
+    removed += 1;
+    if (removed >= excess) {
+      break;
+    }
+  }
+}
 
 export async function resolveSlackThreadStarter(params: {
   channelId: string;
   threadTs: string;
   client: SlackWebClient;
 }): Promise<SlackThreadStarter | null> {
+  evictThreadStarterCache();
   const cacheKey = `${params.channelId}:${params.threadTs}`;
   const cached = THREAD_STARTER_CACHE.get(cacheKey);
+  if (cached && Date.now() - cached.cachedAt <= THREAD_STARTER_CACHE_TTL_MS) {
+    return cached.value;
+  }
   if (cached) {
-    return cached;
+    THREAD_STARTER_CACHE.delete(cacheKey);
   }
   try {
     const response = (await params.client.conversations.replies({
@@ -200,9 +385,114 @@ export async function resolveSlackThreadStarter(params: {
       ts: message.ts,
       files: message.files,
     };
-    THREAD_STARTER_CACHE.set(cacheKey, starter);
+    if (THREAD_STARTER_CACHE.has(cacheKey)) {
+      THREAD_STARTER_CACHE.delete(cacheKey);
+    }
+    THREAD_STARTER_CACHE.set(cacheKey, {
+      value: starter,
+      cachedAt: Date.now(),
+    });
+    evictThreadStarterCache();
     return starter;
   } catch {
     return null;
+  }
+}
+
+export function resetSlackThreadStarterCacheForTest(): void {
+  THREAD_STARTER_CACHE.clear();
+}
+
+export type SlackThreadMessage = {
+  text: string;
+  userId?: string;
+  ts?: string;
+  botId?: string;
+  files?: SlackFile[];
+};
+
+type SlackRepliesPageMessage = {
+  text?: string;
+  user?: string;
+  bot_id?: string;
+  ts?: string;
+  files?: SlackFile[];
+};
+
+type SlackRepliesPage = {
+  messages?: SlackRepliesPageMessage[];
+  response_metadata?: { next_cursor?: string };
+};
+
+/**
+ * Fetches the most recent messages in a Slack thread (excluding the current message).
+ * Used to populate thread context when a new thread session starts.
+ *
+ * Uses cursor pagination and keeps only the latest N retained messages so long threads
+ * still produce up-to-date context without unbounded memory growth.
+ */
+export async function resolveSlackThreadHistory(params: {
+  channelId: string;
+  threadTs: string;
+  client: SlackWebClient;
+  currentMessageTs?: string;
+  limit?: number;
+}): Promise<SlackThreadMessage[]> {
+  const maxMessages = params.limit ?? 20;
+  if (!Number.isFinite(maxMessages) || maxMessages <= 0) {
+    return [];
+  }
+
+  // Slack recommends no more than 200 per page.
+  const fetchLimit = 200;
+  const retained: SlackRepliesPageMessage[] = [];
+  let cursor: string | undefined;
+
+  try {
+    do {
+      const response = (await params.client.conversations.replies({
+        channel: params.channelId,
+        ts: params.threadTs,
+        limit: fetchLimit,
+        inclusive: true,
+        ...(cursor ? { cursor } : {}),
+      })) as SlackRepliesPage;
+
+      for (const msg of response.messages ?? []) {
+        // Keep messages with text OR file attachments
+        if (!msg.text?.trim() && !msg.files?.length) {
+          continue;
+        }
+        if (params.currentMessageTs && msg.ts === params.currentMessageTs) {
+          continue;
+        }
+        retained.push(msg);
+        if (retained.length > maxMessages) {
+          retained.shift();
+        }
+      }
+
+      const next = response.response_metadata?.next_cursor;
+      cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
+    } while (cursor);
+
+    return retained.map((msg) => ({
+      // For file-only messages, create a placeholder showing attached filenames
+      text: (() => {
+        const bt = (msg as { blocks?: SlackBlock[] }).blocks?.length
+          ? extractFullTextFromBlocks((msg as { blocks?: SlackBlock[] }).blocks!)
+          : undefined;
+        if (bt) return bt;
+        return msg.text?.trim()
+          ? msg.text
+          : `[attached: ${msg.files?.map((f) => f.name ?? "file").join(", ")}]`;
+      })(),
+      userId: msg.user,
+      botId: msg.bot_id,
+      ts: msg.ts,
+      files: msg.files,
+    }));
+  } catch {
+    return [];
   }
 }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -1,13 +1,8 @@
-import type { FinalizedMsgContext } from "../../../auto-reply/templating.js";
-import type { ResolvedSlackAccount } from "../../accounts.js";
-import type { SlackMessageEvent } from "../../types.js";
-import type { PreparedSlackMessage } from "./types.js";
 import { resolveAckReaction } from "../../../agents/identity.js";
 import { hasControlCommand } from "../../../auto-reply/command-detection.js";
 import { shouldHandleTextCommands } from "../../../auto-reply/commands-registry.js";
 import {
   formatInboundEnvelope,
-  formatThreadStarterEnvelope,
   resolveEnvelopeFormatOptions,
 } from "../../../auto-reply/envelope.js";
 import {
@@ -19,6 +14,7 @@ import {
   buildMentionRegexes,
   matchesMentionWithExplicit,
 } from "../../../auto-reply/reply/mentions.js";
+import type { FinalizedMsgContext } from "../../../auto-reply/templating.js";
 import {
   shouldAckReaction as shouldAckReactionGate,
   type AckReactionScope,
@@ -36,15 +32,26 @@ import { buildPairingReply } from "../../../pairing/pairing-messages.js";
 import { upsertChannelPairingRequest } from "../../../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
-import { buildUntrustedChannelMetadata } from "../../../security/channel-metadata.js";
+import type { ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
 import { sendMessageSlack } from "../../send.js";
 import { resolveSlackThreadContext } from "../../threading.js";
+import type { SlackMessageEvent } from "../../types.js";
+import { extractFullTextFromBlocks } from "../../blocks-fallback.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-list.js";
 import { resolveSlackEffectiveAllowFrom } from "../auth.js";
 import { resolveSlackChannelConfig } from "../channel-config.js";
+import { stripSlackMentionsForCommandDetection } from "../commands.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
-import { resolveSlackMedia, resolveSlackThreadStarter } from "../media.js";
+import {
+  resolveSlackAttachmentContent,
+  MAX_SLACK_MEDIA_FILES,
+  resolveSlackMedia,
+  resolveSlackThreadHistory,
+  resolveSlackThreadStarter,
+} from "../media.js";
+import { resolveSlackRoomContextHints } from "../room-context.js";
+import type { PreparedSlackMessage } from "./types.js";
 
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
@@ -121,7 +128,9 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const { allowFromLower } = await resolveSlackEffectiveAllowFrom(ctx);
+  const { allowFromLower } = await resolveSlackEffectiveAllowFrom(ctx, {
+    includePairingStore: isDirectMessage,
+  });
 
   if (isDirectMessage) {
     const directUserId = message.user;
@@ -137,6 +146,7 @@ export async function prepareSlackMessage(params: {
       const allowMatch = resolveSlackAllowListMatch({
         allowList: allowFromLower,
         id: directUserId,
+        allowNameMatching: ctx.allowNameMatching,
       });
       const allowMatchMeta = formatAllowlistMatchMeta(allowMatch);
       if (!allowMatch.allowed) {
@@ -146,6 +156,7 @@ export async function prepareSlackMessage(params: {
           const { code, created } = await upsertChannelPairingRequest({
             channel: "slack",
             id: directUserId,
+            accountId: account.accountId,
             meta: { name: senderName },
           });
           if (created) {
@@ -188,7 +199,7 @@ export async function prepareSlackMessage(params: {
     accountId: account.accountId,
     teamId: ctx.teamId || undefined,
     peer: {
-      kind: isDirectMessage ? "dm" : isRoom ? "channel" : "group",
+      kind: isDirectMessage ? "direct" : isRoom ? "channel" : "group",
       id: isDirectMessage ? (message.user ?? "unknown") : message.channel,
     },
   });
@@ -239,6 +250,7 @@ export async function prepareSlackMessage(params: {
         allowList: channelConfig?.users,
         userId: senderId,
         userName: senderName,
+        allowNameMatching: ctx.allowNameMatching,
       })
     : true;
   if (isRoom && !channelUserAuthorized) {
@@ -250,12 +262,15 @@ export async function prepareSlackMessage(params: {
     cfg,
     surface: "slack",
   });
-  const hasControlCommandInMessage = hasControlCommand(message.text ?? "", cfg);
+  // Strip Slack mentions (<@U123>) before command detection so "@Labrador /new" is recognized
+  const textForCommandDetection = stripSlackMentionsForCommandDetection(message.text ?? "");
+  const hasControlCommandInMessage = hasControlCommand(textForCommandDetection, cfg);
 
   const ownerAuthorized = resolveSlackAllowListMatch({
     allowList: allowFromLower,
     id: senderId,
     name: senderName,
+    allowNameMatching: ctx.allowNameMatching,
   }).allowed;
   const channelUsersAllowlistConfigured =
     isRoom && Array.isArray(channelConfig?.users) && channelConfig.users.length > 0;
@@ -265,6 +280,7 @@ export async function prepareSlackMessage(params: {
           allowList: channelConfig?.users,
           userId: senderId,
           userName: senderName,
+          allowNameMatching: ctx.allowNameMatching,
         })
       : false;
   const commandGate = resolveControlCommandGate({
@@ -336,12 +352,47 @@ export async function prepareSlackMessage(params: {
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
+
+  // Resolve forwarded message content (text + media) from Slack attachments
+  const attachmentContent = await resolveSlackAttachmentContent({
+    attachments: message.attachments,
+    token: ctx.botToken,
+    maxBytes: ctx.mediaMaxBytes,
+  });
+
+  // Merge forwarded media into the message's media array
+  const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
+  const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;
+
+  const mediaPlaceholder = effectiveDirectMedia
+    ? effectiveDirectMedia.map((m) => m.placeholder).join(" ")
+    : undefined;
+
+  // When files were attached but all downloads failed, create a fallback
+  // placeholder so the message is still delivered to the agent instead of
+  // being silently dropped (#25064).
+  const fileOnlyFallback =
+    !mediaPlaceholder && (message.files?.length ?? 0) > 0
+      ? message
+          .files!.slice(0, MAX_SLACK_MEDIA_FILES)
+          .map((f) => f.name?.trim() || "file")
+          .join(", ")
+      : undefined;
+  const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;
+
+  const blocksText = message.blocks?.length ? extractFullTextFromBlocks(message.blocks) : undefined;
+  const rawBody =
+    [blocksText || (message.text ?? "").trim(), attachmentContent?.text, mediaPlaceholder, fileOnlyPlaceholder]
+      .filter(Boolean)
+      .join("\n") || "";
   if (!rawBody) {
     return null;
   }
 
-  const ackReaction = resolveAckReaction(cfg, route.agentId);
+  const ackReaction = resolveAckReaction(cfg, route.agentId, {
+    channel: "slack",
+    accountId: account.accountId,
+  });
   const ackReactionValue = ackReaction ?? "";
 
   const shouldAckReaction = () =>
@@ -397,7 +448,11 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       From: slackFrom,
     }) ?? (isDirectMessage ? senderName : roomLabel);
-  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}]`;
+  const threadInfo =
+    isThreadReply && threadTs
+      ? ` thread_ts: ${threadTs}${message.parent_user_id ? ` parent_user_id: ${message.parent_user_id}` : ""}`
+      : "";
+  const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}${threadInfo}]`;
   const storePath = resolveStorePath(ctx.cfg.session?.store, {
     agentId: route.agentId,
   });
@@ -441,20 +496,15 @@ export async function prepareSlackMessage(params: {
 
   const slackTo = isDirectMessage ? `user:${message.user}` : `channel:${message.channel}`;
 
-  const untrustedChannelMetadata = isRoomish
-    ? buildUntrustedChannelMetadata({
-        source: "slack",
-        label: "Slack channel description",
-        entries: [channelInfo?.topic, channelInfo?.purpose],
-      })
-    : undefined;
-  const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
-  const groupSystemPrompt =
-    systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+  const { untrustedChannelMetadata, groupSystemPrompt } = resolveSlackRoomContextHints({
+    isRoomish,
+    channelInfo,
+    channelConfig,
+  });
 
   let threadStarterBody: string | undefined;
+  let threadHistoryBody: string | undefined;
+  let threadSessionPreviousTimestamp: number | undefined;
   let threadLabel: string | undefined;
   let threadStarterMedia: Awaited<ReturnType<typeof resolveSlackMedia>> = null;
   if (isThreadReply && threadTs) {
@@ -464,41 +514,104 @@ export async function prepareSlackMessage(params: {
       client: ctx.app.client,
     });
     if (starter?.text) {
-      const starterUser = starter.userId ? await ctx.resolveUserName(starter.userId) : null;
-      const starterName = starterUser?.name ?? starter.userId ?? "Unknown";
-      const starterWithId = `${starter.text}\n[slack message id: ${starter.ts ?? threadTs} channel: ${message.channel}]`;
-      threadStarterBody = formatThreadStarterEnvelope({
-        channel: "Slack",
-        author: starterName,
-        timestamp: starter.ts ? Math.round(Number(starter.ts) * 1000) : undefined,
-        body: starterWithId,
-        envelope: envelopeOptions,
-      });
+      // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
+      threadStarterBody = starter.text;
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
       threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
       // If current message has no files but thread starter does, fetch starter's files
-      if (!media && starter.files && starter.files.length > 0) {
+      if (!effectiveDirectMedia && starter.files && starter.files.length > 0) {
         threadStarterMedia = await resolveSlackMedia({
           files: starter.files,
           token: ctx.botToken,
           maxBytes: ctx.mediaMaxBytes,
         });
         if (threadStarterMedia) {
+          const starterPlaceholders = threadStarterMedia.map((m) => m.placeholder).join(", ");
           logVerbose(
-            `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,
+            `slack: hydrated thread starter file ${starterPlaceholders} from root message`,
           );
         }
       }
     } else {
       threadLabel = `Slack thread ${roomLabel}`;
     }
+
+    // Fetch full thread history for new thread sessions
+    // This provides context of previous messages (including bot replies) in the thread
+    // Use the thread session key (not base session key) to determine if this is a new session
+    const threadInitialHistoryLimit = account.config?.thread?.initialHistoryLimit ?? 20;
+    threadSessionPreviousTimestamp = readSessionUpdatedAt({
+      storePath,
+      sessionKey, // Thread-specific session key
+    });
+    if (threadInitialHistoryLimit > 0) {
+      const threadHistory = await resolveSlackThreadHistory({
+        channelId: message.channel,
+        threadTs,
+        client: ctx.app.client,
+        currentMessageTs: message.ts,
+        limit: threadInitialHistoryLimit,
+      });
+
+      if (threadHistory.length > 0) {
+        // Batch resolve user names to avoid N sequential API calls
+        const uniqueUserIds = [
+          ...new Set(threadHistory.map((m) => m.userId).filter((id): id is string => Boolean(id))),
+        ];
+        const userMap = new Map<string, { name?: string }>();
+        await Promise.all(
+          uniqueUserIds.map(async (id) => {
+            const user = await ctx.resolveUserName(id);
+            if (user) {
+              userMap.set(id, user);
+            }
+          }),
+        );
+
+        const historyParts: string[] = [];
+        for (const historyMsg of threadHistory) {
+          const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
+          const msgSenderName =
+            msgUser?.name ?? (historyMsg.botId ? `Bot (${historyMsg.botId})` : "Unknown");
+          const isBot = Boolean(historyMsg.botId);
+          const role = isBot ? "assistant" : "user";
+          const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${message.channel}]`;
+          historyParts.push(
+            formatInboundEnvelope({
+              channel: "Slack",
+              from: `${msgSenderName} (${role})`,
+              timestamp: historyMsg.ts ? Math.round(Number(historyMsg.ts) * 1000) : undefined,
+              body: msgWithId,
+              chatType: "channel",
+              envelope: envelopeOptions,
+            }),
+          );
+        }
+        threadHistoryBody = historyParts.join("\n\n");
+        logVerbose(
+          `slack: populated thread history with ${threadHistory.length} messages for new session`,
+        );
+      }
+    }
   }
 
-  // Use thread starter media if current message has none
-  const effectiveMedia = media ?? threadStarterMedia;
+  // Use direct media (including forwarded attachment media) if available, else thread starter media
+  const effectiveMedia = effectiveDirectMedia ?? threadStarterMedia;
+  const firstMedia = effectiveMedia?.[0];
+
+  const inboundHistory =
+    isRoomish && ctx.historyLimit > 0
+      ? (ctx.channelHistories.get(historyKey) ?? []).map((entry) => ({
+          sender: entry.sender,
+          body: entry.body,
+          timestamp: entry.timestamp,
+        }))
+      : undefined;
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
+    BodyForAgent: rawBody,
+    InboundHistory: inboundHistory,
     RawBody: rawBody,
     CommandBody: rawBody,
     From: slackFrom,
@@ -520,12 +633,23 @@ export async function prepareSlackMessage(params: {
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
     ThreadStarterBody: threadStarterBody,
+    ThreadHistoryBody: threadHistoryBody,
+    IsFirstThreadTurn:
+      isThreadReply && threadTs && !threadSessionPreviousTimestamp ? true : undefined,
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: effectiveMedia?.path,
-    MediaType: effectiveMedia?.contentType,
-    MediaUrl: effectiveMedia?.path,
+    MediaPath: firstMedia?.path,
+    MediaType: firstMedia?.contentType,
+    MediaUrl: firstMedia?.path,
+    MediaPaths:
+      effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
+    MediaUrls:
+      effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
+    MediaTypes:
+      effectiveMedia && effectiveMedia.length > 0
+        ? effectiveMedia.map((m) => m.contentType ?? "")
+        : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,
@@ -541,6 +665,7 @@ export async function prepareSlackMessage(params: {
           channel: "slack",
           to: `user:${message.user}`,
           accountId: route.accountId,
+          threadId: threadContext.messageThreadId,
         }
       : undefined,
     onRecordError: (err) => {

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -2,9 +2,44 @@ export type SlackFile = {
   id?: string;
   name?: string;
   mimetype?: string;
+  subtype?: string;
   size?: number;
   url_private?: string;
   url_private_download?: string;
+};
+
+export type SlackAttachment = {
+  fallback?: string;
+  text?: string;
+  pretext?: string;
+  author_name?: string;
+  author_id?: string;
+  from_url?: string;
+  ts?: string;
+  channel_name?: string;
+  channel_id?: string;
+  is_msg_unfurl?: boolean;
+  is_share?: boolean;
+  image_url?: string;
+  image_width?: number;
+  image_height?: number;
+  thumb_url?: string;
+  files?: SlackFile[];
+  message_blocks?: unknown[];
+};
+
+export type SlackBlockElement = {
+  type?: string;
+  text?: string;
+};
+
+export type SlackBlock = {
+  type?: string;
+  block_id?: string;
+  text?: { type?: string; text?: string };
+  elements?: SlackBlockElement[];
+  alt_text?: string;
+  title?: { type?: string; text?: string };
 };
 
 export type SlackMessageEvent = {
@@ -21,6 +56,8 @@ export type SlackMessageEvent = {
   channel: string;
   channel_type?: "im" | "mpim" | "channel" | "group";
   files?: SlackFile[];
+  attachments?: SlackAttachment[];
+  blocks?: SlackBlock[];
 };
 
 export type SlackAppMentionEvent = {
@@ -35,4 +72,6 @@ export type SlackAppMentionEvent = {
   parent_user_id?: string;
   channel: string;
   channel_type?: "im" | "mpim" | "channel" | "group";
+  attachments?: SlackAttachment[];
+  blocks?: SlackBlock[];
 };


### PR DESCRIPTION
## Problem

Bot-to-bot Slack messages are truncated because:
1. **Inbound**: `prepare.ts` only reads `message.text`, ignoring `message.blocks` (where full content lives for bot messages)
2. **Outbound**: `buildSlackBlocksFallbackText` returns text from only the FIRST block instead of concatenating all blocks

When bots send messages using Block Kit, Slack sets `message.text` to a truncated ~40 char fallback. The actual content is in `message.blocks`.

## Changes

### `src/slack/types.ts`
- Added `SlackBlockElement` and `SlackBlock` types
- Added `blocks?: SlackBlock[]` to `SlackMessageEvent` and `SlackAppMentionEvent`

### `src/slack/blocks-fallback.ts`
- Added `extractFullTextFromBlocks()` — extracts and concatenates text from all section, header, and context blocks
- Fixed `buildSlackBlocksFallbackText()` to collect text from ALL blocks instead of returning on first match

### `src/slack/monitor/message-handler/prepare.ts`
- When building `rawBody`, extract text from `message.blocks` and prefer it over `message.text`

### `src/slack/monitor/media.ts`
- Same fix for thread history: prefer blocks text over `msg.text`

## Testing
- `pnpm build` ✅
- Existing `blocks-fallback.test.ts` tests pass ✅ (3/3)