### PR TITLE
fix(discord): preserve attachment metadata when download fails (#28296)

### DIFF
--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -243,6 +243,16 @@ async function appendResolvedMediaFromAttachments(params: {
     } catch (err) {
       const id = attachment.id ?? attachment.url;
       logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+      // Fallback: preserve the original CDN URL so the agent can still access
+      // the attachment via downstream media-understanding (which re-fetches by URL)
+      // instead of silently dropping it from the inbound context.
+      if (attachment.url) {
+        params.out.push({
+          path: attachment.url,
+          contentType: attachment.content_type ?? undefined,
+          placeholder: inferPlaceholder(attachment),
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #28296

**Root cause:** `appendResolvedMediaFromAttachments` silently drops attachments when
`fetchRemoteMedia` or `saveMediaBuffer` throws. The agent's inbound context ends up
with empty `MediaPaths`/`MediaUrls`/`MediaTypes`, so it has no way to access or even
know about the attachment.

**Fix:** On download failure, push the original Discord CDN URL as a fallback into
the media list. The downstream `normalizeAttachments` (media-understanding) already
supports URL-only entries and will re-fetch at understanding time. Even if that also
fails, the agent still sees the attachment placeholder in the message text.

**Changes:**
- `src/discord/monitor/message-utils.ts`: 10-line fallback in the catch block
- `src/discord/monitor/message-utils.test.ts`: 4 new test cases covering
  fetchRemoteMedia failure, saveMediaBuffer failure, mixed success/failure,
  and forwarded attachment failure

**Why this is safe:**
- `buildMediaPayload` treats `path` as an opaque string — it flows through to
  `MediaPath`/`MediaUrl`/`MediaPaths`/`MediaUrls` unchanged
- `normalizeAttachments` already handles URL-only entries (lines 95-104)
- No behavioral change on the success path; the fallback only fires in the catch block