### PR TITLE
feat: notify user on model failover

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -385,6 +385,8 @@ export async function runWithModelFallback<T>(params: {
   fallbacksOverride?: string[];
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
+  /** Called when the system switches to a fallback model so the user can be notified. */
+  onFallbackSwitch?: (message: string) => void | Promise<void>;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveFallbackCandidates({
     cfg: params.cfg,
@@ -435,6 +437,13 @@ export async function runWithModelFallback<T>(params: {
             error: decision.error,
             reason: decision.reason,
           });
+          // Notify the user about the cooldown skip if there's a next candidate
+          const next = candidates[i + 1];
+          if (next && params.onFallbackSwitch) {
+            await params.onFallbackSwitch(
+              `⚠️ ${candidate.provider}/${candidate.model} in cooldown (rate_limit). Trying ${next.provider}/${next.model}...`,
+            );
+          }
           continue;
         }
 
@@ -495,6 +504,15 @@ export async function runWithModelFallback<T>(params: {
         attempt: i + 1,
         total: candidates.length,
       });
+
+      // Notify the user about the failover if there's a next candidate to try
+      const next = candidates[i + 1];
+      if (next && params.onFallbackSwitch) {
+        const reason = described.reason ?? "error";
+        await params.onFallbackSwitch(
+          `⚠️ ${candidate.provider}/${candidate.model} unavailable (${reason}). Trying ${next.provider}/${next.model}...`,
+        );
+      }
     }
   }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -182,6 +182,11 @@ export async function runAgentTurnWithFallback(params: {
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
+        onFallbackSwitch: params.opts?.onBlockReply
+          ? async (message) => {
+              await params.opts?.onBlockReply?.({ text: message });
+            }
+          : undefined,
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.


### PR DESCRIPTION
## Summary

- Problem: When model failover occurs (rate limit or error), users have no visibility into why their request may be slower or using a different model.
- Why it matters: Transparency helps users understand service behavior and set expectations for response quality/latency.
- What changed: Added `onFallbackSwitch` callback to `runWithModelFallback` that emits a user-facing notification when switching to a fallback model. Wired it through `runAgentTurnWithFallback` via the existing `onBlockReply` mechanism.
- What did NOT change (scope boundary): No changes to fallback logic itself, model selection, or retry behavior.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- None

## User-visible / Behavior Changes

Users now receive a notification message when model failover occurs, showing which model was unavailable and which fallback model is being tried.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: Any with fallback configured

### Steps

1. Configure multiple model fallbacks
2. Trigger a rate limit or error on the primary model
3. Observe the notification message about failover

### Expected

- User sees a message like "model-a unavailable (rate_limit). Trying model-b..."

### Actual

- Confirmed notification is emitted via onBlockReply

## Evidence

- [x] Trace/log snippets (verified notification fires during failover)

## Human Verification (required)

- Verified scenarios: Model failover with rate_limit cooldown skip and error-based fallback
- Edge cases checked: No next candidate (notification not sent), undefined onFallbackSwitch (no-op)
- What you did **not** verify: Full E2E across all channel surfaces

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the onFallbackSwitch param is optional and has no effect if not provided
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Duplicate or spurious notifications during normal model selection

## Risks and Mitigations

- Risk: Notification messages could be noisy if failover happens frequently
  - Mitigation: Notifications only fire when there is a next candidate to try, and use the existing onBlockReply path which respects channel delivery rules

AI-assisted: yes (Claude)
Testing: lightly tested
I understand what this code does.
