### PR TITLE
fix: filter TUI model selector to show only authenticated providers

### DIFF
--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -19,7 +19,9 @@ const ensureAuthProfileStore = vi.hoisted(() =>
     profiles: {},
   })),
 );
-const listProfilesForProvider = vi.hoisted(() => vi.fn(() => []));
+const listProfilesForProvider = vi.hoisted(() =>
+  vi.fn((_store: unknown, _provider: string) => [] as string[]),
+);
 const upsertAuthProfile = vi.hoisted(() => vi.fn());
 const upsertAuthProfileWithLock = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("../agents/auth-profiles.js", () => ({
@@ -247,5 +249,107 @@ describe("applyModelFallbacksFromSelection", () => {
       primary: "anthropic/claude-opus-4-5",
       fallbacks: ["openai/gpt-5.2"],
     });
+  });
+});
+
+describe("promptDefaultModel auth filtering", () => {
+  it("filters models to only show providers with auth when no allowlist is configured", async () => {
+    // Mock catalog with models from multiple providers
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "anthropic",
+        id: "claude-opus-4-5",
+        name: "Claude Opus 4.5",
+      },
+      {
+        provider: "openai",
+        id: "gpt-5.2",
+        name: "GPT-5.2",
+      },
+      {
+        provider: "google",
+        id: "gemini-2.0",
+        name: "Gemini 2.0",
+      },
+    ]);
+
+    // Mock auth: only anthropic has profiles
+    listProfilesForProvider.mockImplementation((_store: unknown, provider: string) => {
+      return provider === "anthropic" ? ["anthropic:default"] : [];
+    });
+    resolveEnvApiKey.mockReturnValue(undefined);
+    getCustomProviderApiKey.mockReturnValue(undefined);
+
+    const select = vi.fn(async (params) => {
+      return params.options[0]?.value ?? "";
+    });
+    const prompter = makePrompter({ select });
+
+    // Config with no allowlist configured
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
+
+    await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      agentDir: "/tmp/test-agent",
+      // ignoreAllowlist defaults to false
+    });
+
+    const options = select.mock.calls[0]?.[0]?.options ?? [];
+    const modelValues = options.map((opt: { value: string }) => opt.value);
+
+    // Should only show anthropic models since that's the only provider with auth
+    expect(modelValues).toContain("anthropic/claude-opus-4-5");
+    expect(modelValues).not.toContain("openai/gpt-5.2");
+    expect(modelValues).not.toContain("google/gemini-2.0");
+  });
+
+  it("shows all models from allowed providers when allowlist is configured", async () => {
+    loadModelCatalog.mockResolvedValue([
+      {
+        provider: "anthropic",
+        id: "claude-opus-4-5",
+        name: "Claude Opus 4.5",
+      },
+      {
+        provider: "openai",
+        id: "gpt-5.2",
+        name: "GPT-5.2",
+      },
+    ]);
+
+    const select = vi.fn(async (params) => {
+      return params.options[0]?.value ?? "";
+    });
+    const prompter = makePrompter({ select });
+
+    // Config with allowlist
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-5": {},
+            "openai/gpt-5.2": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await promptDefaultModel({
+      config,
+      prompter,
+      allowKeep: false,
+      includeManual: false,
+      agentDir: "/tmp/test-agent",
+    });
+
+    const options = select.mock.calls[0]?.[0]?.options ?? [];
+    const modelValues = options.map((opt: { value: string }) => opt.value);
+
+    // Should show both models since they're in the allowlist
+    expect(modelValues).toContain("anthropic/claude-opus-4-5");
+    expect(modelValues).toContain("openai/gpt-5.2");
   });
 });

--- a/src/commands/model-picker.ts
+++ b/src/commands/model-picker.ts
@@ -45,14 +45,18 @@ function hasAuthForProvider(
   provider: string,
   cfg: OpenClawConfig,
   store: ReturnType<typeof ensureAuthProfileStore>,
-) {
-  if (listProfilesForProvider(store, provider).length > 0) {
+): boolean {
+  // Map plan providers to their base providers for auth lookup
+  // e.g., "volcengine-plan" -> "volcengine", "byteplus-plan" -> "byteplus"
+  const authProvider = provider.replace(/-plan$/, "");
+
+  if (listProfilesForProvider(store, authProvider).length > 0) {
     return true;
   }
-  if (resolveEnvApiKey(provider)) {
+  if (resolveEnvApiKey(authProvider)) {
     return true;
   }
-  if (getCustomProviderApiKey(cfg, provider)) {
+  if (getCustomProviderApiKey(cfg, authProvider)) {
     return true;
   }
   return false;
@@ -178,6 +182,7 @@ export async function promptDefaultModel(
   params: PromptDefaultModelParams,
 ): Promise<PromptDefaultModelResult> {
   const cfg = params.config;
+  const agentDir = params.agentDir;
   const allowKeep = params.allowKeep ?? true;
   const includeManual = params.includeManual ?? true;
   const includeVllm = params.includeVllm ?? false;
@@ -187,6 +192,9 @@ export async function promptDefaultModel(
     ? normalizeProviderId(preferredProviderRaw)
     : undefined;
   const configuredRaw = resolveConfiguredModelRaw(cfg);
+
+  // Create auth checker early to avoid duplicate creation and enable reuse
+  const hasAuth = createProviderAuthChecker({ cfg, agentDir });
 
   const resolved = resolveConfiguredModelRef({
     cfg,
@@ -211,12 +219,19 @@ export async function promptDefaultModel(
   });
   let models = catalog;
   if (!ignoreAllowlist) {
-    const { allowedCatalog } = buildAllowedModelSet({
+    const { allowAny, allowedCatalog } = buildAllowedModelSet({
       cfg,
       catalog,
       defaultProvider: DEFAULT_PROVIDER,
     });
-    models = allowedCatalog.length > 0 ? allowedCatalog : catalog;
+    if (allowAny) {
+      // When no allowlist is configured, filter to show only models from
+      // providers that have authentication configured. This prevents showing
+      // unavailable models in the TUI picker.
+      models = catalog.filter((entry) => hasAuth(entry.provider));
+    } else if (allowedCatalog.length > 0) {
+      models = allowedCatalog;
+    }
   }
 
   if (models.length === 0) {
@@ -268,9 +283,6 @@ export async function promptDefaultModel(
       models = models.filter((entry) => !isAnthropicLegacyModel(entry));
     }
   }
-
-  const agentDir = params.agentDir;
-  const hasAuth = createProviderAuthChecker({ cfg, agentDir });
 
   const options: WizardSelectOption[] = [];
   if (allowKeep) {


### PR DESCRIPTION
## Problem

When using `/models` in the TUI, it listed all models from the catalog instead of just the configured and available ones. Users could pick any model, and if the model was not available (no authentication configured), the result was non-deterministic.

Fixes #28588

## Root Cause

The `buildAllowedModelSet` function returns `allowAny: true` and the full catalog when no allowlist is configured. The original code checked `allowedCatalog.length > 0` before checking `allowAny`, so it always used the full catalog when no allowlist was set.

## Changes

### Updated `promptDefaultModel` in `src/commands/model-picker.ts`
- **Prioritized `allowAny` check**: When `allowAny` is true (no allowlist configured), filter models to only show providers that have authentication configured
- **Authentication check**: Uses `createProviderAuthChecker` to verify providers have auth via:
  - Auth profiles (stored credentials)
  - Environment variables (e.g., `ANTHROPIC_API_KEY`)
  - Custom provider API keys in config

### Added tests in `src/commands/model-picker.test.ts`
- Test case: Filters to only authenticated providers when no allowlist is configured
- Test case: Shows all allowed models when allowlist is explicitly configured

## Behavior Changes

### Before
- `/models` showed all models from the catalog
- Users could select models from providers without authentication
- Selection would fail at runtime with auth errors

### After
- `/models` shows only models from providers with authentication when no allowlist is set
- Users can still configure an explicit allowlist to show specific models
- Improves UX by preventing selection of unavailable models

## Testing

```bash
npm test -- src/commands/model-picker.test.ts
# All 9 tests pass ✓
```

## Verification

- [x] Code formatted with `oxfmt`
- [x] Linting passes with `oxlint`
- [x] TypeScript check passes with `tsgo`
- [x] All existing tests continue to pass
- [x] New tests added for the fix

## Risk Assessment

**Low** - This is a UI filtering change that:
- Does not affect model selection when allowlist is configured
- Does not change any API or configuration format
- Only improves the user experience by filtering out unavailable options
- Has comprehensive test coverage