### PR TITLE
Feature: bwrap as sandbox backend

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -7,11 +7,18 @@ status: active
 
 # Sandbox CLI
 
-Manage Docker-based sandbox containers for isolated agent execution.
+Manage sandbox containers and inspect effective sandbox policy.
 
 ## Overview
 
-OpenClaw can run agents in isolated Docker containers for security. The `sandbox` commands help you manage these containers, especially after updates or configuration changes.
+OpenClaw can run agents in isolated sandboxes for security. Two backends are
+supported: **Docker** (persistent containers) and **bwrap** (Linux namespace
+isolation). The `sandbox` commands help you manage containers and inspect
+effective policy.
+
+Note: `sandbox list` and `sandbox recreate` apply to the **Docker backend
+only** (bwrap has no persistent containers to manage). `sandbox explain` works
+with both backends.
 
 ## Commands
 
@@ -123,12 +130,15 @@ Gateway’s container naming and avoids mismatches when scope/session keys chang
 
 Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sandbox` (per-agent overrides go in `agents.list[].sandbox`):
 
+**Docker backend:**
+
 ```jsonc
 {
   "agents": {
     "defaults": {
       "sandbox": {
         "mode": "all", // off, non-main, all
+        "backend": "docker", // docker (default) or bwrap
         "scope": "agent", // session, agent, shared
         "docker": {
           "image": "openclaw-sandbox:bookworm-slim",
@@ -138,6 +148,29 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
         "prune": {
           "idleHours": 24, // Auto-prune after 24h idle
           "maxAgeDays": 7, // Auto-prune after 7 days
+        },
+      },
+    },
+  },
+}
+```
+
+**bwrap backend** (Linux only, no Docker required):
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "all",
+        "backend": "bwrap",
+        "scope": "session",
+        "bwrap": {
+          "workdir": "/workspace",
+          "unshareNet": true,
+          "unsharePid": true,
+          "readOnlyRoot": true,
+          "mountProc": true,
         },
       },
     },

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -288,6 +288,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       },
       sandbox: {
         mode: "non-main",
+        backend: "docker", // or "bwrap" for Linux namespace isolation
         perSession: true,
         workspaceRoot: "~/.openclaw/sandboxes",
         docker: {

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -931,7 +931,7 @@ See [Typing Indicators](/concepts/typing-indicators).
 
 ### `agents.defaults.sandbox`
 
-Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway/sandboxing) for the full guide.
+Optional **sandboxing** for the embedded agent. Two backends are supported: **Docker** (default) and **bubblewrap (bwrap)**. See [Sandboxing](/gateway/sandboxing) for the full guide.
 
 ```json5
 {
@@ -939,6 +939,7 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
     defaults: {
       sandbox: {
         mode: "non-main", // off | non-main | all
+        backend: "docker", // docker | bwrap
         scope: "agent", // session | agent | shared
         workspaceAccess: "none", // none | ro | rw
         workspaceRoot: "~/.openclaw/sandboxes",
@@ -966,6 +967,21 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
           dns: ["1.1.1.1", "8.8.8.8"],
           extraHosts: ["internal.service:10.0.0.5"],
           binds: ["/home/user/source:/source:rw"],
+        },
+        bwrap: {
+          workdir: "/workspace",
+          readOnlyRoot: true,
+          tmpfs: ["/tmp", "/var/tmp", "/run"],
+          unshareNet: true,
+          unsharePid: true,
+          unshareIpc: true,
+          unshareCgroup: false,
+          newSession: true,
+          dieWithParent: true,
+          mountProc: true,
+          rootBinds: ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc"],
+          extraBinds: ["/home/user/data:/data:ro"],
+          env: { LANG: "C.UTF-8" },
         },
         browser: {
           enabled: false,
@@ -1013,6 +1029,11 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
 
 <Accordion title="Sandbox details">
 
+**Backend:**
+
+- `docker` (default): persistent Docker containers. Requires Docker Engine.
+- `bwrap`: lightweight Linux namespace isolation via [bubblewrap](https://github.com/containers/bubblewrap). No Docker required. Linux only.
+
 **Workspace access:**
 
 - `none`: per-scope sandbox workspace under `~/.openclaw/sandboxes`
@@ -1035,7 +1056,7 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
 
 **`docker.binds`** mounts additional host directories; global and per-agent binds are merged.
 
-**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in main config.
+**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in main config. Only available with the Docker backend.
 noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL (instead of exposing the password in the shared URL).
 
 - `allowHostControl: false` (default) blocks sandboxed sessions from targeting the host browser.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -203,8 +203,9 @@ When validation fails:
   </Accordion>
 
   <Accordion title="Enable sandboxing">
-    Run agent sessions in isolated Docker containers:
+    Run agent sessions in isolated sandboxes. Two backends are available:
 
+    **Docker** (default):
     ```json5
     {
       agents: {
@@ -219,6 +220,23 @@ When validation fails:
     ```
 
     Build the image first: `scripts/sandbox-setup.sh`
+
+    **Bubblewrap (bwrap)** — Linux only, no Docker required:
+    ```json5
+    {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "non-main",
+            backend: "bwrap",
+            scope: "session",
+          },
+        },
+      },
+    }
+    ```
+
+    Requires `bwrap` on `$PATH` (`apt install bubblewrap`).
 
     See [Sandboxing](/gateway/sandboxing) for the full guide and [full reference](/gateway/configuration-reference#sandbox) for all options.
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -198,8 +198,11 @@ catalog and allowlist and warns when it won’t resolve or is disallowed.
 
 ### 7) Sandbox image repair
 
-When sandboxing is enabled, doctor checks Docker images and offers to build or
-switch to legacy names if the current image is missing.
+When sandboxing is enabled with the Docker backend, doctor checks Docker images
+and offers to build or switch to legacy names if the current image is missing.
+
+When using the bwrap backend, doctor checks that the `bwrap` binary is available
+on `$PATH` and that user namespaces are enabled on the host.
 
 ### 8) Gateway service migrations and cleanup hints
 

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -9,7 +9,7 @@ status: active
 
 OpenClaw has three related (but different) controls:
 
-1. **Sandbox** (`agents.defaults.sandbox.*` / `agents.list[].sandbox.*`) decides **where tools run** (Docker vs host).
+1. **Sandbox** (`agents.defaults.sandbox.*` / `agents.list[].sandbox.*`) decides **where tools run** (Docker / bwrap / host).
 2. **Tool policy** (`tools.*`, `tools.sandbox.tools.*`, `agents.list[].tools.*`) decides **which tools are available/allowed**.
 3. **Elevated** (`tools.elevated.*`, `agents.list[].tools.elevated.*`) is an **exec-only escape hatch** to run on the host when you’re sandboxed.
 
@@ -33,17 +33,25 @@ It prints:
 
 ## Sandbox: where tools run
 
-Sandboxing is controlled by `agents.defaults.sandbox.mode`:
+Sandboxing is controlled by `agents.defaults.sandbox.mode` and `agents.defaults.sandbox.backend`:
+
+Mode:
 
 - `"off"`: everything runs on the host.
-- `"non-main"`: only non-main sessions are sandboxed (common “surprise” for groups/channels).
+- `"non-main"`: only non-main sessions are sandboxed (common "surprise" for groups/channels).
 - `"all"`: everything is sandboxed.
 
-See [Sandboxing](/gateway/sandboxing) for the full matrix (scope, workspace mounts, images).
+Backend:
+
+- `"docker"` (default): persistent Docker containers.
+- `"bwrap"`: lightweight Linux namespace isolation via bubblewrap. No Docker required.
+
+See [Sandboxing](/gateway/sandboxing) for the full matrix (scope, workspace mounts, images, bwrap config).
 
 ### Bind mounts (security quick check)
 
-- `docker.binds` _pierces_ the sandbox filesystem: whatever you mount is visible inside the container with the mode you set (`:ro` or `:rw`).
+- Docker: `docker.binds` _pierces_ the sandbox filesystem: whatever you mount is visible inside the container with the mode you set (`:ro` or `:rw`).
+- bwrap: `bwrap.extraBinds` does the same for namespace mounts.
 - Default is read-write if you omit the mode; prefer `:ro` for source/secrets.
 - `scope: "shared"` ignores per-agent binds (only global binds apply).
 - Binding `/var/run/docker.sock` effectively hands host control to the sandbox; only do this intentionally.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -7,8 +7,13 @@ status: active
 
 # Sandboxing
 
-OpenClaw can run **tools inside Docker containers** to reduce blast radius.
-This is **optional** and controlled by configuration (`agents.defaults.sandbox` or
+OpenClaw can run **tools inside isolated sandboxes** to reduce blast radius.
+Two sandbox backends are supported:
+
+- **Docker** (default): persistent containers via Docker Engine.
+- **Bubblewrap (bwrap)**: lightweight Linux namespace isolation without Docker.
+
+Sandboxing is **optional** and controlled by configuration (`agents.defaults.sandbox` or
 `agents.list[].sandbox`). If sandboxing is off, tools run on the host.
 The Gateway stays on the host; tool execution runs in an isolated sandbox
 when enabled.
@@ -186,6 +191,99 @@ Debugging:
 Each agent can override sandbox + tools:
 `agents.list[].sandbox` and `agents.list[].tools` (plus `agents.list[].tools.sandbox.tools` for sandbox tool policy).
 See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for precedence.
+
+## Backend: Docker vs Bubblewrap
+
+`agents.defaults.sandbox.backend` selects the isolation runtime:
+
+- `"docker"` (default): uses persistent Docker containers. Requires Docker Engine.
+- `"bwrap"`: uses [bubblewrap](https://github.com/containers/bubblewrap) Linux
+  namespace isolation. No Docker required. Each tool invocation runs in a fresh
+  namespace — there is no persistent container.
+
+### When to use bwrap
+
+- Linux hosts where Docker is unavailable or undesirable (e.g. VPS without Docker, CI, Podman-only setups).
+- You want lightweight per-invocation isolation without container image management.
+- You don't need the browser sandbox (bwrap does not support sandboxed browser containers).
+
+### When to use Docker
+
+- You want the strongest isolation with cgroups, seccomp, AppArmor, and resource limits.
+- You need sandboxed browser support (Chromium + CDP in a container).
+- You're on macOS or Windows (bwrap is Linux-only).
+
+### Minimal bwrap enable example
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "non-main",
+        backend: "bwrap",
+        scope: "session",
+        workspaceAccess: "none",
+      },
+    },
+  },
+}
+```
+
+Requirements:
+
+- Linux with user namespace support (`sysctl kernel.unprivileged_userns_clone=1` or root).
+- `bwrap` binary on `$PATH` (install via `apt install bubblewrap`, `dnf install bubblewrap`, etc.).
+- The host filesystem paths `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/etc` are
+  bind-mounted read-only into the namespace by default.
+
+### bwrap configuration
+
+`agents.defaults.sandbox.bwrap` controls namespace settings:
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        backend: "bwrap",
+        mode: "all",
+        workspaceAccess: "rw",
+        bwrap: {
+          workdir: "/workspace", // namespace CWD (default: "/workspace")
+          readOnlyRoot: true, // read-only root fs (default: true)
+          tmpfs: ["/tmp", "/var/tmp", "/run"], // tmpfs mounts (default)
+          unshareNet: true, // no network (default: true)
+          unsharePid: true, // PID namespace (default: true)
+          unshareIpc: true, // IPC namespace (default: true)
+          unshareCgroup: false, // cgroup namespace (default: false)
+          newSession: true, // TIOCSTI protection (default: true)
+          dieWithParent: true, // kill on parent exit (default: true)
+          mountProc: true, // mount /proc in namespace (default: true)
+          rootBinds: ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc"],
+          extraBinds: ["/home/user/data:/data:ro"],
+          env: { LANG: "C.UTF-8" },
+        },
+      },
+    },
+  },
+}
+```
+
+### Differences from Docker backend
+
+| Feature                   | Docker                        | bwrap                          |
+| ------------------------- | ----------------------------- | ------------------------------ |
+| Persistent container      | Yes                           | No (fresh namespace per call)  |
+| Container image           | Required                      | Not needed                     |
+| Browser sandbox           | Supported                     | Not supported                  |
+| Network isolation         | `docker.network: "none"`      | `bwrap.unshareNet: true`       |
+| Resource limits (cgroups) | `memory`, `cpus`, `pidsLimit` | Not available                  |
+| Seccomp / AppArmor        | Supported                     | Not available                  |
+| Custom bind mounts        | `docker.binds`                | `bwrap.extraBinds`             |
+| Setup command             | Runs once per container       | Runs once per namespace        |
+| `sandbox recreate`        | Removes container             | No-op (no container to remove) |
+| Platform                  | Linux, macOS, Windows         | Linux only                     |
 
 ## Minimal enable example
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -14,7 +14,7 @@ Docker is **optional**. Use it only if you want a containerized gateway or to va
 
 - **Yes**: you want an isolated, throwaway gateway environment or to run OpenClaw on a host without local installs.
 - **No**: you’re running on your own machine and just want the fastest dev loop. Use the normal install flow instead.
-- **Sandboxing note**: agent sandboxing uses Docker too, but it does **not** require the full gateway to run in Docker. See [Sandboxing](/gateway/sandboxing).
+- **Sandboxing note**: agent sandboxing uses Docker too, but it does **not** require the full gateway to run in Docker. On Linux, you can also use the [bubblewrap (bwrap) sandbox backend](/gateway/sandboxing#backend-docker-vs-bubblewrap) as a lightweight alternative that doesn't require Docker at all. See [Sandboxing](/gateway/sandboxing).
 
 This guide covers:
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -471,7 +471,14 @@ if (fallbackThinking) {
 
 ## Sandbox Integration
 
-When sandbox mode is enabled, tools and paths are constrained:
+When sandbox mode is enabled, tools and paths are constrained.
+`resolveSandboxContext()` branches on the configured backend:
+
+- **Docker** (`backend: "docker"`): creates/starts a persistent container via
+  `ensureSandboxContainer()`, file I/O goes through `SandboxFsBridge` (Docker exec).
+- **bwrap** (`backend: "bwrap"`): checks `bwrap` availability via
+  `ensureBwrapAvailable()`, file I/O goes through `BwrapFsBridgeImpl`
+  (each operation spawns a fresh namespace).
 
 ```typescript
 const sandbox = await resolveSandboxContext({
@@ -482,10 +489,20 @@ const sandbox = await resolveSandboxContext({
 
 if (sandboxRoot) {
   // Use sandboxed read/edit/write tools
-  // Exec runs in container
-  // Browser uses bridge URL
+  // Exec runs in container (docker) or namespace (bwrap)
+  // Browser uses bridge URL (Docker only)
 }
 ```
+
+Key files:
+
+- `src/agents/sandbox/context.ts` — backend-aware context resolution
+- `src/agents/sandbox/docker.ts` — Docker container lifecycle
+- `src/agents/sandbox/bwrap.ts` — bwrap arg building + availability checks
+- `src/agents/sandbox/bwrap-fs-bridge.ts` — `SandboxFsBridge` impl for bwrap
+- `src/agents/sandbox/fs-bridge.ts` — Docker `SandboxFsBridge` impl
+- `src/agents/bash-tools.exec-runtime.ts` — exec spawn (branches on backend)
+- `src/agents/bash-tools.shared.ts` — `buildDockerExecArgs` / `buildBwrapExecArgs`
 
 ## Provider-Specific Handling
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -34,6 +34,48 @@ Step-by-step VPS guide: [exe.dev](/install/exe-dev)
 - [Gateway runbook](/gateway)
 - [Configuration](/gateway/configuration)
 
+## Sandboxing
+
+On Linux, you can sandbox agent tools using two backends:
+
+- **Docker**: persistent containers via Docker Engine. See [Docker install](/install/docker).
+- **Bubblewrap (bwrap)**: lightweight Linux namespace isolation without Docker. Install via your package manager:
+
+```bash
+# Debian/Ubuntu
+sudo apt install bubblewrap
+
+# Fedora/RHEL
+sudo dnf install bubblewrap
+
+# Arch
+sudo pacman -S bubblewrap
+```
+
+Enable bwrap sandboxing:
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        mode: "non-main",
+        backend: "bwrap",
+      },
+    },
+  },
+}
+```
+
+bwrap requires Linux with user namespace support. Check:
+
+```bash
+sysctl kernel.unprivileged_userns_clone
+# Should return 1. If 0: sudo sysctl kernel.unprivileged_userns_clone=1
+```
+
+See [Sandboxing](/gateway/sandboxing) for the full guide.
+
 ## Gateway service install (CLI)
 
 Use one of these:

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -93,7 +93,7 @@ Nothing is explicitly out of scope for this threat model.
 │                 TRUST BOUNDARY 3: Tool Execution                 │
 │  ┌──────────────────────────────────────────────────────────┐   │
 │  │                  EXECUTION SANDBOX                        │   │
-│  │  • Docker sandbox OR Host (exec-approvals)                │   │
+│  │  • Docker sandbox OR bwrap sandbox OR Host (exec-approvals)│   │
 │  │  • Node remote execution                                  │   │
 │  │  • SSRF protection (DNS pinning + IP blocking)            │   │
 │  └──────────────────────────────────────────────────────────┘   │
@@ -397,15 +397,15 @@ Nothing is explicitly out of scope for this threat model.
 
 #### T-IMPACT-001: Unauthorized Command Execution
 
-| Attribute               | Value                                               |
-| ----------------------- | --------------------------------------------------- |
-| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                |
-| **Description**         | Attacker executes arbitrary commands on user system |
-| **Attack Vector**       | Prompt injection combined with exec approval bypass |
-| **Affected Components** | Bash tool, command execution                        |
-| **Current Mitigations** | Exec approvals, Docker sandbox option               |
-| **Residual Risk**       | Critical - Host execution without sandbox           |
-| **Recommendations**     | Default to sandbox, improve approval UX             |
+| Attribute               | Value                                                       |
+| ----------------------- | ----------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0031 - Erode AI Model Integrity                        |
+| **Description**         | Attacker executes arbitrary commands on user system         |
+| **Attack Vector**       | Prompt injection combined with exec approval bypass         |
+| **Affected Components** | Bash tool, command execution                                |
+| **Current Mitigations** | Exec approvals, Docker sandbox option, bwrap sandbox option |
+| **Residual Risk**       | Critical - Host execution without sandbox                   |
+| **Recommendations**     | Default to sandbox (Docker or bwrap), improve approval UX   |
 
 #### T-IMPACT-002: Resource Exhaustion (DoS)
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -9,6 +9,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { buildBwrapExecArgs } from "./bash-tools.shared.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
 import { logWarn } from "../logger.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
@@ -377,6 +378,27 @@ export async function runExecProcess(opts: {
         stdinMode: "pipe-open";
       } = (() => {
     if (opts.sandbox) {
+      if (opts.sandbox.backend === "bwrap" && opts.sandbox.bwrap) {
+        // Bubblewrap backend: each exec is a fresh namespace invocation.
+        return {
+          mode: "child" as const,
+          argv: [
+            "bwrap",
+            ...buildBwrapExecArgs({
+              cfg: opts.sandbox.bwrap,
+              workspaceDir: opts.sandbox.workspaceDir,
+              workspaceAccess: opts.sandbox.workspaceAccess ?? "rw",
+              command: execCommand,
+              workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+              env: opts.env,
+              tty: opts.usePty,
+            }),
+          ],
+          env: process.env,
+          stdinMode: opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const),
+        };
+      }
+      // Docker backend: exec into existing container.
       return {
         mode: "child" as const,
         argv: [

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -4,14 +4,24 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { sliceUtf16Safe } from "../utils.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import { buildBwrapArgs } from "./sandbox/bwrap.js";
+import type { SandboxBwrapConfig } from "./sandbox/types.bwrap.js";
+import type { SandboxWorkspaceAccess } from "./sandbox/types.js";
 
 const CHUNK_LIMIT = 8 * 1024;
 
 export type BashSandboxConfig = {
+  /** Sandbox backend in use. */
+  backend: "docker" | "bwrap";
+  /** Docker container name (only meaningful for docker backend). */
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;
   env?: Record<string, string>;
+  /** Bwrap config (only present for bwrap backend). */
+  bwrap?: SandboxBwrapConfig;
+  /** Workspace access mode (used by bwrap to set bind mount permissions). */
+  workspaceAccess?: SandboxWorkspaceAccess;
 };
 
 export function buildSandboxEnv(params: {
@@ -77,6 +87,32 @@ export function buildDockerExecArgs(params: {
     : "";
   args.push(params.containerName, "sh", "-lc", `${pathExport}${params.command}`);
   return args;
+}
+
+/**
+ * Build a bwrap argv (excluding the "bwrap" binary) for an exec tool invocation.
+ * Unlike Docker, each invocation spins up a fresh namespace.
+ */
+export function buildBwrapExecArgs(params: {
+  cfg: SandboxBwrapConfig;
+  workspaceDir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+  command: string;
+  workdir?: string;
+  env: Record<string, string>;
+  tty: boolean;
+}): string[] {
+  // Delegate to the bwrap module's buildBwrapArgs which handles namespace flags,
+  // bind mounts, etc. We only need to merge env and workdir here.
+  return buildBwrapArgs({
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    workspaceAccess: params.workspaceAccess,
+    command: params.command,
+    workdir: params.workdir,
+    env: params.env,
+    tty: params.tty,
+  });
 }
 
 export async function resolveSandboxWorkdir(params: {

--- a/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
+++ b/src/agents/pi-embedded-runner.buildembeddedsandboxinfo.test.ts
@@ -5,6 +5,7 @@ import type { SandboxContext } from "./sandbox.js";
 function createSandboxContext(overrides?: Partial<SandboxContext>): SandboxContext {
   const base = {
     enabled: true,
+    backend: "docker",
     sessionKey: "session:test",
     workspaceDir: "/tmp/openclaw-sandbox",
     agentWorkspaceDir: "/tmp/openclaw-workspace",

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -570,6 +570,7 @@ describe("Agent-specific tool filtering", () => {
       agentDir: "/tmp/agent-restricted",
       sandbox: {
         enabled: true,
+        backend: "docker",
         sessionKey: "agent:restricted:main",
         workspaceDir: "/tmp/sandbox",
         agentWorkspaceDir: "/tmp/test-restricted",

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -400,10 +400,13 @@ export function createOpenClawCodingTools(options?: {
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
     sandbox: sandbox
       ? {
+          backend: sandbox.backend ?? "docker",
           containerName: sandbox.containerName,
           workspaceDir: sandbox.workspaceDir,
           containerWorkdir: sandbox.containerWorkdir,
-          env: sandbox.docker.env,
+          env: sandbox.backend === "bwrap" ? sandbox.bwrap?.env : sandbox.docker.env,
+          bwrap: sandbox.bwrap,
+          workspaceAccess: sandbox.workspaceAccess,
         }
       : undefined,
   });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -48,6 +48,7 @@ function buildConfig(enableNoVnc: boolean): SandboxConfig {
   return {
     mode: "all",
     scope: "session",
+    backend: "docker",
     workspaceAccess: "none",
     workspaceRoot: "/tmp/openclaw-sandboxes",
     docker: {
@@ -81,6 +82,18 @@ function buildConfig(enableNoVnc: boolean): SandboxConfig {
     prune: {
       idleHours: 24,
       maxAgeDays: 7,
+    },
+    bwrap: {
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      unshareNet: true,
+      unsharePid: true,
+      unshareIpc: true,
+      unshareCgroup: false,
+      newSession: true,
+      dieWithParent: true,
+      mountProc: true,
     },
   };
 }

--- a/src/agents/sandbox/bwrap-fs-bridge.test.ts
+++ b/src/agents/sandbox/bwrap-fs-bridge.test.ts
@@ -1,0 +1,373 @@
+import fs from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./bwrap.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./bwrap.js")>();
+  return {
+    ...actual,
+    execBwrapRaw: vi.fn(),
+    buildBwrapFsBridgeArgs: actual.buildBwrapFsBridgeArgs,
+    parseBwrapBind: actual.parseBwrapBind,
+  };
+});
+
+vi.mock("../../infra/boundary-file-read.js", () => ({
+  openBoundaryFile: vi.fn(),
+}));
+
+import { openBoundaryFile, type BoundaryFileOpenResult } from "../../infra/boundary-file-read.js";
+import { createBwrapFsBridge } from "./bwrap-fs-bridge.js";
+import { execBwrapRaw } from "./bwrap.js";
+import { createSandboxTestContext } from "./test-fixtures.js";
+import type { SandboxBwrapConfig } from "./types.bwrap.js";
+import type { SandboxContext } from "./types.js";
+
+const mockedExecBwrapRaw = vi.mocked(execBwrapRaw);
+const mockedOpenBoundaryFile = vi.mocked(openBoundaryFile);
+
+const DEFAULT_BWRAP_CFG: SandboxBwrapConfig = {
+  workdir: "/workspace",
+  readOnlyRoot: true,
+  tmpfs: ["/tmp"],
+  unshareNet: true,
+  unsharePid: true,
+  unshareIpc: true,
+  unshareCgroup: false,
+  newSession: true,
+  dieWithParent: true,
+  mountProc: true,
+};
+
+function createBwrapSandbox(overrides?: Partial<SandboxContext>): SandboxContext {
+  return createSandboxTestContext({
+    overrides: {
+      backend: "bwrap",
+      containerName: "",
+      bwrap: DEFAULT_BWRAP_CFG,
+      ...overrides,
+    },
+  });
+}
+
+describe("bwrap fs-bridge", () => {
+  beforeEach(() => {
+    mockedExecBwrapRaw.mockReset();
+    mockedOpenBoundaryFile.mockReset();
+    vi.spyOn(fs, "closeSync").mockImplementation(() => {});
+  });
+
+  const BOUNDARY_OK = { ok: true, fd: 999 } as BoundaryFileOpenResult;
+  const BOUNDARY_MISSING = { ok: false, reason: "path" } as BoundaryFileOpenResult;
+
+  /**
+   * Set up mocks so assertPathSafety passes:
+   *  - openBoundaryFile returns ok with a fake fd
+   *  - the second execBwrapRaw call (canonical path resolution) returns the
+   *    same container path so it stays in-bounds
+   */
+  function mockPathSafetyPass(containerPath: string) {
+    // openBoundaryFile succeeds
+    mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+    // Canonical path resolution call returns the path unchanged
+    mockedExecBwrapRaw.mockImplementation(async (args) => {
+      // The canonical-resolution script contains "readlink -f"
+      const joined = args.join(" ");
+      if (joined.includes("readlink")) {
+        return {
+          stdout: Buffer.from(containerPath + "\n"),
+          stderr: Buffer.alloc(0),
+          code: 0,
+        };
+      }
+      // Default: return empty success
+      return { stdout: Buffer.from("file contents"), stderr: Buffer.alloc(0), code: 0 };
+    });
+  }
+
+  describe("readFile", () => {
+    it("reads a file via bwrap cat", async () => {
+      mockPathSafetyPass("/workspace/test.txt");
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      const result = await bridge.readFile({ filePath: "/workspace/test.txt" });
+
+      expect(result.toString("utf8")).toBe("file contents");
+      // Two calls: one for cat, one for canonical resolution
+      expect(mockedExecBwrapRaw).toHaveBeenCalled();
+
+      // Find the cat call
+      const catCall = mockedExecBwrapRaw.mock.calls.find(([args]) =>
+        args.join(" ").includes('cat -- "$1"'),
+      );
+      expect(catCall).toBeDefined();
+    });
+  });
+
+  describe("writeFile", () => {
+    it("writes a file via bwrap stdin pipe", async () => {
+      mockPathSafetyPass("/workspace/output.txt");
+
+      const sandbox = createBwrapSandbox({ workspaceAccess: "rw" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      await bridge.writeFile({
+        filePath: "/workspace/output.txt",
+        data: "hello world",
+      });
+
+      expect(mockedExecBwrapRaw).toHaveBeenCalled();
+      // Find the write call (the one with stdin input)
+      const writeCall = mockedExecBwrapRaw.mock.calls.find(
+        ([_args, opts]) => opts && Buffer.isBuffer(opts.input),
+      );
+      expect(writeCall).toBeDefined();
+      expect(writeCall![1]!.input!.toString("utf8")).toBe("hello world");
+    });
+
+    it("rejects writes when workspaceAccess is ro", async () => {
+      const sandbox = createBwrapSandbox({ workspaceAccess: "ro" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+
+      await expect(
+        bridge.writeFile({ filePath: "/workspace/test.txt", data: "x" }),
+      ).rejects.toThrow(/read-only/);
+    });
+  });
+
+  describe("stat", () => {
+    it("parses stat output for a regular file", async () => {
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          return {
+            stdout: Buffer.from("/workspace/file.ts\n"),
+            stderr: Buffer.alloc(0),
+            code: 0,
+          };
+        }
+        return {
+          stdout: Buffer.from("regular file|1234|1700000000"),
+          stderr: Buffer.alloc(0),
+          code: 0,
+        };
+      });
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      const result = await bridge.stat({ filePath: "/workspace/file.ts" });
+
+      expect(result).toEqual({
+        type: "file",
+        size: 1234,
+        mtimeMs: 1700000000000,
+      });
+    });
+
+    it("returns null for non-existent file", async () => {
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_MISSING);
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          return {
+            stdout: Buffer.from("/workspace/nope\n"),
+            stderr: Buffer.alloc(0),
+            code: 0,
+          };
+        }
+        return {
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from("stat: cannot stat '/workspace/nope': No such file or directory"),
+          code: 1,
+        };
+      });
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      const result = await bridge.stat({ filePath: "/workspace/nope" });
+
+      expect(result).toBeNull();
+    });
+
+    it("parses directory stat output", async () => {
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          return {
+            stdout: Buffer.from("/workspace/src\n"),
+            stderr: Buffer.alloc(0),
+            code: 0,
+          };
+        }
+        return {
+          stdout: Buffer.from("directory|4096|1700000000"),
+          stderr: Buffer.alloc(0),
+          code: 0,
+        };
+      });
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      const result = await bridge.stat({ filePath: "/workspace/src" });
+
+      expect(result).toEqual({
+        type: "directory",
+        size: 4096,
+        mtimeMs: 1700000000000,
+      });
+    });
+  });
+
+  describe("mkdirp", () => {
+    it("creates directories via bwrap mkdir", async () => {
+      mockPathSafetyPass("/workspace/a/b/c");
+
+      const sandbox = createBwrapSandbox({ workspaceAccess: "rw" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      await bridge.mkdirp({ filePath: "/workspace/a/b/c" });
+
+      expect(mockedExecBwrapRaw).toHaveBeenCalled();
+      const mkdirCall = mockedExecBwrapRaw.mock.calls.find(([args]) =>
+        args.join(" ").includes('mkdir -p -- "$1"'),
+      );
+      expect(mkdirCall).toBeDefined();
+    });
+  });
+
+  describe("remove", () => {
+    it("removes files via bwrap rm", async () => {
+      mockPathSafetyPass("/workspace/old.txt");
+
+      const sandbox = createBwrapSandbox({ workspaceAccess: "rw" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      await bridge.remove({ filePath: "/workspace/old.txt" });
+
+      expect(mockedExecBwrapRaw).toHaveBeenCalled();
+      const rmCall = mockedExecBwrapRaw.mock.calls.find(([args]) => args.join(" ").includes("rm"));
+      expect(rmCall).toBeDefined();
+    });
+
+    it("uses recursive flag when specified", async () => {
+      mockPathSafetyPass("/workspace/dir");
+
+      const sandbox = createBwrapSandbox({ workspaceAccess: "rw" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      await bridge.remove({ filePath: "/workspace/dir", recursive: true });
+
+      const rmCall = mockedExecBwrapRaw.mock.calls.find(([args]) =>
+        args.join(" ").includes("rm -f -r"),
+      );
+      expect(rmCall).toBeDefined();
+    });
+  });
+
+  describe("rename", () => {
+    it("moves files via bwrap mv", async () => {
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+      let callCount = 0;
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          callCount++;
+          // First canonical call is for "from", second for "to"
+          const path = callCount === 1 ? "/workspace/a.txt" : "/workspace/b.txt";
+          return { stdout: Buffer.from(path + "\n"), stderr: Buffer.alloc(0), code: 0 };
+        }
+        return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 };
+      });
+
+      const sandbox = createBwrapSandbox({ workspaceAccess: "rw" });
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+      await bridge.rename({ from: "/workspace/a.txt", to: "/workspace/b.txt" });
+
+      expect(mockedExecBwrapRaw).toHaveBeenCalled();
+      const mvCall = mockedExecBwrapRaw.mock.calls.find(([a]) =>
+        a.join(" ").includes('mv -- "$1" "$2"'),
+      );
+      expect(mvCall).toBeDefined();
+    });
+  });
+
+  describe("assertPathSafety", () => {
+    it("rejects read when canonical path escapes mount", async () => {
+      // openBoundaryFile succeeds (host-side ok)
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+      // Canonical resolution returns an out-of-mount path (like /etc/passwd)
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          return {
+            stdout: Buffer.from("/etc/passwd\n"),
+            stderr: Buffer.alloc(0),
+            code: 0,
+          };
+        }
+        return { stdout: Buffer.from("root:x:0:0:root"), stderr: Buffer.alloc(0), code: 0 };
+      });
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+
+      await expect(bridge.readFile({ filePath: "/workspace/evil-link" })).rejects.toThrow(
+        /escapes allowed mounts/,
+      );
+    });
+
+    it("rejects read when host boundary file check fails", async () => {
+      mockedOpenBoundaryFile.mockResolvedValue({
+        ok: false,
+        reason: "validation",
+        error: new Error("Symlink escape detected"),
+      } as BoundaryFileOpenResult);
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: DEFAULT_BWRAP_CFG });
+
+      await expect(bridge.readFile({ filePath: "/workspace/sneaky" })).rejects.toThrow(
+        /Symlink escape detected/,
+      );
+    });
+  });
+
+  describe("extraBinds in mount map", () => {
+    it("resolves paths under extraBinds", async () => {
+      const cfgWithExtra: SandboxBwrapConfig = {
+        ...DEFAULT_BWRAP_CFG,
+        extraBinds: ["/host-data:/container-data:rw"],
+      };
+      mockPathSafetyPass("/container-data/file.txt");
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: cfgWithExtra });
+      const resolved = bridge.resolvePath({ filePath: "/container-data/file.txt" });
+      expect(resolved.containerPath).toBe("/container-data/file.txt");
+      expect(resolved.hostPath).toContain("/host-data");
+    });
+
+    it("reads files from extraBinds paths", async () => {
+      const cfgWithExtra: SandboxBwrapConfig = {
+        ...DEFAULT_BWRAP_CFG,
+        extraBinds: ["/host-data:/container-data:rw"],
+      };
+
+      mockedOpenBoundaryFile.mockResolvedValue(BOUNDARY_OK);
+      mockedExecBwrapRaw.mockImplementation(async (args) => {
+        const joined = args.join(" ");
+        if (joined.includes("readlink")) {
+          return {
+            stdout: Buffer.from("/container-data/file.txt\n"),
+            stderr: Buffer.alloc(0),
+            code: 0,
+          };
+        }
+        return { stdout: Buffer.from("extra data"), stderr: Buffer.alloc(0), code: 0 };
+      });
+
+      const sandbox = createBwrapSandbox();
+      const bridge = createBwrapFsBridge({ sandbox, bwrapCfg: cfgWithExtra });
+      const result = await bridge.readFile({ filePath: "/container-data/file.txt" });
+      expect(result.toString("utf8")).toBe("extra data");
+    });
+  });
+});

--- a/src/agents/sandbox/bwrap-fs-bridge.ts
+++ b/src/agents/sandbox/bwrap-fs-bridge.ts
@@ -1,0 +1,382 @@
+import fs from "node:fs";
+import { openBoundaryFile } from "../../infra/boundary-file-read.js";
+import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../../infra/path-alias-guards.js";
+import {
+  buildBwrapFsBridgeArgs,
+  execBwrapRaw,
+  parseBwrapBind,
+  type BwrapExecResult,
+} from "./bwrap.js";
+import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.js";
+import {
+  buildSandboxFsMounts,
+  resolveSandboxFsPathWithMounts,
+  type SandboxFsMount,
+  type SandboxResolvedFsPath,
+} from "./fs-paths.js";
+import { isPathInsideContainerRoot, normalizeContainerPath } from "./path-utils.js";
+import type { SandboxBwrapConfig } from "./types.bwrap.js";
+import type { SandboxContext, SandboxWorkspaceAccess } from "./types.js";
+
+type RunCommandOptions = {
+  args?: string[];
+  stdin?: Buffer | string;
+  allowFailure?: boolean;
+  signal?: AbortSignal;
+};
+
+type PathSafetyOptions = {
+  action: string;
+  aliasPolicy?: PathAliasPolicy;
+  requireWritable?: boolean;
+  allowMissingTarget?: boolean;
+};
+
+/**
+ * SandboxFsBridge implementation backed by bubblewrap.
+ *
+ * Every file operation spawns a short-lived bwrap namespace that mounts
+ * the workspace directory and runs a shell one-liner (cat, stat, mkdir, …).
+ * This mirrors the Docker fs-bridge pattern but uses bwrap instead of
+ * `docker exec`.
+ */
+export class BwrapFsBridgeImpl implements SandboxFsBridge {
+  private readonly sandbox: SandboxContext;
+  private readonly bwrapCfg: SandboxBwrapConfig;
+  private readonly mounts: SandboxFsMount[];
+  private readonly mountsByContainer: SandboxFsMount[];
+
+  constructor(sandbox: SandboxContext, bwrapCfg: SandboxBwrapConfig) {
+    this.sandbox = sandbox;
+    this.bwrapCfg = bwrapCfg;
+
+    // Start with the standard mounts (workspace, agent, docker binds).
+    const baseMounts = buildSandboxFsMounts(sandbox);
+
+    // Append bwrap.extraBinds so the fs-bridge mount map covers them.
+    const extraMounts: SandboxFsMount[] = [];
+    for (const spec of bwrapCfg.extraBinds ?? []) {
+      const parsed = parseBwrapBind(spec);
+      if (parsed) {
+        extraMounts.push({
+          hostRoot: parsed.host,
+          containerRoot: normalizeContainerPath(parsed.container),
+          writable: parsed.writable,
+          source: "bind",
+        });
+      }
+    }
+
+    this.mounts = dedupeExtraMounts([...baseMounts, ...extraMounts]);
+    this.mountsByContainer = [...this.mounts].toSorted(
+      (a, b) => b.containerRoot.length - a.containerRoot.length,
+    );
+  }
+
+  resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath {
+    const target = this.resolveResolvedPath(params);
+    return {
+      hostPath: target.hostPath,
+      relativePath: target.relativePath,
+      containerPath: target.containerPath,
+    };
+  }
+
+  async readFile(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<Buffer> {
+    const target = this.resolveResolvedPath(params);
+    await this.assertPathSafety(target, { action: "read files" });
+    const result = await this.runCommand('set -eu; cat -- "$1"', {
+      args: [target.containerPath],
+      signal: params.signal,
+    });
+    return result.stdout;
+  }
+
+  async writeFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "write files");
+    await this.assertPathSafety(target, { action: "write files", requireWritable: true });
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    const script =
+      params.mkdir === false
+        ? 'set -eu; cat >"$1"'
+        : 'set -eu; dir=$(dirname -- "$1"); if [ "$dir" != "." ]; then mkdir -p -- "$dir"; fi; cat >"$1"';
+    await this.runCommand(script, {
+      args: [target.containerPath],
+      stdin: buffer,
+      signal: params.signal,
+    });
+  }
+
+  async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "create directories");
+    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await this.runCommand('set -eu; mkdir -p -- "$1"', {
+      args: [target.containerPath],
+      signal: params.signal,
+    });
+  }
+
+  async remove(params: {
+    filePath: string;
+    cwd?: string;
+    recursive?: boolean;
+    force?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "remove files");
+    await this.assertPathSafety(target, {
+      action: "remove files",
+      requireWritable: true,
+      aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
+    });
+    const flags = [params.force === false ? "" : "-f", params.recursive ? "-r" : ""].filter(
+      Boolean,
+    );
+    const rmCommand = flags.length > 0 ? `rm ${flags.join(" ")}` : "rm";
+    await this.runCommand(`set -eu; ${rmCommand} -- "$1"`, {
+      args: [target.containerPath],
+      signal: params.signal,
+    });
+  }
+
+  async rename(params: {
+    from: string;
+    to: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const from = this.resolveResolvedPath({ filePath: params.from, cwd: params.cwd });
+    const to = this.resolveResolvedPath({ filePath: params.to, cwd: params.cwd });
+    this.ensureWriteAccess(from, "rename files");
+    this.ensureWriteAccess(to, "rename files");
+    await this.assertPathSafety(from, {
+      action: "rename files",
+      requireWritable: true,
+      aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
+    });
+    await this.assertPathSafety(to, {
+      action: "rename files",
+      requireWritable: true,
+    });
+    await this.runCommand(
+      'set -eu; dir=$(dirname -- "$2"); if [ "$dir" != "." ]; then mkdir -p -- "$dir"; fi; mv -- "$1" "$2"',
+      {
+        args: [from.containerPath, to.containerPath],
+        signal: params.signal,
+      },
+    );
+  }
+
+  async stat(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<SandboxFsStat | null> {
+    const target = this.resolveResolvedPath(params);
+    await this.assertPathSafety(target, { action: "stat files" });
+    const result = await this.runCommand('set -eu; stat -c "%F|%s|%Y" -- "$1"', {
+      args: [target.containerPath],
+      signal: params.signal,
+      allowFailure: true,
+    });
+    if (result.code !== 0) {
+      const stderr = result.stderr.toString("utf8");
+      if (stderr.includes("No such file or directory")) {
+        return null;
+      }
+      const message = stderr.trim() || `stat failed with code ${result.code}`;
+      throw new Error(`stat failed for ${target.containerPath}: ${message}`);
+    }
+    const text = result.stdout.toString("utf8").trim();
+    const [typeRaw, sizeRaw, mtimeRaw] = text.split("|");
+    const size = Number.parseInt(sizeRaw ?? "0", 10);
+    const mtime = Number.parseInt(mtimeRaw ?? "0", 10) * 1000;
+    return {
+      type: coerceStatType(typeRaw),
+      size: Number.isFinite(size) ? size : 0,
+      mtimeMs: Number.isFinite(mtime) ? mtime : 0,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal
+  // -------------------------------------------------------------------------
+
+  private async runCommand(
+    script: string,
+    options: RunCommandOptions = {},
+  ): Promise<BwrapExecResult> {
+    const bwrapArgs = buildBwrapFsBridgeArgs({
+      cfg: this.bwrapCfg,
+      workspaceDir: this.sandbox.workspaceDir,
+      workspaceAccess: this.sandbox.workspaceAccess,
+      script,
+      scriptArgs: options.args,
+    });
+    return execBwrapRaw(bwrapArgs, {
+      input: options.stdin,
+      allowFailure: options.allowFailure,
+      signal: options.signal,
+    });
+  }
+
+  private ensureWriteAccess(target: SandboxResolvedFsPath, action: string) {
+    if (!allowsWrites(this.sandbox.workspaceAccess) || !target.writable) {
+      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+    }
+  }
+
+  private async assertPathSafety(target: SandboxResolvedFsPath, options: PathSafetyOptions) {
+    // 1. Lexical mount check — verify the container path falls within a known mount.
+    const lexicalMount = this.resolveMountByContainerPath(target.containerPath);
+    if (!lexicalMount) {
+      throw new Error(
+        `Sandbox path escapes allowed mounts; cannot ${options.action}: ${target.containerPath}`,
+      );
+    }
+
+    // 2. Host-side boundary file open — catches TOCTOU symlink races on the host.
+    const guarded = await openBoundaryFile({
+      absolutePath: target.hostPath,
+      rootPath: lexicalMount.hostRoot,
+      boundaryLabel: "sandbox mount root",
+      aliasPolicy: options.aliasPolicy,
+    });
+    if (!guarded.ok) {
+      if (guarded.reason !== "path" || options.allowMissingTarget === false) {
+        throw guarded.error instanceof Error
+          ? guarded.error
+          : new Error(
+              `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
+            );
+      }
+    } else {
+      fs.closeSync(guarded.fd);
+    }
+
+    // 3. Canonical container-path check — resolve symlinks *inside* the namespace
+    //    and verify the canonical path still falls within an allowed mount.
+    const canonicalContainerPath = await this.resolveCanonicalContainerPath({
+      containerPath: target.containerPath,
+      allowFinalSymlinkForUnlink: options.aliasPolicy?.allowFinalSymlinkForUnlink === true,
+    });
+    const canonicalMount = this.resolveMountByContainerPath(canonicalContainerPath);
+    if (!canonicalMount) {
+      throw new Error(
+        `Sandbox path escapes allowed mounts; cannot ${options.action}: ${target.containerPath}`,
+      );
+    }
+    if (options.requireWritable && !canonicalMount.writable) {
+      throw new Error(
+        `Sandbox path is read-only; cannot ${options.action}: ${target.containerPath}`,
+      );
+    }
+  }
+
+  private resolveMountByContainerPath(containerPath: string): SandboxFsMount | null {
+    const normalized = normalizeContainerPath(containerPath);
+    for (const mount of this.mountsByContainer) {
+      if (isPathInsideContainerRoot(normalizeContainerPath(mount.containerRoot), normalized)) {
+        return mount;
+      }
+    }
+    return null;
+  }
+
+  private async resolveCanonicalContainerPath(params: {
+    containerPath: string;
+    allowFinalSymlinkForUnlink: boolean;
+  }): Promise<string> {
+    const script = [
+      "set -eu",
+      'target="$1"',
+      'allow_final="$2"',
+      'suffix=""',
+      'probe="$target"',
+      'if [ "$allow_final" = "1" ] && [ -L "$target" ]; then probe=$(dirname -- "$target"); fi',
+      'cursor="$probe"',
+      'while [ ! -e "$cursor" ] && [ ! -L "$cursor" ]; do',
+      '  parent=$(dirname -- "$cursor")',
+      '  if [ "$parent" = "$cursor" ]; then break; fi',
+      '  base=$(basename -- "$cursor")',
+      '  suffix="/$base$suffix"',
+      '  cursor="$parent"',
+      "done",
+      'canonical=$(readlink -f -- "$cursor")',
+      'printf "%s%s\\n" "$canonical" "$suffix"',
+    ].join("\n");
+    const result = await this.runCommand(script, {
+      args: [params.containerPath, params.allowFinalSymlinkForUnlink ? "1" : "0"],
+    });
+    const canonical = result.stdout.toString("utf8").trim();
+    if (!canonical.startsWith("/")) {
+      throw new Error(`Failed to resolve canonical sandbox path: ${params.containerPath}`);
+    }
+    return normalizeContainerPath(canonical);
+  }
+
+  private resolveResolvedPath(params: { filePath: string; cwd?: string }): SandboxResolvedFsPath {
+    return resolveSandboxFsPathWithMounts({
+      filePath: params.filePath,
+      cwd: params.cwd ?? this.sandbox.workspaceDir,
+      defaultWorkspaceRoot: this.sandbox.workspaceDir,
+      defaultContainerRoot: this.sandbox.containerWorkdir,
+      mounts: this.mounts,
+    });
+  }
+}
+
+function allowsWrites(access: SandboxWorkspaceAccess): boolean {
+  return access === "rw";
+}
+
+function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {
+  if (!typeRaw) {
+    return "other";
+  }
+  const normalized = typeRaw.trim().toLowerCase();
+  if (normalized.includes("directory")) {
+    return "directory";
+  }
+  if (normalized.includes("file")) {
+    return "file";
+  }
+  return "other";
+}
+
+export function createBwrapFsBridge(params: {
+  sandbox: SandboxContext;
+  bwrapCfg: SandboxBwrapConfig;
+}): SandboxFsBridge {
+  return new BwrapFsBridgeImpl(params.sandbox, params.bwrapCfg);
+}
+
+function dedupeExtraMounts(mounts: SandboxFsMount[]): SandboxFsMount[] {
+  const seen = new Set<string>();
+  const deduped: SandboxFsMount[] = [];
+  for (const mount of mounts) {
+    const key = `${mount.hostRoot}=>${mount.containerRoot}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(mount);
+  }
+  return deduped;
+}

--- a/src/agents/sandbox/bwrap.test.ts
+++ b/src/agents/sandbox/bwrap.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+import { buildBwrapArgs, buildBwrapFsBridgeArgs, resolveBwrapConfig } from "./bwrap.js";
+import type { SandboxBwrapConfig } from "./types.bwrap.js";
+
+function createDefaultBwrapConfig(overrides?: Partial<SandboxBwrapConfig>): SandboxBwrapConfig {
+  return {
+    workdir: "/workspace",
+    readOnlyRoot: true,
+    tmpfs: ["/tmp", "/var/tmp", "/run"],
+    unshareNet: true,
+    unsharePid: true,
+    unshareIpc: true,
+    unshareCgroup: false,
+    newSession: true,
+    dieWithParent: true,
+    mountProc: true,
+    ...overrides,
+  };
+}
+
+describe("buildBwrapArgs", () => {
+  it("builds basic namespace isolation args", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "rw",
+      command: "echo hello",
+    });
+
+    // Should contain namespace flags
+    expect(args).toContain("--unshare-net");
+    expect(args).toContain("--unshare-pid");
+    expect(args).toContain("--unshare-ipc");
+    expect(args).not.toContain("--unshare-cgroup");
+
+    // Should contain security flags
+    expect(args).toContain("--new-session");
+    expect(args).toContain("--die-with-parent");
+
+    // Should mount workspace rw
+    const bindIdx = args.indexOf("--bind");
+    expect(bindIdx).toBeGreaterThanOrEqual(0);
+    expect(args[bindIdx + 1]).toBe("/home/user/project");
+    expect(args[bindIdx + 2]).toBe("/workspace");
+
+    // Should contain proc and dev
+    expect(args).toContain("--proc");
+    expect(args).toContain("--dev");
+
+    // Should end with command
+    const dashDashIdx = args.indexOf("--");
+    expect(dashDashIdx).toBeGreaterThan(0);
+    expect(args[dashDashIdx + 1]).toBe("sh");
+    expect(args[dashDashIdx + 2]).toBe("-c");
+    expect(args[dashDashIdx + 3]).toBe("echo hello");
+  });
+
+  it("mounts workspace read-only when workspaceAccess is ro", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "ro",
+      command: "ls",
+    });
+
+    const roBindIdx = args.findIndex(
+      (a, i) => a === "--ro-bind" && args[i + 1] === "/home/user/project",
+    );
+    expect(roBindIdx).toBeGreaterThanOrEqual(0);
+    expect(args[roBindIdx + 2]).toBe("/workspace");
+  });
+
+  it("uses --bind for rootBinds when readOnlyRoot is false", () => {
+    const cfg = createDefaultBwrapConfig({ readOnlyRoot: false });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    // Root bind paths that exist should use --bind, not --ro-bind
+    const rootPaths = ["/usr", "/bin", "/lib", "/etc"].filter((p) => args.includes(p));
+    for (const rp of rootPaths) {
+      // Pattern: --bind <hostPath> <hostPath>
+      const idx = args.findIndex(
+        (a, i) => a === "--bind" && args[i + 1] === rp && args[i + 2] === rp,
+      );
+      expect(idx, `expected --bind ${rp} ${rp}`).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("uses --ro-bind for rootBinds when readOnlyRoot is true (default)", () => {
+    const cfg = createDefaultBwrapConfig({ readOnlyRoot: true });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    const rootPaths = ["/usr", "/bin", "/lib", "/etc"].filter((p) => args.includes(p));
+    for (const rp of rootPaths) {
+      const idx = args.findIndex(
+        (a, i) => a === "--ro-bind" && args[i + 1] === rp && args[i + 2] === rp,
+      );
+      expect(idx, `expected --ro-bind ${rp} ${rp}`).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("does not mount workspace when workspaceAccess is none", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "none",
+      command: "ls",
+    });
+
+    // Should not have /home/user/project bound
+    expect(args.filter((a) => a === "/home/user/project")).toHaveLength(0);
+  });
+
+  it("creates tmpfs at workdir when workspaceAccess is none", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "none",
+      command: "pwd",
+    });
+
+    // A tmpfs at /workspace should ensure --chdir works
+    const tmpfsIndices = args.reduce<number[]>((acc, v, i) => {
+      if (v === "--tmpfs" && args[i + 1] === "/workspace") {
+        acc.push(i);
+      }
+      return acc;
+    }, []);
+    expect(tmpfsIndices.length).toBeGreaterThanOrEqual(1);
+
+    // --chdir should still point to the workdir
+    const chdirIdx = args.indexOf("--chdir");
+    expect(args[chdirIdx + 1]).toBe("/workspace");
+  });
+
+  it("creates tmpfs mounts from config", () => {
+    const cfg = createDefaultBwrapConfig({ tmpfs: ["/tmp", "/run"] });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    const tmpfsIndices = args.reduce<number[]>((acc, v, i) => {
+      if (v === "--tmpfs") {
+        acc.push(i);
+      }
+      return acc;
+    }, []);
+    expect(tmpfsIndices.length).toBe(2);
+    expect(args[tmpfsIndices[0] + 1]).toBe("/tmp");
+    expect(args[tmpfsIndices[1] + 1]).toBe("/run");
+  });
+
+  it("sets environment with --clearenv and --setenv", () => {
+    const cfg = createDefaultBwrapConfig({ env: { MY_VAR: "hello" } });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "env",
+    });
+
+    expect(args).toContain("--clearenv");
+
+    // Should set default vars
+    const setenvIndices = args.reduce<number[]>((acc, v, i) => {
+      if (v === "--setenv") {
+        acc.push(i);
+      }
+      return acc;
+    }, []);
+    const envPairs = setenvIndices.map((i) => [args[i + 1], args[i + 2]]);
+    expect(envPairs).toContainEqual(["HOME", "/workspace"]);
+    expect(envPairs).toContainEqual(["MY_VAR", "hello"]);
+    expect(envPairs).toContainEqual(["LANG", "C.UTF-8"]);
+  });
+
+  it("merges per-invocation env over config env", () => {
+    const cfg = createDefaultBwrapConfig({ env: { A: "from-config" } });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "env",
+      env: { A: "from-invocation", B: "extra" },
+    });
+
+    const setenvIndices = args.reduce<number[]>((acc, v, i) => {
+      if (v === "--setenv") {
+        acc.push(i);
+      }
+      return acc;
+    }, []);
+    const envPairs = setenvIndices.map((i) => [args[i + 1], args[i + 2]]);
+    // Per-invocation env should win
+    expect(envPairs).toContainEqual(["A", "from-invocation"]);
+    expect(envPairs).toContainEqual(["B", "extra"]);
+    expect(envPairs.filter(([k]) => k === "A")).toHaveLength(1);
+  });
+
+  it("sets workdir via --chdir", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "pwd",
+      workdir: "/workspace/subdir",
+    });
+
+    const chdirIdx = args.indexOf("--chdir");
+    expect(chdirIdx).toBeGreaterThanOrEqual(0);
+    expect(args[chdirIdx + 1]).toBe("/workspace/subdir");
+  });
+
+  it("defaults --chdir to cfg.workdir when no workdir given", () => {
+    const cfg = createDefaultBwrapConfig({ workdir: "/myworkspace" });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "pwd",
+    });
+
+    const chdirIdx = args.indexOf("--chdir");
+    expect(args[chdirIdx + 1]).toBe("/myworkspace");
+  });
+
+  it("handles extraBinds with rw and ro modes", () => {
+    const cfg = createDefaultBwrapConfig({
+      extraBinds: ["/data:/container-data:rw", "/secrets:/container-secrets"],
+    });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    // /data should be --bind (writable)
+    const bindDataIdx = args.findIndex((a, i) => a === "--bind" && args[i + 1] === "/data");
+    expect(bindDataIdx).toBeGreaterThanOrEqual(0);
+    expect(args[bindDataIdx + 2]).toBe("/container-data");
+
+    // /secrets should be --ro-bind (read-only, no :rw suffix)
+    const roBindSecretsIdx = args.findIndex(
+      (a, i) => a === "--ro-bind" && args[i + 1] === "/secrets",
+    );
+    expect(roBindSecretsIdx).toBeGreaterThanOrEqual(0);
+    expect(args[roBindSecretsIdx + 2]).toBe("/container-secrets");
+  });
+
+  it("skips network unsharing when unshareNet is false", () => {
+    const cfg = createDefaultBwrapConfig({ unshareNet: false });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "curl example.com",
+    });
+
+    expect(args).not.toContain("--unshare-net");
+  });
+
+  it("enables cgroup unsharing when configured", () => {
+    const cfg = createDefaultBwrapConfig({ unshareCgroup: true });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    expect(args).toContain("--unshare-cgroup");
+  });
+
+  it("mounts /proc by default", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    expect(args).toContain("--proc");
+  });
+
+  it("skips /proc mount when mountProc is false", () => {
+    const cfg = createDefaultBwrapConfig({ mountProc: false });
+    const args = buildBwrapArgs({
+      cfg,
+      workspaceDir: "/w",
+      workspaceAccess: "rw",
+      command: "ls",
+    });
+
+    expect(args).not.toContain("--proc");
+    // /dev should still be mounted
+    expect(args).toContain("--dev");
+  });
+});
+
+describe("buildBwrapFsBridgeArgs", () => {
+  it("produces args ending with script and positional args", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapFsBridgeArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "rw",
+      script: 'set -eu; cat -- "$1"',
+      scriptArgs: ["/workspace/file.txt"],
+    });
+
+    // Should end with: "--", "sh", "-c", <script>, "bwrap-fs", <path>
+    const dashDashIdx = args.indexOf("--");
+    expect(args[dashDashIdx + 1]).toBe("sh");
+    expect(args[dashDashIdx + 2]).toBe("-c");
+    expect(args[dashDashIdx + 3]).toBe('set -eu; cat -- "$1"');
+    expect(args[dashDashIdx + 4]).toBe("bwrap-fs");
+    expect(args[dashDashIdx + 5]).toBe("/workspace/file.txt");
+  });
+
+  it("works without scriptArgs", () => {
+    const cfg = createDefaultBwrapConfig();
+    const args = buildBwrapFsBridgeArgs({
+      cfg,
+      workspaceDir: "/home/user/project",
+      workspaceAccess: "rw",
+      script: "set -eu; ls /workspace",
+    });
+
+    // Should end with: "--", "sh", "-c", <script>
+    const dashDashIdx = args.indexOf("--");
+    expect(args.slice(dashDashIdx)).toEqual(["--", "sh", "-c", "set -eu; ls /workspace"]);
+  });
+});
+
+describe("resolveBwrapConfig", () => {
+  it("returns sensible defaults with no input", () => {
+    const cfg = resolveBwrapConfig({});
+    expect(cfg.workdir).toBe("/workspace");
+    expect(cfg.readOnlyRoot).toBe(true);
+    expect(cfg.unshareNet).toBe(true);
+    expect(cfg.unsharePid).toBe(true);
+    expect(cfg.unshareIpc).toBe(true);
+    expect(cfg.unshareCgroup).toBe(false);
+    expect(cfg.newSession).toBe(true);
+    expect(cfg.dieWithParent).toBe(true);
+    expect(cfg.mountProc).toBe(true);
+    expect(cfg.tmpfs).toEqual(["/tmp", "/var/tmp", "/run"]);
+    expect(cfg.env).toEqual({ LANG: "C.UTF-8" });
+  });
+
+  it("merges agent over global config", () => {
+    const cfg = resolveBwrapConfig({
+      globalBwrap: {
+        workdir: "/global-workspace",
+        unshareNet: false,
+        env: { A: "global" },
+        extraBinds: ["/shared:/shared"],
+      },
+      agentBwrap: {
+        workdir: "/agent-workspace",
+        env: { B: "agent" },
+        extraBinds: ["/agent-data:/data"],
+      },
+    });
+
+    // Agent overrides global for scalar fields
+    expect(cfg.workdir).toBe("/agent-workspace");
+    // Agent env merges with global env
+    expect(cfg.env).toEqual({ A: "global", B: "agent" });
+    // Extra binds are concatenated
+    expect(cfg.extraBinds).toEqual(["/shared:/shared", "/agent-data:/data"]);
+    // Unset agent fields fall back to global
+    expect(cfg.unshareNet).toBe(false);
+  });
+
+  it("agent scalar fields take precedence over global", () => {
+    const cfg = resolveBwrapConfig({
+      globalBwrap: { unsharePid: true, newSession: true },
+      agentBwrap: { unsharePid: false, newSession: false },
+    });
+
+    expect(cfg.unsharePid).toBe(false);
+    expect(cfg.newSession).toBe(false);
+  });
+});

--- a/src/agents/sandbox/bwrap.ts
+++ b/src/agents/sandbox/bwrap.ts
@@ -1,0 +1,331 @@
+import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import type { SandboxBwrapConfig } from "./types.bwrap.js";
+import type { SandboxWorkspaceAccess } from "./types.js";
+
+/** Host paths mounted read-only to form the base userland inside the namespace. */
+const DEFAULT_ROOT_BINDS = ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc"];
+
+export const DEFAULT_BWRAP_WORKDIR = "/workspace";
+
+let bwrapChecked = false;
+let bwrapAvailable = false;
+
+export async function ensureBwrapAvailable(): Promise<void> {
+  if (bwrapChecked) {
+    if (!bwrapAvailable) {
+      throw new Error("bubblewrap (bwrap) binary not found on PATH.");
+    }
+    return;
+  }
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn("bwrap", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout?.on("data", (d: Buffer) => {
+      stdout += d.toString();
+    });
+    child.on("error", () => {
+      bwrapChecked = true;
+      bwrapAvailable = false;
+      reject(new Error("bubblewrap (bwrap) binary not found on PATH."));
+    });
+    child.on("close", (code) => {
+      bwrapChecked = true;
+      bwrapAvailable = code === 0;
+      if (!bwrapAvailable) {
+        reject(new Error(`bwrap --version exited with code ${code}: ${stdout.trim()}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/** Reset the cached availability check (for tests). */
+export function resetBwrapAvailabilityCache(): void {
+  bwrapChecked = false;
+  bwrapAvailable = false;
+}
+
+export type BwrapExecParams = {
+  cfg: SandboxBwrapConfig;
+  workspaceDir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+  command: string;
+  workdir?: string;
+  env?: Record<string, string>;
+  tty?: boolean;
+};
+
+/**
+ * Build a complete bwrap argv (excluding the "bwrap" binary itself) that
+ * isolates `command` inside a mount/pid/net namespace.
+ *
+ * The workspace directory is bind-mounted at `cfg.workdir` (default
+ * `/workspace`). Everything else is read-only or tmpfs.
+ */
+export function buildBwrapArgs(params: BwrapExecParams): string[] {
+  const { cfg, workspaceDir, workspaceAccess, command } = params;
+  const args: string[] = [];
+
+  const rootBinds = cfg.rootBinds ?? DEFAULT_ROOT_BINDS;
+  const rootBindFlag = cfg.readOnlyRoot ? "--ro-bind" : "--bind";
+  for (const hostPath of rootBinds) {
+    if (existsSafe(hostPath)) {
+      args.push(rootBindFlag, hostPath, hostPath);
+    }
+  }
+
+  if (workspaceAccess === "rw") {
+    args.push("--bind", workspaceDir, cfg.workdir);
+  } else if (workspaceAccess === "ro") {
+    args.push("--ro-bind", workspaceDir, cfg.workdir);
+  }
+
+  for (const entry of cfg.tmpfs) {
+    args.push("--tmpfs", entry);
+  }
+
+  if (cfg.mountProc) {
+    args.push("--proc", "/proc");
+  } else {
+    // ro-bind /proc
+    args.push("--ro-bind", "/proc", "/proc");
+  }
+
+  args.push("--dev", "/dev");
+
+  if (cfg.unshareNet) {
+    args.push("--unshare-net");
+  }
+  if (cfg.unsharePid) {
+    args.push("--unshare-pid");
+  }
+  if (cfg.unshareIpc) {
+    args.push("--unshare-ipc");
+  }
+  if (cfg.unshareCgroup) {
+    args.push("--unshare-cgroup");
+  }
+
+  if (cfg.newSession) {
+    args.push("--new-session");
+  }
+  if (cfg.dieWithParent) {
+    args.push("--die-with-parent");
+  }
+
+  for (const spec of cfg.extraBinds ?? []) {
+    const parsed = parseBwrapBind(spec);
+    if (parsed) {
+      args.push(parsed.writable ? "--bind" : "--ro-bind", parsed.host, parsed.container);
+    }
+  }
+
+  // Clear the environment first, then set explicit vars.
+  args.push("--clearenv");
+  const env = {
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    HOME: cfg.workdir,
+    LANG: "C.UTF-8",
+    TERM: "xterm-256color",
+    ...cfg.env,
+    ...params.env,
+  };
+  for (const [key, value] of Object.entries(env)) {
+    args.push("--setenv", key, value);
+  }
+
+  const workdir = params.workdir ?? cfg.workdir;
+
+  // workspaceAccess === "none" → no workspace mount, but ensure workdir exists
+  // so --chdir does not fail.
+  if (workspaceAccess === "none") {
+    args.push("--tmpfs", workdir);
+  }
+
+  args.push("--chdir", workdir);
+  args.push("--", "sh", "-c", command);
+
+  return args;
+}
+
+/**
+ * Build bwrap args specifically for a filesystem bridge operation (cat, stat, etc).
+ * These are short-lived, non-interactive, and always run with the workspace mounted.
+ */
+export function buildBwrapFsBridgeArgs(params: {
+  cfg: SandboxBwrapConfig;
+  workspaceDir: string;
+  workspaceAccess: SandboxWorkspaceAccess;
+  script: string;
+  scriptArgs?: string[];
+}): string[] {
+  const args = buildBwrapArgs({
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    workspaceAccess: params.workspaceAccess,
+    command: params.script,
+  });
+
+  // bwrap doesn't have the docker pattern of `sh -c 'script' scriptName arg1 arg2`.
+  // Instead, the script itself must reference positional args.
+  // We embed the args into the script via `sh -c 'script' _ arg1 arg2`.
+  // Rewrite the last entry (which is the command) to include positional args.
+  if (params.scriptArgs?.length) {
+    // The args end with: "--", "sh", "-c", <script>
+    // We need to append: "bwrap-fs", ...scriptArgs
+    args.push("bwrap-fs", ...params.scriptArgs);
+  }
+
+  return args;
+}
+
+export type BwrapExecResult = {
+  stdout: Buffer;
+  stderr: Buffer;
+  code: number;
+};
+
+export function execBwrapRaw(
+  args: string[],
+  opts?: {
+    input?: Buffer | string;
+    allowFailure?: boolean;
+    signal?: AbortSignal;
+  },
+): Promise<BwrapExecResult> {
+  return new Promise<BwrapExecResult>((resolve, reject) => {
+    const child = spawn("bwrap", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let aborted = false;
+
+    const signal = opts?.signal;
+    const handleAbort = () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      child.kill("SIGTERM");
+    };
+    if (signal) {
+      if (signal.aborted) {
+        handleAbort();
+      } else {
+        signal.addEventListener("abort", handleAbort);
+      }
+    }
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+
+    child.on("error", (error) => {
+      signal?.removeEventListener("abort", handleAbort);
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      signal?.removeEventListener("abort", handleAbort);
+      const stdout = Buffer.concat(stdoutChunks);
+      const stderr = Buffer.concat(stderrChunks);
+      if (aborted || signal?.aborted) {
+        const err = new Error("Aborted");
+        err.name = "AbortError";
+        reject(err);
+        return;
+      }
+      const exitCode = code ?? 0;
+      if (exitCode !== 0 && !opts?.allowFailure) {
+        const message = stderr.length > 0 ? stderr.toString("utf8").trim() : "";
+        const error = Object.assign(new Error(message || `bwrap failed with code ${exitCode}`), {
+          code: exitCode,
+          stdout,
+          stderr,
+        });
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr, code: exitCode });
+    });
+
+    const stdin = child.stdin;
+    if (stdin) {
+      if (opts?.input !== undefined) {
+        stdin.end(opts.input);
+      } else {
+        stdin.end();
+      }
+    }
+  });
+}
+
+function existsSafe(p: string): boolean {
+  try {
+    return existsSync(p) && statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function parseBwrapBind(
+  spec: string,
+): { host: string; container: string; writable: boolean } | null {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const host = parts[0].trim();
+  const container = parts[1].trim();
+  const options = (parts[2] ?? "").trim().toLowerCase();
+  if (!host || !container) {
+    return null;
+  }
+
+  return {
+    host,
+    container,
+    writable: options === "rw",
+  };
+}
+
+export function resolveBwrapConfig(params: {
+  globalBwrap?: Partial<SandboxBwrapConfig>;
+  agentBwrap?: Partial<SandboxBwrapConfig>;
+}): SandboxBwrapConfig {
+  const g = params.globalBwrap;
+  const a = params.agentBwrap;
+  const env = a?.env
+    ? { ...(g?.env ?? { LANG: "C.UTF-8" }), ...a.env }
+    : (g?.env ?? { LANG: "C.UTF-8" });
+  const extraBinds = [...(g?.extraBinds ?? []), ...(a?.extraBinds ?? [])];
+
+  return {
+    workdir: a?.workdir ?? g?.workdir ?? DEFAULT_BWRAP_WORKDIR,
+    readOnlyRoot: a?.readOnlyRoot ?? g?.readOnlyRoot ?? true,
+    tmpfs: a?.tmpfs ?? g?.tmpfs ?? ["/tmp", "/var/tmp", "/run"],
+    unshareNet: a?.unshareNet ?? g?.unshareNet ?? true,
+    unsharePid: a?.unsharePid ?? g?.unsharePid ?? true,
+    unshareIpc: a?.unshareIpc ?? g?.unshareIpc ?? true,
+    unshareCgroup: a?.unshareCgroup ?? g?.unshareCgroup ?? false,
+    newSession: a?.newSession ?? g?.newSession ?? true,
+    dieWithParent: a?.dieWithParent ?? g?.dieWithParent ?? true,
+    mountProc: a?.mountProc ?? g?.mountProc ?? true,
+    rootBinds: a?.rootBinds ?? g?.rootBinds,
+    extraBinds: extraBinds.length ? extraBinds : undefined,
+    env,
+  };
+}

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveAgentConfig } from "../agent-scope.js";
+import { resolveBwrapConfig } from "./bwrap.js";
 import {
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
   DEFAULT_SANDBOX_BROWSER_CDP_PORT,
@@ -17,6 +18,7 @@ import {
 } from "./constants.js";
 import { resolveSandboxToolPolicyForAgent } from "./tool-policy.js";
 import type {
+  SandboxBackend,
   SandboxBrowserConfig,
   SandboxConfig,
   SandboxDockerConfig,
@@ -187,9 +189,12 @@ export function resolveSandboxConfigForAgent(
 
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, agentId);
 
+  const backend: SandboxBackend = agentSandbox?.backend ?? agent?.backend ?? "docker";
+
   return {
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
     scope,
+    backend,
     workspaceAccess: agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none",
     workspaceRoot:
       agentSandbox?.workspaceRoot ?? agent?.workspaceRoot ?? DEFAULT_SANDBOX_WORKSPACE_ROOT,
@@ -197,6 +202,10 @@ export function resolveSandboxConfigForAgent(
       scope,
       globalDocker: agent?.docker,
       agentDocker: agentSandbox?.docker,
+    }),
+    bwrap: resolveBwrapConfig({
+      globalBwrap: agent?.bwrap,
+      agentBwrap: agentSandbox?.bwrap,
     }),
     browser: resolveSandboxBrowserConfig({
       scope,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -8,6 +8,8 @@ import { resolveUserPath } from "../../utils.js";
 import { syncSkillsToWorkspace } from "../skills.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
 import { ensureSandboxBrowser } from "./browser.js";
+import { createBwrapFsBridge } from "./bwrap-fs-bridge.js";
+import { ensureBwrapAvailable } from "./bwrap.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
 import { ensureSandboxContainer } from "./docker.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
@@ -125,18 +127,28 @@ export async function resolveSandboxContext(params: {
     workspaceDir: params.workspaceDir,
   });
 
-  const docker = await resolveSandboxDockerUser({
-    docker: cfg.docker,
-    workspaceDir,
-  });
-  const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
+  const backend = cfg.backend;
 
-  const containerName = await ensureSandboxContainer({
-    sessionKey: rawSessionKey,
-    workspaceDir,
-    agentWorkspaceDir,
-    cfg: resolvedCfg,
-  });
+  // --- Docker backend: resolve user and create/start persistent container ---
+  let containerName = "";
+  let resolvedCfg = cfg;
+  if (backend === "docker") {
+    const docker = await resolveSandboxDockerUser({
+      docker: cfg.docker,
+      workspaceDir,
+    });
+    resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
+
+    containerName = await ensureSandboxContainer({
+      sessionKey: rawSessionKey,
+      workspaceDir,
+      agentWorkspaceDir,
+      cfg: resolvedCfg,
+    });
+  } else {
+    // bwrap: validate that bwrap is available on PATH
+    await ensureBwrapAvailable();
+  }
 
   const evaluateEnabled =
     params.config?.browser?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;
@@ -168,19 +180,24 @@ export async function resolveSandboxContext(params: {
 
   const sandboxContext: SandboxContext = {
     enabled: true,
+    backend,
     sessionKey: rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,
     workspaceAccess: resolvedCfg.workspaceAccess,
     containerName,
-    containerWorkdir: resolvedCfg.docker.workdir,
+    containerWorkdir: backend === "bwrap" ? cfg.bwrap.workdir : resolvedCfg.docker.workdir,
     docker: resolvedCfg.docker,
+    bwrap: backend === "bwrap" ? cfg.bwrap : undefined,
     tools: resolvedCfg.tools,
     browserAllowHostControl: resolvedCfg.browser.allowHostControl,
     browser: browser ?? undefined,
   };
 
-  sandboxContext.fsBridge = createSandboxFsBridge({ sandbox: sandboxContext });
+  sandboxContext.fsBridge =
+    backend === "bwrap"
+      ? createBwrapFsBridge({ sandbox: sandboxContext, bwrapCfg: cfg.bwrap })
+      : createSandboxFsBridge({ sandbox: sandboxContext });
 
   return sandboxContext;
 }
@@ -205,6 +222,6 @@ export async function ensureSandboxWorkspaceForSession(params: {
 
   return {
     workspaceDir,
-    containerWorkdir: cfg.docker.workdir,
+    containerWorkdir: cfg.backend === "bwrap" ? cfg.bwrap.workdir : cfg.docker.workdir,
   };
 }

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -87,6 +87,7 @@ function createSandboxConfig(dns: string[], binds?: string[]): SandboxConfig {
   return {
     mode: "all",
     scope: "shared",
+    backend: "docker",
     workspaceAccess: "rw",
     workspaceRoot: "~/.openclaw/sandboxes",
     docker: {
@@ -119,6 +120,18 @@ function createSandboxConfig(dns: string[], binds?: string[]): SandboxConfig {
     },
     tools: { allow: [], deny: [] },
     prune: { idleHours: 24, maxAgeDays: 7 },
+    bwrap: {
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      unshareNet: true,
+      unsharePid: true,
+      unshareIpc: true,
+      unshareCgroup: false,
+      newSession: true,
+      dieWithParent: true,
+      mountProc: true,
+    },
   };
 }
 

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -28,6 +28,7 @@ export function createSandboxTestContext(params?: {
 
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: "sandbox:test",
     workspaceDir: "/tmp/workspace",
     agentWorkspaceDir: "/tmp/workspace",

--- a/src/agents/sandbox/types.bwrap.ts
+++ b/src/agents/sandbox/types.bwrap.ts
@@ -1,0 +1,62 @@
+/**
+ * Configuration for bubblewrap (bwrap) sandbox backend.
+ *
+ * Unlike Docker, bwrap creates a fresh mount/pid/net namespace per command
+ * invocation — there is no persistent container. This config describes the
+ * namespace shape that every bwrap invocation will use.
+ */
+export type SandboxBwrapConfig = {
+  /** Working directory inside the namespace (workspace mount target). */
+  workdir: string;
+
+  /** Mount the root filesystem read-only. Default: true. */
+  readOnlyRoot: boolean;
+
+  /**
+   * Paths to mount as tmpfs inside the namespace.
+   * Default: ["/tmp", "/var/tmp", "/run"].
+   */
+  tmpfs: string[];
+
+  /** Disable network access via --unshare-net. Default: true (no network). */
+  unshareNet: boolean;
+
+  /** Unshare PID namespace. Default: true. */
+  unsharePid: boolean;
+
+  /** Unshare IPC namespace. Default: true. */
+  unshareIpc: boolean;
+
+  /** Unshare cgroup namespace. Default: false. */
+  unshareCgroup: boolean;
+
+  /** Use --new-session to prevent TIOCSTI attacks. Default: true. */
+  newSession: boolean;
+
+  /** Use --die-with-parent to kill sandbox when parent exits. Default: true. */
+  dieWithParent: boolean;
+
+  /**
+   * Mount a /proc filesystem inside the namespace.
+   * Disable when running bwrap in an already containerised gateway
+   * with no permission to mount /proc.
+   *
+   * Default: true.
+   */
+  mountProc: boolean;
+
+  /**
+   * Additional read-only bind mounts: "hostPath:containerPath".
+   * For writable binds, suffix with ":rw" → "hostPath:containerPath:rw".
+   */
+  extraBinds?: string[];
+
+  /**
+   * Host paths to bind read-only into the namespace for a functioning
+   * userland. Defaults cover /usr, /lib, /lib64, /bin, /sbin, /etc.
+   */
+  rootBinds?: string[];
+
+  /** Environment variables to set inside the namespace. */
+  env?: Record<string, string>;
+};

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -1,7 +1,11 @@
 import type { SandboxFsBridge } from "./fs-bridge.js";
+import type { SandboxBwrapConfig } from "./types.bwrap.js";
 import type { SandboxDockerConfig } from "./types.docker.js";
 
+export type { SandboxBwrapConfig } from "./types.bwrap.js";
 export type { SandboxDockerConfig } from "./types.docker.js";
+
+export type SandboxBackend = "docker" | "bwrap";
 
 export type SandboxToolPolicy = {
   allow?: string[];
@@ -55,9 +59,13 @@ export type SandboxScope = "session" | "agent" | "shared";
 export type SandboxConfig = {
   mode: "off" | "non-main" | "all";
   scope: SandboxScope;
+  /** Sandbox backend. Default: "docker". */
+  backend: SandboxBackend;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceRoot: string;
   docker: SandboxDockerConfig;
+  /** Bubblewrap config — used when backend is "bwrap". */
+  bwrap: SandboxBwrapConfig;
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
   prune: SandboxPruneConfig;
@@ -71,13 +79,18 @@ export type SandboxBrowserContext = {
 
 export type SandboxContext = {
   enabled: boolean;
+  /** Sandbox backend in use for this session. */
+  backend: SandboxBackend;
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
   workspaceAccess: SandboxWorkspaceAccess;
+  /** Docker container name (empty string when backend is "bwrap"). */
   containerName: string;
   containerWorkdir: string;
   docker: SandboxDockerConfig;
+  /** Bubblewrap config — present when backend is "bwrap". */
+  bwrap?: SandboxBwrapConfig;
   tools: SandboxToolPolicy;
   browserAllowHostControl: boolean;
   browser?: SandboxBrowserContext;

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -18,6 +18,7 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
   const workspaceDir = params.workspaceDir;
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: params.sessionKey ?? "sandbox:test",
     workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir ?? workspaceDir,

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -1,5 +1,6 @@
 import type {
   SandboxBrowserSettings,
+  SandboxBwrapSettings,
   SandboxDockerSettings,
   SandboxPruneSettings,
 } from "./types.sandbox.js";
@@ -15,6 +16,11 @@ export type AgentModelConfig =
 
 export type AgentSandboxConfig = {
   mode?: "off" | "non-main" | "all";
+  /**
+   * Sandbox backend: "docker" (default) or "bwrap" (bubblewrap).
+   * bwrap uses Linux namespaces without requiring Docker.
+   */
+  backend?: "docker" | "bwrap";
   /** Agent workspace access inside the sandbox. */
   workspaceAccess?: "none" | "ro" | "rw";
   /**
@@ -30,6 +36,8 @@ export type AgentSandboxConfig = {
   workspaceRoot?: string;
   /** Docker-specific sandbox settings. */
   docker?: SandboxDockerSettings;
+  /** Bubblewrap (bwrap) sandbox settings. */
+  bwrap?: SandboxBwrapSettings;
   /** Optional sandboxed browser settings. */
   browser?: SandboxBrowserSettings;
   /** Auto-prune sandbox settings. */

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -88,6 +88,44 @@ export type SandboxBrowserSettings = {
   binds?: string[];
 };
 
+export type SandboxBwrapSettings = {
+  /** Working directory inside the namespace (workspace mount target). */
+  workdir?: string;
+  /** Mount the root filesystem read-only. Default: true. */
+  readOnlyRoot?: boolean;
+  /** Paths to mount as tmpfs inside the namespace. Default: ["/tmp", "/var/tmp", "/run"]. */
+  tmpfs?: string[];
+  /** Disable network access via --unshare-net. Default: true (no network). */
+  unshareNet?: boolean;
+  /** Unshare PID namespace. Default: true. */
+  unsharePid?: boolean;
+  /** Unshare IPC namespace. Default: true. */
+  unshareIpc?: boolean;
+  /** Unshare cgroup namespace. Default: false. */
+  unshareCgroup?: boolean;
+  /** Use --new-session to prevent TIOCSTI attacks. Default: true. */
+  newSession?: boolean;
+  /** Use --die-with-parent to kill sandbox when parent exits. Default: true. */
+  dieWithParent?: boolean;
+  /**
+   * Mount a /proc filesystem inside the namespace.
+   * Disable for already-containerised environments where /proc is inherited.
+   * Default: true.
+   */
+  mountProc?: boolean;
+  /**
+   * Additional bind mounts: "hostPath:containerPath" or "hostPath:containerPath:rw".
+   */
+  extraBinds?: string[];
+  /**
+   * Host paths to bind read-only into the namespace for a functioning userland.
+   * Defaults: /usr, /lib, /lib64, /bin, /sbin, /etc.
+   */
+  rootBinds?: string[];
+  /** Extra environment variables for sandbox exec. */
+  env?: Record<string, string>;
+};
+
 export type SandboxPruneSettings = {
   /** Prune if idle for more than N hours (0 disables). */
   idleHours?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -467,15 +467,36 @@ const ToolLoopDetectionSchema = z
   })
   .optional();
 
+export const SandboxBwrapSchema = z
+  .object({
+    workdir: z.string().optional(),
+    readOnlyRoot: z.boolean().optional(),
+    tmpfs: z.array(z.string()).optional(),
+    unshareNet: z.boolean().optional(),
+    unsharePid: z.boolean().optional(),
+    unshareIpc: z.boolean().optional(),
+    unshareCgroup: z.boolean().optional(),
+    newSession: z.boolean().optional(),
+    dieWithParent: z.boolean().optional(),
+    mountProc: z.boolean().optional(),
+    extraBinds: z.array(z.string()).optional(),
+    rootBinds: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const AgentSandboxSchema = z
   .object({
     mode: z.union([z.literal("off"), z.literal("non-main"), z.literal("all")]).optional(),
+    backend: z.union([z.literal("docker"), z.literal("bwrap")]).optional(),
     workspaceAccess: z.union([z.literal("none"), z.literal("ro"), z.literal("rw")]).optional(),
     sessionToolsVisibility: z.union([z.literal("spawned"), z.literal("all")]).optional(),
     scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
     perSession: z.boolean().optional(),
     workspaceRoot: z.string().optional(),
     docker: SandboxDockerSchema,
+    bwrap: SandboxBwrapSchema,
     browser: SandboxBrowserSchema,
     prune: SandboxPruneSchema,
   })


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Sandboxing with docker or docker-in-docker requires elevated permissions.
- Why it matters: Users may want tool isolation without a heavy docker backend or without giving the gateway access to privileges. 
- What changed: A new `bwrap` sandbox backend was added alongside the docker backend. It uses linux namespace isolation, and can run unprivileged if user namespaces are enabled in the user's linux kernel.
- What did NOT change (scope boundary): Docker backend behaviour is untouched, default backend continues to be Docker. Browser sandbox is still docker-only.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New config `agents.defaults.sandbox.backend` (docker | bwrap)
- New config  `agents.defaults.sandbox.bwrap` to configure bind mounts and namespace isolation in bwrap
- Per agent overrides for both
- `sandbox recreate`  becomes a no-op with bwrap backend

## Security Impact (required)

- New permissions/capabilities? Yes-ish
    - bwrap requires kernel user namespaces enabled or root. 
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
    - Sandboxed tool execution with bwrap uses bwrap instead of docker exec 
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:
    - bwrap binary is invoked via spawn("bwrap", argv) with no shell interpolation when constructing argv. Default is to unshare everything, spawn new terminal session, and clear env vars. 

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Running on my personal deployment, behaviour tested and it can execute in the sandbox. Works when running the gateway as a container with `no-new-privileges: true` (but with a slightly modified seccomp / apparmor profile). Works when gateway is running directly on the host.
- Edge cases checked: Can't test every edge case, but most tool executions are working fine as far as I can see BUT it does not currently support allocating a TTY for the tool invocation.
- What you did **not** verify: Non-Linux hosts

## Compatibility / Migration

- Backward compatible? Yes, default is still docker, existing configs unaffected
- Config/env changes? Yes, new optional keys mentioned above
- Migration needed? No, opt-in
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove sandboxing backend key / change back to docker
- Files/config to restore: just restore `openclaw.json` to previous state before switching to bwrap backend
- Known bad symptoms reviewers should watch for:
    - bwrap binary missing
    - "permission denied" (EPERM, etc) for no user namespace support in host kernel.  

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk**: bwrap isolation weaker than docker (no seccomp, apparmor, cgroup resource limits)
  - **Mitigation**: You can still use docker, this is really meant to be used when Docker is not available or when already running inside a container
- **Risk**: bwrap unavailable or user namespaces disabled breaks tool execution if bwrap backend is set
  - **Mitigation**: `ensureBwrapAvailable()` fails fast with  clear error message if binary is missing / perms missing