### PR TITLE
fix(feishu): break infinite typing-indicator retry loop on rate-limit / quota errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Typing backoff: re-throw Feishu typing add/remove rate-limit and quota errors (`429`, `99991400`, `99991403`) and detect SDK non-throwing backoff responses so the typing keepalive circuit breaker can stop retries instead of looping indefinitely. (#28494)
 - Feishu/Probe status caching: cache successful `probeFeishu()` bot-info results for 10 minutes (bounded cache with per-account keying) to reduce repeated status/onboarding probe API calls, while bypassing cache for failures and exceptions. (#28907) Thanks @Glucksberg.
 - Feishu/Opus media send type: send `.opus` attachments with `msg_type: "audio"` (instead of `"media"`) so Feishu voice messages deliver correctly while `.mp4` remains `msg_type: "media"` and documents remain `msg_type: "file"`. (#28269) Thanks @Glucksberg.
 - Feishu/Local media sends: propagate `mediaLocalRoots` through Feishu outbound media sending into `loadWebMedia` so local path attachments work with post-CVE local-root enforcement. (#27884) Thanks @joelnishanth.

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFeishuBackoffError, hasBackoffCodeInResponse, FeishuBackoffError } from "./typing.js";
+import { isFeishuBackoffError, getBackoffCodeFromResponse, FeishuBackoffError } from "./typing.js";
 
 describe("isFeishuBackoffError", () => {
   it("returns true for HTTP 429 (AxiosError shape)", () => {
@@ -54,38 +54,38 @@ describe("isFeishuBackoffError", () => {
   });
 });
 
-describe("hasBackoffCodeInResponse", () => {
+describe("getBackoffCodeFromResponse", () => {
   it("returns true for response with quota exceeded code", () => {
     const response = { code: 99991403, msg: "quota exceeded", data: null };
-    expect(hasBackoffCodeInResponse(response)).toBe(true);
+    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 
   it("returns true for response with rate limit code", () => {
     const response = { code: 99991400, msg: "rate limit", data: null };
-    expect(hasBackoffCodeInResponse(response)).toBe(true);
+    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 
   it("returns false for successful response (code 0)", () => {
     const response = { code: 0, msg: "success", data: { reaction_id: "r1" } };
-    expect(hasBackoffCodeInResponse(response)).toBe(false);
+    expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });
 
   it("returns false for other error codes", () => {
     const response = { code: 99991401, msg: "other error", data: null };
-    expect(hasBackoffCodeInResponse(response)).toBe(false);
+    expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });
 
   it("returns false for null", () => {
-    expect(hasBackoffCodeInResponse(null)).toBe(false);
+    expect(getBackoffCodeFromResponse(null)).toBeUndefined();
   });
 
   it("returns false for undefined", () => {
-    expect(hasBackoffCodeInResponse(undefined)).toBe(false);
+    expect(getBackoffCodeFromResponse(undefined)).toBeUndefined();
   });
 
   it("returns false for response without code field", () => {
     const response = { data: { reaction_id: "r1" } };
-    expect(hasBackoffCodeInResponse(response)).toBe(false);
+    expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });
 });
 

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -36,11 +36,11 @@ describe("isFeishuBackoffError", () => {
     expect(isFeishuBackoffError(new Error("network timeout"))).toBe(false);
   });
 
-  it("returns false for null", () => {
+  it("returns undefined for null", () => {
     expect(isFeishuBackoffError(null)).toBe(false);
   });
 
-  it("returns false for undefined", () => {
+  it("returns undefined for undefined", () => {
     expect(isFeishuBackoffError(undefined)).toBe(false);
   });
 
@@ -55,35 +55,35 @@ describe("isFeishuBackoffError", () => {
 });
 
 describe("getBackoffCodeFromResponse", () => {
-  it("returns true for response with quota exceeded code", () => {
+  it("returns backoff code for response with quota exceeded code", () => {
     const response = { code: 99991403, msg: "quota exceeded", data: null };
     expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 
-  it("returns true for response with rate limit code", () => {
+  it("returns backoff code for response with rate limit code", () => {
     const response = { code: 99991400, msg: "rate limit", data: null };
     expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 
-  it("returns false for successful response (code 0)", () => {
+  it("returns undefined for successful response (code 0)", () => {
     const response = { code: 0, msg: "success", data: { reaction_id: "r1" } };
     expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });
 
-  it("returns false for other error codes", () => {
+  it("returns undefined for other error codes", () => {
     const response = { code: 99991401, msg: "other error", data: null };
     expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });
 
-  it("returns false for null", () => {
+  it("returns undefined for null", () => {
     expect(getBackoffCodeFromResponse(null)).toBeUndefined();
   });
 
-  it("returns false for undefined", () => {
+  it("returns undefined for undefined", () => {
     expect(getBackoffCodeFromResponse(undefined)).toBeUndefined();
   });
 
-  it("returns false for response without code field", () => {
+  it("returns undefined for response without code field", () => {
     const response = { data: { reaction_id: "r1" } };
     expect(getBackoffCodeFromResponse(response)).toBeUndefined();
   });

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isFeishuBackoffError } from "./typing.js";
+
+describe("isFeishuBackoffError", () => {
+  it("returns true for HTTP 429 (AxiosError shape)", () => {
+    const err = { response: { status: 429, data: {} } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns true for Feishu quota exceeded code 99991403", () => {
+    const err = { response: { status: 200, data: { code: 99991403 } } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns true for Feishu rate limit code 99991400", () => {
+    const err = { response: { status: 200, data: { code: 99991400 } } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns true for SDK error with top-level code 99991403", () => {
+    const err = { code: 99991403, message: "quota exceeded" };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns false for other HTTP errors (e.g. 500)", () => {
+    const err = { response: { status: 500, data: {} } };
+    expect(isFeishuBackoffError(err)).toBe(false);
+  });
+
+  it("returns false for non-rate-limit Feishu codes", () => {
+    const err = { response: { status: 200, data: { code: 99991401 } } };
+    expect(isFeishuBackoffError(err)).toBe(false);
+  });
+
+  it("returns false for generic Error", () => {
+    expect(isFeishuBackoffError(new Error("network timeout"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isFeishuBackoffError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isFeishuBackoffError(undefined)).toBe(false);
+  });
+
+  it("returns false for string", () => {
+    expect(isFeishuBackoffError("429")).toBe(false);
+  });
+
+  it("returns true for 429 even without data", () => {
+    const err = { response: { status: 429 } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+});

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -17,16 +17,6 @@ describe("isFeishuBackoffError", () => {
     expect(isFeishuBackoffError(err)).toBe(true);
   });
 
-  it("returns true for Feishu tenant quota exceeded code 99991404", () => {
-    const err = { response: { status: 200, data: { code: 99991404 } } };
-    expect(isFeishuBackoffError(err)).toBe(true);
-  });
-
-  it("returns true for Feishu rate limit code 99991429", () => {
-    const err = { response: { status: 200, data: { code: 99991429 } } };
-    expect(isFeishuBackoffError(err)).toBe(true);
-  });
-
   it("returns true for SDK error with code 429", () => {
     const err = { code: 429, message: "too many requests" };
     expect(isFeishuBackoffError(err)).toBe(true);
@@ -77,16 +67,6 @@ describe("getBackoffCodeFromResponse", () => {
 
   it("returns backoff code for response with rate limit code", () => {
     const response = { code: 99991400, msg: "rate limit", data: null };
-    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
-  });
-
-  it("returns backoff code for response with tenant quota code", () => {
-    const response = { code: 99991404, msg: "tenant quota exceeded", data: null };
-    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
-  });
-
-  it("returns backoff code for response with rate limit code 99991429", () => {
-    const response = { code: 99991429, msg: "rate limit", data: null };
     expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -17,6 +17,21 @@ describe("isFeishuBackoffError", () => {
     expect(isFeishuBackoffError(err)).toBe(true);
   });
 
+  it("returns true for Feishu tenant quota exceeded code 99991404", () => {
+    const err = { response: { status: 200, data: { code: 99991404 } } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns true for Feishu rate limit code 99991429", () => {
+    const err = { response: { status: 200, data: { code: 99991429 } } };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
+  it("returns true for SDK error with code 429", () => {
+    const err = { code: 429, message: "too many requests" };
+    expect(isFeishuBackoffError(err)).toBe(true);
+  });
+
   it("returns true for SDK error with top-level code 99991403", () => {
     const err = { code: 99991403, message: "quota exceeded" };
     expect(isFeishuBackoffError(err)).toBe(true);
@@ -62,6 +77,21 @@ describe("getBackoffCodeFromResponse", () => {
 
   it("returns backoff code for response with rate limit code", () => {
     const response = { code: 99991400, msg: "rate limit", data: null };
+    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
+  });
+
+  it("returns backoff code for response with tenant quota code", () => {
+    const response = { code: 99991404, msg: "tenant quota exceeded", data: null };
+    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
+  });
+
+  it("returns backoff code for response with rate limit code 99991429", () => {
+    const response = { code: 99991429, msg: "rate limit", data: null };
+    expect(getBackoffCodeFromResponse(response)).toBe(response.code);
+  });
+
+  it("returns backoff code for response with code 429", () => {
+    const response = { code: 429, msg: "too many requests", data: null };
     expect(getBackoffCodeFromResponse(response)).toBe(response.code);
   });
 

--- a/extensions/feishu/src/typing.test.ts
+++ b/extensions/feishu/src/typing.test.ts
@@ -41,11 +41,11 @@ describe("isFeishuBackoffError", () => {
     expect(isFeishuBackoffError(new Error("network timeout"))).toBe(false);
   });
 
-  it("returns undefined for null", () => {
+  it("returns false for null", () => {
     expect(isFeishuBackoffError(null)).toBe(false);
   });
 
-  it("returns undefined for undefined", () => {
+  it("returns false for undefined", () => {
     expect(isFeishuBackoffError(undefined)).toBe(false);
   });
 

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -106,7 +106,9 @@ export async function addTypingIndicator(params: {
     // instead of throwing. Detect backoff codes and throw to trip the breaker.
     if (hasBackoffCodeInResponse(response)) {
       const code = (response as { code?: number }).code;
-      console.log(`[feishu] typing indicator response contains backoff code ${code}, stopping keepalive`);
+      console.log(
+        `[feishu] typing indicator response contains backoff code ${code}, stopping keepalive`,
+      );
       throw new Error(`Feishu API backoff: code ${code}`);
     }
 
@@ -157,7 +159,9 @@ export async function removeTypingIndicator(params: {
     // Check for backoff codes in non-throwing SDK responses
     if (hasBackoffCodeInResponse(result)) {
       const code = (result as { code?: number }).code;
-      console.log(`[feishu] typing indicator removal response contains backoff code ${code}, stopping keepalive`);
+      console.log(
+        `[feishu] typing indicator removal response contains backoff code ${code}, stopping keepalive`,
+      );
       throw new Error(`Feishu API backoff: code ${code}`);
     }
   } catch (err) {

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -12,12 +12,16 @@ const TYPING_EMOJI = "Typing"; // Typing indicator emoji
  * These must propagate to the typing circuit breaker so the keepalive loop
  * can trip and stop retrying.
  *
+ * - 99991400: Rate limit (too many requests per second)
  * - 99991403: Monthly API call quota exceeded
+ * - 99991404: Tenant API call quota exceeded
+ * - 99991429: API rate limit (alternative code used by some endpoints)
+ * - 429: Standard HTTP 429 returned as a Feishu SDK error code
  * - 99991400: Rate limit (too many requests per second)
  *
  * @see https://open.feishu.cn/document/server-docs/getting-started/server-error-codes
  */
-const FEISHU_BACKOFF_CODES = new Set([99991403, 99991400]);
+const FEISHU_BACKOFF_CODES = new Set([99991400, 99991403, 99991404, 99991429, 429]);
 
 /**
  * Custom error class for Feishu backoff conditions detected from non-throwing

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -14,14 +14,12 @@ const TYPING_EMOJI = "Typing"; // Typing indicator emoji
  *
  * - 99991400: Rate limit (too many requests per second)
  * - 99991403: Monthly API call quota exceeded
- * - 99991404: Tenant API call quota exceeded
- * - 99991429: API rate limit (alternative code used by some endpoints)
  * - 429: Standard HTTP 429 returned as a Feishu SDK error code
  * - 99991400: Rate limit (too many requests per second)
  *
  * @see https://open.feishu.cn/document/server-docs/getting-started/server-error-codes
  */
-const FEISHU_BACKOFF_CODES = new Set([99991400, 99991403, 99991404, 99991429, 429]);
+const FEISHU_BACKOFF_CODES = new Set([99991400, 99991403, 429]);
 
 /**
  * Custom error class for Feishu backoff conditions detected from non-throwing

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -15,9 +15,8 @@ const TYPING_EMOJI = "Typing"; // Typing indicator emoji
  * - 99991400: Rate limit (too many requests per second)
  * - 99991403: Monthly API call quota exceeded
  * - 429: Standard HTTP 429 returned as a Feishu SDK error code
- * - 99991400: Rate limit (too many requests per second)
  *
- * @see https://open.feishu.cn/document/server-docs/getting-started/server-error-codes
+ * @see https://open.feishu.cn/document/server-docs/api-call-guide/generic-error-code
  */
 const FEISHU_BACKOFF_CODES = new Set([99991400, 99991403, 429]);
 


### PR DESCRIPTION
## Summary / 概要

Resubmission of #28157 (auto-closed when fork was accidentally deleted).

重新提交 #28157（fork 仓库被误删导致原 PR 自动关闭）。

All code, tests, and CI results are identical to the original PR (with review feedback addressed).

---

### Problem / 问题
Feishu typing-indicator helpers (`addTypingIndicator` / `removeTypingIndicator`) silently swallow 429 / quota-exceeded errors inside a bare `try-catch`, preventing the circuit breaker from ever tripping. This caused **76,744 failed retries in ~8 hours** when the Feishu API quota was exhausted.

飞书输入状态指示器的 `addTypingIndicator` / `removeTypingIndicator` 在 `try-catch` 中静默吞掉 429/配额耗尽错误，导致断路器永远无法触发。当飞书 API 配额耗尽时，在约 8 小时内产生了 76,744 次失败重试。

### Changes / 改动
- Add `FeishuBackoffError` class with numeric `.code` property
- Add `FEISHU_BACKOFF_CODES` Set with 3 documented error codes:
  - `99991400` — Rate limit (too many requests per second)
  - `99991403` — Monthly API call quota exceeded
  - `429` — HTTP 429 mapped as SDK error code
- Add `isFeishuBackoffError()` type guard (exported)
- Add `getBackoffCodeFromResponse()` helper for normal HTTP responses containing backoff codes
- Re-throw backoff errors in both `addTypingIndicator` and `removeTypingIndicator`
- 25 unit tests covering all paths

Error codes are based on [Feishu official documentation](https://open.feishu.cn/document/server-docs/api-call-guide/generic-error-code). The `Set` structure allows easy extension if new codes are discovered.

### Related / 相关
- Closes #28062
- Supersedes #28157 (identical code)
- Alternative to #28086