### PR TITLE
fix(gateway): detect stale inbound polling in channel health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -306,4 +306,64 @@ describe("channel-health-monitor", () => {
     expect(manager.stopChannel).not.toHaveBeenCalled();
     monitor.stop();
   });
+
+  it("restarts channel with stale inbound activity", async () => {
+    const staleInboundMs = 15 * 60_000;
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: now - staleInboundMs - 1_000,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager, { staleInboundMs });
+    expect(manager.stopChannel).toHaveBeenCalledWith("telegram", "default");
+    expect(manager.startChannel).toHaveBeenCalledWith("telegram", "default");
+    monitor.stop();
+  });
+
+  it("does not restart channel with recent inbound activity", async () => {
+    const staleInboundMs = 15 * 60_000;
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: now - 5 * 60_000,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager, { staleInboundMs });
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("does not trigger stale check when lastInboundAt is null", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const manager = createSnapshotManager({
+      telegram: {
+        default: {
+          running: true,
+          connected: true,
+          enabled: true,
+          configured: true,
+          lastInboundAt: null,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager, { staleInboundMs: 15 * 60_000 });
+    expect(manager.stopChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -8,6 +8,7 @@ const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 3;
+const DEFAULT_STALE_INBOUND_MS = 15 * 60_000;
 const ONE_HOUR_MS = 60 * 60_000;
 
 export type ChannelHealthMonitorDeps = {
@@ -16,6 +17,7 @@ export type ChannelHealthMonitorDeps = {
   startupGraceMs?: number;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
+  staleInboundMs?: number;
   abortSignal?: AbortSignal;
 };
 
@@ -32,12 +34,16 @@ function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean })
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
-function isChannelHealthy(snapshot: {
-  running?: boolean;
-  connected?: boolean;
-  enabled?: boolean;
-  configured?: boolean;
-}): boolean {
+function isChannelHealthy(
+  snapshot: {
+    running?: boolean;
+    connected?: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    lastInboundAt?: number | null;
+  },
+  opts?: { staleInboundMs?: number; nowMs?: number },
+): boolean {
   if (!isManagedAccount(snapshot)) {
     return true;
   }
@@ -46,6 +52,16 @@ function isChannelHealthy(snapshot: {
   }
   if (snapshot.connected === false) {
     return false;
+  }
+  // Detect zombie polling: channel appears running but no inbound activity
+  // for an extended period.  Only trigger when lastInboundAt is set (skip
+  // channels that have never received a message).
+  if (snapshot.lastInboundAt != null) {
+    const staleMs = opts?.staleInboundMs ?? DEFAULT_STALE_INBOUND_MS;
+    const now = opts?.nowMs ?? Date.now();
+    if (now - snapshot.lastInboundAt > staleMs) {
+      return false;
+    }
   }
   return true;
 }
@@ -57,6 +73,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     startupGraceMs = DEFAULT_STARTUP_GRACE_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
+    staleInboundMs = DEFAULT_STALE_INBOUND_MS,
     abortSignal,
   } = deps;
 
@@ -101,7 +118,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
-          if (isChannelHealthy(status)) {
+          if (isChannelHealthy(status, { staleInboundMs, nowMs: now })) {
             continue;
           }
 
@@ -123,11 +140,19 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
+          const isStaleInbound =
+            status.running &&
+            status.connected !== false &&
+            status.lastInboundAt != null &&
+            now - status.lastInboundAt > staleInboundMs;
+
           const reason = !status.running
             ? status.reconnectAttempts && status.reconnectAttempts >= 10
               ? "gave-up"
               : "stopped"
-            : "stuck";
+            : isStaleInbound
+              ? "stale"
+              : "stuck";
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 


### PR DESCRIPTION
## Summary
Fixes #28622

Adds `lastInboundAt` staleness detection to the channel health monitor. Channels that appear running but have not received any inbound message for longer than a configurable threshold (default 15 minutes) are now restarted with reason `"stale"`.

This catches **zombie polling connections** where the TCP socket stays alive but data stops flowing — a common failure mode with Telegram long-polling behind proxies.

## Changes
- Added `DEFAULT_STALE_INBOUND_MS` (15 min) constant
- Extended `isChannelHealthy()` to accept and check `lastInboundAt` timestamp
- Added `staleInboundMs` option to `ChannelHealthMonitorDeps` for configurability
- Added `"stale"` restart reason alongside existing `"stopped"`, `"gave-up"`, `"stuck"`
- Channels with `lastInboundAt === null` (never received a message) are unaffected
- Added 3 test cases covering stale detection, recent activity, and null guard

## Key design decisions
- Only triggers when `lastInboundAt` is non-null — channels that have never received a message are skipped
- Threshold is generous (15 min default) to avoid false positives on low-traffic channels
- Uses the existing restart machinery (stop → resetRestartAttempts → start) with existing cooldown/rate-limit protections

---
🤖 Generated with Claude Code