### PR TITLE
Tools: fix sessions_list transcriptPath resolution

### DIFF
--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -84,7 +83,6 @@ export function createSessionsListTool(opts?: {
       });
 
       const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
-      const storePath = typeof list?.path === "string" ? list.path : undefined;
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const visibilityGuard = await createSessionVisibilityGuard({
         action: "list",
@@ -154,14 +152,13 @@ export function createSessionsListTool(opts?: {
         const sessionFileRaw = (entry as { sessionFile?: unknown }).sessionFile;
         const sessionFile = typeof sessionFileRaw === "string" ? sessionFileRaw : undefined;
         let transcriptPath: string | undefined;
-        if (sessionId && storePath) {
+        if (sessionId) {
           try {
             transcriptPath = resolveSessionFilePath(
               sessionId,
               sessionFile ? { sessionFile } : undefined,
               {
                 agentId: resolveAgentIdFromSessionKey(key),
-                sessionsDir: path.dirname(storePath),
               },
             );
           } catch {


### PR DESCRIPTION
## Summary
- fix `sessions_list` transcript path resolution to always anchor by the session key's `agentId`
- stop deriving transcript paths from gateway `sessions.list` response `path`, which can point to non-canonical store locations
- add a regression test covering non-canonical gateway store paths

## Problem
Issue #28379 reports `sessions_list` returning transcript paths under the wrong directory (for example workspace-root paths) when the gateway store path is not the true agent transcript root.

## Validation
- `pnpm vitest run src/agents/tools/sessions.test.ts`
- `pnpm vitest run src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions.test.ts`
