### PR TITLE
feat(web-search): add support for Tavily and SearXNG search providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,56 @@ Minimal `~/.openclaw/openclaw.json` (model + defaults):
 
 [Full configuration reference (all keys + examples).](https://docs.openclaw.ai/gateway/configuration)
 
+### Web Search
+
+OpenClaw supports multiple web search providers via the `web_search` tool. You can configure them in `~/.openclaw/openclaw.json` or using environment variables.
+
+#### Tavily
+
+[Tavily](https://tavily.com/) is a search engine optimized for AI agents.
+
+1.  **Environment Variable:** Set `TAVILY_API_KEY` in your environment.
+2.  **Configuration:** Update `~/.openclaw/openclaw.json`:
+    ```json
+    {
+      "tools": {
+        "web": {
+          "search": {
+            "provider": "tavily",
+            "tavily": {
+              "apiKey": "your-tavily-api-key"
+            }
+          }
+        }
+      }
+    }
+    ```
+
+#### SearXNG (Self-hosted)
+
+[SearXNG](https://github.com/searxng/searxng) is a free, privacy-respecting metasearch engine you can host yourself.
+
+1.  **Self-hosting with Docker:**
+    ```bash
+    docker run -d -p 8080:8080 searxng/searxng
+    ```
+2.  **Environment Variable:** (Optional) Set `SEARXNG_API_KEY` if your instance requires authentication.
+3.  **Configuration:** Update `~/.openclaw/openclaw.json`:
+    ```json
+    {
+      "tools": {
+        "web": {
+          "search": {
+            "provider": "searxng",
+            "searxng": {
+              "baseUrl": "http://localhost:8080"
+            }
+          }
+        }
+      }
+    }
+    ```
+
 ## Security model (important)
 
 - **Default:** tools run on the host for the **main** session, so the agent has full access when it’s just you.

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -153,6 +153,7 @@ type TavilySearchResponse = {
 
 type SearXNGConfig = {
   baseUrl?: string;
+  apiKey?: string;
 };
 
 type SearXNGSearchResult = {
@@ -451,6 +452,15 @@ function resolveSearXNGConfig(search?: WebSearchConfig): SearXNGConfig {
   return searxng as SearXNGConfig;
 }
 
+function resolveSearXNGApiKey(searxng?: SearXNGConfig): string | undefined {
+  const fromConfig = normalizeApiKey(searxng?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = normalizeApiKey(process.env.SEARXNG_API_KEY);
+  return fromEnv || undefined;
+}
+
 function resolveSearXNGBaseUrl(searxng?: SearXNGConfig): string | undefined {
   return searxng?.baseUrl?.trim() || undefined;
 }
@@ -670,6 +680,7 @@ async function runTavilySearch(params: {
 async function runSearXNGSearch(params: {
   query: string;
   baseUrl: string;
+  apiKey?: string;
   timeoutSeconds: number;
   count: number;
 }): Promise<SearXNGSearchResponse> {
@@ -677,8 +688,16 @@ async function runSearXNGSearch(params: {
   url.searchParams.set("q", params.query);
   url.searchParams.set("format", "json");
 
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (params.apiKey) {
+    headers["Authorization"] = `Bearer ${params.apiKey}`;
+  }
+
   const res = await fetch(url.toString(), {
     method: "GET",
+    headers,
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
   });
 
@@ -829,6 +848,7 @@ async function runWebSearch(params: {
     const data = await runSearXNGSearch({
       query: params.query,
       baseUrl: params.searxngBaseUrl,
+      apiKey: params.apiKey,
       timeoutSeconds: params.timeoutSeconds,
       count: params.count,
     });
@@ -964,6 +984,8 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
+      const searxngConfig = provider === "searxng" ? resolveSearXNGConfig(search) : undefined;
+      const searxngAuth = provider === "searxng" ? resolveSearXNGApiKey(searxngConfig) : undefined;
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey
@@ -971,13 +993,14 @@ export function createWebSearchTool(options?: {
             ? resolveGrokApiKey(grokConfig)
             : provider === "tavily"
               ? resolveTavilyApiKey(resolveTavilyConfig(search))
-              : resolveSearchApiKey(search);
+              : provider === "searxng"
+                ? searxngAuth
+                : resolveSearchApiKey(search);
 
       if (!apiKey && provider !== "searxng") {
         return jsonResult(missingSearchKeyPayload(provider));
       }
 
-      const searxngConfig = provider === "searxng" ? resolveSearXNGConfig(search) : undefined;
       const searxngBaseUrl = resolveSearXNGBaseUrl(searxngConfig);
 
       if (provider === "searxng" && !searxngBaseUrl) {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -18,7 +18,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "tavily"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -31,6 +31,8 @@ const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
+
+const TAVILY_SEARCH_ENDPOINT = "https://api.tavily.com/search";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -135,6 +137,20 @@ type PerplexitySearchResponse = {
   citations?: string[];
 };
 
+type TavilySearchConfig = {
+  apiKey?: string;
+};
+
+type TavilySearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+};
+
+type TavilySearchResponse = {
+  results?: TavilySearchResult[];
+};
+
 type PerplexityBaseUrlHint = "direct" | "openrouter";
 
 function extractGrokContent(data: GrokSearchResponse): {
@@ -184,8 +200,9 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
     search && "apiKey" in search && typeof search.apiKey === "string"
       ? normalizeSecretInput(search.apiKey)
       : "";
-  const fromEnv = normalizeSecretInput(process.env.BRAVE_API_KEY);
-  return fromConfig || fromEnv || undefined;
+  const fromEnvBrave = normalizeSecretInput(process.env.BRAVE_API_KEY);
+  const fromEnvTavily = normalizeSecretInput(process.env.TAVILY_API_KEY);
+  return fromConfig || fromEnvBrave || fromEnvTavily || undefined;
 }
 
 function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
@@ -202,6 +219,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       error: "missing_xai_api_key",
       message:
         "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure tools.web.search.grok.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
+  if (provider === "tavily") {
+    return {
+      error: "missing_tavily_api_key",
+      message:
+        "web_search (tavily) needs a Tavily API key. Set TAVILY_API_KEY in the Gateway environment, or configure tools.web.search.tavily.apiKey.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
@@ -225,6 +250,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "brave") {
     return "brave";
+  }
+  if (raw === "tavily") {
+    return "tavily";
   }
   return "brave";
 }
@@ -365,6 +393,26 @@ function resolveGrokModel(grok?: GrokConfig): string {
 
 function resolveGrokInlineCitations(grok?: GrokConfig): boolean {
   return grok?.inlineCitations === true;
+}
+
+function resolveTavilyConfig(search?: WebSearchConfig): TavilySearchConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const tavily = "tavily" in search ? search.tavily : undefined;
+  if (!tavily || typeof tavily !== "object") {
+    return {};
+  }
+  return tavily as TavilySearchConfig;
+}
+
+function resolveTavilyApiKey(tavily?: TavilySearchConfig): string | undefined {
+  const fromConfig = normalizeApiKey(tavily?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = normalizeApiKey(process.env.TAVILY_API_KEY);
+  return fromEnv || undefined;
 }
 
 function resolveSearchCount(value: unknown, fallback: number): number {
@@ -551,10 +599,38 @@ async function runGrokSearch(params: {
   return { content, citations, inlineCitations };
 }
 
+async function runTavilySearch(params: {
+  query: string;
+  apiKey: string;
+  timeoutSeconds: number;
+  count: number;
+}): Promise<TavilySearchResponse> {
+  const res = await fetch(TAVILY_SEARCH_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      api_key: params.apiKey,
+      query: params.query,
+      max_results: params.count,
+    }),
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+    const detail = detailResult.text;
+    throw new Error(`Tavily API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  return (await res.json()) as TavilySearchResponse;
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
-  apiKey: string;
+  apiKey?: string;
   timeoutSeconds: number;
   cacheTtlMs: number;
   provider: (typeof SEARCH_PROVIDERS)[number];
@@ -572,7 +648,9 @@ async function runWebSearch(params: {
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
       : params.provider === "perplexity"
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
-        : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
+        : params.provider === "tavily"
+          ? `${params.provider}:${params.query}:${params.count}`
+          : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -584,7 +662,7 @@ async function runWebSearch(params: {
   if (params.provider === "perplexity") {
     const { content, citations } = await runPerplexitySearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       baseUrl: params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL,
       model: params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL,
       timeoutSeconds: params.timeoutSeconds,
@@ -612,7 +690,7 @@ async function runWebSearch(params: {
   if (params.provider === "grok") {
     const { content, citations, inlineCitations } = await runGrokSearch({
       query: params.query,
-      apiKey: params.apiKey,
+      apiKey: params.apiKey!,
       model: params.grokModel ?? DEFAULT_GROK_MODEL,
       timeoutSeconds: params.timeoutSeconds,
       inlineCitations: params.grokInlineCitations ?? false,
@@ -632,6 +710,45 @@ async function runWebSearch(params: {
       content: wrapWebContent(content),
       citations,
       inlineCitations,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
+  if (params.provider === "tavily") {
+    const data = await runTavilySearch({
+      query: params.query,
+      apiKey: params.apiKey!,
+      timeoutSeconds: params.timeoutSeconds,
+      count: params.count,
+    });
+
+    const results = Array.isArray(data.results) ? data.results : [];
+    const mapped = results.map((entry) => {
+      const description = entry.content ?? "";
+      const title = entry.title ?? "";
+      const url = entry.url ?? "";
+      const rawSiteName = resolveSiteName(url);
+      return {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        siteName: rawSiteName || undefined,
+      };
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: mapped,
     };
     writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
     return payload;
@@ -661,7 +778,7 @@ async function runWebSearch(params: {
     method: "GET",
     headers: {
       Accept: "application/json",
-      "X-Subscription-Token": params.apiKey,
+      "X-Subscription-Token": params.apiKey!,
     },
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
   });
@@ -723,7 +840,9 @@ export function createWebSearchTool(options?: {
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
       : provider === "grok"
         ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+        : provider === "tavily"
+          ? "Search the web using Tavily Search API. Returns titles, URLs, and content snippets for fast research."
+          : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -738,11 +857,14 @@ export function createWebSearchTool(options?: {
           ? perplexityAuth?.apiKey
           : provider === "grok"
             ? resolveGrokApiKey(grokConfig)
-            : resolveSearchApiKey(search);
+            : provider === "tavily"
+              ? resolveTavilyApiKey(resolveTavilyConfig(search))
+              : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
       }
+
       const params = args as Record<string, unknown>;
       const query = readStringParam(params, "query", { required: true });
       const count =
@@ -770,7 +892,7 @@ export function createWebSearchTool(options?: {
       const result = await runWebSearch({
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
+        apiKey: apiKey,
         timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
         cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         provider,
@@ -803,4 +925,6 @@ export const __testing = {
   resolveGrokModel,
   resolveGrokInlineCitations,
   extractGrokContent,
+  resolveTavilyApiKey,
+  resolveTavilyConfig,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -18,7 +18,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "tavily"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "tavily", "searxng"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -151,6 +151,20 @@ type TavilySearchResponse = {
   results?: TavilySearchResult[];
 };
 
+type SearXNGConfig = {
+  baseUrl?: string;
+};
+
+type SearXNGSearchResult = {
+  title?: string;
+  url?: string;
+  content?: string;
+};
+
+type SearXNGSearchResponse = {
+  results?: SearXNGSearchResult[];
+};
+
 type PerplexityBaseUrlHint = "direct" | "openrouter";
 
 function extractGrokContent(data: GrokSearchResponse): {
@@ -230,6 +244,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "searxng") {
+    return {
+      error: "missing_searxng_base_url",
+      message:
+        "web_search (searxng) needs a base URL. Configure tools.web.search.searxng.baseUrl (e.g., 'http://localhost:8080').",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -253,6 +275,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "tavily") {
     return "tavily";
+  }
+  if (raw === "searxng") {
+    return "searxng";
   }
   return "brave";
 }
@@ -413,6 +438,21 @@ function resolveTavilyApiKey(tavily?: TavilySearchConfig): string | undefined {
   }
   const fromEnv = normalizeApiKey(process.env.TAVILY_API_KEY);
   return fromEnv || undefined;
+}
+
+function resolveSearXNGConfig(search?: WebSearchConfig): SearXNGConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const searxng = search?.searxng;
+  if (!searxng || typeof searxng !== "object") {
+    return {};
+  }
+  return searxng as SearXNGConfig;
+}
+
+function resolveSearXNGBaseUrl(searxng?: SearXNGConfig): string | undefined {
+  return searxng?.baseUrl?.trim() || undefined;
 }
 
 function resolveSearchCount(value: unknown, fallback: number): number {
@@ -627,6 +667,30 @@ async function runTavilySearch(params: {
   return (await res.json()) as TavilySearchResponse;
 }
 
+async function runSearXNGSearch(params: {
+  query: string;
+  baseUrl: string;
+  timeoutSeconds: number;
+  count: number;
+}): Promise<SearXNGSearchResponse> {
+  const url = new URL(`${params.baseUrl}/search`);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("format", "json");
+
+  const res = await fetch(url.toString(), {
+    method: "GET",
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+    const detail = detailResult.text;
+    throw new Error(`SearXNG API error (${res.status}): ${detail || res.statusText}`);
+  }
+
+  return (await res.json()) as SearXNGSearchResponse;
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -642,6 +706,7 @@ async function runWebSearch(params: {
   perplexityModel?: string;
   grokModel?: string;
   grokInlineCitations?: boolean;
+  searxngBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -650,7 +715,9 @@ async function runWebSearch(params: {
         ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
         : params.provider === "tavily"
           ? `${params.provider}:${params.query}:${params.count}`
-          : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
+          : params.provider === "searxng"
+            ? `${params.provider}:${params.query}:${params.count}:${params.searxngBaseUrl}`
+            : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -725,6 +792,49 @@ async function runWebSearch(params: {
 
     const results = Array.isArray(data.results) ? data.results : [];
     const mapped = results.map((entry) => {
+      const description = entry.content ?? "";
+      const title = entry.title ?? "";
+      const url = entry.url ?? "";
+      const rawSiteName = resolveSiteName(url);
+      return {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        siteName: rawSiteName || undefined,
+      };
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: mapped,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
+  if (params.provider === "searxng") {
+    if (!params.searxngBaseUrl) {
+      throw new Error("SearXNG search requires a base URL.");
+    }
+
+    const data = await runSearXNGSearch({
+      query: params.query,
+      baseUrl: params.searxngBaseUrl,
+      timeoutSeconds: params.timeoutSeconds,
+      count: params.count,
+    });
+
+    const results = Array.isArray(data.results) ? data.results : [];
+    const mapped = results.slice(0, params.count).map((entry) => {
       const description = entry.content ?? "";
       const title = entry.title ?? "";
       const url = entry.url ?? "";
@@ -842,7 +952,9 @@ export function createWebSearchTool(options?: {
         ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
         : provider === "tavily"
           ? "Search the web using Tavily Search API. Returns titles, URLs, and content snippets for fast research."
-          : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+          : provider === "searxng"
+            ? "Search the web using SearXNG. Returns titles, URLs, and content snippets for fast search without tracking."
+            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -861,7 +973,14 @@ export function createWebSearchTool(options?: {
               ? resolveTavilyApiKey(resolveTavilyConfig(search))
               : resolveSearchApiKey(search);
 
-      if (!apiKey) {
+      if (!apiKey && provider !== "searxng") {
+        return jsonResult(missingSearchKeyPayload(provider));
+      }
+
+      const searxngConfig = provider === "searxng" ? resolveSearXNGConfig(search) : undefined;
+      const searxngBaseUrl = resolveSearXNGBaseUrl(searxngConfig);
+
+      if (provider === "searxng" && !searxngBaseUrl) {
         return jsonResult(missingSearchKeyPayload(provider));
       }
 
@@ -908,6 +1027,7 @@ export function createWebSearchTool(options?: {
         perplexityModel: resolvePerplexityModel(perplexityConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
+        searxngBaseUrl,
       });
       return jsonResult(result);
     },

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -132,12 +132,12 @@ async function promptWebToolsConfig(
 ): Promise<OpenClawConfig> {
   const existingSearch = nextConfig.tools?.web?.search;
   const existingFetch = nextConfig.tools?.web?.fetch;
-  const hasSearchKey = Boolean(existingSearch?.apiKey);
+  const currentProvider = existingSearch?.provider || "brave";
 
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "It requires a Brave Search API key (you can store it in the config or set BRAVE_API_KEY in the Gateway environment).",
+      "Supports Brave Search, Perplexity Sonar, xAI Grok, and Tavily.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -145,8 +145,10 @@ async function promptWebToolsConfig(
 
   const enableSearch = guardCancel(
     await confirm({
-      message: "Enable web_search (Brave Search)?",
-      initialValue: existingSearch?.enabled ?? hasSearchKey,
+      message: "Enable web_search?",
+      initialValue:
+        existingSearch?.enabled ??
+        (Boolean(existingSearch?.apiKey) || Boolean(process.env.BRAVE_API_KEY)),
     }),
     runtime,
   );
@@ -157,27 +159,94 @@ async function promptWebToolsConfig(
   };
 
   if (enableSearch) {
-    const keyInput = guardCancel(
-      await text({
-        message: hasSearchKey
-          ? "Brave Search API key (leave blank to keep current or use BRAVE_API_KEY)"
-          : "Brave Search API key (paste it here; leave blank to use BRAVE_API_KEY)",
-        placeholder: hasSearchKey ? "Leave blank to keep current" : "BSA...",
+    const provider = guardCancel(
+      await select({
+        message: "Search provider",
+        options: [
+          { value: "brave", label: "Brave Search", hint: "Fast snippets & URLs" },
+          { value: "perplexity", label: "Perplexity", hint: "AI-synthesized answers" },
+          { value: "grok", label: "xAI Grok", hint: "AI-synthesized answers" },
+          { value: "tavily", label: "Tavily", hint: "Detailed search for AI agents" },
+        ],
+        initialValue: currentProvider,
       }),
       runtime,
     );
-    const key = String(keyInput ?? "").trim();
-    if (key) {
-      nextSearch = { ...nextSearch, apiKey: key };
-    } else if (!hasSearchKey) {
-      note(
-        [
-          "No key stored yet, so web_search will stay unavailable.",
-          "Store a key here or set BRAVE_API_KEY in the Gateway environment.",
-          "Docs: https://docs.openclaw.ai/tools/web",
-        ].join("\n"),
-        "Web search",
+
+    nextSearch.provider = provider;
+
+    if (provider === "brave") {
+      const hasKey = Boolean(existingSearch?.apiKey);
+      const keyInput = guardCancel(
+        await text({
+          message: hasKey
+            ? "Brave Search API key (leave blank to keep current or use BRAVE_API_KEY)"
+            : "Brave Search API key (paste it here; leave blank to use BRAVE_API_KEY)",
+          placeholder: hasKey ? "Leave blank to keep current" : "BSA...",
+        }),
+        runtime,
       );
+      const key = String(keyInput ?? "").trim();
+      if (key) {
+        nextSearch = { ...nextSearch, apiKey: key };
+      }
+    } else if (provider === "perplexity") {
+      const existingPerplexity = existingSearch?.perplexity;
+      const hasKey = Boolean(existingPerplexity?.apiKey);
+      const keyInput = guardCancel(
+        await text({
+          message: hasKey
+            ? "Perplexity API key (leave blank to keep current or use PERPLEXITY_API_KEY)"
+            : "Perplexity API key (paste it here; leave blank to use PERPLEXITY_API_KEY)",
+          placeholder: hasKey ? "Leave blank to keep current" : "pplx-...",
+        }),
+        runtime,
+      );
+      const key = String(keyInput ?? "").trim();
+      if (key) {
+        nextSearch = {
+          ...nextSearch,
+          perplexity: { ...existingPerplexity, apiKey: key },
+        };
+      }
+    } else if (provider === "grok") {
+      const existingGrok = existingSearch?.grok;
+      const hasKey = Boolean(existingGrok?.apiKey);
+      const keyInput = guardCancel(
+        await text({
+          message: hasKey
+            ? "xAI API key (leave blank to keep current or use XAI_API_KEY)"
+            : "xAI API key (paste it here; leave blank to use XAI_API_KEY)",
+          placeholder: hasKey ? "Leave blank to keep current" : "xai-...",
+        }),
+        runtime,
+      );
+      const key = String(keyInput ?? "").trim();
+      if (key) {
+        nextSearch = {
+          ...nextSearch,
+          grok: { ...existingGrok, apiKey: key },
+        };
+      }
+    } else if (provider === "tavily") {
+      const existingTavily = existingSearch?.tavily;
+      const hasKey = Boolean(existingTavily?.apiKey);
+      const keyInput = guardCancel(
+        await text({
+          message: hasKey
+            ? "Tavily API key (leave blank to keep current or use TAVILY_API_KEY)"
+            : "Tavily API key (paste it here; leave blank to use TAVILY_API_KEY)",
+          placeholder: hasKey ? "Leave blank to keep current" : "tvly-...",
+        }),
+        runtime,
+      );
+      const key = String(keyInput ?? "").trim();
+      if (key) {
+        nextSearch = {
+          ...nextSearch,
+          tavily: { ...existingTavily, apiKey: key },
+        };
+      }
     }
   }
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -137,7 +137,7 @@ async function promptWebToolsConfig(
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "Supports Brave Search, Perplexity Sonar, xAI Grok, and Tavily.",
+      "Supports Brave Search, Perplexity Sonar, xAI Grok, Tavily, and SearXNG.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -167,6 +167,7 @@ async function promptWebToolsConfig(
           { value: "perplexity", label: "Perplexity", hint: "AI-synthesized answers" },
           { value: "grok", label: "xAI Grok", hint: "AI-synthesized answers" },
           { value: "tavily", label: "Tavily", hint: "Detailed search for AI agents" },
+          { value: "searxng", label: "SearXNG", hint: "Free unlimited search (self-hosted)" },
         ],
         initialValue: currentProvider,
       }),
@@ -245,6 +246,23 @@ async function promptWebToolsConfig(
         nextSearch = {
           ...nextSearch,
           tavily: { ...existingTavily, apiKey: key },
+        };
+      }
+    } else if (provider === "searxng") {
+      const existingSearxng = existingSearch?.searxng;
+      const baseUrlInput = guardCancel(
+        await text({
+          message: "SearXNG base URL",
+          initialValue: existingSearxng?.baseUrl || "http://localhost:8080",
+          placeholder: "http://localhost:8080",
+        }),
+        runtime,
+      );
+      const baseUrl = String(baseUrlInput ?? "").trim();
+      if (baseUrl) {
+        nextSearch = {
+          ...nextSearch,
+          searxng: { ...existingSearxng, baseUrl },
         };
       }
     }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -104,8 +104,10 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.crossContext.marker.suffix":
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
-  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave", "perplexity", "grok", or "tavily").',
+  "tools.web.search.enabled":
+    "Enable the web_search tool (requires a provider API key or baseUrl).",
+  "tools.web.search.provider":
+    'Search provider ("brave", "perplexity", "grok", "tavily", or "searxng").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -117,6 +119,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
   "tools.web.search.tavily.apiKey": "Tavily API key (fallback: TAVILY_API_KEY env var).",
+  "tools.web.search.searxng.baseUrl": "Base URL for SearXNG instance (e.g. http://localhost:8080).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -105,7 +105,7 @@ export const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", "grok", or "tavily").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -116,6 +116,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.tavily.apiKey": "Tavily API key (fallback: TAVILY_API_KEY env var).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -398,8 +398,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "tavily"). */
+      provider?: "brave" | "perplexity" | "grok" | "tavily";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -425,6 +425,11 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** Tavily-specific configuration (used when provider="tavily"). */
+      tavily?: {
+        /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
+        apiKey?: string;
       };
     };
     fetch?: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -435,6 +435,8 @@ export type ToolsConfig = {
       searxng?: {
         /** Base URL for SearXNG instance (e.g. "http://localhost:8080"). */
         baseUrl?: string;
+        /** Optional API key/token for SearXNG instance. */
+        apiKey?: string;
       };
     };
     fetch?: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -398,8 +398,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", or "tavily"). */
-      provider?: "brave" | "perplexity" | "grok" | "tavily";
+      /** Search provider ("brave", "perplexity", "grok", "tavily", or "searxng"). */
+      provider?: "brave" | "perplexity" | "grok" | "tavily" | "searxng";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -430,6 +430,11 @@ export type ToolsConfig = {
       tavily?: {
         /** API key for Tavily (defaults to TAVILY_API_KEY env var). */
         apiKey?: string;
+      };
+      /** SearXNG-specific configuration (used when provider="searxng"). */
+      searxng?: {
+        /** Base URL for SearXNG instance (e.g. "http://localhost:8080"). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -260,9 +260,13 @@ function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   return Boolean(
     search?.apiKey ||
     search?.perplexity?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.tavily?.apiKey ||
     env.BRAVE_API_KEY ||
     env.PERPLEXITY_API_KEY ||
-    env.OPENROUTER_API_KEY,
+    env.OPENROUTER_API_KEY ||
+    env.XAI_API_KEY ||
+    env.TAVILY_API_KEY,
   );
 }
 

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -432,29 +432,35 @@ export async function finalizeOnboardingWizard(
     );
   }
 
-  const webSearchKey = (nextConfig.tools?.web?.search?.apiKey ?? "").trim();
-  const webSearchEnv = (process.env.BRAVE_API_KEY ?? "").trim();
-  const hasWebSearchKey = Boolean(webSearchKey || webSearchEnv);
+  const searchCfg = nextConfig.tools?.web?.search;
+  const provider = searchCfg?.provider || "brave";
+
+  const hasSearchKey =
+    Boolean(searchCfg?.apiKey) ||
+    Boolean(process.env.BRAVE_API_KEY) ||
+    Boolean(searchCfg?.perplexity?.apiKey) ||
+    Boolean(process.env.PERPLEXITY_API_KEY) ||
+    Boolean(process.env.OPENROUTER_API_KEY) ||
+    Boolean(searchCfg?.grok?.apiKey) ||
+    Boolean(process.env.XAI_API_KEY) ||
+    Boolean(searchCfg?.tavily?.apiKey) ||
+    Boolean(process.env.TAVILY_API_KEY);
+
   await prompter.note(
-    hasWebSearchKey
+    hasSearchKey
       ? [
-          "Web search is enabled, so your agent can look things up online when needed.",
-          "",
-          webSearchKey
-            ? "API key: stored in config (tools.web.search.apiKey)."
-            : "API key: provided via BRAVE_API_KEY env var (Gateway environment).",
+          `Web search is enabled (provider: ${provider}), so your agent can look things up online when needed.`,
           "Docs: https://docs.openclaw.ai/tools/web",
         ].join("\n")
       : [
           "If you want your agent to be able to search the web, you’ll need an API key.",
           "",
-          "OpenClaw uses Brave Search for the `web_search` tool. Without a Brave Search API key, web search won’t work.",
+          "OpenClaw supports Brave Search, Perplexity, xAI Grok, and Tavily for the `web_search` tool.",
           "",
           "Set it up interactively:",
           `- Run: ${formatCliCommand("openclaw configure --section web")}`,
-          "- Enable web_search and paste your Brave Search API key",
+          "- Enable web_search and choose your provider and API key.",
           "",
-          "Alternative: set BRAVE_API_KEY in the Gateway environment (no config changes).",
           "Docs: https://docs.openclaw.ai/tools/web",
         ].join("\n"),
     "Web search (optional)",


### PR DESCRIPTION
This PR adds support for two new web search providers: Tavily and SearXNG.