### PR TITLE
fix: add enabled field to WhatsAppConfigSchema and WhatsAppConfig type

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -105,6 +105,30 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.["google-gemini-cli-auth"]?.enabled).toBe(true);
   });
 
+  it("auto-enables whatsapp when config entry exists (no auth check)", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { whatsapp: { dmPolicy: "allowlist", allowFrom: ["+15555550123"] } },
+      },
+      env: {},
+    });
+
+    expect(result.config.channels?.whatsapp?.enabled).toBe(true);
+    expect(result.changes.join("\n")).toContain("WhatsApp configured, enabled automatically.");
+  });
+
+  it("respects explicit disable via channels.whatsapp.enabled = false", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { whatsapp: { dmPolicy: "allowlist", enabled: false } },
+      },
+      env: {},
+    });
+
+    expect(result.config.channels?.whatsapp?.enabled).toBe(false);
+    expect(result.changes).toEqual([]);
+  });
+
   it("skips when plugins are globally disabled", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -79,6 +79,8 @@ type WhatsAppSharedConfig = {
 };
 
 type WhatsAppConfigCore = {
+  /** If false, do not start the WhatsApp channel. Default: true (auto-detected). */
+  enabled?: boolean;
   /** Optional provider capability tags used for agent/runtime guidance. */
   capabilities?: string[];
   /** Markdown formatting overrides (tables). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -97,6 +97,7 @@ export const WhatsAppAccountSchema = WhatsAppSharedSchema.extend({
   });
 
 export const WhatsAppConfigSchema = WhatsAppSharedSchema.extend({
+  enabled: z.boolean().optional(),
   accounts: z.record(z.string(), WhatsAppAccountSchema.optional()).optional(),
   mediaMaxMb: z.number().int().positive().optional().default(50),
   actions: z


### PR DESCRIPTION
## Problem

`WhatsAppConfigSchema` used `.strict()` but was missing an `enabled` field at the top level. 

The auto-enable logic in `applyPluginAutoEnable()` calls `registerPluginEntry("whatsapp")` which writes `channels.whatsapp.enabled = true` to the config. However, because the schema is strict and `enabled` was absent, this field got **stripped on every config parse** — meaning the auto-enable never actually persisted.

The `enabled` field existed only in `WhatsAppAccountSchema` (per-account config), not in the top-level `WhatsAppConfigSchema`.

## Fix

Minimal fix across 3 files:

### `src/config/zod-schema.providers-whatsapp.ts`
Added `enabled: z.boolean().optional()` as the first field in `WhatsAppConfigSchema.extend()`.

### `src/config/types.whatsapp.ts`
Added `enabled?: boolean` to `WhatsAppConfigCore` type with JSDoc comment.

### `src/config/plugin-auto-enable.test.ts`
Added 2 regression tests:
- Auto-enable triggers correctly when WhatsApp config entry exists
- Explicit `enabled: false` is respected (no auto-enable)

## Test Results
```
✓ src/config/plugin-auto-enable.test.ts (15 tests) 39ms
tsc_exit=0
```
All 15 tests pass, TypeScript clean.