### PR TITLE
UI: fix agent overview model save dirty flag

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -817,6 +817,7 @@ export function renderApp(state: AppViewState) {
                   } else {
                     updateConfigFormValue(state, basePath, modelId);
                   }
+                  state.configFormDirty = true;
                 },
                 onModelFallbacksChange: (agentId, fallbacks) => {
                   if (!configValue) {
@@ -866,6 +867,7 @@ export function renderApp(state: AppViewState) {
                     ? { primary, fallbacks: normalized }
                     : { fallbacks: normalized };
                   updateConfigFormValue(state, basePath, next);
+                  state.configFormDirty = true;
                 },
               })
             : nothing


### PR DESCRIPTION
## Summary
- Fix Agent overview page primary model / fallbacks change not enabling Save button.
- Explicitly mark config form dirty when changing agent model or fallbacks so config save becomes available.

## Testing
- Manually verified in Agent tab overview panel: selecting a model or editing fallbacks now enables the Save button.

## Related
- Fixes #28440
