### PR TITLE
fix(agents): enforce Mistral strict9 tool call ID sanitization via OpenAI-compatible proxies

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -74,4 +74,66 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.validateAnthropicTurns).toBe(false);
   });
+
+  // --- #28492: Mistral via OpenAI-compatible proxy providers ---
+
+  it("enables strict9 sanitization for Mistral model via openai-completions without explicit provider", () => {
+    const policy = resolveTranscriptPolicy({
+      modelId: "mistralai/mistral-large-3-675b-instruct-2512",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+    expect(policy.sanitizeMode).toBe("full");
+  });
+
+  it("enables strict9 sanitization for Mistral model via NVIDIA NIM (openai-completions)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "nvidia-nim",
+      modelId: "mistralai/mistral-large-3-675b-instruct-2512",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+    expect(policy.sanitizeMode).toBe("full");
+  });
+
+  it("enables strict9 sanitization for Mixtral model via OpenRouter", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "mistralai/mixtral-8x22b-instruct",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
+
+  it("enables strict9 sanitization for Codestral model via generic proxy", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "my-proxy",
+      modelId: "codestral-latest",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
+
+  it("still disables sanitization for non-Mistral models on OpenAI provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4.1",
+      modelApi: "openai",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
+  });
+
+  it("still enables strict9 for native Mistral provider (no regression)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "mistral",
+      modelId: "mistral-large-latest",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
 });


### PR DESCRIPTION
Fixes #28492

## Problem

Mistral models accessed via OpenAI-compatible proxy providers (NVIDIA NIM, OpenRouter, etc.) using `openai-completions` API fail every tool call with:

> Tool call id was <UUID> but must be a-z, A-Z, 0-9, with a length of 9.

**Root cause:** `resolveTranscriptPolicy` computes `sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds`. When `modelApi` is `openai-completions` and no explicit provider is set, `isOpenAi` evaluates to `true`, suppressing the `strict9` sanitization that Mistral requires. Proxy providers forward requests directly to Mistral, which enforces the 9-char alphanumeric constraint.

## Fix

Introduce `forceMistralSanitize = isMistral && !isOpenAiProvider(provider)`:

- When a Mistral-family model is detected and the provider is **not** native OpenAI (`openai` / `openai-codex`), force-enable `sanitizeToolCallIds` and set `sanitizeMode` to `"full"`.
- Native OpenAI and non-Mistral models are unaffected (no regression).
- Uses the existing `isOpenAiProvider()` check (exact match against `OPENAI_PROVIDERS` set), not the broader `isOpenAi` flag that conflates provider identity with API format.

## Test coverage

6 new test cases covering:
- Mistral via `openai-completions` without explicit provider
- Mistral via NVIDIA NIM
- Mixtral via OpenRouter
- Codestral via generic proxy
- Non-Mistral on OpenAI (no regression)
- Native Mistral provider (no regression)
