### PR TITLE
Feat/control UI drag drop images

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2590,3 +2590,20 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Drag and drop styles for chat textarea */
+.chat-compose__field textarea.chat-compose__textarea--dragging,
+.chat-compose__field textarea.chat-compose__textarea--dragging:focus {
+  border: 2px dashed var(--primary);
+  background-color: rgba(var(--primary-rgb, 59, 130, 246), 0.1);
+  box-shadow: 0 0 0 4px rgba(var(--primary-rgb, 59, 130, 246), 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  .chat-compose__field textarea.chat-compose__textarea--dragging,
+  .chat-compose__field textarea.chat-compose__textarea--dragging:focus {
+    background-color: rgba(var(--primary-rgb, 96, 165, 250), 0.15);
+    box-shadow: 0 0 0 4px rgba(var(--primary-rgb, 96, 165, 250), 0.2);
+  }
+}
+


### PR DESCRIPTION
## Summary

- **Problem:** Control UI chat only supported Ctrl+V paste for images. Drag and drop from Finder didn't work — files would just open in the browser instead of attaching. I kept accidentally opening images when trying to share them in chat.
- **Why it matters:** I use the Control UI daily on my MacBook M2, and dragging images from Finder feels way more natural than copy-pasting. This is a standard pattern in modern web apps (ChatGPT, Claude, etc. all support this), so users expect it to work.
- **What changed:** Added dragover/dragleave/drop event handlers to the chat textarea. Dropped images are converted to data URLs and added as attachments, same as paste. Added visual feedback (dashed border + subtle blue highlight) when dragging over the input.
- **What did NOT change (scope boundary):** Paste behavior is unchanged. Non-image files are ignored (same as current paste behavior). No changes to attachment upload logic, storage, or the backend. The implementation mirrors the existing `handlePaste` function to keep the code style consistent.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue

Fixes #28226

## User-visible / Behavior Changes

Users can now drag image files directly into the chat textarea. Visual feedback (dashed border + subtle background highlight) shows when dragging over the input. Works with PNG, JPEG, WebP, and GIF files. Multiple files can be dropped at once.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.3 (MacBook M2)
- Browser: Chrome 133, Safari 17
- Node: 22.x
- OpenClaw version: 2026.2.26

### Steps

1. Open Control UI at `http://localhost:18789/ui`
2. Start or select a session
3. Drag a PNG/JPEG/WebP from Finder over the chat input
4. Observe dashed border + blue highlight appears
5. Drop the file
6. Image appears as attachment preview above the textarea
7. Send message — image is included in the conversation

### Expected

Image attaches and can be sent.

### Actual (before fix)

Browser opens the image file instead of attaching it.

## Evidence

- [x] Manual testing completed

Tested scenarios:
- Single image drop from Finder (PNG, 2MB)
- Multiple images dropped at once (3 JPEGs)
- Mixed image/non-image files — non-images correctly ignored
- Drag over then leave without dropping — visual feedback clears properly
- Large images (&gt;5MB) — handled correctly
- Rapid successive drops — no issues

## Human Verification (required)

- **Verified on:** Chrome 133 and Safari 17 on macOS 15.3 (MacBook M2)
- **Edge cases checked:** 
  - Large images (&gt;5MB)
  - Drag cancellation (drag over then leave)
  - Rapid successive drops
  - Mixed file types (images + documents)
- **What I didn't verify:** 
  - Linux file managers (no Linux machine available)
  - Windows Explorer (no Windows machine available)
  - Mobile touch-and-drag (would need mobile browser testing)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert the two commits in this PR
- **Files to restore:** `ui/src/ui/views/chat.ts`, `ui/src/styles/components.css`
- **Known bad symptoms:** Drag-and-drop stops working, visual feedback doesn't appear

## Risks and Mitigations

None — this is a pure UI enhancement using standard HTML5 drag-and-drop APIs. No new dependencies, no network calls, no data access changes.

---

I reviewed the implementation against the existing `handlePaste` function to keep the code style consistent. Manual testing done on my MacBook M2.