### PR TITLE
feat(i18n): add European Portuguese (pt-PT) and Argentinian Spanish (es-AR) locales

### DIFF
--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -3,7 +3,14 @@ import type { Locale, TranslationMap } from "./types.ts";
 
 type Subscriber = (locale: Locale) => void;
 
-export const SUPPORTED_LOCALES: ReadonlyArray<Locale> = ["en", "zh-CN", "zh-TW", "pt-BR"];
+export const SUPPORTED_LOCALES: ReadonlyArray<Locale> = [
+  "en",
+  "zh-CN",
+  "zh-TW",
+  "pt-BR",
+  "pt-PT",
+  "es-AR",
+];
 
 export function isSupportedLocale(value: string | null | undefined): value is Locale {
   return value !== null && value !== undefined && SUPPORTED_LOCALES.includes(value as Locale);
@@ -27,8 +34,14 @@ class I18nManager {
     if (navLang.startsWith("zh")) {
       return navLang === "zh-TW" || navLang === "zh-HK" ? "zh-TW" : "zh-CN";
     }
+    if (navLang === "pt-PT" || navLang === "pt") {
+      return "pt-PT";
+    }
     if (navLang.startsWith("pt")) {
       return "pt-BR";
+    }
+    if (navLang.startsWith("es")) {
+      return "es-AR";
     }
     return "en";
   }
@@ -64,6 +77,10 @@ class I18nManager {
           module = await import("../locales/zh-TW.ts");
         } else if (locale === "pt-BR") {
           module = await import("../locales/pt-BR.ts");
+        } else if (locale === "pt-PT") {
+          module = await import("../locales/pt-PT.ts");
+        } else if (locale === "es-AR") {
+          module = await import("../locales/es-AR.ts");
         } else {
           return;
         }

--- a/ui/src/i18n/lib/types.ts
+++ b/ui/src/i18n/lib/types.ts
@@ -1,6 +1,6 @@
 export type TranslationMap = { [key: string]: string | TranslationMap };
 
-export type Locale = "en" | "zh-CN" | "zh-TW" | "pt-BR";
+export type Locale = "en" | "zh-CN" | "zh-TW" | "pt-BR" | "pt-PT" | "es-AR";
 
 export interface I18nConfig {
   locale: Locale;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -118,5 +118,7 @@ export const en: TranslationMap = {
     zhCN: "简体中文 (Simplified Chinese)",
     zhTW: "繁體中文 (Traditional Chinese)",
     ptBR: "Português (Brazilian Portuguese)",
+    ptPT: "Português (European Portuguese)",
+    esAR: "Español (Argentinian Spanish)",
   },
 };

--- a/ui/src/i18n/locales/es-AR.ts
+++ b/ui/src/i18n/locales/es-AR.ts
@@ -71,8 +71,7 @@ export const es_AR: TranslationMap = {
       uptime: "Tiempo Activo",
       tickInterval: "Intervalo de Tick",
       lastChannelsRefresh: "Última Actualización de Canales",
-      channelsHint:
-        "Usá Canales para vincular WhatsApp, Telegram, Discord, Signal o iMessage.",
+      channelsHint: "Usá Canales para vincular WhatsApp, Telegram, Discord, Signal o iMessage.",
     },
     stats: {
       instances: "Instancias",
@@ -106,16 +105,14 @@ export const es_AR: TranslationMap = {
     },
     insecure: {
       hint: "Esta página es HTTP, así que el navegador bloquea la identidad del dispositivo. Usá HTTPS (Tailscale Serve) o abrí {url} en el host del gateway.",
-      stayHttp:
-        "Si necesitás quedarte en HTTP, configurá {config} (solo token).",
+      stayHttp: "Si necesitás quedarte en HTTP, configurá {config} (solo token).",
     },
   },
   chat: {
     disconnected: "Desconectado del gateway.",
     refreshTitle: "Actualizar datos del chat",
     thinkingToggle: "Alternar salida de pensamiento/trabajo del asistente",
-    focusToggle:
-      "Alternar modo foco (ocultar barra lateral + encabezado de página)",
+    focusToggle: "Alternar modo foco (ocultar barra lateral + encabezado de página)",
     onboardingDisabled: "Desactivado durante la configuración inicial",
   },
   languages: {

--- a/ui/src/i18n/locales/es-AR.ts
+++ b/ui/src/i18n/locales/es-AR.ts
@@ -1,0 +1,129 @@
+import type { TranslationMap } from "../lib/types.ts";
+
+export const es_AR: TranslationMap = {
+  common: {
+    version: "Versión",
+    health: "Estado",
+    ok: "OK",
+    offline: "Sin conexión",
+    connect: "Conectar",
+    refresh: "Actualizar",
+    enabled: "Activado",
+    disabled: "Desactivado",
+    na: "n/d",
+    docs: "Documentación",
+    resources: "Recursos",
+  },
+  nav: {
+    chat: "Chat",
+    control: "Control",
+    agent: "Agente",
+    settings: "Configuración",
+    expand: "Expandir barra lateral",
+    collapse: "Contraer barra lateral",
+  },
+  tabs: {
+    agents: "Agentes",
+    overview: "Vista General",
+    channels: "Canales",
+    instances: "Instancias",
+    sessions: "Sesiones",
+    usage: "Consumo",
+    cron: "Tareas Cron",
+    skills: "Habilidades",
+    nodes: "Nodos",
+    chat: "Chat",
+    config: "Configuración",
+    debug: "Depuración",
+    logs: "Registros",
+  },
+  subtitles: {
+    agents: "Gestionar espacios de trabajo, herramientas e identidades de agentes.",
+    overview: "Estado del gateway, puntos de entrada y lectura rápida de salud.",
+    channels: "Gestionar canales y configuraciones.",
+    instances: "Beacons de presencia de clientes y nodos conectados.",
+    sessions: "Inspeccionar sesiones activas y ajustar valores predeterminados por sesión.",
+    usage: "Monitorear el consumo y costos de la API.",
+    cron: "Programar despertares y ejecuciones recurrentes de agentes.",
+    skills: "Gestionar disponibilidad de habilidades e inyección de claves de API.",
+    nodes: "Dispositivos emparejados, capacidades y exposición de comandos.",
+    chat: "Sesión de chat directa con el gateway para intervenciones rápidas.",
+    config: "Editar ~/.openclaw/openclaw.json de forma segura.",
+    debug: "Snapshots del gateway, eventos y llamadas RPC manuales.",
+    logs: "Seguimiento en vivo de los registros del gateway.",
+  },
+  overview: {
+    access: {
+      title: "Acceso al Gateway",
+      subtitle: "Dónde se conecta el panel y cómo se autentica.",
+      wsUrl: "URL WebSocket",
+      token: "Token del Gateway",
+      password: "Contraseña (no almacenada)",
+      sessionKey: "Clave de Sesión Predeterminada",
+      language: "Idioma",
+      connectHint: "Hacé clic en Conectar para aplicar los cambios de conexión.",
+      trustedProxy: "Autenticado mediante proxy de confianza.",
+    },
+    snapshot: {
+      title: "Snapshot",
+      subtitle: "Información más reciente del handshake del gateway.",
+      status: "Estado",
+      uptime: "Tiempo Activo",
+      tickInterval: "Intervalo de Tick",
+      lastChannelsRefresh: "Última Actualización de Canales",
+      channelsHint:
+        "Usá Canales para vincular WhatsApp, Telegram, Discord, Signal o iMessage.",
+    },
+    stats: {
+      instances: "Instancias",
+      instancesHint: "Beacons de presencia en los últimos 5 minutos.",
+      sessions: "Sesiones",
+      sessionsHint: "Claves de sesión recientes registradas por el gateway.",
+      cron: "Cron",
+      cronNext: "Próximo despertar {time}",
+    },
+    notes: {
+      title: "Notas",
+      subtitle: "Recordatorios rápidos para configuraciones de control remoto.",
+      tailscaleTitle: "Tailscale serve",
+      tailscaleText:
+        "Preferí el modo serve para mantener el gateway en loopback con autenticación tailnet.",
+      sessionTitle: "Higiene de sesión",
+      sessionText: "Usá /new o sessions.patch para resetear el contexto.",
+      cronTitle: "Recordatorios de Cron",
+      cronText: "Usá sesiones aisladas para ejecuciones recurrentes.",
+    },
+    auth: {
+      required:
+        "Este gateway requiere autenticación. Agregá un token o contraseña y hacé clic en Conectar.",
+      failed:
+        "Falló la autenticación. Volvé a copiar una URL con token usando {command}, o actualizá el token y hacé clic en Conectar.",
+    },
+    pairing: {
+      hint: "Este dispositivo necesita aprobación de emparejamiento del host del gateway.",
+      mobileHint:
+        "¿Estás en el celular? Copiá la URL completa (incluyendo #token=...) ejecutando openclaw dashboard --no-open en la computadora.",
+    },
+    insecure: {
+      hint: "Esta página es HTTP, así que el navegador bloquea la identidad del dispositivo. Usá HTTPS (Tailscale Serve) o abrí {url} en el host del gateway.",
+      stayHttp:
+        "Si necesitás quedarte en HTTP, configurá {config} (solo token).",
+    },
+  },
+  chat: {
+    disconnected: "Desconectado del gateway.",
+    refreshTitle: "Actualizar datos del chat",
+    thinkingToggle: "Alternar salida de pensamiento/trabajo del asistente",
+    focusToggle:
+      "Alternar modo foco (ocultar barra lateral + encabezado de página)",
+    onboardingDisabled: "Desactivado durante la configuración inicial",
+  },
+  languages: {
+    en: "English",
+    zhCN: "简体中文 (Chino Simplificado)",
+    zhTW: "繁體中文 (Chino Tradicional)",
+    ptBR: "Português (Portugués Brasileño)",
+    ptPT: "Português (Portugués Europeo)",
+    esAR: "Español (Español Argentino)",
+  },
+};

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -120,5 +120,7 @@ export const pt_BR: TranslationMap = {
     zhCN: "简体中文 (Chinês Simplificado)",
     zhTW: "繁體中文 (Chinês Tradicional)",
     ptBR: "Português (Português Brasileiro)",
+    ptPT: "Português (Português Europeu)",
+    esAR: "Español (Espanhol Argentino)",
   },
 };

--- a/ui/src/i18n/locales/pt-PT.ts
+++ b/ui/src/i18n/locales/pt-PT.ts
@@ -1,0 +1,129 @@
+import type { TranslationMap } from "../lib/types.ts";
+
+export const pt_PT: TranslationMap = {
+  common: {
+    version: "Versão",
+    health: "Estado",
+    ok: "OK",
+    offline: "Offline",
+    connect: "Ligar",
+    refresh: "Atualizar",
+    enabled: "Ativado",
+    disabled: "Desativado",
+    na: "n/d",
+    docs: "Documentação",
+    resources: "Recursos",
+  },
+  nav: {
+    chat: "Chat",
+    control: "Controlo",
+    agent: "Agente",
+    settings: "Definições",
+    expand: "Expandir barra lateral",
+    collapse: "Recolher barra lateral",
+  },
+  tabs: {
+    agents: "Agentes",
+    overview: "Visão Geral",
+    channels: "Canais",
+    instances: "Instâncias",
+    sessions: "Sessões",
+    usage: "Utilização",
+    cron: "Tarefas Cron",
+    skills: "Competências",
+    nodes: "Nós",
+    chat: "Chat",
+    config: "Configuração",
+    debug: "Depuração",
+    logs: "Registos",
+  },
+  subtitles: {
+    agents: "Gerir espaços de trabalho, ferramentas e identidades de agentes.",
+    overview: "Estado do gateway, pontos de entrada e leitura rápida de saúde.",
+    channels: "Gerir canais e configurações.",
+    instances: "Beacons de presença de clientes e nós ligados.",
+    sessions: "Inspecionar sessões ativas e ajustar predefinições por sessão.",
+    usage: "Monitorizar utilização e custos da API.",
+    cron: "Agendar despertares e execuções recorrentes de agentes.",
+    skills: "Gerir disponibilidade de competências e injeção de chaves de API.",
+    nodes: "Dispositivos emparelhados, capacidades e exposição de comandos.",
+    chat: "Sessão de chat direta com o gateway para intervenções rápidas.",
+    config: "Editar ~/.openclaw/openclaw.json com segurança.",
+    debug: "Snapshots do gateway, eventos e chamadas RPC manuais.",
+    logs: "Acompanhamento em tempo real dos registos do gateway.",
+  },
+  overview: {
+    access: {
+      title: "Acesso ao Gateway",
+      subtitle: "Onde o painel de controlo se liga e como se autentica.",
+      wsUrl: "URL WebSocket",
+      token: "Token do Gateway",
+      password: "Palavra-passe (não armazenada)",
+      sessionKey: "Chave de Sessão Predefinida",
+      language: "Idioma",
+      connectHint: "Clique em Ligar para aplicar as alterações de ligação.",
+      trustedProxy: "Autenticado por proxy de confiança.",
+    },
+    snapshot: {
+      title: "Snapshot",
+      subtitle: "Informações mais recentes do handshake do gateway.",
+      status: "Estado",
+      uptime: "Tempo de Atividade",
+      tickInterval: "Intervalo de Tick",
+      lastChannelsRefresh: "Última Atualização de Canais",
+      channelsHint:
+        "Utilize Canais para vincular WhatsApp, Telegram, Discord, Signal ou iMessage.",
+    },
+    stats: {
+      instances: "Instâncias",
+      instancesHint: "Beacons de presença nos últimos 5 minutos.",
+      sessions: "Sessões",
+      sessionsHint: "Chaves de sessão recentes monitorizadas pelo gateway.",
+      cron: "Cron",
+      cronNext: "Próximo despertar {time}",
+    },
+    notes: {
+      title: "Notas",
+      subtitle: "Lembretes rápidos para configurações de controlo remoto.",
+      tailscaleTitle: "Tailscale serve",
+      tailscaleText:
+        "Prefira o modo serve para manter o gateway em loopback com autenticação tailnet.",
+      sessionTitle: "Higiene de sessão",
+      sessionText: "Utilize /new ou sessions.patch para repor o contexto.",
+      cronTitle: "Lembretes de Cron",
+      cronText: "Utilize sessões isoladas para execuções recorrentes.",
+    },
+    auth: {
+      required:
+        "Este gateway requer autenticação. Adicione um token ou palavra-passe e clique em Ligar.",
+      failed:
+        "Falha na autenticação. Copie novamente um URL com token utilizando {command}, ou atualize o token e clique em Ligar.",
+    },
+    pairing: {
+      hint: "Este dispositivo necessita de aprovação de emparelhamento do anfitrião do gateway.",
+      mobileHint:
+        "No telemóvel? Copie o URL completo (incluindo #token=...) executando openclaw dashboard --no-open no computador.",
+    },
+    insecure: {
+      hint: "Esta página é HTTP, pelo que o navegador bloqueia a identidade do dispositivo. Utilize HTTPS (Tailscale Serve) ou abra {url} no anfitrião do gateway.",
+      stayHttp:
+        "Se precisar de permanecer em HTTP, defina {config} (apenas token).",
+    },
+  },
+  chat: {
+    disconnected: "Desligado do gateway.",
+    refreshTitle: "Atualizar dados do chat",
+    thinkingToggle: "Alternar saída de pensamento/trabalho do assistente",
+    focusToggle:
+      "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",
+    onboardingDisabled: "Desativado durante a integração",
+  },
+  languages: {
+    en: "English",
+    zhCN: "简体中文 (Chinês Simplificado)",
+    zhTW: "繁體中文 (Chinês Tradicional)",
+    ptBR: "Português (Português do Brasil)",
+    ptPT: "Português (Português Europeu)",
+    esAR: "Español (Espanhol Argentino)",
+  },
+};

--- a/ui/src/i18n/locales/pt-PT.ts
+++ b/ui/src/i18n/locales/pt-PT.ts
@@ -71,8 +71,7 @@ export const pt_PT: TranslationMap = {
       uptime: "Tempo de Atividade",
       tickInterval: "Intervalo de Tick",
       lastChannelsRefresh: "Última Atualização de Canais",
-      channelsHint:
-        "Utilize Canais para vincular WhatsApp, Telegram, Discord, Signal ou iMessage.",
+      channelsHint: "Utilize Canais para vincular WhatsApp, Telegram, Discord, Signal ou iMessage.",
     },
     stats: {
       instances: "Instâncias",
@@ -106,16 +105,14 @@ export const pt_PT: TranslationMap = {
     },
     insecure: {
       hint: "Esta página é HTTP, pelo que o navegador bloqueia a identidade do dispositivo. Utilize HTTPS (Tailscale Serve) ou abra {url} no anfitrião do gateway.",
-      stayHttp:
-        "Se precisar de permanecer em HTTP, defina {config} (apenas token).",
+      stayHttp: "Se precisar de permanecer em HTTP, defina {config} (apenas token).",
     },
   },
   chat: {
     disconnected: "Desligado do gateway.",
     refreshTitle: "Atualizar dados do chat",
     thinkingToggle: "Alternar saída de pensamento/trabalho do assistente",
-    focusToggle:
-      "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",
+    focusToggle: "Alternar modo de foco (ocultar barra lateral + cabeçalho da página)",
     onboardingDisabled: "Desativado durante a integração",
   },
   languages: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -117,5 +117,7 @@ export const zh_CN: TranslationMap = {
     zhCN: "简体中文 (简体中文)",
     zhTW: "繁體中文 (繁体中文)",
     ptBR: "Português (巴西葡萄牙语)",
+    ptPT: "Português (欧洲葡萄牙语)",
+    esAR: "Español (阿根廷西班牙语)",
   },
 };

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -117,5 +117,7 @@ export const zh_TW: TranslationMap = {
     zhCN: "简体中文 (簡體中文)",
     zhTW: "繁體中文 (繁體中文)",
     ptBR: "Português (巴西葡萄牙語)",
+    ptPT: "Português (歐洲葡萄牙語)",
+    esAR: "Español (阿根廷西班牙語)",
   },
 };


### PR DESCRIPTION
## Summary

Add two new regional locale variants to the OpenClaw Control UI, contributing to the i18n initiative tracked in #3460.

### New Languages
- 🇵🇹 **European Portuguese (pt-PT)** — distinct from Brazilian Portuguese with proper PT-PT vocabulary:
  - `Definições` instead of `Configurações`
  - `Registos` instead of `Logs`
  - `Ligar` instead of `Conectar`
  - `Telemóvel` instead of `Celular`
  - `Palavra-passe` instead of `Senha`
  - `Gerir` instead of `Gerenciar`
- 🇦🇷 **Argentinian Spanish (es-AR)** — with voseo conjugation (the defining feature of River Plate Spanish):
  - `Hacé clic` instead of `Haz clic`
  - `Usá` instead of `Usa`
  - `Copiá` instead of `Copia`
  - `Configurá` instead of `Configura`

### Changes
- **2 new locale files**: `pt-PT.ts`, `es-AR.ts` — complete translations of all 122 UI strings
- **Updated `types.ts`**: Extended `Locale` type with `pt-PT` and `es-AR`
- **Updated `translate.ts`**:
  - Added new locales to `SUPPORTED_LOCALES`
  - Added lazy imports for each new locale
  - Browser language detection: `pt` (no region) → `pt-PT`, `pt-BR` → `pt-BR`, `es-*` → `es-AR`
- **Updated existing locales** (en, pt-BR, zh-CN, zh-TW): Added language labels for pt-PT and es-AR

### Translation Quality
- **PT-PT**: Author is a native Portuguese speaker based in Switzerland with deep knowledge of European vs Brazilian Portuguese distinctions. Every string reviewed for PT-PT accuracy.
- **ES-AR**: Voseo conjugation verified against RAE (Real Academia Española) standards for Rioplatense Spanish.

### Architecture
Follows the existing i18n architecture. No new dependencies, no structural changes — just new locale files and registration.

Closes part of #3460