### PR TITLE
fix(android): skip TLS heuristic for IP addresses in canvas URL normalization

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -634,70 +634,73 @@ class GatewaySession(
     }
   }
 
-  private fun normalizeCanvasHostUrl(
-    raw: String?,
-    endpoint: GatewayEndpoint,
-    isTlsConnection: Boolean,
-  ): String? {
-    val trimmed = raw?.trim().orEmpty()
-    val parsed = trimmed.takeIf { it.isNotBlank() }?.let { runCatching { java.net.URI(it) }.getOrNull() }
-    val host = parsed?.host?.trim().orEmpty()
-    val port = parsed?.port ?: -1
-    val scheme = parsed?.scheme?.trim().orEmpty().ifBlank { "http" }
-    val suffix = buildUrlSuffix(parsed)
+}
 
-    // If raw URL is a non-loopback address and this connection uses TLS,
-    // normalize scheme/port to the endpoint we actually connected to.
-    if (trimmed.isNotBlank() && host.isNotBlank() && !isLoopbackHost(host)) {
-      val needsTlsRewrite =
-        isTlsConnection &&
-          (
-            !scheme.equals("https", ignoreCase = true) ||
-              (port > 0 && port != endpoint.port) ||
-              (port <= 0 && endpoint.port != 443)
-            )
-      if (needsTlsRewrite) {
-        return buildCanvasUrl(host = host, scheme = "https", port = endpoint.port, suffix = suffix)
-      }
-      return trimmed
+// --- Extracted helpers (internal for testability) ---
+
+internal fun normalizeCanvasHostUrl(
+  raw: String?,
+  endpoint: GatewayEndpoint,
+  isTlsConnection: Boolean,
+): String? {
+  val trimmed = raw?.trim().orEmpty()
+  val parsed = trimmed.takeIf { it.isNotBlank() }?.let { runCatching { java.net.URI(it) }.getOrNull() }
+  val host = parsed?.host?.trim().orEmpty()
+  val port = parsed?.port ?: -1
+  val scheme = parsed?.scheme?.trim().orEmpty().ifBlank { "http" }
+  val suffix = buildCanvasUrlSuffix(parsed)
+
+  // If raw URL is a non-loopback address and this connection uses TLS,
+  // normalize scheme/port to the endpoint we actually connected to.
+  if (trimmed.isNotBlank() && host.isNotBlank() && !isLoopbackHost(host)) {
+    val needsTlsRewrite =
+      isTlsConnection &&
+        (
+          !scheme.equals("https", ignoreCase = true) ||
+            (port > 0 && port != endpoint.port) ||
+            (port <= 0 && endpoint.port != 443)
+          )
+    if (needsTlsRewrite) {
+      return buildCanvasUrl(host = host, scheme = "https", port = endpoint.port, suffix = suffix)
     }
-
-    val fallbackHost =
-      endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.host.trim()
-    if (fallbackHost.isEmpty()) return trimmed.ifBlank { null }
-
-    // For TLS connections, use the connected endpoint's scheme/port instead of raw canvas metadata.
-    val fallbackScheme = if (isTlsConnection) "https" else scheme
-    // For TLS, always use the connected endpoint port.
-    val fallbackPort = if (isTlsConnection) endpoint.port else (endpoint.canvasPort ?: endpoint.port)
-    return buildCanvasUrl(host = fallbackHost, scheme = fallbackScheme, port = fallbackPort, suffix = suffix)
+    return trimmed
   }
 
-  private fun buildCanvasUrl(host: String, scheme: String, port: Int, suffix: String): String {
-    val loweredScheme = scheme.lowercase()
-    val formattedHost = if (host.contains(":")) "[${host}]" else host
-    val portSuffix = if ((loweredScheme == "https" && port == 443) || (loweredScheme == "http" && port == 80)) "" else ":$port"
-    return "$loweredScheme://$formattedHost$portSuffix$suffix"
-  }
+  val fallbackHost =
+    endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
+      ?: endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
+      ?: endpoint.host.trim()
+  if (fallbackHost.isEmpty()) return trimmed.ifBlank { null }
 
-  private fun buildUrlSuffix(uri: java.net.URI?): String {
-    if (uri == null) return ""
-    val path = uri.rawPath?.takeIf { it.isNotBlank() } ?: ""
-    val query = uri.rawQuery?.takeIf { it.isNotBlank() }?.let { "?$it" } ?: ""
-    val fragment = uri.rawFragment?.takeIf { it.isNotBlank() }?.let { "#$it" } ?: ""
-    return "$path$query$fragment"
-  }
+  // For TLS connections, use the connected endpoint's scheme/port instead of raw canvas metadata.
+  val fallbackScheme = if (isTlsConnection) "https" else scheme
+  // For TLS, always use the connected endpoint port.
+  val fallbackPort = if (isTlsConnection) endpoint.port else (endpoint.canvasPort ?: endpoint.port)
+  return buildCanvasUrl(host = fallbackHost, scheme = fallbackScheme, port = fallbackPort, suffix = suffix)
+}
 
-  private fun isLoopbackHost(raw: String?): Boolean {
-    val host = raw?.trim()?.lowercase().orEmpty()
-    if (host.isEmpty()) return false
-    if (host == "localhost") return true
-    if (host == "::1") return true
-    if (host == "0.0.0.0" || host == "::") return true
-    return host.startsWith("127.")
-  }
+internal fun buildCanvasUrl(host: String, scheme: String, port: Int, suffix: String): String {
+  val loweredScheme = scheme.lowercase()
+  val formattedHost = if (host.contains(":")) "[${host}]" else host
+  val portSuffix = if ((loweredScheme == "https" && port == 443) || (loweredScheme == "http" && port == 80)) "" else ":$port"
+  return "$loweredScheme://$formattedHost$portSuffix$suffix"
+}
+
+internal fun buildCanvasUrlSuffix(uri: java.net.URI?): String {
+  if (uri == null) return ""
+  val path = uri.rawPath?.takeIf { it.isNotBlank() } ?: ""
+  val query = uri.rawQuery?.takeIf { it.isNotBlank() }?.let { "?$it" } ?: ""
+  val fragment = uri.rawFragment?.takeIf { it.isNotBlank() }?.let { "#$it" } ?: ""
+  return "$path$query$fragment"
+}
+
+internal fun isLoopbackHost(raw: String?): Boolean {
+  val host = raw?.trim()?.lowercase().orEmpty()
+  if (host.isEmpty()) return false
+  if (host == "localhost") return true
+  if (host == "::1") return true
+  if (host == "0.0.0.0" || host == "::") return true
+  return host.startsWith("127.")
 }
 
 private fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject

--- a/apps/android/app/src/test/java/ai/openclaw/android/gateway/NormalizeCanvasHostUrlTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/gateway/NormalizeCanvasHostUrlTest.kt
@@ -1,0 +1,266 @@
+package ai.openclaw.android.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Tests for [normalizeCanvasHostUrl] and related helpers.
+ *
+ * Regression guard for https://github.com/openclaw/openclaw/issues/20608:
+ * IPv4 addresses must not trigger TLS upgrades on plain-HTTP connections.
+ */
+class NormalizeCanvasHostUrlTest {
+
+  // --- IPv4 on plain HTTP (the issue scenario) ---
+
+  @Test
+  fun ipv4LanAddress_noTls_preservesOriginalUrl() {
+    val ep = endpoint(host = "192.168.1.83", port = 18789)
+    val result = normalizeCanvasHostUrl("http://192.168.1.83:18789", ep, isTlsConnection = false)
+    assertEquals("http://192.168.1.83:18789", result)
+  }
+
+  @Test
+  fun ipv4LanAddress_noTls_preservesCanvasPath() {
+    val ep = endpoint(host = "192.168.1.83", port = 18789)
+    val raw = "http://192.168.1.83:18789/_openclaw_/a2ui/"
+    val result = normalizeCanvasHostUrl(raw, ep, isTlsConnection = false)
+    assertEquals(raw, result)
+  }
+
+  @Test
+  fun ipv4Address_noTls_doesNotUpgradeToHttps() {
+    val ep = endpoint(host = "10.0.0.5", port = 18789)
+    val result = normalizeCanvasHostUrl("http://10.0.0.5:18789", ep, isTlsConnection = false)
+    assertEquals("http://10.0.0.5:18789", result)
+  }
+
+  // --- IPv4 with TLS ---
+
+  @Test
+  fun ipv4Address_withTls_rewritesToHttps() {
+    val ep = endpoint(host = "192.168.1.83", port = 443)
+    val result = normalizeCanvasHostUrl("http://192.168.1.83:18789", ep, isTlsConnection = true)
+    assertEquals("https://192.168.1.83", result)
+  }
+
+  @Test
+  fun ipv4Address_withTls_nonStandardPort() {
+    val ep = endpoint(host = "192.168.1.83", port = 8443)
+    val result = normalizeCanvasHostUrl("http://192.168.1.83:18789", ep, isTlsConnection = true)
+    assertEquals("https://192.168.1.83:8443", result)
+  }
+
+  // --- Domain names ---
+
+  @Test
+  fun domainName_noTls_preservesOriginalUrl() {
+    val ep = endpoint(host = "my-gateway.example.com", port = 18789)
+    val result = normalizeCanvasHostUrl("http://my-gateway.example.com:18789", ep, isTlsConnection = false)
+    assertEquals("http://my-gateway.example.com:18789", result)
+  }
+
+  @Test
+  fun domainName_withTls_rewritesToHttpsOnPort443() {
+    val ep = endpoint(host = "gateway.example.com", port = 443)
+    val result = normalizeCanvasHostUrl("http://gateway.example.com:18789", ep, isTlsConnection = true)
+    assertEquals("https://gateway.example.com", result)
+  }
+
+  // --- Loopback addresses ---
+
+  @Test
+  fun localhost_noTls_fallsBackToEndpointHost() {
+    val ep = endpoint(host = "192.168.1.83", port = 18789)
+    val result = normalizeCanvasHostUrl("http://localhost:18789", ep, isTlsConnection = false)
+    assertEquals("http://192.168.1.83:18789", result)
+  }
+
+  @Test
+  fun loopbackIp_noTls_fallsBackToEndpointHost() {
+    val ep = endpoint(host = "10.0.0.5", port = 18789)
+    val result = normalizeCanvasHostUrl("http://127.0.0.1:18789", ep, isTlsConnection = false)
+    assertEquals("http://10.0.0.5:18789", result)
+  }
+
+  // --- Fallback: null/blank raw URL ---
+
+  @Test
+  fun nullRaw_noTls_fallsBackToEndpointHost() {
+    val ep = endpoint(host = "192.168.1.83", port = 18789)
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = false)
+    assertEquals("http://192.168.1.83:18789", result)
+  }
+
+  @Test
+  fun blankRaw_noTls_fallsBackToEndpointHost() {
+    val ep = endpoint(host = "10.0.0.5", port = 18789)
+    val result = normalizeCanvasHostUrl("  ", ep, isTlsConnection = false)
+    assertEquals("http://10.0.0.5:18789", result)
+  }
+
+  @Test
+  fun nullRaw_withTls_fallsBackToHttpsEndpoint() {
+    val ep = endpoint(host = "192.168.1.83", port = 443)
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = true)
+    assertEquals("https://192.168.1.83", result)
+  }
+
+  // --- Fallback host priority: tailnetDns > lanHost > host ---
+
+  @Test
+  fun fallback_prefersTailnetDns() {
+    val ep = endpoint(host = "10.0.0.5", port = 18789, tailnetDns = "gateway.tailnet.ts.net", lanHost = "192.168.1.83")
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = false)
+    assertEquals("http://gateway.tailnet.ts.net:18789", result)
+  }
+
+  @Test
+  fun fallback_prefersLanHostOverHost() {
+    val ep = endpoint(host = "10.0.0.5", port = 18789, lanHost = "192.168.1.83")
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = false)
+    assertEquals("http://192.168.1.83:18789", result)
+  }
+
+  // --- Canvas port ---
+
+  @Test
+  fun fallback_usesCanvasPortWhenNotTls() {
+    val ep = endpoint(host = "192.168.1.83", port = 18789, canvasPort = 8080)
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = false)
+    assertEquals("http://192.168.1.83:8080", result)
+  }
+
+  @Test
+  fun fallback_tls_ignoresCanvasPort() {
+    val ep = endpoint(host = "192.168.1.83", port = 443, canvasPort = 8080)
+    val result = normalizeCanvasHostUrl(null, ep, isTlsConnection = true)
+    assertEquals("https://192.168.1.83", result)
+  }
+
+  // --- TLS rewrite preserves suffix ---
+
+  @Test
+  fun tlsRewrite_preservesPathAndQuery() {
+    val ep = endpoint(host = "gateway.example.com", port = 443)
+    val raw = "http://gateway.example.com:18789/_openclaw_/a2ui/?token=abc"
+    val result = normalizeCanvasHostUrl(raw, ep, isTlsConnection = true)
+    assertEquals("https://gateway.example.com/_openclaw_/a2ui/?token=abc", result)
+  }
+
+  // --- Already-correct HTTPS URL with TLS ---
+
+  @Test
+  fun alreadyHttps_matchingPort_noRewrite() {
+    val ep = endpoint(host = "gateway.example.com", port = 443)
+    val raw = "https://gateway.example.com"
+    val result = normalizeCanvasHostUrl(raw, ep, isTlsConnection = true)
+    assertEquals(raw, result)
+  }
+
+  // --- IPv6 ---
+
+  @Test
+  fun ipv6Address_noTls_preservesOriginalUrl() {
+    val ep = endpoint(host = "::1", port = 18789)
+    // Loopback IPv6 triggers fallback path
+    val result = normalizeCanvasHostUrl("http://[::1]:18789", ep, isTlsConnection = false)
+    // Fallback host is "::1" (loopback), so endpoint.host is used as-is
+    assertEquals("http://[::1]:18789", result)
+  }
+
+  // --- isLoopbackHost helper ---
+
+  @Test
+  fun isLoopbackHost_localhost() {
+    assertTrue(isLoopbackHost("localhost"))
+  }
+
+  @Test
+  fun isLoopbackHost_127prefix() {
+    assertTrue(isLoopbackHost("127.0.0.1"))
+    assertTrue(isLoopbackHost("127.0.0.2"))
+  }
+
+  @Test
+  fun isLoopbackHost_ipv6Loopback() {
+    assertTrue(isLoopbackHost("::1"))
+  }
+
+  @Test
+  fun isLoopbackHost_bindAll() {
+    assertTrue(isLoopbackHost("0.0.0.0"))
+    assertTrue(isLoopbackHost("::"))
+  }
+
+  @Test
+  fun isLoopbackHost_lanIp_notLoopback() {
+    assertFalse(isLoopbackHost("192.168.1.83"))
+    assertFalse(isLoopbackHost("10.0.0.5"))
+  }
+
+  @Test
+  fun isLoopbackHost_domain_notLoopback() {
+    assertFalse(isLoopbackHost("example.com"))
+    assertFalse(isLoopbackHost("gateway.local"))
+  }
+
+  @Test
+  fun isLoopbackHost_null_notLoopback() {
+    assertFalse(isLoopbackHost(null))
+  }
+
+  @Test
+  fun isLoopbackHost_blank_notLoopback() {
+    assertFalse(isLoopbackHost(""))
+    assertFalse(isLoopbackHost("  "))
+  }
+
+  // --- buildCanvasUrl helper ---
+
+  @Test
+  fun buildCanvasUrl_httpsPort443_omitsPort() {
+    assertEquals("https://example.com", buildCanvasUrl("example.com", "https", 443, ""))
+  }
+
+  @Test
+  fun buildCanvasUrl_httpPort80_omitsPort() {
+    assertEquals("http://example.com", buildCanvasUrl("example.com", "http", 80, ""))
+  }
+
+  @Test
+  fun buildCanvasUrl_nonStandardPort_includesPort() {
+    assertEquals("https://example.com:8443", buildCanvasUrl("example.com", "https", 8443, ""))
+  }
+
+  @Test
+  fun buildCanvasUrl_ipv6_bracketWrapped() {
+    assertEquals("http://[::1]:18789", buildCanvasUrl("::1", "http", 18789, ""))
+  }
+
+  @Test
+  fun buildCanvasUrl_withSuffix() {
+    assertEquals("https://example.com:8443/path?q=1", buildCanvasUrl("example.com", "https", 8443, "/path?q=1"))
+  }
+
+  // --- helpers ---
+
+  private fun endpoint(
+    host: String,
+    port: Int,
+    lanHost: String? = null,
+    tailnetDns: String? = null,
+    canvasPort: Int? = null,
+  ) = GatewayEndpoint(
+    stableId = "test|${host.lowercase()}|$port",
+    name = "$host:$port",
+    host = host,
+    port = port,
+    lanHost = lanHost,
+    tailnetDns = tailnetDns,
+    canvasPort = canvasPort,
+  )
+}


### PR DESCRIPTION
## Summary

Closes #20608.

- Extracts `normalizeCanvasHostUrl`, `buildCanvasUrl`, `buildCanvasUrlSuffix`, and `isLoopbackHost` from private `GatewaySession` methods to package-level `internal` functions for testability.
- Adds comprehensive unit tests (`NormalizeCanvasHostUrlTest.kt`) covering IPv4 addresses, domain names, loopback detection, TLS rewrite logic, fallback host priority, and URL suffix preservation.

The core bug (dots-in-hostname heuristic incorrectly triggering TLS for IPv4 addresses) was already fixed in e5399835b by replacing the `endpoint.host.contains(".")` heuristic with the explicit `isTlsConnection` parameter. This PR adds the regression test suite to prevent reintroduction of the bug.

## Test plan

- [ ] Verify `NormalizeCanvasHostUrlTest` passes (26 test cases covering IPv4/IPv6, TLS/non-TLS, loopback, domain names, fallback paths, and URL suffix handling)
- [ ] Verify existing `GatewaySessionInvokeTest` still passes
- [ ] Manual: connect Android app to LAN gateway via IP (e.g. `192.168.1.83:18789`) without TLS and confirm A2UI loads correctly over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)