### PR TITLE
fix: detect stale channel polling via lastInboundAt in health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -306,4 +306,78 @@ describe("channel-health-monitor", () => {
     expect(manager.stopChannel).not.toHaveBeenCalled();
     monitor.stop();
   });
+
+  it("restarts stale channels (no inbound for >15 minutes)", async () => {
+    const staleTimestamp = Date.now() - 16 * 60_000; // 16 minutes ago
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: staleTimestamp,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).toHaveBeenCalledWith("telegram", "default");
+    expect(manager.resetRestartAttempts).toHaveBeenCalledWith("telegram", "default");
+    expect(manager.startChannel).toHaveBeenCalledWith("telegram", "default");
+    monitor.stop();
+  });
+
+  it("skips healthy channels with recent inbound activity", async () => {
+    const recentTimestamp = Date.now() - 5 * 60_000; // 5 minutes ago
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: recentTimestamp,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("skips channels that have never received inbound (lastInboundAt is null)", async () => {
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: null,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("skips channels that have never received inbound (lastInboundAt is undefined)", async () => {
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -8,6 +8,7 @@ const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 3;
+const DEFAULT_STALE_INBOUND_THRESHOLD_MS = 15 * 60_000; // 15 minutes
 const ONE_HOUR_MS = 60 * 60_000;
 
 export type ChannelHealthMonitorDeps = {
@@ -32,12 +33,16 @@ function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean })
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
-function isChannelHealthy(snapshot: {
-  running?: boolean;
-  connected?: boolean;
-  enabled?: boolean;
-  configured?: boolean;
-}): boolean {
+function isChannelHealthy(
+  snapshot: {
+    running?: boolean;
+    connected?: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    lastInboundAt?: number | null;
+  },
+  staleThresholdMs: number = DEFAULT_STALE_INBOUND_THRESHOLD_MS,
+): boolean {
   if (!isManagedAccount(snapshot)) {
     return true;
   }
@@ -47,6 +52,15 @@ function isChannelHealthy(snapshot: {
   if (snapshot.connected === false) {
     return false;
   }
+
+  // Detect zombie polling: running but no inbound for too long
+  if (snapshot.lastInboundAt != null) {
+    const stalenessMs = Date.now() - snapshot.lastInboundAt;
+    if (stalenessMs > staleThresholdMs) {
+      return false; // trigger restart
+    }
+  }
+
   return true;
 }
 
@@ -105,6 +119,17 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
+          // Log stale detection for observability
+          if (
+            status.lastInboundAt != null &&
+            Date.now() - status.lastInboundAt > DEFAULT_STALE_INBOUND_THRESHOLD_MS
+          ) {
+            const stalenessMin = Math.round((Date.now() - status.lastInboundAt) / 60_000);
+            log.warn?.(
+              `[${channelId}:${accountId}] health-monitor: detected stale channel (no inbound for ${stalenessMin}min)`,
+            );
+          }
+
           const key = rKey(channelId, accountId);
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,
@@ -127,7 +152,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             ? status.reconnectAttempts && status.reconnectAttempts >= 10
               ? "gave-up"
               : "stopped"
-            : "stuck";
+            : status.connected === false
+              ? "disconnected"
+              : status.lastInboundAt != null &&
+                  Date.now() - status.lastInboundAt > DEFAULT_STALE_INBOUND_THRESHOLD_MS
+                ? "stale"
+                : "stuck";
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 


### PR DESCRIPTION
## Problem

The channel health monitor (`src/gateway/channel-health-monitor.ts`) previously checked only `running` and `connected` status to determine channel health. This missed a critical failure mode: **zombie polling connections** where the channel appears running but silently stops receiving updates.

`ChannelAccountSnapshot` already tracks `lastInboundAt`, `lastEventAt`, and `lastOutboundAt` timestamps, but these were not used by the health monitor.

### Observed Scenario

Telegram long-polling can silently die when the upstream proxy/network partially fails — the TCP connection stays alive but data stops flowing. In this state:
- `running === true` (grammY runner hasn't crashed)
- `connected` is not set to `false` (no explicit disconnect)
- `isChannelHealthy()` returns `true`
- **No updates are received for an extended period** (50+ minutes observed)

Fixes #28622

## Changes

### Updated `isChannelHealthy()` function
- Added `lastInboundAt` parameter to detect stale channels
- Added staleness check: if `lastInboundAt` is older than 15 minutes, channel is considered unhealthy
- Only triggers when `lastInboundAt` is non-null (skips channels that have never received a message)

### Added `DEFAULT_STALE_INBOUND_THRESHOLD_MS`
- Default threshold: 15 minutes (configurable constant)
- Balanced to avoid false positives on low-traffic channels while catching zombie connections

### Enhanced restart reason logic
- Added `"stale"` restart reason alongside existing `"stopped"`, `"gave-up"`, `"stuck"`
- Logs warning with staleness duration when stale channel is detected for observability

```typescript
const reason = !status.running
  ? status.reconnectAttempts && status.reconnectAttempts >= 10
    ? "gave-up"
    : "stopped"
  : status.connected === false
    ? "disconnected"
    : status.lastInboundAt != null &&
        Date.now() - status.lastInboundAt > DEFAULT_STALE_INBOUND_THRESHOLD_MS
      ? "stale"
      : "stuck";
```

## Testing

```bash
npm test -- src/gateway/channel-health-monitor.test.ts
# All 20 tests pass ✓
```

### New test cases added:
- ✅ `restarts stale channels (no inbound for >15 minutes)`
- ✅ `skips healthy channels with recent inbound activity`
- ✅ `skips channels that have never received inbound (lastInboundAt is null)`
- ✅ `skips channels that have never received inbound (lastInboundAt is undefined)`

## Verification

- [x] Code formatted with `oxfmt`
- [x] Linting passes with `oxlint` (0 warnings, 0 errors)
- [x] TypeScript check passes with `tsgo`
- [x] All existing tests continue to pass (16 existing + 4 new = 20 total)
- [x] New tests added for the fix

## Behavior Changes

### Before
- Zombie polling connections (running but no data flow) were not detected
- Channels could be stuck for 50+ minutes without automatic recovery
- Only manual gateway restart would recover polling

### After
- Health monitor detects channels with no inbound activity for >15 minutes
- Automatic restart triggered with reason `"stale"`
- Warning logged with staleness duration for observability

## Risk Assessment

**Low** - This is an additive health check that:
- Does not change existing behavior for healthy channels
- Only adds detection for previously undetected failure mode
- Uses existing `lastInboundAt` field already tracked by channels
- Has comprehensive test coverage for edge cases