### PR TITLE
feat(plugins): add api.invokeAgent() for direct agent invocation from plugins

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { agentCommand } from "../commands/agent.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
@@ -499,6 +500,20 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerCommand: (command) => registerCommand(record, command),
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts),
+      invokeAgent: async (opts) => {
+        const result = await agentCommand({
+          message: opts.message,
+          sessionKey: opts.sessionKey,
+          extraSystemPrompt: opts.systemPrompt,
+          deliver: false,
+          timeout: opts.timeout?.toString(),
+        });
+        const payloads = result.payloads ?? [];
+        return payloads
+          .map((p) => (typeof p.text === "string" ? p.text : ""))
+          .filter(Boolean)
+          .join("\n\n");
+      },
     };
   };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -281,6 +281,16 @@ export type OpenClawPluginApi = {
     handler: PluginHookHandlerMap[K],
     opts?: { priority?: number },
   ) => void;
+  /**
+   * Invoke an agent directly without going through the HTTP gateway.
+   * Returns the agent's response text.
+   */
+  invokeAgent: (opts: {
+    message: string;
+    sessionKey?: string;
+    systemPrompt?: string;
+    timeout?: number;
+  }) => Promise<string>;
 };
 
 export type PluginOrigin = "bundled" | "global" | "workspace" | "config";


### PR DESCRIPTION
## Summary

- Adds `api.invokeAgent()` to `OpenClawPluginApi` in `src/plugins/types.ts`
- Implements it in `createApi()` in `src/plugins/registry.ts` by calling `agentCommand()` directly
- Allows plugins to invoke an agent and receive a text response without going through the HTTP gateway

## Motivation

Plugins that need to converse with an agent (e.g. a voice chat plugin receiving speech input and needing an AI response) currently have no clean path. The only option is:

1. Enable `gateway.http.endpoints.chatCompletions: true`
2. Make an HTTP POST to `127.0.0.1:<port>/v1/chat/completions` — a loopback call from within the same process

This is wasteful and requires extra configuration. `api.invokeAgent()` gives plugins a first-class, direct path to agent invocation, consistent with how built-in channels work internally.

## Usage

```typescript
const response = await api.invokeAgent({
  message: "Hello from a plugin",
  sessionKey: "my-agent",           // optional, routes to specific session
  systemPrompt: "Keep it brief.",   // optional extra system context
  timeout: 30000,                   // optional ms
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)