### PR TITLE
fix(failover): treat HTTP 529 (Anthropic overloaded) as failover-eligible

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -176,6 +176,9 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
+  if (status === 529) {
+    return "timeout";
+  }
   if (status === 400) {
     return "format";
   }


### PR DESCRIPTION
## Summary

HTTP 529 (Anthropic overloaded) is not recognized by `resolveFailoverReasonFromError` in `failover-error.ts`, causing the model fallback loop to skip alternatives entirely.

## Problem

When Anthropic returns 529:
1. `coerceToFailoverError` → `resolveFailoverReasonFromError` returns `null` (529 not handled)
2. `model-fallback.ts` sees `!isFailoverError(normalized)` → throws immediately
3. Fallback models are never tried
4. The outer `isTransientHttpError` retry in `agent-runner-execution.ts` catches it, but only retries the whole chain once — if the primary is still down, the user gets an error

## Fix

Add 529 to `resolveFailoverReasonFromError` so the inner fallback loop can try alternative models before the outer retry kicks in.

## Change type
- [x] Bug fix

## Scope
- [x] Agents / model routing

## Security impact
None

## Evidence
Tested in production with proxy providers where 529 is frequent. Before fix: OpenClaw becomes unresponsive when primary returns 529 despite healthy fallbacks. After fix: fallback models are tried immediately.

## Compatibility
Fully backward compatible. Only adds a new status code to an existing switch-like chain.

## Related
Fixes #28502
Related: #8112, #26578, PR #25138

---
*This PR was authored with AI assistance.*