### PR TITLE
fix(irc): dedupe active account client to prevent duplicate IRC sessions

### DIFF
--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { resolveIrcInboundTarget } from "./monitor.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  _testResetActiveIrcClients,
+  _testSetActiveIrcClient,
+  resolveIrcInboundTarget,
+} from "./monitor.js";
 
 describe("irc monitor inbound target", () => {
   it("keeps channel target for group messages", () => {
@@ -39,5 +43,39 @@ describe("irc monitor inbound target", () => {
       target: "openclaw-bot",
       rawTarget: "openclaw-bot",
     });
+  });
+});
+
+describe("irc monitor active client replacement", () => {
+  it("quits previous active client when replacing same account", () => {
+    _testResetActiveIrcClients();
+
+    const previousQuit = vi.fn();
+    const previous = {
+      nick: "OpenClaw",
+      isReady: () => true,
+      sendRaw: () => {},
+      join: () => {},
+      sendPrivmsg: () => {},
+      quit: previousQuit,
+      close: () => {},
+    };
+
+    const next = {
+      nick: "OpenClaw",
+      isReady: () => true,
+      sendRaw: () => {},
+      join: () => {},
+      sendPrivmsg: () => {},
+      quit: vi.fn(),
+      close: () => {},
+    };
+
+    _testSetActiveIrcClient("default", previous);
+    _testSetActiveIrcClient("default", next);
+
+    expect(previousQuit).toHaveBeenCalledWith("restart");
+
+    _testResetActiveIrcClients();
   });
 });


### PR DESCRIPTION
﻿## Summary
Fixes #28415.

IRC users reported duplicate active connections (nick + nick_) even when only one IRC account is configured. This usually indicates concurrent/redundant live clients for the same account.

## Root cause
`monitorIrcProvider()` had no account-level active-client replacement guard. If startup/reconciliation/restart paths trigger another start for the same account, previous client could remain active long enough for nick collision fallback to produce `nick_`.

## What changed
- Added account-scoped active client registry in IRC monitor.
- On registering a new active client for an account, existing active client is quit with reason `restart`.
- On stop, the active entry is cleared only if it still points to that client.
- Added targeted regression test to verify replacement calls `quit("restart")` on previous client.

## Validation
- Ran: `pnpm test extensions/irc/src/monitor.test.ts` ✅

## Impact
Prevents duplicate live IRC sessions for the same account and avoids nick collision fallback clones (`OpenClaw_`) during redundant starts.
