### PR TITLE
chore: gitignore Cursor, Claude, and IDE config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,10 +95,19 @@ USER.md
 /local/
 package-lock.json
 .claude/settings.local.json
+.claude/
 .agents/
 .agents
 .agent/
 skills-lock.json
+
+# IDE / editor / agent config (NEVER COMMIT)
+.cursor/
+.vscode/
+CODEBASE_ANALYSIS.md
+CREDENTIAL_FIREWALL_PLAN.md
+SECRETS_PROVIDER_PLAN.md
+agent-transcripts/
 
 # Local iOS signing overrides
 apps/ios/LocalSigning.xcconfig


### PR DESCRIPTION
## Summary

- Add `.cursor/`, `.vscode/`, `.claude/`, `agent-transcripts/` to `.gitignore`
- Add local analysis files (`CODEBASE_ANALYSIS.md`, `CREDENTIAL_FIREWALL_PLAN.md`, `SECRETS_PROVIDER_PLAN.md`) to `.gitignore`
- Prevents IDE/agent configuration files from being accidentally committed

## Test plan

- [x] Verify `git status` no longer shows untracked IDE config files
- [x] Verify tracked `CLAUDE.md` symlink is NOT affected (it's a repo-level symlink to `AGENTS.md`)

Made with [Cursor](https://cursor.com)