### PR TITLE
fix(telegram): avoid overriding proxy-aware undici dispatcher

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -679,6 +679,35 @@ openclaw message send --channel telegram --target @name --message "hi"
 
   </Accordion>
 
+  <Accordion title="Telegram is online, but model requests fail in proxy environments">
+
+    Symptoms:
+    - Telegram health checks and bot updates look normal.
+    - model requests (for example `openai-codex`) fail with transport errors such as:
+      - `fetch failed`
+      - `ERR_TLS_CERT_ALTNAME_INVALID`
+      - `UND_ERR_CONNECT_TIMEOUT`
+
+    What to check:
+    - Keep gateway proxy envs configured when your host requires proxy egress:
+      - `NODE_USE_ENV_PROXY=1`
+      - `HTTP_PROXY=...`
+      - `HTTPS_PROXY=...`
+      - `ALL_PROXY=...`
+    - Verify with:
+
+```bash
+openclaw config get env.vars --json
+openclaw gateway restart
+openclaw logs --follow
+```
+
+    Notes:
+    - Newer OpenClaw builds keep proxy-aware routing when Telegram applies Node 22 network workarounds.
+    - If this still reproduces on your version, upgrade to the latest release and re-test.
+
+  </Accordion>
+
   <Accordion title="Polling or network instability">
 
     - Node 22+ + custom fetch/proxy can trigger immediate abort behavior if AbortSignal types mismatch.

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -690,6 +690,25 @@ Telegram 反应作为**单独的 `message_reaction` 事件**到达，而不是�
 - 确保你的 Telegram 用户 ID 已授权（通过配对或 `channels.telegram.allowFrom`）
 - 即使在 `groupPolicy: "open"` 的群组中，命令也需要授权
 
+**Telegram 正常在线，但模型请求在代理环境下失败：**
+
+- 现象：
+  - Telegram 健康检查和收消息都正常
+  - 模型请求（例如 `openai-codex`）报传输错误，如：
+    - `fetch failed`
+    - `ERR_TLS_CERT_ALTNAME_INVALID`
+    - `UND_ERR_CONNECT_TIMEOUT`
+- 检查网关代理环境变量是否完整：
+  - `NODE_USE_ENV_PROXY=1`
+  - `HTTP_PROXY=...`
+  - `HTTPS_PROXY=...`
+  - `ALL_PROXY=...`
+- 可用以下命令验证：
+  - `openclaw config get env.vars --json`
+  - `openclaw gateway restart`
+  - `openclaw logs --follow`
+- 说明：较新版本会在 Telegram 的 Node 22 网络兼容逻辑下保留代理路由；如果你的版本仍复现，先升级到最新版本再复测。
+
 **长轮询在 Node 22+ 上立即中止（通常与代理/自定义 fetch 有关）：**
 
 - Node 22+ 对 `AbortSignal` 实例更严格；外部信号可以立即中止 `fetch` 调用。

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -198,6 +198,17 @@ describe("resolveTelegramFetch", () => {
     expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
   });
 
+  it("does not replace global dispatcher when lowercase proxy envs are configured", async () => {
+    vi.stubEnv("all_proxy", "socks5://127.0.0.1:1082");
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
+  });
+
   it("sets global dispatcher only once across repeated equal decisions", async () => {
     clearProxyEnvsForTest();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -33,6 +33,21 @@ vi.mock("undici", () => ({
 }));
 
 const originalFetch = globalThis.fetch;
+const PROXY_ENV_KEYS = [
+  "NODE_USE_ENV_PROXY",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
+
+function clearProxyEnvsForTest(): void {
+  for (const key of PROXY_ENV_KEYS) {
+    vi.stubEnv(key, "");
+  }
+}
 
 afterEach(() => {
   resetTelegramFetchStateForTests();
@@ -148,6 +163,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
+    clearProxyEnvsForTest();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
@@ -160,7 +176,30 @@ describe("resolveTelegramFetch", () => {
     });
   });
 
+  it("does not replace global dispatcher when NODE_USE_ENV_PROXY is enabled", async () => {
+    vi.stubEnv("NODE_USE_ENV_PROXY", "1");
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
+  });
+
+  it("does not replace global dispatcher when proxy URL envs are configured", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:1082");
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(true);
+  });
+
   it("sets global dispatcher only once across repeated equal decisions", async () => {
+    clearProxyEnvsForTest();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
@@ -169,6 +208,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("updates global dispatcher when autoSelectFamily decision changes", async () => {
+    clearProxyEnvsForTest();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram startup applies Node 22 network workarounds by replacing the global undici dispatcher, which can override proxy-aware routing.
- Why it matters: In proxy-required environments, unrelated model traffic (for example `openai-codex`) can bypass proxy routing and fail (`fetch failed`, TLS cert mismatch, connect timeout).
- What changed: Added proxy-env guard in `src/telegram/fetch.ts` so global dispatcher replacement is skipped when proxy env routing is configured.
- What did NOT change (scope boundary): No change to Telegram Bot API request semantics, no change to `autoSelectFamily` / DNS decisions, no config-schema change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #25676

## User-visible / Behavior Changes

- In proxy-routed environments (`NODE_USE_ENV_PROXY=1` and/or proxy URL envs), Telegram initialization no longer replaces the global undici dispatcher.
- This preserves proxy-aware model traffic routing and avoids proxy-bypass transport failures.
- Added troubleshooting guidance in Telegram docs (EN + zh-CN).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (ARM64)
- Runtime/container: Node 25 + pnpm
- Model/provider: openai-codex / gpt-5.2-codex
- Integration/channel (if any): Telegram + Gateway
- Relevant config (redacted): `NODE_USE_ENV_PROXY=1`, `HTTP_PROXY/HTTPS_PROXY/ALL_PROXY` set

### Steps

1. Start gateway with Telegram enabled and proxy env routing configured.
2. Trigger Telegram startup path and run a model request through gateway.
3. Observe behavior with and without this patch.

### Expected

- Telegram workaround should not override proxy-aware dispatcher when proxy env routing is enabled.
- Model requests continue using proxy routing.

### Actual

- Before patch: model transport could fail in proxy deployments (for example `fetch failed`, `ERR_TLS_CERT_ALTNAME_INVALID`, `UND_ERR_CONNECT_TIMEOUT`).
- After patch: regression tests pass; proxy-aware dispatcher is preserved under proxy envs.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Focused unit tests for `src/telegram/fetch.test.ts` pass (14/14).
  - Added coverage for uppercase and lowercase proxy env detection (`NODE_USE_ENV_PROXY`, `HTTPS_PROXY`, `all_proxy`).
- Edge cases checked:
  - Existing dispatcher behavior remains unchanged when proxy envs are absent.
  - Existing one-time/decision-change dispatcher tests remain green.
- What you did **not** verify:
  - Full `pnpm build && pnpm check && pnpm test` suite.
  - Additional channel integrations beyond Telegram path.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit(s) affecting `src/telegram/fetch.ts` and `src/telegram/fetch.test.ts`.
- Files/config to restore:
  - `src/telegram/fetch.ts`
  - `src/telegram/fetch.test.ts`
  - docs updates are optional and can be retained or reverted independently.
- Known bad symptoms reviewers should watch for:
  - Telegram network workaround no longer setting global dispatcher even when no proxy env is configured.

## Risks and Mitigations

- Risk: Proxy env detection may be too broad and skip dispatcher replacement in cases where envs are set but unused.
  - Mitigation: Limited to explicit proxy env presence, preserves existing behavior when no proxy envs are configured, and covered by tests.

## AI-assisted

- AI-assisted: Yes (Codex-assisted implementation and drafting).
- Testing degree: Focused and validated on touched unit tests + real-world reproduction logs.
- Prompt/session logs: Available in PR discussion context.
- Confirmed understanding: Yes; changes are constrained to Telegram network workaround gating and related docs/tests.
