### PR TITLE
Telegram: add 60s download timeout to prevent gateway hang on video messages

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -33,6 +33,7 @@ type FetchMediaOptions = {
   maxRedirects?: number;
   ssrfPolicy?: SsrFPolicy;
   lookupFn?: LookupFn;
+  timeoutMs?: number;
 };
 
 function stripQuotes(value: string): string {
@@ -89,6 +90,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     maxRedirects,
     ssrfPolicy,
     lookupFn,
+    timeoutMs,
   } = options;
 
   let res: Response;
@@ -102,6 +104,7 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       maxRedirects,
       policy: ssrfPolicy,
       lookupFn,
+      timeoutMs,
     });
     res = result.response;
     finalUrl = result.finalUrl;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -328,6 +328,7 @@ export async function resolveMedia(
       filePathHint: filePath,
       maxBytes,
       ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+      timeoutMs: 60_000,
     });
     const originalName = fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);


### PR DESCRIPTION
## Summary

Fixes #28506

The gateway hangs indefinitely when receiving incoming Telegram video messages (~8MB) because `fetchRemoteMedia` calls `fetchWithSsrFGuard` without a timeout. If the Telegram file download stalls, the entire gateway blocks — no typing indicator, no response, and subsequent messages are also ignored. The only recovery is a manual gateway restart.

## Changes

- Added `timeoutMs` option to `FetchMediaOptions` in `src/media/fetch.ts` and forward it to `fetchWithSsrFGuard` (which already supports `timeoutMs` internally via `buildAbortSignal`)
- Set `timeoutMs: 60_000` (60 seconds) for Telegram media downloads in `resolveMedia()` in `src/telegram/bot/delivery.ts`
- Added test in `src/media/fetch.test.ts` verifying that a stalled download is aborted when `timeoutMs` expires

## Why 60 seconds?

- Telegram Bot API has a 20MB download limit; most files are well under 10MB
- 60s is generous enough for slow connections but prevents indefinite hangs
- The existing `getFile` retry logic already handles transient network errors separately

## Test Results

- All 4 `fetch.test.ts` tests pass (including new timeout test)
- All 11 `delivery.resolve-media-retry.test.ts` tests pass (existing tests unchanged)