### PR TITLE
feat(tts): add local TTS provider

### DIFF
--- a/docs/tts.md
+++ b/docs/tts.md
@@ -295,7 +295,7 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (`openai` | `elevenlabs` | `edge`, requires `allowProvider: true`)
+- `provider` (`openai` | `elevenlabs` | `edge` | `local`, requires `allowProvider: true`)
 - `voice` (OpenAI voice) or `voiceId` (ElevenLabs)
 - `model` (OpenAI TTS model or ElevenLabs model id)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -28,13 +28,13 @@ Edge TTS uses Microsoft Edge's online neural TTS service via the `node-edge-tts`
 library. It's a hosted service (not local), uses Microsoft’s endpoints, and does
 not require an API key. `node-edge-tts` exposes speech configuration options and
 output formats, but not all options are supported by the Edge service.
-citeturn2search0
+citeturn2search0
 
 Because Edge TTS is a public web service without a published SLA or quota, treat
 it as best-effort. If you need guaranteed limits and support, use OpenAI or
 ElevenLabs. Microsoft's Speech REST API documents a 10‑minute audio limit per
 request; Edge TTS does not publish limits, so assume similar or lower limits.
-citeturn0search3
+citeturn0search3
 
 ## Optional keys
 
@@ -378,7 +378,7 @@ These override `messages.tts.*` for that host.
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
     from the Edge service. citeturn2search0
   - Output format values follow Microsoft Speech output formats (including
-    Ogg/WebM Opus). citeturn1search0
+    Ogg/WebM Opus). citeturn1search0
   - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,32 +9,27 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, Edge
-TTS, or a local command. It works anywhere OpenClaw can send audio; Telegram
-gets a round voice-note bubble.
+OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, Edge TTS, or a local command.
+It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
-- **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when
-  no API keys)
-- **Local** (primary or fallback provider; runs a custom command on the gateway
-  host)
+- **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
+- **Local** (primary or fallback provider; runs a custom command on the gateway host)
 
 ### Edge TTS notes
 
 Edge TTS uses Microsoft Edge's online neural TTS service via the `node-edge-tts`
 library. It's a hosted service (not local), uses Microsoft’s endpoints, and does
 not require an API key. `node-edge-tts` exposes speech configuration options and
-output formats, but not all options are supported by the Edge service.
-citeturn2search0
+output formats, but not all options are supported by the Edge service. citeturn2search0
 
-Because Edge TTS is a public web service without a published SLA or quota, treat
-it as best-effort. If you need guaranteed limits and support, use OpenAI or
-ElevenLabs. Microsoft's Speech REST API documents a 10‑minute audio limit per
-request; Edge TTS does not publish limits, so assume similar or lower limits.
-citeturn0search3
+Because Edge TTS is a public web service without a published SLA or quota, treat it
+as best-effort. If you need guaranteed limits and support, use OpenAI or ElevenLabs.
+Microsoft's Speech REST API documents a 10‑minute audio limit per request; Edge TTS
+does not publish limits, so assume similar or lower limits. citeturn0search3
 
 ## Optional keys
 
@@ -43,13 +38,12 @@ If you want OpenAI or ElevenLabs:
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
 
-Edge TTS does **not** require an API key. If no API keys are found, OpenClaw
-defaults to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
+Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
+to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
 
-If multiple providers are configured, the selected provider is used first and
-the others are fallback options. Auto-summary uses the configured `summaryModel`
-(or `agents.defaults.model.primary`), so that provider must also be
-authenticated if you enable summaries.
+If multiple providers are configured, the selected provider is used first and the others are fallback options.
+Auto-summary uses the configured `summaryModel` (or `agents.defaults.model.primary`),
+so that provider must also be authenticated if you enable summaries.
 
 ## Service links
 
@@ -62,16 +56,16 @@ authenticated if you enable summaries.
 
 ## Is it enabled by default?
 
-No. Auto‑TTS is **off** by default. Enable it in config with `messages.tts.auto`
-or per session with `/tts always` (alias: `/tts on`).
+No. Auto‑TTS is **off** by default. Enable it in config with
+`messages.tts.auto` or per session with `/tts always` (alias: `/tts on`).
 
 Edge TTS **is** enabled by default once TTS is on, and is used automatically
 when no OpenAI or ElevenLabs API keys are available.
 
 ## Config
 
-TTS config lives under `messages.tts` in `openclaw.json`. Full schema is in
-[Gateway configuration](/gateway/configuration).
+TTS config lives under `messages.tts` in `openclaw.json`.
+Full schema is in [Gateway configuration](/gateway/configuration).
 
 ### Minimal config (enable + provider)
 
@@ -244,25 +238,19 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, `"edge"`, or `"local"` (fallback is
-  automatic).
-- If `provider` is **unset**, OpenClaw prefers `openai` (if key), then
-  `elevenlabs` (if key), otherwise `edge`.
+- `provider`: `"elevenlabs"`, `"openai"`, `"edge"`, or `"local"` (fallback is automatic).
+- If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
+  otherwise `edge`.
 - `local.command`: executable path for the local TTS command.
-- `local.args`: arguments passed to the command. Supports `{{Text}}`,
-  `{{Output}}`, `{{Channel}}`, and `{{Format}}` placeholders (same convention as
-  media/link CLI runners).
-- `summaryModel`: optional cheap model for auto-summary; defaults to
-  `agents.defaults.model.primary`.
+- `local.args`: arguments passed to the command. Supports `{{Text}}`, `{{Output}}`, `{{Channel}}`, and `{{Format}}` placeholders (same convention as media/link CLI runners).
+- `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
   - `allowProvider` defaults to `false` (provider switching is opt-in).
-- `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if
-  exceeded.
+- `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if exceeded.
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
-- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`,
-  `OPENAI_API_KEY`).
+- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `openai.baseUrl`: override the OpenAI TTS endpoint.
   - Resolution order: `messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
@@ -277,28 +265,24 @@ Then run:
 - `edge.enabled`: allow Edge TTS usage (default `true`; no API key).
 - `edge.voice`: Edge neural voice name (e.g. `en-US-MichelleNeural`).
 - `edge.lang`: language code (e.g. `en-US`).
-- `edge.outputFormat`: Edge output format (e.g.
-  `audio-24khz-48kbitrate-mono-mp3`).
-  - See Microsoft Speech output formats for valid values; not all formats are
-    supported by Edge.
-- `edge.rate` / `edge.pitch` / `edge.volume`: percent strings (e.g. `+10%`,
-  `-5%`).
+- `edge.outputFormat`: Edge output format (e.g. `audio-24khz-48kbitrate-mono-mp3`).
+  - See Microsoft Speech output formats for valid values; not all formats are supported by Edge.
+- `edge.rate` / `edge.pitch` / `edge.volume`: percent strings (e.g. `+10%`, `-5%`).
 - `edge.saveSubtitles`: write JSON subtitles alongside the audio file.
 - `edge.proxy`: proxy URL for Edge TTS requests.
 - `edge.timeoutMs`: request timeout override (ms).
 
 ## Model-driven overrides (default on)
 
-By default, the model **can** emit TTS directives for a single reply. When
-`messages.tts.auto` is `tagged`, these directives are required to trigger audio.
+By default, the model **can** emit TTS directives for a single reply.
+When `messages.tts.auto` is `tagged`, these directives are required to trigger audio.
 
 When enabled, the model can emit `[[tts:...]]` directives to override the voice
 for a single reply, plus an optional `[[tts:text]]...[[/tts:text]]` block to
 provide expressive tags (laughter, singing cues, etc) that should only appear in
 the audio.
 
-`provider=...` directives are ignored unless
-`modelOverrides.allowProvider: true`.
+`provider=...` directives are ignored unless `modelOverrides.allowProvider: true`.
 
 Example reply payload:
 
@@ -333,8 +317,7 @@ Disable all model overrides:
 }
 ```
 
-Optional allowlist (enable provider switching while keeping other knobs
-configurable):
+Optional allowlist (enable provider switching while keeping other knobs configurable):
 
 ```json5
 {
@@ -367,18 +350,14 @@ These override `messages.tts.*` for that host.
 
 ## Output formats (fixed)
 
-- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from
-  OpenAI).
-  - 48kHz / 64kbps is a good voice-note tradeoff and required for the round
-    bubble.
+- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
+  - 48kHz / 64kbps is a good voice-note tradeoff and required for the round bubble.
 - **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
-- **Edge TTS**: uses `edge.outputFormat` (default
-  `audio-24khz-48kbitrate-mono-mp3`).
+- **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
     from the Edge service. citeturn2search0
-  - Output format values follow Microsoft Speech output formats (including
-    Ogg/WebM Opus). citeturn1search0
+  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus). citeturn1search0
   - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
@@ -391,12 +370,12 @@ When enabled, OpenClaw:
 
 - skips TTS if the reply already contains media or a `MEDIA:` directive.
 - skips very short replies (< 10 chars).
-- summarizes long replies when enabled using `agents.defaults.model.primary` (or
-  `summaryModel`).
+- summarizes long replies when enabled using `agents.defaults.model.primary` (or `summaryModel`).
 - attaches the generated audio to the reply.
 
 If the reply exceeds `maxLength` and summary is off (or no API key for the
-summary model), audio is skipped and the normal text reply is sent.
+summary model), audio
+is skipped and the normal text reply is sent.
 
 ## Flow diagram
 
@@ -415,8 +394,8 @@ Reply -> TTS enabled?
 
 ## Slash command usage
 
-There is a single command: `/tts`. See [Slash commands](/tools/slash-commands)
-for enablement details.
+There is a single command: `/tts`.
+See [Slash commands](/tools/slash-commands) for enablement details.
 
 Discord note: `/tts` is a built-in Discord command, so OpenClaw registers
 `/voice` as the native command there. Text `/tts ...` still works.
@@ -437,8 +416,7 @@ Notes:
 
 - Commands require an authorized sender (allowlist/owner rules still apply).
 - `commands.text` or native command registration must be enabled.
-- `off|always|inbound|tagged` are per‑session toggles (`/tts on` is an alias for
-  `/tts always`).
+- `off|always|inbound|tagged` are per‑session toggles (`/tts on` is an alias for `/tts always`).
 - `limit` and `summary` are stored in local prefs, not the main config.
 - `/tts audio` generates a one-off audio reply (does not toggle TTS on).
 

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -9,26 +9,32 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, or Edge TTS.
-It works anywhere OpenClaw can send audio; Telegram gets a round voice-note bubble.
+OpenClaw can convert outbound replies into audio using ElevenLabs, OpenAI, Edge
+TTS, or a local command. It works anywhere OpenClaw can send audio; Telegram
+gets a round voice-note bubble.
 
 ## Supported services
 
 - **ElevenLabs** (primary or fallback provider)
 - **OpenAI** (primary or fallback provider; also used for summaries)
-- **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when no API keys)
+- **Edge TTS** (primary or fallback provider; uses `node-edge-tts`, default when
+  no API keys)
+- **Local** (primary or fallback provider; runs a custom command on the gateway
+  host)
 
 ### Edge TTS notes
 
 Edge TTS uses Microsoft Edge's online neural TTS service via the `node-edge-tts`
 library. It's a hosted service (not local), uses Microsoft’s endpoints, and does
 not require an API key. `node-edge-tts` exposes speech configuration options and
-output formats, but not all options are supported by the Edge service. citeturn2search0
+output formats, but not all options are supported by the Edge service.
+citeturn2search0
 
-Because Edge TTS is a public web service without a published SLA or quota, treat it
-as best-effort. If you need guaranteed limits and support, use OpenAI or ElevenLabs.
-Microsoft's Speech REST API documents a 10‑minute audio limit per request; Edge TTS
-does not publish limits, so assume similar or lower limits. citeturn0search3
+Because Edge TTS is a public web service without a published SLA or quota, treat
+it as best-effort. If you need guaranteed limits and support, use OpenAI or
+ElevenLabs. Microsoft's Speech REST API documents a 10‑minute audio limit per
+request; Edge TTS does not publish limits, so assume similar or lower limits.
+citeturn0search3
 
 ## Optional keys
 
@@ -37,12 +43,13 @@ If you want OpenAI or ElevenLabs:
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `OPENAI_API_KEY`
 
-Edge TTS does **not** require an API key. If no API keys are found, OpenClaw defaults
-to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
+Edge TTS does **not** require an API key. If no API keys are found, OpenClaw
+defaults to Edge TTS (unless disabled via `messages.tts.edge.enabled=false`).
 
-If multiple providers are configured, the selected provider is used first and the others are fallback options.
-Auto-summary uses the configured `summaryModel` (or `agents.defaults.model.primary`),
-so that provider must also be authenticated if you enable summaries.
+If multiple providers are configured, the selected provider is used first and
+the others are fallback options. Auto-summary uses the configured `summaryModel`
+(or `agents.defaults.model.primary`), so that provider must also be
+authenticated if you enable summaries.
 
 ## Service links
 
@@ -55,16 +62,16 @@ so that provider must also be authenticated if you enable summaries.
 
 ## Is it enabled by default?
 
-No. Auto‑TTS is **off** by default. Enable it in config with
-`messages.tts.auto` or per session with `/tts always` (alias: `/tts on`).
+No. Auto‑TTS is **off** by default. Enable it in config with `messages.tts.auto`
+or per session with `/tts always` (alias: `/tts on`).
 
 Edge TTS **is** enabled by default once TTS is on, and is used automatically
 when no OpenAI or ElevenLabs API keys are available.
 
 ## Config
 
-TTS config lives under `messages.tts` in `openclaw.json`.
-Full schema is in [Gateway configuration](/gateway/configuration).
+TTS config lives under `messages.tts` in `openclaw.json`. Full schema is in
+[Gateway configuration](/gateway/configuration).
 
 ### Minimal config (enable + provider)
 
@@ -139,6 +146,38 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 }
 ```
 
+### Local command TTS
+
+Run any local executable for synthesis. Output path is passed via the
+`{{Output}}` placeholder.
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "local",
+      local: {
+        command: "/usr/local/bin/my-tts",
+        args: ["--text", "{{Text}}", "--out", "{{Output}}", "--format", "{{Format}}"],
+      },
+    },
+  },
+}
+```
+
+Available placeholders for `local.args`:
+
+| Placeholder   | Value                                                     |
+| ------------- | --------------------------------------------------------- |
+| `{{Text}}`    | The text to synthesize                                    |
+| `{{Output}}`  | Absolute path where the command must write the audio file |
+| `{{Channel}}` | Channel id (e.g. `telegram`, `whatsapp`) or `unknown`     |
+| `{{Format}}`  | Target format (`opus` for Telegram, `mp3` otherwise)      |
+
+The command must write a valid audio file to `{{Output}}` and exit with code 0.
+Fallback to the next provider occurs on non-zero exit.
+
 ### Disable Edge TTS
 
 ```json5
@@ -205,17 +244,25 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts]]` tags.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: `"elevenlabs"`, `"openai"`, or `"edge"` (fallback is automatic).
-- If `provider` is **unset**, OpenClaw prefers `openai` (if key), then `elevenlabs` (if key),
-  otherwise `edge`.
-- `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
+- `provider`: `"elevenlabs"`, `"openai"`, `"edge"`, or `"local"` (fallback is
+  automatic).
+- If `provider` is **unset**, OpenClaw prefers `openai` (if key), then
+  `elevenlabs` (if key), otherwise `edge`.
+- `local.command`: executable path for the local TTS command.
+- `local.args`: arguments passed to the command. Supports `{{Text}}`,
+  `{{Output}}`, `{{Channel}}`, and `{{Format}}` placeholders (same convention as
+  media/link CLI runners).
+- `summaryModel`: optional cheap model for auto-summary; defaults to
+  `agents.defaults.model.primary`.
   - Accepts `provider/model` or a configured model alias.
 - `modelOverrides`: allow the model to emit TTS directives (on by default).
   - `allowProvider` defaults to `false` (provider switching is opt-in).
-- `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if exceeded.
+- `maxTextLength`: hard cap for TTS input (chars). `/tts audio` fails if
+  exceeded.
 - `timeoutMs`: request timeout (ms).
 - `prefsPath`: override the local prefs JSON path (provider/limit/summary).
-- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`, `OPENAI_API_KEY`).
+- `apiKey` values fall back to env vars (`ELEVENLABS_API_KEY`/`XI_API_KEY`,
+  `OPENAI_API_KEY`).
 - `elevenlabs.baseUrl`: override ElevenLabs API base URL.
 - `openai.baseUrl`: override the OpenAI TTS endpoint.
   - Resolution order: `messages.tts.openai.baseUrl` -> `OPENAI_TTS_BASE_URL` -> `https://api.openai.com/v1`
@@ -230,24 +277,28 @@ Then run:
 - `edge.enabled`: allow Edge TTS usage (default `true`; no API key).
 - `edge.voice`: Edge neural voice name (e.g. `en-US-MichelleNeural`).
 - `edge.lang`: language code (e.g. `en-US`).
-- `edge.outputFormat`: Edge output format (e.g. `audio-24khz-48kbitrate-mono-mp3`).
-  - See Microsoft Speech output formats for valid values; not all formats are supported by Edge.
-- `edge.rate` / `edge.pitch` / `edge.volume`: percent strings (e.g. `+10%`, `-5%`).
+- `edge.outputFormat`: Edge output format (e.g.
+  `audio-24khz-48kbitrate-mono-mp3`).
+  - See Microsoft Speech output formats for valid values; not all formats are
+    supported by Edge.
+- `edge.rate` / `edge.pitch` / `edge.volume`: percent strings (e.g. `+10%`,
+  `-5%`).
 - `edge.saveSubtitles`: write JSON subtitles alongside the audio file.
 - `edge.proxy`: proxy URL for Edge TTS requests.
 - `edge.timeoutMs`: request timeout override (ms).
 
 ## Model-driven overrides (default on)
 
-By default, the model **can** emit TTS directives for a single reply.
-When `messages.tts.auto` is `tagged`, these directives are required to trigger audio.
+By default, the model **can** emit TTS directives for a single reply. When
+`messages.tts.auto` is `tagged`, these directives are required to trigger audio.
 
 When enabled, the model can emit `[[tts:...]]` directives to override the voice
 for a single reply, plus an optional `[[tts:text]]...[[/tts:text]]` block to
 provide expressive tags (laughter, singing cues, etc) that should only appear in
 the audio.
 
-`provider=...` directives are ignored unless `modelOverrides.allowProvider: true`.
+`provider=...` directives are ignored unless
+`modelOverrides.allowProvider: true`.
 
 Example reply payload:
 
@@ -282,7 +333,8 @@ Disable all model overrides:
 }
 ```
 
-Optional allowlist (enable provider switching while keeping other knobs configurable):
+Optional allowlist (enable provider switching while keeping other knobs
+configurable):
 
 ```json5
 {
@@ -315,14 +367,18 @@ These override `messages.tts.*` for that host.
 
 ## Output formats (fixed)
 
-- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from OpenAI).
-  - 48kHz / 64kbps is a good voice-note tradeoff and required for the round bubble.
+- **Telegram**: Opus voice note (`opus_48000_64` from ElevenLabs, `opus` from
+  OpenAI).
+  - 48kHz / 64kbps is a good voice-note tradeoff and required for the round
+    bubble.
 - **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
-- **Edge TTS**: uses `edge.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
+- **Edge TTS**: uses `edge.outputFormat` (default
+  `audio-24khz-48kbitrate-mono-mp3`).
   - `node-edge-tts` accepts an `outputFormat`, but not all formats are available
     from the Edge service. citeturn2search0
-  - Output format values follow Microsoft Speech output formats (including Ogg/WebM Opus). citeturn1search0
+  - Output format values follow Microsoft Speech output formats (including
+    Ogg/WebM Opus). citeturn1search0
   - Telegram `sendVoice` accepts OGG/MP3/M4A; use OpenAI/ElevenLabs if you need
     guaranteed Opus voice notes. citeturn1search1
   - If the configured Edge output format fails, OpenClaw retries with MP3.
@@ -335,12 +391,12 @@ When enabled, OpenClaw:
 
 - skips TTS if the reply already contains media or a `MEDIA:` directive.
 - skips very short replies (< 10 chars).
-- summarizes long replies when enabled using `agents.defaults.model.primary` (or `summaryModel`).
+- summarizes long replies when enabled using `agents.defaults.model.primary` (or
+  `summaryModel`).
 - attaches the generated audio to the reply.
 
 If the reply exceeds `maxLength` and summary is off (or no API key for the
-summary model), audio
-is skipped and the normal text reply is sent.
+summary model), audio is skipped and the normal text reply is sent.
 
 ## Flow diagram
 
@@ -359,8 +415,8 @@ Reply -> TTS enabled?
 
 ## Slash command usage
 
-There is a single command: `/tts`.
-See [Slash commands](/tools/slash-commands) for enablement details.
+There is a single command: `/tts`. See [Slash commands](/tools/slash-commands)
+for enablement details.
 
 Discord note: `/tts` is a built-in Discord command, so OpenClaw registers
 `/voice` as the native command there. Text `/tts ...` still works.
@@ -381,7 +437,8 @@ Notes:
 
 - Commands require an authorized sender (allowlist/owner rules still apply).
 - `commands.text` or native command registration must be enabled.
-- `off|always|inbound|tagged` are per‑session toggles (`/tts on` is an alias for `/tts always`).
+- `off|always|inbound|tagged` are per‑session toggles (`/tts on` is an alias for
+  `/tts always`).
 - `limit` and `summary` are stored in local prefs, not the main config.
 - `/tts audio` generates a one-off audio reply (does not toggle TTS on).
 

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -56,7 +56,8 @@ function ttsUsage(): ReplyPayload {
       `**Providers:**\n` +
       `• edge — Free, fast (default)\n` +
       `• openai — High quality (requires API key)\n` +
-      `• elevenlabs — Premium voices (requires API key)\n\n` +
+      `• elevenlabs — Premium voices (requires API key)\n` +
+      `• local — Custom command on gateway host\n\n` +
       `**Text Limit (default: 1500, max: 4096):**\n` +
       `When text exceeds the limit:\n` +
       `• Summary ON: AI summarizes, then generates audio\n` +
@@ -162,6 +163,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
+      const hasLocal = isTtsProviderConfigured(config, "local");
       return {
         shouldContinue: false,
         reply: {
@@ -171,13 +173,19 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Local command: ${hasLocal ? "✅" : "❌"}\n` +
+            `Usage: /tts provider openai | elevenlabs | edge | local`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "local"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -107,6 +107,11 @@ export type MsgContext = {
   LinkUnderstanding?: string[];
   Prompt?: string;
   MaxChars?: number;
+  /** Local TTS provider template variables. */
+  Text?: string;
+  Output?: string;
+  Channel?: string;
+  Format?: string;
   ChatType?: string;
   /** Human label for envelope headers (conversation label, not sender). */
   ConversationLabel?: string;

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,6 +1,6 @@
 import type { SecretInput } from "./types.secrets.js";
 
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "local";
 
 export type TtsMode = "final" | "all";
 
@@ -79,6 +79,13 @@ export type TtsConfig = {
     saveSubtitles?: boolean;
     proxy?: string;
     timeoutMs?: number;
+  };
+  /** Local command-based TTS provider. */
+  local?: {
+    /** Executable to run for TTS synthesis. */
+    command: string;
+    /** Arguments passed to the command. Supports {{Text}}, {{Output}}, {{Channel}}, {{Format}} placeholders. */
+    args?: string[];
   };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -353,7 +353,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "local"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -427,6 +427,13 @@ export const TtsConfigSchema = z
     prefsPath: z.string().optional(),
     maxTextLength: z.number().int().min(1).optional(),
     timeoutMs: z.number().int().min(1000).max(120000).optional(),
+    local: z
+      .object({
+        command: z.string().optional(),
+        args: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -429,7 +429,7 @@ export const TtsConfigSchema = z
     timeoutMs: z.number().int().min(1000).max(120000).optional(),
     local: z
       .object({
-        command: z.string().optional(),
+        command: z.string(),
         args: z.array(z.string()).optional(),
       })
       .strict()

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -5,8 +5,8 @@ import {
   getTtsProvider,
   isTtsEnabled,
   isTtsProviderConfigured,
-  resolveTtsAutoMode,
   resolveTtsApiKey,
+  resolveTtsAutoMode,
   resolveTtsConfig,
   resolveTtsPrefsPath,
   resolveTtsProviderOrder,
@@ -39,6 +39,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
         edgeEnabled: isTtsProviderConfigured(config, "edge"),
+        localEnabled: isTtsProviderConfigured(config, "local"),
       });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
@@ -100,13 +101,18 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "local"
+    ) {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, edge, or local.",
         ),
       );
       return;
@@ -145,6 +151,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             id: "edge",
             name: "Edge TTS",
             configured: isTtsProviderConfigured(config, "edge"),
+            models: [],
+          },
+          {
+            id: "local",
+            name: "Local TTS",
+            configured: isTtsProviderConfigured(config, "local"),
             models: [],
           },
         ],

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -156,7 +156,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "edge" ||
+              rawValue === "local"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1075,7 +1075,7 @@ describe("tts", () => {
 
         expect(result.success).toBe(true);
         expect(result.provider).toBe("local");
-        expect(result.audioPath).toMatch(/\.mp3$/);
+        expect(result.audioPath).toMatch(/\.ogg$/); // whatsapp is a voice-bubble channel
         expect(result.latencyMs).toBeGreaterThanOrEqual(0);
         expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
       });
@@ -1151,9 +1151,9 @@ describe("tts", () => {
 
         expect(capturedArgv[0]).toBe("/bin/tts");
         expect(capturedArgv[1]).toBe("synthesize this"); // {{Text}}
-        expect(capturedArgv[2]).toMatch(/\.mp3$/); // {{Output}}
+        expect(capturedArgv[2]).toMatch(/\.ogg$/); // {{Output}} — whatsapp is a voice-bubble channel
         expect(capturedArgv[3]).toBe("whatsapp"); // {{Channel}}
-        expect(capturedArgv[4]).toBe("mp3"); // {{Format}}
+        expect(capturedArgv[4]).toBe("opus"); // {{Format}} — whatsapp is a voice-bubble channel
       });
 
       it("passes no extra args when args array is empty", async () => {
@@ -1312,8 +1312,8 @@ describe("tts", () => {
         });
 
         expect(result.success).toBe(true);
-        expect(result.voiceCompatible).toBe(false);
-        expect(result.audioPath).toMatch(/\.mp3$/);
+        expect(result.voiceCompatible).toBe(true); // whatsapp is a voice-bubble channel
+        expect(result.audioPath).toMatch(/\.ogg$/); // whatsapp is a voice-bubble channel
       });
 
       it("falls back to local when the primary provider (openai) has no API key", async () => {

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AssistantMessage, completeSimple } from "@mariozechner/pi-ai";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
@@ -25,11 +26,25 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthApiKey: vi.fn(async () => null),
 }));
 
+// Capture original existsSync before vi.mock replaces it, so tests outside
+// the local-provider textToSpeech describe can restore the real behaviour.
+// `var` is used (instead of `let`) because vi.mock factories are hoisted above
+// `let`/`const` declarations and would hit the temporal dead zone otherwise.
+// eslint-disable-next-line no-var
+var _origExistsSync: typeof existsSync;
+
 vi.mock("../process/exec.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../process/exec.js")>();
   return { ...original, runCommandWithTimeout: vi.fn() };
 });
 
+// Wrap existsSync so the local-provider tests can control whether the output
+// file is "present" without touching the real filesystem.
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  _origExistsSync = original.existsSync;
+  return { ...original, existsSync: vi.fn(original.existsSync) };
+});
 vi.mock("../agents/pi-embedded-runner/model.js", () => ({
   resolveModel: vi.fn((provider: string, modelId: string) => ({
     model: {
@@ -1030,6 +1045,18 @@ describe("tts", () => {
     // ── textToSpeech ────────────────────────────────────────────────────────
 
     describe("textToSpeech", () => {
+      // The mocked runCommandWithTimeout never writes a real file; make
+      // existsSync return true by default so success-path tests pass.  The
+      // readPrefs callers that also use existsSync are wrapped in try/catch and
+      // tolerate a missing file, so this override is safe for the whole block.
+      beforeEach(() => {
+        vi.mocked(existsSync).mockReturnValue(true);
+      });
+      afterEach(() => {
+        // Restore passthrough behaviour for tests outside this describe block.
+        vi.mocked(existsSync).mockImplementation(_origExistsSync);
+      });
+
       it("returns success with an mp3 audioPath for non-Telegram channels", async () => {
         const result = await tts.textToSpeech({
           text: "Hello world",
@@ -1385,6 +1412,25 @@ describe("tts", () => {
         });
 
         expect(capturedArgv[1]).toBe("unknown");
+      });
+
+      it("falls back with error when command exits 0 but output file is missing", async () => {
+        // Simulate a command that ignores {{Output}} and writes to stdout instead.
+        vi.mocked(existsSync).mockReturnValue(false);
+
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-no-file-${Date.now()}.json`,
+          channel: "whatsapp",
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain(
+          "local: command exited 0 but did not create output file",
+        );
+        // Provider fallback should have been attempted (all others unconfigured here).
+        expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -360,6 +360,14 @@ describe("tts", () => {
       expect(result.overrides.provider).toBe("edge");
     });
 
+    it("accepts local as provider override", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Hello [[tts:provider=local]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.overrides.provider).toBe("local");
+    });
+
     it("rejects provider override by default while keeping voice overrides enabled", () => {
       const policy = resolveModelOverridePolicy({ enabled: true });
       const input = "Hello [[tts:provider=edge voice=alloy]] world";

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,9 +1,10 @@
-import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { type AssistantMessage, completeSimple } from "@mariozechner/pi-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { runCommandWithTimeout } from "../process/exec.js";
 import { withEnv } from "../test-utils/env.js";
 import * as tts from "./tts.js";
 
@@ -19,6 +20,11 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
   getOAuthProviders: () => [],
   getOAuthApiKey: vi.fn(async () => null),
 }));
+
+vi.mock("../process/exec.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../process/exec.js")>();
+  return { ...original, runCommandWithTimeout: vi.fn() };
+});
 
 vi.mock("../agents/pi-embedded-runner/model.js", () => ({
   resolveModel: vi.fn((provider: string, modelId: string) => ({
@@ -67,7 +73,9 @@ const {
   resolveEdgeOutputFormat,
 } = _test;
 
-const mockAssistantMessage = (content: AssistantMessage["content"]): AssistantMessage => ({
+const mockAssistantMessage = (
+  content: AssistantMessage["content"],
+): AssistantMessage => ({
   role: "assistant",
   content,
   api: "openai-completions",
@@ -119,7 +127,9 @@ describe("tts", () => {
         { value: "voice?param=value", expected: false },
       ] as const;
       for (const testCase of cases) {
-        expect(isValidVoiceId(testCase.value), testCase.value).toBe(testCase.expected);
+        expect(isValidVoiceId(testCase.value), testCase.value).toBe(
+          testCase.expected,
+        );
       }
     });
   });
@@ -129,7 +139,9 @@ describe("tts", () => {
       for (const voice of OPENAI_TTS_VOICES) {
         expect(isValidOpenAIVoice(voice)).toBe(true);
       }
-      for (const newerVoice of ["ballad", "cedar", "juniper", "marin", "verse"]) {
+      for (
+        const newerVoice of ["ballad", "cedar", "juniper", "marin", "verse"]
+      ) {
         expect(isValidOpenAIVoice(newerVoice), newerVoice).toBe(true);
       }
     });
@@ -143,7 +155,9 @@ describe("tts", () => {
     });
 
     it("treats the default endpoint with trailing slash as the default endpoint", () => {
-      expect(isValidOpenAIVoice("kokoro-custom-voice", "https://api.openai.com/v1/")).toBe(false);
+      expect(
+        isValidOpenAIVoice("kokoro-custom-voice", "https://api.openai.com/v1/"),
+      ).toBe(false);
     });
   });
 
@@ -164,26 +178,39 @@ describe("tts", () => {
         { model: "gpt-4", expected: false },
       ] as const;
       for (const testCase of cases) {
-        expect(isValidOpenAIModel(testCase.model), testCase.model).toBe(testCase.expected);
+        expect(isValidOpenAIModel(testCase.model), testCase.model).toBe(
+          testCase.expected,
+        );
       }
     });
 
     it("treats the default endpoint with trailing slash as the default endpoint", () => {
-      expect(isValidOpenAIModel("kokoro-custom-model", "https://api.openai.com/v1/")).toBe(false);
+      expect(
+        isValidOpenAIModel("kokoro-custom-model", "https://api.openai.com/v1/"),
+      ).toBe(false);
     });
   });
 
   describe("resolveOpenAITtsInstructions", () => {
     it("keeps instructions only for gpt-4o-mini-tts variants", () => {
-      expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", " Speak warmly ")).toBe(
+      expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", " Speak warmly "))
+        .toBe(
+          "Speak warmly",
+        );
+      expect(
+        resolveOpenAITtsInstructions(
+          "gpt-4o-mini-tts-2025-12-15",
+          "Speak warmly",
+        ),
+      ).toBe(
         "Speak warmly",
       );
-      expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts-2025-12-15", "Speak warmly")).toBe(
-        "Speak warmly",
-      );
-      expect(resolveOpenAITtsInstructions("tts-1", "Speak warmly")).toBeUndefined();
-      expect(resolveOpenAITtsInstructions("tts-1-hd", "Speak warmly")).toBeUndefined();
-      expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", "   ")).toBeUndefined();
+      expect(resolveOpenAITtsInstructions("tts-1", "Speak warmly"))
+        .toBeUndefined();
+      expect(resolveOpenAITtsInstructions("tts-1-hd", "Speak warmly"))
+        .toBeUndefined();
+      expect(resolveOpenAITtsInstructions("gpt-4o-mini-tts", "   "))
+        .toBeUndefined();
     });
   });
 
@@ -230,9 +257,15 @@ describe("tts", () => {
       for (const testCase of cases) {
         const output = resolveOutputFormat(testCase.channel);
         expect(output.openai, testCase.channel).toBe(testCase.expected.openai);
-        expect(output.elevenlabs, testCase.channel).toBe(testCase.expected.elevenlabs);
-        expect(output.extension, testCase.channel).toBe(testCase.expected.extension);
-        expect(output.voiceCompatible, testCase.channel).toBe(testCase.expected.voiceCompatible);
+        expect(output.elevenlabs, testCase.channel).toBe(
+          testCase.expected.elevenlabs,
+        );
+        expect(output.extension, testCase.channel).toBe(
+          testCase.expected.extension,
+        );
+        expect(output.voiceCompatible, testCase.channel).toBe(
+          testCase.expected.voiceCompatible,
+        );
       }
     });
   });
@@ -265,14 +298,19 @@ describe("tts", () => {
       ] as const;
       for (const testCase of cases) {
         const config = resolveTtsConfig(testCase.cfg);
-        expect(resolveEdgeOutputFormat(config), testCase.name).toBe(testCase.expected);
+        expect(resolveEdgeOutputFormat(config), testCase.name).toBe(
+          testCase.expected,
+        );
       }
     });
   });
 
   describe("parseTtsDirectives", () => {
     it("extracts overrides and strips directives when enabled", () => {
-      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowProvider: true,
+      });
       const input =
         "Hello [[tts:provider=elevenlabs voiceId=pMsXgVXv3BLzUgSXRplE stability=0.4 speed=1.1]] world\n\n" +
         "[[tts:text]](laughs) Read the song once more.[[/tts:text]]";
@@ -287,7 +325,10 @@ describe("tts", () => {
     });
 
     it("accepts edge as provider override", () => {
-      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowProvider: true,
+      });
       const input = "Hello [[tts:provider=edge]] world";
       const result = parseTtsDirectives(input, policy);
 
@@ -332,7 +373,9 @@ describe("tts", () => {
       const result = parseTtsDirectives(input, policy, defaultBaseUrl);
 
       expect(result.overrides.openai?.voice).toBeUndefined();
-      expect(result.warnings).toContain('invalid OpenAI voice "kokoro-chinese"');
+      expect(result.warnings).toContain(
+        'invalid OpenAI voice "kokoro-chinese"',
+      );
     });
   });
 
@@ -383,7 +426,9 @@ describe("tts", () => {
 
     it("uses summaryModel override when configured", async () => {
       const cfg: OpenClawConfig = {
-        agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+        agents: {
+          defaults: { model: { primary: "anthropic/claude-opus-4-5" } },
+        },
         messages: { tts: { summaryModel: "openai/gpt-4.1-mini" } },
       };
       const config = resolveTtsConfig(cfg);
@@ -395,7 +440,12 @@ describe("tts", () => {
         timeoutMs: 30_000,
       });
 
-      expect(resolveModel).toHaveBeenCalledWith("openai", "gpt-4.1-mini", undefined, cfg);
+      expect(resolveModel).toHaveBeenCalledWith(
+        "openai",
+        "gpt-4.1-mini",
+        undefined,
+        cfg,
+      );
     });
 
     it("registers the Ollama api before direct summarization", async () => {
@@ -424,7 +474,10 @@ describe("tts", () => {
         timeoutMs: 30_000,
       });
 
-      expect(ensureCustomApiRegistered).toHaveBeenCalledWith("ollama", expect.any(Function));
+      expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+        "ollama",
+        expect.any(Function),
+      );
     });
 
     it("validates targetLength bounds", async () => {
@@ -447,7 +500,8 @@ describe("tts", () => {
             `Invalid targetLength: ${testCase.targetLength}`,
           );
         } else {
-          await expect(call, String(testCase.targetLength)).resolves.toBeDefined();
+          await expect(call, String(testCase.targetLength)).resolves
+            .toBeDefined();
         }
       }
     });
@@ -660,7 +714,11 @@ describe("tts", () => {
         tts: {
           auto: "inbound",
           provider: "openai",
-          openai: { apiKey: "test-key", model: "gpt-4o-mini-tts", voice: "alloy" },
+          openai: {
+            apiKey: "test-key",
+            model: "gpt-4o-mini-tts",
+            voice: "alloy",
+          },
         },
       },
     };
@@ -725,7 +783,9 @@ describe("tts", () => {
             kind: "final",
             inboundAudio: testCase.inboundAudio,
           });
-          expect(fetchMock, testCase.name).toHaveBeenCalledTimes(testCase.expectedFetchCalls);
+          expect(fetchMock, testCase.name).toHaveBeenCalledTimes(
+            testCase.expectedFetchCalls,
+          );
           if (testCase.expectSamePayload) {
             expect(result, testCase.name).toBe(testCase.payload);
           } else {
@@ -759,6 +819,355 @@ describe("tts", () => {
 
         expect(result.mediaUrl).toBeDefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("local provider", () => {
+    const baseCfg = (): OpenClawConfig => ({
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: {
+        tts: {
+          auto: "always",
+          provider: "local",
+          // Disable all cloud providers so they don't pollute errors.
+          edge: { enabled: false },
+          local: {
+            command: "/usr/local/bin/fake-tts",
+            args: ["--text", "{{Text}}", "--out", "{{Output}}"],
+          },
+        },
+      },
+    });
+
+    const okResult = () => ({
+      stdout: "",
+      stderr: "",
+      code: 0 as number | null,
+      signal: null as NodeJS.Signals | null,
+      killed: false,
+      termination: "exit" as const,
+    });
+
+    beforeEach(() => {
+      vi.mocked(runCommandWithTimeout).mockResolvedValue(okResult());
+    });
+
+    // ── config resolution ───────────────────────────────────────────────────
+
+    describe("resolveTtsConfig", () => {
+      it("maps local.command and local.args from raw config", () => {
+        const config = tts.resolveTtsConfig(baseCfg());
+        expect(config.local?.command).toBe("/usr/local/bin/fake-tts");
+        expect(config.local?.args).toEqual([
+          "--text",
+          "{{Text}}",
+          "--out",
+          "{{Output}}",
+        ]);
+      });
+
+      it("defaults args to [] when omitted", () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              local: { command: "/bin/tts" },
+            },
+          },
+        };
+        const config = tts.resolveTtsConfig(cfg);
+        expect(config.local?.args).toEqual([]);
+      });
+
+      it("sets config.local to undefined when command is missing or absent", () => {
+        const cases: OpenClawConfig[] = [
+          {
+            agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+            messages: { tts: {} },
+          },
+          {
+            agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+            // @ts-expect-error – intentionally testing runtime behaviour
+            messages: { tts: { local: {} } },
+          },
+          {
+            agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+            // @ts-expect-error – intentionally testing runtime behaviour
+            messages: { tts: { local: { command: "" } } },
+          },
+        ];
+        for (const cfg of cases) {
+          expect(tts.resolveTtsConfig(cfg).local).toBeUndefined();
+        }
+      });
+    });
+
+    // ── isTtsProviderConfigured ──────────────────────────────────────────────
+
+    describe("isTtsProviderConfigured", () => {
+      it("returns true when local.command is set", () => {
+        const config = tts.resolveTtsConfig(baseCfg());
+        expect(tts.isTtsProviderConfigured(config, "local")).toBe(true);
+      });
+
+      it("returns false when local config is absent", () => {
+        const config = tts.resolveTtsConfig({
+          agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+          messages: { tts: {} },
+        });
+        expect(tts.isTtsProviderConfigured(config, "local")).toBe(false);
+      });
+    });
+
+    // ── textToSpeech ────────────────────────────────────────────────────────
+
+    describe("textToSpeech", () => {
+      it("returns success with an mp3 audioPath for non-Telegram channels", async () => {
+        const result = await tts.textToSpeech({
+          text: "Hello world",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-test-${Date.now()}.json`,
+          channel: "whatsapp",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe("local");
+        expect(result.audioPath).toMatch(/\.mp3$/);
+        expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+        expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
+      });
+
+      it("uses .ogg extension and opus format placeholder for Telegram", async () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              local: {
+                command: "/bin/tts",
+                args: ["--format", "{{Format}}", "--out", "{{Output}}"],
+              },
+            },
+          },
+        };
+
+        vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+          // Capture what was passed so we can assert on it.
+          (vi.mocked(runCommandWithTimeout) as ReturnType<typeof vi.fn> & {
+            lastArgv?: string[];
+          }).lastArgv = argv;
+          return okResult();
+        });
+
+        const result = await tts.textToSpeech({
+          text: "Hello Telegram",
+          cfg,
+          prefsPath: `/tmp/tts-local-telegram-${Date.now()}.json`,
+          channel: "telegram",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.audioPath).toMatch(/\.ogg$/);
+        const argv =
+          (vi.mocked(runCommandWithTimeout) as ReturnType<typeof vi.fn> & {
+            lastArgv?: string[];
+          }).lastArgv ?? [];
+        expect(argv).toContain("opus");
+      });
+
+      it("substitutes {{Text}}, {{Output}}, {{Channel}}, {{Format}} placeholders in args", async () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              local: {
+                command: "/bin/tts",
+                args: ["{{Text}}", "{{Output}}", "{{Channel}}", "{{Format}}"],
+              },
+            },
+          },
+        };
+
+        let capturedArgv: string[] = [];
+        vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+          capturedArgv = argv;
+          return okResult();
+        });
+
+        const prefsPath = `/tmp/tts-local-placeholders-${Date.now()}.json`;
+        await tts.textToSpeech({
+          text: "synthesize this",
+          cfg,
+          prefsPath,
+          channel: "whatsapp",
+        });
+
+        expect(capturedArgv[0]).toBe("/bin/tts");
+        expect(capturedArgv[1]).toBe("synthesize this"); // {{Text}}
+        expect(capturedArgv[2]).toMatch(/\.mp3$/); // {{Output}}
+        expect(capturedArgv[3]).toBe("whatsapp"); // {{Channel}}
+        expect(capturedArgv[4]).toBe("mp3"); // {{Format}}
+      });
+
+      it("passes no extra args when args array is empty", async () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              local: { command: "/bin/tts" },
+            },
+          },
+        };
+
+        let capturedArgv: string[] = [];
+        vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+          capturedArgv = argv;
+          return okResult();
+        });
+
+        await tts.textToSpeech({
+          text: "hello",
+          cfg,
+          prefsPath: `/tmp/tts-local-noargs-${Date.now()}.json`,
+        });
+
+        expect(capturedArgv).toEqual(["/bin/tts"]);
+      });
+
+      it("passes timeoutMs from config through to runCommandWithTimeout", async () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              timeoutMs: 12345,
+              local: { command: "/bin/tts" },
+            },
+          },
+        };
+
+        let capturedOpts: unknown;
+        vi.mocked(runCommandWithTimeout).mockImplementation(
+          async (_argv, opts) => {
+            capturedOpts = opts;
+            return okResult();
+          },
+        );
+
+        await tts.textToSpeech({
+          text: "hello",
+          cfg,
+          prefsPath: `/tmp/tts-local-timeout-${Date.now()}.json`,
+        });
+
+        expect((capturedOpts as { timeoutMs: number }).timeoutMs).toBe(12345);
+      });
+
+      it("falls through with error when no command is configured", async () => {
+        // No local.command → config.local is undefined → 'continue' to next provider.
+        // All cloud providers also disabled/unconfigured → overall failure.
+        const cfg: OpenClawConfig = {
+          agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+          messages: {
+            tts: {
+              auto: "always",
+              provider: "local",
+              edge: { enabled: false },
+              // local intentionally omitted
+            },
+          },
+        };
+
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg,
+          prefsPath: `/tmp/tts-local-noconfig-${Date.now()}.json`,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("local: no command configured");
+        // runCommandWithTimeout should never have been called.
+        expect(runCommandWithTimeout).not.toHaveBeenCalled();
+      });
+
+      it("throws and falls back when exit code is non-zero", async () => {
+        vi.mocked(runCommandWithTimeout).mockResolvedValue({
+          ...okResult(),
+          code: 1,
+          stderr: "voice synthesis failed",
+        });
+
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-fail-${Date.now()}.json`,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("local: voice synthesis failed");
+      });
+
+      it("uses fallback message when exit is non-zero and stderr is empty", async () => {
+        vi.mocked(runCommandWithTimeout).mockResolvedValue({
+          ...okResult(),
+          code: 127,
+          stderr: "   ",
+        });
+
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-empty-stderr-${Date.now()}.json`,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("local TTS command failed");
+      });
+
+      it("falls back to remaining providers when local throws", async () => {
+        vi.mocked(runCommandWithTimeout).mockRejectedValue(
+          new Error("ENOENT: command not found"),
+        );
+
+        // Local fails, edge disabled, no cloud keys → all-failure result.
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-throw-${Date.now()}.json`,
+        });
+
+        expect(result.success).toBe(false);
+        // Local error is captured; other providers also tried.
+        expect(result.error).toContain("local: ENOENT: command not found");
+      });
+
+      it("channel is 'unknown' when no channel is provided", async () => {
+        let capturedArgv: string[] = [];
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              local: { command: "/bin/tts", args: ["{{Channel}}"] },
+            },
+          },
+        };
+        vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+          capturedArgv = argv;
+          return okResult();
+        });
+
+        await tts.textToSpeech({
+          text: "hello",
+          cfg,
+          prefsPath: `/tmp/tts-local-nochannel-${Date.now()}.json`,
+          // channel intentionally omitted
+        });
+
+        expect(capturedArgv[1]).toBe("unknown");
       });
     });
   });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -4,8 +4,12 @@ import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
 import { getApiKeyForModel } from "../agents/model-auth.js";
 import { resolveModel } from "../agents/pi-embedded-runner/model.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  TtsConfigSchema,
+  TtsProviderSchema,
+} from "../config/zod-schema.core.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import * as tts from "./tts.js";
 
 vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
@@ -57,7 +61,13 @@ vi.mock("../agents/custom-api-registry.js", () => ({
   ensureCustomApiRegistered: vi.fn(),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const {
+  _test,
+  resolveTtsConfig,
+  maybeApplyTtsToPayload,
+  getTtsProvider,
+  resolveTtsProviderOrder,
+} = tts;
 
 const {
   isValidVoiceId,
@@ -536,6 +546,35 @@ describe("tts", () => {
       messages: { tts: {} },
     };
 
+    it("returns 'local' when explicitly set via config (providerSource: config)", () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: {
+          tts: { provider: "local", local: { command: "/bin/tts" } },
+        },
+      };
+      const config = resolveTtsConfig(cfg);
+      withEnv(
+        {
+          OPENAI_API_KEY: undefined,
+          ELEVENLABS_API_KEY: undefined,
+          XI_API_KEY: undefined,
+        },
+        () => {
+          expect(getTtsProvider(config, "/tmp/no-prefs-in-test.json")).toBe(
+            "local",
+          );
+        },
+      );
+    });
+
+    it("returns 'local' when set as user prefs override", () => {
+      const config = resolveTtsConfig(baseCfg);
+      const prefsPath = `/tmp/tts-prefs-local-${Date.now()}.json`;
+      tts.setTtsProvider(prefsPath, "local");
+      expect(getTtsProvider(config, prefsPath)).toBe("local");
+    });
+
     it("selects provider based on available API keys", () => {
       const cases = [
         {
@@ -704,6 +743,75 @@ describe("tts", () => {
         const body = JSON.parse(init.body as string) as Record<string, unknown>;
         expect(body.instructions).toBe("Speak warmly");
       });
+    });
+  });
+
+  describe("resolveTtsProviderOrder", () => {
+    it("places local first when primary is local", () => {
+      const order = resolveTtsProviderOrder("local");
+      expect(order[0]).toBe("local");
+      expect(order).toContain("openai");
+      expect(order).toContain("elevenlabs");
+      expect(order).toContain("edge");
+      expect(order).toHaveLength(4);
+    });
+
+    it("includes local in the fallback list for every other primary", () => {
+      for (const primary of ["openai", "elevenlabs", "edge"] as const) {
+        const order = resolveTtsProviderOrder(primary);
+        expect(order[0], primary).toBe(primary);
+        expect(order, primary).toContain("local");
+        expect(order, primary).toHaveLength(4);
+      }
+    });
+  });
+
+  describe("TTS Zod schema", () => {
+    it("TtsProviderSchema accepts 'local'", () => {
+      expect(TtsProviderSchema.parse("local")).toBe("local");
+    });
+
+    it("TtsProviderSchema rejects an unknown provider value", () => {
+      expect(() => TtsProviderSchema.parse("unknown-provider")).toThrow();
+    });
+
+    it("TtsConfigSchema validates a local block with command and args", () => {
+      const result = TtsConfigSchema.safeParse({
+        provider: "local",
+        local: {
+          command: "/bin/tts",
+          args: ["{{Text}}", "--out", "{{Output}}"],
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.local?.command).toBe("/bin/tts");
+      expect(result.data?.local?.args).toEqual([
+        "{{Text}}",
+        "--out",
+        "{{Output}}",
+      ]);
+    });
+
+    it("TtsConfigSchema validates a local block with only command (no args)", () => {
+      const result = TtsConfigSchema.safeParse({
+        local: { command: "/bin/tts" },
+      });
+      expect(result.success).toBe(true);
+      expect(result.data?.local?.command).toBe("/bin/tts");
+      expect(result.data?.local?.args).toBeUndefined();
+    });
+
+    it("TtsConfigSchema rejects a local block with unknown keys", () => {
+      const result = TtsConfigSchema.safeParse({
+        local: { command: "/bin/tts", unknownKey: true },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("TtsConfigSchema rejects a local block without a command (command required at schema level)", () => {
+      // command is required in the Zod schema to match types.tts.ts
+      const result = TtsConfigSchema.safeParse({ local: {} });
+      expect(result.success).toBe(false);
     });
   });
 
@@ -893,7 +1001,6 @@ describe("tts", () => {
           },
           {
             agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
-            // @ts-expect-error – intentionally testing runtime behaviour
             messages: { tts: { local: { command: "" } } },
           },
         ];
@@ -954,9 +1061,11 @@ describe("tts", () => {
 
         vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
           // Capture what was passed so we can assert on it.
-          (vi.mocked(runCommandWithTimeout) as ReturnType<typeof vi.fn> & {
-            lastArgv?: string[];
-          }).lastArgv = argv;
+          (
+            vi.mocked(runCommandWithTimeout) as ReturnType<typeof vi.fn> & {
+              lastArgv?: string[];
+            }
+          ).lastArgv = argv;
           return okResult();
         });
 
@@ -972,7 +1081,8 @@ describe("tts", () => {
         const argv =
           (vi.mocked(runCommandWithTimeout) as ReturnType<typeof vi.fn> & {
             lastArgv?: string[];
-          }).lastArgv ?? [];
+          })
+            .lastArgv ?? [];
         expect(argv).toContain("opus");
       });
 
@@ -1142,6 +1252,113 @@ describe("tts", () => {
         expect(result.success).toBe(false);
         // Local error is captured; other providers also tried.
         expect(result.error).toContain("local: ENOENT: command not found");
+      });
+
+      it("sets voiceCompatible true for Telegram .ogg output", async () => {
+        const result = await tts.textToSpeech({
+          text: "Hello Telegram",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-voicecompat-${Date.now()}.json`,
+          channel: "telegram",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.voiceCompatible).toBe(true);
+      });
+
+      it("sets voiceCompatible false for non-Telegram .mp3 output", async () => {
+        // .mp3 is in TELEGRAM_VOICE_AUDIO_EXTENSIONS so voiceCompatible is true
+        // (it can be sent as voice in capable channels); the Telegram-specific
+        // audioAsVoice flag is gated separately by channelId in maybeApplyTtsToPayload.
+        const result = await tts.textToSpeech({
+          text: "Hello world",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-voicecompat-mp3-${Date.now()}.json`,
+          channel: "whatsapp",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.voiceCompatible).toBe(true);
+        expect(result.audioPath).toMatch(/\.mp3$/);
+      });
+
+      it("falls back to local when the primary provider (openai) has no API key", async () => {
+        const cfg: OpenClawConfig = {
+          agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+          messages: {
+            tts: {
+              auto: "always",
+              provider: "openai",
+              edge: { enabled: false },
+              local: { command: "/bin/tts" },
+              // openai.apiKey intentionally absent
+            },
+          },
+        };
+
+        const result = await withEnvAsync(
+          {
+            OPENAI_API_KEY: undefined,
+            ELEVENLABS_API_KEY: undefined,
+            XI_API_KEY: undefined,
+          },
+          async () =>
+            tts.textToSpeech({
+              text: "hello world",
+              cfg,
+              prefsPath: `/tmp/tts-local-fallback-${Date.now()}.json`,
+            }),
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.provider).toBe("local");
+      });
+
+      it("treats null exit code as non-zero and propagates fallback message", async () => {
+        vi.mocked(runCommandWithTimeout).mockResolvedValue({
+          ...okResult(),
+          code: null,
+          termination: "signal" as const,
+          signal: "SIGTERM" as NodeJS.Signals,
+        });
+
+        const result = await tts.textToSpeech({
+          text: "hello",
+          cfg: baseCfg(),
+          prefsPath: `/tmp/tts-local-nullexit-${Date.now()}.json`,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("local TTS command failed");
+      });
+
+      it("passes literal args (no placeholders) unchanged to the command", async () => {
+        const cfg: OpenClawConfig = {
+          ...baseCfg(),
+          messages: {
+            tts: {
+              ...baseCfg().messages!.tts,
+              local: {
+                command: "/bin/tts",
+                args: ["--quiet", "--rate", "1.0"],
+              },
+            },
+          },
+        };
+
+        let capturedArgv: string[] = [];
+        vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+          capturedArgv = argv;
+          return okResult();
+        });
+
+        await tts.textToSpeech({
+          text: "hello",
+          cfg,
+          prefsPath: `/tmp/tts-local-literal-args-${Date.now()}.json`,
+        });
+
+        expect(capturedArgv).toEqual(["/bin/tts", "--quiet", "--rate", "1.0"]);
       });
 
       it("channel is 'unknown' when no channel is provided", async () => {

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1294,9 +1294,8 @@ describe("tts", () => {
       });
 
       it("sets voiceCompatible false for non-Telegram .mp3 output", async () => {
-        // .mp3 is in TELEGRAM_VOICE_AUDIO_EXTENSIONS so voiceCompatible is true
-        // (it can be sent as voice in capable channels); the Telegram-specific
-        // audioAsVoice flag is gated separately by channelId in maybeApplyTtsToPayload.
+        // Keep parity with cloud providers: non-Telegram outputs should not
+        // advertise voice compatibility, even when the extension is voice-capable.
         const result = await tts.textToSpeech({
           text: "Hello world",
           cfg: baseCfg(),
@@ -1305,7 +1304,7 @@ describe("tts", () => {
         });
 
         expect(result.success).toBe(true);
-        expect(result.voiceCompatible).toBe(true);
+        expect(result.voiceCompatible).toBe(false);
         expect(result.audioPath).toMatch(/\.mp3$/);
       });
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1441,4 +1441,128 @@ describe("tts", () => {
       });
     });
   });
+  // ── textToSpeechTelephony (local provider) ──────────────────────────────
+
+  describe("local provider — textToSpeechTelephony", () => {
+    const baseCfg = (): OpenClawConfig => ({
+      agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+      messages: {
+        tts: {
+          auto: "always",
+          provider: "local",
+          edge: { enabled: false },
+          local: {
+            command: "/usr/local/bin/fake-tts",
+            args: ["--format", "{{Format}}", "--out", "{{Output}}"],
+          },
+        },
+      },
+    });
+
+    const okResult = () => ({
+      stdout: "",
+      stderr: "",
+      code: 0 as number | null,
+      signal: null as NodeJS.Signals | null,
+      killed: false,
+      termination: "exit" as const,
+    });
+
+    beforeEach(() => {
+      vi.mocked(runCommandWithTimeout).mockResolvedValue(okResult());
+      vi.mocked(existsSync).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.mocked(existsSync).mockImplementation(_origExistsSync);
+    });
+
+    it("returns success with pcm format and 22050 sample rate", async () => {
+      const { writeFileSync } = await import("node:fs");
+      vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+        // Write a real PCM file to {{Output}} so readFileSync in the implementation succeeds.
+        const outIdx = argv.indexOf("--out");
+        if (outIdx !== -1) {
+          writeFileSync(argv[outIdx + 1], Buffer.alloc(44100));
+        }
+        return okResult();
+      });
+
+      const result = await tts.textToSpeechTelephony({
+        text: "Hello telephony",
+        cfg: baseCfg(),
+        prefsPath: `/tmp/tts-local-telephony-${Date.now()}.json`,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.provider).toBe("local");
+      expect(result.outputFormat).toBe("pcm");
+      expect(result.sampleRate).toBe(22050);
+      expect(result.audioBuffer).toBeDefined();
+    });
+
+    it("passes Format=pcm and Channel=telephony placeholders to command", async () => {
+      const { writeFileSync } = await import("node:fs");
+      const cfg: OpenClawConfig = {
+        ...baseCfg(),
+        messages: {
+          tts: {
+            ...baseCfg().messages!.tts,
+            local: {
+              command: "/usr/local/bin/fake-tts",
+              args: ["--format", "{{Format}}", "--channel", "{{Channel}}", "--out", "{{Output}}"],
+            },
+          },
+        },
+      };
+      let capturedArgv: string[] = [];
+      vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+        capturedArgv = argv;
+        // Write a fake PCM file to {{Output}} so readFileSync succeeds.
+        const outIdx = argv.indexOf("--out");
+        if (outIdx !== -1) {
+          writeFileSync(argv[outIdx + 1], Buffer.alloc(0));
+        }
+        return okResult();
+      });
+
+      await tts.textToSpeechTelephony({
+        text: "test",
+        cfg,
+        prefsPath: `/tmp/tts-local-telephony-args-${Date.now()}.json`,
+      });
+
+      expect(capturedArgv).toContain("pcm"); // {{Format}} resolved
+      expect(capturedArgv).toContain("telephony"); // {{Channel}} resolved
+    });
+
+    it("falls back with error when local command is not configured", async () => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: { tts: { provider: "local", edge: { enabled: false } } },
+      };
+
+      const result = await tts.textToSpeechTelephony({
+        text: "hello",
+        cfg,
+        prefsPath: `/tmp/tts-local-telephony-nocommand-${Date.now()}.json`,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("local: no command configured");
+    });
+
+    it("falls back with error when command exits 0 but output file is missing", async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = await tts.textToSpeechTelephony({
+        text: "hello",
+        cfg: baseCfg(),
+        prefsPath: `/tmp/tts-local-telephony-nofile-${Date.now()}.json`,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("local: command exited 0 but did not create output file");
+    });
+  });
 });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -520,9 +520,13 @@ function resolveOutputFormat(channelId?: string | null) {
 }
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
-  if (!channel) return null;
+  if (!channel) {
+    return null;
+  }
   const normalized = normalizeChannelId(channel);
-  if (normalized) return normalized;
+  if (normalized) {
+    return normalized;
+  }
   // Fall back to raw string when registry lookup fails (e.g. tts tool context)
   return (channel.trim().toLowerCase() as ChannelId) || null;
 }
@@ -695,10 +699,25 @@ export async function textToSpeech(params: {
           Format: ttsFormat,
         };
         const args = (localCfg.args ?? []).map((a) => applyTemplate(a, templCtx));
-        const localResult = await runCommandWithTimeout([localCfg.command, ...args], {
-          timeoutMs: config.timeoutMs,
-        });
+        let localResult: Awaited<ReturnType<typeof runCommandWithTimeout>>;
+        try {
+          localResult = await runCommandWithTimeout([localCfg.command, ...args], {
+            timeoutMs: config.timeoutMs,
+          });
+        } catch (err) {
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
+          throw err;
+        }
         if (localResult.code !== 0) {
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
           throw new Error(localResult.stderr.trim() || "local TTS command failed");
         }
         scheduleCleanup(tempDir);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -737,7 +737,8 @@ export async function textToSpeech(params: {
           continue;
         }
         scheduleCleanup(tempDir);
-        const voiceCompatible = isVoiceCompatibleAudio({ fileName: audioPath });
+        const voiceCompatible =
+          channelId === "telegram" ? isVoiceCompatibleAudio({ fileName: audioPath }) : false;
         return {
           success: true,
           audioPath,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -852,6 +852,61 @@ export async function textToSpeechTelephony(params: {
         continue;
       }
 
+      if (provider === "local") {
+        const localCfg = config.local;
+        if (!localCfg?.command) {
+          errors.push("local: no command configured");
+          continue;
+        }
+        // local telephony: script must write raw 16-bit signed LE mono PCM at
+        // 22050 Hz to {{Output}} when {{Format}}=pcm. OpenClaw resamples to
+        // 8 kHz µ-law for delivery — the same pipeline used for ElevenLabs.
+        const LOCAL_TELEPHONY_SAMPLE_RATE = 22050;
+        const tempRoot = resolvePreferredOpenClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const audioPath = path.join(tempDir, `voice-${Date.now()}.pcm`);
+        const templCtx = {
+          Text: params.text,
+          Output: audioPath,
+          Channel: "telephony",
+          Format: "pcm",
+        };
+        const args = (localCfg.args ?? []).map((a) => applyTemplate(a, templCtx));
+        try {
+          const localResult = await runCommandWithTimeout([localCfg.command, ...args], {
+            timeoutMs: config.timeoutMs,
+          });
+          if (localResult.code !== 0) {
+            throw new Error(localResult.stderr.trim() || "local TTS command failed");
+          }
+          if (!existsSync(audioPath)) {
+            errors.push(
+              "local: command exited 0 but did not create output file — check {{Output}} placeholder in args",
+            );
+            rmSync(tempDir, { recursive: true, force: true });
+            continue;
+          }
+          const audioBuffer = readFileSync(audioPath);
+          scheduleCleanup(tempDir);
+          return {
+            success: true,
+            audioBuffer,
+            latencyMs: Date.now() - providerStart,
+            provider,
+            outputFormat: "pcm",
+            sampleRate: LOCAL_TELEPHONY_SAMPLE_RATE,
+          };
+        } catch (err) {
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
+          throw err;
+        }
+      }
+
       const apiKey = resolveTtsApiKey(config, provider);
       if (!apiKey) {
         errors.push(`${provider}: no API key`);

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -2,30 +2,32 @@ import { randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
-  writeFileSync,
   mkdtempSync,
-  rmSync,
+  readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { applyTemplate } from "../auto-reply/templating.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import type {
-  TtsConfig,
   TtsAutoMode,
+  TtsConfig,
   TtsMode,
-  TtsProvider,
   TtsModelOverrideConfig,
+  TtsProvider,
 } from "../config/types.tts.js";
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
+import { runCommandWithTimeout } from "../process/exec.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
@@ -137,6 +139,10 @@ export type ResolvedTtsConfig = {
   prefsPath?: string;
   maxTextLength: number;
   timeoutMs: number;
+  local?: {
+    command: string;
+    args: string[];
+  };
 };
 
 type TtsUserPrefs = {
@@ -326,6 +332,9 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
     timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    local: raw.local?.command
+      ? { command: raw.local.command, args: raw.local.args ?? [] }
+      : undefined,
   };
 }
 
@@ -511,7 +520,11 @@ function resolveOutputFormat(channelId?: string | null) {
 }
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
-  return channel ? normalizeChannelId(channel) : null;
+  if (!channel) return null;
+  const normalized = normalizeChannelId(channel);
+  if (normalized) return normalized;
+  // Fall back to raw string when registry lookup fails (e.g. tts tool context)
+  return (channel.trim().toLowerCase() as ChannelId) || null;
 }
 
 function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {
@@ -531,7 +544,7 @@ export function resolveTtsApiKey(
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge", "local"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -540,6 +553,9 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
   if (provider === "edge") {
     return config.edge.enabled;
+  }
+  if (provider === "local") {
+    return Boolean(config.local?.command);
   }
   return Boolean(resolveTtsApiKey(config, provider));
 }
@@ -654,6 +670,44 @@ export async function textToSpeech(params: {
           latencyMs: Date.now() - providerStart,
           provider,
           outputFormat: edgeResult.outputFormat,
+          voiceCompatible,
+        };
+      }
+
+      if (provider === "local") {
+        const localCfg = config.local;
+        if (!localCfg?.command) {
+          errors.push("local: no command configured");
+          continue;
+        }
+        const tempRoot = resolvePreferredOpenClawTmpDir();
+        mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+        const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+        const ext = channelId === "telegram" ? ".ogg" : ".mp3";
+        const audioPath = path.join(tempDir, `voice-${Date.now()}${ext}`);
+        const ttsChannel = channelId ?? "unknown";
+        const ttsFormat = channelId === "telegram" ? "opus" : "mp3";
+        // {{PascalCase}} placeholders in args align with media/link CLI runner convention.
+        const templCtx = {
+          Text: params.text,
+          Output: audioPath,
+          Channel: ttsChannel,
+          Format: ttsFormat,
+        };
+        const args = (localCfg.args ?? []).map((a) => applyTemplate(a, templCtx));
+        const localResult = await runCommandWithTimeout([localCfg.command, ...args], {
+          timeoutMs: config.timeoutMs,
+        });
+        if (localResult.code !== 0) {
+          throw new Error(localResult.stderr.trim() || "local TTS command failed");
+        }
+        scheduleCleanup(tempDir);
+        const voiceCompatible = isVoiceCompatibleAudio({ fileName: audioPath });
+        return {
+          success: true,
+          audioPath,
+          latencyMs: Date.now() - providerStart,
+          provider,
           voiceCompatible,
         };
       }

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -690,10 +690,10 @@ export async function textToSpeech(params: {
         const tempRoot = resolvePreferredOpenClawTmpDir();
         mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
         const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
-        const ext = channelId === "telegram" ? ".ogg" : ".mp3";
+        const ext = output.extension === ".opus" ? ".ogg" : ".mp3";
         const audioPath = path.join(tempDir, `voice-${Date.now()}${ext}`);
         const ttsChannel = channelId ?? "unknown";
-        const ttsFormat = channelId === "telegram" ? "opus" : "mp3";
+        const ttsFormat = output.extension === ".opus" ? "opus" : "mp3";
         // {{PascalCase}} placeholders in args align with media/link CLI runner convention.
         const templCtx = {
           Text: params.text,
@@ -741,7 +741,9 @@ export async function textToSpeech(params: {
         }
         scheduleCleanup(tempDir);
         const voiceCompatible =
-          channelId === "telegram" ? isVoiceCompatibleAudio({ fileName: audioPath }) : false;
+          channelId && VOICE_BUBBLE_CHANNELS.has(channelId)
+            ? isVoiceCompatibleAudio({ fileName: audioPath })
+            : false;
         return {
           success: true,
           audioPath,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -720,6 +720,22 @@ export async function textToSpeech(params: {
           }
           throw new Error(localResult.stderr.trim() || "local TTS command failed");
         }
+        // Verify the command actually wrote the expected output file.  A zero
+        // exit code is not sufficient: the command may ignore {{Output}} and
+        // write to stdout/elsewhere instead.  Without this check the caller
+        // would treat the result as successful, skip provider fallback, and
+        // later fail when it tries to open a non-existent path.
+        if (!existsSync(audioPath)) {
+          try {
+            rmSync(tempDir, { recursive: true, force: true });
+          } catch {
+            // ignore cleanup errors
+          }
+          errors.push(
+            "local: command exited 0 but did not create output file — check {{Output}} placeholder in args",
+          );
+          continue;
+        }
         scheduleCleanup(tempDir);
         const voiceCompatible = isVoiceCompatibleAudio({ fileName: audioPath });
         return {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -332,8 +332,11 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
     timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    local: raw.local?.command
-      ? { command: raw.local.command, args: raw.local.args ?? [] }
+    local: raw.local?.command?.trim()
+      ? {
+          command: raw.local.command.trim(),
+          args: raw.local.args?.map((arg) => arg.trim()).filter(Boolean) ?? [],
+        }
       : undefined,
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** No way to use a local/offline TTS engine (e.g. Piper, Coqui) — only cloud providers were supported.
- **Why it matters:** Useful on self-hosted setups (Pi, VPS) where you don't want or can't use cloud TTS.
- **What changed:** New `local` provider type that shells out to any command. Args support `{{Text}}`, `{{Output}}`, `{{Channel}}`, `{{Format}}` placeholders (same convention as media/link CLI runners). Async via `runCommandWithTimeout`, falls back to next provider on non-zero exit.
- **What did NOT change:** Existing providers (openai, elevenlabs, edge) are untouched. Local is opt-in via `provider: "local"`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

New config block:
```json5
messages: {
  tts: {
    provider: "local",
    local: {
      command: "/path/to/tts.sh",
      args: ["--text", "{{Text}}", "--out", "{{Output}}"],
    },
  },
}