### PR TITLE
fix(heartbeat): skip heartbeat when session was recently active

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -635,7 +635,15 @@ export async function runHeartbeatOnce(opts: {
     });
     return { status: "skipped", reason: preflight.skipReason };
   }
+
+  // Check if session was recently active (within 60 seconds) to avoid conflicting
+  // with user message delivery context (#28639)
   const { entry, sessionKey, storePath } = preflight.session;
+  const SESSION_ACTIVE_THRESHOLD_MS = 60000; // 60 seconds
+  if (entry?.updatedAt && startedAt - entry.updatedAt < SESSION_ACTIVE_THRESHOLD_MS) {
+    return { status: "skipped", reason: "session-recently-active" };
+  }
+
   const previousUpdatedAt = entry?.updatedAt;
   const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();


### PR DESCRIPTION
Avoid heartbeat conflicting with user message delivery context by skipping heartbeat if the session was updated within the last 60 seconds.

This fixes the issue where heartbeat replies were sent to the wrong channel when a user message arrived at the same time as a heartbeat trigger.

Fixes #28639

---

## Changes

- Added check in `runHeartbeatOnce` to skip heartbeat if session was updated within the last 60 seconds
- This prevents heartbeat from interfering with user message delivery context