### PR TITLE
fix(llm-task): correct import path for bundled install

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -25,6 +25,7 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built): use extensionAPI which exports runEmbeddedPiAgent
+  // @ts-expect-error dist/ only exists after build; this path is correct for bundled installs
   const mod = await import("../../../dist/extensionAPI.js");
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -24,8 +24,8 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
     // ignore
   }
 
-  // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
+  // Bundled install (built): use extensionAPI which exports runEmbeddedPiAgent
+  const mod = await import("../../../dist/extensionAPI.js");
   if (typeof mod.runEmbeddedPiAgent !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }


### PR DESCRIPTION
## Summary
- Fix import path for bundled install in llm-task extension
- Change fallback path from `src/agents/pi-embedded-runner.js` to `dist/extensionAPI.js`

In npm-installed OpenClaw, the `src/` directory does not exist, causing "Cannot find module" error when using llm-task extension.

## Root Cause
The `loadRunEmbeddedPiAgent()` function has two import attempts (source checkout vs bundled install), but both used the same path `../../../src/agents/pi-embedded-runner.js`. In a built/npm install, there is no `src/` directory.

## Fix
Change the fallback import path to `../../../dist/extensionAPI.js`, which is the correct location for bundled installs.

## Test plan
- [x] Existing unit tests pass (8 tests in `extensions/llm-task/src/llm-task-tool.test.ts`)
- [ ] Manual test with bundled install (`npm install -g openclaw`)

Fixes #28468