### PR TITLE
fix(agents): validate bootstrap cache freshness via mtime checks

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -9,9 +9,13 @@ import {
 } from "./bootstrap-cache.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
-vi.mock("./workspace.js", () => ({
-  loadWorkspaceBootstrapFiles: vi.fn(),
-}));
+vi.mock("./workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./workspace.js")>();
+  return {
+    ...actual,
+    loadWorkspaceBootstrapFiles: vi.fn(),
+  };
+});
 
 import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
@@ -224,6 +228,47 @@ describe("mtime-based staleness detection", () => {
     // Second load — should detect creation and reload
     const r2 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
     expect(r2[0]?.content).toBe("# Tools");
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads when MEMORY.md is created after initial cache (optional file)", async () => {
+    const memoryPath = path.join(tmpDir, "MEMORY.md");
+    // Initial load returns no memory file (it didn't exist)
+    const v1: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+    ];
+    const v2: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+      {
+        name: "MEMORY.md" as WorkspaceBootstrapFile["name"],
+        path: memoryPath,
+        content: "# Memory",
+        missing: false,
+      },
+    ];
+    mockLoad.mockResolvedValueOnce(v1).mockResolvedValueOnce(v2);
+
+    // First load — MEMORY.md absent, not in file list but watched via sentinel
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Create MEMORY.md on disk
+    fs.writeFileSync(memoryPath, "# Memory");
+
+    // Second load — should detect creation of optional file and reload
+    const r2 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(r2).toHaveLength(2);
+    expect(r2[1]?.content).toBe("# Memory");
     expect(mockLoad).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearAllBootstrapSnapshots,
@@ -96,5 +99,102 @@ describe("clearBootstrapSnapshot", () => {
     // sk2 should still be cached.
     await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "sk2" });
     expect(mockLoad).toHaveBeenCalledTimes(2); // sk1 x1, sk2 x1
+  });
+});
+
+describe("mtime-based staleness detection", () => {
+  let tmpDir: string;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    clearAllBootstrapSnapshots();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bootstrap-cache-test-"));
+    tmpFile = path.join(tmpDir, "USER.md");
+    fs.writeFileSync(tmpFile, "# v1");
+  });
+
+  afterEach(() => {
+    clearAllBootstrapSnapshots();
+    vi.clearAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reloads when a cached file's mtime changes", async () => {
+    const v1: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+    ];
+    const v2: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v2",
+        missing: false,
+      },
+    ];
+    mockLoad.mockResolvedValueOnce(v1).mockResolvedValueOnce(v2);
+
+    // First load — caches v1
+    const r1 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(r1[0]?.content).toBe("# v1");
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Modify file on disk (bumps mtime)
+    const futureTime = new Date(Date.now() + 2000);
+    fs.writeFileSync(tmpFile, "# v2");
+    fs.utimesSync(tmpFile, futureTime, futureTime);
+
+    // Second load — stale mtime detected, reloads
+    const r2 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(r2[0]?.content).toBe("# v2");
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads when a cached file is deleted", async () => {
+    const v1: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+    ];
+    const v2: WorkspaceBootstrapFile[] = [
+      { name: "USER.md" as WorkspaceBootstrapFile["name"], path: tmpFile, missing: true },
+    ];
+    mockLoad.mockResolvedValueOnce(v1).mockResolvedValueOnce(v2);
+
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Delete the file
+    fs.unlinkSync(tmpFile);
+
+    // Should detect deletion and reload
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reload when file is unchanged", async () => {
+    const v1: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+    ];
+    mockLoad.mockResolvedValue(v1);
+
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+
+    // File unchanged — should only load once
+    expect(mockLoad).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -231,6 +231,37 @@ describe("mtime-based staleness detection", () => {
     expect(mockLoad).toHaveBeenCalledTimes(2);
   });
 
+  it("does not false-positive stale when MEMORY.md exists (optional file tracking)", async () => {
+    // Regression: optional file seeding must stat the path rather than blindly
+    // using MISSING_SENTINEL, otherwise on case-insensitive filesystems (macOS)
+    // memory.md resolves to MEMORY.md and the cache appears stale every time.
+    const memoryPath = path.join(tmpDir, "MEMORY.md");
+    fs.writeFileSync(memoryPath, "# Memory");
+
+    const v1: WorkspaceBootstrapFile[] = [
+      {
+        name: "USER.md" as WorkspaceBootstrapFile["name"],
+        path: tmpFile,
+        content: "# v1",
+        missing: false,
+      },
+      {
+        name: "MEMORY.md" as WorkspaceBootstrapFile["name"],
+        path: memoryPath,
+        content: "# Memory",
+        missing: false,
+      },
+    ];
+    mockLoad.mockResolvedValue(v1);
+
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+
+    // Should only load once — optional file seeding must not cause false staleness
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+  });
+
   it("reloads when MEMORY.md is created after initial cache (optional file)", async () => {
     const memoryPath = path.join(tmpDir, "MEMORY.md");
     // Initial load returns no memory file (it didn't exist)

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -197,4 +197,33 @@ describe("mtime-based staleness detection", () => {
     // File unchanged — should only load once
     expect(mockLoad).toHaveBeenCalledTimes(1);
   });
+
+  it("reloads when a previously missing file is created", async () => {
+    const missingPath = path.join(tmpDir, "TOOLS.md");
+    const v1: WorkspaceBootstrapFile[] = [
+      { name: "TOOLS.md" as WorkspaceBootstrapFile["name"], path: missingPath, missing: true },
+    ];
+    const v2: WorkspaceBootstrapFile[] = [
+      {
+        name: "TOOLS.md" as WorkspaceBootstrapFile["name"],
+        path: missingPath,
+        content: "# Tools",
+        missing: false,
+      },
+    ];
+    mockLoad.mockResolvedValueOnce(v1).mockResolvedValueOnce(v2);
+
+    // First load — file missing, cached as missing
+    const r1 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(r1[0]?.missing).toBe(true);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+
+    // Create the file on disk
+    fs.writeFileSync(missingPath, "# Tools");
+
+    // Second load — should detect creation and reload
+    const r2 = await getOrLoadBootstrapFiles({ workspaceDir: tmpDir, sessionKey: "s1" });
+    expect(r2[0]?.content).toBe("# Tools");
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,5 +1,11 @@
 import { statSync } from "node:fs";
-import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
+import path from "node:path";
+import {
+  DEFAULT_MEMORY_ALT_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
+  loadWorkspaceBootstrapFiles,
+  type WorkspaceBootstrapFile,
+} from "./workspace.js";
 
 interface CachedSnapshot {
   files: WorkspaceBootstrapFile[];
@@ -11,8 +17,18 @@ const cache = new Map<string, CachedSnapshot>();
 
 const MISSING_SENTINEL = -1;
 
+/**
+ * Optional bootstrap files that `loadWorkspaceBootstrapFiles` only includes
+ * when they exist on disk. We watch their paths even when absent so that
+ * creating one mid-session invalidates the cache.
+ */
+const OPTIONAL_BOOTSTRAP_FILENAMES = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME];
+
 /** Capture mtimeMs for each bootstrap file (missing files use a sentinel). */
-function snapshotMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
+function snapshotMtimes(
+  files: WorkspaceBootstrapFile[],
+  workspaceDir: string,
+): Map<string, number> {
   const m = new Map<string, number>();
   for (const f of files) {
     if (f.missing) {
@@ -23,6 +39,13 @@ function snapshotMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
       } catch {
         m.set(f.path, MISSING_SENTINEL);
       }
+    }
+  }
+  // Seed optional files that may not be in the list yet.
+  for (const name of OPTIONAL_BOOTSTRAP_FILENAMES) {
+    const filePath = path.join(workspaceDir, name);
+    if (!m.has(filePath)) {
+      m.set(filePath, MISSING_SENTINEL);
     }
   }
   return m;
@@ -56,7 +79,7 @@ export async function getOrLoadBootstrapFiles(params: {
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, { files, mtimes: snapshotMtimes(files) });
+  cache.set(params.sessionKey, { files, mtimes: snapshotMtimes(files, params.workspaceDir) });
   return files;
 }
 

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -42,10 +42,16 @@ function snapshotMtimes(
     }
   }
   // Seed optional files that may not be in the list yet.
+  // Use stat (not a blind sentinel) so case-insensitive filesystems (macOS)
+  // don't false-positive when e.g. MEMORY.md exists but memory.md is seeded.
   for (const name of OPTIONAL_BOOTSTRAP_FILENAMES) {
     const filePath = path.join(workspaceDir, name);
     if (!m.has(filePath)) {
-      m.set(filePath, MISSING_SENTINEL);
+      try {
+        m.set(filePath, statSync(filePath).mtimeMs);
+      } catch {
+        m.set(filePath, MISSING_SENTINEL);
+      }
     }
   }
   return m;

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,18 +1,55 @@
+import { statSync } from "node:fs";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
-const cache = new Map<string, WorkspaceBootstrapFile[]>();
+interface CachedSnapshot {
+  files: WorkspaceBootstrapFile[];
+  /** file path → mtimeMs at the time of caching */
+  mtimes: Map<string, number>;
+}
+
+const cache = new Map<string, CachedSnapshot>();
+
+/** Capture mtimeMs for each non-missing bootstrap file. */
+function snapshotMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const f of files) {
+    if (!f.missing) {
+      try {
+        m.set(f.path, statSync(f.path).mtimeMs);
+      } catch {
+        // file may have been deleted since load — skip
+      }
+    }
+  }
+  return m;
+}
+
+/** True when any cached file's mtime has changed on disk. */
+function isStale(snap: CachedSnapshot): boolean {
+  for (const [filePath, cachedMtime] of snap.mtimes) {
+    try {
+      if (statSync(filePath).mtimeMs !== cachedMtime) {
+        return true;
+      }
+    } catch {
+      // file deleted → stale
+      return true;
+    }
+  }
+  return false;
+}
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
 }): Promise<WorkspaceBootstrapFile[]> {
-  const existing = cache.get(params.sessionKey);
-  if (existing) {
-    return existing;
+  const snap = cache.get(params.sessionKey);
+  if (snap && !isStale(snap)) {
+    return snap.files;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(params.sessionKey, { files, mtimes: snapshotMtimes(files) });
   return files;
 }
 

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -9,15 +9,19 @@ interface CachedSnapshot {
 
 const cache = new Map<string, CachedSnapshot>();
 
-/** Capture mtimeMs for each non-missing bootstrap file. */
+const MISSING_SENTINEL = -1;
+
+/** Capture mtimeMs for each bootstrap file (missing files use a sentinel). */
 function snapshotMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
   const m = new Map<string, number>();
   for (const f of files) {
-    if (!f.missing) {
+    if (f.missing) {
+      m.set(f.path, MISSING_SENTINEL);
+    } else {
       try {
         m.set(f.path, statSync(f.path).mtimeMs);
       } catch {
-        // file may have been deleted since load — skip
+        m.set(f.path, MISSING_SENTINEL);
       }
     }
   }
@@ -28,12 +32,15 @@ function snapshotMtimes(files: WorkspaceBootstrapFile[]): Map<string, number> {
 function isStale(snap: CachedSnapshot): boolean {
   for (const [filePath, cachedMtime] of snap.mtimes) {
     try {
-      if (statSync(filePath).mtimeMs !== cachedMtime) {
+      const currentMtime = statSync(filePath).mtimeMs;
+      if (cachedMtime === MISSING_SENTINEL || currentMtime !== cachedMtime) {
         return true;
       }
     } catch {
-      // file deleted → stale
-      return true;
+      // file doesn't exist on disk — stale only if it was present before
+      if (cachedMtime !== MISSING_SENTINEL) {
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
## Summary

- The per-session bootstrap cache in `bootstrap-cache.ts` never validated freshness — once cached on first load, workspace files (USER.md, MEMORY.md, AGENTS.md, etc.) were served stale indefinitely to running sessions
- Now stores file mtimes alongside the snapshot and stats on each cache hit (~7-9 cheap syscalls) to detect changes, reloading only when a file's mtime has changed or a file was deleted
- Preserves the cache optimization (no disk reads when nothing changed)

Closes #28594

## Test plan

- [x] Existing `bootstrap-cache.test.ts` tests pass (cache hit, cache miss, clear, independent sessions)
- [x] New test: cache reloads when a file's mtime changes
- [x] New test: cache reloads when a cached file is deleted
- [x] New test: cache does NOT reload when files are unchanged (perf preserved)
- [x] `workspace.bootstrap-cache.test.ts` and `bootstrap-files.test.ts` still pass
- [x] `pnpm check` (lint + format + typecheck) passes
- [ ] Manual verification: write to USER.md from one group topic session, read from another — data is visible without gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)