### PR TITLE
Release: publish safe-ops and skill usage kit

### DIFF
--- a/docs/safe-ops-and-skill-usage/quickstart.md
+++ b/docs/safe-ops-and-skill-usage/quickstart.md
@@ -1,0 +1,70 @@
+---
+summary: "Install and enable OpenClaw safe operations plus skill usage tracking."
+read_when:
+  - You want to share safety and usage features with others
+  - You need a minimal setup checklist for a fresh machine
+title: "Safe Ops and Skill Usage Quickstart"
+---
+
+# Safe Ops and Skill Usage Quickstart
+
+This guide helps you ship and consume two features together:
+
+- Safe operations guardrail (`openclaw-safe-ops`)
+- Skill usage tracking (`openclaw skills usage`)
+
+## Scope and safety defaults
+
+Only share these artifacts:
+
+- `scripts/openclaw-safe.sh`
+- `skills/openclaw-safe-ops/SKILL.md`
+- `skills/skill-usage-tracker/SKILL.md`
+- `src/agents/skills-usage-store.ts`
+- `src/agents/skills-usage-tracker.ts`
+- `src/auto-reply/reply/get-reply-inline-actions.ts`
+- `src/commands/agent.ts`
+- `src/cli/skills-cli.ts`
+- Related tests under `src/agents`, `src/cli`, and `src/commands`
+- `openclaw.example.json` (template only)
+
+Never share local runtime state such as `~/.openclaw/openclaw.json` or any real credentials.
+
+## Install
+
+```bash
+pnpm install
+```
+
+Optional alias for safer high-risk operations:
+
+```bash
+alias ocl-safe="/absolute/path/to/openclaw/scripts/openclaw-safe.sh"
+```
+
+## Configure (template-first)
+
+Copy from template and fill your own values:
+
+```bash
+cp openclaw.example.json ~/.openclaw/openclaw.json
+```
+
+Then replace placeholders with real values on the target machine.
+
+## Use
+
+- Run high-risk changes through wrapper:
+  - `ocl-safe gateway restart`
+  - `ocl-safe config set ...`
+  - `ocl-safe plugins update ...`
+- Check usage counters:
+  - `openclaw skills usage`
+  - `openclaw skills usage --format json`
+  - `openclaw skills usage --format markdown`
+
+Related:
+
+- [skills CLI](/cli/skills)
+- [Skills](/tools/skills)
+- [ClawHub](/tools/clawhub)

--- a/docs/safe-ops-and-skill-usage/release.md
+++ b/docs/safe-ops-and-skill-usage/release.md
@@ -1,0 +1,61 @@
+---
+summary: "Publish checklist for GitHub and ClawHub with a single version and release note."
+read_when:
+  - You are publishing these two features externally
+  - You need a consistent release process across channels
+title: "Safe Ops and Skill Usage Release"
+---
+
+# Safe Ops and Skill Usage Release
+
+This checklist keeps GitHub and ClawHub releases consistent.
+
+## Pre-release checks
+
+1. Run tests for skill usage changes.
+2. Run the verification checklist from [Verification](/safe-ops-and-skill-usage/verify).
+3. Confirm no secrets or local state files are included.
+
+## Versioning
+
+Use one version string for both channels (for example `2026.2.27-safe-ops-skill-usage.1`).
+
+## Release note template
+
+Use the exact same note on both GitHub and ClawHub:
+
+```text
+Includes:
+- Safe operations guardrail via openclaw-safe-ops and scripts/openclaw-safe.sh
+- Skill usage tracking with JSON diagnostics (mapped/unmapped split + attribution strategy version)
+
+Verification:
+- openclaw-safe.sh --dry-run gateway restart
+- openclaw skills usage
+- openclaw skills usage --format json
+- openclaw skills usage --format markdown
+- one explicit skill command run confirms commandCalls increments
+
+Known boundaries:
+- Shell-based skills may show low mappedToolCalls because they do not dispatch OpenClaw tools directly.
+```
+
+## Publish steps
+
+### GitHub
+
+1. Create tag from the verified commit.
+2. Create release with the shared release note.
+3. Attach verification output if required by your workflow.
+
+### ClawHub
+
+1. Publish using the same version string.
+2. Paste the same release note text.
+3. Confirm install and update metadata is visible.
+
+## Post-release sanity
+
+- Install from GitHub path and run verification.
+- Install from ClawHub path and run verification.
+- Compare outputs; they must match the same feature set.

--- a/docs/safe-ops-and-skill-usage/scope.md
+++ b/docs/safe-ops-and-skill-usage/scope.md
@@ -1,0 +1,49 @@
+---
+summary: "Release scope lock for shipping only safe-ops and skill-usage features."
+read_when:
+  - You want to prevent unrelated changes from being published
+  - You need a whitelist before creating release commits
+title: "Safe Ops and Skill Usage Scope Lock"
+---
+
+# Safe Ops and Skill Usage Scope Lock
+
+Use this whitelist before commit and release.
+
+## Include
+
+- `scripts/openclaw-safe.sh`
+- `skills/openclaw-safe-ops/SKILL.md`
+- `skills/skill-usage-tracker/SKILL.md`
+- `src/agents/skills-usage-store.ts`
+- `src/agents/skills-usage-tracker.ts`
+- `src/agents/skills/workspace.ts`
+- `src/agents/skills-install.ts`
+- `src/auto-reply/reply/get-reply-inline-actions.ts`
+- `src/commands/agent.ts`
+- `src/gateway/server.impl.ts`
+- `src/cli/skills-cli.ts`
+- `src/agents/skills-usage-store.test.ts`
+- `src/agents/skills-usage-tracker.test.ts`
+- `src/commands/agent.test.ts`
+- `src/cli/skills-cli.usage.test.ts`
+- `openclaw.example.json`
+- `docs/safe-ops-and-skill-usage/*`
+
+## Exclude
+
+- Any file under `.cursor/`
+- Any file under `~/.openclaw/`
+- Temporary logs and local scripts
+- Unrelated feature branches and experiments
+
+## Quick check
+
+Before release:
+
+```bash
+git status --short
+git diff --name-only
+```
+
+If any changed file is outside the include list, stop and split the release.

--- a/docs/safe-ops-and-skill-usage/security.md
+++ b/docs/safe-ops-and-skill-usage/security.md
@@ -1,0 +1,47 @@
+---
+summary: "Security rules for shipping safe operations and skill usage tracking."
+read_when:
+  - You are preparing a public release
+  - You need to avoid leaking local credentials or runtime state
+title: "Safe Ops and Skill Usage Security"
+---
+
+# Safe Ops and Skill Usage Security
+
+Use these rules when sharing to GitHub or ClawHub.
+
+## Never publish local runtime state
+
+Do not publish:
+
+- `~/.openclaw/openclaw.json`
+- `~/.openclaw/credentials/*`
+- `~/.openclaw/sessions/*`
+- Any file containing real tokens, phone numbers, or hostnames
+
+Publish only `openclaw.example.json` as a template.
+
+## Keep release scope minimal
+
+Only include files required by:
+
+- Safe operations workflow (`openclaw-safe-ops`)
+- Skill usage tracker and CLI output
+
+Exclude unrelated experiments, local plan files, and temporary scripts.
+
+## Required guardrails
+
+- For risky actions, prefer `scripts/openclaw-safe.sh`.
+- Run verification checklist before every release.
+- Fail closed: if verification fails, do not publish.
+
+## Release wording consistency
+
+Use the same release summary for GitHub and ClawHub:
+
+- What is included
+- How to verify
+- Known boundaries (for example, shell-based skills may have lower mapped-tool attribution)
+
+This keeps user expectations aligned across channels.

--- a/docs/safe-ops-and-skill-usage/verify.md
+++ b/docs/safe-ops-and-skill-usage/verify.md
@@ -1,0 +1,70 @@
+---
+summary: "Verification checklist for safe operations and skill usage tracking."
+read_when:
+  - You want to confirm both shared features work after install
+  - You need release acceptance criteria before publishing
+title: "Safe Ops and Skill Usage Verification"
+---
+
+# Safe Ops and Skill Usage Verification
+
+Run this checklist on a clean target machine before publishing.
+
+## 1) Safe wrapper dry-run
+
+```bash
+./scripts/openclaw-safe.sh --dry-run gateway restart
+```
+
+Expected:
+
+- Command exits successfully.
+- Output indicates dry-run execution without changing runtime state.
+
+## 2) Usage commands available
+
+```bash
+openclaw skills usage
+openclaw skills usage --format json
+openclaw skills usage --format markdown
+```
+
+Expected:
+
+- All three commands return successfully.
+- JSON output includes summary and tracker sections.
+
+## 3) JSON diagnostics fields
+
+Validate these fields exist in `--format json` output:
+
+- `summary.mappedToolCallsTotal`
+- `summary.mappedByRunContext`
+- `summary.mappedByStaticDispatch`
+- `summary.unmappedToolCalls`
+- `summary.mappingCoverage`
+- `summary.attributionStrategy`
+- `summary.attributionStrategyVersion`
+- `tracker.runCacheEntries`
+
+## 4) Explicit skill command increments `commandCalls`
+
+Trigger one explicit skill command from a local run:
+
+```bash
+openclaw agent --local --message "/weather Beijing" --to +15550001111 --timeout 5
+openclaw skills usage --format json
+```
+
+Expected:
+
+- The related skill row shows `commandCalls` increased by at least 1.
+
+## 5) Registration sanity
+
+Ensure these skills are present in usage rows:
+
+- `openclaw-safe-ops`
+- `skill-usage-tracker`
+
+If any check fails, block publishing and fix before release.

--- a/openclaw.example.json
+++ b/openclaw.example.json
@@ -1,0 +1,18 @@
+{
+  "gateway": {
+    "bind": "loopback",
+    "port": 18789
+  },
+  "channels": {
+    "dingtalk-connector": {
+      "enabled": true,
+      "clientId": "YOUR_DINGTALK_CLIENT_ID",
+      "clientSecret": "YOUR_DINGTALK_CLIENT_SECRET",
+      "dmPolicy": "pairing",
+      "allowFrom": ["YOUR_DINGTALK_USER_ID"]
+    }
+  },
+  "plugins": {
+    "allow": ["dingtalk-connector"]
+  }
+}

--- a/scripts/openclaw-safe.sh
+++ b/scripts/openclaw-safe.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  openclaw-safe.sh [--dry-run] [--no-health-check] <openclaw args...>
+
+Examples:
+  ./scripts/openclaw-safe.sh gateway restart
+  ./scripts/openclaw-safe.sh plugins update dingtalk-connector
+  ./scripts/openclaw-safe.sh --dry-run config set channels.dingtalk-connector.dmPolicy pairing
+
+Behavior:
+  - Detects high-risk OpenClaw operations.
+  - Creates a timestamped backup of ~/.openclaw/openclaw.json before risky changes.
+  - Runs post-change health checks.
+  - On failure, restores config from backup and restarts gateway.
+EOF
+}
+
+log() {
+  printf '[openclaw-safe] %s\n' "$*"
+}
+
+is_high_risk() {
+  local args="$*"
+  [[ "$args" =~ (^|[[:space:]])gateway[[:space:]]+(restart|start|stop|install|uninstall|run|status)($|[[:space:]]) ]] && return 0
+  [[ "$args" =~ (^|[[:space:]])config[[:space:]]+(set|unset)($|[[:space:]]) ]] && return 0
+  [[ "$args" =~ (^|[[:space:]])plugins[[:space:]]+(install|update|uninstall|enable|disable)($|[[:space:]]) ]] && return 0
+  [[ "$args" =~ openclaw\.json ]] && return 0
+  return 1
+}
+
+DRY_RUN=0
+NO_HEALTH_CHECK=0
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-health-check)
+      NO_HEALTH_CHECK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-$STATE_DIR/openclaw.json}"
+TS="$(date +%Y%m%d-%H%M%S)"
+SAFE_BACKUP="$STATE_DIR/openclaw.json.safe.${TS}.bak"
+BACKUP_CREATED=0
+CMD_STR="${POSITIONAL[*]}"
+
+if is_high_risk "$CMD_STR"; then
+  if [[ -f "$CONFIG_PATH" ]]; then
+    log "High-risk command detected: $CMD_STR"
+    log "Creating backup: $SAFE_BACKUP"
+    if [[ "$DRY_RUN" -eq 0 ]]; then
+      cp "$CONFIG_PATH" "$SAFE_BACKUP"
+      BACKUP_CREATED=1
+    fi
+  else
+    log "Config file not found at $CONFIG_PATH; skipping manual backup."
+  fi
+else
+  log "Command not flagged as high-risk; running directly."
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "Dry-run: would run -> pnpm openclaw ${POSITIONAL[*]}"
+  exit 0
+fi
+
+set +e
+pnpm openclaw "${POSITIONAL[@]}"
+CMD_EXIT=$?
+set -e
+
+health_check() {
+  if [[ "$NO_HEALTH_CHECK" -eq 1 ]]; then
+    log "Skipping health checks (--no-health-check)."
+    return 0
+  fi
+
+  log "Running health checks..."
+  pnpm openclaw channels status --probe >/dev/null
+  pnpm openclaw status --deep >/dev/null
+}
+
+if [[ "$CMD_EXIT" -ne 0 ]]; then
+  log "Command failed with exit code $CMD_EXIT."
+  if [[ "$BACKUP_CREATED" -eq 1 && -f "$SAFE_BACKUP" ]]; then
+    log "Restoring config from backup: $SAFE_BACKUP"
+    cp "$SAFE_BACKUP" "$CONFIG_PATH"
+    log "Restarting gateway after rollback..."
+    pnpm openclaw gateway restart >/dev/null || true
+  fi
+  exit "$CMD_EXIT"
+fi
+
+if ! health_check; then
+  log "Post-change health check failed."
+  if [[ "$BACKUP_CREATED" -eq 1 && -f "$SAFE_BACKUP" ]]; then
+    log "Rolling back config: $SAFE_BACKUP"
+    cp "$SAFE_BACKUP" "$CONFIG_PATH"
+    log "Restarting gateway after rollback..."
+    pnpm openclaw gateway restart >/dev/null || true
+  fi
+  exit 2
+fi
+
+log "Command and health checks succeeded."
+if [[ "$BACKUP_CREATED" -eq 1 ]]; then
+  log "Backup kept at: $SAFE_BACKUP"
+fi

--- a/skills/openclaw-safe-ops/SKILL.md
+++ b/skills/openclaw-safe-ops/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: openclaw-safe-ops
+description: Execute high-risk OpenClaw operations with backup, health checks, and rollback. Use when running gateway restart/start/stop/install/uninstall/run, config set/unset, plugins install/update/uninstall/enable/disable, or editing openclaw.json.
+metadata: { "openclaw": { "emoji": "🛟", "skillKey": "openclaw-safe-ops" } }
+---
+
+# OpenClaw Safe Ops
+
+Use this workflow whenever an operation can break OpenClaw runtime or channel connectivity.
+
+## High-Risk Operations
+
+- `openclaw gateway restart|start|stop|install|uninstall|run|status`
+- `openclaw config set|unset`
+- `openclaw plugins install|update|uninstall|enable|disable`
+- Any change touching `~/.openclaw/openclaw.json`
+
+## Preferred Execution Path
+
+Run risky commands through the safety wrapper first:
+
+```bash
+./scripts/openclaw-safe.sh <openclaw args...>
+```
+
+Examples:
+
+```bash
+./scripts/openclaw-safe.sh gateway restart
+./scripts/openclaw-safe.sh config set channels.dingtalk-connector.dmPolicy pairing
+./scripts/openclaw-safe.sh plugins update dingtalk-connector
+```
+
+## Manual Fallback Workflow
+
+If wrapper is unavailable, execute this sequence exactly:
+
+1. Backup config:
+   - `cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.manual.$(date +%Y%m%d-%H%M%S).bak`
+2. Run one risky command only.
+3. Validate immediately:
+   - `openclaw channels status --probe`
+   - `openclaw status --deep`
+4. If validation fails:
+   - `cp ~/.openclaw/openclaw.json.bak ~/.openclaw/openclaw.json`
+   - `openclaw gateway restart`
+   - `openclaw status --deep`
+
+## Reporting Format
+
+After each risky operation, report:
+
+- Command executed
+- Backup path used
+- Health check result
+- Rollback status (applied or not)

--- a/skills/skill-usage-tracker/SKILL.md
+++ b/skills/skill-usage-tracker/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: skill-usage-tracker
+description: Track OpenClaw skill invocation counts and export usage reports.
+metadata: { "openclaw": { "emoji": "📊", "skillKey": "skill-usage-tracker" } }
+---
+
+# Skill Usage Tracker
+
+This skill documents the built-in usage telemetry for OpenClaw skills.
+
+## What Gets Counted
+
+- Explicit skill command invocations (for example `/skill foo ...` or `/<skill-command> ...`)
+- Mapped tool calls inferred from tool-event streams
+- Newly discovered or installed skills are auto-registered with zero counts
+
+## View Usage
+
+Use the CLI command:
+
+```bash
+openclaw skills usage
+```
+
+## Export Formats
+
+```bash
+openclaw skills usage --format json
+openclaw skills usage --format csv
+openclaw skills usage --format markdown
+```
+
+## Filters
+
+```bash
+openclaw skills usage --top 20
+openclaw skills usage --since 2026-02-26T00:00:00Z
+```

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -7,6 +7,7 @@ import { scanDirectoryWithSummary } from "../security/skill-scanner.js";
 import { resolveUserPath } from "../utils.js";
 import { installDownloadSpec } from "./skills-install-download.js";
 import { formatInstallFailureMessage } from "./skills-install-output.js";
+import { registerSkillsUsageEntries } from "./skills-usage-store.js";
 import {
   hasBinary,
   loadWorkspaceSkillEntries,
@@ -420,6 +421,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
   }
   if (spec.kind === "download") {
     const downloadResult = await installDownloadSpec({ entry, spec, timeoutMs });
+    if (downloadResult.ok) {
+      await registerSkillsUsageEntries([entry.skill.name]);
+    }
     return withWarnings(downloadResult, warnings);
   }
 
@@ -466,5 +470,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
     }
   }
 
-  return withWarnings(await executeInstallCommand({ argv, timeoutMs, env }), warnings);
+  const installResult = await executeInstallCommand({ argv, timeoutMs, env });
+  if (installResult.ok) {
+    await registerSkillsUsageEntries([entry.skill.name]);
+  }
+  return withWarnings(installResult, warnings);
 }

--- a/src/agents/skills-usage-store.test.ts
+++ b/src/agents/skills-usage-store.test.ts
@@ -26,7 +26,7 @@ afterEach(async () => {
   );
 });
 
-describe("skills-usage-store", () => {
+describe.sequential("skills-usage-store", () => {
   it("registers skills and increments command/mapped counters", async () => {
     await withTempStateDir();
     const mod = await import("./skills-usage-store.js");

--- a/src/agents/skills-usage-store.test.ts
+++ b/src/agents/skills-usage-store.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+const tempDirs: string[] = [];
+
+async function withTempStateDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-usage-"));
+  tempDirs.push(dir);
+  process.env.OPENCLAW_STATE_DIR = dir;
+  vi.resetModules();
+  return dir;
+}
+
+afterEach(async () => {
+  if (ORIGINAL_STATE_DIR === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+  }
+  vi.resetModules();
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("skills-usage-store", () => {
+  it("registers skills and increments command/mapped counters", async () => {
+    await withTempStateDir();
+    const mod = await import("./skills-usage-store.js");
+    await mod.registerSkillsUsageEntries(["skill-a", "skill-b"]);
+    await mod.incrementSkillCommandUsage("skill-a");
+    await mod.incrementMappedToolUsage(["skill-a", "skill-b"]);
+
+    const store = await mod.loadSkillsUsageStore();
+    const skillA = store.skills["skill-a"];
+    const skillB = store.skills["skill-b"];
+    expect(skillA?.commandCalls).toBe(1);
+    expect(skillA?.mappedToolCalls).toBe(1);
+    expect(skillA?.totalCalls).toBe(2);
+    expect(skillB?.commandCalls).toBe(0);
+    expect(skillB?.mappedToolCalls).toBe(1);
+    expect(skillB?.totalCalls).toBe(1);
+    expect(store.meta.unmappedToolCalls).toBe(0);
+    expect(store.meta.mappedByRunContext).toBe(0);
+    expect(store.meta.mappedByStaticDispatch).toBe(0);
+  });
+
+  it("increments unmapped tool counters", async () => {
+    await withTempStateDir();
+    const mod = await import("./skills-usage-store.js");
+    await mod.incrementUnmappedToolUsage();
+    await mod.incrementUnmappedToolUsage(2);
+    await mod.incrementMappedByRunContextUsage(3);
+    await mod.incrementMappedByStaticDispatchUsage(4);
+    const store = await mod.loadSkillsUsageStore();
+    expect(store.meta.unmappedToolCalls).toBe(3);
+    expect(store.meta.mappedByRunContext).toBe(3);
+    expect(store.meta.mappedByStaticDispatch).toBe(4);
+  });
+
+  it("falls back to .bak when primary file is invalid", async () => {
+    const stateDir = await withTempStateDir();
+    const mod = await import("./skills-usage-store.js");
+    const storePath = mod.resolveSkillsUsageStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, "{not-json", "utf-8");
+    await fs.writeFile(
+      `${storePath}.bak`,
+      JSON.stringify({
+        version: 1,
+        updatedAt: "2026-02-26T00:00:00.000Z",
+        skills: {
+          backupSkill: {
+            firstSeenAt: "2026-02-26T00:00:00.000Z",
+            lastSeenAt: "2026-02-26T00:00:00.000Z",
+            commandCalls: 1,
+            mappedToolCalls: 2,
+            totalCalls: 3,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const loaded = await mod.loadSkillsUsageStore();
+    expect(loaded.skills.backupSkill?.totalCalls).toBe(3);
+    expect(loaded.meta.unmappedToolCalls).toBe(0);
+    expect(loaded.meta.mappedByRunContext).toBe(0);
+    expect(loaded.meta.mappedByStaticDispatch).toBe(0);
+    expect(path.dirname(storePath)).toContain(path.basename(stateDir));
+  });
+});

--- a/src/agents/skills-usage-store.ts
+++ b/src/agents/skills-usage-store.ts
@@ -1,0 +1,336 @@
+import fs from "node:fs";
+import path from "node:path";
+import { writeJsonFileAtomically } from "../plugin-sdk/json-store.js";
+import { CONFIG_DIR, safeParseJson } from "../utils.js";
+import { serializeByKey } from "./skills/serialize.js";
+
+const fsp = fs.promises;
+const SKILLS_USAGE_FILE = "skills-usage.json";
+const SKILLS_USAGE_VERSION = 1;
+
+export type SkillUsageEntry = {
+  firstSeenAt: string;
+  lastSeenAt: string;
+  commandCalls: number;
+  mappedToolCalls: number;
+  totalCalls: number;
+};
+
+export type SkillsUsageStore = {
+  version: number;
+  updatedAt: string;
+  meta: {
+    unmappedToolCalls: number;
+    mappedByRunContext: number;
+    mappedByStaticDispatch: number;
+  };
+  skills: Record<string, SkillUsageEntry>;
+};
+
+export type SkillsUsageRow = {
+  skillName: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  commandCalls: number;
+  mappedToolCalls: number;
+  totalCalls: number;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function createEmptyStore(now: string = nowIso()): SkillsUsageStore {
+  return {
+    version: SKILLS_USAGE_VERSION,
+    updatedAt: now,
+    meta: {
+      unmappedToolCalls: 0,
+      mappedByRunContext: 0,
+      mappedByStaticDispatch: 0,
+    },
+    skills: {},
+  };
+}
+
+function isValidNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function sanitizeEntry(entry: unknown, now: string): SkillUsageEntry | null {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return null;
+  }
+  const record = entry as Record<string, unknown>;
+  const firstSeenAt =
+    typeof record.firstSeenAt === "string" && record.firstSeenAt.trim() ? record.firstSeenAt : now;
+  const lastSeenAt =
+    typeof record.lastSeenAt === "string" && record.lastSeenAt.trim() ? record.lastSeenAt : now;
+  const commandCalls = isValidNumber(record.commandCalls) ? Math.floor(record.commandCalls) : 0;
+  const mappedToolCalls = isValidNumber(record.mappedToolCalls)
+    ? Math.floor(record.mappedToolCalls)
+    : 0;
+  const totalRaw = isValidNumber(record.totalCalls)
+    ? Math.floor(record.totalCalls)
+    : commandCalls + mappedToolCalls;
+  const totalCalls = Math.max(totalRaw, commandCalls + mappedToolCalls);
+  return {
+    firstSeenAt,
+    lastSeenAt,
+    commandCalls,
+    mappedToolCalls,
+    totalCalls,
+  };
+}
+
+function sanitizeStore(input: unknown, now: string = nowIso()): SkillsUsageStore {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return createEmptyStore(now);
+  }
+  const record = input as Record<string, unknown>;
+  const skillsRecord =
+    record.skills && typeof record.skills === "object" && !Array.isArray(record.skills)
+      ? (record.skills as Record<string, unknown>)
+      : {};
+  const skills: Record<string, SkillUsageEntry> = {};
+  for (const [rawName, value] of Object.entries(skillsRecord)) {
+    const skillName = rawName.trim();
+    if (!skillName) {
+      continue;
+    }
+    const entry = sanitizeEntry(value, now);
+    if (!entry) {
+      continue;
+    }
+    skills[skillName] = entry;
+  }
+  return {
+    version: SKILLS_USAGE_VERSION,
+    updatedAt:
+      typeof record.updatedAt === "string" && record.updatedAt.trim() ? record.updatedAt : now,
+    meta: {
+      unmappedToolCalls: isValidNumber(
+        (record.meta as { unmappedToolCalls?: unknown })?.unmappedToolCalls,
+      )
+        ? Math.floor((record.meta as { unmappedToolCalls?: number }).unmappedToolCalls ?? 0)
+        : 0,
+      mappedByRunContext: isValidNumber(
+        (record.meta as { mappedByRunContext?: unknown })?.mappedByRunContext,
+      )
+        ? Math.floor((record.meta as { mappedByRunContext?: number }).mappedByRunContext ?? 0)
+        : 0,
+      mappedByStaticDispatch: isValidNumber(
+        (record.meta as { mappedByStaticDispatch?: unknown })?.mappedByStaticDispatch,
+      )
+        ? Math.floor(
+            (record.meta as { mappedByStaticDispatch?: number }).mappedByStaticDispatch ?? 0,
+          )
+        : 0,
+    },
+    skills,
+  };
+}
+
+export function resolveSkillsUsageStorePath(): string {
+  return path.join(CONFIG_DIR, SKILLS_USAGE_FILE);
+}
+
+function resolveSkillsUsageBackupPath(filePath: string): string {
+  return `${filePath}.bak`;
+}
+
+async function readStoreFromPath(filePath: string): Promise<SkillsUsageStore | null> {
+  try {
+    const raw = await fsp.readFile(filePath, "utf-8");
+    const parsed = safeParseJson<unknown>(raw);
+    if (parsed === null) {
+      return null;
+    }
+    return sanitizeStore(parsed);
+  } catch (error) {
+    const code = (error as { code?: string })?.code;
+    if (code === "ENOENT") {
+      return createEmptyStore();
+    }
+    return null;
+  }
+}
+
+export async function loadSkillsUsageStore(): Promise<SkillsUsageStore> {
+  const filePath = resolveSkillsUsageStorePath();
+  const primary = await readStoreFromPath(filePath);
+  if (primary) {
+    return primary;
+  }
+  const backup = await readStoreFromPath(resolveSkillsUsageBackupPath(filePath));
+  return backup ?? createEmptyStore();
+}
+
+async function persistSkillsUsageStore(store: SkillsUsageStore): Promise<void> {
+  const filePath = resolveSkillsUsageStorePath();
+  const backupPath = resolveSkillsUsageBackupPath(filePath);
+  await fsp.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  try {
+    await fsp.copyFile(filePath, backupPath);
+  } catch (error) {
+    const code = (error as { code?: string })?.code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+  await writeJsonFileAtomically(filePath, store);
+}
+
+async function mutateStore(
+  mutator: (store: SkillsUsageStore, now: string) => void,
+): Promise<SkillsUsageStore> {
+  const filePath = resolveSkillsUsageStorePath();
+  return serializeByKey(`skills-usage:${filePath}`, async () => {
+    const now = nowIso();
+    const store = await loadSkillsUsageStore();
+    mutator(store, now);
+    store.updatedAt = now;
+    await persistSkillsUsageStore(store);
+    return store;
+  });
+}
+
+function ensureSkillRecord(
+  store: SkillsUsageStore,
+  skillName: string,
+  now: string,
+): SkillUsageEntry {
+  const existing = store.skills[skillName];
+  if (existing) {
+    existing.lastSeenAt = now;
+    return existing;
+  }
+  const created: SkillUsageEntry = {
+    firstSeenAt: now,
+    lastSeenAt: now,
+    commandCalls: 0,
+    mappedToolCalls: 0,
+    totalCalls: 0,
+  };
+  store.skills[skillName] = created;
+  return created;
+}
+
+export async function registerSkillsUsageEntries(skillNames: string[]): Promise<SkillsUsageStore> {
+  return mutateStore((store, now) => {
+    for (const rawName of skillNames) {
+      const skillName = rawName.trim();
+      if (!skillName) {
+        continue;
+      }
+      ensureSkillRecord(store, skillName, now);
+    }
+  });
+}
+
+export async function incrementSkillCommandUsage(skillName: string): Promise<SkillsUsageStore> {
+  return mutateStore((store, now) => {
+    const name = skillName.trim();
+    if (!name) {
+      return;
+    }
+    const entry = ensureSkillRecord(store, name, now);
+    entry.commandCalls += 1;
+    entry.totalCalls = entry.commandCalls + entry.mappedToolCalls;
+    entry.lastSeenAt = now;
+  });
+}
+
+export async function incrementMappedToolUsage(skillNames: string[]): Promise<SkillsUsageStore> {
+  return mutateStore((store, now) => {
+    for (const rawName of skillNames) {
+      const skillName = rawName.trim();
+      if (!skillName) {
+        continue;
+      }
+      const entry = ensureSkillRecord(store, skillName, now);
+      entry.mappedToolCalls += 1;
+      entry.totalCalls = entry.commandCalls + entry.mappedToolCalls;
+      entry.lastSeenAt = now;
+    }
+  });
+}
+
+export async function incrementUnmappedToolUsage(count = 1): Promise<SkillsUsageStore> {
+  return mutateStore((store) => {
+    const incrementBy = Number.isFinite(count) && count > 0 ? Math.max(1, Math.floor(count)) : 1;
+    store.meta.unmappedToolCalls += incrementBy;
+  });
+}
+
+export async function incrementMappedByRunContextUsage(count = 1): Promise<SkillsUsageStore> {
+  return mutateStore((store) => {
+    const incrementBy = Number.isFinite(count) && count > 0 ? Math.max(1, Math.floor(count)) : 1;
+    store.meta.mappedByRunContext += incrementBy;
+  });
+}
+
+export async function incrementMappedByStaticDispatchUsage(count = 1): Promise<SkillsUsageStore> {
+  return mutateStore((store) => {
+    const incrementBy = Number.isFinite(count) && count > 0 ? Math.max(1, Math.floor(count)) : 1;
+    store.meta.mappedByStaticDispatch += incrementBy;
+  });
+}
+
+export function buildSkillsUsageRows(store: SkillsUsageStore): SkillsUsageRow[] {
+  return Object.entries(store.skills)
+    .map(([skillName, entry]) => ({
+      skillName,
+      firstSeenAt: entry.firstSeenAt,
+      lastSeenAt: entry.lastSeenAt,
+      commandCalls: entry.commandCalls,
+      mappedToolCalls: entry.mappedToolCalls,
+      totalCalls: entry.totalCalls,
+    }))
+    .toSorted((a, b) => b.totalCalls - a.totalCalls || a.skillName.localeCompare(b.skillName));
+}
+
+function csvCell(value: string | number): string {
+  const text = String(value);
+  if (!/[",\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function formatSkillsUsageCsv(rows: SkillsUsageRow[]): string {
+  const header = [
+    "skill",
+    "commandCalls",
+    "mappedToolCalls",
+    "totalCalls",
+    "firstSeenAt",
+    "lastSeenAt",
+  ];
+  const body = rows.map((row) =>
+    [
+      row.skillName,
+      row.commandCalls,
+      row.mappedToolCalls,
+      row.totalCalls,
+      row.firstSeenAt,
+      row.lastSeenAt,
+    ]
+      .map(csvCell)
+      .join(","),
+  );
+  return [header.join(","), ...body].join("\n");
+}
+
+export function formatSkillsUsageMarkdown(rows: SkillsUsageRow[]): string {
+  const lines = [
+    "| Skill | Command Calls | Mapped Tool Calls | Total Calls | First Seen | Last Seen |",
+    "| --- | ---: | ---: | ---: | --- | --- |",
+  ];
+  for (const row of rows) {
+    lines.push(
+      `| ${row.skillName} | ${row.commandCalls} | ${row.mappedToolCalls} | ${row.totalCalls} | ${row.firstSeenAt} | ${row.lastSeenAt} |`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/agents/skills-usage-tracker.test.ts
+++ b/src/agents/skills-usage-tracker.test.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./skills.js", () => ({
+  buildWorkspaceSkillCommandSpecs: () => [
+    {
+      name: "hello",
+      skillName: "hello-skill",
+      description: "hello",
+      dispatch: {
+        kind: "tool",
+        toolName: "read_file",
+        argMode: "raw",
+      },
+    },
+  ],
+}));
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+const tempDirs: string[] = [];
+
+async function setupStateDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-tracker-"));
+  tempDirs.push(dir);
+  process.env.OPENCLAW_STATE_DIR = dir;
+  vi.resetModules();
+  return dir;
+}
+
+beforeEach(async () => {
+  await setupStateDir();
+});
+
+afterEach(async () => {
+  if (ORIGINAL_STATE_DIR === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+  }
+  vi.resetModules();
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("skills-usage-tracker", () => {
+  it("tracks command invocations and mapped tool results with dedupe", async () => {
+    const tracker = await import("./skills-usage-tracker.js");
+    const storeMod = await import("./skills-usage-store.js");
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+
+    tracker.registerSkillsUsageTracking({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+    });
+    tracker.trackSkillCommandInvocation("hello-skill");
+
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "read_file",
+        toolCallId: "tool-1",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "read_file",
+        toolCallId: "tool-1",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const store = await storeMod.loadSkillsUsageStore();
+    expect(store.skills["hello-skill"]?.commandCalls).toBe(1);
+    expect(store.skills["hello-skill"]?.mappedToolCalls).toBe(1);
+    expect(store.skills["hello-skill"]?.totalCalls).toBe(2);
+    expect(store.meta.mappedByStaticDispatch).toBe(1);
+    expect(store.meta.mappedByRunContext).toBe(0);
+
+    tracker.__resetSkillsUsageTrackerForTest();
+  });
+
+  it("tracks unmapped tool results", async () => {
+    const tracker = await import("./skills-usage-tracker.js");
+    const storeMod = await import("./skills-usage-store.js");
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+
+    tracker.registerSkillsUsageTracking({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+    });
+
+    emitAgentEvent({
+      runId: "run-unmapped",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "unknown_tool_name",
+        toolCallId: "tool-unmapped-1",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const store = await storeMod.loadSkillsUsageStore();
+    expect(store.meta.unmappedToolCalls).toBe(1);
+    expect(store.meta.mappedByRunContext).toBe(0);
+    expect(store.meta.mappedByStaticDispatch).toBe(0);
+    tracker.__resetSkillsUsageTrackerForTest();
+  });
+
+  it("prefers run context attribution over static mapping", async () => {
+    const tracker = await import("./skills-usage-tracker.js");
+    const storeMod = await import("./skills-usage-store.js");
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+
+    tracker.registerSkillsUsageTracking({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+    });
+    tracker.trackSkillCommandInvocation("context-skill", { runId: "run-ctx" });
+    emitAgentEvent({
+      runId: "run-ctx",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "read_file",
+        toolCallId: "tool-context-1",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const store = await storeMod.loadSkillsUsageStore();
+    expect(store.skills["context-skill"]?.mappedToolCalls).toBe(1);
+    expect(store.meta.mappedByRunContext).toBe(1);
+    expect(store.meta.mappedByStaticDispatch).toBe(0);
+    tracker.__resetSkillsUsageTrackerForTest();
+  });
+
+  it("prunes run cache by ttl and maxRuns", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    const tracker = await import("./skills-usage-tracker.js");
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+
+    tracker.__configureSkillsUsageTrackerForTest({ ttlMs: 100, maxRuns: 1 });
+    tracker.registerSkillsUsageTracking({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+    });
+
+    nowSpy.mockReturnValue(1000);
+    emitAgentEvent({
+      runId: "run-a",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "read_file",
+        toolCallId: "tool-a-1",
+      },
+    });
+
+    nowSpy.mockReturnValue(1500);
+    emitAgentEvent({
+      runId: "run-b",
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "read_file",
+        toolCallId: "tool-b-1",
+      },
+    });
+
+    const diagnostics = tracker.getSkillsUsageTrackerDiagnostics();
+    expect(diagnostics.runCacheEntries).toBe(1);
+    expect(diagnostics.runContextEntries).toBe(0);
+
+    tracker.__resetSkillsUsageTrackerForTest();
+    nowSpy.mockRestore();
+  });
+});

--- a/src/agents/skills-usage-tracker.ts
+++ b/src/agents/skills-usage-tracker.ts
@@ -1,0 +1,223 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { onAgentEvent } from "../infra/agent-events.js";
+import {
+  incrementMappedByRunContextUsage,
+  incrementMappedByStaticDispatchUsage,
+  incrementUnmappedToolUsage,
+  incrementMappedToolUsage,
+  incrementSkillCommandUsage,
+  registerSkillsUsageEntries,
+} from "./skills-usage-store.js";
+import { buildWorkspaceSkillCommandSpecs } from "./skills.js";
+
+const toolToSkills = new Map<string, Set<string>>();
+const runToolCalls = new Map<string, { seenToolCallIds: Set<string>; updatedAtMs: number }>();
+const runContext = new Map<string, { skillName: string; updatedAtMs: number }>();
+const pendingSessionContext = new Map<string, { skillName: string; updatedAtMs: number }>();
+let trackerUnsubscribe: (() => void) | null = null;
+const DEFAULT_TRACKER_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_TRACKER_MAX_RUNS = 2000;
+let trackerTtlMs = DEFAULT_TRACKER_TTL_MS;
+let trackerMaxRuns = DEFAULT_TRACKER_MAX_RUNS;
+
+function normalizeToolName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function pruneRunCache(now: number) {
+  const ttlThreshold = now - Math.max(0, trackerTtlMs);
+  for (const [runId, entry] of runToolCalls) {
+    if (entry.updatedAtMs < ttlThreshold) {
+      runToolCalls.delete(runId);
+      runContext.delete(runId);
+    }
+  }
+  for (const [sessionKey, entry] of pendingSessionContext) {
+    if (entry.updatedAtMs < ttlThreshold) {
+      pendingSessionContext.delete(sessionKey);
+    }
+  }
+  if (runToolCalls.size <= trackerMaxRuns) {
+    return;
+  }
+  const sortedOldestFirst = Array.from(runToolCalls.entries()).toSorted(
+    (a, b) => a[1].updatedAtMs - b[1].updatedAtMs,
+  );
+  const overflowCount = runToolCalls.size - trackerMaxRuns;
+  for (let index = 0; index < overflowCount; index += 1) {
+    const runId = sortedOldestFirst[index]?.[0];
+    if (runId) {
+      runToolCalls.delete(runId);
+      runContext.delete(runId);
+    }
+  }
+}
+
+function registerToolDispatchMappings(
+  workspaceDir: string,
+  config: OpenClawConfig,
+  skillFilter?: string[],
+) {
+  const commands = buildWorkspaceSkillCommandSpecs(workspaceDir, {
+    config,
+    skillFilter,
+  });
+  const discoveredSkills = new Set<string>();
+  for (const command of commands) {
+    discoveredSkills.add(command.skillName);
+    if (command.dispatch?.kind !== "tool") {
+      continue;
+    }
+    const toolName = normalizeToolName(command.dispatch.toolName);
+    if (!toolName) {
+      continue;
+    }
+    const mapped = toolToSkills.get(toolName) ?? new Set<string>();
+    mapped.add(command.skillName);
+    toolToSkills.set(toolName, mapped);
+  }
+  if (discoveredSkills.size > 0) {
+    void registerSkillsUsageEntries(Array.from(discoveredSkills));
+  }
+  pruneRunCache(nowMs());
+}
+
+function registerRunContext(params: { runId?: string; sessionKey?: string; skillName: string }) {
+  const skillName = params.skillName.trim();
+  if (!skillName) {
+    return;
+  }
+  const now = nowMs();
+  if (params.runId?.trim()) {
+    runContext.set(params.runId.trim(), { skillName, updatedAtMs: now });
+  }
+  if (params.sessionKey?.trim()) {
+    pendingSessionContext.set(params.sessionKey.trim(), { skillName, updatedAtMs: now });
+  }
+}
+
+function ensureTrackerSubscribed() {
+  if (trackerUnsubscribe) {
+    return;
+  }
+  trackerUnsubscribe = onAgentEvent((evt) => {
+    const now = nowMs();
+    pruneRunCache(now);
+
+    if (evt.stream === "lifecycle") {
+      const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+      const sessionKey = typeof evt.sessionKey === "string" ? evt.sessionKey.trim() : "";
+      if (phase === "start" && sessionKey) {
+        const pending = pendingSessionContext.get(sessionKey);
+        if (pending) {
+          runContext.set(evt.runId, { skillName: pending.skillName, updatedAtMs: now });
+          pendingSessionContext.delete(sessionKey);
+        }
+      }
+      if (phase === "end" || phase === "error") {
+        runToolCalls.delete(evt.runId);
+        runContext.delete(evt.runId);
+      }
+      return;
+    }
+
+    if (evt.stream === "tool") {
+      const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+      if (phase !== "result") {
+        return;
+      }
+      const toolCallId = typeof evt.data.toolCallId === "string" ? evt.data.toolCallId.trim() : "";
+      const toolNameRaw = typeof evt.data.name === "string" ? evt.data.name : "";
+      const toolName = normalizeToolName(toolNameRaw);
+      if (!toolCallId || !toolName) {
+        return;
+      }
+      const cacheEntry = runToolCalls.get(evt.runId) ?? {
+        seenToolCallIds: new Set<string>(),
+        updatedAtMs: now,
+      };
+      if (cacheEntry.seenToolCallIds.has(toolCallId)) {
+        cacheEntry.updatedAtMs = now;
+        runToolCalls.set(evt.runId, cacheEntry);
+        return;
+      }
+      cacheEntry.seenToolCallIds.add(toolCallId);
+      cacheEntry.updatedAtMs = now;
+      runToolCalls.set(evt.runId, cacheEntry);
+      const context = runContext.get(evt.runId);
+      if (context?.skillName) {
+        context.updatedAtMs = now;
+        runContext.set(evt.runId, context);
+        void incrementMappedByRunContextUsage(1);
+        void incrementMappedToolUsage([context.skillName]);
+        return;
+      }
+      const mappedSkills = toolToSkills.get(toolName);
+      if (!mappedSkills || mappedSkills.size === 0) {
+        void incrementUnmappedToolUsage(1);
+        return;
+      }
+      void incrementMappedByStaticDispatchUsage(1);
+      void incrementMappedToolUsage(Array.from(mappedSkills));
+      return;
+    }
+  });
+}
+
+export function trackSkillCommandInvocation(
+  skillName: string,
+  context?: { runId?: string; sessionKey?: string },
+) {
+  const name = skillName.trim();
+  if (!name) {
+    return;
+  }
+  registerRunContext({ skillName: name, runId: context?.runId, sessionKey: context?.sessionKey });
+  void incrementSkillCommandUsage(name);
+}
+
+export function registerSkillsUsageTracking(params: {
+  workspaceDir: string;
+  config: OpenClawConfig;
+  skillFilter?: string[];
+}) {
+  ensureTrackerSubscribed();
+  registerToolDispatchMappings(params.workspaceDir, params.config, params.skillFilter);
+}
+
+export function getSkillsUsageTrackerDiagnostics() {
+  return {
+    mappedTools: toolToSkills.size,
+    runCacheEntries: runToolCalls.size,
+    runContextEntries: runContext.size,
+    pendingSessionContextEntries: pendingSessionContext.size,
+    ttlMs: trackerTtlMs,
+    maxRuns: trackerMaxRuns,
+  };
+}
+
+export function __resetSkillsUsageTrackerForTest() {
+  if (trackerUnsubscribe) {
+    trackerUnsubscribe();
+    trackerUnsubscribe = null;
+  }
+  toolToSkills.clear();
+  runToolCalls.clear();
+  runContext.clear();
+  pendingSessionContext.clear();
+  trackerTtlMs = DEFAULT_TRACKER_TTL_MS;
+  trackerMaxRuns = DEFAULT_TRACKER_MAX_RUNS;
+}
+
+export function __configureSkillsUsageTrackerForTest(config: { ttlMs?: number; maxRuns?: number }) {
+  if (typeof config.ttlMs === "number" && Number.isFinite(config.ttlMs) && config.ttlMs >= 0) {
+    trackerTtlMs = config.ttlMs;
+  }
+  if (typeof config.maxRuns === "number" && Number.isFinite(config.maxRuns) && config.maxRuns > 0) {
+    trackerMaxRuns = Math.floor(config.maxRuns);
+  }
+}

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import { resolveSandboxPath } from "../sandbox-paths.js";
+import { registerSkillsUsageEntries } from "../skills-usage-store.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
 import { shouldIncludeSkill } from "./config.js";
 import { normalizeSkillFilter } from "./filter.js";
@@ -402,6 +403,8 @@ function loadSkillEntries(
       invocation: resolveSkillInvocationPolicy(frontmatter),
     };
   });
+  // Keep usage registry in sync with discovered skills (best-effort, non-blocking).
+  void registerSkillsUsageEntries(skillEntries.map((entry) => entry.skill.name));
   return skillEntries;
 }
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,5 +1,15 @@
 import type { Command } from "commander";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  buildSkillsUsageRows,
+  formatSkillsUsageCsv,
+  formatSkillsUsageMarkdown,
+  loadSkillsUsageStore,
+} from "../agents/skills-usage-store.js";
+import {
+  getSkillsUsageTrackerDiagnostics,
+  registerSkillsUsageTracking,
+} from "../agents/skills-usage-tracker.js";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -32,6 +42,155 @@ async function runSkillsAction(render: (report: SkillStatusReport) => string): P
     defaultRuntime.error(String(err));
     defaultRuntime.exit(1);
   }
+}
+
+type SkillsUsageFormat = "table" | "json" | "csv" | "markdown";
+type SkillsUsageOutputRow = {
+  skillName: string;
+  commandCalls: number;
+  mappedToolCalls: number;
+  totalCalls: number;
+  firstSeenAt: string;
+  lastSeenAt: string;
+};
+
+function formatUsageTable(rows: SkillsUsageOutputRow[]): string {
+  if (rows.length === 0) {
+    return "No skill usage records found.";
+  }
+  const header = ["Skill", "Command", "MappedTool", "Total", "FirstSeen", "LastSeen"];
+  const body = rows.map((row) => [
+    row.skillName,
+    String(row.commandCalls),
+    String(row.mappedToolCalls),
+    String(row.totalCalls),
+    row.firstSeenAt,
+    row.lastSeenAt,
+  ]);
+  const widths = header.map((text, index) =>
+    Math.max(text.length, ...body.map((line) => line[index]?.length ?? 0)),
+  );
+  const formatLine = (line: string[]) =>
+    line.map((cell, index) => cell.padEnd(widths[index], " ")).join("  ");
+  return [
+    formatLine(header),
+    formatLine(widths.map((width) => "-".repeat(width))),
+    ...body.map(formatLine),
+  ].join("\n");
+}
+
+export const __formatSkillsUsageTableForTest = formatUsageTable;
+
+function buildUsageJsonPayload(params: {
+  rows: SkillsUsageOutputRow[];
+  totalSkills: number;
+  since: string | null;
+  mappedToolCallsTotal: number;
+  mappedByRunContext: number;
+  mappedByStaticDispatch: number;
+  unmappedToolCalls: number;
+  tracker: ReturnType<typeof getSkillsUsageTrackerDiagnostics>;
+}) {
+  const mappingDenominator = params.mappedToolCallsTotal + params.unmappedToolCalls;
+  const mappingCoverage =
+    mappingDenominator > 0 ? params.mappedToolCallsTotal / mappingDenominator : null;
+  return {
+    summary: {
+      totalSkills: params.totalSkills,
+      generatedAt: new Date().toISOString(),
+      since: params.since,
+      mappedToolCallsTotal: params.mappedToolCallsTotal,
+      mappedByRunContext: params.mappedByRunContext,
+      mappedByStaticDispatch: params.mappedByStaticDispatch,
+      unmappedToolCalls: params.unmappedToolCalls,
+      mappingCoverage,
+      attributionStrategy: "context-priority",
+      attributionStrategyVersion: 1,
+    },
+    tracker: params.tracker,
+    rows: params.rows,
+  };
+}
+
+export const __buildSkillsUsageJsonPayloadForTest = buildUsageJsonPayload;
+
+function parseTop(value?: string): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("--top must be a positive integer.");
+  }
+  return parsed;
+}
+
+function parseSince(value?: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) {
+    throw new Error("--since must be a valid date/time (ISO recommended).");
+  }
+  return new Date(ts).toISOString();
+}
+
+async function runSkillsUsageAction(opts: {
+  format?: string;
+  top?: string;
+  since?: string;
+}): Promise<void> {
+  const cfg = loadConfig();
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  registerSkillsUsageTracking({ workspaceDir, config: cfg });
+  const store = await loadSkillsUsageStore();
+  const format = (opts.format?.trim().toLowerCase() || "table") as SkillsUsageFormat;
+  if (!["table", "json", "csv", "markdown"].includes(format)) {
+    throw new Error('--format must be one of: "table", "json", "csv", "markdown".');
+  }
+  const top = parseTop(opts.top);
+  const since = parseSince(opts.since);
+  let rows = buildSkillsUsageRows(store);
+  if (since) {
+    rows = rows.filter((row) => Date.parse(row.lastSeenAt) >= Date.parse(since));
+  }
+  if (top !== undefined) {
+    rows = rows.slice(0, top);
+  }
+
+  if (format === "json") {
+    const mappedByRunContext = store.meta.mappedByRunContext;
+    const mappedByStaticDispatch = store.meta.mappedByStaticDispatch;
+    const mappedToolCallsTotal = mappedByRunContext + mappedByStaticDispatch;
+    const unmappedToolCalls = store.meta.unmappedToolCalls;
+    defaultRuntime.log(
+      JSON.stringify(
+        buildUsageJsonPayload({
+          rows,
+          totalSkills: rows.length,
+          since: since ?? null,
+          mappedToolCallsTotal,
+          mappedByRunContext,
+          mappedByStaticDispatch,
+          unmappedToolCalls,
+          tracker: getSkillsUsageTrackerDiagnostics(),
+        }),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  if (format === "csv") {
+    defaultRuntime.log(formatSkillsUsageCsv(rows));
+    return;
+  }
+  if (format === "markdown") {
+    defaultRuntime.log(formatSkillsUsageMarkdown(rows));
+    return;
+  }
+  defaultRuntime.log(formatUsageTable(rows));
 }
 
 /**
@@ -72,6 +231,21 @@ export function registerSkillsCli(program: Command) {
     .option("--json", "Output as JSON", false)
     .action(async (opts) => {
       await runSkillsAction((report) => formatSkillsCheck(report, opts));
+    });
+
+  skills
+    .command("usage")
+    .description("Show skill usage counters and exports")
+    .option("--format <format>", "Output format: table|json|csv|markdown", "table")
+    .option("--top <n>", "Limit to top N skills")
+    .option("--since <time>", "Filter by lastSeenAt >= time (ISO date/time)")
+    .action(async (opts) => {
+      try {
+        await runSkillsUsageAction(opts);
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
     });
 
   // Default action (no subcommand) - show list

--- a/src/cli/skills-cli.usage.test.ts
+++ b/src/cli/skills-cli.usage.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSkillsUsageCsv,
+  formatSkillsUsageMarkdown,
+  type SkillsUsageRow,
+} from "../agents/skills-usage-store.js";
+import {
+  __buildSkillsUsageJsonPayloadForTest,
+  __formatSkillsUsageTableForTest,
+} from "./skills-cli.js";
+
+const rows: SkillsUsageRow[] = [
+  {
+    skillName: "alpha",
+    commandCalls: 2,
+    mappedToolCalls: 3,
+    totalCalls: 5,
+    firstSeenAt: "2026-02-26T00:00:00.000Z",
+    lastSeenAt: "2026-02-26T01:00:00.000Z",
+  },
+  {
+    skillName: "beta",
+    commandCalls: 0,
+    mappedToolCalls: 1,
+    totalCalls: 1,
+    firstSeenAt: "2026-02-26T02:00:00.000Z",
+    lastSeenAt: "2026-02-26T03:00:00.000Z",
+  },
+];
+
+describe("skills usage formatting", () => {
+  it("formats default table output", () => {
+    const output = __formatSkillsUsageTableForTest(rows);
+    expect(output).toContain("Skill");
+    expect(output).toContain("alpha");
+    expect(output).toContain("MappedTool");
+  });
+
+  it("formats csv output", () => {
+    const output = formatSkillsUsageCsv(rows);
+    expect(output).toContain(
+      "skill,commandCalls,mappedToolCalls,totalCalls,firstSeenAt,lastSeenAt",
+    );
+    expect(output).toContain("alpha,2,3,5");
+  });
+
+  it("formats markdown output", () => {
+    const output = formatSkillsUsageMarkdown(rows);
+    expect(output).toContain("| Skill | Command Calls | Mapped Tool Calls | Total Calls |");
+    expect(output).toContain("| alpha | 2 | 3 | 5 |");
+  });
+
+  it("builds json diagnostics output", () => {
+    const payload = __buildSkillsUsageJsonPayloadForTest({
+      rows,
+      totalSkills: rows.length,
+      since: null,
+      mappedToolCallsTotal: 4,
+      mappedByRunContext: 3,
+      mappedByStaticDispatch: 1,
+      unmappedToolCalls: 1,
+      tracker: {
+        mappedTools: 2,
+        runCacheEntries: 1,
+        runContextEntries: 1,
+        pendingSessionContextEntries: 0,
+        ttlMs: 1000,
+        maxRuns: 10,
+      },
+    });
+    expect(payload.summary.mappedToolCallsTotal).toBe(4);
+    expect(payload.summary.mappedByRunContext).toBe(3);
+    expect(payload.summary.mappedByStaticDispatch).toBe(1);
+    expect(payload.summary.unmappedToolCalls).toBe(1);
+    expect(payload.summary.mappingCoverage).toBe(0.8);
+    expect(payload.summary.attributionStrategy).toBe("context-priority");
+    expect(payload.summary.attributionStrategyVersion).toBe(1);
+    expect(payload.tracker.runCacheEntries).toBe(1);
+  });
+});

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+import { registerSkillsUsageTracking } from "../agents/skills-usage-tracker.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
@@ -380,6 +381,7 @@ export async function startGatewayServer(
   initSubagentRegistry();
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
+  registerSkillsUsageTracking({ workspaceDir: defaultWorkspaceDir, config: cfgAtStart });
   const baseMethods = listGatewayMethods();
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway


### PR DESCRIPTION
## Summary
- add OpenClaw safe operations guardrail via `scripts/openclaw-safe.sh` and `skills/openclaw-safe-ops/SKILL.md`
- add skill usage tracking store/tracker and CLI exports (`openclaw skills usage` with json/csv/markdown)
- add release-safe deliverables (`openclaw.example.json` and docs under `docs/safe-ops-and-skill-usage/`)

## Test plan
- pnpm vitest run src/agents/skills-usage-store.test.ts src/agents/skills-usage-tracker.test.ts src/cli/skills-cli.usage.test.ts src/commands/agent.test.ts
- node dist/index.js skills usage
- node dist/index.js skills usage --format json
- node dist/index.js skills usage --format markdown
- ./scripts/openclaw-safe.sh --dry-run gateway restart

Made with [Cursor](https://cursor.com)