### PR TITLE
fix: disable rejectHardlinks for pnpm-installed plugin manifests

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -229,6 +229,7 @@ function readPackageManifest(dir: string): PackageManifest | null {
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     return null;
@@ -330,6 +331,7 @@ function resolvePackageEntrySource(params: {
     absolutePath: source,
     rootPath: params.packageDir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     params.diagnostics.push({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -530,6 +530,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       absolutePath: candidate.source,
       rootPath: pluginRoot,
       boundaryLabel: "plugin root",
+      rejectHardlinks: false,
       // Discovery stores rootDir as realpath but source may still be a lexical alias
       // (e.g. /var/... vs /private/var/... on macOS). Canonical boundary checks
       // still enforce containment; skip lexical pre-check to avoid false escapes.

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -48,6 +48,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
     absolutePath: manifestPath,
     rootPath: rootDir,
     boundaryLabel: "plugin root",
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "path") {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -69,6 +69,7 @@ async function readInstalledPackageVersion(dir: string): Promise<string | undefi
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "installed plugin directory",
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     return undefined;


### PR DESCRIPTION
## Summary

When OpenClaw is installed via **pnpm**, all files under `node_modules/openclaw/` are hard links (`nlink > 1`) because pnpm uses a content-addressable store that shares files across packages via hard links.

OpenClaw 2026.2.26 added security checks that reject hard-linked files in the plugin system. This affects **both** plugin manifests (`openclaw.plugin.json`) and plugin entry points (`index.ts`, `index.js`, etc.), which means:

1. Plugin manifest loading fails with: `unsafe plugin manifest path`
2. Plugin entry point loading fails with: `plugin entry path escapes plugin root or fails alias checks`

This makes **all plugins unusable** when installed via pnpm — including critical ones like telegram, whatsapp, memory-core, and device-pair. The result is that messaging channels stop working entirely.

### Client-side workaround

Users can work around this by breaking hard links and switching pnpm to copy mode:
```bash
# Break existing hard links
find /path/to/openclaw/extensions -type f -links +1 -exec sh -c 'cp "$1" "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;
# Prevent future hard links
pnpm config set package-import-method copy
```

## Fix

Added `rejectHardlinks: false` to all 5 `openBoundaryFileSync` call sites across the plugin system:

- `src/plugins/manifest.ts` — `loadPluginManifest` (manifest read)
- `src/plugins/discovery.ts` — `readPackageManifest` and `resolvePackageEntrySource` (manifest + entry point discovery)
- `src/plugins/loader.ts` — `loadOpenClawPlugins` (entry point loading)
- `src/plugins/update.ts` — `readInstalledPackageVersion` (update check)

The boundary path checks (`rootPath` containment via `resolveBoundaryPathSync`) still enforce that plugin files are within their expected directories, so the security model is preserved — only the hard link count check is relaxed.

Hard link rejection makes sense for user-writable paths (preventing TOCTOU via link manipulation), but installed plugin files in a read-only package store are not a security risk — they are the expected state for pnpm installations.

## Test plan

- [x] Verified on a pnpm-installed OpenClaw (2026.2.26) where all plugins were failing
- [x] After breaking hard links locally, all plugins load and channels reconnect
- [x] The `rejectHardlinks: false` flag correctly bypasses the `nlink > 1` check in both `openVerifiedFileSync` and `openFileWithinRoot`
- [ ] Confirm no regression for npm/yarn installs (hard links not present, so the flag is a no-op)