### PR TITLE
fix(telegram): respect plugin requireAuth:false for callback_query in DMs

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -53,6 +53,7 @@ import {
 } from "./group-access.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
+import { matchPluginCommand } from "../plugins/commands.js";
 import {
   buildModelsKeyboard,
   buildProviderKeyboard,
@@ -1071,8 +1072,18 @@ export const registerTelegramHandlers = ({
       const { resolvedThreadId, storeAllowFrom } = eventAuthContext;
       const senderId = callback.from?.id ? String(callback.from.id) : "";
       const senderUsername = callback.from?.username ?? "";
-      const authorizationMode: TelegramEventAuthorizationMode =
+      let authorizationMode: TelegramEventAuthorizationMode =
         inlineButtonsScope === "allowlist" ? "callback-allowlist" : "callback-scope";
+
+      // Respect plugin command requireAuth: false for inline button callbacks.
+      // When a plugin explicitly opts out of auth, its inline buttons should
+      // also work without DM authorization (matching typed-command behavior).
+      if (authorizationMode === "callback-allowlist" && data.startsWith("/")) {
+        const pluginMatch = matchPluginCommand(data);
+        if (pluginMatch?.command.requireAuth === false) {
+          authorizationMode = "callback-scope";
+        }
+      }
       const senderAuthorization = authorizeTelegramEventSender({
         chatId,
         chatTitle: callbackMessage.chat.title,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -23,6 +23,7 @@ import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { matchPluginCommand } from "../plugins/commands.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -53,7 +54,6 @@ import {
 } from "./group-access.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
-import { matchPluginCommand } from "../plugins/commands.js";
 import {
   buildModelsKeyboard,
   buildProviderKeyboard,


### PR DESCRIPTION
## Summary

Fixes #28659

When `inlineButtonsScope` is `"allowlist"` (default), the `callback_query` handler enforces DM authorization regardless of the target plugin command's `requireAuth` setting. This causes inline buttons to **silently fail in DMs** for plugins that set `requireAuth: false`, even though the same command works when typed manually.

## Root Cause

In `bot-handlers.ts`, the callback_query handler resolves `authorizationMode` based solely on `inlineButtonsScope`:

```typescript
const authorizationMode = inlineButtonsScope === "allowlist" ? "callback-allowlist" : "callback-scope";
```

For `callback-allowlist` mode, `enforceDirectAuthorization: true` requires DM senders to pass the pairing/allowlist check. But plugin commands registered with `requireAuth: false` intentionally opt out of auth — typed `/command` in DM works because `resolveTelegramCommandAuth` skips the check when `requireAuth: false`.

The disconnect: **callback_query ignores the plugin's auth setting, blocking inline buttons that the plugin explicitly made public.**

## Fix

Before the auth check, look up whether the callback data matches a plugin command with `requireAuth: false`. If so, relax from `callback-allowlist` to `callback-scope` mode (which skips DM authorization but still enforces group policy via `shouldSkipGroupMessage`).

```typescript
if (authorizationMode === "callback-allowlist" && data.startsWith("/")) {
  const pluginMatch = matchPluginCommand(data);
  if (pluginMatch?.command.requireAuth === false) {
    authorizationMode = "callback-scope";
  }
}
```

## Scope

- Only affects plugin commands that **explicitly** set `requireAuth: false`
- Only relaxes from `callback-allowlist` → `callback-scope` (group policy still enforced)
- No change to behavior for `requireAuth: true` (default) plugin commands
- No change to non-plugin callback_query handling (pagination, model selection)