### PR TITLE
fix(doctor): detect groupPolicy=allowlist with empty groupAllowFrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ Docs: https://docs.openclaw.ai
 - Plugins/Install: clear stale install errors when an npm package is not found so follow-up install attempts report current state correctly. (#25073) Thanks @dalefrieswthat.
 - OpenAI Responses/Compaction: rewrite and unify the OpenAI Responses store patches to treat empty `baseUrl` as non-direct, honor `compat.supportsStore=false`, and auto-inject server-side compaction `context_management` for compatible direct OpenAI models (with per-model opt-out/threshold overrides). Landed from contributor PRs #16930 (@OiPunk), #22441 (@EdwardWu7), and #25088 (@MoerAI). Thanks @OiPunk, @EdwardWu7, and @MoerAI.
 
+## Unreleased
+
+### Fixes
+
+- Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
+
 ## 2026.2.26
 
 ### Changes

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1308,9 +1308,12 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       undefined;
 
     if (groupPolicy === "allowlist") {
-      const groupAllowFrom =
+      const rawGroupAllowFrom =
         (account.groupAllowFrom as Array<string | number> | undefined) ??
         (parent?.groupAllowFrom as Array<string | number> | undefined);
+      // Match runtime semantics: resolveGroupAllowFromSources treats
+      // empty arrays as unset and falls back to allowFrom.
+      const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
       const effectiveGroupAllowFrom = groupAllowFrom ?? effectiveAllowFrom;
 
       if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1267,10 +1267,15 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
 
   const warnings: string[] = [];
 
+  // Discord and Slack enforce group allowlists via guild/channel config
+  // (guilds.*.channels / channels.*), not sender-based groupAllowFrom.
+  const usesChannelBasedGroupAllowlist = new Set(["discord", "slack"]);
+
   const checkAccount = (
     account: Record<string, unknown>,
     prefix: string,
     parent?: Record<string, unknown>,
+    channelName?: string,
   ) => {
     const dmEntry = account.dm;
     const dm =
@@ -1307,7 +1312,12 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       (parent?.groupPolicy as string | undefined) ??
       undefined;
 
-    if (groupPolicy === "allowlist") {
+    // Skip sender-based check for channels that use channel/guild allowlists
+    // (Discord: guilds.*.channels, Slack: channels.*).
+    if (
+      groupPolicy === "allowlist" &&
+      (!channelName || !usesChannelBasedGroupAllowlist.has(channelName))
+    ) {
       const rawGroupAllowFrom =
         (account.groupAllowFrom as Array<string | number> | undefined) ??
         (parent?.groupAllowFrom as Array<string | number> | undefined);
@@ -1330,7 +1340,7 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     if (!channelConfig || typeof channelConfig !== "object") {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`);
+    checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
 
     const accounts = channelConfig.accounts;
     if (accounts && typeof accounts === "object") {
@@ -1340,7 +1350,12 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
         if (!account || typeof account !== "object") {
           continue;
         }
-        checkAccount(account, `channels.${channelName}.accounts.${accountId}`, channelConfig);
+        checkAccount(
+          account,
+          `channels.${channelName}.accounts.${accountId}`,
+          channelConfig,
+          channelName,
+        );
       }
     }
   }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1267,9 +1267,28 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
 
   const warnings: string[] = [];
 
-  // Discord and Slack enforce group allowlists via guild/channel config
-  // (guilds.*.channels / channels.*), not sender-based groupAllowFrom.
-  const usesChannelBasedGroupAllowlist = new Set(["discord", "slack"]);
+  const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    // These channels enforce group access via channel/space config, not sender-based
+    // groupAllowFrom lists.
+    return !(channelName === "discord" || channelName === "slack" || channelName === "googlechat");
+  };
+
+  const allowsGroupAllowFromFallback = (channelName?: string): boolean => {
+    if (!channelName) {
+      return true;
+    }
+    // Keep doctor warnings aligned with runtime access semantics.
+    return !(
+      channelName === "googlechat" ||
+      channelName === "imessage" ||
+      channelName === "matrix" ||
+      channelName === "msteams" ||
+      channelName === "irc"
+    );
+  };
 
   const checkAccount = (
     account: Record<string, unknown>,
@@ -1312,24 +1331,27 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       (parent?.groupPolicy as string | undefined) ??
       undefined;
 
-    // Skip sender-based check for channels that use channel/guild allowlists
-    // (Discord: guilds.*.channels, Slack: channels.*).
-    if (
-      groupPolicy === "allowlist" &&
-      (!channelName || !usesChannelBasedGroupAllowlist.has(channelName))
-    ) {
+    if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
       const rawGroupAllowFrom =
         (account.groupAllowFrom as Array<string | number> | undefined) ??
         (parent?.groupAllowFrom as Array<string | number> | undefined);
       // Match runtime semantics: resolveGroupAllowFromSources treats
       // empty arrays as unset and falls back to allowFrom.
       const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom) ? rawGroupAllowFrom : undefined;
-      const effectiveGroupAllowFrom = groupAllowFrom ?? effectiveAllowFrom;
+      const fallbackToAllowFrom = allowsGroupAllowFromFallback(channelName);
+      const effectiveGroupAllowFrom =
+        groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
 
       if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
-        warnings.push(
-          `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
-        );
+        if (fallbackToAllowFrom) {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
+          );
+        } else {
+          warnings.push(
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
+          );
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary

`openclaw doctor` detects `dmPolicy="allowlist"` with empty `allowFrom` (added in #27892), but misses the parallel case: `groupPolicy="allowlist"` without `groupAllowFrom` or `allowFrom`. After the .26 security hardening, `resolveDmGroupAccessDecision` fails closed on empty group allowlists, silently dropping **all** group/channel messages with only a verbose-level log.

This adds a matching check to `detectEmptyAllowlistPolicy` so `openclaw doctor` surfaces a clear warning with remediation steps when `groupPolicy="allowlist"` has no effective group allowlist.

## Changes

- Extend `detectEmptyAllowlistPolicy` in `doctor-config-flow.ts` to also check `groupPolicy="allowlist"` with empty `groupAllowFrom` (falling back to `allowFrom`)
- Warning message includes three remediation paths: add `groupAllowFrom`, add `allowFrom`, or set `groupPolicy` to `"open"`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test -- src/commands/doctor-config-flow.test.ts` — all 17 tests pass
- [x] `pnpm test -- src/config/config.allowlist-requires-allowfrom.test.ts` — all 14 tests pass
- [x] Verified on live bare-metal install: Mattermost messages were silently dropped with `groupPolicy: "allowlist"` and no `groupAllowFrom`; adding `groupAllowFrom: ["*"]` restored message delivery

Closes #27552