### PR TITLE
fix: clamp heartbeat setTimeout to prevent overflow with intervals >24.8 days

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1030,10 +1030,18 @@ export function startHeartbeatRunner(opts: {
       return;
     }
     const delay = Math.max(0, nextDue - now);
+    const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
+    const safeDelay = Math.min(delay, MAX_SAFE_TIMEOUT_MS);
+    if (delay > MAX_SAFE_TIMEOUT_MS) {
+      log.warn(
+        `heartbeat: interval exceeds 32-bit setTimeout limit (~24.8 days), clamping to ${MAX_SAFE_TIMEOUT_MS}ms`,
+        { requestedMs: delay, clampedMs: safeDelay },
+      );
+    }
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
-    }, delay);
+    }, safeDelay);
     state.timer.unref?.();
   };
 


### PR DESCRIPTION
## Summary

Fixes #28405

When `agents.defaults.heartbeat.every` is set to a duration exceeding Node.js's 32-bit signed integer limit (~24.8 days / 2,147,483,647ms), the gateway enters an infinite loop of `TimeoutOverflowWarning`, consuming 100% CPU and leaking memory.

## Root Cause

Node.js's `setTimeout` overflows when given a value > 2^31 - 1, clamping it to 1ms internally. This causes the timer to fire immediately, and the callback re-arms the same oversized timer, creating an infinite loop.

## Fix

- Clamp the `setTimeout` delay to `2_147_483_647` (max safe 32-bit signed integer)
- Log a warning when clamping occurs so users are aware their interval is being limited

## Testing

- Existing heartbeat tests pass (`pnpm vitest run src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`)

## Related

- #7194 — Same overflow class of bug in `waitForSubagentCompletion` (fixed by #11664)
- #9576 — `clamp setTimeout values to 32-bit safe max to prevent gateway hang`