### PR TITLE
fix(docker): share gateway network namespace for CLI connectivity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,11 @@ services:
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+    # Share the gateway's network namespace so the CLI can reach ws://127.0.0.1:18789
+    # (plaintext ws:// is blocked for non-loopback hosts by security checks)
+    network_mode: service:openclaw-gateway
+    depends_on:
+      - openclaw-gateway
     stdin_open: true
     tty: true
     init: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
-    # Share the gateway's network namespace so the CLI can reach ws://127.0.0.1:18789
-    # (plaintext ws:// is blocked for non-loopback hosts by security checks)
     network_mode: service:openclaw-gateway
     depends_on:
       - openclaw-gateway


### PR DESCRIPTION
## Problem

When running `openclaw-cli` as a separate Docker Compose service, the CLI
fails to connect to the gateway with `gateway closed (1006 abnormal closure)`.

The CLI defaults to `ws://127.0.0.1:18789`, and the WebSocket client blocks
plaintext `ws://` connections to non-loopback hosts for security. There is no
config option or env var to override the gateway URL to a Docker service
hostname.

## Fix

Set `network_mode: service:openclaw-gateway` on `openclaw-cli` so it shares
the gateway's network namespace and can reach it via loopback, and add
`depends_on` to ensure correct startup order.

## Testing

```bash
docker compose run --rm openclaw-cli devices list
