### PR TITLE
fix(dashboard): surface API errors in chat thread

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -341,6 +341,61 @@ describe("handleChatEvent", () => {
     });
   });
 
+  it("surfaces error event as inline chat message and sets lastError", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hello" }],
+      timestamp: 1,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial...",
+      chatStreamStartedAt: 100,
+      chatMessages: [existingMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "model timeout",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.lastError).toBe("model timeout");
+    // Error should appear as an inline message in the chat thread
+    expect(state.chatMessages).toHaveLength(2);
+    expect(state.chatMessages[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Error: model timeout" }],
+    });
+  });
+
+  it("uses default error text when errorMessage is missing", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.lastError).toBe("chat error");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Error: chat error" }],
+    });
+  });
+
   it("processes aborted from own run without message and empty stream", () => {
     const existingMessage = {
       role: "user",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -68,7 +68,9 @@ export async function loadChatHistory(state: ChatState) {
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
   } catch (err) {
-    state.lastError = String(err);
+    const error = String(err);
+    state.lastError = error;
+    console.error("[chat] loadChatHistory failed:", err);
   } finally {
     state.chatLoading = false;
   }
@@ -210,6 +212,7 @@ export async function sendChatMessage(
     state.chatStream = null;
     state.chatStreamStartedAt = null;
     state.lastError = error;
+    console.error("[chat] sendChatMessage failed:", err);
     state.chatMessages = [
       ...state.chatMessages,
       {
@@ -237,6 +240,7 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
     return true;
   } catch (err) {
     state.lastError = String(err);
+    console.error("[chat] abortChatRun failed:", err);
     return false;
   }
 }
@@ -309,10 +313,21 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
+    const errorText = payload.errorMessage ?? "chat error";
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
-    state.lastError = payload.errorMessage ?? "chat error";
+    state.lastError = errorText;
+    console.error("[chat] chat error event:", errorText);
+    // Surface the error inline so the user sees feedback in the chat thread
+    state.chatMessages = [
+      ...state.chatMessages,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Error: " + errorText }],
+        timestamp: Date.now(),
+      },
+    ];
   }
   return payload.state;
 }


### PR DESCRIPTION
## Summary

Fixes #25578 -- When API errors occur during chat (backend timeouts, model failures, etc.), the dashboard now provides clear user feedback instead of silently swallowing the error.

### Changes

**`ui/src/ui/controllers/chat.ts`:**
- **`handleChatEvent` (error state):** Previously only set `lastError` (a top-of-card banner that can be missed and gets cleared by the next history load). Now also appends an inline error message to `chatMessages`, matching the existing pattern in `sendChatMessage`'s catch block. Users see "Error: <message>" directly in the chat thread.
- **`sendChatMessage`:** Added `console.error` for browser console debugging.
- **`loadChatHistory`:** Added `console.error` for browser console debugging.
- **`abortChatRun`:** Added `console.error` for browser console debugging.

**`ui/src/ui/controllers/chat.test.ts`:**
- Added test: error event with `errorMessage` surfaces inline and sets `lastError`.
- Added test: error event without `errorMessage` uses default "chat error" text.

### What users now see

| Before | After |
|--------|-------|
| Prompt vanishes, no feedback | Error message appears inline in chat thread |
| Nothing in browser console | `[chat] chat error event: <msg>` logged to console |
| Banner error cleared on next history load | Inline error persists in chat history |

## Test plan

- [x] `ui/src/ui/controllers/chat.test.ts` -- 13 tests pass (2 new)
- [x] `ui/src/ui/views/chat.test.ts` -- 8 tests pass
- [x] `pnpm check` passes
- [ ] Manual: trigger a backend error during chat and verify the error appears inline

Closes #25578