### PR TITLE
feat: add baseUrl to OpenAI TTS config for Kokoro/local TTS

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -56,6 +56,7 @@ export type TtsConfig = {
   /** OpenAI configuration. */
   openai?: {
     apiKey?: string;
+    baseUrl?: string;
     model?: string;
     voice?: string;
   };

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -400,6 +400,7 @@ export const TtsConfigSchema = z
     openai: z
       .object({
         apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
         model: z.string().optional(),
         voice: z.string().optional(),
       })

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -99,6 +99,7 @@ function parseNumberValue(value: string): number | undefined {
 export function parseTtsDirectives(
   text: string,
   policy: ResolvedTtsModelOverrides,
+  openaiBaseUrl?: string,
 ): TtsDirectiveParseResult {
   if (!policy.enabled) {
     return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
@@ -151,7 +152,7 @@ export function parseTtsDirectives(
             if (!policy.allowVoice) {
               break;
             }
-            if (isValidOpenAIVoice(rawValue)) {
+            if (isValidOpenAIVoice(rawValue, openaiBaseUrl)) {
               overrides.openai = { ...overrides.openai, voice: rawValue };
             } else {
               warnings.push(`invalid OpenAI voice "${rawValue}"`);
@@ -180,7 +181,7 @@ export function parseTtsDirectives(
             if (!policy.allowModelId) {
               break;
             }
-            if (isValidOpenAIModel(rawValue)) {
+            if (isValidOpenAIModel(rawValue, openaiBaseUrl)) {
               overrides.openai = { ...overrides.openai, model: rawValue };
             } else {
               overrides.elevenlabs = { ...overrides.elevenlabs, modelId: rawValue };
@@ -334,15 +335,16 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  *
  * Note: Read at runtime (not module load) to support config.env loading.
  */
-function getOpenAITtsBaseUrl(): string {
-  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
-    /\/+$/,
-    "",
-  );
+function getOpenAITtsBaseUrl(configBaseUrl?: string): string {
+  return (
+    configBaseUrl?.trim() ||
+    process.env.OPENAI_TTS_BASE_URL?.trim() ||
+    "https://api.openai.com/v1"
+  ).replace(/\/+$/, "");
 }
 
-function isCustomOpenAIEndpoint(): boolean {
-  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
+function isCustomOpenAIEndpoint(configBaseUrl?: string): boolean {
+  return getOpenAITtsBaseUrl(configBaseUrl) !== "https://api.openai.com/v1";
 }
 export const OPENAI_TTS_VOICES = [
   "alloy",
@@ -363,17 +365,17 @@ export const OPENAI_TTS_VOICES = [
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
-export function isValidOpenAIModel(model: string): boolean {
+export function isValidOpenAIModel(model: string, configBaseUrl?: string): boolean {
   // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(configBaseUrl)) {
     return true;
   }
   return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
 }
 
-export function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
+export function isValidOpenAIVoice(voice: string, configBaseUrl?: string): voice is OpenAiTtsVoice {
   // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(configBaseUrl)) {
     return true;
   }
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
@@ -595,13 +597,14 @@ export async function openaiTTS(params: {
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
+  baseUrl?: string;
 }): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, model, voice, responseFormat, timeoutMs, baseUrl } = params;
 
-  if (!isValidOpenAIModel(model)) {
+  if (!isValidOpenAIModel(model, baseUrl)) {
     throw new Error(`Invalid model: ${model}`);
   }
-  if (!isValidOpenAIVoice(voice)) {
+  if (!isValidOpenAIVoice(voice, baseUrl)) {
     throw new Error(`Invalid voice: ${voice}`);
   }
 
@@ -609,7 +612,7 @@ export async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
+    const response = await fetch(`${getOpenAITtsBaseUrl(baseUrl)}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
## Summary

- Problem: OpenAI TTS config lacks a `baseUrl` field, so users cannot point TTS at local/custom OpenAI-compatible servers (e.g., Kokoro) through configuration alone -- only via `OPENAI_TTS_BASE_URL` env var.
- Why it matters: Local TTS servers like Kokoro use different models/voices than OpenAI and need a configurable endpoint. Config-based setup is more discoverable and portable than env vars.
- What changed: Added `baseUrl` to the OpenAI TTS config type, zod schema, and wired it through to the `openaiTTS` fetch call. Model/voice validation is relaxed when a custom baseUrl is set. API key defaults to `"not-needed"` when baseUrl is configured (local servers often skip auth).
- What did NOT change (scope boundary): ElevenLabs and Edge TTS configs are untouched. The existing `OPENAI_TTS_BASE_URL` env var still works (config takes priority).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## User-visible / Behavior Changes

- New `messages.tts.openai.baseUrl` config field to point OpenAI TTS at a custom server
- When `baseUrl` is set, any model/voice name is accepted (not just OpenAI defaults)
- When `baseUrl` is set and no API key is configured, the key defaults to `"not-needed"`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes -- API key defaults to `"not-needed"` when `baseUrl` is set, avoiding the need to set a dummy key for local servers
- New/changed network calls? Yes -- TTS requests can now go to user-configured URLs instead of only `api.openai.com`
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The baseUrl is user-configured; TTS text is already sent to an external endpoint. This just lets the user choose which endpoint.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: Kokoro (local OpenAI-compatible TTS)
- Integration/channel (if any): N/A
- Relevant config (redacted): `messages.tts.openai.baseUrl: "http://localhost:8880/v1"`

### Steps

1. Install Kokoro or another OpenAI-compatible TTS server locally
2. Set `messages.tts.openai.baseUrl` to the local server URL in config
3. Set `messages.tts.openai.model` and `messages.tts.openai.voice` to server-supported values
4. Send a message with TTS enabled

### Expected

- TTS audio generated from the local server

### Actual

- TTS audio generated from the local server

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New tests cover baseUrl wiring, validation relaxation, and config resolution.

## Human Verification (required)

- Verified scenarios: Build passes, manual TTS with Kokoro local server
- Edge cases checked: Empty/whitespace baseUrl resolves to undefined, env var fallback still works, config takes priority over env var
- What you did **not** verify: Full E2E with all TTS providers simultaneously

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes -- new optional `messages.tts.openai.baseUrl` field
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `baseUrl` from config; behavior reverts to default OpenAI endpoint
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: TTS failing when baseUrl is misconfigured

## Risks and Mitigations

- Risk: Misconfigured baseUrl could cause TTS failures
  - Mitigation: Existing timeout and error handling applies; users opt-in explicitly

AI-assisted: yes (Claude)
Testing: lightly tested (build + manual verification with Kokoro)
I understand what this code does.