### PR TITLE
fix(plugins): forward meta argument in runtime logger wrapper

### DIFF
--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -456,10 +456,10 @@ function createRuntimeLogging(): PluginRuntime["logging"] {
         level: opts?.level ? normalizeLogLevel(opts.level) : undefined,
       });
       return {
-        debug: (message) => logger.debug?.(message),
-        info: (message) => logger.info(message),
-        warn: (message) => logger.warn(message),
-        error: (message) => logger.error(message),
+        debug: (message, meta) => (meta ? logger.debug?.(message, meta) : logger.debug?.(message)),
+        info: (message, meta) => (meta ? logger.info(message, meta) : logger.info(message)),
+        warn: (message, meta) => (meta ? logger.warn(message, meta) : logger.warn(message)),
+        error: (message, meta) => (meta ? logger.error(message, meta) : logger.error(message)),
       };
     },
   };


### PR DESCRIPTION
## Summary
- Forwards the optional meta parameter in plugin runtime logger wrapper
- Previously meta was silently dropped, hiding extension error details
- Fixes debugging for msteams and other extensions that pass structured error metadata

Fixes #26766

🤖 Generated with [Claude Code](https://claude.com/claude-code)