### PR TITLE
feat(web-search): add SearXNG as a native self-hosted search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,10 @@ Docs: https://docs.openclaw.ai
 
 - **BREAKING:** Gateway auth now requires explicit `gateway.auth.mode` when both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs). Set `gateway.auth.mode` to `token` or `password` before upgrade to avoid startup/pairing/TUI failures. (#35094) Thanks @joshavant.
 
+### Changes
+
+- Web Search/SearXNG: add `searxng` as a first-class `web_search` provider. Point OpenClaw at any self-hosted SearXNG instance for no-API-key, multi-engine aggregated search with support for category filtering (`general`, `images`, `news`, `videos`, `files`, `social media`), engine selection, language, and safe-search controls. Configure via `tools.web.search.provider: "searxng"` and `tools.web.search.searxng.url`.
+
 ### Fixes
 
 - Models/MiniMax: stop advertising removed `MiniMax-M2.5-Lightning` in built-in provider catalogs, onboarding metadata, and docs; keep the supported fast-tier model as `MiniMax-M2.5-highspeed`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,13 +370,11 @@ Docs: https://docs.openclaw.ai
 - Google/Gemini 3.1 Flash-Lite: add first-class `google/gemini-3.1-flash-lite-preview` support across model-id normalization, default aliases, media-understanding image lookups, Google Gemini CLI forward-compat fallback, and docs.
 - Agents/compaction model override: allow `agents.defaults.compaction.model` to route compaction summarization through a different model than the main session, and document the override across config help/reference surfaces. (#38753) thanks @starbuck100.
 
+- Web Search/SearXNG: add `searxng` as a first-class `web_search` provider. Point OpenClaw at any self-hosted SearXNG instance for no-API-key, multi-engine aggregated search with support for category filtering (`general`, `images`, `news`, `videos`, `files`, `social media`), engine selection, language, and safe-search controls. Configure via `tools.web.search.provider: "searxng"` and `tools.web.search.searxng.url`.
+
 ### Breaking
 
 - **BREAKING:** Gateway auth now requires explicit `gateway.auth.mode` when both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs). Set `gateway.auth.mode` to `token` or `password` before upgrade to avoid startup/pairing/TUI failures. (#35094) Thanks @joshavant.
-
-### Changes
-
-- Web Search/SearXNG: add `searxng` as a first-class `web_search` provider. Point OpenClaw at any self-hosted SearXNG instance for no-API-key, multi-engine aggregated search with support for category filtering (`general`, `images`, `news`, `videos`, `files`, `social media`), engine selection, language, and safe-search controls. Configure via `tools.web.search.provider: "searxng"` and `tools.web.search.searxng.url`.
 
 ### Fixes
 

--- a/docker-compose.searxng-isolated.yml
+++ b/docker-compose.searxng-isolated.yml
@@ -1,0 +1,105 @@
+# docker-compose.searxng-isolated.yml
+#
+# Network-isolated SearXNG overlay for OpenClaw.
+#
+# Security model:
+#   - "internal" network: OpenClaw gateway + CLI. No internet egress.
+#   - "egress" network: SearXNG only. Has internet access for upstream engine queries.
+#   - SearXNG bridges both networks — it's the ONLY path from OpenClaw to the public web.
+#   - OpenClaw containers cannot resolve or reach any external host directly.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.searxng-isolated.yml up -d
+#
+# The base docker-compose.yml provides openclaw-gateway and openclaw-cli.
+# This overlay:
+#   1. Adds the SearXNG service with a hardened settings.yml and rate limiter
+#   2. Creates isolated networks with egress control
+#   3. Moves OpenClaw containers onto the internal-only network
+#   4. Bridges SearXNG across both networks
+#
+# Verified against SearXNG on CT 210 (192.168.1.210:8080) in a Proxmox lab
+# environment with 85 enabled engines. The settings.yml restricts to a
+# curated allowlist of 5 engines for agent use.
+
+services:
+  searxng:
+    image: searxng/searxng:2024.12.15-b21ed189b
+    container_name: openclaw-searxng
+    restart: unless-stopped
+    volumes:
+      - ./scripts/searxng-isolated/settings.yml:/etc/searxng/settings.yml:ro
+      - ./scripts/searxng-isolated/limiter.toml:/etc/searxng/limiter.toml:ro
+    networks:
+      internal:
+        # Static alias so OpenClaw config can use http://searxng:8080
+        aliases:
+          - searxng
+      egress: {}
+    # Bind only to localhost on the host — not exposed to the LAN.
+    # Remove this port mapping entirely in production (internal-only access).
+    ports:
+      - "127.0.0.1:8888:8080"
+    environment:
+      - SEARXNG_BASE_URL=http://searxng:8080
+      - INSTANCE_NAME=openclaw-search
+      # Required: generate with `openssl rand -hex 32` and set in .env or shell
+      - SEARXNG_SECRET_KEY=${SEARXNG_SECRET_KEY:?Set SEARXNG_SECRET_KEY in .env}
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://127.0.0.1:8080/",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+
+  # Override: move gateway to internal-only network
+  openclaw-gateway:
+    networks:
+      internal:
+        aliases:
+          - openclaw-gateway
+    # Remove from default network — gateway has NO direct internet access.
+    # All web search goes through SearXNG on the internal network.
+
+  # NOTE: openclaw-cli uses network_mode: "service:openclaw-gateway" in the base
+  # compose file, so it shares the gateway's network stack. Moving the gateway
+  # to the internal network implicitly isolates the CLI too — no override needed.
+
+networks:
+  # Internal network: OpenClaw + SearXNG can communicate.
+  # No internet egress — containers here cannot reach external hosts.
+  internal:
+    driver: bridge
+    internal: true  # <-- This is the key: Docker blocks all outbound traffic
+
+  # Egress network: SearXNG only. Has internet access for upstream queries.
+  # OpenClaw containers are NOT attached to this network.
+  egress:
+    driver: bridge
+    # NOT internal — this network has internet access
+

--- a/docker-compose.searxng-isolated.yml
+++ b/docker-compose.searxng-isolated.yml
@@ -58,15 +58,7 @@ services:
     tmpfs:
       - /tmp:size=64m
     healthcheck:
-      test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1:8080/",
-        ]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8080/"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -95,11 +87,10 @@ networks:
   # No internet egress — containers here cannot reach external hosts.
   internal:
     driver: bridge
-    internal: true  # <-- This is the key: Docker blocks all outbound traffic
+    internal: true # <-- This is the key: Docker blocks all outbound traffic
 
   # Egress network: SearXNG only. Has internet access for upstream queries.
   # OpenClaw containers are NOT attached to this network.
   egress:
     driver: bridge
     # NOT internal — this network has internet access
-

--- a/docs/tools/web-searxng-isolation.md
+++ b/docs/tools/web-searxng-isolation.md
@@ -1,0 +1,221 @@
+---
+summary: "Network-isolated web search using SearXNG as a controlled egress gateway"
+read_when:
+  - You want to restrict agent internet access to search-only
+  - You need to audit all agent web queries
+  - You want network-level isolation for Docker deployments
+  - You want to control which search engines agents can use
+title: "SearXNG Network Isolation"
+---
+
+# SearXNG network isolation
+
+> **This is optional.** The SearXNG provider works with any reachable instance —
+> bare-metal, VM, LXC, Docker, or remote. Just set `tools.web.search.searxng.url`
+> and you're done. This guide adds an **opt-in** Docker network isolation layer
+> on top of that for deployments with stricter security requirements.
+
+Run SearXNG as a **network-isolated search gateway** so that OpenClaw agents can
+search the web but cannot make arbitrary outbound connections.
+
+## Why isolate?
+
+In a standard deployment, the OpenClaw gateway has unrestricted internet access.
+When an agent uses `web_search`, results flow through the configured provider
+API — but the gateway process itself can reach any host. This is fine for most
+use cases, but some deployments need tighter control:
+
+- **Compliance**: audit every query the agent makes to the public internet
+- **Containment**: prevent agents from exfiltrating data via arbitrary HTTP
+- **Engine control**: restrict which search engines serve results (e.g. no social media, no file-sharing)
+- **Rate governance**: enforce query budgets at the network layer, not just application config
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  internal network (no internet)                     │
+│                                                     │
+│  ┌──────────────┐       ┌──────────────────────┐   │
+│  │ openclaw-gw  │──────▶│      searxng         │   │
+│  │ openclaw-cli │ :8080 │  (bridge to egress)  │   │
+│  └──────────────┘       └──────────┬───────────┘   │
+│                                     │               │
+└─────────────────────────────────────┼───────────────┘
+                                      │
+┌─────────────────────────────────────┼───────────────┐
+│  egress network (internet access)   │               │
+│                                     ▼               │
+│                          upstream search engines    │
+│                     (brave, duckduckgo, startpage,  │
+│                      wikipedia, stackoverflow)      │
+└─────────────────────────────────────────────────────┘
+```
+
+**How it works:**
+
+1. Docker's `internal: true` flag on the internal network blocks all outbound
+   traffic — containers on this network cannot reach any host outside Docker.
+2. SearXNG is attached to **both** networks. It receives search API requests on
+   the internal network and forwards them to upstream engines via the egress network.
+3. OpenClaw containers are attached **only** to the internal network. Their sole
+   path to the public internet is the SearXNG JSON API on port 8080.
+
+## Quick start
+
+```bash
+# From the openclaw repo root:
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.searxng-isolated.yml \
+  up -d
+```
+
+Then configure OpenClaw to use the containerized SearXNG:
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "searxng",
+        searxng: {
+          // "searxng" resolves via Docker DNS on the internal network
+          url: "http://searxng:8080",
+        },
+      },
+    },
+  },
+}
+```
+
+## What's included
+
+| File                                    | Purpose                                                                           |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| `docker-compose.searxng-isolated.yml`   | Compose overlay defining networks, SearXNG service, and gateway network overrides |
+| `scripts/searxng-isolated/settings.yml` | Hardened SearXNG config with curated 5-engine allowlist and JSON-only output      |
+| `scripts/searxng-isolated/limiter.toml` | Rate limiter: 60 QPM sustained / 30 burst for JSON API                            |
+
+## Customizing the engine allowlist
+
+The default `settings.yml` enables 5 engines chosen for reliability and
+complementary coverage:
+
+| Engine        | Category | Lab results   | Notes                        |
+| ------------- | -------- | ------------- | ---------------------------- |
+| DuckDuckGo    | general  | 6/28 results  | Privacy-focused, no tracking |
+| Brave         | general  | 20/28 results | Highest result volume        |
+| Startpage     | general  | 2/28 results  | Google proxy, no tracking    |
+| Wikipedia     | general  | reference     | High-signal for research     |
+| StackOverflow | it, q&a  | reference     | Essential for coding tasks   |
+
+These numbers come from testing against a live SearXNG instance (CT 210,
+`192.168.1.210:8080`) with 85 engines enabled — only 3 engines returned
+results for a general query, confirming that a focused allowlist loses
+nothing while reducing attack surface.
+
+To add engines, uncomment sections in `settings.yml`:
+
+```yaml
+# News engines (for current-events tasks)
+- name: google news
+  engine: google_news
+  shortcut: gn
+  disabled: false
+
+# Science engines (for research tasks)
+- name: arxiv
+  engine: arxiv
+  shortcut: arx
+  disabled: false
+```
+
+## Verifying isolation
+
+After `docker compose up`, confirm the network topology:
+
+```bash
+# 1. SearXNG should be reachable from the gateway
+docker exec openclaw-gateway \
+  wget -qO- http://searxng:8080/ > /dev/null && echo "OK"
+
+# 2. Gateway should NOT be able to reach the internet
+docker exec openclaw-gateway \
+  wget -qO- --timeout=3 http://example.com 2>&1 | grep -q "bad address" && \
+  echo "ISOLATED: no internet access"
+
+# 3. SearXNG should be able to reach the internet (for upstream queries)
+docker exec openclaw-searxng \
+  wget -qO- --timeout=3 http://example.com > /dev/null 2>&1 && \
+  echo "EGRESS: searxng has internet"
+
+# 4. Run a test search through the isolated path
+docker exec openclaw-gateway \
+  wget -qO- "http://searxng:8080/search?q=test&format=json" | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(f'{len(d[\"results\"])} results from {set(r[\"engine\"] for r in d[\"results\"])}')"
+```
+
+## Monitoring
+
+SearXNG has built-in metrics when `enable_metrics: true` is set in
+`settings.yml`. Query volume, engine response times, and error rates are
+available at `http://searxng:8080/stats` (HTML) or via the `/config`
+JSON endpoint.
+
+For production deployments, you can:
+
+- Mount a logging volume and parse SearXNG access logs
+- Use the OpenClaw `config-audit.jsonl` log to correlate agent sessions with search queries
+- Add a Prometheus exporter sidecar for Grafana dashboards
+
+## Reliability
+
+Lab testing showed SearXNG availability is not guaranteed even on LAN:
+
+```
+# Gateway health check logs from a Proxmox lab deployment:
+#   Day 1: 10 unreachable events over ~2 hours (service restart)
+#   Day 7:  7 unreachable events over ~6 hours (host maintenance)
+#   Day 8+: 22 consecutive reachable checks (stable after recovery)
+```
+
+The Docker healthcheck in the compose file monitors SearXNG and will
+restart it automatically. OpenClaw's built-in `web_search` error handling
+returns a clear `searxng_unreachable` error to the agent when the instance
+is down — the agent can then decide whether to retry or proceed without
+search results.
+
+## Comparison with non-isolated SearXNG
+
+| Aspect          | Standard SearXNG            | Isolated SearXNG           |
+| --------------- | --------------------------- | -------------------------- |
+| Internet access | Gateway has full internet   | Gateway has none           |
+| Search path     | Gateway → SearXNG → engines | Same, but only path        |
+| Engine control  | SearXNG config              | Same                       |
+| Audit           | SearXNG logs                | Same + network-level proof |
+| `web_fetch`     | Works (direct HTTP)         | **Blocked** — no egress    |
+| Arbitrary HTTP  | Works                       | **Blocked**                |
+
+> **Note:** Network isolation blocks `web_fetch` since it requires direct HTTP
+> access. If you need both `web_search` (isolated) and `web_fetch`, run SearXNG
+> isolated but keep the gateway on a filtered network with egress rules instead
+> of `internal: true`.
+
+## Proxmox / LXC alternative
+
+If you run OpenClaw on Proxmox, you can achieve the same isolation using LXC
+firewall rules instead of Docker networks:
+
+```bash
+# On the Proxmox host, restrict the OpenClaw CT to only reach the SearXNG CT:
+pct set <ct-openclaw> -firewall 1
+# Allow OpenClaw → SearXNG
+pvesh create /nodes/<proxmox-node>/lxc/<ct-openclaw>/firewall/rules \
+  --type in --action ACCEPT --dest <searxng-ip> --dport 8080 --proto tcp
+# Block all other egress
+pvesh create /nodes/<proxmox-node>/lxc/<ct-openclaw>/firewall/rules \
+  --type out --action DROP
+```
+
+Then configure OpenClaw with `tools.web.search.searxng.url: "http://<searxng-ip>:8080"`.

--- a/docs/tools/web-searxng-isolation.md
+++ b/docs/tools/web-searxng-isolation.md
@@ -110,10 +110,10 @@ complementary coverage:
 | Wikipedia     | general  | reference     | High-signal for research     |
 | StackOverflow | it, q&a  | reference     | Essential for coding tasks   |
 
-These numbers come from testing against a live SearXNG instance (CT 210,
-`192.168.1.210:8080`) with 85 engines enabled — only 3 engines returned
-results for a general query, confirming that a focused allowlist loses
-nothing while reducing attack surface.
+These numbers come from testing against a live SearXNG instance with 85
+engines enabled — only 3 engines returned results for a general query,
+confirming that a focused allowlist loses nothing while reducing attack
+surface.
 
 To add engines, uncomment sections in `settings.yml`:
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -317,6 +317,20 @@ search:
 - SearXNG must have `format: json` enabled in its `settings.yml`.
 - A remote SearXNG instance is fully supported — just set `url` to any reachable address.
 
+### Advanced: network-isolated search (optional)
+
+SearXNG works with any deployment — bare-metal, VM, LXC, Docker, or remote.
+Just set `url` to wherever your instance is running and OpenClaw will use it.
+
+For deployments that additionally need to restrict agent internet access to
+search-only, an **optional** Docker compose overlay is provided that runs
+SearXNG as a network-isolated egress gateway. This is not required for normal
+use — it's for compliance or containment scenarios where the agent must
+provably have no direct internet access.
+
+See [SearXNG Network Isolation](/tools/web-searxng-isolation) for the
+compose overlay, hardened engine allowlist, and verification steps.
+
 ## web_search
 
 Search the web using your configured provider.
@@ -324,12 +338,13 @@ Search the web using your configured provider.
 ### Requirements
 
 - `tools.web.search.enabled` must not be `false` (default: enabled)
-- API key for your chosen provider:
+- API key or instance URL for your chosen provider:
   - **Brave**: `BRAVE_API_KEY` or `tools.web.search.apiKey`
   - **Gemini**: `GEMINI_API_KEY` or `tools.web.search.gemini.apiKey`
   - **Grok**: `XAI_API_KEY` or `tools.web.search.grok.apiKey`
   - **Kimi**: `KIMI_API_KEY`, `MOONSHOT_API_KEY`, or `tools.web.search.kimi.apiKey`
   - **Perplexity**: `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY`, or `tools.web.search.perplexity.apiKey`
+  - **SearXNG**: no API key — set `tools.web.search.searxng.url` (default: `http://localhost:8080`)
 - All provider key fields above support SecretRef objects.
 
 ### Config
@@ -352,7 +367,7 @@ Search the web using your configured provider.
 
 ### Tool parameters
 
-All parameters work for Brave and for native Perplexity Search API unless noted.
+All parameters work for Brave and for native Perplexity Search API unless noted. SearXNG supports `query`, `count`, and `language`.
 
 Perplexity's OpenRouter / Sonar compatibility path supports only `query` and `freshness`.
 If you set `tools.web.search.perplexity.baseUrl` / `model`, use `OPENROUTER_API_KEY`, or configure an `sk-or-...` key, Search API-only filters return explicit errors.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,9 +1,10 @@
 ---
-summary: "Web search + fetch tools (Brave, Gemini, Grok, Kimi, and Perplexity providers)"
+summary: "Web search + fetch tools (Brave, Gemini, Grok, Kimi, Perplexity, and SearXNG providers)"
 read_when:
   - You want to enable web_search or web_fetch
   - You need provider API key setup
   - You want to use Gemini with Google Search grounding
+  - You want to use SearXNG for self-hosted, API-key-free search
 title: "Web Tools"
 ---
 
@@ -11,7 +12,7 @@ title: "Web Tools"
 
 OpenClaw ships two lightweight web tools:
 
-- `web_search` — Search the web using Brave Search API, Gemini with Google Search grounding, Grok, Kimi, or Perplexity Search API.
+- `web_search` — Search the web using Brave Search API, Gemini with Google Search grounding, Grok, Kimi, Perplexity Search API, or a self-hosted SearXNG instance (no API key required).
 - `web_fetch` — HTTP fetch + readable extraction (HTML → markdown/text).
 
 These are **not** browser automation. For JS-heavy sites or logins, use the
@@ -36,6 +37,7 @@ See [Brave Search setup](/brave-search) and [Perplexity Search setup](/perplexit
 | **Grok**                  | AI-synthesized answers + citations | —                                            | Uses xAI web-grounded responses                                                | `XAI_API_KEY`                               |
 | **Kimi**                  | AI-synthesized answers + citations | —                                            | Uses Moonshot web search                                                       | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
 | **Perplexity Search API** | Structured results with snippets   | `country`, `language`, time, `domain_filter` | Supports content extraction controls; OpenRouter uses Sonar compatibility path | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| **SearXNG**               | Structured results with snippets   | `engines`, `categories`, `language`          | Self-hosted, no API key, aggregates multiple engines                           | None                                        |
 
 ### Auto-detection
 
@@ -224,6 +226,96 @@ For a gateway install, put it in `~/.openclaw/.env`.
 - Redirect resolution uses strict SSRF defaults, so redirects to private/internal targets are blocked.
 - The default model (`gemini-2.5-flash`) is fast and cost-effective.
   Any Gemini model that supports grounding can be used.
+
+## Using SearXNG (self-hosted, no API key)
+
+[SearXNG](https://github.com/searxng/searxng) is a free, open-source metasearch engine that
+aggregates results from Google, Bing, DuckDuckGo, and dozens of other engines simultaneously —
+then de-duplicates and ranks them. Unlike single-provider APIs, SearXNG can return results across
+multiple categories: web, images, news, videos, files, and social media.
+
+> **License note:** SearXNG is licensed under AGPLv3. OpenClaw does not bundle or distribute
+> SearXNG. You must install and run your own instance. See the
+> [official installation guide](https://docs.searxng.org/admin/installation.html).
+
+### Why SearXNG?
+
+- **No API key required** — point OpenClaw at your instance URL and you're done
+- **Aggregated results** — combines many engines in a single query, reducing single-source bias
+- **Category filtering** — `general`, `images`, `news`, `videos`, `files`, `social media`
+- **Engine control** — restrict to specific engines (e.g. only `["google", "duckduckgo"]`)
+- **Privacy** — results are fetched server-side from your own instance
+
+### Installing SearXNG
+
+```bash
+# Docker (fastest)
+docker run -d -p 8080:8080 \
+  -e BASE_URL="http://localhost:8080" \
+  -e INSTANCE_NAME="my-searxng" \
+  searxng/searxng
+
+# Or follow the full guide:
+# https://docs.searxng.org/admin/installation.html
+```
+
+Enable JSON output in your SearXNG `settings.yml`:
+
+```yaml
+search:
+  formats:
+    - html
+    - json # required for OpenClaw integration
+```
+
+### Setting up SearXNG in OpenClaw
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "searxng",
+        searxng: {
+          url: "http://192.168.1.210:8080", // your SearXNG instance
+        },
+      },
+    },
+  },
+}
+```
+
+### Advanced configuration
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "searxng",
+        searxng: {
+          url: "http://192.168.1.210:8080",
+          // Restrict to specific engines (omit to use instance defaults)
+          engines: ["google", "duckduckgo", "bing"],
+          // Category: "general" | "images" | "news" | "videos" | "files" | "social media"
+          categories: "general",
+          // Language (default: "en")
+          language: "en",
+          // Safe search: 0 = off, 1 = moderate, 2 = strict
+          safeSearch: 0,
+        },
+      },
+    },
+  },
+}
+```
+
+### Notes
+
+- Results include `engine` and `category` fields in addition to title, URL, and snippet.
+- The `count` / `maxResults` config applies as normal (default: 5, max: 10).
+- SearXNG must have `format: json` enabled in its `settings.yml`.
+- A remote SearXNG instance is fully supported — just set `url` to any reachable address.
 
 ## web_search
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -310,7 +310,7 @@ search:
 }
 ```
 
-### Notes
+### SearXNG notes
 
 - Results include `engine` and `category` fields in addition to title, URL, and snippet.
 - The `count` / `maxResults` config applies as normal (default: 5, max: 10).

--- a/scripts/searxng-isolated/limiter.toml
+++ b/scripts/searxng-isolated/limiter.toml
@@ -1,0 +1,27 @@
+# SearXNG rate limiter for OpenClaw isolated search
+#
+# Prevents runaway agent search loops from overwhelming upstream engines.
+# Tuned for agent workloads: burst-friendly but with hard ceiling.
+#
+# Lab observation: typical agent sessions issue 2-5 searches per conversation
+# turn, with rare bursts of 10-15 during deep research tasks.
+#
+# SearXNG uses a sliding-window rate limiter where `limit` is the sustained
+# rate (requests/minute) and `burst` is the max instantaneous spike allowed.
+
+[botdetection.ip_limit]
+
+# Link token is not needed — this is an API-only instance behind Docker network
+link_token = false
+
+[botdetection.ip_limit.filter_request]
+# HTML requests per minute (not used in API-only mode, but set as a safety net)
+limit = 10
+burst = 5
+
+[botdetection.ip_limit.filter_request.api]
+# JSON API requests per minute from the OpenClaw gateway container.
+# 60 QPM sustained with burst of 30 allows deep research sessions
+# while preventing infinite search loops.
+limit = 60
+burst = 30

--- a/scripts/searxng-isolated/settings.yml
+++ b/scripts/searxng-isolated/settings.yml
@@ -1,0 +1,164 @@
+# SearXNG settings for OpenClaw isolated search
+#
+# Hardened configuration: only curated engines enabled, JSON format required,
+# rate-limited, no public-facing UI features.
+#
+# Engine selection rationale (from lab testing on CT 210, 192.168.1.210:8080):
+#   - 85 engines enabled on default SearXNG yielded 28 results for a test query
+#   - Only 3 engines (brave:20, duckduckgo:6, startpage:2) returned general results
+#   - Restricting to 5 high-quality engines reduces attack surface and response time
+#     while maintaining result diversity and redundancy
+#
+# To add engines: uncomment entries below or add from the full SearXNG engine list.
+# See: https://docs.searxng.org/admin/engines/configured_engines.html
+
+use_default_settings: false
+
+general:
+  instance_name: "openclaw-search"
+  # Disable debug — reduces log verbosity and information leakage
+  debug: false
+  # Enable privacy-focused defaults
+  donation_url: false
+  contact_url: false
+  enable_metrics: true
+
+search:
+  # JSON format is REQUIRED for OpenClaw integration
+  formats:
+    - json
+  # Disable HTML format — this instance serves API clients, not browsers
+  # Uncomment "html" only if you need the SearXNG web UI for debugging
+  # formats:
+  #   - json
+  #   - html
+
+  safe_search: 0       # 0=off, 1=moderate, 2=strict. Override via OpenClaw config.
+  default_lang: "en"
+  autocomplete: ""      # Disabled — not used by API clients
+  ban_time_on_fail: 5   # Seconds to ban an engine after failure
+  max_ban_time_on_fail: 120
+
+server:
+  port: 8080
+  bind_address: "0.0.0.0"
+  # Set SEARXNG_SECRET_KEY in your environment (generate with: openssl rand -hex 32).
+  # SearXNG reads this env var automatically at startup.
+  # Rate limiter uses limiter.toml (mounted separately)
+  limiter: true
+  public_instance: false
+  # Disable image proxy — reduces memory and outbound connections
+  image_proxy: false
+
+ui:
+  # Minimal UI — this is an API-only instance
+  default_theme: simple
+  # Disable features not needed by API clients
+  infinite_scroll: false
+  center_alignment: true
+  query_in_title: false
+
+# Engine allowlist — only these engines are active.
+# All others from the default SearXNG config are implicitly disabled.
+#
+# Selection criteria:
+#   1. Consistent JSON API response format
+#   2. Reliable uptime (observed in lab: brave, duckduckgo, startpage all >99%)
+#   3. safesearch support for family-safe deployments
+#   4. Complementary result sets (reduces single-source bias)
+#   5. No API key required (engines that need keys are listed but disabled)
+
+engines:
+
+  # ── General web search (primary) ─────────────────────────────
+  #
+  # These 3 engines provided all results in lab testing.
+  # brave (20 results), duckduckgo (6), startpage (2) for a test query.
+
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+    disabled: false
+
+  - name: brave
+    engine: brave
+    shortcut: br
+    disabled: false
+
+  - name: startpage
+    engine: startpage
+    shortcut: sp
+    disabled: false
+
+  # ── Supplementary engines ────────────────────────────────────
+  #
+  # Wikipedia and StackOverflow provide high-signal results for
+  # agent workflows (research, coding tasks).
+
+  - name: wikipedia
+    engine: wikipedia
+    shortcut: wp
+    disabled: false
+
+  - name: stackoverflow
+    engine: stackoverflow
+    shortcut: so
+    disabled: false
+
+  # ── News (optional) ──────────────────────────────────────────
+  #
+  # Uncomment to enable news category results.
+  # Useful for agents that need current events context.
+
+  # - name: google news
+  #   engine: google_news
+  #   shortcut: gn
+  #   disabled: false
+
+  # - name: bing news
+  #   engine: bing_news
+  #   shortcut: bin
+  #   disabled: false
+
+  # ── Science / research (optional) ───────────────────────────
+  #
+  # Uncomment for research-heavy agent workflows.
+
+  # - name: arxiv
+  #   engine: arxiv
+  #   shortcut: arx
+  #   disabled: false
+
+  # - name: google scholar
+  #   engine: google_scholar
+  #   shortcut: gs
+  #   disabled: false
+
+  # - name: semantic scholar
+  #   engine: semantic_scholar
+  #   shortcut: ss
+  #   disabled: false
+
+  # ── Code / IT (optional) ─────────────────────────────────────
+
+  # - name: github
+  #   engine: github
+  #   shortcut: gh
+  #   disabled: false
+
+  # - name: mdn
+  #   engine: mdn
+  #   shortcut: mdn
+  #   disabled: false
+
+outgoing:
+  # Request timeout for upstream engines.
+  # Lab observation: all 5 enabled engines respond within 3s.
+  request_timeout: 5.0
+  # Max concurrent requests to upstream engines
+  pool_connections: 100
+  pool_maxsize: 20
+  # Respect robots.txt on engines that check it
+  enable_http2: true
+  # User agent for upstream requests
+  useragent_suffix: "openclaw-search"

--- a/scripts/searxng-isolated/settings.yml
+++ b/scripts/searxng-isolated/settings.yml
@@ -33,10 +33,10 @@ search:
   #   - json
   #   - html
 
-  safe_search: 0       # 0=off, 1=moderate, 2=strict. Override via OpenClaw config.
+  safe_search: 0 # 0=off, 1=moderate, 2=strict. Override via OpenClaw config.
   default_lang: "en"
-  autocomplete: ""      # Disabled — not used by API clients
-  ban_time_on_fail: 5   # Seconds to ban an engine after failure
+  autocomplete: "" # Disabled — not used by API clients
+  ban_time_on_fail: 5 # Seconds to ban an engine after failure
   max_ban_time_on_fail: 120
 
 server:
@@ -69,7 +69,6 @@ ui:
 #   5. No API key required (engines that need keys are listed but disabled)
 
 engines:
-
   # ── General web search (primary) ─────────────────────────────
   #
   # These 3 engines provided all results in lab testing.

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -22,7 +22,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "searxng"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -333,6 +333,30 @@ type KimiConfig = {
   model?: string;
 };
 
+type SearxngConfig = {
+  url?: string;
+  engines?: string[];
+  categories?: string;
+  language?: string;
+  safeSearch?: 0 | 1 | 2;
+};
+
+type SearxngResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+  engine?: string;
+  score?: number;
+  category?: string;
+  publishedDate?: string;
+};
+
+type SearxngResponse = {
+  query?: string;
+  results?: SearxngResult[];
+  number_of_results?: number;
+};
+
 type GrokSearchResponse = {
   output?: Array<{
     type?: string;
@@ -593,6 +617,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "searxng") {
+    return {
+      error: "searxng_unreachable",
+      message:
+        "web_search (searxng) could not reach the configured SearXNG instance. Ensure it is running and set tools.web.search.searxng.url in your config.",
+      docs: "https://docs.openclaw.ai/tools/web#searxng",
+    };
+  }
   return {
     error: "missing_perplexity_api_key",
     message:
@@ -620,6 +652,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "perplexity") {
     return "perplexity";
+  }
+  if (raw === "searxng") {
+    return "searxng";
   }
 
   // Auto-detect provider from available API keys (alphabetical order)
@@ -887,6 +922,92 @@ function resolveKimiBaseUrl(kimi?: KimiConfig): string {
   const fromConfig =
     kimi && "baseUrl" in kimi && typeof kimi.baseUrl === "string" ? kimi.baseUrl.trim() : "";
   return fromConfig || DEFAULT_KIMI_BASE_URL;
+}
+
+function resolveSearxngConfig(search?: WebSearchConfig): SearxngConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const searxng = "searxng" in search ? search.searxng : undefined;
+  if (!searxng || typeof searxng !== "object") {
+    return {};
+  }
+  return searxng as SearxngConfig;
+}
+
+const DEFAULT_SEARXNG_URL = "http://localhost:8080";
+const DEFAULT_SEARXNG_CATEGORIES = "general";
+const DEFAULT_SEARXNG_LANGUAGE = "en";
+
+function resolveSearxngUrl(searxng?: SearxngConfig): string {
+  const fromConfig =
+    searxng && "url" in searxng && typeof searxng.url === "string" ? searxng.url.trim() : "";
+  return fromConfig || DEFAULT_SEARXNG_URL;
+}
+
+async function runSearxngSearch(params: {
+  query: string;
+  count: number;
+  url: string;
+  engines?: string[];
+  categories?: string;
+  language?: string;
+  safeSearch?: number;
+  timeoutSeconds: number;
+}): Promise<{
+  results: Array<{
+    title: string;
+    url: string;
+    description: string;
+    engine?: string;
+    category?: string;
+    published?: string;
+  }>;
+}> {
+  const endpoint = new URL("/search", params.url);
+  endpoint.searchParams.set("q", params.query);
+  endpoint.searchParams.set("format", "json");
+  endpoint.searchParams.set("categories", params.categories || DEFAULT_SEARXNG_CATEGORIES);
+  endpoint.searchParams.set("language", params.language || DEFAULT_SEARXNG_LANGUAGE);
+  endpoint.searchParams.set("safesearch", String(params.safeSearch ?? 0));
+  if (params.engines && params.engines.length > 0) {
+    endpoint.searchParams.set("engines", params.engines.join(","));
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: endpoint.toString(),
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "OpenClaw/1.0 (web_search; +https://openclaw.ai)",
+        },
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 16_000 });
+        throw new Error(`SearXNG error (${res.status}): ${detailResult.text || res.statusText}`);
+      }
+
+      const data = (await res.json()) as SearxngResponse;
+      const raw = Array.isArray(data.results) ? data.results : [];
+      const trimmed = raw.slice(0, params.count);
+
+      return {
+        results: trimmed.map((entry) => ({
+          title: entry.title ?? "",
+          url: entry.url ?? "",
+          description: entry.content ?? "",
+          engine: entry.engine,
+          category: entry.category,
+          published: entry.publishedDate,
+        })),
+      };
+    },
+  );
 }
 
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
@@ -1603,6 +1724,11 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  searxngUrl?: string;
+  searxngEngines?: string[];
+  searxngCategories?: string;
+  searxngLanguage?: string;
+  searxngSafeSearch?: number;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1614,6 +1740,8 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+            : params.provider === "searxng"
+              ? `${params.searxngUrl ?? DEFAULT_SEARXNG_URL}:${params.searxngCategories || DEFAULT_SEARXNG_CATEGORIES}`
             : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
@@ -1769,6 +1897,42 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "searxng") {
+    const { results } = await runSearxngSearch({
+      query: params.query,
+      count: params.count,
+      url: params.searxngUrl ?? DEFAULT_SEARXNG_URL,
+      engines: params.searxngEngines,
+      categories: params.searxngCategories,
+      language: params.searxngLanguage,
+      safeSearch: params.searxngSafeSearch,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: results.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: results.map((r) => ({
+        title: r.title ? wrapWebContent(r.title, "web_search") : "",
+        url: r.url,
+        description: r.description ? wrapWebContent(r.description, "web_search") : "",
+        engine: r.engine,
+        category: r.category,
+        published: r.published,
+      })),
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1911,6 +2075,7 @@ export function createWebSearchTool(options?: {
   const kimiConfig = resolveKimiConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
+  const searxngConfig = resolveSearxngConfig(search);
 
   const description =
     provider === "perplexity"
@@ -1923,8 +2088,10 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : braveMode === "llm-context"
-              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
+            : provider === "searxng"
+              ? "Search the web using a self-hosted SearXNG metasearch engine. Aggregates results across multiple engines (Google, Bing, DuckDuckGo, and more) with no API key required. Supports category filtering (general, images, news, videos, files, social media) and engine selection."
+              : braveMode === "llm-context"
+                ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
               : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
@@ -1951,7 +2118,7 @@ export function createWebSearchTool(options?: {
                 ? resolveGeminiApiKey(geminiConfig)
                 : resolveSearchApiKey(search);
 
-      if (!apiKey) {
+      if (!apiKey && provider !== "searxng") {
         return jsonResult(missingSearchKeyPayload(provider));
       }
 
@@ -2163,7 +2330,7 @@ export function createWebSearchTool(options?: {
       const result = await runWebSearch({
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
+        apiKey: apiKey ?? "",
         timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
         cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         provider,
@@ -2186,6 +2353,11 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        searxngUrl: resolveSearxngUrl(searxngConfig),
+        searxngEngines: searxngConfig.engines,
+        searxngCategories: searxngConfig.categories,
+        searxngLanguage: searxngConfig.language,
+        searxngSafeSearch: searxngConfig.safeSearch,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1748,7 +1748,7 @@ async function runWebSearch(params: {
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
             : params.provider === "searxng"
               ? `${params.searxngUrl ?? DEFAULT_SEARXNG_URL}:${params.searxngCategories || DEFAULT_SEARXNG_CATEGORIES}:${params.searxngEngines?.join(",") || ""}:${params.searxngLanguage || DEFAULT_SEARXNG_LANGUAGE}:${params.searxngSafeSearch ?? 0}`
-            : "";
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -2104,7 +2104,7 @@ export function createWebSearchTool(options?: {
               ? "Search the web using a self-hosted SearXNG metasearch engine. Aggregates results across multiple engines (Google, Bing, DuckDuckGo, and more) with no API key required. Supports category filtering (general, images, news, videos, files, social media) and engine selection."
               : braveMode === "llm-context"
                 ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
-              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+                : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -964,7 +964,10 @@ async function runSearxngSearch(params: {
     published?: string;
   }>;
 }> {
-  const endpoint = new URL("/search", params.url);
+  // Build endpoint preserving any subpath the user may have configured
+  // (e.g. https://host/searxng/ → https://host/searxng/search).
+  const base = params.url.replace(/\/?$/, "/");
+  const endpoint = new URL("search", base);
   endpoint.searchParams.set("q", params.query);
   endpoint.searchParams.set("format", "json");
   endpoint.searchParams.set("categories", params.categories || DEFAULT_SEARXNG_CATEGORIES);
@@ -974,40 +977,42 @@ async function runSearxngSearch(params: {
     endpoint.searchParams.set("engines", params.engines.join(","));
   }
 
-  return withTrustedWebSearchEndpoint(
-    {
-      url: endpoint.toString(),
-      timeoutSeconds: params.timeoutSeconds,
-      init: {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-          "User-Agent": "OpenClaw/1.0 (web_search; +https://openclaw.ai)",
-        },
+  const { response: res, release } = await fetchWithSsrFGuard({
+    url: endpoint.toString(),
+    timeoutMs: params.timeoutSeconds * 1000,
+    policy: TRUSTED_NETWORK_SSRF_POLICY,
+    init: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "OpenClaw/1.0 (web_search; +https://openclaw.ai)",
       },
     },
-    async (res) => {
-      if (!res.ok) {
-        const detailResult = await readResponseText(res, { maxBytes: 16_000 });
-        throw new Error(`SearXNG error (${res.status}): ${detailResult.text || res.statusText}`);
-      }
+  });
 
-      const data = (await res.json()) as SearxngResponse;
-      const raw = Array.isArray(data.results) ? data.results : [];
-      const trimmed = raw.slice(0, params.count);
+  try {
+    if (!res.ok) {
+      const detailResult = await readResponseText(res, { maxBytes: 16_000 });
+      throw new Error(`SearXNG error (${res.status}): ${detailResult.text || res.statusText}`);
+    }
 
-      return {
-        results: trimmed.map((entry) => ({
-          title: entry.title ?? "",
-          url: entry.url ?? "",
-          description: entry.content ?? "",
-          engine: entry.engine,
-          category: entry.category,
-          published: entry.publishedDate,
-        })),
-      };
-    },
-  );
+    const data = (await res.json()) as SearxngResponse;
+    const raw = Array.isArray(data.results) ? data.results : [];
+    const trimmed = raw.slice(0, params.count);
+
+    return {
+      results: trimmed.map((entry) => ({
+        title: entry.title ?? "",
+        url: entry.url ?? "",
+        description: entry.content ?? "",
+        engine: entry.engine,
+        category: entry.category,
+        published: entry.publishedDate,
+      })),
+    };
+  } finally {
+    await release();
+  }
 }
 
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
@@ -1741,7 +1746,7 @@ async function runWebSearch(params: {
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
             : params.provider === "searxng"
-              ? `${params.searxngUrl ?? DEFAULT_SEARXNG_URL}:${params.searxngCategories || DEFAULT_SEARXNG_CATEGORIES}`
+              ? `${params.searxngUrl ?? DEFAULT_SEARXNG_URL}:${params.searxngCategories || DEFAULT_SEARXNG_CATEGORIES}:${params.searxngEngines?.join(",") || ""}:${params.searxngLanguage || DEFAULT_SEARXNG_LANGUAGE}:${params.searxngSafeSearch ?? 0}`
             : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -622,7 +622,7 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       error: "searxng_unreachable",
       message:
         "web_search (searxng) could not reach the configured SearXNG instance. Ensure it is running and set tools.web.search.searxng.url in your config.",
-      docs: "https://docs.openclaw.ai/tools/web#searxng",
+      docs: "https://docs.openclaw.ai/tools/web#using-searxng-self-hosted-no-api-key",
     };
   }
   return {
@@ -1904,7 +1904,7 @@ async function runWebSearch(params: {
   }
 
   if (params.provider === "searxng") {
-    const { results } = await runSearxngSearch({
+    const searchResult = await runSearxngSearch({
       query: params.query,
       count: params.count,
       url: params.searxngUrl ?? DEFAULT_SEARXNG_URL,
@@ -1913,7 +1913,13 @@ async function runWebSearch(params: {
       language: params.searxngLanguage,
       safeSearch: params.searxngSafeSearch,
       timeoutSeconds: params.timeoutSeconds,
-    });
+    }).catch(() => null);
+
+    if (!searchResult) {
+      return missingSearchKeyPayload("searxng");
+    }
+
+    const { results } = searchResult;
 
     const payload = {
       query: params.query,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -977,42 +977,40 @@ async function runSearxngSearch(params: {
     endpoint.searchParams.set("engines", params.engines.join(","));
   }
 
-  const { response: res, release } = await fetchWithSsrFGuard({
-    url: endpoint.toString(),
-    timeoutMs: params.timeoutSeconds * 1000,
-    policy: TRUSTED_NETWORK_SSRF_POLICY,
-    init: {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        "User-Agent": "OpenClaw/1.0 (web_search; +https://openclaw.ai)",
+  return withWebToolsNetworkGuard(
+    {
+      url: endpoint.toString(),
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "OpenClaw/1.0 (web_search; +https://openclaw.ai)",
+        },
       },
     },
-  });
+    async ({ response: res }) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 16_000 });
+        throw new Error(`SearXNG error (${res.status}): ${detailResult.text || res.statusText}`);
+      }
 
-  try {
-    if (!res.ok) {
-      const detailResult = await readResponseText(res, { maxBytes: 16_000 });
-      throw new Error(`SearXNG error (${res.status}): ${detailResult.text || res.statusText}`);
-    }
+      const data = (await res.json()) as SearxngResponse;
+      const raw = Array.isArray(data.results) ? data.results : [];
+      const trimmed = raw.slice(0, params.count);
 
-    const data = (await res.json()) as SearxngResponse;
-    const raw = Array.isArray(data.results) ? data.results : [];
-    const trimmed = raw.slice(0, params.count);
-
-    return {
-      results: trimmed.map((entry) => ({
-        title: entry.title ?? "",
-        url: entry.url ?? "",
-        description: entry.content ?? "",
-        engine: entry.engine,
-        category: entry.category,
-        published: entry.publishedDate,
-      })),
-    };
-  } finally {
-    await release();
-  }
+      return {
+        results: trimmed.map((entry) => ({
+          title: entry.title ?? "",
+          url: entry.url ?? "",
+          description: entry.content ?? "",
+          engine: entry.engine,
+          category: entry.category,
+          published: entry.publishedDate,
+        })),
+      };
+    },
+  );
 }
 
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -981,6 +981,9 @@ async function runSearxngSearch(params: {
     {
       url: endpoint.toString(),
       timeoutSeconds: params.timeoutSeconds,
+      // SearXNG is a user-configured self-hosted endpoint (may be localhost or LAN IP),
+      // so we apply the trusted SSRF policy the same way other user-endpoint providers do.
+      policy: WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY,
       init: {
         method: "GET",
         headers: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -977,13 +977,13 @@ async function runSearxngSearch(params: {
     endpoint.searchParams.set("engines", params.engines.join(","));
   }
 
-  return withWebToolsNetworkGuard(
+  return withTrustedWebToolsEndpoint(
     {
       url: endpoint.toString(),
       timeoutSeconds: params.timeoutSeconds,
-      // SearXNG is a user-configured self-hosted endpoint (may be localhost or LAN IP),
-      // so we apply the trusted SSRF policy the same way other user-endpoint providers do.
-      policy: WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY,
+      // SearXNG is a user-configured self-hosted endpoint (may be localhost or LAN IP);
+      // withTrustedWebToolsEndpoint applies the trusted SSRF policy used by all
+      // user-configured providers (Kimi, etc.).
       init: {
         method: "GET",
         headers: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2155,6 +2155,7 @@ export function createWebSearchTool(options?: {
       if (
         language &&
         provider !== "brave" &&
+        provider !== "searxng" &&
         !(provider === "perplexity" && supportsStructuredPerplexityFilters)
       ) {
         return jsonResult({
@@ -2162,7 +2163,7 @@ export function createWebSearchTool(options?: {
           message:
             provider === "perplexity"
               ? "language filtering is only supported by the native Perplexity Search API path. Remove Perplexity baseUrl/model overrides or use a direct PERPLEXITY_API_KEY to enable it."
-              : `language filtering is not supported by the ${provider} provider. Only Brave and Perplexity support language filtering.`,
+              : `language filtering is not supported by the ${provider} provider. Only Brave, Perplexity, and SearXNG support language filtering.`,
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
@@ -2364,7 +2365,7 @@ export function createWebSearchTool(options?: {
         searxngUrl: resolveSearxngUrl(searxngConfig),
         searxngEngines: searxngConfig.engines,
         searxngCategories: searxngConfig.categories,
-        searxngLanguage: searxngConfig.language,
+        searxngLanguage: provider === "searxng" && language ? language : searxngConfig.language,
         searxngSafeSearch: searxngConfig.safeSearch,
       });
       return jsonResult(result);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2122,7 +2122,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "searxng"
+                  ? undefined
+                  : resolveSearchApiKey(search);
 
       if (!apiKey && provider !== "searxng") {
         return jsonResult(missingSearchKeyPayload(provider));

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -283,9 +283,47 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.apiKey).toBe("BSA-plain");
   });
 
-  it("exports all 5 providers in SEARCH_PROVIDER_OPTIONS", () => {
-    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(5);
+  it("exports all 6 providers in SEARCH_PROVIDER_OPTIONS", () => {
+    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(6);
     const values = SEARCH_PROVIDER_OPTIONS.map((e) => e.value);
-    expect(values).toEqual(["brave", "gemini", "grok", "kimi", "perplexity"]);
+    expect(values).toEqual(["brave", "gemini", "grok", "kimi", "perplexity", "searxng"]);
+  });
+
+  it("sets provider and searxng url when user provides one", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "searxng",
+      textValue: "http://192.168.1.210:8080",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("searxng");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
+    expect(result.tools?.web?.search?.searxng?.url).toBe("http://192.168.1.210:8080");
+  });
+
+  it("shows missing-url note when searxng selected with no url", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter, notes } = createPrompter({
+      selectValue: "searxng",
+      textValue: "",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("searxng");
+    const missingNote = notes.find((n) => n.message.includes("No SearXNG URL configured"));
+    expect(missingNote).toBeDefined();
+  });
+
+  it("does not call buildSearchEnvRef for searxng in ref mode", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "searxng",
+      textValue: "http://localhost:8080",
+    });
+    // Should not throw — SearXNG has no envKeys so buildSearchEnvRef would throw
+    const result = await setupSearch(cfg, runtime, prompter, {
+      secretInputMode: "ref", // pragma: allowlist secret
+    });
+    expect(result.tools?.web?.search?.provider).toBe("searxng");
+    expect(result.tools?.web?.search?.searxng?.url).toBe("http://localhost:8080");
   });
 });

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -10,7 +10,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "searxng";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -62,6 +62,14 @@ export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
     placeholder: "pplx-...",
     signupUrl: "https://www.perplexity.ai/settings/api",
   },
+  {
+    value: "searxng",
+    label: "SearXNG (self-hosted)",
+    hint: "No API key · self-hosted metasearch instance",
+    envKeys: [],
+    placeholder: "http://localhost:8080",
+    signupUrl: "https://docs.searxng.org/admin/installation.html",
+  },
 ] as const;
 
 export function hasKeyInEnv(entry: SearchProviderEntry): boolean {
@@ -81,6 +89,8 @@ function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown 
       return search?.kimi?.apiKey;
     case "perplexity":
       return search?.perplexity?.apiKey;
+    case "searxng":
+      return undefined;
   }
 }
 
@@ -143,6 +153,9 @@ export function applySearchKey(
       break;
     case "perplexity":
       search.perplexity = { ...search.perplexity, apiKey: key };
+      break;
+    case "searxng":
+      // SearXNG has no API key; provider is set above, URL via tools.web.search.searxng.url
       break;
   }
   return {

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -257,6 +257,48 @@ export async function setupSearch(
   }
 
   const entry = SEARCH_PROVIDER_OPTIONS.find((e) => e.value === choice)!;
+
+  // SearXNG requires no API key — prompt for instance URL instead.
+  if (choice === "searxng") {
+    const existingUrl = config.tools?.web?.search?.searxng?.url;
+    const urlInput = await prompter.text({
+      message: existingUrl
+        ? "SearXNG instance URL (leave blank to keep current)"
+        : "SearXNG instance URL",
+      placeholder: existingUrl ?? entry.placeholder,
+    });
+    const url = urlInput?.trim() || existingUrl;
+    const result: OpenClawConfig = {
+      ...config,
+      tools: {
+        ...config.tools,
+        web: {
+          ...config.tools?.web,
+          search: {
+            ...config.tools?.web?.search,
+            provider: "searxng" as const,
+            enabled: true,
+            searxng: {
+              ...config.tools?.web?.search?.searxng,
+              ...(url ? { url } : {}),
+            },
+          },
+        },
+      },
+    };
+    if (!url) {
+      await prompter.note(
+        [
+          "No SearXNG URL configured — web_search won't work until an instance URL is set.",
+          `Setup guide: ${entry.signupUrl}`,
+          "Docs: https://docs.openclaw.ai/tools/web#searxng",
+        ].join("\n"),
+        "Web search",
+      );
+    }
+    return preserveDisabledState(config, result);
+  }
+
   const existingKey = resolveExistingKey(config, choice);
   const keyConfigured = hasExistingKey(config, choice);
   const envAvailable = hasKeyInEnv(entry);

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -173,3 +173,64 @@ describe("web search provider auto-detection", () => {
     ).toBe("gemini");
   });
 });
+
+describe("searxng provider config", () => {
+  it("accepts searxng provider with url", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "searxng",
+        providerConfig: {
+          url: "http://192.168.1.210:8080",
+        },
+      }),
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts searxng provider with full config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "searxng",
+        providerConfig: {
+          url: "http://192.168.1.210:8080",
+          engines: ["google", "duckduckgo"],
+          categories: "images",
+          language: "en",
+          safeSearch: 0,
+        },
+      }),
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts searxng provider with no extra config (uses defaults)", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "searxng",
+      }),
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("explicit searxng provider wins regardless of available API keys", () => {
+    const result = resolveSearchProvider({ provider: "searxng" } as unknown as Parameters<
+      typeof resolveSearchProvider
+    >[0]);
+    expect(result).toBe("searxng");
+  });
+
+  it("rejects unknown safeSearch value", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "searxng",
+        providerConfig: {
+          url: "http://localhost:8080",
+          safeSearch: 5 as 0 | 1 | 2,
+        },
+      }),
+    );
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -661,7 +661,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "searxng"). Auto-detected from available API keys if omitted. Use "searxng" for self-hosted, API-key-free search.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -678,6 +678,14 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.kimi.baseUrl":
     'Kimi base URL override (default: "https://api.moonshot.ai/v1").',
   "tools.web.search.kimi.model": 'Kimi model override (default: "moonshot-v1-128k").',
+  "tools.web.search.searxng.url":
+    'Base URL of your SearXNG instance (default: "http://localhost:8080"). You must run SearXNG yourself — see https://docs.searxng.org/admin/installation.html.',
+  "tools.web.search.searxng.engines":
+    'Limit search to specific engines (e.g. ["google", "duckduckgo", "bing"]). Omit to use your instance\'s configured defaults.',
+  "tools.web.search.searxng.categories":
+    'Result category filter. One of: "general", "images", "news", "videos", "files", "social media". Default: "general".',
+  "tools.web.search.searxng.language": 'Search language code (default: "en").',
+  "tools.web.search.searxng.safeSearch": "Safe search level: 0 = off, 1 = moderate, 2 = strict.",
   "tools.web.search.perplexity.apiKey":
     "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). Direct Perplexity keys default to the Search API; OpenRouter keys use Sonar chat completions.",
   "tools.web.search.perplexity.baseUrl":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -659,7 +659,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key, or use SearXNG for key-free search).",
+  "tools.web.search.enabled":
+    "Enable the web_search tool (requires a provider API key, or use SearXNG for key-free search).",
   "tools.web.search.provider":
     'Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "searxng"). Auto-detected from available API keys if omitted. Use "searxng" for self-hosted, API-key-free search.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -659,7 +659,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
+  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key, or use SearXNG for key-free search).",
   "tools.web.search.provider":
     'Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "searxng"). Auto-detected from available API keys if omitted. Use "searxng" for self-hosted, API-key-free search.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -229,6 +229,11 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.perplexity.apiKey": "Perplexity API Key", // pragma: allowlist secret
   "tools.web.search.perplexity.baseUrl": "Perplexity Base URL",
   "tools.web.search.perplexity.model": "Perplexity Model",
+  "tools.web.search.searxng.url": "SearXNG Instance URL",
+  "tools.web.search.searxng.engines": "SearXNG Engines",
+  "tools.web.search.searxng.categories": "SearXNG Categories",
+  "tools.web.search.searxng.language": "SearXNG Language",
+  "tools.web.search.searxng.safeSearch": "SearXNG Safe Search",
   "tools.web.fetch.enabled": "Enable Web Fetch Tool",
   "tools.web.fetch.maxChars": "Web Fetch Max Chars",
   "tools.web.fetch.maxCharsCap": "Web Fetch Hard Max Chars",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -457,8 +457,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "searxng"). */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "searxng";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -505,6 +505,19 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         model?: string;
+      };
+      /** SearXNG-specific configuration (used when provider="searxng"). No API key required. */
+      searxng?: {
+        /** Base URL of your SearXNG instance (default: "http://localhost:8080"). */
+        url?: string;
+        /** Limit queries to specific engines (e.g. ["google", "duckduckgo"]). Omit to use instance defaults. */
+        engines?: string[];
+        /** Result category: "general" | "images" | "news" | "videos" | "files" | "social media". Default: "general". */
+        categories?: string;
+        /** Search language code (default: "en"). */
+        language?: string;
+        /** Safe search level: 0 = off, 1 = moderate, 2 = strict. Default: 0. */
+        safeSearch?: 0 | 1 | 2;
       };
     };
     fetch?: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -512,8 +512,8 @@ export type ToolsConfig = {
         url?: string;
         /** Limit queries to specific engines (e.g. ["google", "duckduckgo"]). Omit to use instance defaults. */
         engines?: string[];
-        /** Result category: "general" | "images" | "news" | "videos" | "files" | "social media". Default: "general". */
-        categories?: string;
+        /** Result category. Default: "general". */
+        categories?: "general" | "images" | "news" | "videos" | "files" | "social media";
         /** Search language code (default: "en"). */
         language?: string;
         /** Safe search level: 0 = off, 1 = moderate, 2 = strict. Default: 0. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("searxng"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -311,6 +312,16 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        url: z.string().optional(),
+        engines: z.array(z.string()).optional(),
+        categories: z.string().optional(),
+        language: z.string().optional(),
+        safeSearch: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -319,7 +319,9 @@ export const ToolsWebSearchSchema = z
       .object({
         url: z.string().optional(),
         engines: z.array(z.string()).optional(),
-        categories: z.enum(["general", "images", "news", "videos", "files", "social media"]).optional(),
+        categories: z
+          .enum(["general", "images", "news", "videos", "files", "social media"])
+          .optional(),
         language: z.string().optional(),
         safeSearch: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
       })

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -319,7 +319,7 @@ export const ToolsWebSearchSchema = z
       .object({
         url: z.string().optional(),
         engines: z.array(z.string()).optional(),
-        categories: z.string().optional(),
+        categories: z.enum(["general", "images", "news", "videos", "files", "social media"]).optional(),
         language: z.string().optional(),
         safeSearch: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
       })

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -246,7 +246,7 @@ export function resolveGatewayAuth(params: {
     passwordPrecedence: "config-first", // pragma: allowlist secret
   });
   const token = resolvedCredentials.token;
-  const password = resolvedCredentials.password;
+  const password = resolvedCredentials.password; // pragma: allowlist secret
   const trustedProxy = authConfig.trustedProxy;
 
   let mode: ResolvedGatewayAuth["mode"];

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -292,6 +292,68 @@ function collectMessagesTtsAssignments(params: {
   });
 }
 
+function collectToolsWebSearchAssignments(params: {
+  config: OpenClawConfig;
+  defaults: SecretDefaults | undefined;
+  context: ResolverContext;
+}): void {
+  const tools = params.config.tools as Record<string, unknown> | undefined;
+  if (!isRecord(tools) || !isRecord(tools.web) || !isRecord(tools.web.search)) {
+    return;
+  }
+  const search = tools.web.search;
+  const searchEnabled = search.enabled !== false;
+  const rawProvider =
+    typeof search.provider === "string" ? search.provider.trim().toLowerCase() : "";
+  const selectedProvider =
+    rawProvider === "brave" ||
+    rawProvider === "gemini" ||
+    rawProvider === "grok" ||
+    rawProvider === "kimi" ||
+    rawProvider === "perplexity" ||
+    rawProvider === "searxng"
+      ? rawProvider
+      : undefined;
+  const paths = [
+    "apiKey",
+    "gemini.apiKey",
+    "grok.apiKey",
+    "kimi.apiKey",
+    "perplexity.apiKey",
+  ] as const;
+  for (const path of paths) {
+    const [scope, field] = path.includes(".") ? path.split(".", 2) : [undefined, path];
+    const target = scope ? search[scope] : search;
+    if (!isRecord(target)) {
+      continue;
+    }
+    const active = scope
+      ? searchEnabled && (selectedProvider === undefined || selectedProvider === scope)
+      : searchEnabled && (selectedProvider === undefined || selectedProvider === "brave");
+    const inactiveReason = !searchEnabled
+      ? "tools.web.search is disabled."
+      : scope
+        ? selectedProvider === undefined
+          ? undefined
+          : `tools.web.search.provider is "${selectedProvider}".`
+        : selectedProvider === undefined
+          ? undefined
+          : `tools.web.search.provider is "${selectedProvider}".`;
+    collectSecretInputAssignment({
+      value: target[field],
+      path: `tools.web.search.${path}`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active,
+      inactiveReason,
+      apply: (value) => {
+        target[field] = value;
+      },
+    });
+  }
+}
+
 function collectCronAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -10,7 +10,7 @@ import {
   type SecretDefaults,
 } from "./runtime-shared.js";
 
-const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "searxng"] as const;
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
@@ -87,7 +87,8 @@ function normalizeProvider(value: unknown): WebSearchProvider | undefined {
     normalized === "gemini" ||
     normalized === "grok" ||
     normalized === "kimi" ||
-    normalized === "perplexity"
+    normalized === "perplexity" ||
+    normalized === "searxng"
   ) {
     return normalized;
   }
@@ -329,6 +330,9 @@ function envVarsForProvider(provider: WebSearchProvider): string[] {
   if (provider === "kimi") {
     return ["KIMI_API_KEY", "MOONSHOT_API_KEY"];
   }
+  if (provider === "searxng") {
+    return [];
+  }
   return ["PERPLEXITY_API_KEY", "OPENROUTER_API_KEY"];
 }
 
@@ -398,14 +402,21 @@ export async function resolveRuntimeWebTools(params: {
   }
 
   if (searchEnabled && search) {
-    const candidates = configuredProvider ? [configuredProvider] : [...WEB_SEARCH_PROVIDERS];
+    // SearXNG requires no API key — skip the key resolution loop entirely.
+    const candidates =
+      configuredProvider === "searxng"
+        ? []
+        : configuredProvider
+          ? [configuredProvider]
+          : [...WEB_SEARCH_PROVIDERS];
     const unresolvedWithoutFallback: Array<{
       provider: WebSearchProvider;
       path: string;
       reason: string;
     }> = [];
 
-    let selectedProvider: WebSearchProvider | undefined;
+    let selectedProvider: WebSearchProvider | undefined =
+      configuredProvider === "searxng" ? "searxng" : undefined;
     let selectedResolution: SecretResolutionResult | undefined;
 
     for (const provider of candidates) {
@@ -549,6 +560,24 @@ export async function resolveRuntimeWebTools(params: {
         context: params.context,
         path,
         details: `tools.web.search auto-detected provider is "${searchMetadata.selectedProvider}".`,
+      });
+    }
+  } else if (searchEnabled && search && configuredProvider === "searxng") {
+    // SearXNG needs no API key — mark all key-based provider refs as inactive.
+    for (const provider of WEB_SEARCH_PROVIDERS) {
+      if (provider === "searxng") {
+        continue;
+      }
+      const path =
+        provider === "brave" ? "tools.web.search.apiKey" : `tools.web.search.${provider}.apiKey`;
+      const value = resolveProviderKeyValue(search, provider);
+      if (!hasConfiguredSecretRef(value, defaults)) {
+        continue;
+      }
+      pushInactiveSurfaceWarning({
+        context: params.context,
+        path,
+        details: `tools.web.search.provider is "searxng".`,
       });
     }
   } else if (search && !searchEnabled) {

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -383,6 +383,48 @@ describe("secrets runtime snapshot", () => {
     );
   });
 
+  it("treats all web search api key refs as inactive when provider is searxng", async () => {
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "searxng",
+              apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_API_KEY" },
+              gemini: {
+                apiKey: { source: "env", provider: "default", id: "WEB_SEARCH_GEMINI_API_KEY" },
+              },
+              grok: {
+                apiKey: { source: "env", provider: "default", id: "MISSING_GROK_API_KEY" },
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: () => ({ version: 1, profiles: {} }),
+    });
+
+    expect(snapshot.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+          path: "tools.web.search.apiKey",
+        }),
+        expect.objectContaining({
+          code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+          path: "tools.web.search.gemini.apiKey",
+        }),
+        expect.objectContaining({
+          code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+          path: "tools.web.search.grok.apiKey",
+        }),
+      ]),
+    );
+  });
+
   it("resolves selected web search provider ref even when provider config is disabled", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({
       config: asConfig({


### PR DESCRIPTION
## Summary

Adds `searxng` as a first-class `web_search` provider alongside Brave, Perplexity, Gemini, Grok, and Kimi.

SearXNG is a free, open-source metasearch engine that aggregates results from Google, Bing, DuckDuckGo, and dozens of other engines simultaneously — then de-duplicates and ranks them. Unlike every other provider in OpenClaw, SearXNG requires **no API key** and supports result categories beyond plain web search: images, news, videos, files, and social media.

## Why SearXNG?

- **No API key required** — point at your instance URL and go
- **Multi-engine aggregation** — combines many search engines in a single query, reducing single-source bias and improving result diversity
- **Category filtering** — `general`, `images`, `news`, `videos`, `files`, `social media`; the only OpenClaw provider that can return image and video results
- **Engine control** — restrict to specific engines (e.g. `["google", "duckduckgo"]`) or let your instance defaults apply
- **Privacy** — all queries are made server-side from your own instance, no third-party API tracking
- **Self-hosted resilience** — not subject to API rate limits, quota exhaustion, or key rotation

> **License note:** SearXNG is licensed under AGPLv3. OpenClaw does not bundle or distribute SearXNG. Users must install and run their own instance. See [docs.searxng.org/admin/installation.html](https://docs.searxng.org/admin/installation.html). This PR contains no SearXNG source code.

## Changes

### Core (`src/agents/tools/web-search.ts`)
- Add `"searxng"` to `SEARCH_PROVIDERS`
- Add `SearxngConfig`, `SearxngResult`, `SearxngResponse` types
- Implement `resolveSearxngConfig()` and `resolveSearxngUrl()` helpers
- Implement `runSearxngSearch()` — GET `/search?format=json` with category, engine, language, safeSearch params
- Add SearXNG case to `resolveSearchProvider()`, `runWebSearch()` (cache key + execution block), and `createWebSearchTool()` (description + config wiring)
- SearXNG skips the API key gate — no key needed, just a reachable URL

### Config schema (`src/config/zod-schema.agent-runtime.ts`)
- Add `z.literal("searxng")` to provider union
- Add `searxng` config object: `url`, `engines[]`, `categories`, `language`, `safeSearch` (0|1|2)

### TypeScript types (`src/config/types.tools.ts`)
- Add `"searxng"` to `provider` union
- Add inline-documented `searxng` config shape

### Labels + help text (`src/config/schema.labels.ts`, `src/config/schema.help.ts`)
- 5 new label entries
- 5 new help strings; `url` help text explicitly directs users to install SearXNG themselves

### Docs (`docs/tools/web.md`)
- Add SearXNG to the provider comparison table
- New **Using SearXNG** section: what it is, why use it, Docker install snippet, `settings.yml` JSON format requirement, basic + advanced config examples, notes on `image_proxy` and result fields

### Tests (`src/config/config.web-search-provider.test.ts`)
- 5 new tests: full config, minimal config, no-config defaults, explicit provider wins, invalid `safeSearch` rejected

### Changelog
- User-facing entry under `2026.2.26 (Unreleased)`

## Config example

```json5
{
  tools: {
    web: {
      search: {
        provider: "searxng",
        searxng: {
          url: "http://192.168.1.210:8080",
          engines: ["google", "duckduckgo", "bing"],
          categories: "general", // or "images", "news", "videos", "files", "social media"
          language: "en",
          safeSearch: 0,
        },
      },
    },
  },
}
```

## Testing

```
pnpm vitest run src/config/config.web-search-provider.test.ts
# 19/19 passing
pnpm tsgo
# no errors
```

## Future work (out of scope for this PR)

- `fetchArtifacts` flag to chain `web_search (images)` → `web_fetch` for actual image retrieval
- Brave image/news/video category endpoints (separate provider extension)
- Auto-detection of SearXNG when `tools.web.search.searxng.url` is configured with no explicit provider set