### PR TITLE
fix(discord): make slow listener threshold configurable

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -252,6 +252,8 @@ export type DiscordAccountConfig = {
   actions?: DiscordActionConfig;
   /** Control reply threading when reply tags are present (off|first|all). */
   replyToMode?: ReplyToMode;
+  /** Milliseconds before a Discord listener is considered slow (default: 30000). */
+  slowListenerThresholdMs?: number;
   /**
    * Alias for dm.policy (prefer this so it inherits cleanly via base->account shallow merge).
    * Legacy key: channels.discord.dm.policy.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -455,6 +455,7 @@ export const DiscordAccountSchema = z
       .strict()
       .optional(),
     replyToMode: ReplyToModeSchema.optional(),
+    slowListenerThresholdMs: z.number().int().min(1000).max(300_000).optional(),
     // Aliases for channels.discord.dm.policy / channels.discord.dm.allowFrom. Prefer these for
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -54,9 +54,10 @@ type DiscordReactionListenerParams = {
   allowNameMatching: boolean;
   guildEntries?: Record<string, import("./allow-list.js").DiscordGuildEntryResolved>;
   logger: Logger;
+  slowListenerThresholdMs?: number;
 };
 
-const DISCORD_SLOW_LISTENER_THRESHOLD_MS = 30_000;
+const DISCORD_SLOW_LISTENER_THRESHOLD_MS_DEFAULT = 30_000;
 const discordEventQueueLog = createSubsystemLogger("discord/event-queue");
 
 function logSlowDiscordListener(params: {
@@ -64,8 +65,12 @@ function logSlowDiscordListener(params: {
   listener: string;
   event: string;
   durationMs: number;
+  slowListenerThresholdMs?: number;
 }) {
-  if (params.durationMs < DISCORD_SLOW_LISTENER_THRESHOLD_MS) {
+  if (
+    params.durationMs <
+    (params.slowListenerThresholdMs ?? DISCORD_SLOW_LISTENER_THRESHOLD_MS_DEFAULT)
+  ) {
     return;
   }
   const duration = formatDurationSeconds(params.durationMs, {
@@ -89,6 +94,7 @@ async function runDiscordListenerWithSlowLog(params: {
   event: string;
   run: () => Promise<void>;
   onError?: (err: unknown) => void;
+  slowListenerThresholdMs?: number;
 }) {
   const startedAt = Date.now();
   try {
@@ -105,6 +111,7 @@ async function runDiscordListenerWithSlowLog(params: {
       listener: params.listener,
       event: params.event,
       durationMs: Date.now() - startedAt,
+      slowListenerThresholdMs: params.slowListenerThresholdMs,
     });
   }
 }
@@ -121,6 +128,7 @@ export class DiscordMessageListener extends MessageCreateListener {
   constructor(
     private handler: DiscordMessageHandler,
     private logger?: Logger,
+    private slowListenerThresholdMs?: number,
   ) {
     super();
   }
@@ -135,6 +143,7 @@ export class DiscordMessageListener extends MessageCreateListener {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord handler failed: ${String(err)}`));
       },
+      slowListenerThresholdMs: this.slowListenerThresholdMs,
     });
   }
 }
@@ -185,6 +194,7 @@ async function runDiscordReactionHandler(params: {
     logger: params.handlerParams.logger,
     listener: params.listener,
     event: params.event,
+    slowListenerThresholdMs: params.handlerParams.slowListenerThresholdMs,
     run: () =>
       handleDiscordReactionEvent({
         data: params.data,

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -591,7 +591,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       discordRestFetch,
     });
 
-    registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
+    const slowListenerThresholdMs = discordCfg.slowListenerThresholdMs;
+    registerDiscordListener(
+      client.listeners,
+      new DiscordMessageListener(messageHandler, logger, slowListenerThresholdMs),
+    );
     registerDiscordListener(
       client.listeners,
       new DiscordReactionListener({
@@ -608,6 +612,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         allowNameMatching: isDangerousNameMatchingEnabled(discordCfg),
         guildEntries,
         logger,
+        slowListenerThresholdMs,
       }),
     );
     registerDiscordListener(
@@ -626,6 +631,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         allowNameMatching: isDangerousNameMatchingEnabled(discordCfg),
         guildEntries,
         logger,
+        slowListenerThresholdMs,
       }),
     );
 


### PR DESCRIPTION
## Summary

Fixes #28566 — the `DISCORD_SLOW_LISTENER_THRESHOLD_MS` was hardcoded at 30,000ms, causing a SIGUSR1 storm on gateways using slower LLM providers or large context windows. One user reported **417 SIGUSR1 events per day** on an otherwise healthy gateway.

## Changes

- **New config option**: `channels.discord.slowListenerThresholdMs` (min: 1000ms, max: 300,000ms, default: 30,000ms)
- Threaded through `DiscordMessageListener`, `DiscordReactionListener`, and `DiscordReactionRemoveListener`
- Falls back to 30,000ms when not configured — **zero breaking change**

## Usage

```json
{
  "channels": {
    "discord": {
      "slowListenerThresholdMs": 120000
    }
  }
}
```

## Files Changed (4 files, +22/-3 lines)

| File | Change |
|------|--------|
| `src/config/zod-schema.providers-core.ts` | Add `slowListenerThresholdMs` to Discord schema |
| `src/config/types.discord.ts` | Add type definition |
| `src/discord/monitor/listeners.ts` | Accept configurable threshold, fall back to default |
| `src/discord/monitor/provider.ts` | Read config and pass to all listener constructors |

## Validation

- `pnpm build` ✅
- `tsc --noEmit` ✅ (zero type errors)
- `oxfmt` ✅

## Impact

- Operators on slow providers (Anthropic with large contexts, local models, etc.) can raise the threshold to eliminate false-positive SIGUSR1 restarts
- Default behavior unchanged for existing installations
- Minimal surface area: 4 files, 22 lines added