### PR TITLE
fix(sandbox): actionable error when Docker is missing (#28401)

### DIFF
--- a/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
+++ b/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { execDockerRaw } from "./docker.js";
+
+describe("execDockerRaw", () => {
+  it("wraps docker ENOENT with an actionable configuration error", async () => {
+    await withEnvAsync({ PATH: "" }, async () => {
+      let err: unknown;
+      try {
+        await execDockerRaw(["version"]);
+      } catch (caught) {
+        err = caught;
+      }
+
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toMatchObject({ code: "INVALID_CONFIG" });
+      expect((err as Error).message).toContain("Sandbox mode requires Docker");
+      expect((err as Error).message).toContain("agents.defaults.sandbox.mode=off");
+    });
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -65,6 +65,21 @@ export function execDockerRaw(
       if (signal) {
         signal.removeEventListener("abort", handleAbort);
       }
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        const friendly = Object.assign(
+          new Error(
+            'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker (and ensure "docker" is available), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.',
+          ),
+          { code: "INVALID_CONFIG", cause: error },
+        );
+        reject(friendly);
+        return;
+      }
       reject(error);
     });
 


### PR DESCRIPTION
## Summary

- Problem: With sandbox enabled, if Docker is missing from PATH, agent turns can fail immediately with a generic `spawn docker ENOENT` message.
- Why it matters: This is a common setup issue in minimal environments and produces a non-actionable failure before any reply is generated.
- What changed: `execDockerRaw()` in `src/agents/sandbox/docker.ts` now wraps `ENOENT` spawn errors with an actionable configuration error message (install Docker / ensure `docker` is on PATH, or set `agents.defaults.sandbox.mode=off`); added a regression test in `src/agents/sandbox/docker.execDockerRaw.enoent.test.ts`.
- What did NOT change (scope boundary): Sandbox behavior is unchanged when Docker is available; no fallback behavior or policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28401
- Related #

## User-visible / Behavior Changes

When Docker is missing, sandbox-related failures now include an actionable error message that points to installing Docker or disabling sandbox mode.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js
- Model/provider: N/A (unit test only)
- Integration/channel (if any): sandbox/docker
- Relevant config (redacted): N/A

### Steps

1. Set `agents.defaults.sandbox.mode` to `all`.
2. Ensure `docker` is not available in PATH.
3. Trigger an agent turn that uses the sandbox.

### Expected

- A clear, actionable configuration error.

### Actual

- Generic failure: `spawn docker ENOENT`.

## Evidence

Test runs:
- `pnpm test -- src/agents/sandbox/docker.execDockerRaw.enoent.test.ts`
- `pnpm check`

## Human Verification (required)

- Verified scenarios: missing-Docker spawn path returns an actionable error message.
- Edge cases checked: N/A.
- What you did **not** verify: end-to-end sandbox execution with a real Docker daemon.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/sandbox/docker.ts`.
- Known bad symptoms reviewers should watch for: regressions in non-ENOENT Docker failures.

## Risks and Mitigations

None.
