### PR TITLE
feat(gateway): add gateway.service.launcher config for custom service wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/Service launcher: add `gateway.service.launcher` config for custom LaunchAgent/systemd wrapper scripts, with `~` path expansion, existence/executable validation, `OPENCLAW_ENTRY` env forwarding, and service-audit bypass for launcher-managed services.
 - Highlight: External Secrets Management introduces a full `openclaw secrets` workflow (`audit`, `configure`, `apply`, `reload`) with runtime snapshot activation, strict `secrets apply` target-path validation, safer migration scrubbing, ref-only auth-profile support, and dedicated docs. (#26155) Thanks @joshavant.
 - ACP/Thread-bound agents: make ACP agents first-class runtimes for thread sessions with `acp` spawn/send dispatch integration, acpx backend bridging, lifecycle controls, startup reconciliation, runtime cleanup, and coalesced thread replies. (#23580) thanks @osolmaz.
 - Agents/Routing CLI: add `openclaw agents bindings`, `openclaw agents bind`, and `openclaw agents unbind` for account-scoped route management, including channel-only to account-scoped binding upgrades, role-aware binding identity handling, plugin-resolved binding account IDs, and optional account-binding prompts in `openclaw channels add`. (#27195) thanks @gumadeiras.

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -119,11 +119,6 @@ export async function gatherDaemonStatus(
     service.readCommand(process.env).catch(() => null),
     service.readRuntime(process.env).catch((err) => ({ status: "unknown", detail: String(err) })),
   ]);
-  const configAudit = await auditGatewayServiceConfig({
-    env: process.env,
-    command,
-  });
-
   const serviceEnv = command?.environment ?? undefined;
   const mergedDaemonEnv = {
     ...(process.env as Record<string, string | undefined>),
@@ -148,6 +143,12 @@ export async function gatherDaemonStatus(
   ]);
   const cliCfg = cliIO.loadConfig();
   const daemonCfg = daemonIO.loadConfig();
+
+  const configAudit = await auditGatewayServiceConfig({
+    env: process.env,
+    command,
+    launcher: cliCfg.gateway?.service?.launcher,
+  });
 
   const cliConfigSummary: ConfigSummary = {
     path: cliSnapshot?.path ?? cliConfigPath,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -147,7 +147,7 @@ export async function gatherDaemonStatus(
   const configAudit = await auditGatewayServiceConfig({
     env: process.env,
     command,
-    launcher: cliCfg.gateway?.service?.launcher,
+    launcher: daemonCfg.gateway?.service?.launcher ?? cliCfg.gateway?.service?.launcher,
   });
 
   const cliConfigSummary: ConfigSummary = {

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -320,6 +320,25 @@ describe("buildGatewayInstallPlan — launcher config", () => {
     ).rejects.toThrow("script not found");
   });
 
+  it("throws when launcher path is relative", async () => {
+    mockNodeGatewayPlanFixture();
+
+    await expect(
+      buildGatewayInstallPlan({
+        env: {},
+        port: 3000,
+        runtime: "node",
+        config: {
+          gateway: {
+            service: {
+              launcher: "scripts/gateway-launcher.sh",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("path must be absolute or start with ~/");
+  });
+
   it("throws when launcher script is not executable", async () => {
     const nonExecPath = path.join(tmpDir, "not-executable.sh");
     fs.writeFileSync(nonExecPath, "#!/bin/sh\n", { mode: 0o644 });

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -294,7 +294,8 @@ describe("buildGatewayInstallPlan — launcher config", () => {
       });
 
       expect(plan.programArguments).toHaveLength(1);
-      expect(plan.programArguments[0]).not.toContain("~");
+      // Verify tilde expansion happened (don't check for *any* ~, Windows 8.3 short names like RUNNER~1 contain ~).
+      expect(plan.programArguments[0]).not.toMatch(/^~[/\\]/);
       expect(plan.programArguments[0]).toBe(homeLauncher);
     } finally {
       fs.rmSync(homeSubdir, { recursive: true, force: true });

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolvePreferredNodePath: vi.fn(),
@@ -231,6 +234,165 @@ describe("buildGatewayInstallPlan", () => {
 
     expect(plan.environment.HOME).toBe("/Users/service");
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+  });
+});
+
+describe("buildGatewayInstallPlan — launcher config", () => {
+  let tmpDir: string;
+  let launcherPath: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-launcher-test-"));
+    launcherPath = path.join(tmpDir, "gateway-launcher.sh");
+    fs.writeFileSync(launcherPath, "#!/bin/sh\nexec node gateway", { mode: 0o755 });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("uses custom launcher script as sole program argument when config.gateway.service.launcher is set", async () => {
+    mockNodeGatewayPlanFixture();
+
+    const plan = await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "node",
+      config: {
+        gateway: {
+          service: {
+            launcher: launcherPath,
+          },
+        },
+      },
+    });
+
+    expect(plan.programArguments).toEqual([launcherPath]);
+  });
+
+  it("expands ~ in launcher path to home directory", async () => {
+    // Create executable script in the real home directory temp location.
+    const homeSubdir = path.join(os.homedir(), ".openclaw-test-launcher");
+    const homeLauncher = path.join(homeSubdir, "launcher.sh");
+    fs.mkdirSync(homeSubdir, { recursive: true });
+    fs.writeFileSync(homeLauncher, "#!/bin/sh\nexec node gateway", { mode: 0o755 });
+
+    try {
+      mockNodeGatewayPlanFixture();
+
+      const plan = await buildGatewayInstallPlan({
+        env: {},
+        port: 3000,
+        runtime: "node",
+        config: {
+          gateway: {
+            service: {
+              launcher: "~/.openclaw-test-launcher/launcher.sh",
+            },
+          },
+        },
+      });
+
+      expect(plan.programArguments).toHaveLength(1);
+      expect(plan.programArguments[0]).not.toContain("~");
+      expect(plan.programArguments[0]).toBe(homeLauncher);
+    } finally {
+      fs.rmSync(homeSubdir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when launcher script does not exist", async () => {
+    mockNodeGatewayPlanFixture();
+
+    await expect(
+      buildGatewayInstallPlan({
+        env: {},
+        port: 3000,
+        runtime: "node",
+        config: {
+          gateway: {
+            service: {
+              launcher: "/nonexistent/path/launcher.sh",
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("script not found");
+  });
+
+  it("throws when launcher script is not executable", async () => {
+    const nonExecPath = path.join(tmpDir, "not-executable.sh");
+    fs.writeFileSync(nonExecPath, "#!/bin/sh\n", { mode: 0o644 });
+    mockNodeGatewayPlanFixture();
+
+    await expect(
+      buildGatewayInstallPlan({
+        env: {},
+        port: 3000,
+        runtime: "node",
+        config: {
+          gateway: {
+            service: {
+              launcher: nonExecPath,
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("not executable");
+  });
+
+  it("uses default program arguments when no launcher is configured", async () => {
+    mockNodeGatewayPlanFixture();
+
+    const plan = await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "node",
+    });
+
+    expect(plan.programArguments).toEqual(["node", "gateway"]);
+  });
+
+  it("passes entryPath to buildServiceEnvironment when program args contain a script file before gateway", async () => {
+    mocks.resolvePreferredNodePath.mockResolvedValue("/opt/node");
+    mocks.resolveGatewayProgramArguments.mockResolvedValue({
+      programArguments: ["/opt/node", "/Users/me/openclaw/dist/entry.js", "gateway"],
+      workingDirectory: "/Users/me",
+    });
+    mocks.buildServiceEnvironment.mockReturnValue({ OPENCLAW_PORT: "3000" });
+
+    await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "node",
+    });
+
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entryPath: "/Users/me/openclaw/dist/entry.js",
+      }),
+    );
+  });
+
+  it("does not set entryPath when the arg before gateway is a binary, not a script", async () => {
+    mocks.resolvePreferredNodePath.mockResolvedValue("/opt/bun");
+    mocks.resolveGatewayProgramArguments.mockResolvedValue({
+      programArguments: ["/opt/homebrew/bin/bun", "gateway"],
+      workingDirectory: "/Users/me",
+    });
+    mocks.buildServiceEnvironment.mockReturnValue({ OPENCLAW_PORT: "3000" });
+
+    await buildGatewayInstallPlan({
+      env: {},
+      port: 3000,
+      runtime: "bun",
+    });
+
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entryPath: undefined,
+      }),
+    );
   });
 });
 

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -339,26 +339,30 @@ describe("buildGatewayInstallPlan — launcher config", () => {
     ).rejects.toThrow("path must be absolute or start with ~/");
   });
 
-  it("throws when launcher script is not executable", async () => {
-    const nonExecPath = path.join(tmpDir, "not-executable.sh");
-    fs.writeFileSync(nonExecPath, "#!/bin/sh\n", { mode: 0o644 });
-    mockNodeGatewayPlanFixture();
+  // Windows does not enforce Unix-style executable permissions; fs.accessSync(X_OK) is a no-op.
+  it.skipIf(process.platform === "win32")(
+    "throws when launcher script is not executable",
+    async () => {
+      const nonExecPath = path.join(tmpDir, "not-executable.sh");
+      fs.writeFileSync(nonExecPath, "#!/bin/sh\n", { mode: 0o644 });
+      mockNodeGatewayPlanFixture();
 
-    await expect(
-      buildGatewayInstallPlan({
-        env: {},
-        port: 3000,
-        runtime: "node",
-        config: {
-          gateway: {
-            service: {
-              launcher: nonExecPath,
+      await expect(
+        buildGatewayInstallPlan({
+          env: {},
+          port: 3000,
+          runtime: "node",
+          config: {
+            gateway: {
+              service: {
+                launcher: nonExecPath,
+              },
             },
           },
-        },
-      }),
-    ).rejects.toThrow("not executable");
-  });
+        }),
+      ).rejects.toThrow("not executable");
+    },
+  );
 
   it("uses default program arguments when no launcher is configured", async () => {
     mockNodeGatewayPlanFixture();

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -108,7 +108,10 @@ export function gatewayInstallErrorHint(platform = process.platform): string {
 function resolveLauncherPath(raw: string): string {
   const expanded =
     raw.startsWith("~/") || raw.startsWith("~\\") ? path.join(os.homedir(), raw.slice(2)) : raw;
-  return path.resolve(expanded);
+  if (!path.isAbsolute(expanded)) {
+    throw new Error(`gateway.service.launcher: path must be absolute or start with ~/: ${raw}`);
+  }
+  return expanded;
 }
 
 /** Validate that the launcher script exists and is executable. Throws on failure. */

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -104,9 +104,10 @@ export function gatewayInstallErrorHint(platform = process.platform): string {
     : `Tip: rerun \`${formatCliCommand("openclaw gateway install")}\` after fixing the error.`;
 }
 
-/** Resolve a launcher path, expanding leading `~` to the user's home directory. */
+/** Resolve a launcher path, expanding leading `~/` or `~\` to the user's home directory. */
 function resolveLauncherPath(raw: string): string {
-  const expanded = raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(2)) : raw;
+  const expanded =
+    raw.startsWith("~/") || raw.startsWith("~\\") ? path.join(os.homedir(), raw.slice(2)) : raw;
   return path.resolve(expanded);
 }
 

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -224,6 +224,7 @@ export async function maybeRepairGatewayServiceConfig(
     env: process.env,
     command,
     expectedGatewayToken,
+    launcher: cfg.gateway?.service?.launcher,
   });
   const needsNodeRuntime = needsNodeRuntimeMigration(audit.issues);
   const systemNodeInfo = needsNodeRuntime

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -315,6 +315,13 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+export type GatewayServiceConfig = {
+  /** Custom launcher script path for the gateway LaunchAgent/systemd service.
+   *  When set, the service uses this script as ProgramArguments instead of
+   *  directly invoking node + entry.js. Supports ~ expansion. */
+  launcher?: string;
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -356,6 +363,8 @@ export type GatewayConfig = {
   allowRealIpFallback?: boolean;
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
+  /** Service launcher configuration for LaunchAgent/systemd. */
+  service?: GatewayServiceConfig;
   /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -687,6 +687,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        service: z
+          .object({
+            launcher: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -83,6 +83,55 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(true);
   });
 
+  it("does not flag gateway-command-missing when launcher matches installed command", async () => {
+    const home = process.env.HOME ?? "/tmp";
+    const launcherPath = `${home}/.openclaw/scripts/gateway-launcher.sh`;
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: home },
+      platform: "darwin",
+      launcher: "~/.openclaw/scripts/gateway-launcher.sh",
+      command: {
+        programArguments: [launcherPath],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayCommandMissing),
+    ).toBe(false);
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayLauncherMismatch),
+    ).toBe(false);
+  });
+
+  it("flags launcher mismatch when installed command differs from configured launcher", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      launcher: "~/.openclaw/scripts/gateway-launcher.sh",
+      command: {
+        programArguments: ["/some/other/script.sh"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayLauncherMismatch),
+    ).toBe(true);
+  });
+
+  it("flags gateway-command-missing when no launcher and no gateway subcommand", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      command: {
+        programArguments: ["/Users/me/.openclaw/scripts/gateway-launcher.sh"],
+        environment: { PATH: "/usr/bin:/bin" },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayCommandMissing),
+    ).toBe(true);
+  });
+
   it("does not flag gateway token mismatch when service token matches config token", async () => {
     const audit = await auditGatewayServiceConfig({
       env: { HOME: "/tmp" },

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   auditGatewayServiceConfig,
@@ -84,8 +86,10 @@ describe("auditGatewayServiceConfig", () => {
   });
 
   it("does not flag gateway-command-missing when launcher matches installed command", async () => {
-    const home = process.env.HOME ?? "/tmp";
-    const launcherPath = `${home}/.openclaw/scripts/gateway-launcher.sh`;
+    // Use os.homedir() + path.join to match what resolveLauncherConfigPath produces
+    // (avoids forward-slash vs backslash mismatches on Windows).
+    const home = os.homedir();
+    const launcherPath = path.join(home, ".openclaw", "scripts", "gateway-launcher.sh");
     const audit = await auditGatewayServiceConfig({
       env: { HOME: home },
       platform: "darwin",

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -386,11 +386,17 @@ export async function auditGatewayServiceConfig(params: {
   command: GatewayServiceCommand;
   platform?: NodeJS.Platform;
   expectedGatewayToken?: string;
+  /** When set, the service uses a custom launcher script; skip gateway-command audit. */
+  launcher?: string;
 }): Promise<ServiceConfigAudit> {
   const issues: ServiceConfigIssue[] = [];
   const platform = params.platform ?? process.platform;
 
-  auditGatewayCommand(params.command?.programArguments, issues);
+  // When a custom launcher is configured, ProgramArguments is [launcherPath] which
+  // won't contain a literal "gateway" arg — that's expected, so skip the check.
+  if (!params.launcher) {
+    auditGatewayCommand(params.command?.programArguments, issues);
+  }
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
   auditGatewayServicePath(params.command, issues, params.env, platform);
   await auditGatewayRuntime(params.env, params.command, issues, platform);

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -205,11 +205,13 @@ function auditGatewayCommand(programArguments: string[] | undefined, issues: Ser
   }
 }
 
-/** Resolve a launcher config value to an absolute path (mirrors daemon-install-helpers). */
+/** Resolve a launcher config value to an absolute path (mirrors daemon-install-helpers).
+ *  Does NOT call path.resolve — relative paths are rejected at install time,
+ *  so this avoids cwd-dependent resolution during audit. */
 function resolveLauncherConfigPath(raw: string): string {
   const expanded =
     raw.startsWith("~/") || raw.startsWith("~\\") ? path.join(os.homedir(), raw.slice(2)) : raw;
-  return path.resolve(expanded);
+  return expanded;
 }
 
 function auditLauncherCommand(

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { resolveLaunchAgentPlistPath } from "./launchd.js";
 import { isBunRuntime, isNodeRuntime } from "./runtime-binary.js";
@@ -39,6 +40,7 @@ export const SERVICE_AUDIT_CODES = {
   gatewayRuntimeBun: "gateway-runtime-bun",
   gatewayRuntimeNodeVersionManager: "gateway-runtime-node-version-manager",
   gatewayRuntimeNodeSystemMissing: "gateway-runtime-node-system-missing",
+  gatewayLauncherMismatch: "gateway-launcher-mismatch",
   gatewayTokenDrift: "gateway-token-drift",
   launchdKeepAlive: "launchd-keep-alive",
   launchdRunAtLoad: "launchd-run-at-load",
@@ -199,6 +201,32 @@ function auditGatewayCommand(programArguments: string[] | undefined, issues: Ser
       code: SERVICE_AUDIT_CODES.gatewayCommandMissing,
       message: "Service command does not include the gateway subcommand",
       level: "aggressive",
+    });
+  }
+}
+
+/** Resolve a launcher config value to an absolute path (mirrors daemon-install-helpers). */
+function resolveLauncherConfigPath(raw: string): string {
+  const expanded =
+    raw.startsWith("~/") || raw.startsWith("~\\") ? path.join(os.homedir(), raw.slice(2)) : raw;
+  return path.resolve(expanded);
+}
+
+function auditLauncherCommand(
+  programArguments: string[] | undefined,
+  launcher: string,
+  issues: ServiceConfigIssue[],
+) {
+  if (!programArguments || programArguments.length === 0) {
+    return;
+  }
+  const resolvedLauncher = resolveLauncherConfigPath(launcher);
+  const installedCommand = programArguments[0];
+  if (installedCommand !== resolvedLauncher) {
+    issues.push({
+      code: SERVICE_AUDIT_CODES.gatewayLauncherMismatch,
+      message: "Installed service command does not match configured launcher",
+      detail: `expected ${resolvedLauncher}, got ${installedCommand}`,
     });
   }
 }
@@ -386,15 +414,16 @@ export async function auditGatewayServiceConfig(params: {
   command: GatewayServiceCommand;
   platform?: NodeJS.Platform;
   expectedGatewayToken?: string;
-  /** When set, the service uses a custom launcher script; skip gateway-command audit. */
+  /** When set, the service uses a custom launcher script; validate against ProgramArguments. */
   launcher?: string;
 }): Promise<ServiceConfigAudit> {
   const issues: ServiceConfigIssue[] = [];
   const platform = params.platform ?? process.platform;
 
-  // When a custom launcher is configured, ProgramArguments is [launcherPath] which
-  // won't contain a literal "gateway" arg — that's expected, so skip the check.
-  if (!params.launcher) {
+  if (params.launcher) {
+    // Validate that the installed ProgramArguments matches the configured launcher.
+    auditLauncherCommand(params.command?.programArguments, params.launcher, issues);
+  } else {
     auditGatewayCommand(params.command?.programArguments, issues);
   }
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -354,6 +354,23 @@ describe("buildServiceEnvironment", () => {
     });
     expect(env.NODE_EXTRA_CA_CERTS).toBe("/custom/certs/ca.pem");
   });
+
+  it("sets OPENCLAW_ENTRY when entryPath is provided", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+      entryPath: "/Users/me/openclaw/dist/entry.js",
+    });
+    expect(env.OPENCLAW_ENTRY).toBe("/Users/me/openclaw/dist/entry.js");
+  });
+
+  it("leaves OPENCLAW_ENTRY undefined when entryPath is not provided", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/home/user" },
+      port: 18789,
+    });
+    expect(env.OPENCLAW_ENTRY).toBeUndefined();
+  });
 });
 
 describe("buildNodeServiceEnvironment", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -236,6 +236,7 @@ export function buildServiceEnvironment(params: {
   port: number;
   token?: string;
   launchdLabel?: string;
+  entryPath?: string;
   platform?: NodeJS.Platform;
 }): Record<string, string | undefined> {
   const { env, port, token, launchdLabel } = params;
@@ -270,6 +271,7 @@ export function buildServiceEnvironment(params: {
     OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
     OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
     OPENCLAW_SERVICE_VERSION: VERSION,
+    OPENCLAW_ENTRY: params.entryPath,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw update`, `openclaw doctor --fix`, and `openclaw gateway install` all regenerate the LaunchAgent/systemd plist from scratch, always producing `ProgramArguments = [node, entry.js, gateway, --port, N]`. This silently overwrites any custom launcher wrapper setup.
- **Why it matters:** Users running the gateway with lifecycle wrappers — health checks, tailscale serve binding, graceful SIGTERM handling — lose their configuration on every update. There is no supported way to tell OpenClaw "use my launcher script."
- **What changed:** Added `gateway.service.launcher` config option (string, supports `~` expansion). When set, `buildGatewayInstallPlan()` validates the script exists and is executable, then uses it as `ProgramArguments` instead of the auto-resolved node + entry.js args. Also added `OPENCLAW_ENTRY` to the service environment so launcher scripts can locate entry.js without hardcoding paths.
- **What did NOT change (scope boundary):** Default behavior is completely unchanged — without the config key, everything works exactly as before. No changes to the gateway runtime, protocol, or any other service install logic.

> **Note:** This is a new (small) feature. Happy to open a Discussion first if the team prefers that flow for feature PRs. Opened directly as a PR since the change is self-contained and backward-compatible.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

- New optional config key: `gateway.service.launcher` (string, supports `~` expansion)
- New env var in service plist/unit: `OPENCLAW_ENTRY` (path to entry.js)
- When `gateway.service.launcher` is set, `gateway install` uses the script path as `ProgramArguments` instead of `[node, entry.js, gateway, --port, N]`
- If the launcher script doesn't exist or isn't executable, `gateway install` fails with a clear error message

Example config:
```json
{
  "gateway": {
    "service": {
      "launcher": "~/.openclaw/scripts/gateway-launcher.sh"
    }
  }
}
```

## Security Impact (required)

- New permissions/capabilities? `No` — the launcher script runs with the same privileges as the existing gateway process (user-level LaunchAgent/systemd user unit)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — ProgramArguments already accepted arbitrary paths; this adds a config-driven path instead of hardcoded resolution
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.5 (Darwin 24.6.0, arm64)
- Runtime: Node 22.x via nvm
- Model/provider: N/A (service install layer, not model-dependent)
- Integration/channel: LaunchAgent (macOS)
- Relevant config:
  ```json
  {
    "gateway": {
      "port": 18789,
      "service": {
        "launcher": "~/.openclaw/scripts/gateway-launcher.sh"
      }
    }
  }
  ```

### Steps

1. Create a launcher script (e.g. `~/.openclaw/scripts/gateway-launcher.sh`, `chmod +x`) that uses `$OPENCLAW_ENTRY` and `$OPENCLAW_GATEWAY_PORT` env vars to start the gateway
2. Add `"service": { "launcher": "~/.openclaw/scripts/gateway-launcher.sh" }` to the `gateway` section of `openclaw.json`
3. Run `openclaw gateway install --force`

### Expected

- Plist `ProgramArguments` contains the launcher script path (not node + entry.js)
- `OPENCLAW_ENTRY` env var is set in the plist EnvironmentVariables
- Gateway starts via the launcher script
- Subsequent `gateway install --force` preserves the launcher

### Actual

- All of the above confirmed on macOS 15.5

## Evidence

- Plist inspection: `ProgramArguments = [/Users/.../.openclaw/scripts/gateway-launcher.sh]`
- `OPENCLAW_ENTRY` present in plist `EnvironmentVariables`
- `ps aux | grep gateway-launcher` shows launcher process running
- Gateway responds healthy on configured port
- Re-running `gateway install --force` preserves the launcher path
- `pnpm tsgo` — passes (0 errors)
- `pnpm lint` — passes (0 warnings, 0 errors)
- `oxfmt --check` — passes on all changed files

## Human Verification (required)

- Verified scenarios: install with launcher, install without launcher (fallback), missing script error, non-executable script error, `~` expansion, re-install preserves launcher
- Edge cases checked: removing `gateway.service.launcher` from config reverts to default behavior; `OPENCLAW_ENTRY` is `undefined` when entry.js can't be extracted from args (graceful no-op)
- What I did **not** verify: systemd (Linux) — tested macOS LaunchAgent only

## Compatibility / Migration

- Backward compatible? `Yes` — the config key is optional; omitting it preserves existing behavior exactly
- Config/env changes? `Yes` — new optional `gateway.service.launcher` config key, new `OPENCLAW_ENTRY` env var in service environment (always set, harmless when unused)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `gateway.service` from `openclaw.json` and run `openclaw gateway install --force` — reverts to direct node invocation
- Files/config to restore: Only `openclaw.json` (remove the `service` key)
- Known bad symptoms: If launcher script is deleted but config still references it, `gateway install` fails with a clear error pointing to the missing file

## Risks and Mitigations

- Risk: Launcher script has a bug (exits immediately, wrong shebang) causing the gateway to enter a restart loop via KeepAlive.
  - Mitigation: Same risk as any misconfigured ProgramArguments today. User removes the config key and reinstalls to recover. Validation at install time catches missing/non-executable scripts upfront.

---

### AI Disclosure

This PR was developed with assistance from Claude (Anthropic). The implementation was designed collaboratively, with all changes reviewed, tested locally, and understood by the author. Testing was hands-on against a live macOS LaunchAgent setup — not just generated and submitted.