### PR TITLE
fix(tui): /models picker showed unavailable models

### DIFF
--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -25,11 +25,19 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
-      const configuredProviders = new Set(
-        Object.keys(cfg.models?.providers ?? {})
-          .map((provider) => normalizeProviderId(provider.trim()))
-          .filter(Boolean),
-      );
+      // Include providers from config AND providers with env-var API keys set
+      // so implicitly authenticated providers also appear in the picker.
+      const explicitProviders = Object.keys(cfg.models?.providers ?? {})
+        .map((provider) => normalizeProviderId(provider.trim()))
+        .filter(Boolean);
+
+      const { PROVIDER_ENV_API_KEY_CANDIDATES } =
+        await import("../../agents/model-auth-env-vars.js");
+      const envProviders = Object.entries(PROVIDER_ENV_API_KEY_CANDIDATES)
+        .filter(([, envVars]) => envVars.some((envVar) => process.env[envVar]))
+        .map(([provider]) => normalizeProviderId(provider));
+
+      const configuredProviders = new Set([...explicitProviders, ...envProviders]);
       const { allowAny, allowedCatalog } = buildAllowedModelSet({
         cfg,
         catalog,

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
-import { buildAllowedModelSet } from "../../agents/model-selection.js";
+import { buildAllowedModelSet, normalizeProviderId } from "../../agents/model-selection.js";
 import { loadConfig } from "../../config/config.js";
 import {
   ErrorCodes,
@@ -27,7 +27,7 @@ export const modelsHandlers: GatewayRequestHandlers = {
       const cfg = loadConfig();
       const configuredProviders = new Set(
         Object.keys(cfg.models?.providers ?? {})
-          .map((provider) => provider.trim().toLowerCase())
+          .map((provider) => normalizeProviderId(provider.trim()))
           .filter(Boolean),
       );
       const { allowAny, allowedCatalog } = buildAllowedModelSet({
@@ -37,7 +37,9 @@ export const modelsHandlers: GatewayRequestHandlers = {
       });
       const hasConfiguredProviders = configuredProviders.size > 0;
       const providerScopedCatalog = hasConfiguredProviders
-        ? catalog.filter((entry) => configuredProviders.has(entry.provider.trim().toLowerCase()))
+        ? catalog.filter((entry) =>
+            configuredProviders.has(normalizeProviderId(entry.provider.trim())),
+          )
         : catalog;
       const models = allowAny
         ? providerScopedCatalog.length > 0

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -25,12 +25,25 @@ export const modelsHandlers: GatewayRequestHandlers = {
     try {
       const catalog = await context.loadGatewayModelCatalog();
       const cfg = loadConfig();
-      const { allowedCatalog } = buildAllowedModelSet({
+      const configuredProviders = new Set(
+        Object.keys(cfg.models?.providers ?? {})
+          .map((provider) => provider.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      const { allowAny, allowedCatalog } = buildAllowedModelSet({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
       });
-      const models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+      const hasConfiguredProviders = configuredProviders.size > 0;
+      const providerScopedCatalog = hasConfiguredProviders
+        ? catalog.filter((entry) => configuredProviders.has(entry.provider.trim().toLowerCase()))
+        : catalog;
+      const models = allowAny
+        ? providerScopedCatalog.length > 0
+          ? providerScopedCatalog
+          : catalog
+        : allowedCatalog;
       respond(true, { models }, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(err)));

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -316,6 +316,39 @@ describe("gateway server models + voicewake", () => {
     expect(piSdkMock.discoverCalls).toBe(1);
   });
 
+  test("models.list scopes to configured providers when no allowlist is set", async () => {
+    await withModelsConfig(
+      {
+        models: {
+          providers: {
+            openai: {
+              apiKeyEnv: "OPENAI_API_KEY",
+            },
+          },
+        },
+      },
+      async () => {
+        seedPiCatalog();
+        const res = await listModels();
+
+        expect(res.ok).toBe(true);
+        expect(res.payload?.models).toEqual([
+          {
+            id: "gpt-test-a",
+            name: "A-Model",
+            provider: "openai",
+            contextWindow: 8000,
+          },
+          {
+            id: "gpt-test-z",
+            name: "gpt-test-z",
+            provider: "openai",
+          },
+        ]);
+      },
+    );
+  });
+
   test("models.list filters to allowlisted configured models by default", async () => {
     await expectAllowlistedModels({
       primary: "openai/gpt-test-z",


### PR DESCRIPTION
## Summary
- scope `models.list` fallback results to configured providers when no explicit model allowlist exists
- keep existing behavior when explicit allowlist is present
- add gateway regression test for provider-scoped fallback

## Why
Issue #28588 reports `/models` in TUI listing many models that are not configured/selectable. This patch narrows picker entries to configured providers in the common allow-any case, avoiding misleading options.

## Testing
- `pnpm -C openclaw-repo test src/gateway/server.models-voicewake-misc.test.ts`

Closes #28588
