### PR TITLE
fix(sessions_list): resolve transcriptPath in agent sessions dir

### DIFF
--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -161,7 +160,6 @@ export function createSessionsListTool(opts?: {
               sessionFile ? { sessionFile } : undefined,
               {
                 agentId: resolveAgentIdFromSessionKey(key),
-                sessionsDir: path.dirname(storePath),
               },
             );
           } catch {


### PR DESCRIPTION
Fixes #28379.

## Problem
 was computing  using , which can point at the workspace directory rather than the agent state sessions directory.

## Fix
Let  resolve the sessions dir from  (derived from the session key), so  points at .

## Notes
- Removes an unused  import.
- Tests: 
> openclaw@2026.2.26 test /root/.openclaw/workspace/openclaw
> node scripts/test-parallel.mjs src/agents/openclaw-tools.sessions.test.ts


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/root/.openclaw/workspace/openclaw[39m

 [32m✓[39m src/agents/openclaw-tools.sessions.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 110[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m18 passed[39m[22m[90m (18)[39m
[2m   Start at [22m 15:44:04
[2m   Duration [22m 12.67s[2m (transform 7.95s, setup 324ms, import 12.10s, tests 110ms, environment 0ms)[22m, 
> openclaw@2026.2.26 test /root/.openclaw/workspace/openclaw
> node scripts/test-parallel.mjs src/agents/tools/sessions.test.ts


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/root/.openclaw/workspace/openclaw[39m

 [32m✓[39m src/agents/tools/sessions.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 18[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m11 passed[39m[22m[90m (11)[39m
[2m   Start at [22m 15:44:18
[2m   Duration [22m 4.07s[2m (transform 2.29s, setup 279ms, import 3.63s, tests 18ms, environment 0ms)[22m.