### PR TITLE
feat(heartbeat): add event history ring buffer and lifecycle hooks

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -374,6 +374,92 @@ is managing multiple sessions/codexes and you want to see why it decided to ping
 you — but it can also leak more internal detail than you want. Prefer keeping it
 off in group chats.
 
+## Hooks
+
+Heartbeat runs emit hook events that let you react to the heartbeat lifecycle
+without modifying core code. Register handlers for `heartbeat:before` and
+`heartbeat:after` in any hook (workspace, managed, or bundled).
+
+See [Hooks → Heartbeat Events](/automation/hooks#heartbeat-events) for context
+fields, type definitions, and examples.
+
+### Why hooks?
+
+Hooks are the **extensibility surface** for heartbeat runs. Without them, any
+logic that needs to run before or after a heartbeat (metrics collection, health
+scoring, alert escalation, stuck detection) must be implemented as a separate
+scheduled task, duplicating scheduling, deduplication, and session resolution.
+
+With hooks, extensions receive structured context (agent ID, session key,
+status, duration) and run in-process — no extra cron jobs, no polling, no
+race conditions.
+
+### Example: HOOK.md for a heartbeat hook
+
+```markdown
+---
+name: heartbeat-metrics
+description: "Log heartbeat outcomes for monitoring"
+metadata: { "openclaw": { "emoji": "📊", "events": ["heartbeat:after"] } }
+---
+
+# Heartbeat Metrics
+
+Logs heartbeat status and duration after each run.
+```
+
+## Event History
+
+Heartbeat events are recorded in an in-memory ring buffer (last 50 events).
+Use `getHeartbeatEventHistory()` to query recent outcomes for trend analysis,
+health dashboards, or alert logic.
+
+### Why event history?
+
+A single `getLastHeartbeatEvent()` is not enough when you need to:
+
+- Compute a failure rate over a window (e.g., 3 of last 10 failed)
+- Detect stuck patterns (e.g., every run returns `ok-empty` for hours)
+- Build a health score from recent outcomes
+- Show a status timeline in a dashboard
+
+The ring buffer keeps the last 50 events in memory with zero persistence
+overhead. It is the **data source** that hooks and skills can query to make
+informed decisions.
+
+### API
+
+```typescript
+import { getHeartbeatEventHistory, getLastHeartbeatEvent } from "../infra/heartbeat-events.js";
+
+// Get all recorded events (up to 50)
+const all = getHeartbeatEventHistory();
+
+// Get the last 10 events
+const recent = getHeartbeatEventHistory(10);
+
+// Compute failure rate
+const failRate = recent.filter((e) => e.status === "failed").length / recent.length;
+
+// Still available: last single event
+const last = getLastHeartbeatEvent();
+```
+
+### Event payload
+
+Each event in the history has the same shape as `HeartbeatEventPayload`:
+
+```typescript
+{
+  ts: number,              // Unix timestamp (ms)
+  agentId: string,         // Agent identifier
+  status: "sent" | "ok-empty" | "ok-token" | "skipped" | "failed",
+  durationMs?: number,     // Wall-clock duration
+  channel?: string,        // Delivery channel
+  reason?: string,         // Why the run was triggered
+}
+```
+
 ## Cost awareness
 
 Heartbeats run full agent turns. Shorter intervals burn more tokens. Keep

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "heartbeat";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -91,6 +97,54 @@ export type MessageSentHookEvent = InternalHookEvent & {
   type: "message";
   action: "sent";
   context: MessageSentHookContext;
+};
+
+// ============================================================================
+// Heartbeat Hook Events
+// ============================================================================
+
+/** Context available before the heartbeat agent call. */
+export type HeartbeatBeforeHookContext = {
+  /** Normalized agent identifier. */
+  agentId: string;
+  /** Session key for this heartbeat run. */
+  sessionKey: string;
+  /** Trigger reason (e.g., "interval", "cron", "manual", "hook:..."). */
+  reason?: string;
+  /** Resolved heartbeat prompt that will be sent to the model. */
+  prompt: string;
+};
+
+export type HeartbeatBeforeHookEvent = InternalHookEvent & {
+  type: "heartbeat";
+  action: "before";
+  context: HeartbeatBeforeHookContext;
+};
+
+/** Context available after the heartbeat run completes. */
+export type HeartbeatAfterHookContext = {
+  /** Normalized agent identifier. */
+  agentId: string;
+  /** Session key for this heartbeat run. */
+  sessionKey: string;
+  /** Trigger reason. */
+  reason?: string;
+  /** Outcome status matching HeartbeatEventPayload.status. */
+  status: "sent" | "ok-empty" | "ok-token" | "skipped" | "failed";
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number;
+  /** First 200 chars of the heartbeat reply (if any). */
+  preview?: string;
+  /** Delivery channel (e.g., "telegram", "whatsapp"). */
+  channel?: string;
+  /** Whether the reply included media attachments. */
+  hasMedia?: boolean;
+};
+
+export type HeartbeatAfterHookEvent = InternalHookEvent & {
+  type: "heartbeat";
+  action: "after";
+  context: HeartbeatAfterHookContext;
 };
 
 export interface InternalHookEvent {
@@ -281,4 +335,28 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
     typeof context.channelId === "string" &&
     typeof context.success === "boolean"
   );
+}
+
+export function isHeartbeatBeforeEvent(
+  event: InternalHookEvent,
+): event is HeartbeatBeforeHookEvent {
+  if (event.type !== "heartbeat" || event.action !== "before") {
+    return false;
+  }
+  const context = event.context as Partial<HeartbeatBeforeHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.agentId === "string" && typeof context.prompt === "string";
+}
+
+export function isHeartbeatAfterEvent(event: InternalHookEvent): event is HeartbeatAfterHookEvent {
+  if (event.type !== "heartbeat" || event.action !== "after") {
+    return false;
+  }
+  const context = event.context as Partial<HeartbeatAfterHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.agentId === "string" && typeof context.status === "string";
 }

--- a/src/infra/heartbeat-events.test.ts
+++ b/src/infra/heartbeat-events.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HEARTBEAT_HISTORY_MAX,
+  clearHeartbeatEventHistory,
+  emitHeartbeatEvent,
+  getHeartbeatEventHistory,
+  getLastHeartbeatEvent,
+} from "./heartbeat-events.js";
+
+describe("heartbeat event history", () => {
+  afterEach(() => {
+    clearHeartbeatEventHistory();
+  });
+
+  it("returns empty array initially", () => {
+    expect(getHeartbeatEventHistory()).toEqual([]);
+  });
+
+  it("records events in chronological order", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 100 });
+    emitHeartbeatEvent({ status: "ok-empty", durationMs: 50 });
+    emitHeartbeatEvent({ status: "failed", reason: "timeout", durationMs: 200 });
+
+    const history = getHeartbeatEventHistory();
+    expect(history).toHaveLength(3);
+    expect(history[0].status).toBe("sent");
+    expect(history[1].status).toBe("ok-empty");
+    expect(history[2].status).toBe("failed");
+  });
+
+  it("enriches events with a timestamp", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 100 });
+
+    const history = getHeartbeatEventHistory();
+    expect(history[0].ts).toBeTypeOf("number");
+    expect(history[0].ts).toBeGreaterThan(0);
+  });
+
+  it("caps history at HEARTBEAT_HISTORY_MAX", () => {
+    for (let i = 0; i < HEARTBEAT_HISTORY_MAX + 20; i++) {
+      emitHeartbeatEvent({ status: "sent", durationMs: i });
+    }
+
+    const history = getHeartbeatEventHistory();
+    expect(history).toHaveLength(HEARTBEAT_HISTORY_MAX);
+    // Oldest entries are pruned; the first remaining should be event #20
+    expect(history[0].durationMs).toBe(20);
+  });
+
+  it("getHeartbeatEventHistory returns last N with limit", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 1 });
+    emitHeartbeatEvent({ status: "ok-token", durationMs: 2 });
+    emitHeartbeatEvent({ status: "failed", reason: "err", durationMs: 3 });
+    emitHeartbeatEvent({ status: "skipped", reason: "dup", durationMs: 4 });
+
+    const last2 = getHeartbeatEventHistory(2);
+    expect(last2).toHaveLength(2);
+    expect(last2[0].durationMs).toBe(3);
+    expect(last2[1].durationMs).toBe(4);
+  });
+
+  it("getHeartbeatEventHistory returns empty for zero or negative limit", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 1 });
+    emitHeartbeatEvent({ status: "sent", durationMs: 2 });
+
+    expect(getHeartbeatEventHistory(0)).toEqual([]);
+    expect(getHeartbeatEventHistory(-1)).toEqual([]);
+    expect(getHeartbeatEventHistory(-100)).toEqual([]);
+  });
+
+  it("getHeartbeatEventHistory returns all when limit exceeds size", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 1 });
+    emitHeartbeatEvent({ status: "sent", durationMs: 2 });
+
+    const result = getHeartbeatEventHistory(100);
+    expect(result).toHaveLength(2);
+  });
+
+  it("getHeartbeatEventHistory returns all when no limit provided", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 1 });
+    emitHeartbeatEvent({ status: "sent", durationMs: 2 });
+    emitHeartbeatEvent({ status: "sent", durationMs: 3 });
+
+    const result = getHeartbeatEventHistory();
+    expect(result).toHaveLength(3);
+  });
+
+  it("clearHeartbeatEventHistory resets all state", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 100 });
+    emitHeartbeatEvent({ status: "ok-empty", durationMs: 50 });
+
+    expect(getHeartbeatEventHistory()).toHaveLength(2);
+    expect(getLastHeartbeatEvent()).not.toBeNull();
+
+    clearHeartbeatEventHistory();
+
+    expect(getHeartbeatEventHistory()).toHaveLength(0);
+    expect(getLastHeartbeatEvent()).toBeNull();
+  });
+
+  it("getLastHeartbeatEvent still works alongside history", () => {
+    emitHeartbeatEvent({ status: "sent", durationMs: 100 });
+    emitHeartbeatEvent({ status: "failed", reason: "err", durationMs: 200 });
+
+    const last = getLastHeartbeatEvent();
+    expect(last).not.toBeNull();
+    expect(last!.status).toBe("failed");
+    expect(last!.durationMs).toBe(200);
+
+    // Should be the same object as the last entry in history
+    const history = getHeartbeatEventHistory();
+    expect(history[history.length - 1]).toBe(last);
+  });
+});

--- a/src/infra/heartbeat-runner.heartbeat-hooks.test.ts
+++ b/src/infra/heartbeat-runner.heartbeat-hooks.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearInternalHooks,
+  registerInternalHook,
+  type HeartbeatAfterHookContext,
+  type HeartbeatBeforeHookContext,
+  type InternalHookEvent,
+} from "../hooks/internal-hooks.js";
+import { clearHeartbeatEventHistory } from "./heartbeat-events.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { withTempHeartbeatSandbox, seedMainSessionStore } from "./heartbeat-runner.test-utils.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+describe("heartbeat hooks integration", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+    clearHeartbeatEventHistory();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+    clearHeartbeatEventHistory();
+    vi.restoreAllMocks();
+  });
+
+  it("fires heartbeat:before with prompt and agentId before LLM call", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = {
+        agents: { defaults: { heartbeat: { every: "30m", target: "none" } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockResolvedValue({
+        payloads: [{ text: "All clear" }],
+      });
+
+      const beforeEvents: InternalHookEvent[] = [];
+      registerInternalHook("heartbeat:before", (event) => {
+        beforeEvents.push(event);
+      });
+
+      await runHeartbeatOnce({ cfg });
+
+      expect(beforeEvents).toHaveLength(1);
+      const ctx = beforeEvents[0].context as HeartbeatBeforeHookContext;
+      expect(ctx.agentId).toBe("main");
+      expect(typeof ctx.prompt).toBe("string");
+      expect(ctx.prompt.length).toBeGreaterThan(0);
+      expect(typeof ctx.sessionKey).toBe("string");
+    });
+  });
+
+  it("fires heartbeat:after with status on each outcome", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = {
+        agents: { defaults: { heartbeat: { every: "30m", target: "none" } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      // Return empty payload → ok-empty path
+      replySpy.mockResolvedValue({ payloads: [{}] });
+
+      const afterEvents: InternalHookEvent[] = [];
+      registerInternalHook("heartbeat:after", (event) => {
+        afterEvents.push(event);
+      });
+
+      await runHeartbeatOnce({ cfg });
+
+      expect(afterEvents).toHaveLength(1);
+      const ctx = afterEvents[0].context as HeartbeatAfterHookContext;
+      expect(ctx.agentId).toBe("main");
+      expect(typeof ctx.durationMs).toBe("number");
+      expect(ctx.durationMs).toBeGreaterThanOrEqual(0);
+      // status could be ok-empty or skipped depending on delivery target
+      expect(["ok-empty", "ok-token", "skipped", "sent"]).toContain(ctx.status);
+    });
+  });
+
+  it("heartbeat:before fires before heartbeat:after", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = {
+        agents: { defaults: { heartbeat: { every: "30m", target: "none" } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockResolvedValue({ payloads: [{}] });
+
+      const order: string[] = [];
+      registerInternalHook("heartbeat:before", () => {
+        order.push("before");
+      });
+      registerInternalHook("heartbeat:after", () => {
+        order.push("after");
+      });
+
+      await runHeartbeatOnce({ cfg });
+
+      expect(order).toEqual(["before", "after"]);
+    });
+  });
+
+  it("hook errors do not prevent heartbeat completion", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = {
+        agents: { defaults: { heartbeat: { every: "30m", target: "none" } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockResolvedValue({ payloads: [{}] });
+
+      registerInternalHook("heartbeat:before", () => {
+        throw new Error("before hook exploded");
+      });
+      registerInternalHook("heartbeat:after", () => {
+        throw new Error("after hook exploded");
+      });
+
+      // Should complete without throwing despite hook errors
+      const result = await runHeartbeatOnce({ cfg });
+      expect(result.status).not.toBe("failed");
+    });
+  });
+
+  it("fires heartbeat:after with status='failed' on error", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = {
+        agents: { defaults: { heartbeat: { every: "30m", target: "none" } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockRejectedValue(new Error("LLM call failed"));
+
+      const afterEvents: InternalHookEvent[] = [];
+      registerInternalHook("heartbeat:after", (event) => {
+        afterEvents.push(event);
+      });
+
+      const result = await runHeartbeatOnce({ cfg });
+      expect(result.status).toBe("failed");
+
+      expect(afterEvents).toHaveLength(1);
+      const ctx = afterEvents[0].context as HeartbeatAfterHookContext;
+      expect(ctx.status).toBe("failed");
+      expect(ctx.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -35,6 +35,12 @@ import {
   updateSessionStore,
 } from "../config/sessions.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
+import {
+  createInternalHookEvent,
+  triggerInternalHook,
+  type HeartbeatAfterHookContext,
+  type HeartbeatBeforeHookContext,
+} from "../hooks/internal-hooks.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -693,6 +699,16 @@ export async function runHeartbeatOnce(opts: {
       channel: delivery.channel !== "none" ? delivery.channel : undefined,
       accountId: delivery.accountId,
     });
+    await triggerInternalHook(
+      createInternalHookEvent("heartbeat", "after", sessionKey, {
+        agentId,
+        sessionKey,
+        reason: opts.reason,
+        status: "skipped",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+      } satisfies HeartbeatAfterHookContext),
+    ).catch(() => {});
     return { status: "skipped", reason: "alerts-disabled" };
   }
 
@@ -734,6 +750,25 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
+    // ── heartbeat:after helper ──
+    // Emits a single after-hook at each exit point so external hooks can
+    // observe every heartbeat outcome (sent, ok, skipped, failed).
+    const emitAfterHook = async (
+      status: HeartbeatAfterHookContext["status"],
+      extra?: Partial<Pick<HeartbeatAfterHookContext, "preview" | "channel" | "hasMedia">>,
+    ) => {
+      await triggerInternalHook(
+        createInternalHookEvent("heartbeat", "after", sessionKey, {
+          agentId,
+          sessionKey,
+          reason: opts.reason,
+          status,
+          durationMs: Date.now() - startedAt,
+          ...extra,
+        } satisfies HeartbeatAfterHookContext),
+      );
+    };
+
     // Capture transcript state before the heartbeat run so we can prune if HEARTBEAT_OK
     const transcriptState = await captureTranscriptState({
       storePath,
@@ -746,6 +781,17 @@ export async function runHeartbeatOnce(opts: {
     const replyOpts = heartbeatModelOverride
       ? { isHeartbeat: true, heartbeatModelOverride, suppressToolErrorWarnings }
       : { isHeartbeat: true, suppressToolErrorWarnings };
+
+    // ── heartbeat:before hook ──
+    await triggerInternalHook(
+      createInternalHookEvent("heartbeat", "before", sessionKey, {
+        agentId,
+        sessionKey,
+        reason: opts.reason,
+        prompt,
+      } satisfies HeartbeatBeforeHookContext),
+    );
+
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
@@ -773,6 +819,9 @@ export async function runHeartbeatOnce(opts: {
         accountId: delivery.accountId,
         silent: !okSent,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-empty") : undefined,
+      });
+      await emitAfterHook("ok-empty", {
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
       });
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
@@ -809,6 +858,9 @@ export async function runHeartbeatOnce(opts: {
         accountId: delivery.accountId,
         silent: !okSent,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
+      });
+      await emitAfterHook("ok-token", {
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
       });
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
@@ -847,6 +899,9 @@ export async function runHeartbeatOnce(opts: {
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,
       });
+      await emitAfterHook("skipped", {
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+      });
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
@@ -867,6 +922,7 @@ export async function runHeartbeatOnce(opts: {
         hasMedia: mediaUrls.length > 0,
         accountId: delivery.accountId,
       });
+      await emitAfterHook("skipped");
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
@@ -886,6 +942,7 @@ export async function runHeartbeatOnce(opts: {
         accountId: delivery.accountId,
         indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
       });
+      await emitAfterHook("skipped", { channel: delivery.channel });
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
@@ -911,6 +968,7 @@ export async function runHeartbeatOnce(opts: {
           channel: delivery.channel,
           reason: readiness.reason,
         });
+        await emitAfterHook("skipped", { channel: delivery.channel });
         return { status: "skipped", reason: readiness.reason };
       }
     }
@@ -960,6 +1018,11 @@ export async function runHeartbeatOnce(opts: {
       accountId: delivery.accountId,
       indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
     });
+    await emitAfterHook("sent", {
+      preview: previewText?.slice(0, 200),
+      channel: delivery.channel,
+      hasMedia: mediaUrls.length > 0,
+    });
     return { status: "ran", durationMs: Date.now() - startedAt };
   } catch (err) {
     const reason = formatErrorMessage(err);
@@ -972,6 +1035,16 @@ export async function runHeartbeatOnce(opts: {
       indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
     });
     log.error(`heartbeat failed: ${reason}`, { error: reason });
+    // Fire after-hook in catch; swallow errors to avoid masking the original failure.
+    await triggerInternalHook(
+      createInternalHookEvent("heartbeat", "after", sessionKey, {
+        agentId,
+        sessionKey,
+        reason: opts.reason,
+        status: "failed",
+        durationMs: Date.now() - startedAt,
+      } satisfies HeartbeatAfterHookContext),
+    ).catch(() => {});
     return { status: "failed", reason };
   }
 }


### PR DESCRIPTION
## Summary

Heartbeat runs previously had no observability or extensibility surface — only a single `getLastHeartbeatEvent()` and no hook integration. This PR adds two foundational features:

- **Event History Ring Buffer** — In-memory ring buffer retaining the last 50 heartbeat events via `getHeartbeatEventHistory(limit?)`. Enables trend analysis, health scoring, failure rate computation, and stuck-pattern detection without external persistence overhead.

- **Heartbeat Lifecycle Hooks** — `heartbeat:before` and `heartbeat:after` internal hook events emitted at every exit path of `runHeartbeatOnce()`. Provides structured context (`agentId`, `sessionKey`, `status`, `durationMs`, `preview`, `channel`, `hasMedia`) so skills, hooks, and extensions can build metrics, escalation, and monitoring on top of the heartbeat lifecycle.

### Why these two features together?

They form the **foundation layer** for future work (health scoring, alert escalation, stuck detection, custom heartbeat extensions):
- Without **history**, there is nothing to analyze across runs
- Without **hooks**, there is nowhere to run analysis in-process

Discussion: https://github.com/openclaw/openclaw/discussions/28582

### Files changed

| Area | Files | What |
|------|-------|------|
| Core | `src/infra/heartbeat-events.ts` | Ring buffer + `getHeartbeatEventHistory()` + `clearHeartbeatEventHistory()` |
| Core | `src/hooks/internal-hooks.ts` | `"heartbeat"` event type, `HeartbeatBefore/AfterHookContext` types, type guards |
| Core | `src/infra/heartbeat-runner.ts` | Emit `heartbeat:before` + `heartbeat:after` at all exit paths including alerts-disabled skip |
| Tests | `src/infra/heartbeat-events.test.ts` | 10 tests — ring buffer ordering, cap, limit, edge cases, clear |
| Tests | `src/hooks/internal-hooks.test.ts` | +11 tests — heartbeat type guards + hook triggering |
| Tests | `src/infra/heartbeat-runner.heartbeat-hooks.test.ts` | 5 integration tests — end-to-end hook emission |
| Docs | `docs/automation/hooks.md` | Heartbeat Events section with context types + examples |
| Docs | `docs/gateway/heartbeat.md` | Hooks + Event History sections with API reference |

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run src/infra/heartbeat-events.test.ts` — 10/10 passed
- [x] `npx vitest run src/hooks/internal-hooks.test.ts` — 42/42 passed
- [x] `npx vitest run src/infra/heartbeat-runner.heartbeat-hooks.test.ts` — 5/5 passed
- [x] `npx vitest run` — 13,683 passed, 0 regressions
- [x] `oxfmt --check` — all files formatted
- [x] `oxlint --type-aware` — 0 errors