### PR TITLE
fix(agents): suppress NO_REPLY in completion message and A2A announce flow

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -76,6 +76,10 @@ function buildCompletionDeliveryMessage(params: {
   if (isAnnounceSkip(findingsText)) {
     return "";
   }
+  // Suppress NO_REPLY so it is never treated as valid findings (#27531)
+  if (isSilentReplyText(findingsText, SILENT_REPLY_TOKEN)) {
+    return "";
+  }
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
   // Cron completions are standalone messages — skip the subagent status header.
   if (params.announceType === "cron job") {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -118,7 +119,13 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
-    if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {
+    if (
+      announceTarget &&
+      announceReply &&
+      announceReply.trim() &&
+      !isAnnounceSkip(announceReply) &&
+      !isSilentReplyText(announceReply, SILENT_REPLY_TOKEN)
+    ) {
       try {
         await callGateway({
           method: "send",


### PR DESCRIPTION
## Summary

Fixes #27531 -- Sub-agent announce flow leaks `NO_REPLY` to channels.

- **`buildCompletionDeliveryMessage`** in `subagent-announce.ts`: Added `isSilentReplyText` check alongside the existing `isAnnounceSkip` check so `NO_REPLY` findings produce an empty completion message instead of garbage like "Subagent xxx finished\n\nNO_REPLY". This is defense-in-depth since the early return at line 1164 already catches `NO_REPLY` in the main flow.
- **`sessions-send-tool.a2a.ts`**: Added `isSilentReplyText` check to the A2A announce delivery guard. Previously, only `isAnnounceSkip` was checked, so a `NO_REPLY` from the agent step would pass through and be sent to the channel via `callGateway({ method: "send" })`.

## Test plan

- [x] All 66 `subagent-announce` tests pass (including existing `NO_REPLY` suppression test)
- [x] `sessions-send` gateway tests pass
- [x] `auto-reply/tokens` tests pass
- [x] TypeScript type checks pass (`pnpm tsgo`)
- [x] Lint/format checks pass (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)