### PR TITLE
fix(ui): map generic dashboard fetch errors to auth-specific messages

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -205,6 +205,48 @@ describe("connectGateway", () => {
     expect(host.lastErrorCode).toBeNull();
   });
 
+  it("maps generic fetch-failed auth errors to actionable token mismatch message", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Fetch failed",
+        details: { code: "AUTH_TOKEN_MISMATCH" },
+      },
+    });
+
+    expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
+    expect(host.lastError).toContain("gateway token mismatch");
+  });
+
+  it("maps generic fetch-failed auth errors to actionable rate-limit message", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "Failed to fetch",
+        details: { code: "AUTH_RATE_LIMITED" },
+      },
+    });
+
+    expect(host.lastErrorCode).toBe("AUTH_RATE_LIMITED");
+    expect(host.lastError).toContain("too many failed authentication attempts");
+  });
+
   it("prefers structured connect errors over close reason", () => {
     const host = createHost();
 


### PR DESCRIPTION
Fixes #28586

## Summary
Improve Control UI error reporting when gateway auth failures are surfaced as generic browser fetch errors.

## Problem
In some auth failure paths, the dashboard could show a generic `Fetch failed` / `Failed to fetch` message even when the underlying cause was actionable (for example token mismatch or auth rate-limit lockout).

## Root cause
- `ui/src/ui/app-gateway.ts` set `lastError` directly from `error.message` in `onClose`.
- When browser/network layers collapsed the message to a generic fetch failure, users lost auth-specific guidance even though `lastErrorCode` was available.

## Changes
### 1) Auth-aware fallback mapping in `app-gateway`
File: `ui/src/ui/app-gateway.ts`

When `error.message` is generic fetch-failure text and `lastErrorCode` is auth-related, map to clearer actionable messages:
- `AUTH_TOKEN_MISMATCH` -> token mismatch guidance
- `AUTH_RATE_LIMITED` -> retry-later auth lockout guidance
- `AUTH_UNAUTHORIZED` -> authentication failed guidance

### 2) Regression tests
File: `ui/src/ui/app-gateway.node.test.ts`

Added tests for generic fetch-failure messages with structured auth detail codes:
- token mismatch case
- auth rate-limited case

Both verify that user-facing error text becomes auth-specific instead of generic fetch-failure text.
