### PR TITLE
fix(plugins): prevent global hook runner replacement on cache miss

### DIFF
--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -20,6 +20,12 @@ let globalRegistry: PluginRegistry | null = null;
  * Called once when plugins are loaded during gateway startup.
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
+  // Don't replace if already initialized — services won't be re-started
+  // for the new registry, leaving hooks with dead closures.
+  if (globalHookRunner) {
+    return;
+  }
+
   globalRegistry = registry;
   globalHookRunner = createHookRunner(registry, {
     logger: {


### PR DESCRIPTION
## Summary

`loadOpenClawPlugins()` can be called twice per agent run — once at gateway startup, once when resolving tools for the agent. The second call may have a different `workspaceDir`, causing a plugin registry cache miss that re-creates the entire registry.

The new registry has unstarted service closures (`ready=false`), so hooks like `before_agent_start` silently exit via their early return guard. Meanwhile, `before_prompt_build` still works because the pi-embedded-runner passes the per-agent hook runner through params, which still references the first (working) registry.

This PR guards `initializeGlobalHookRunner()` with an early return if the global runner is already initialized, preserving the original registry and its live service closures.

## Changes

- `src/plugins/hook-runner-global.ts` — add early return guard in `initializeGlobalHookRunner()` (+6 lines)

## Test plan

- [x] Verified that `before_agent_start` hooks fire correctly after the fix
- [x] Verified that `before_prompt_build` hooks continue to work
- [x] Gateway restart + agent run cycle produces expected hook execution