### PR TITLE
fix(exec): apply default timeout to backgrounded exec sessions

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -142,33 +142,16 @@ test("background exec still times out after tool signal abort", async () => {
   });
 });
 
-test("background exec without explicit timeout ignores default timeout", async () => {
+test("background exec without explicit timeout uses default timeout", async () => {
   const tool = createTestExecTool({
     allowBackground: true,
     backgroundMs: 0,
     timeoutSec: BACKGROUND_TIMEOUT_SEC,
   });
-  const result = await tool.execute("toolcall", { command: BACKGROUND_HOLD_CMD, background: true });
-  expect(result.details.status).toBe("running");
-  const sessionId = (result.details as { sessionId: string }).sessionId;
-  const waitMs = Math.max(ABORT_SETTLE_MS + 80, BACKGROUND_TIMEOUT_SEC * 1000 + 80);
-
-  const startedAt = Date.now();
-  await expect
-    .poll(
-      () => {
-        const running = getSession(sessionId);
-        const finished = getFinishedSession(sessionId);
-        return Date.now() - startedAt >= waitMs && !finished && running?.exited === false;
-      },
-      {
-        timeout: waitMs + ABORT_WAIT_TIMEOUT_MS,
-        interval: POLL_INTERVAL_MS,
-      },
-    )
-    .toBe(true);
-
-  cleanupRunningSession(sessionId);
+  await expectBackgroundSessionTimesOut({
+    tool,
+    executeParams: { command: BACKGROUND_HOLD_CMD, background: true },
+  });
 });
 
 test("yielded background exec still times out", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -456,11 +456,7 @@ export function createExecTool(
       }
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
-      const backgroundTimeoutBypass =
-        allowBackground && explicitTimeoutSec === null && (backgroundRequested || yieldRequested);
-      const effectiveTimeout = backgroundTimeoutBypass
-        ? null
-        : (explicitTimeoutSec ?? defaultTimeoutSec);
+      const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 


### PR DESCRIPTION
## Summary
- Problem: backgrounded `exec` sessions skipped `tools.exec.timeoutSec` whenever the call omitted `timeout`
- Why it matters: runaway skill-spawned commands could run indefinitely unless every call remembered to set `timeout`
- What changed: background and yield-driven sessions now inherit the same default timeout as foreground exec runs when no explicit `timeout` is provided
- What did NOT change: this does not add CPU/memory cgroup limits; it hardens wall-clock timeout behavior only

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Related #28629

## User-visible / Behavior Changes
- Backgrounded `exec` runs now time out by default using `tools.exec.timeoutSec` unless `timeout` is explicitly set.

## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification
### Environment
- OS: Linux (arm64)
- Runtime/container: local dev workspace
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): `tools.exec.timeoutSec` set in test harness

### Steps
1. Run background `exec` without explicit `timeout` while `tools.exec.timeoutSec` is configured.
2. Observe session lifecycle.

### Expected
- Background session terminates at default timeout.

### Actual
- Verified with updated test that it times out and exits as failed due timeout.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification
- Verified scenarios: targeted test for background abort + timeout paths, including default timeout behavior.
- Edge cases checked: explicit timeout + yield background path still times out.
- What you did not verify: full end-to-end gateway runtime on a live deployment.

## Compatibility / Migration
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery
- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/agents/bash-tools.exec.ts`, `src/agents/bash-tools.exec.background-abort.test.ts`.
- Known bad symptoms reviewers should watch for: long-running background jobs ending earlier than expected if they relied on implicit no-timeout behavior.

## Risks and Mitigations
- Risk: workloads that depended on implicit infinite background runs may now time out.
  - Mitigation: set explicit `timeout` per call to desired value.