### PR TITLE
feat: add @openclaw/acp-standard plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -244,6 +244,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/acpx/**"
+"extensions: acp-standard":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/acp-standard/**"
 "extensions: minimax-portal-auth":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/acp-standard/README.md
+++ b/extensions/acp-standard/README.md
@@ -1,0 +1,68 @@
+# @openclaw/acp-standard
+
+OpenClaw ACP runtime backend for **any standard ACP agent** — Kiro, Copilot, Cline, and [19+ others](https://agentclientprotocol.com/get-started/registry).
+
+## What it does
+
+This plugin implements the `AcpRuntime` interface using standard [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) JSON-RPC 2.0 over stdio. It spawns any ACP-compatible agent binary and translates between OpenClaw's internal event model and the ACP wire protocol.
+
+```
+OpenClaw gateway
+  └─ acp-standard plugin (this)
+       └─ any ACP agent (kiro-cli acp, copilot --acp --stdio, etc.)
+            └─ JSON-RPC 2.0 over stdio
+```
+
+## Quick start
+
+```bash
+openclaw plugins install @openclaw/acp-standard
+openclaw config set plugins.entries.acp-standard.enabled true
+```
+
+Configure in `openclaw.json`:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "acp-standard",
+  },
+  plugins: {
+    entries: {
+      "acp-standard": {
+        enabled: true,
+        config: {
+          command: "kiro-cli",
+          args: ["acp"],
+        },
+      },
+    },
+  },
+}
+```
+
+## Config options
+
+| Key       | Type     | Default       | Description                 |
+| --------- | -------- | ------------- | --------------------------- |
+| `command` | string   | `"kiro-cli"`  | Agent binary command        |
+| `args`    | string[] | `["acp"]`     | Arguments to start ACP mode |
+| `cwd`     | string   | workspace dir | Working directory           |
+| `env`     | object   | `{}`          | Extra environment variables |
+
+## Protocol mapping
+
+| OpenClaw AcpRuntime | Standard ACP JSON-RPC 2.0                  |
+| ------------------- | ------------------------------------------ |
+| `ensureSession()`   | `initialize` + `session/new`               |
+| `runTurn()`         | `session/prompt` → stream `session/update` |
+| `cancel()`          | `session/cancel`                           |
+| `close()`           | SIGTERM agent process                      |
+| `setMode()`         | `session/set_mode`                         |
+
+## Related
+
+- [openclaw/openclaw#28511](https://github.com/openclaw/openclaw/issues/28511) — Feature request
+- [ACP Registry](https://agentclientprotocol.com/get-started/registry) — 19+ compatible agents
+- [ACP Specification](https://agentclientprotocol.com/) — Protocol spec

--- a/extensions/acp-standard/index.ts
+++ b/extensions/acp-standard/index.ts
@@ -1,0 +1,19 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createStandardAcpConfigSchema } from "./src/config.js";
+import { createStandardAcpService } from "./src/service.js";
+
+const plugin = {
+  id: "acp-standard",
+  name: "Standard ACP Runtime",
+  description: "ACP runtime backend for any standard ACP agent via JSON-RPC 2.0 over stdio.",
+  configSchema: createStandardAcpConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.registerService(
+      createStandardAcpService({
+        pluginConfig: api.pluginConfig,
+      }),
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/acp-standard/openclaw.plugin.json
+++ b/extensions/acp-standard/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "acp-standard",
+  "name": "Standard ACP Runtime",
+  "description": "ACP runtime backend for any standard ACP agent (Kiro, Copilot, Cline, etc.) via JSON-RPC 2.0 over stdio.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "command": {
+        "type": "string"
+      },
+      "args": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "cwd": {
+        "type": "string"
+      },
+      "env": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    }
+  },
+  "uiHints": {
+    "command": {
+      "label": "Agent Command",
+      "help": "Binary command for the ACP agent (e.g. kiro-cli, copilot, cline)."
+    },
+    "args": {
+      "label": "Agent Arguments",
+      "help": "Arguments to start ACP mode (e.g. ['acp'] for kiro-cli, ['--acp', '--stdio'] for others)."
+    },
+    "cwd": {
+      "label": "Working Directory",
+      "help": "Default cwd for ACP session operations."
+    },
+    "env": {
+      "label": "Environment Variables",
+      "help": "Extra environment variables passed to the agent process.",
+      "advanced": true
+    }
+  }
+}

--- a/extensions/acp-standard/package.json
+++ b/extensions/acp-standard/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/acp-standard",
+  "version": "2026.2.26",
+  "description": "OpenClaw ACP runtime backend for standard ACP agents (JSON-RPC 2.0 over stdio)",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/acp-standard/src/config.ts
+++ b/extensions/acp-standard/src/config.ts
@@ -1,0 +1,70 @@
+import type { OpenClawPluginConfigSchema } from "openclaw/plugin-sdk";
+
+export type StandardAcpPluginConfig = {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+};
+
+export type ResolvedStandardAcpConfig = {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(path: string[], message: string) {
+  return { success: false as const, error: { issues: [{ path, message }] } };
+}
+
+export function createStandardAcpConfigSchema(): OpenClawPluginConfigSchema {
+  return {
+    safeParse(value: unknown) {
+      if (value === undefined) return { success: true, data: undefined };
+      if (!isRecord(value)) return fail([], "expected config object");
+      if (value.command !== undefined && typeof value.command !== "string")
+        return fail(["command"], "must be a string");
+      if (
+        value.args !== undefined &&
+        (!Array.isArray(value.args) || !value.args.every((a: unknown) => typeof a === "string"))
+      )
+        return fail(["args"], "must be an array of strings");
+      if (value.cwd !== undefined && typeof value.cwd !== "string")
+        return fail(["cwd"], "must be a string");
+      if (
+        value.env !== undefined &&
+        (!isRecord(value.env) || !Object.values(value.env).every((v) => typeof v === "string"))
+      )
+        return fail(["env"], "must be an object with string values");
+      return { success: true, data: value };
+    },
+    jsonSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        command: { type: "string" },
+        args: { type: "array", items: { type: "string" } },
+        cwd: { type: "string" },
+        env: { type: "object", additionalProperties: { type: "string" } },
+      },
+    },
+  };
+}
+
+export function resolveStandardAcpConfig(params: {
+  rawConfig: unknown;
+  workspaceDir?: string;
+}): ResolvedStandardAcpConfig {
+  const raw = (params.rawConfig ?? {}) as StandardAcpPluginConfig;
+  return {
+    command: raw.command ?? "kiro-cli",
+    args: raw.args ?? ["acp"],
+    cwd: raw.cwd ?? params.workspaceDir ?? process.cwd(),
+    env: raw.env ?? {},
+  };
+}

--- a/extensions/acp-standard/src/runtime.test.ts
+++ b/extensions/acp-standard/src/runtime.test.ts
@@ -1,0 +1,359 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AcpRuntimeEvent } from "../../../src/acp/runtime/types.js";
+import type { ResolvedStandardAcpConfig } from "./config.js";
+import { StandardAcpRuntime } from "./runtime.js";
+
+const NOOP_LOGGER = {
+  info: (_message: string) => {},
+  warn: (_message: string) => {},
+  error: (_message: string) => {},
+  debug: (_message: string) => {},
+};
+
+/**
+ * Minimal mock ACP agent that speaks JSON-RPC 2.0 over stdio.
+ * Supports: initialize, session/new, session/prompt, session/cancel, session/set_mode.
+ * Behaviour is controlled via environment variables:
+ *   MOCK_FAIL_INIT=1    → return error on initialize
+ *   MOCK_HANG_PROMPT=1  → never respond to session/prompt
+ *   MOCK_BAD_JSON=1     → write malformed JSON on stdout before responding
+ */
+const MOCK_AGENT_SCRIPT = String.raw`#!/usr/bin/env node
+const readline = require("node:readline");
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(obj) { process.stdout.write(JSON.stringify(obj) + "\n"); }
+
+rl.on("line", (line) => {
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  const { id, method, params } = msg;
+
+  if (process.env.MOCK_BAD_JSON === "1" && method === "session/prompt") {
+    process.stdout.write("NOT_JSON\n");
+  }
+
+  if (method === "initialize") {
+    if (process.env.MOCK_FAIL_INIT === "1") {
+      send({ jsonrpc: "2.0", id, error: { code: -1, message: "init failed" } });
+      return;
+    }
+    send({ jsonrpc: "2.0", id, result: { protocolVersion: 1, agentInfo: { name: "mock" } } });
+    return;
+  }
+
+  if (method === "session/new") {
+    send({ jsonrpc: "2.0", id, result: { sessionId: "mock-session-1" } });
+    return;
+  }
+
+  if (method === "session/prompt") {
+    if (process.env.MOCK_HANG_PROMPT === "1") return; // never respond
+    // Stream a text chunk then complete
+    send({ jsonrpc: "2.0", method: "session/update", params: {
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hello" } }
+    }});
+    send({ jsonrpc: "2.0", id, result: { stopReason: "end_turn" } });
+    return;
+  }
+
+  if (method === "session/cancel") {
+    send({ jsonrpc: "2.0", id, result: {} });
+    return;
+  }
+
+  if (method === "session/set_mode") {
+    send({ jsonrpc: "2.0", id, result: {} });
+    return;
+  }
+
+  send({ jsonrpc: "2.0", id, error: { code: -32601, message: "unknown method" } });
+});
+`;
+
+let tmpDir: string;
+let scriptPath: string;
+
+async function setup(): Promise<string> {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "acp-test-"));
+  scriptPath = path.join(tmpDir, "mock-agent.cjs");
+  await writeFile(scriptPath, MOCK_AGENT_SCRIPT);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+function makeConfig(env?: Record<string, string>): ResolvedStandardAcpConfig {
+  return {
+    command: process.execPath,
+    args: [scriptPath],
+    cwd: tmpDir,
+    env: env ?? {},
+  };
+}
+
+function makeRuntime(env?: Record<string, string>): StandardAcpRuntime {
+  return new StandardAcpRuntime(makeConfig(env), NOOP_LOGGER);
+}
+
+async function collectEvents(
+  runtime: StandardAcpRuntime,
+  sessionKey: string,
+  text: string,
+  signal?: AbortSignal,
+): Promise<AcpRuntimeEvent[]> {
+  const handle = await runtime.ensureSession({ sessionKey, agent: "mock", mode: "persistent" });
+  const events: AcpRuntimeEvent[] = [];
+  for await (const event of runtime.runTurn({
+    handle,
+    text,
+    mode: "prompt",
+    requestId: "r1",
+    signal,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("StandardAcpRuntime", () => {
+  afterEach(async () => {
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  // --- probeAvailability ---
+
+  it("marks healthy when command exits 0", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    await runtime.probeAvailability();
+    expect(runtime.isHealthy()).toBe(true);
+  });
+
+  it("marks unhealthy for missing command", async () => {
+    await setup();
+    const runtime = new StandardAcpRuntime(
+      { command: "/no/such/binary", args: [], cwd: tmpDir, env: {} },
+      NOOP_LOGGER,
+    );
+    await runtime.probeAvailability();
+    expect(runtime.isHealthy()).toBe(false);
+  });
+
+  // --- ensureSession ---
+
+  it("initializes and returns a session handle", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const handle = await runtime.ensureSession({
+      sessionKey: "s1",
+      agent: "mock",
+      mode: "persistent",
+    });
+    expect(handle.sessionKey).toBe("s1");
+    expect(handle.runtimeSessionName).toBe("mock-session-1");
+    runtime.closeAll();
+  });
+
+  it("reuses existing session on second call", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const h1 = await runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" });
+    const h2 = await runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" });
+    expect(h1.runtimeSessionName).toBe(h2.runtimeSessionName);
+    runtime.closeAll();
+  });
+
+  it("deduplicates concurrent ensureSession calls for the same key", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const [h1, h2] = await Promise.all([
+      runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" }),
+      runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" }),
+    ]);
+    expect(h1.runtimeSessionName).toBe(h2.runtimeSessionName);
+    runtime.closeAll();
+  });
+
+  it("cleans up on initialization failure", async () => {
+    await setup();
+    const runtime = makeRuntime({ MOCK_FAIL_INIT: "1" });
+    await expect(
+      runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" }),
+    ).rejects.toThrow();
+    // Second attempt should also try fresh (not return stale agent).
+    await expect(
+      runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" }),
+    ).rejects.toThrow();
+  });
+
+  // --- runTurn ---
+
+  it("streams text and completes with done", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const events = await collectEvents(runtime, "s1", "hi");
+    expect(events.some((e) => e.type === "text_delta")).toBe(true);
+    expect(events.at(-1)).toMatchObject({ type: "done", stopReason: "end_turn" });
+    runtime.closeAll();
+  });
+
+  it("handles malformed JSON lines without crashing", async () => {
+    await setup();
+    const runtime = makeRuntime({ MOCK_BAD_JSON: "1" });
+    const events = await collectEvents(runtime, "s1", "hi");
+    // Should still complete despite the bad line
+    expect(events.some((e) => e.type === "done")).toBe(true);
+    runtime.closeAll();
+  });
+
+  it("yields cancelled done for pre-aborted signal", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const handle = await runtime.ensureSession({
+      sessionKey: "s1",
+      agent: "mock",
+      mode: "persistent",
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const events: AcpRuntimeEvent[] = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "hi",
+      mode: "prompt",
+      requestId: "r1",
+      signal: controller.signal,
+    })) {
+      events.push(event);
+    }
+    expect(events).toEqual([{ type: "done", stopReason: "cancelled" }]);
+    runtime.closeAll();
+  });
+
+  it("yields cancelled done on mid-turn abort", async () => {
+    await setup();
+    const runtime = makeRuntime({ MOCK_HANG_PROMPT: "1" });
+    const handle = await runtime.ensureSession({
+      sessionKey: "s1",
+      agent: "mock",
+      mode: "persistent",
+    });
+    const controller = new AbortController();
+    const events: AcpRuntimeEvent[] = [];
+    // Abort after a short delay
+    setTimeout(() => controller.abort(), 200);
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "hi",
+      mode: "prompt",
+      requestId: "r1",
+      signal: controller.signal,
+    })) {
+      events.push(event);
+    }
+    expect(events.at(-1)).toMatchObject({ type: "done", stopReason: "cancelled" });
+    runtime.closeAll();
+  });
+
+  // --- unexpected process exit ---
+
+  it("yields error when agent process exits unexpectedly", async () => {
+    await setup();
+    // Script that exits immediately after session/new
+    const crashScript = path.join(tmpDir, "crash-agent.cjs");
+    await writeFile(
+      crashScript,
+      String.raw`#!/usr/bin/env node
+const rl = require("node:readline").createInterface({ input: process.stdin });
+let ready = false;
+rl.on("line", (line) => {
+  const msg = JSON.parse(line);
+  if (msg.method === "initialize") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: 1 } }) + "\n");
+    return;
+  }
+  if (msg.method === "session/new") {
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { sessionId: "s" } }) + "\n");
+    ready = true;
+    return;
+  }
+  if (msg.method === "session/prompt" && ready) {
+    process.exit(1); // crash
+  }
+});
+`,
+    );
+    await chmod(crashScript, 0o755);
+
+    const runtime = new StandardAcpRuntime(
+      { command: process.execPath, args: [crashScript], cwd: tmpDir, env: {} },
+      NOOP_LOGGER,
+    );
+    const handle = await runtime.ensureSession({
+      sessionKey: "s1",
+      agent: "mock",
+      mode: "persistent",
+    });
+    const events: AcpRuntimeEvent[] = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "hi",
+      mode: "prompt",
+      requestId: "r1",
+    })) {
+      events.push(event);
+    }
+    expect(events.some((e) => e.type === "error")).toBe(true);
+  });
+
+  // --- doctor ---
+
+  it("returns ok doctor report when healthy", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const report = await runtime.doctor!();
+    expect(report.ok).toBe(true);
+  });
+
+  it("returns not-ok doctor report for missing command", async () => {
+    await setup();
+    const runtime = new StandardAcpRuntime(
+      { command: "/no/such/binary", args: [], cwd: tmpDir, env: {} },
+      NOOP_LOGGER,
+    );
+    const report = await runtime.doctor!();
+    expect(report.ok).toBe(false);
+    expect(report.code).toBe("ACP_BACKEND_UNAVAILABLE");
+  });
+
+  // --- setMode ---
+
+  it("sends set_mode request without error", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    const handle = await runtime.ensureSession({
+      sessionKey: "s1",
+      agent: "mock",
+      mode: "persistent",
+    });
+    await expect(runtime.setMode!({ handle, mode: "fast" })).resolves.toBeUndefined();
+    runtime.closeAll();
+  });
+
+  // --- closeAll ---
+
+  it("kills all agent processes on closeAll", async () => {
+    await setup();
+    const runtime = makeRuntime();
+    await runtime.ensureSession({ sessionKey: "s1", agent: "mock", mode: "persistent" });
+    await runtime.ensureSession({ sessionKey: "s2", agent: "mock", mode: "persistent" });
+    runtime.closeAll();
+    const status = await runtime.getStatus!({
+      handle: { sessionKey: "s1", backend: "acp-standard", runtimeSessionName: "x", cwd: tmpDir },
+    });
+    expect(status.summary).toBe("no process");
+  });
+});

--- a/extensions/acp-standard/src/runtime.ts
+++ b/extensions/acp-standard/src/runtime.ts
@@ -1,0 +1,416 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { Writable } from "node:stream";
+import type {
+  AcpRuntime,
+  AcpRuntimeCapabilities,
+  AcpRuntimeDoctorReport,
+  AcpRuntimeEnsureInput,
+  AcpRuntimeEvent,
+  AcpRuntimeHandle,
+  AcpRuntimeStatus,
+  AcpRuntimeTurnInput,
+  PluginLogger,
+} from "openclaw/plugin-sdk";
+import { AcpRuntimeError } from "openclaw/plugin-sdk";
+import type { ResolvedStandardAcpConfig } from "./config.js";
+
+export const STANDARD_ACP_BACKEND_ID = "acp-standard";
+
+/** Timeout for control-plane requests (initialize, session/new, etc.). */
+const CONTROL_TIMEOUT_MS = 30_000;
+
+/** Methods that are expected to return quickly. */
+const CONTROL_METHODS = new Set([
+  "initialize",
+  "session/new",
+  "session/cancel",
+  "session/set_mode",
+]);
+
+type AgentProcess = {
+  child: ChildProcess;
+  stdin: Writable;
+  sessionId: string | null;
+  nextId: number;
+  pending: Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>;
+  notifications: ((event: AcpRuntimeEvent) => void) | null;
+};
+
+const CAPABILITIES: AcpRuntimeCapabilities = {
+  controls: ["session/set_mode"],
+};
+
+export class StandardAcpRuntime implements AcpRuntime {
+  private healthy = false;
+  private agents = new Map<string, AgentProcess>();
+  private initializing = new Map<string, Promise<AcpRuntimeHandle>>();
+
+  constructor(
+    private readonly config: ResolvedStandardAcpConfig,
+    private readonly logger?: PluginLogger,
+  ) {}
+
+  isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  private get spawnEnv(): NodeJS.ProcessEnv {
+    return { ...process.env, ...this.config.env };
+  }
+
+  async probeAvailability(): Promise<void> {
+    try {
+      const child = spawn(this.config.command, ["--help"], {
+        cwd: this.config.cwd,
+        stdio: "ignore",
+        env: this.spawnEnv,
+      });
+      const code = await new Promise<number>((resolve) => {
+        child.on("close", (c) => resolve(c ?? 1));
+        child.on("error", () => resolve(1));
+      });
+      this.healthy = code === 0;
+    } catch {
+      this.healthy = false;
+    }
+  }
+
+  async ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle> {
+    const key = input.sessionKey;
+
+    // Return in-flight initialization to prevent concurrent spawns for the same key.
+    const inflight = this.initializing.get(key);
+    if (inflight) return inflight;
+
+    if (this.agents.has(key)) {
+      const agent = this.agents.get(key)!;
+      return {
+        sessionKey: key,
+        backend: STANDARD_ACP_BACKEND_ID,
+        runtimeSessionName: agent.sessionId ?? key,
+        cwd: input.cwd ?? this.config.cwd,
+      };
+    }
+
+    const promise = this.initAgent(key, input);
+    this.initializing.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      this.initializing.delete(key);
+    }
+  }
+
+  private async initAgent(key: string, input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle> {
+    const agent = this.spawnAgent(key);
+    this.agents.set(key, agent);
+
+    try {
+      await this.sendRequest(agent, "initialize", {
+        protocolVersion: "0.1",
+        clientInfo: { name: "openclaw", version: "1.0.0" },
+      });
+
+      const sessionResult = (await this.sendRequest(agent, "session/new", {
+        cwd: input.cwd ?? this.config.cwd,
+        mcpServers: [],
+      })) as Record<string, unknown>;
+      agent.sessionId = (sessionResult?.sessionId as string) ?? key;
+    } catch (err) {
+      agent.child.kill("SIGTERM");
+      this.agents.delete(key);
+      throw err;
+    }
+
+    return {
+      sessionKey: key,
+      backend: STANDARD_ACP_BACKEND_ID,
+      runtimeSessionName: agent.sessionId ?? key,
+      cwd: input.cwd ?? this.config.cwd,
+    };
+  }
+
+  async *runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
+    // Short-circuit if the signal is already aborted.
+    if (input.signal?.aborted) {
+      yield { type: "done", stopReason: "cancelled" };
+      return;
+    }
+
+    const agent = this.agents.get(input.handle.sessionKey);
+    if (!agent) {
+      throw new AcpRuntimeError("ACP_TURN_FAILED", "No agent process for session.");
+    }
+
+    const events: AcpRuntimeEvent[] = [];
+    let resolveWait: (() => void) | null = null;
+    let done = false;
+
+    agent.notifications = (event) => {
+      events.push(event);
+      resolveWait?.();
+    };
+
+    // Push error event on unexpected process exit so the loop never hangs.
+    const onClose = () => {
+      if (!done) {
+        events.push({ type: "error", message: "agent process exited unexpectedly" });
+        resolveWait?.();
+      }
+    };
+    agent.child.on("close", onClose);
+
+    const onAbort = () => {
+      void this.cancel({ handle: input.handle });
+      // Force-terminate the turn so the iterator always unwinds.
+      if (!done) {
+        events.push({ type: "done", stopReason: "cancelled" });
+        resolveWait?.();
+      }
+    };
+    input.signal?.addEventListener("abort", onAbort, { once: true });
+
+    const promptPromise = this.sendRequest(agent, "session/prompt", {
+      sessionId: agent.sessionId,
+      prompt: [{ type: "text", text: input.text }],
+    });
+
+    // When the prompt response arrives, treat it as turn completion
+    // (agents may resolve the prompt without sending a TurnEnd notification).
+    promptPromise
+      .then((result) => {
+        if (!done) {
+          const res = result as Record<string, unknown> | undefined;
+          const stopReason = (res?.stopReason as string) ?? "end_turn";
+          events.push({ type: "done", stopReason });
+          resolveWait?.();
+        }
+      })
+      .catch((err) => {
+        if (!done) {
+          events.push({ type: "error", message: String(err) });
+          resolveWait?.();
+        }
+      });
+
+    try {
+      while (!done) {
+        if (events.length > 0) {
+          const event = events.shift()!;
+          yield event;
+          if (event.type === "done" || event.type === "error") {
+            done = true;
+          }
+        } else {
+          await new Promise<void>((r) => {
+            resolveWait = r;
+          });
+        }
+      }
+    } finally {
+      agent.notifications = null;
+      agent.child.removeListener("close", onClose);
+      input.signal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  getCapabilities(): AcpRuntimeCapabilities {
+    return CAPABILITIES;
+  }
+
+  async getStatus(input: { handle: AcpRuntimeHandle }): Promise<AcpRuntimeStatus> {
+    const agent = this.agents.get(input.handle.sessionKey);
+    return {
+      summary: agent ? `running, sessionId=${agent.sessionId}` : "no process",
+    };
+  }
+
+  async setMode(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void> {
+    const agent = this.agents.get(input.handle.sessionKey);
+    if (!agent) return;
+    await this.sendRequest(agent, "session/set_mode", {
+      sessionId: agent.sessionId,
+      modeId: input.mode,
+    });
+  }
+
+  async doctor(): Promise<AcpRuntimeDoctorReport> {
+    try {
+      await this.probeAvailability();
+      return this.healthy
+        ? { ok: true, message: `${this.config.command} available` }
+        : {
+            ok: false,
+            code: "ACP_BACKEND_UNAVAILABLE",
+            message: `${this.config.command} not responding`,
+          };
+    } catch (err) {
+      return { ok: false, code: "ACP_BACKEND_UNAVAILABLE", message: String(err) };
+    }
+  }
+
+  async cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void> {
+    const agent = this.agents.get(input.handle.sessionKey);
+    if (!agent) return;
+    await this.sendRequest(agent, "session/cancel", {
+      sessionId: agent.sessionId,
+    }).catch(() => {});
+  }
+
+  async close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void> {
+    const agent = this.agents.get(input.handle.sessionKey);
+    if (!agent) return;
+    agent.child.kill("SIGTERM");
+    this.agents.delete(input.handle.sessionKey);
+  }
+
+  /** Kill all spawned agent processes. Called during service shutdown. */
+  closeAll(): void {
+    for (const [key, agent] of this.agents) {
+      agent.child.kill("SIGTERM");
+      this.agents.delete(key);
+    }
+  }
+
+  // --- JSON-RPC 2.0 transport ---
+
+  private spawnAgent(key: string): AgentProcess {
+    const child = spawn(this.config.command, this.config.args, {
+      cwd: this.config.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: this.spawnEnv,
+    });
+
+    // stdio: ["pipe","pipe","pipe"] guarantees these are non-null.
+    const stdin = child.stdin!;
+    const stdout = child.stdout!;
+    const stderr = child.stderr!;
+
+    const agent: AgentProcess = {
+      child,
+      stdin,
+      sessionId: null,
+      nextId: 1,
+      pending: new Map(),
+      notifications: null,
+    };
+
+    // Handle spawn failures (e.g. ENOENT) without crashing the host process.
+    child.on("error", (err) => {
+      this.logger?.warn?.(`[acp-standard:${key}] spawn error: ${err.message}`);
+      for (const p of agent.pending.values()) {
+        p.reject(err);
+      }
+      agent.pending.clear();
+      if (this.agents.get(key) === agent) this.agents.delete(key);
+    });
+
+    const rl = createInterface({ input: stdout });
+    rl.on("line", (line) => {
+      try {
+        const msg = JSON.parse(line) as Record<string, unknown>;
+
+        if ("id" in msg && msg.id != null) {
+          const id = msg.id as number;
+          const p = agent.pending.get(id);
+          if (p) {
+            agent.pending.delete(id);
+            if ("error" in msg) {
+              p.reject(new Error(JSON.stringify(msg.error)));
+            } else {
+              p.resolve(msg.result);
+            }
+          }
+          return;
+        }
+
+        if ("method" in msg && msg.method === "session/update") {
+          const params = msg.params as Record<string, unknown> | undefined;
+          if (!params) return;
+          const event = this.mapNotificationToEvent(params);
+          if (event) agent.notifications?.(event);
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    });
+
+    stderr.on("data", (chunk: Buffer) => {
+      this.logger?.warn?.(`[acp-standard:${key}] stderr: ${String(chunk).trim()}`);
+    });
+
+    child.on("close", () => {
+      for (const p of agent.pending.values()) {
+        p.reject(new Error("agent process exited"));
+      }
+      agent.pending.clear();
+      if (this.agents.get(key) === agent) this.agents.delete(key);
+    });
+
+    return agent;
+  }
+
+  private sendRequest(agent: AgentProcess, method: string, params: unknown): Promise<unknown> {
+    const id = agent.nextId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    const timeoutMs = CONTROL_METHODS.has(method) ? CONTROL_TIMEOUT_MS : undefined;
+
+    return new Promise((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      if (timeoutMs) {
+        timer = setTimeout(() => {
+          agent.pending.delete(id);
+          reject(new Error(`JSON-RPC request timed out: ${method}`));
+        }, timeoutMs);
+      }
+
+      agent.pending.set(id, {
+        resolve: (v) => {
+          if (timer) clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          if (timer) clearTimeout(timer);
+          reject(e);
+        },
+      });
+
+      agent.stdin.write(msg + "\n", (err) => {
+        if (err) {
+          if (timer) clearTimeout(timer);
+          agent.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  private mapNotificationToEvent(params: Record<string, unknown>): AcpRuntimeEvent | null {
+    // ACP session/update envelope: { update: { sessionUpdate: "...", ... } }
+    const update = params.update as Record<string, unknown> | undefined;
+    if (!update) return null;
+    const kind = update.sessionUpdate as string | undefined;
+
+    switch (kind) {
+      case "agent_message_chunk": {
+        const content = update.content as Record<string, unknown> | undefined;
+        return {
+          type: "text_delta",
+          text: (content?.text as string) ?? "",
+          stream: "output",
+        };
+      }
+      case "tool_call":
+        return { type: "tool_call", text: (update.title as string) ?? "tool" };
+      case "tool_call_update":
+        return {
+          type: "status",
+          text: `tool ${(update.toolCallId as string) ?? ""}: ${(update.status as string) ?? ""}`,
+        };
+      default:
+        return null;
+    }
+  }
+}

--- a/extensions/acp-standard/src/service.ts
+++ b/extensions/acp-standard/src/service.ts
@@ -1,0 +1,60 @@
+import type {
+  AcpRuntime,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk";
+import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "openclaw/plugin-sdk";
+import { resolveStandardAcpConfig } from "./config.js";
+import { STANDARD_ACP_BACKEND_ID, StandardAcpRuntime } from "./runtime.js";
+
+type StandardAcpRuntimeLike = AcpRuntime & {
+  probeAvailability(): Promise<void>;
+  isHealthy(): boolean;
+  closeAll(): void;
+};
+
+export function createStandardAcpService(params: {
+  pluginConfig?: unknown;
+}): OpenClawPluginService {
+  let runtime: StandardAcpRuntimeLike | null = null;
+
+  return {
+    id: "acp-standard-runtime",
+    async start(ctx: OpenClawPluginServiceContext): Promise<void> {
+      const config = resolveStandardAcpConfig({
+        rawConfig: params.pluginConfig,
+        workspaceDir: ctx.workspaceDir,
+      });
+      runtime = new StandardAcpRuntime(config, ctx.logger);
+
+      registerAcpRuntimeBackend({
+        id: STANDARD_ACP_BACKEND_ID,
+        runtime,
+        healthy: () => runtime?.isHealthy() ?? false,
+      });
+      ctx.logger.info(
+        `acp-standard backend registered (${config.command} ${config.args.join(" ")})`,
+      );
+
+      void (async () => {
+        try {
+          await runtime?.probeAvailability();
+          if (runtime?.isHealthy()) {
+            ctx.logger.info("acp-standard backend ready");
+          } else {
+            ctx.logger.warn("acp-standard backend probe failed");
+          }
+        } catch (err) {
+          ctx.logger.warn(
+            `acp-standard setup failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })();
+    },
+    async stop(): Promise<void> {
+      runtime?.closeAll();
+      unregisterAcpRuntimeBackend(STANDARD_ACP_BACKEND_ID);
+      runtime = null;
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,8 @@ importers:
         specifier: ^0.10.0
         version: 0.10.0
 
+  extensions/acp-standard: {}
+
   extensions/acpx:
     dependencies:
       acpx:


### PR DESCRIPTION
## Summary
- ACP runtime plugin (`@openclaw/acp-standard`) for any standard ACP agent (Kiro CLI, Copilot, Cline, [20+ others](https://agentclientprotocol.com))
- JSON-RPC 2.0 over stdio, implements full `AcpRuntime` interface
- Concurrent session dedup, abort→cancel semantics, stale-callback guards
- 15 unit tests with mock ACP agent script

## Test plan
- Unit: `npx vitest run extensions/acp-standard/src/runtime.test.ts --config vitest.extensions.config.ts`
- Live tested with Kiro CLI: initialize → session/new → session/prompt → full round-trip

🤖 AI-assisted