### PR TITLE
Cron: fill missing nextRunAtMs on startup so runMissedJobs sees all j…

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -106,6 +106,8 @@ export async function start(state: CronServiceState) {
         startupInterruptedJobIds.add(job.id);
       }
     }
+    // Fill in missing nextRunAtMs so runMissedJobs can consider all jobs (#10045).
+    recomputeNextRunsForMaintenance(state);
     await persist(state);
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: After gateway restart, some cron jobs had missing `nextRunAtMs`, so `runMissedJobs` could skip them and `nextWakeAtMs` could jump forward, effectively skipping runs that should have fired.
- Why it matters: Scheduled automations (daily jobs, reminders, maintenance tasks) could silently miss executions across restarts, breaking user workflows.
- What changed: In `cron start()`, after clearing stale `runningAtMs` markers, we call `recomputeNextRunsForMaintenance(state)` once and persist, so all enabled jobs missing `nextRunAtMs` get a computed schedule before `runMissedJobs` runs.
- What did NOT change (scope boundary): No changes to cron expressions, job payloads, delivery mechanisms, or the core timer/onTimer logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #10045
- Related #

## User-visible / Behavior Changes

- Cron jobs that were previously skipped after restart (due to missing `nextRunAtMs`) will now be considered by `runMissedJobs` and executed as expected.
- No config or CLI behavior changed; the fix is internal to cron scheduler startup.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Local gateway with cron enabled
- Model/provider: N/A
- Integration/channel (if any): Any that relies on cron-driven automation
- Relevant config (redacted): `cron.enabled: true` with at least one scheduled job.

### Steps

1. Configure one or more cron jobs that should fire at known times.
2. Stop the gateway, adjust system time or wait so that the jobs become due while the gateway is down, then restart the gateway.
3. Observe that after restart, `runMissedJobs` now picks up due jobs (with missing `nextRunAtMs` previously) and runs them, and `nextWakeAtMs` reflects the next proper run.

### Expected

- All due jobs are either executed on restart via `runMissedJobs` or scheduled correctly for their next run; no silent skips.

### Actual

- Before fix: Jobs with missing `nextRunAtMs` might be ignored by `runMissedJobs`, leading to effectively skipped runs and incorrect `nextWakeAtMs`.
- After fix: `recomputeNextRunsForMaintenance` seeds missing `nextRunAtMs` before `runMissedJobs`, so the scheduler behaves correctly.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (cron regression tests, including `service.issue-regressions` and `gateway/server.cron`, pass with the new startup behavior)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check`, focused cron regression tests (`src/cron/service.issue-regressions.test.ts`, `src/gateway/server.cron.test.ts`), and `pnpm openclaw gateway status --json`.
- Edge cases checked: Interaction with existing maintenance recompute paths (`recomputeNextRunsForMaintenance`), ensuring we only fill missing `nextRunAtMs` and do not advance past-due jobs.
- What you did **not** verify: All possible cron expression edge cases and long-running production