### PR TITLE
Gateway+UI: keep webchat live during model fallback

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -455,7 +455,8 @@ export function createAgentEventHandler({
       }
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
-      } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
+      } else if (!isAborted && lifecyclePhase === "end") {
+        const jobState: "done" | "error" = evt.data?.error ? "error" : "done";
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
@@ -467,19 +468,20 @@ export function createAgentEventHandler({
             finished.clientRunId,
             evt.runId,
             evt.seq,
-            lifecyclePhase === "error" ? "error" : "done",
+            jobState,
             evt.data?.error,
           );
         } else {
-          emitChatFinal(
-            sessionKey,
-            eventRunId,
-            evt.runId,
-            evt.seq,
-            lifecyclePhase === "error" ? "error" : "done",
-            evt.data?.error,
-          );
+          emitChatFinal(sessionKey, eventRunId, evt.runId, evt.seq, jobState, evt.data?.error);
         }
+      } else if (!isAborted && lifecyclePhase === "error") {
+        // Embedded agent reported an error for this run. For interactive chat
+        // surfaces, do not treat this as a terminal chat failure – model
+        // fallback may retry the run with the same runId. We only reset the
+        // streaming buffer; the outer runner will emit a lifecycle "end" with
+        // an error payload if all fallbacks ultimately fail.
+        chatRunState.buffers.delete(clientRunId);
+        chatRunState.deltaSentAt.delete(clientRunId);
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         chatRunState.abortedRuns.delete(clientRunId);
         chatRunState.abortedRuns.delete(evt.runId);


### PR DESCRIPTION
Closes #28410.

When the primary model fails with stopReason=\"error\" and model fallback retries the run with the same runId, the webchat UI would freeze on a loading spinner even though the fallback model completes successfully.

This change:
- Treats lifecycle:error from embedded runs as non-terminal for chat streaming. We now only terminate the chat run (shift the registry and emit a terminal chat event) on lifecycle:end, inferring jobState=\"error\" when an error payload is present.
- Clears only the streaming buffer/delta timing on lifecycle:error so that runWithModelFallback can continue streaming with the same clientRunId.
- Adds defensive recovery in the web UI chat controller so that if we are in an error state (chatRunId=null, lastError set) but receive new delta events for the same session, we restore chatRunId and clear lastError, allowing the fallback model response to stream in real time.

This aligns the backend lifecycle handling with the model fallback runner semantics and prevents the webchat UI from getting stuck when fallbacks succeed.