### PR TITLE
fix(reply): isolate heartbeat/user routing context to prevent cross-chat mixups

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.useRealTimers();
-  runEmbeddedAttemptMock.mockClear();
+  runEmbeddedAttemptMock.mockReset();
   resolveCopilotApiTokenMock.mockReset();
 });
 
@@ -303,7 +303,7 @@ async function runAutoPinnedRotationCase(params: {
   sessionKey: string;
   runId: string;
 }) {
-  runEmbeddedAttemptMock.mockClear();
+  runEmbeddedAttemptMock.mockReset();
   return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
     await writeAuthStore(agentDir);
     mockFailedThenSuccessfulAttempt(params.errorMessage);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -18,6 +18,7 @@ import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   type DeliveryContext,
   deliveryContextFromSession,
+  deliveryContextKey,
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.js";
@@ -447,10 +448,7 @@ function resolveAnnounceOrigin(
   const normalizedEntry = deliveryContextFromSession(entry);
   if (normalizedRequester?.channel && isInternalMessageChannel(normalizedRequester.channel)) {
     // Ignore internal channel hints (webchat) so a valid persisted route
-    // can still be used for outbound delivery. Non-standard channels that
-    // are not in the deliverable list should NOT be stripped here — doing
-    // so causes the session entry's stale lastChannel (often WhatsApp) to
-    // override the actual requester origin, leading to delivery failures.
+    // can still be used for outbound delivery.
     return mergeDeliveryContext(
       {
         accountId: normalizedRequester.accountId,
@@ -459,19 +457,20 @@ function resolveAnnounceOrigin(
       normalizedEntry,
     );
   }
-  // requesterOrigin (captured at spawn time) reflects the channel the user is
-  // actually on and must take priority over the session entry, which may carry
-  // stale lastChannel / lastTo values from a previous channel interaction.
-  const entryForMerge =
-    normalizedRequester?.to &&
-    normalizedRequester.threadId == null &&
-    normalizedEntry?.threadId != null
-      ? (() => {
-          const { threadId: _ignore, ...rest } = normalizedEntry;
-          return rest;
-        })()
-      : normalizedEntry;
-  return mergeDeliveryContext(normalizedRequester, entryForMerge);
+
+  // requesterOrigin (captured at spawn time) is authoritative for outbound routing.
+  // Only merge fallback fields from session entry when both contexts point to the
+  // same concrete delivery target to avoid cross-chat contamination under concurrency.
+  if (normalizedRequester) {
+    const requesterKey = deliveryContextKey(normalizedRequester);
+    const entryKey = deliveryContextKey(normalizedEntry);
+    if (requesterKey && entryKey && requesterKey === entryKey) {
+      return mergeDeliveryContext(normalizedRequester, normalizedEntry);
+    }
+    return normalizedRequester;
+  }
+
+  return normalizedEntry;
 }
 
 async function resolveSubagentCompletionOrigin(params: {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -468,7 +468,14 @@ function resolveAnnounceOrigin(
       normalizedEntry?.channel === normalizedRequester.channel &&
       normalizedEntry?.to === normalizedRequester.to;
     if (sameDestination) {
-      return mergeDeliveryContext(normalizedRequester, normalizedEntry);
+      const entryForMerge =
+        normalizedRequester.threadId == null && normalizedEntry?.threadId != null
+          ? (() => {
+              const { threadId: _ignore, ...rest } = normalizedEntry;
+              return rest;
+            })()
+          : normalizedEntry;
+      return mergeDeliveryContext(normalizedRequester, entryForMerge);
     }
     return normalizedRequester;
   }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -18,7 +18,6 @@ import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
   type DeliveryContext,
   deliveryContextFromSession,
-  deliveryContextKey,
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.js";
@@ -459,12 +458,16 @@ function resolveAnnounceOrigin(
   }
 
   // requesterOrigin (captured at spawn time) is authoritative for outbound routing.
-  // Only merge fallback fields from session entry when both contexts point to the
-  // same concrete delivery target to avoid cross-chat contamination under concurrency.
+  // Only merge fallback fields from session entry when both contexts target the
+  // same channel+destination to avoid cross-chat contamination while still
+  // preserving account/thread fallbacks for that destination.
   if (normalizedRequester) {
-    const requesterKey = deliveryContextKey(normalizedRequester);
-    const entryKey = deliveryContextKey(normalizedEntry);
-    if (requesterKey && entryKey && requesterKey === entryKey) {
+    const sameDestination =
+      normalizedRequester.channel &&
+      normalizedRequester.to &&
+      normalizedEntry?.channel === normalizedRequester.channel &&
+      normalizedEntry?.to === normalizedRequester.to;
+    if (sameDestination) {
       return mergeDeliveryContext(normalizedRequester, normalizedEntry);
     }
     return normalizedRequester;

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -19,14 +19,24 @@ type OriginRoutingMetadata = Pick<
 >;
 
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
+  // Use one concrete source item to avoid mixing channel/to/account/thread from
+  // different queued messages under concurrent traffic.
+  const source =
+    [...items]
+      .toReversed()
+      .find(
+        (item) =>
+          item.originatingChannel ||
+          item.originatingTo ||
+          item.originatingAccountId ||
+          (item.originatingThreadId != null && item.originatingThreadId !== ""),
+      ) ?? items.at(-1);
+
   return {
-    originatingChannel: items.find((item) => item.originatingChannel)?.originatingChannel,
-    originatingTo: items.find((item) => item.originatingTo)?.originatingTo,
-    originatingAccountId: items.find((item) => item.originatingAccountId)?.originatingAccountId,
-    // Support both number (Telegram topic) and string (Slack thread_ts) thread IDs.
-    originatingThreadId: items.find(
-      (item) => item.originatingThreadId != null && item.originatingThreadId !== "",
-    )?.originatingThreadId,
+    originatingChannel: source?.originatingChannel,
+    originatingTo: source?.originatingTo,
+    originatingAccountId: source?.originatingAccountId,
+    originatingThreadId: source?.originatingThreadId,
   };
 }
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -457,7 +457,6 @@ export async function initSessionState(params: {
     persistedLastChannel: preservedEntry?.lastChannel,
     sessionKey,
   });
-<<<<<<< HEAD
   const lastToRaw = resolveLastToRaw({
     originatingChannelRaw,
     originatingToRaw: isSyntheticProvider ? undefined : ctx.OriginatingTo,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -461,21 +461,21 @@ export async function initSessionState(params: {
     originatingChannelRaw,
     originatingToRaw: isSyntheticProvider ? undefined : ctx.OriginatingTo,
     toRaw: isSyntheticProvider ? undefined : ctx.To,
-    persistedLastTo: baseEntry?.lastTo,
-    persistedLastChannel: baseEntry?.lastChannel,
+    persistedLastTo: preservedEntry?.lastTo,
+    persistedLastChannel: preservedEntry?.lastChannel,
     sessionKey,
   });
   const lastAccountIdRaw = isSyntheticProvider
-    ? baseEntry?.lastAccountId
-    : ctx.AccountId || baseEntry?.lastAccountId;
+    ? preservedEntry?.lastAccountId
+    : ctx.AccountId || preservedEntry?.lastAccountId;
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a
   // previous interaction that happened inside a topic/thread.
   const lastThreadIdRaw = isSyntheticProvider
     ? isThread
-      ? baseEntry?.lastThreadId
+      ? preservedEntry?.lastThreadId
       : undefined
-    : ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
+    : ctx.MessageThreadId || (isThread ? preservedEntry?.lastThreadId : undefined);
   const deliveryFields = normalizeSessionDeliveryFields({
     deliveryContext: {
       channel: lastChannelRaw,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -439,6 +439,7 @@ export async function initSessionState(params: {
   }
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
+  const preservedEntry = baseEntry ?? entry;
   // Track the originating channel/to for announce routing (subagent announce-back).
   // Synthetic providers (heartbeat/cron/exec events) should not mutate persistent
   // delivery routing context used for user-originated replies.
@@ -453,7 +454,7 @@ export async function initSessionState(params: {
     : (ctx.OriginatingChannel as string | undefined);
   const lastChannelRaw = resolveLastChannelRaw({
     originatingChannelRaw,
-    persistedLastChannel: baseEntry?.lastChannel,
+    persistedLastChannel: preservedEntry?.lastChannel,
     sessionKey,
   });
 <<<<<<< HEAD

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -440,25 +440,42 @@ export async function initSessionState(params: {
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
   // Track the originating channel/to for announce routing (subagent announce-back).
-  const originatingChannelRaw = ctx.OriginatingChannel as string | undefined;
+  // Synthetic providers (heartbeat/cron/exec events) should not mutate persistent
+  // delivery routing context used for user-originated replies.
+  const providerRaw = String(ctx.Provider ?? "")
+    .trim()
+    .toLowerCase();
+  const isSyntheticProvider =
+    providerRaw === "heartbeat" || providerRaw === "cron-event" || providerRaw === "exec-event";
+
+  const originatingChannelRaw = isSyntheticProvider
+    ? undefined
+    : (ctx.OriginatingChannel as string | undefined);
   const lastChannelRaw = resolveLastChannelRaw({
     originatingChannelRaw,
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
   });
+<<<<<<< HEAD
   const lastToRaw = resolveLastToRaw({
     originatingChannelRaw,
-    originatingToRaw: ctx.OriginatingTo,
-    toRaw: ctx.To,
+    originatingToRaw: isSyntheticProvider ? undefined : ctx.OriginatingTo,
+    toRaw: isSyntheticProvider ? undefined : ctx.To,
     persistedLastTo: baseEntry?.lastTo,
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
   });
-  const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
+  const lastAccountIdRaw = isSyntheticProvider
+    ? baseEntry?.lastAccountId
+    : ctx.AccountId || baseEntry?.lastAccountId;
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a
   // previous interaction that happened inside a topic/thread.
-  const lastThreadIdRaw = ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
+  const lastThreadIdRaw = isSyntheticProvider
+    ? isThread
+      ? baseEntry?.lastThreadId
+      : undefined
+    : ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
   const deliveryFields = normalizeSessionDeliveryFields({
     deliveryContext: {
       channel: lastChannelRaw,


### PR DESCRIPTION
Fixes #28639

## Summary
This PR provides an alternative fix approach to #28646.

Instead of mitigating by skipping heartbeat when a session is recently active, this PR fixes routing isolation at the source.

## How this differs from #28646
- #28646: time-window mitigation (skip heartbeat during recent activity).
- This PR: deterministic routing isolation.

Specifically, this PR:
1) prevents mixed origin metadata assembly in queue drain routing,
2) prevents synthetic providers (heartbeat/cron/exec) from mutating persisted session delivery context used by user-originated replies.

## Root causes addressed
### 1) Mixed origin metadata assembly
File: `src/auto-reply/reply/queue/drain.ts`

`resolveOriginRoutingMetadata(items)` previously selected `originatingChannel`, `originatingTo`, `originatingAccountId`, and `originatingThreadId` independently across the batch via separate `find(...)` calls.
Under concurrent/mixed queue contents, this could combine fields from different messages.

### 2) Synthetic-provider routing context leakage
File: `src/auto-reply/reply/session.ts`

Session delivery context (`lastChannel/lastTo/lastAccountId/lastThreadId`) could be updated during synthetic runs (`heartbeat`, `cron-event`, `exec-event`), creating cross-talk with normal user-message routing.

## Changes
### A) Keep routing tuple from a single source item
File: `src/auto-reply/reply/queue/drain.ts`

- `resolveOriginRoutingMetadata(items)` now resolves one concrete source item and uses that item's full routing tuple.
- Avoids cross-item channel/to/account/thread mixing.

### B) Do not persist synthetic-provider routing into user delivery context
File: `src/auto-reply/reply/session.ts`

- Detect synthetic providers: `heartbeat`, `cron-event`, `exec-event`.
- For synthetic runs, do not overwrite persisted `last*` delivery routing fields.
- Preserves user-originated routing context integrity.

## Local validation
- `pnpm vitest run src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/session.test.ts`
- Result: 79 tests passed
