### PR TITLE
fix(chrome-extension): use relay default port 18795 for current gateway defaults

### DIFF
--- a/assets/chrome-extension/README.md
+++ b/assets/chrome-extension/README.md
@@ -5,7 +5,7 @@ Purpose: attach OpenClaw to an existing Chrome tab so the Gateway can automate i
 ## Dev / load unpacked
 
 1. Build/run OpenClaw Gateway with browser control enabled.
-2. Ensure the relay server is reachable at `http://127.0.0.1:18792/` (default).
+2. Ensure the relay server is reachable at `http://127.0.0.1:18795/` (default for gateway port 18792).
 3. Install the extension to a stable path:
 
    ```bash
@@ -19,5 +19,5 @@ Purpose: attach OpenClaw to an existing Chrome tab so the Gateway can automate i
 
 ## Options
 
-- `Relay port`: defaults to `18792`.
+- `Relay port`: defaults to `18795` (gateway port + 3 with current defaults).
 - `Gateway token`: required. Set this to `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`).

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -1,6 +1,6 @@
 import { buildRelayWsUrl, isRetryableReconnectError, reconnectDelayMs } from './background-utils.js'
 
-const DEFAULT_PORT = 18792
+const DEFAULT_PORT = 18795
 
 const BADGE = {
   on: { text: 'ON', color: '#FF5A36' },

--- a/assets/chrome-extension/options-validation.js
+++ b/assets/chrome-extension/options-validation.js
@@ -1,4 +1,4 @@
-const PORT_GUIDANCE = 'Use gateway port + 3 (for gateway 18789, relay is 18792).'
+const PORT_GUIDANCE = 'Use gateway port + 3 (for gateway 18792, relay is 18795).'
 
 function hasCdpVersionShape(data) {
   return !!data && typeof data === 'object' && 'Browser' in data && 'Protocol-Version' in data

--- a/assets/chrome-extension/options.html
+++ b/assets/chrome-extension/options.html
@@ -187,7 +187,7 @@
             <button id="save" type="button">Save</button>
           </div>
           <div class="hint">
-            Default port: <code>18792</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
+            Default port: <code>18795</code>. Extension connects to: <code id="relay-url">http://127.0.0.1:&lt;port&gt;/</code>.
             Gateway token must match <code>gateway.auth.token</code> (or <code>OPENCLAW_GATEWAY_TOKEN</code>).
           </div>
           <div class="status" id="status"></div>

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -1,7 +1,7 @@
 import { deriveRelayToken } from './background-utils.js'
 import { classifyRelayCheckException, classifyRelayCheckResponse } from './options-validation.js'
 
-const DEFAULT_PORT = 18792
+const DEFAULT_PORT = 18795
 
 function clampPort(value) {
   const n = Number.parseInt(String(value || ''), 10)

--- a/src/browser/chrome-extension-options-validation.test.ts
+++ b/src/browser/chrome-extension-options-validation.test.ts
@@ -59,7 +59,7 @@ describe("chrome extension options validation", () => {
       action: "status",
       kind: "error",
       message:
-        "Wrong port: this is likely the gateway, not the relay. Use gateway port + 3 (for gateway 18789, relay is 18792).",
+        "Wrong port: this is likely the gateway, not the relay. Use gateway port + 3 (for gateway 18792, relay is 18795).",
     });
   });
 
@@ -72,7 +72,7 @@ describe("chrome extension options validation", () => {
       action: "status",
       kind: "error",
       message:
-        "Wrong port: expected relay /json/version response. Use gateway port + 3 (for gateway 18789, relay is 18792).",
+        "Wrong port: expected relay /json/version response. Use gateway port + 3 (for gateway 18792, relay is 18795).",
     });
   });
 
@@ -98,7 +98,7 @@ describe("chrome extension options validation", () => {
     expect(result).toEqual({
       kind: "error",
       message:
-        "Wrong port: this is not a relay endpoint. Use gateway port + 3 (for gateway 18789, relay is 18792).",
+        "Wrong port: this is not a relay endpoint. Use gateway port + 3 (for gateway 18792, relay is 18795).",
     });
   });
 


### PR DESCRIPTION
Fixes #28353\n\n## Summary\n- update the Chrome extension default relay port from 18792 to 18795\n- update options UI/help text and extension README to reflect the current default mapping (gateway 18792 -> relay 18795)\n- update options-validation guidance and tests to match\n\n## Why\nThe extension currently defaults to the gateway port. With current defaults, the relay runs on gateway port + 3, so the default should be 18795. Using 18792 causes the extension to connect to the wrong WebSocket endpoint and fail attach.\n\n## Validation\n- pnpm vitest src/browser/chrome-extension-options-validation.test.ts\n- pnpm check\n- pnpm check:docs\n- pnpm protocol:check