### PR TITLE
feat(telegram): expose apiRoot config for custom Bot API server

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -128,6 +128,8 @@ export type TelegramAccountConfig = {
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;
+  /** Custom Telegram Bot API server root URL (e.g. "http://localhost:8081"). Defaults to https://api.telegram.org. */
+  apiRoot?: string;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -167,6 +167,13 @@ export const TelegramAccountSchemaBase = z
       .strict()
       .optional(),
     proxy: z.string().optional(),
+    apiRoot: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Custom Telegram Bot API server root URL (e.g. http://localhost:8081). Passed to grammY as apiRoot. Defaults to https://api.telegram.org.",
+      ),
     webhookUrl: z
       .string()
       .optional()

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -133,11 +133,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = telegramCfg.apiRoot?.trim() || undefined;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || apiRoot
       ? {
           ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -118,9 +118,10 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
   };
 }
 
-function resolveTelegramClientOptions(
-  account: ResolvedTelegramAccount,
-): ApiClientOptions | undefined {
+function resolveTelegramClientOptions(account: ResolvedTelegramAccount): {
+  client?: ApiClientOptions;
+  apiRoot?: string;
+} {
   const proxyUrl = account.config.proxy?.trim();
   const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
@@ -131,12 +132,15 @@ function resolveTelegramClientOptions(
     Number.isFinite(account.config.timeoutSeconds)
       ? Math.max(1, Math.floor(account.config.timeoutSeconds))
       : undefined;
-  return fetchImpl || timeoutSeconds
-    ? {
-        ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
-        ...(timeoutSeconds ? { timeoutSeconds } : {}),
-      }
-    : undefined;
+  const apiRoot = account.config.apiRoot?.trim() || undefined;
+  const client =
+    fetchImpl || timeoutSeconds
+      ? {
+          ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
+          ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        }
+      : undefined;
+  return { client, apiRoot };
 }
 
 function resolveToken(explicit: string | undefined, params: { accountId: string; token: string }) {
@@ -330,8 +334,11 @@ function resolveTelegramApiContext(opts: {
     accountId: opts.accountId,
   });
   const token = resolveToken(opts.token, account);
-  const client = resolveTelegramClientOptions(account);
-  const api = (opts.api ?? new Bot(token, client ? { client } : undefined).api) as TelegramApi;
+  const { client, apiRoot } = resolveTelegramClientOptions(account);
+  const mergedClient =
+    client || apiRoot ? { ...client, ...(apiRoot ? { apiRoot } : {}) } : undefined;
+  const api = (opts.api ??
+    new Bot(token, mergedClient ? { client: mergedClient } : undefined).api) as TelegramApi;
   return { cfg, account, api };
 }
 
@@ -1192,8 +1199,10 @@ export async function createForumTopicTelegram(
   const token = resolveToken(opts.token, account);
   // Accept topic-qualified targets (e.g. telegram:group:<id>:topic:<thread>)
   // but createForumTopic must always target the base supergroup chat id.
-  const client = resolveTelegramClientOptions(account);
-  const api = opts.api ?? new Bot(token, client ? { client } : undefined).api;
+  const { client, apiRoot } = resolveTelegramClientOptions(account);
+  const mergedClient =
+    client || apiRoot ? { ...client, ...(apiRoot ? { apiRoot } : {}) } : undefined;
+  const api = opts.api ?? new Bot(token, mergedClient ? { client: mergedClient } : undefined).api;
   const target = parseTelegramTarget(chatId);
   const normalizedChatId = await resolveAndPersistChatId({
     cfg,


### PR DESCRIPTION
## Summary
Fixes #28535

Adds `channels.telegram.apiRoot` config option that passes through to grammY's `ApiClientOptions.apiRoot`. This enables using a self-hosted [Telegram Bot API server](https://github.com/tdlib/telegram-bot-api) for higher upload limits (up to 2 GB), faster file access, or privacy-sensitive deployments.

## Changes
- Added `apiRoot?: string` to `TelegramConfig` type (`types.telegram.ts`)
- Added `apiRoot` with URL validation to Zod schema (`zod-schema.providers-core.ts`)
- Updated `resolveTelegramClientOptions()` in `send.ts` to return `apiRoot` alongside client options
- Updated both `resolveTelegramApiContext()` and `createForumTopic` API creation to merge `apiRoot` into grammY client options
- Updated `bot.ts` to read and pass `apiRoot` to the Bot constructor

## Usage

```json5
{
  channels: {
    telegram: {
      apiRoot: "http://localhost:8081",
      botToken: "123:abc"
    }
  }
}
```

Also works with multi-account configs via `channels.telegram.accounts.*.apiRoot`.

When unset, behavior is unchanged (grammY defaults to `https://api.telegram.org`).

---
🤖 Generated with Claude Code