### PR TITLE
fix: handle null response.parts in generate_image.py

### DIFF
--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -140,6 +140,13 @@ def main():
 
         # Process response and convert to PNG
         image_saved = False
+        if not response.parts:
+            if hasattr(response, 'text') and response.text:
+                print(f"Model response: {response.text}", file=sys.stderr)
+            if hasattr(response, 'prompt_feedback') and response.prompt_feedback:
+                print(f"Prompt feedback: {response.prompt_feedback}", file=sys.stderr)
+            print("Error: No image was generated. The model returned no content.", file=sys.stderr)
+            sys.exit(1)
         for part in response.parts:
             if part.text is not None:
                 print(f"Model response: {part.text}")


### PR DESCRIPTION
## Summary

- Problem: When the Gemini API refuses or fails an image-editing request, it returns `response.parts = None`. The script blindly iterates over it, causing a `'NoneType' object is not iterable` crash.
- Why it matters: Users get an unhelpful traceback instead of a clear error message explaining why image generation failed.
- What changed: Added a null/empty guard before iterating `response.parts`, with diagnostic output (model text response and prompt feedback) printed to stderr before exiting.
- What did NOT change (scope boundary): No changes to the happy path or image processing logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

Instead of crashing with a Python traceback when the model returns no content, the script now prints a clear error message (and any available model feedback) to stderr, then exits with code 1.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Python 3.10+ with google-genai
- Model/provider: Gemini 3 Pro Image Preview

### Steps

1. Run `generate_image.py` with input images that trigger a content policy refusal
2. The API returns `response.parts = None`

### Expected

- Clear error message explaining no image was generated, with any available model feedback

### Actual (before fix)

- `TypeError: 'NoneType' object is not iterable` traceback

## Evidence

- [x] Trace/log snippets: crash traceback on `for part in response.parts:` when parts is None

## Human Verification (required)

- Verified scenarios: Confirmed the null guard correctly catches None response.parts
- Edge cases checked: Empty parts list (falsy), response with text but no image
- What you did **not** verify: Full end-to-end with live Gemini API refusal

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `skills/nano-banana-pro/scripts/generate_image.py`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None.

AI-assisted: yes (Claude)
Testing: lightly tested
I understand what this code does.