### PR TITLE
fix(config): add missing `enabled` field to WhatsAppConfigSchema

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -95,6 +95,8 @@ type WhatsAppConfigCore = {
 
 export type WhatsAppConfig = WhatsAppConfigCore &
   WhatsAppSharedConfig & {
+    /** If false, do not start the WhatsApp channel. Default: true. */
+    enabled?: boolean;
     /** Optional per-account WhatsApp configuration (multi-account). */
     accounts?: Record<string, WhatsAppAccountConfig>;
     /** Per-action tool gating (default: true for all). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -97,6 +97,7 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   });
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({
+  enabled: z.boolean().optional(),
   accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
   mediaMaxMb: z.number().int().positive().optional().default(50),
   actions: z


### PR DESCRIPTION
## Summary

- Adds `enabled: z.boolean().optional()` to `WhatsAppConfigSchema` (top-level `channels.whatsapp`) so it matches other channel schemas
- Adds matching `enabled?: boolean` to the `WhatsAppConfig` TypeScript type
- Fixes onboarding crash where `enablePluginInConfig()` writes `enabled: true` to `channels.whatsapp`, which the `.strict()` Zod schema previously rejected

Closes #28443

## Test plan

- [x] `pnpm tsgo` passes
- [x] WhatsApp onboarding tests pass (`src/channels/plugins/onboarding/whatsapp.test.ts`)
- [x] Config schema tests pass (`src/config/zod-schema.*.test.ts`)
- [ ] Manual: run `openclaw setup` or `openclaw channels add` and configure WhatsApp without validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)