### PR TITLE
fix: correctly report Tailscale status by checking service state

### DIFF
--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -5,7 +5,7 @@ import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { probeGateway } from "../gateway/probe.js";
 import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { resolveOsSummary } from "../infra/os-summary.js";
-import { getTailnetHostname } from "../infra/tailscale.js";
+import { checkTailscaledService, getTailnetHostname } from "../infra/tailscale.js";
 import { getMemorySearchManager } from "../memory/index.js";
 import type { MemoryProviderStatus } from "../memory/types.js";
 import { runExec } from "../process/exec.js";
@@ -81,8 +81,15 @@ export async function scanStatus(
 
       progress.setLabel("Checking Tailscale…");
       const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+
+      // Check if tailscaled service is actually running, regardless of config
+      const tailscaleServiceStatus = await checkTailscaledService(runExec, {
+        timeoutMs: 2000,
+      }).catch(() => ({ running: false }));
+
+      // Only attempt to get DNS if service is running AND mode is not "off"
       const tailscaleDns =
-        tailscaleMode === "off"
+        tailscaleMode === "off" || !tailscaleServiceStatus.running
           ? null
           : await getTailnetHostname((cmd, args) =>
               runExec(cmd, args, { timeoutMs: 1200, maxBuffer: 200_000 }),

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -9,6 +9,7 @@ const {
   enableTailscaleServe,
   disableTailscaleServe,
   ensureFunnel,
+  checkTailscaledService,
 } = tailscale;
 const tailscaleBin = expect.stringMatching(/tailscale$/i);
 
@@ -216,5 +217,50 @@ describe("tailscale helpers", () => {
     await expect(enableTailscaleServe(3000, exec as never)).rejects.toBe(originalError);
 
     expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  describe("checkTailscaledService", () => {
+    it("returns running: true when tailscale status succeeds", async () => {
+      const exec = vi.fn().mockResolvedValue({ stdout: "running" });
+      const result = await checkTailscaledService(exec as never);
+      expect(result.running).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(exec).toHaveBeenCalledWith(
+        tailscaleBin,
+        ["status"],
+        expect.objectContaining({ timeoutMs: 3000 }),
+      );
+    });
+
+    it("returns running: false when service is not running", async () => {
+      const exec = vi.fn().mockRejectedValue(new Error("tailscaled is not running"));
+      const result = await checkTailscaledService(exec as never);
+      expect(result.running).toBe(false);
+      expect(result.error).toBe("tailscaled service is not running");
+    });
+
+    it("returns running: false on connection refused error", async () => {
+      const exec = vi.fn().mockRejectedValue(new Error("connection refused"));
+      const result = await checkTailscaledService(exec as never);
+      expect(result.running).toBe(false);
+      expect(result.error).toBe("tailscaled service is not running");
+    });
+
+    it("returns running: false with original error for other failures", async () => {
+      const exec = vi.fn().mockRejectedValue(new Error("command not found"));
+      const result = await checkTailscaledService(exec as never);
+      expect(result.running).toBe(false);
+      expect(result.error).toBe("command not found");
+    });
+
+    it("respects custom timeout option", async () => {
+      const exec = vi.fn().mockResolvedValue({ stdout: "" });
+      await checkTailscaledService(exec as never, { timeoutMs: 5000 });
+      expect(exec).toHaveBeenCalledWith(
+        tailscaleBin,
+        ["status"],
+        expect.objectContaining({ timeoutMs: 5000 }),
+      );
+    });
   });
 });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -174,6 +174,39 @@ export async function readTailscaleStatusJson(
   return stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
 }
 
+/**
+ * Check if the tailscaled service is actually running by attempting to get status.
+ * This is more accurate than checking config alone, as it verifies the daemon is active.
+ *
+ * @returns Object with running status and optional error message
+ */
+export async function checkTailscaledService(
+  exec: typeof runExec = runExec,
+  opts?: { timeoutMs?: number },
+): Promise<{ running: boolean; error?: string }> {
+  try {
+    const tailscaleBin = await getTailscaleBinary();
+    await exec(tailscaleBin, ["status"], {
+      timeoutMs: opts?.timeoutMs ?? 3000,
+      maxBuffer: 100_000,
+    });
+    return { running: true };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    // Check for specific error patterns that indicate service is not running
+    if (
+      errorMsg.includes("not running") ||
+      errorMsg.includes("connection refused") ||
+      errorMsg.includes("no such host") ||
+      errorMsg.includes("failed to connect")
+    ) {
+      return { running: false, error: "tailscaled service is not running" };
+    }
+    // For other errors (like command not found), still report as not running
+    return { running: false, error: errorMsg };
+  }
+}
+
 export async function ensureGoInstalled(
   exec: typeof runExec = runExec,
   prompt: typeof promptYesNo = promptYesNo,


### PR DESCRIPTION
## Problem

Previously, `openclaw status` only checked the `tailscale.mode` config value without verifying if the `tailscaled` service was actually running. This could misleadingly report Tailscale as enabled even when the service was stopped.

Fixes #28604

## Changes

### New Function: `checkTailscaledService()`
- Added to `src/infra/tailscale.ts`
- Attempts to run `tailscale status` to verify the daemon is responsive
- Returns `{ running: boolean, error?: string }` with clear status
- Handles common error patterns:
  - "not running"
  - "connection refused" 
  - "no such host"
  - "failed to connect"

### Updated `status.scan.ts`
- Now calls `checkTailscaledService()` before attempting to get DNS hostname
- Only attempts DNS lookup if service is confirmed running AND mode is not "off"
- Prevents misleading status reports when service is stopped

### Tests
- Added 5 comprehensive test cases for `checkTailscaledService()`:
  - Service running (success case)
  - Service not running
  - Connection refused error
  - Other errors (command not found, etc.)
  - Custom timeout option

## Testing

```bash
# Run new tests
npm test -- src/infra/tailscale.test.ts

# All tests pass ✓
```

## Verification

- [x] Code formatted with `oxfmt`
- [x] Linting passes with `oxlint`
- [x] TypeScript check passes with `tsgo`
- [x] All existing tests continue to pass
- [x] New tests added for the fix

## Risk Assessment

**Low** - This is a read-only status check change that:
- Does not modify any configuration
- Does not affect Tailscale service operation
- Only improves accuracy of status reporting
- Has comprehensive test coverage