### PR TITLE
fix: handle HTTP 529 (Anthropic overloaded) in model failover

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -18,6 +18,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
+    // Anthropic 529 (overloaded) should also trigger failover.
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -173,7 +173,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  if (status === 502 || status === 503 || status === 504 || status === 529) {
     return "timeout";
   }
   if (status === 400) {


### PR DESCRIPTION
## Summary

When the Anthropic API returns HTTP 529 (overloaded), OpenClaw fails to trigger model fallback and becomes completely unresponsive — even when working fallback models are configured.

### Root Cause

`resolveFailoverReasonFromError` in `src/agents/failover-error.ts` handles 402, 429, 401/403, 408, 502/503/504, 400 — but **not 529**.

When 529 is returned:
1. `coerceToFailoverError` receives an error with no recognized status → returns `null`
2. `model-fallback.ts` sees `!isFailoverError(normalized)` → `throw err` immediately
3. Fallback loop is skipped entirely
4. Agent becomes unresponsive until the primary model recovers

### Fix

Add `529` to the transient server error condition alongside `502 || 503 || 504`, mapping it to the `timeout` failover reason.

### Changes
- `src/agents/failover-error.ts`: Added `status === 529` to transient error handling
- `src/agents/failover-error.test.ts`: Added test assertion for 529 → timeout

### Testing
- Unit test added and passing locally
- No new dependencies

Fixes #28502