### PR TITLE
feat(compact): send immediate feedback when /compact is triggered

### DIFF
--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -74,18 +74,26 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const ackChannel = params.ctx.OriginatingChannel || (params.command.channel as any);
   const ackTo = params.ctx.OriginatingTo || params.command.from || params.command.to;
   if (ackChannel && ackTo) {
-    await routeReply({
-      payload: { text: "🗜️ Compacting… It may take a while." },
-      channel: ackChannel,
-      to: ackTo,
-      sessionKey: params.sessionKey,
-      accountId: params.ctx.AccountId,
-      threadId: params.ctx.MessageThreadId,
-      cfg: params.cfg,
-      mirror: false, // ack is UI-only; don't pollute session transcript before compaction
-    }).catch(() => {
+    try {
+      const ackResult = await routeReply({
+        payload: { text: "🗜️ Compacting… It may take a while." },
+        channel: ackChannel,
+        to: ackTo,
+        sessionKey: params.sessionKey,
+        accountId: params.ctx.AccountId,
+        threadId: params.ctx.MessageThreadId,
+        cfg: params.cfg,
+        mirror: false, // ack is UI-only; don't pollute session transcript before compaction
+      });
+      // routeReply returns { ok: false } for non-routable channels instead of throwing
+      if (!ackResult.ok) {
+        logVerbose(
+          `compact-ack: routeReply returned ok=false${ackResult.error ? ` (${ackResult.error})` : ""}`,
+        );
+      }
+    } catch {
       logVerbose("compact-ack: failed to send immediate feedback");
-    });
+    }
   }
   const customInstructions = extractCompactInstructions({
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -74,7 +74,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   const ackChannel = params.ctx.OriginatingChannel || (params.command.channel as any);
   const ackTo = params.ctx.OriginatingTo || params.command.from || params.command.to;
   if (ackChannel && ackTo) {
-    void routeReply({
+    await routeReply({
       payload: { text: "🗜️ Compacting… It may take a while." },
       channel: ackChannel,
       to: ackTo,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -15,6 +15,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { formatContextUsageShort, formatTokenCount } from "../status.js";
 import type { CommandHandler } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { routeReply } from "./route-reply.js";
 import { incrementCompactionCount } from "./session-updates.js";
 
 function extractCompactInstructions(params: {
@@ -67,6 +68,24 @@ export const handleCompactCommand: CommandHandler = async (params) => {
   if (isEmbeddedPiRunActive(sessionId)) {
     abortEmbeddedPiRun(sessionId);
     await waitForEmbeddedPiRunEnd(sessionId, 15_000);
+  }
+  // Send immediate feedback so the user knows compaction has started
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const ackChannel = params.ctx.OriginatingChannel || (params.command.channel as any);
+  const ackTo = params.ctx.OriginatingTo || params.command.from || params.command.to;
+  if (ackChannel && ackTo) {
+    void routeReply({
+      payload: { text: "🗜️ Compacting… It may take a while." },
+      channel: ackChannel,
+      to: ackTo,
+      sessionKey: params.sessionKey,
+      accountId: params.ctx.AccountId,
+      threadId: params.ctx.MessageThreadId,
+      cfg: params.cfg,
+      mirror: false, // ack is UI-only; don't pollute session transcript before compaction
+    }).catch(() => {
+      logVerbose("compact-ack: failed to send immediate feedback");
+    });
   }
   const customInstructions = extractCompactInstructions({
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,


### PR DESCRIPTION
## Summary

When a user types `/compact`, send "🗜️ Compacting… It may take a while." immediately before starting the compaction process. This provides instant visual feedback instead of leaving the user waiting blindly.

### Changes

- Fire-and-forget `routeReply()` with `.catch()` for error observability
- `mirror: false` to avoid polluting session transcript before compaction
- Follows the same channel/to fallback pattern as `commands-core.ts`

### pr-ship score: 3/10 🟢

🤖 Generated with [Claude Code](https://claude.com/claude-code)