### PR TITLE
feat(sandbox): generic macOS seatbelt sandbox backend

### DIFF
--- a/assets/seatbelt-profiles/demo-open.sb
+++ b/assets/seatbelt-profiles/demo-open.sb
@@ -17,9 +17,19 @@
 (allow process-exec)
 (allow network*)
 
-; Allow workspace + temp access.
-(allow file-read* file-write* (subpath (param "PROJECT_DIR")))
-(allow file-read* file-write* (subpath (param "WORKSPACE_DIR")))
+; Always allow reads in project + workspace paths.
+(allow file-read* (subpath (param "PROJECT_DIR")))
+(allow file-read* (subpath (param "WORKSPACE_DIR")))
+
+; WORKSPACE_ACCESS controls write permission at the profile layer.
+(if (string=? (param "WORKSPACE_ACCESS") "rw")
+  (allow file-write* (subpath (param "PROJECT_DIR")))
+  (deny file-write* (subpath (param "PROJECT_DIR"))))
+(if (string=? (param "WORKSPACE_ACCESS") "rw")
+  (allow file-write* (subpath (param "WORKSPACE_DIR")))
+  (deny file-write* (subpath (param "WORKSPACE_DIR"))))
+
+; Keep runtime temp writable.
 (allow file-read* file-write* (subpath (param "TMPDIR")))
 
 ; Protect installed seatbelt profiles from runtime mutation.

--- a/assets/seatbelt-profiles/demo-open.sb
+++ b/assets/seatbelt-profiles/demo-open.sb
@@ -1,0 +1,32 @@
+; OpenClaw seatbelt demo profile: demo-open
+; Intent: developer-friendly baseline with network/process access and broad workspace access.
+; Customize for production use.
+
+(version 1)
+(import "system.sb")
+
+(param "PROJECT_DIR")
+(param "WORKSPACE_DIR")
+(param "STATE_DIR")
+(param "AGENT_ID")
+(param "SEATBELT_PROFILE_DIR")
+(param "WORKSPACE_ACCESS")
+(param "TMPDIR")
+
+; Permit command execution and networking for normal tooling workflows.
+(allow process-exec)
+(allow network*)
+
+; Allow workspace + temp access.
+(allow file-read* file-write* (subpath (param "PROJECT_DIR")))
+(allow file-read* file-write* (subpath (param "WORKSPACE_DIR")))
+(allow file-read* file-write* (subpath (param "TMPDIR")))
+
+; Protect installed seatbelt profiles from runtime mutation.
+(deny file-write* (subpath (param "SEATBELT_PROFILE_DIR")))
+
+; Keep session history isolation generic: block broad cross-agent reads,
+; then explicitly allow this agent's own sessions.
+(deny file-read* (subpath (string-append (param "STATE_DIR") "/agents")))
+(allow file-read*
+  (subpath (string-append (param "STATE_DIR") "/agents/" (param "AGENT_ID") "/sessions")))

--- a/assets/seatbelt-profiles/demo-restricted.sb
+++ b/assets/seatbelt-profiles/demo-restricted.sb
@@ -1,0 +1,30 @@
+; OpenClaw seatbelt demo profile: demo-restricted
+; Intent: lock-down example. This profile is intentionally restrictive and likely
+; requires customization for real workloads.
+
+(version 1)
+(import "system.sb")
+(deny default)
+
+(param "PROJECT_DIR")
+(param "WORKSPACE_DIR")
+(param "STATE_DIR")
+(param "AGENT_ID")
+(param "SEATBELT_PROFILE_DIR")
+(param "WORKSPACE_ACCESS")
+(param "TMPDIR")
+
+; Restricted execution model.
+(allow process-exec)
+(deny network*)
+
+; Always allow reads in project workspace.
+(allow file-read* (subpath (param "PROJECT_DIR")))
+
+; WORKSPACE_ACCESS controls write permission at the profile layer.
+(if (string=? (param "WORKSPACE_ACCESS") "rw")
+  (allow file-write* (subpath (param "PROJECT_DIR")))
+  (deny file-write* (subpath (param "PROJECT_DIR"))))
+
+; Keep runtime temp writable.
+(allow file-read* file-write* (subpath (param "TMPDIR")))

--- a/assets/seatbelt-profiles/demo-websearch.sb
+++ b/assets/seatbelt-profiles/demo-websearch.sb
@@ -1,0 +1,25 @@
+; OpenClaw seatbelt demo profile: demo-websearch
+; Intent: network-centric profile with minimal local data access.
+; Customize for production use.
+
+(version 1)
+(import "system.sb")
+
+(param "PROJECT_DIR")
+(param "WORKSPACE_DIR")
+(param "STATE_DIR")
+(param "AGENT_ID")
+(param "SEATBELT_PROFILE_DIR")
+(param "WORKSPACE_ACCESS")
+(param "TMPDIR")
+
+(allow process-exec)
+(allow network*)
+
+; Explicitly deny project/state data access for web-search style runs.
+(deny file-read* file-write* (subpath (param "PROJECT_DIR")))
+(deny file-read* file-write* (subpath (param "WORKSPACE_DIR")))
+(deny file-read* file-write* (subpath (param "STATE_DIR")))
+
+; Allow temp files for transient runtime needs.
+(allow file-read* file-write* (subpath (param "TMPDIR")))

--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -7,11 +7,11 @@ status: active
 
 # Sandbox CLI
 
-Manage Docker-based sandbox containers for isolated agent execution.
+Manage sandbox runtimes (Docker and seatbelt) for isolated agent execution.
 
 ## Overview
 
-OpenClaw can run agents in isolated Docker containers for security. The `sandbox` commands help you manage these containers, especially after updates or configuration changes.
+OpenClaw can run agents in isolated sandboxes for security. Docker remains the default backend, and macOS hosts can also use the seatbelt backend. The `sandbox` commands help you inspect effective policy and manage runtime containers where applicable.
 
 ## Commands
 
@@ -119,6 +119,16 @@ openclaw sandbox recreate --agent alfred
 Tip: prefer `openclaw sandbox recreate` over manual `docker rm`. It uses the
 Gateway’s container naming and avoids mismatches when scope/session keys change.
 
+## Seatbelt backend notes
+
+For macOS-native sandboxing with `sandbox-exec`, set `sandbox.backend: "seatbelt"`.
+
+See: [Seatbelt Sandbox Backend](/sandbox/seatbelt) for:
+
+- demo profiles (`demo-open`, `demo-websearch`, `demo-restricted`)
+- profile parameter wiring
+- allowlist/safeBins enforcement behavior for seatbelt
+
 ## Configuration
 
 Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sandbox` (per-agent overrides go in `agents.list[].sandbox`):
@@ -148,5 +158,6 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
 ## See Also
 
 - [Sandbox Documentation](/gateway/sandboxing)
+- [Seatbelt Sandbox Backend](/sandbox/seatbelt)
 - [Agent Configuration](/concepts/agent-workspace)
 - [Doctor Command](/gateway/doctor) - Check sandbox setup

--- a/docs/plans/2026-02-26-generic-seatbelt-sandbox.md
+++ b/docs/plans/2026-02-26-generic-seatbelt-sandbox.md
@@ -1,0 +1,301 @@
+# Generic macOS Seatbelt Sandbox Backend — Spec + Implementation Plan
+
+> **For the implementer:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Add a generic macOS-only sandbox backend using `sandbox-exec` (Seatbelt) starting from upstream release `v2026.2.26`, reaching parity with our fork’s *process + filesystem* sandboxing (but **not** the network proxy).
+
+**Architecture:** Reuse the existing sandbox architecture (Docker backend) and add a second backend (`seatbelt`) that runs sandboxed execs on the host via `sandbox-exec`, with a native filesystem bridge. Access control is defined by a seatbelt profile selected via config (logical profile name → `${profileDir}/${name}.sb`).
+
+**Tech Stack:** Node.js, TypeScript, OpenClaw gateway sandbox plumbing, macOS `sandbox-exec` + `.sb` profiles.
+
+---
+
+## Executive summary
+
+We add:
+
+- `sandbox.backend: "seatbelt" | "docker"` (default docker)
+- `agents.*.sandbox.seatbelt.profile` **required when backend=seatbelt**
+- `agents.*.sandbox.seatbelt.profileDir` (optional; defaults under `STATE_DIR/seatbelt-profiles`)
+- Shipped demo profiles (logical names):
+  - `demo-open` — permissive process exec + network allowed, deny writing seatbelt profile dir, deny reading other agents’ sessions
+  - `demo-websearch` — permissive process exec + network allowed, *no access to workspace/state/user data*
+  - `demo-restricted` — restrictive process exec + no network, RW only to workspace (intentionally “too locked down” demo)
+
+We **do not** include the fork’s seatbelt proxy in v1.
+
+We also fix a security/behavior gap:
+
+- Today, exec allowlist/safeBins enforcement only runs in the `host=gateway` path.
+- When `exec.host=sandbox`, the allowlist gate is bypassed.
+- For v1 we will add **gateway-side allowlist enforcement for seatbelt sandbox runs** (backend=seatbelt) even when `host=sandbox`.
+
+### Rationale: why seatbelt-only allowlist enforcement (not docker)
+
+SafeBins/allowlist matching relies on resolving the executed binary’s path. With the docker backend the binary exists *inside the container*, so host-side resolution is not reliable without adding container-aware resolution (future work).
+
+Seatbelt runs on the host filesystem, so resolving/allowlisting binaries is meaningful and can be enforced consistently.
+
+---
+
+## Goals
+
+1. **Generic**: no hardcoded paths, no “our agents”, no reliance on our proxy/tokens/infra.
+2. **Schema locality**: seatbelt config lives under `sandbox.seatbelt.*`.
+3. **Least surprise**: seatbelt backend behaves like docker sandbox at the UX level:
+   - workspace semantics consistent with `workspaceAccess` and sandbox scope
+   - sandboxed `exec` works the same from the agent’s perspective
+4. **Defense in depth**:
+   - seatbelt profile is the OS-layer authority for filesystem/network/process operations
+   - gateway exec allowlist enforced for seatbelt sandbox runs (even when host=sandbox)
+5. **Reviewability**: PR includes this spec and reviewer checklist.
+
+## Non-goals (v1)
+
+- No network domain filtering proxy, no per-agent proxy tokens.
+- No cross-sandbox (docker) allowlist enforcement for host=sandbox.
+- No dynamic per-agent profile generation.
+
+---
+
+## Config: proposed schema changes
+
+### Add sandbox backend selector
+
+- `agents.defaults.sandbox.backend: "docker" | "seatbelt"` (default: docker)
+
+### Add seatbelt config (schema-local)
+
+Under `agents.defaults.sandbox.seatbelt` and per-agent overrides under `agents.list[].sandbox.seatbelt`:
+
+- `profileDir: string` (default: `${STATE_DIR}/seatbelt-profiles`)
+- `profile: string` (**required when backend=seatbelt**) — logical name (no `.sb` required)
+- `params?: Record<string,string>` — extra `-D` key/values
+
+#### Profile resolution
+
+- If `profile` does not end with `.sb`, append `.sb`.
+- Resolve `profilePath = path.join(profileDir, resolvedProfileFile)`.
+
+### Required validation
+
+On gateway startup (config load / validate stage):
+
+- If any agent’s effective sandbox backend is `seatbelt` and effective seatbelt profile is missing/empty → **throw** with clear error:
+  - what key is missing
+  - example config snippet
+  - mention `openclaw doctor`
+
+- If platform is not macOS (`process.platform !== "darwin"`) and backend=seatbelt is configured → **throw** with clear error.
+
+---
+
+## Runtime behavior
+
+### Workspace semantics
+
+Seatbelt uses the same sandbox workspace layout logic as docker:
+
+- When `workspaceAccess === "rw"` → sandbox workspace path is the agent workspace directory.
+- When `workspaceAccess !== "rw"` → sandbox workspace path is the sandbox workspace directory under the sandbox workspace root.
+
+The seatbelt profile should gate filesystem access primarily via `PROJECT_DIR` (mapped to the effective sandbox `workspaceDir`).
+
+### HOME semantics
+
+Keep `HOME` = real user home (compatibility / Keychain), but seatbelt profile is the authority for whether access is allowed.
+
+### Seatbelt `-D` parameters
+
+Populate these automatically when backend=seatbelt:
+
+- `PROJECT_DIR` = effective sandbox workspace dir
+- `WORKSPACE_DIR` = agent’s workspace dir
+- `STATE_DIR` = OpenClaw state dir
+- `AGENT_ID` = effective agent id
+- `SEATBELT_PROFILE_DIR` = effective profileDir
+- `WORKSPACE_ACCESS` = `rw` | `ro` | `none`
+- `TMPDIR` = "/tmp"
+
+Merge user-provided `seatbelt.params` after the auto-generated base (user keys override).
+
+### Filesystem bridge
+
+Implement a native fs bridge for seatbelt backend that uses Node `fs` directly (no container mapping). Still enforce `workspaceAccess` at the tool layer (matching docker’s “second guard”).
+
+### Exec allowlist enforcement (seatbelt only)
+
+When `exec` runs with `host=sandbox` AND `sandbox.backend=seatbelt`:
+
+- Apply the existing allowlist/safeBins analysis before running `sandbox-exec`.
+- If effective exec security is `allowlist` and allowlist is not satisfied → deny.
+- If safeBins satisfied → generate an enforced command plan and run it.
+
+This should not change docker behavior in v1.
+
+---
+
+## Demo profiles to ship
+
+All demo profiles are optional examples; users can (and should) customize.
+
+### `demo-open`
+
+Intent: “developer-friendly” default for mac users.
+
+- `process-exec`: permissive
+- `network`: allow
+- `filesystem`: allow broadly, but explicitly deny:
+  - writes to `${SEATBELT_PROFILE_DIR}`
+  - reads of other agents’ session dirs under `${STATE_DIR}/agents/*/sessions` except its own `${STATE_DIR}/agents/${AGENT_ID}/sessions`
+
+### `demo-websearch`
+
+Intent: network-only style profile.
+
+- `process-exec`: permissive
+- `network`: allow
+- `filesystem`: deny access to user/workspace/state data:
+  - deny reads/writes to `${PROJECT_DIR}`
+  - deny reads/writes to `${STATE_DIR}`
+  - allow only minimal system libs + `/tmp` needed to run
+
+### `demo-restricted`
+
+Intent: “how to lock it down” demonstration; likely unusable without customization.
+
+- `process-exec`: restrictive (explicit allowlist; minimal)
+- `network`: deny
+- `filesystem`:
+  - allow file-read* to `${PROJECT_DIR}`
+  - allow file-write* to `${PROJECT_DIR}` only when `WORKSPACE_ACCESS == "rw"`
+  - deny file-write* to `${PROJECT_DIR}` when `WORKSPACE_ACCESS == "ro"`
+
+> Document loudly that this profile is intentionally extremely restrictive.
+
+---
+
+## Reviewer checklist (genericness)
+
+Reviewers should confirm:
+
+- No hardcoded absolute paths (no `/Users/<name>` etc).
+- No references to our proxy/tokens/per-agent proxy lifecycle.
+- No references to our internal agent names/roles.
+- Profiles use only `param` variables (`PROJECT_DIR`, `STATE_DIR`, etc).
+- Any denies of session/history are generic (`${STATE_DIR}/agents/...`), not bespoke.
+- Allowlist enforcement added only for seatbelt backend, with explicit rationale.
+
+---
+
+## Implementation plan (bite-sized tasks)
+
+### Task 0: Branch setup
+
+**Goal:** Start feature branch from release tag.
+
+**Steps:**
+1. Create branch from `v2026.2.26` (not beta):
+   - `git checkout -b feat/seatbelt-sandbox-generic v2026.2.26`
+2. Add this doc to repo at `docs/plans/2026-02-26-generic-seatbelt-sandbox.md` and commit first.
+
+### Task 1: Add config types for seatbelt backend
+
+**Files (expected):**
+- Modify: `src/config/types.sandbox.ts`
+- Modify: `src/config/types.agents-shared.ts` (or wherever AgentSandboxConfig is defined)
+- Modify: zod schema(s) validating sandbox config
+
+**Steps:**
+1. Add `backend?: "docker" | "seatbelt"` to sandbox config.
+2. Add `seatbelt?: { profileDir?: string; profile?: string; params?: Record<string,string> }`.
+3. Add validation: if backend=seatbelt then `seatbelt.profile` must be present.
+4. Add validation: backend=seatbelt only on darwin.
+5. Tests: add unit tests for config validation errors.
+
+### Task 2: Add seatbelt sandbox types + context wiring
+
+**Files (expected):**
+- Modify: `src/agents/sandbox/types.ts`
+- Add: `src/agents/sandbox/types.seatbelt.ts`
+- Modify: `src/agents/sandbox/config.ts`
+- Modify: `src/agents/sandbox/context.ts`
+
+**Steps:**
+1. Extend `SandboxBackend` union to include `seatbelt`.
+2. Resolve effective seatbelt config (`profileDir/profile/params`).
+3. In sandbox context resolution: if backend=seatbelt, return a sandbox context without creating a docker container.
+4. Populate `-D` params (PROJECT_DIR, STATE_DIR, etc) + WORKSPACE_ACCESS.
+
+### Task 3: Add native FS bridge for seatbelt backend
+
+**Files:**
+- Add: `src/agents/sandbox/seatbelt-fs-bridge.ts`
+- Modify: `src/agents/sandbox/context.ts` to attach fsBridge
+
+**Steps:**
+1. Implement SandboxFsBridge with direct `fs` calls.
+2. Enforce workspaceAccess at tool layer (deny writes when ro).
+3. Tests for read/write behavior.
+
+### Task 4: Seatbelt exec runtime support (no proxy)
+
+**Files:**
+- Modify: `src/agents/bash-tools.exec-runtime.ts`
+- Modify: `src/agents/bash-tools.shared.ts`
+
+**Steps:**
+1. Add `sandbox-exec` argv path for backend=seatbelt.
+2. Remove any proxy env injection (v1).
+3. Ensure env export includes `HOME` real home (compat).
+
+### Task 5: Shipped demo profiles + install/copy logic
+
+**Files:**
+- Add: `assets/seatbelt-profiles/demo-open.sb`
+- Add: `assets/seatbelt-profiles/demo-websearch.sb`
+- Add: `assets/seatbelt-profiles/demo-restricted.sb`
+- Add/Modify: a startup hook to ensure `${STATE_DIR}/seatbelt-profiles` exists and copy demo profiles if missing.
+
+**Steps:**
+1. Decide source location inside repo for demo profiles (assets folder).
+2. On gateway startup, copy profiles into profileDir if file missing.
+3. Document customization instructions.
+
+### Task 6: Enforce exec allowlist/safeBins for seatbelt sandbox runs
+
+**Files:**
+- Modify: `src/agents/bash-tools.exec.ts` and/or a shared helper
+
+**Steps:**
+1. If `host=sandbox` and backend=seatbelt, run allowlist analysis.
+2. If allowlist mode and not satisfied → deny.
+3. If satisfied by safeBins/allowlist → compute enforced command and run.
+4. Add unit tests that demonstrate:
+   - allowlist miss blocks
+   - safeBins allowed passes
+
+### Task 7: Documentation
+
+**Files:**
+- Add: `docs/sandbox/seatbelt.md` (or best docs location)
+
+**Must include:**
+- Config examples
+- Demo profiles explanation
+- “restricted is intentionally too locked down” callout
+- allowlist enforcement rationale (seatbelt-only)
+
+### Task 8: Final verification
+
+Run:
+- unit tests covering sandbox + config validation
+- build
+- smoke test: run a seatbelt-sandboxed exec on mac
+
+---
+
+## Handoff notes for PR
+
+- This doc must be included in the PR (committed to the repo).
+- PR description should call out non-goals and future work.

--- a/docs/sandbox/seatbelt.md
+++ b/docs/sandbox/seatbelt.md
@@ -1,0 +1,109 @@
+---
+title: Seatbelt Sandbox Backend
+summary: "Run sandboxed exec on macOS using sandbox-exec with profile-driven policy."
+read_when: "You are configuring or reviewing sandbox.backend=seatbelt behavior."
+status: active
+---
+
+# Seatbelt Sandbox Backend
+
+OpenClaw supports a macOS-native sandbox backend:
+
+- `sandbox.backend: "seatbelt"`
+- execution via `sandbox-exec`
+- policy via `.sb` seatbelt profiles
+
+This backend is designed for macOS hosts where Docker is not desired for sandboxed exec.
+
+## Config example
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "all",
+        "backend": "seatbelt",
+        "workspaceAccess": "rw",
+        "seatbelt": {
+          "profile": "demo-open",
+          "profileDir": "~/.openclaw/seatbelt-profiles",
+          "params": {
+            "EXTRA_FLAG": "1"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Runtime parameters passed to profiles
+
+OpenClaw populates these profile params automatically:
+
+- `PROJECT_DIR`
+- `WORKSPACE_DIR`
+- `STATE_DIR`
+- `AGENT_ID`
+- `SEATBELT_PROFILE_DIR`
+- `WORKSPACE_ACCESS`
+- `TMPDIR`
+
+User-supplied `sandbox.seatbelt.params` are merged after defaults and may override keys.
+
+## Demo profiles shipped by OpenClaw
+
+On startup (and when seatbelt context is resolved), OpenClaw ensures demo profiles are present in the configured `profileDir`.
+
+Installed files:
+
+- `demo-open.sb`
+- `demo-websearch.sb`
+- `demo-restricted.sb`
+
+These files are copied only when missing (never overwritten).
+
+### Profile intent
+
+- **demo-open**: permissive developer baseline (process + network + workspace access)
+- **demo-websearch**: network-centric, denies project/state data reads/writes
+- **demo-restricted**: intentionally strict profile for lock-down examples
+
+> `demo-restricted` is intentionally hard to use as-is. Treat it as a template, not a default.
+
+## `workspaceAccess=ro` enforcement at profile layer
+
+`demo-restricted.sb` enforces `WORKSPACE_ACCESS` in profile policy:
+
+- always allows `file-read*` on `PROJECT_DIR`
+- allows `file-write*` on `PROJECT_DIR` only when `WORKSPACE_ACCESS == "rw"`
+- denies writes when `WORKSPACE_ACCESS != "rw"` (including `ro`)
+
+## Exec allowlist/safeBins enforcement (seatbelt)
+
+When `exec` runs with:
+
+- `host: "sandbox"`
+- effective backend: `seatbelt`
+- effective exec security: `allowlist`
+
+OpenClaw now applies allowlist/safeBins evaluation before invoking `sandbox-exec`:
+
+- allowlist miss => deny
+- allowlist/safeBins satisfied => run enforced command plan
+
+### Why this is seatbelt-only right now
+
+Docker parity is intentionally deferred. Docker requires container-aware command/path resolution to avoid false negatives caused by host-vs-container path translation and mount mappings.
+
+## Reviewer checklist (genericness)
+
+Use this checklist in reviews:
+
+- no hardcoded `/Users/<name>` (or other machine-specific absolute paths)
+- no proxy/token assumptions in seatbelt runtime path
+- no internal role-name coupling in profile logic
+- profiles use params (`PROJECT_DIR`, `STATE_DIR`, `AGENT_ID`, `SEATBELT_PROFILE_DIR`, `WORKSPACE_ACCESS`)
+- session access rules are generic (`${STATE_DIR}/agents/...` style)
+- seatbelt allowlist enforcement is explicit; docker defer rationale is documented

--- a/docs/sandbox/seatbelt.md
+++ b/docs/sandbox/seatbelt.md
@@ -50,7 +50,7 @@ OpenClaw populates these profile params automatically:
 - `WORKSPACE_ACCESS`
 - `TMPDIR`
 
-User-supplied `sandbox.seatbelt.params` are merged after defaults and may override keys.
+User-supplied `sandbox.seatbelt.params` are merged with defaults, but reserved runtime keys (`PROJECT_DIR`, `WORKSPACE_DIR`, `STATE_DIR`, `AGENT_ID`, `SEATBELT_PROFILE_DIR`, `WORKSPACE_ACCESS`, `TMPDIR`) are always enforced by OpenClaw and cannot be overridden.
 
 ## Demo profiles shipped by OpenClaw
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -22,6 +22,7 @@ import {
 } from "./bash-process-registry.js";
 import {
   buildDockerExecArgs,
+  buildSeatbeltExecArgs,
   chunkString,
   clampWithDefault,
   readEnvInt,
@@ -377,6 +378,21 @@ export async function runExecProcess(opts: {
         stdinMode: "pipe-open";
       } = (() => {
     if (opts.sandbox) {
+      if (opts.sandbox.backend === "seatbelt") {
+        return {
+          mode: "child" as const,
+          argv: [
+            "sandbox-exec",
+            ...buildSeatbeltExecArgs({
+              command: execCommand,
+              profilePath: opts.sandbox.seatbelt.profilePath,
+              definitions: opts.sandbox.seatbelt.params,
+            }),
+          ],
+          env: opts.env,
+          stdinMode: opts.usePty ? ("pipe-open" as const) : ("pipe-closed" as const),
+        };
+      }
       return {
         mode: "child" as const,
         argv: [

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -2,7 +2,15 @@ import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import { type ExecHost, maxAsk, minSecurity } from "../infra/exec-approvals.js";
+import {
+  type ExecHost,
+  buildEnforcedShellCommand,
+  evaluateShellAllowlist,
+  maxAsk,
+  minSecurity,
+  recordAllowlistUse,
+  resolveExecApprovals,
+} from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   getShellPathFromLoginShell,
@@ -455,6 +463,59 @@ export function createExecTool(
           return gatewayResult.pendingResult;
         }
         execCommandOverride = gatewayResult.execCommandOverride;
+      }
+
+      // Seatbelt host-sandbox runs execute on the host via sandbox-exec, so we must
+      // enforce exec allowlist/safeBins here (same policy posture as gateway/node).
+      // Docker parity is intentionally deferred: container-aware command/path resolution
+      // needs a follow-up pass to avoid false negatives across container mount mappings.
+      if (host === "sandbox" && sandbox?.backend === "seatbelt") {
+        const approvals = resolveExecApprovals(agentId, {
+          security,
+          ask,
+        });
+        const hostSecurity = minSecurity(security, approvals.agent.security);
+        if (hostSecurity === "deny") {
+          throw new Error("exec denied: host=sandbox backend=seatbelt security=deny");
+        }
+
+        if (hostSecurity === "allowlist") {
+          const allowlistEval = evaluateShellAllowlist({
+            command: params.command,
+            allowlist: approvals.allowlist,
+            safeBins,
+            safeBinProfiles,
+            cwd: workdir,
+            env,
+            platform: process.platform,
+            trustedSafeBinDirs,
+          });
+          if (!allowlistEval.analysisOk || !allowlistEval.allowlistSatisfied) {
+            throw new Error("exec denied: host=sandbox backend=seatbelt allowlist-miss");
+          }
+
+          const enforced = buildEnforcedShellCommand({
+            command: params.command,
+            segments: allowlistEval.segments,
+            platform: process.platform,
+          });
+          if (!enforced.ok || !enforced.command) {
+            throw new Error(
+              `exec denied: allowlist execution plan unavailable (${enforced.reason})`,
+            );
+          }
+          execCommandOverride = enforced.command;
+
+          const resolvedPath = allowlistEval.segments[0]?.resolution?.resolvedPath;
+          const seen = new Set<string>();
+          for (const match of allowlistEval.allowlistMatches) {
+            if (seen.has(match.pattern)) {
+              continue;
+            }
+            seen.add(match.pattern);
+            recordAllowlistUse(approvals.file, agentId, match, params.command, resolvedPath);
+          }
+        }
       }
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { type ExecHost, maxAsk, minSecurity } from "../infra/exec-approvals.js";
@@ -377,6 +378,7 @@ export function createExecTool(
             paramsEnv: params.env,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
+            homeOverride: sandbox.backend === "seatbelt" ? homedir() : undefined,
           })
         : mergedEnv;
 

--- a/src/agents/bash-tools.seatbelt-allowlist.test.ts
+++ b/src/agents/bash-tools.seatbelt-allowlist.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
+
+const {
+  runExecProcessMock,
+  resolveExecApprovalsMock,
+  evaluateShellAllowlistMock,
+  buildEnforcedShellCommandMock,
+  recordAllowlistUseMock,
+} = vi.hoisted(() => ({
+  runExecProcessMock: vi.fn(),
+  resolveExecApprovalsMock: vi.fn(),
+  evaluateShellAllowlistMock: vi.fn(),
+  buildEnforcedShellCommandMock: vi.fn(),
+  recordAllowlistUseMock: vi.fn(),
+}));
+
+vi.mock("./bash-tools.exec-runtime.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./bash-tools.exec-runtime.js")>();
+  return {
+    ...mod,
+    runExecProcess: runExecProcessMock,
+  };
+});
+
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
+  return {
+    ...mod,
+    resolveExecApprovals: resolveExecApprovalsMock,
+    evaluateShellAllowlist: evaluateShellAllowlistMock,
+    buildEnforcedShellCommand: buildEnforcedShellCommandMock,
+    recordAllowlistUse: recordAllowlistUseMock,
+  };
+});
+
+const { createExecTool } = await import("./bash-tools.exec.js");
+
+function createApprovals(security: "deny" | "allowlist" | "full" = "allowlist"): ExecApprovalsResolved {
+  return {
+    path: "/tmp/exec-approvals.json",
+    socketPath: "/tmp/exec-approvals.sock",
+    token: "token",
+    defaults: {
+      security,
+      ask: "off",
+      askFallback: "deny",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security,
+      ask: "off",
+      askFallback: "deny",
+      autoAllowSkills: false,
+    },
+    allowlist: [{ pattern: "/usr/bin/echo" }],
+    file: {
+      version: 1,
+      socket: { path: "/tmp/exec-approvals.sock", token: "token" },
+      defaults: {
+        security,
+        ask: "off",
+        askFallback: "deny",
+        autoAllowSkills: false,
+      },
+      agents: {},
+    },
+  };
+}
+
+function createRunHandle(workdir: string) {
+  const startedAt = Date.now();
+  return {
+    session: {
+      id: "sess-1",
+      command: "echo ok",
+      backgrounded: false,
+      startedAt,
+      cwd: workdir,
+      tail: "",
+      aggregated: "ok",
+      exited: true,
+      notifyOnExit: false,
+      exitNotified: false,
+    },
+    startedAt,
+    kill: () => {},
+    promise: Promise.resolve({
+      status: "completed" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 5,
+      aggregated: "ok",
+      timedOut: false,
+    }),
+  };
+}
+
+describe("exec seatbelt allowlist enforcement", () => {
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-exec-"));
+    resolveExecApprovalsMock.mockReturnValue(createApprovals("allowlist"));
+    evaluateShellAllowlistMock.mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: true,
+      allowlistMatches: [{ pattern: "/usr/bin/echo" }],
+      segments: [{ argv: ["echo", "ok"], resolution: { resolvedPath: "/usr/bin/echo" } }],
+      segmentSatisfiedBy: [],
+    });
+    buildEnforcedShellCommandMock.mockReturnValue({ ok: true, command: "echo enforced" });
+    runExecProcessMock.mockImplementation(async (opts: { workdir: string }) =>
+      createRunHandle(opts.workdir),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("denies seatbelt sandbox execution on allowlist miss", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      allowlistMatches: [],
+      segments: [],
+      segmentSatisfiedBy: [],
+    });
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "allowlist",
+      ask: "off",
+      sandbox: {
+        backend: "seatbelt",
+        workspaceDir,
+        containerWorkdir: "/workspace",
+        seatbelt: {
+          profilePath: path.join(workspaceDir, "demo-open.sb"),
+          params: {},
+        },
+      },
+    });
+
+    await expect(tool.execute("call-deny", { command: "echo ok" })).rejects.toThrow(
+      /allowlist-miss/,
+    );
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+  });
+
+  it("allows seatbelt sandbox execution when allowlist/safeBins evaluation passes", async () => {
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "allowlist",
+      ask: "off",
+      sandbox: {
+        backend: "seatbelt",
+        workspaceDir,
+        containerWorkdir: "/workspace",
+        seatbelt: {
+          profilePath: path.join(workspaceDir, "demo-open.sb"),
+          params: {},
+        },
+      },
+    });
+
+    const result = await tool.execute("call-allow", { command: "echo ok" });
+    expect(result.details.status).toBe("completed");
+    expect(runExecProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "echo ok",
+        execCommand: "echo enforced",
+      }),
+    );
+    expect(recordAllowlistUseMock).toHaveBeenCalled();
+  });
+
+  it("does not apply the new allowlist guardrail to docker sandbox backend yet", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      analysisOk: true,
+      allowlistSatisfied: false,
+      allowlistMatches: [],
+      segments: [],
+      segmentSatisfiedBy: [],
+    });
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "allowlist",
+      ask: "off",
+      sandbox: {
+        backend: "docker",
+        workspaceDir,
+        containerWorkdir: "/workspace",
+        containerName: "openclaw-test-sandbox",
+      },
+    });
+
+    const result = await tool.execute("call-docker", { command: "echo ok" });
+    expect(result.details.status).toBe("completed");
+    expect(evaluateShellAllowlistMock).not.toHaveBeenCalled();
+    expect(runExecProcessMock).toHaveBeenCalled();
+  });
+});

--- a/src/agents/bash-tools.seatbelt-runtime.test.ts
+++ b/src/agents/bash-tools.seatbelt-runtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildSandboxEnv, buildSeatbeltExecArgs } from "./bash-tools.shared.js";
+
+describe("seatbelt exec runtime helpers", () => {
+  it("builds sandbox-exec args with profile and -D definitions", () => {
+    const args = buildSeatbeltExecArgs({
+      command: "echo hello",
+      profilePath: "/tmp/seatbelt/demo-open.sb",
+      definitions: {
+        PROJECT_DIR: "/tmp/workspace",
+        WORKSPACE_ACCESS: "ro",
+      },
+    });
+
+    expect(args).toEqual([
+      "-f",
+      "/tmp/seatbelt/demo-open.sb",
+      "-D",
+      "PROJECT_DIR=/tmp/workspace",
+      "-D",
+      "WORKSPACE_ACCESS=ro",
+      "sh",
+      "-lc",
+      "echo hello",
+    ]);
+  });
+
+  it("keeps HOME pinned to the host home override", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      containerWorkdir: "/workspace",
+      sandboxEnv: { LANG: "C.UTF-8", HOME: "/tmp/sandbox-home" },
+      paramsEnv: { HOME: "/tmp/request-home", FOO: "bar" },
+      homeOverride: "/Users/claw",
+    });
+
+    expect(env.HOME).toBe("/Users/claw");
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.FOO).toBe("bar");
+    expect(env.LANG).toBe("C.UTF-8");
+  });
+
+  it("does not inject proxy environment variables by default", () => {
+    const env = buildSandboxEnv({
+      defaultPath: "/usr/bin",
+      containerWorkdir: "/workspace",
+      homeOverride: "/Users/claw",
+    });
+
+    expect(env).not.toHaveProperty("HTTP_PROXY");
+    expect(env).not.toHaveProperty("HTTPS_PROXY");
+    expect(env).not.toHaveProperty("ALL_PROXY");
+    expect(env).not.toHaveProperty("NO_PROXY");
+  });
+});

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -7,28 +7,46 @@ import { assertSandboxPath } from "./sandbox-paths.js";
 
 const CHUNK_LIMIT = 8 * 1024;
 
-export type BashSandboxConfig = {
-  containerName: string;
+type BashSandboxBaseConfig = {
   workspaceDir: string;
   containerWorkdir: string;
   env?: Record<string, string>;
 };
+
+export type BashDockerSandboxConfig = BashSandboxBaseConfig & {
+  backend?: "docker";
+  containerName: string;
+};
+
+export type BashSeatbeltSandboxConfig = BashSandboxBaseConfig & {
+  backend: "seatbelt";
+  seatbelt: {
+    profilePath: string;
+    params?: Record<string, string>;
+  };
+};
+
+export type BashSandboxConfig = BashDockerSandboxConfig | BashSeatbeltSandboxConfig;
 
 export function buildSandboxEnv(params: {
   defaultPath: string;
   paramsEnv?: Record<string, string>;
   sandboxEnv?: Record<string, string>;
   containerWorkdir: string;
+  homeOverride?: string;
 }) {
   const env: Record<string, string> = {
     PATH: params.defaultPath,
-    HOME: params.containerWorkdir,
+    HOME: params.homeOverride ?? params.containerWorkdir,
   };
   for (const [key, value] of Object.entries(params.sandboxEnv ?? {})) {
     env[key] = value;
   }
   for (const [key, value] of Object.entries(params.paramsEnv ?? {})) {
     env[key] = value;
+  }
+  if (params.homeOverride) {
+    env.HOME = params.homeOverride;
   }
   return env;
 }
@@ -76,6 +94,19 @@ export function buildDockerExecArgs(params: {
     ? 'export PATH="${OPENCLAW_PREPEND_PATH}:$PATH"; unset OPENCLAW_PREPEND_PATH; '
     : "";
   args.push(params.containerName, "sh", "-lc", `${pathExport}${params.command}`);
+  return args;
+}
+
+export function buildSeatbeltExecArgs(params: {
+  command: string;
+  profilePath: string;
+  definitions?: Record<string, string>;
+}) {
+  const args = ["-f", params.profilePath];
+  for (const [key, value] of Object.entries(params.definitions ?? {})) {
+    args.push("-D", `${key}=${value}`);
+  }
+  args.push("sh", "-lc", params.command);
   return args;
 }
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -399,12 +399,24 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
     sandbox: sandbox
-      ? {
-          containerName: sandbox.containerName,
-          workspaceDir: sandbox.workspaceDir,
-          containerWorkdir: sandbox.containerWorkdir,
-          env: sandbox.docker.env,
-        }
+      ? sandbox.backend === "seatbelt"
+        ? {
+            backend: "seatbelt",
+            workspaceDir: sandbox.workspaceDir,
+            containerWorkdir: sandbox.containerWorkdir,
+            env: sandbox.docker.env,
+            seatbelt: {
+              profilePath: sandbox.seatbelt?.profilePath ?? "",
+              params: sandbox.seatbelt?.params ?? {},
+            },
+          }
+        : {
+            backend: "docker",
+            containerName: sandbox.containerName,
+            workspaceDir: sandbox.workspaceDir,
+            containerWorkdir: sandbox.containerWorkdir,
+            env: sandbox.docker.env,
+          }
       : undefined,
   });
   const processTool = createProcessTool({

--- a/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
+++ b/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
@@ -435,4 +435,37 @@ describe("Agent-specific sandbox config", () => {
       }
     }
   });
+
+  it("resolves seatbelt context without docker container setup", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            backend: "seatbelt",
+            workspaceAccess: "ro",
+            seatbelt: {
+              profile: "demo-open",
+              params: {
+                WORKSPACE_ACCESS: "override-rw",
+                CUSTOM_FLAG: "enabled",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const context = await resolveContext(cfg, "agent:main:thread:123", "/tmp/test-seatbelt");
+    expect(context).toBeDefined();
+    expect(context?.backend).toBe("seatbelt");
+    expect(context?.seatbelt?.profile).toBe("demo-open");
+    expect(context?.seatbelt?.profilePath).toContain("demo-open.sb");
+    expect(context?.seatbelt?.params.CUSTOM_FLAG).toBe("enabled");
+    // User params override auto-generated values.
+    expect(context?.seatbelt?.params.WORKSPACE_ACCESS).toBe("override-rw");
+    expect(context?.seatbelt?.params.PROJECT_DIR).toBe(context?.workspaceDir);
+    expect(context?.seatbelt?.params.WORKSPACE_DIR).toBe(context?.agentWorkspaceDir);
+    expect(spawnCalls.some((call) => call.command === "docker")).toBe(false);
+  });
 });

--- a/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
+++ b/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
@@ -459,6 +459,7 @@ describe("Agent-specific sandbox config", () => {
     const context = await resolveContext(cfg, "agent:main:thread:123", "/tmp/test-seatbelt");
     expect(context).toBeDefined();
     expect(context?.backend).toBe("seatbelt");
+    expect(context?.fsBridge).toBeDefined();
     expect(context?.seatbelt?.profile).toBe("demo-open");
     expect(context?.seatbelt?.profilePath).toContain("demo-open.sb");
     expect(context?.seatbelt?.params.CUSTOM_FLAG).toBe("enabled");

--- a/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
+++ b/src/agents/sandbox-agent-config.agent-specific-sandbox-config.test.ts
@@ -463,8 +463,8 @@ describe("Agent-specific sandbox config", () => {
     expect(context?.seatbelt?.profile).toBe("demo-open");
     expect(context?.seatbelt?.profilePath).toContain("demo-open.sb");
     expect(context?.seatbelt?.params.CUSTOM_FLAG).toBe("enabled");
-    // User params override auto-generated values.
-    expect(context?.seatbelt?.params.WORKSPACE_ACCESS).toBe("override-rw");
+    // Reserved params are enforced by runtime defaults (non-overridable).
+    expect(context?.seatbelt?.params.WORKSPACE_ACCESS).toBe("ro");
     expect(context?.seatbelt?.params.PROJECT_DIR).toBe(context?.workspaceDir);
     expect(context?.seatbelt?.params.WORKSPACE_DIR).toBe(context?.agentWorkspaceDir);
     expect(spawnCalls.some((call) => call.command === "docker")).toBe(false);

--- a/src/agents/sandbox/config.seatbelt.test.ts
+++ b/src/agents/sandbox/config.seatbelt.test.ts
@@ -1,0 +1,124 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveSandboxConfigForAgent } from "./config.js";
+import { DEFAULT_SANDBOX_SEATBELT_PROFILE_DIR } from "./constants.js";
+
+describe("resolveSandboxConfigForAgent (seatbelt)", () => {
+  it("defaults backend to docker", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+          },
+        },
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "main");
+    expect(sandbox.backend).toBe("docker");
+  });
+
+  it("resolves seatbelt defaults with profileDir fallback", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+            },
+          },
+        },
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "main");
+    expect(sandbox.backend).toBe("seatbelt");
+    expect(sandbox.seatbelt.profile).toBe("demo-open");
+    expect(sandbox.seatbelt.profileDir).toBe(DEFAULT_SANDBOX_SEATBELT_PROFILE_DIR);
+  });
+
+  it("merges seatbelt params with agent override precedence", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            scope: "agent",
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+              params: {
+                ALPHA: "global",
+                SHARED: "global",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "work",
+            sandbox: {
+              seatbelt: {
+                profileDir: "~/seatbelt-profiles-work",
+                params: {
+                  ALPHA: "agent",
+                  BETA: "agent",
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "work");
+    expect(sandbox.seatbelt.profileDir).toBe(path.join(os.homedir(), "seatbelt-profiles-work"));
+    expect(sandbox.seatbelt.params).toEqual({
+      ALPHA: "agent",
+      SHARED: "global",
+      BETA: "agent",
+    });
+  });
+
+  it("ignores agent seatbelt overrides under shared scope", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            scope: "shared",
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+              params: {
+                ALPHA: "global",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "work",
+            sandbox: {
+              seatbelt: {
+                profile: "demo-restricted",
+                params: {
+                  ALPHA: "agent",
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "work");
+    expect(sandbox.seatbelt.profile).toBe("demo-open");
+    expect(sandbox.seatbelt.params).toEqual({ ALPHA: "global" });
+  });
+});

--- a/src/agents/sandbox/config.seatbelt.test.ts
+++ b/src/agents/sandbox/config.seatbelt.test.ts
@@ -121,4 +121,48 @@ describe("resolveSandboxConfigForAgent (seatbelt)", () => {
     expect(sandbox.seatbelt.profile).toBe("demo-open");
     expect(sandbox.seatbelt.params).toEqual({ ALPHA: "global" });
   });
+
+  it("inherits seatbelt.profile from defaults for agent backend override", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            sandbox: {
+              backend: "seatbelt",
+            },
+          },
+        ],
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "worker");
+    expect(sandbox.backend).toBe("seatbelt");
+    expect(sandbox.seatbelt.profile).toBe("demo-open");
+  });
+
+  it("throws when seatbelt backend has no merged profile", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            backend: "seatbelt",
+          },
+        },
+      },
+    };
+
+    expect(() => resolveSandboxConfigForAgent(cfg, "main")).toThrow(/sandbox.seatbelt.profile/);
+  });
+
 });

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -246,7 +246,7 @@ export function resolveSandboxConfigForAgent(
     }),
   };
 
-  if (resolved.backend === "seatbelt" && !resolved.seatbelt.profile?.trim()) {
+  if (resolved.backend === "seatbelt" && !resolved.seatbelt?.profile?.trim()) {
     const scopedAgentId = agentId?.trim() || "main";
     throw new Error(
       `Seatbelt sandbox requires sandbox.seatbelt.profile after defaults/agent merge for agent "${scopedAgentId}". Set agents.defaults.sandbox.seatbelt.profile or an agent-specific override.`,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -213,7 +213,7 @@ export function resolveSandboxConfigForAgent(
 
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, agentId);
 
-  return {
+  const resolved: SandboxConfig = {
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
     backend: agentSandbox?.backend ?? agent?.backend ?? DEFAULT_SANDBOX_BACKEND,
     scope,
@@ -245,4 +245,13 @@ export function resolveSandboxConfigForAgent(
       agentPrune: agentSandbox?.prune,
     }),
   };
+
+  if (resolved.backend === "seatbelt" && !resolved.seatbelt.profile?.trim()) {
+    const scopedAgentId = agentId?.trim() || "main";
+    throw new Error(
+      `Seatbelt sandbox requires sandbox.seatbelt.profile after defaults/agent merge for agent "${scopedAgentId}". Set agents.defaults.sandbox.seatbelt.profile or an agent-specific override.`,
+    );
+  }
+
+  return resolved;
 }

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveUserPath } from "../../utils.js";
 import { resolveAgentConfig } from "../agent-scope.js";
 import {
+  DEFAULT_SANDBOX_BACKEND,
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
   DEFAULT_SANDBOX_BROWSER_CDP_PORT,
   DEFAULT_SANDBOX_BROWSER_IMAGE,
@@ -12,6 +14,7 @@ import {
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_SEATBELT_PROFILE_DIR,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -22,6 +25,7 @@ import type {
   SandboxDockerConfig,
   SandboxPruneConfig,
   SandboxScope,
+  SandboxSeatbeltConfig,
 } from "./types.js";
 
 export const DANGEROUS_SANDBOX_DOCKER_BOOLEAN_KEYS = [
@@ -119,6 +123,28 @@ export function resolveSandboxDockerConfig(params: {
   };
 }
 
+export function resolveSandboxSeatbeltConfig(params: {
+  scope: SandboxScope;
+  globalSeatbelt?: Partial<SandboxSeatbeltConfig>;
+  agentSeatbelt?: Partial<SandboxSeatbeltConfig>;
+}): SandboxSeatbeltConfig {
+  const agentSeatbelt = params.scope === "shared" ? undefined : params.agentSeatbelt;
+  const globalSeatbelt = params.globalSeatbelt;
+  const profileDir = resolveUserPath(
+    agentSeatbelt?.profileDir ?? globalSeatbelt?.profileDir ?? DEFAULT_SANDBOX_SEATBELT_PROFILE_DIR,
+  );
+
+  const paramsMerged = agentSeatbelt?.params
+    ? { ...(globalSeatbelt?.params ?? {}), ...agentSeatbelt.params }
+    : globalSeatbelt?.params;
+
+  return {
+    profileDir,
+    profile: agentSeatbelt?.profile ?? globalSeatbelt?.profile,
+    params: paramsMerged,
+  };
+}
+
 export function resolveSandboxBrowserConfig(params: {
   scope: SandboxScope;
   globalBrowser?: Partial<SandboxBrowserConfig>;
@@ -189,10 +215,16 @@ export function resolveSandboxConfigForAgent(
 
   return {
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
+    backend: agentSandbox?.backend ?? agent?.backend ?? DEFAULT_SANDBOX_BACKEND,
     scope,
     workspaceAccess: agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none",
     workspaceRoot:
       agentSandbox?.workspaceRoot ?? agent?.workspaceRoot ?? DEFAULT_SANDBOX_WORKSPACE_ROOT,
+    seatbelt: resolveSandboxSeatbeltConfig({
+      scope,
+      globalSeatbelt: agent?.seatbelt,
+      agentSeatbelt: agentSandbox?.seatbelt,
+    }),
     docker: resolveSandboxDockerConfig({
       scope,
       globalDocker: agent?.docker,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -4,9 +4,13 @@ import { STATE_DIR } from "../../config/config.js";
 
 export const DEFAULT_SANDBOX_WORKSPACE_ROOT = path.join(STATE_DIR, "sandboxes");
 
+export const DEFAULT_SANDBOX_BACKEND = "docker" as const;
+
 export const DEFAULT_SANDBOX_IMAGE = "openclaw-sandbox:bookworm-slim";
 export const DEFAULT_SANDBOX_CONTAINER_PREFIX = "openclaw-sbx-";
 export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
+
+export const DEFAULT_SANDBOX_SEATBELT_PROFILE_DIR = path.join(STATE_DIR, "seatbelt-profiles");
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 

--- a/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
+++ b/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSandboxContext } from "./context.js";
 
+const describeSeatbelt = process.platform === "darwin" ? describe : describe.skip;
+
 function createSeatbeltConfig(params: {
   profileDir: string;
   profile: string;
@@ -27,7 +29,7 @@ function createSeatbeltConfig(params: {
   } as OpenClawConfig;
 }
 
-describe("resolveSeatbeltContextConfig profile handling", () => {
+describeSeatbelt("resolveSeatbeltContextConfig profile handling", () => {
   const cleanupPaths: string[] = [];
 
   afterEach(async () => {
@@ -89,5 +91,23 @@ describe("resolveSeatbeltContextConfig profile handling", () => {
 
     const profileDirEntries = await fs.readdir(profileDir);
     expect(profileDirEntries).toEqual([]);
+  });
+
+  it("throws a distinct unreadable-profile error", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-unreadable-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    const profilePath = path.join(profileDir, "private.sb");
+    await fs.writeFile(profilePath, '(version 1)\n(allow default)\n', "utf8");
+    await fs.chmod(profilePath, 0o000);
+
+    await expect(
+      resolveSandboxContext({
+        config: createSeatbeltConfig({ profileDir, profile: "private" }),
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      }),
+    ).rejects.toThrow(/exists but is not readable/);
   });
 });

--- a/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
+++ b/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveSandboxContext } from "./context.js";
+
+function createSeatbeltConfig(params: {
+  profileDir: string;
+  profile: string;
+  workspaceAccess?: "none" | "ro" | "rw";
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        sandbox: {
+          mode: "all",
+          backend: "seatbelt",
+          workspaceAccess: params.workspaceAccess ?? "rw",
+          seatbelt: {
+            profileDir: params.profileDir,
+            profile: params.profile,
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("resolveSeatbeltContextConfig profile handling", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanupPaths.splice(0).map(async (target) => {
+        await fs.chmod(target, 0o755).catch(() => undefined);
+        await fs.rm(target, { recursive: true, force: true }).catch(() => undefined);
+      }),
+    );
+  });
+
+  it("does not require profileDir writes when profile already exists", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-ro-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    const profilePath = path.join(profileDir, "custom.sb");
+    await fs.writeFile(profilePath, '(version 1)\n(allow default)\n', "utf8");
+    await fs.chmod(profileDir, 0o555);
+
+    const context = await resolveSandboxContext({
+      config: createSeatbeltConfig({ profileDir, profile: "custom" }),
+      sessionKey: "agent:main:main",
+      workspaceDir,
+    });
+
+    expect(context?.backend).toBe("seatbelt");
+    expect(context?.seatbelt?.profilePath).toBe(profilePath);
+  });
+
+  it("best-effort installs demo profiles when requested profile is missing", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-install-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    const context = await resolveSandboxContext({
+      config: createSeatbeltConfig({ profileDir, profile: "demo-open" }),
+      sessionKey: "agent:main:main",
+      workspaceDir,
+    });
+
+    expect(context?.backend).toBe("seatbelt");
+    await expect(fs.access(path.join(profileDir, "demo-open.sb"))).resolves.toBeUndefined();
+  });
+
+  it("throws a clear error when profile is still missing after best-effort install", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-missing-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    await expect(
+      resolveSandboxContext({
+        config: createSeatbeltConfig({ profileDir, profile: "custom-missing" }),
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      }),
+    ).rejects.toThrow(/Seatbelt profile "custom-missing" not found/);
+
+    await expect(
+      resolveSandboxContext({
+        config: createSeatbeltConfig({ profileDir, profile: "custom-missing" }),
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      }),
+    ).rejects.toThrow(/openclaw doctor/);
+  });
+});

--- a/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
+++ b/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
@@ -78,20 +78,16 @@ describe("resolveSeatbeltContextConfig profile handling", () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
     cleanupPaths.push(profileDir, workspaceDir);
 
-    await expect(
-      resolveSandboxContext({
-        config: createSeatbeltConfig({ profileDir, profile: "custom-missing" }),
-        sessionKey: "agent:main:main",
-        workspaceDir,
-      }),
-    ).rejects.toThrow(/Seatbelt profile "custom-missing" not found/);
+    const contextPromise = resolveSandboxContext({
+      config: createSeatbeltConfig({ profileDir, profile: "custom-missing" }),
+      sessionKey: "agent:main:main",
+      workspaceDir,
+    });
 
-    await expect(
-      resolveSandboxContext({
-        config: createSeatbeltConfig({ profileDir, profile: "custom-missing" }),
-        sessionKey: "agent:main:main",
-        workspaceDir,
-      }),
-    ).rejects.toThrow(/openclaw doctor/);
+    await expect(contextPromise).rejects.toThrow(/Seatbelt profile "custom-missing" not found/);
+    await expect(contextPromise).rejects.toThrow(/openclaw doctor/);
+
+    const profileDirEntries = await fs.readdir(profileDir);
+    expect(profileDirEntries).toEqual([]);
   });
 });

--- a/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
+++ b/src/agents/sandbox/context.seatbelt-profile-resolution.test.ts
@@ -11,6 +11,7 @@ function createSeatbeltConfig(params: {
   profileDir: string;
   profile: string;
   workspaceAccess?: "none" | "ro" | "rw";
+  profileParams?: Record<string, string>;
 }): OpenClawConfig {
   return {
     agents: {
@@ -22,6 +23,7 @@ function createSeatbeltConfig(params: {
           seatbelt: {
             profileDir: params.profileDir,
             profile: params.profile,
+            params: params.profileParams,
           },
         },
       },
@@ -75,6 +77,22 @@ describeSeatbelt("resolveSeatbeltContextConfig profile handling", () => {
     await expect(fs.access(path.join(profileDir, "demo-open.sb"))).resolves.toBeUndefined();
   });
 
+  it("handles demo profile names with explicit .sb suffix", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-install-ext-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    const context = await resolveSandboxContext({
+      config: createSeatbeltConfig({ profileDir, profile: "demo-open.sb" }),
+      sessionKey: "agent:main:main",
+      workspaceDir,
+    });
+
+    expect(context?.backend).toBe("seatbelt");
+    expect(context?.seatbelt?.profile).toBe("demo-open");
+    await expect(fs.access(path.join(profileDir, "demo-open.sb"))).resolves.toBeUndefined();
+  });
+
   it("throws a clear error when profile is still missing after best-effort install", async () => {
     const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-missing-"));
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
@@ -109,5 +127,50 @@ describeSeatbelt("resolveSeatbeltContextConfig profile handling", () => {
         workspaceDir,
       }),
     ).rejects.toThrow(/exists but is not readable/);
+  });
+
+
+  it("rejects traversal-like profile names even if config bypasses schema parsing", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-traversal-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    await expect(
+      resolveSandboxContext({
+        config: createSeatbeltConfig({ profileDir, profile: "../evil" }) as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      }),
+    ).rejects.toThrow(/Invalid seatbelt profile/);
+  });
+
+  it("keeps reserved seatbelt params non-overridable while preserving custom params", async () => {
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-profile-params-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-work-"));
+    cleanupPaths.push(profileDir, workspaceDir);
+
+    await fs.writeFile(path.join(profileDir, "custom.sb"), '(version 1)\n(allow default)\n', "utf8");
+
+    const context = await resolveSandboxContext({
+      config: createSeatbeltConfig({
+        profileDir,
+        profile: "custom",
+        workspaceAccess: "ro",
+        profileParams: {
+          WORKSPACE_ACCESS: "rw",
+          AGENT_ID: "evil-agent",
+          STATE_DIR: "/tmp/evil",
+          CUSTOM_FLAG: "on",
+        },
+      }),
+      sessionKey: "agent:main:main",
+      workspaceDir,
+    });
+
+    expect(context?.backend).toBe("seatbelt");
+    expect(context?.seatbelt?.params.WORKSPACE_ACCESS).toBe("ro");
+    expect(context?.seatbelt?.params.AGENT_ID).toBe("main");
+    expect(context?.seatbelt?.params.STATE_DIR).not.toBe("/tmp/evil");
+    expect(context?.seatbelt?.params.CUSTOM_FLAG).toBe("on");
   });
 });

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { DEFAULT_BROWSER_EVALUATE_ENABLED } from "../../browser/constants.js";
 import { ensureBrowserControlAuth, resolveBrowserControlAuth } from "../../browser/control-auth.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadConfig } from "../../config/config.js";
+import { loadConfig, STATE_DIR } from "../../config/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveUserPath } from "../../utils.js";
 import { syncSkillsToWorkspace } from "../skills.js";
@@ -14,7 +15,12 @@ import { createSandboxFsBridge } from "./fs-bridge.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
-import type { SandboxContext, SandboxDockerConfig, SandboxWorkspaceInfo } from "./types.js";
+import type {
+  SandboxContext,
+  SandboxDockerConfig,
+  SandboxSeatbeltContext,
+  SandboxWorkspaceInfo,
+} from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
 async function ensureSandboxWorkspaceLayout(params: {
@@ -105,6 +111,43 @@ function resolveSandboxSession(params: { config?: OpenClawConfig; sessionKey?: s
   return { rawSessionKey, runtime, cfg };
 }
 
+function resolveSeatbeltContextConfig(params: {
+  cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+  agentId: string;
+}): SandboxSeatbeltContext | undefined {
+  if (params.cfg.backend !== "seatbelt") {
+    return undefined;
+  }
+  const rawProfile = params.cfg.seatbelt.profile?.trim();
+  if (!rawProfile) {
+    return undefined;
+  }
+  const profile = rawProfile.endsWith(".sb") ? rawProfile.slice(0, -3) : rawProfile;
+  const profileFile = `${profile}.sb`;
+
+  const defaults = {
+    PROJECT_DIR: params.workspaceDir,
+    WORKSPACE_DIR: params.agentWorkspaceDir,
+    STATE_DIR,
+    AGENT_ID: params.agentId,
+    SEATBELT_PROFILE_DIR: params.cfg.seatbelt.profileDir,
+    WORKSPACE_ACCESS: params.cfg.workspaceAccess,
+    TMPDIR: "/tmp",
+  };
+
+  return {
+    profileDir: params.cfg.seatbelt.profileDir,
+    profile,
+    profilePath: path.join(params.cfg.seatbelt.profileDir, profileFile),
+    params: {
+      ...defaults,
+      ...(params.cfg.seatbelt.params ?? {}),
+    },
+  };
+}
+
 export async function resolveSandboxContext(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
@@ -114,9 +157,11 @@ export async function resolveSandboxContext(params: {
   if (!resolved) {
     return null;
   }
-  const { rawSessionKey, cfg } = resolved;
+  const { rawSessionKey, cfg, runtime } = resolved;
 
-  await maybePruneSandboxes(cfg);
+  if (cfg.backend === "docker") {
+    await maybePruneSandboxes(cfg);
+  }
 
   const { agentWorkspaceDir, scopeKey, workspaceDir } = await ensureSandboxWorkspaceLayout({
     cfg,
@@ -124,6 +169,30 @@ export async function resolveSandboxContext(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
+
+  const seatbelt = resolveSeatbeltContextConfig({
+    cfg,
+    workspaceDir,
+    agentWorkspaceDir,
+    agentId: runtime.agentId,
+  });
+
+  if (cfg.backend === "seatbelt") {
+    return {
+      enabled: true,
+      backend: "seatbelt",
+      sessionKey: rawSessionKey,
+      workspaceDir,
+      agentWorkspaceDir,
+      workspaceAccess: cfg.workspaceAccess,
+      containerName: "",
+      containerWorkdir: workspaceDir,
+      docker: cfg.docker,
+      seatbelt,
+      tools: cfg.tools,
+      browserAllowHostControl: cfg.browser.allowHostControl,
+    };
+  }
 
   const docker = await resolveSandboxDockerUser({
     docker: cfg.docker,
@@ -168,6 +237,7 @@ export async function resolveSandboxContext(params: {
 
   const sandboxContext: SandboxContext = {
     enabled: true,
+    backend: "docker",
     sessionKey: rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,
@@ -175,6 +245,7 @@ export async function resolveSandboxContext(params: {
     containerName,
     containerWorkdir: resolvedCfg.docker.workdir,
     docker: resolvedCfg.docker,
+    seatbelt,
     tools: resolvedCfg.tools,
     browserAllowHostControl: resolvedCfg.browser.allowHostControl,
     browser: browser ?? undefined,
@@ -204,7 +275,8 @@ export async function ensureSandboxWorkspaceForSession(params: {
   });
 
   return {
+    backend: cfg.backend,
     workspaceDir,
-    containerWorkdir: cfg.docker.workdir,
+    containerWorkdir: cfg.backend === "seatbelt" ? workspaceDir : cfg.docker.workdir,
   };
 }

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DEFAULT_BROWSER_EVALUATE_ENABLED } from "../../browser/constants.js";
@@ -130,16 +131,26 @@ async function resolveSeatbeltContextConfig(params: {
   const profileFile = `${profile}.sb`;
   const profilePath = path.join(params.cfg.seatbelt.profileDir, profileFile);
 
-  const hasProfile = async () => {
+  const getProfileState = async (): Promise<"ok" | "missing" | "unreadable"> => {
     try {
-      await fs.access(profilePath);
-      return true;
-    } catch {
-      return false;
+      await fs.access(profilePath, fsConstants.R_OK);
+      return "ok";
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      return code === "ENOENT" ? "missing" : "unreadable";
     }
   };
 
-  if (!(await hasProfile())) {
+  const unreadableMessage =
+    `Seatbelt profile "${profile}" exists but is not readable at ${profilePath}. ` +
+    "Check file ownership and permissions.";
+
+  const initialState = await getProfileState();
+  if (initialState !== "ok") {
+    if (initialState === "unreadable") {
+      throw new Error(unreadableMessage);
+    }
+
     const isDemoProfile = SEATBELT_DEMO_PROFILE_NAMES.includes(
       profile as (typeof SEATBELT_DEMO_PROFILE_NAMES)[number],
     );
@@ -155,12 +166,23 @@ async function resolveSeatbeltContextConfig(params: {
       }
     }
 
-    if (!(await hasProfile())) {
+    const finalState = await getProfileState();
+    if (finalState !== "ok") {
+      if (finalState === "unreadable") {
+        throw new Error(unreadableMessage);
+      }
+
       const help =
         `Seatbelt profile "${profile}" not found at ${profilePath}. ` +
         "Set sandbox.seatbelt.profile/profileDir to an existing profile, or run `openclaw doctor`.";
       if (ensureError) {
-        throw new Error(help + ` Auto-install attempt failed: ${String(ensureError)}.`);
+        const message = ensureError instanceof Error ? ensureError.message : String(ensureError);
+        const wrapped = new Error(help + ` Auto-install attempt failed: ${message}.`);
+        (wrapped as Error & { cause?: unknown }).cause = ensureError;
+        throw wrapped;
+      }
+      if (isDemoProfile) {
+        throw new Error(help + " Demo profile auto-install was attempted but profile is still missing.");
       }
       throw new Error(help);
     }

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -128,10 +128,37 @@ async function resolveSeatbeltContextConfig(params: {
   }
   const profile = rawProfile.endsWith(".sb") ? rawProfile.slice(0, -3) : rawProfile;
   const profileFile = `${profile}.sb`;
+  const profilePath = path.join(params.cfg.seatbelt.profileDir, profileFile);
 
-  await ensureSeatbeltDemoProfiles({
-    profileDir: params.cfg.seatbelt.profileDir,
-  });
+  const hasProfile = async () => {
+    try {
+      await fs.access(profilePath);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (!(await hasProfile())) {
+    let ensureError: unknown;
+    try {
+      await ensureSeatbeltDemoProfiles({
+        profileDir: params.cfg.seatbelt.profileDir,
+      });
+    } catch (error) {
+      ensureError = error;
+    }
+
+    if (!(await hasProfile())) {
+      const help =
+        `Seatbelt profile "${profile}" not found at ${profilePath}. ` +
+        "Set sandbox.seatbelt.profile/profileDir to an existing profile, or run `openclaw doctor`.";
+      if (ensureError) {
+        throw new Error(help + ` Auto-install attempt failed: ${String(ensureError)}.`);
+      }
+      throw new Error(help);
+    }
+  }
 
   const defaults = {
     PROJECT_DIR: params.workspaceDir,
@@ -146,7 +173,7 @@ async function resolveSeatbeltContextConfig(params: {
   return {
     profileDir: params.cfg.seatbelt.profileDir,
     profile,
-    profilePath: path.join(params.cfg.seatbelt.profileDir, profileFile),
+    profilePath,
     params: {
       ...defaults,
       ...(params.cfg.seatbelt.params ?? {}),

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -14,6 +14,7 @@ import { ensureSandboxContainer } from "./docker.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
+import { createSeatbeltFsBridge } from "./seatbelt-fs-bridge.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
 import type {
   SandboxContext,
@@ -178,7 +179,7 @@ export async function resolveSandboxContext(params: {
   });
 
   if (cfg.backend === "seatbelt") {
-    return {
+    const sandboxContext: SandboxContext = {
       enabled: true,
       backend: "seatbelt",
       sessionKey: rawSessionKey,
@@ -192,6 +193,10 @@ export async function resolveSandboxContext(params: {
       tools: cfg.tools,
       browserAllowHostControl: cfg.browser.allowHostControl,
     };
+
+    sandboxContext.fsBridge = createSeatbeltFsBridge({ sandbox: sandboxContext });
+
+    return sandboxContext;
   }
 
   const docker = await resolveSandboxDockerUser({

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -15,7 +15,7 @@ import { createSandboxFsBridge } from "./fs-bridge.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { createSeatbeltFsBridge } from "./seatbelt-fs-bridge.js";
-import { ensureSeatbeltDemoProfiles } from "./seatbelt-profiles.js";
+import { ensureSeatbeltDemoProfiles, SEATBELT_DEMO_PROFILE_NAMES } from "./seatbelt-profiles.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
 import type {
   SandboxContext,
@@ -140,13 +140,19 @@ async function resolveSeatbeltContextConfig(params: {
   };
 
   if (!(await hasProfile())) {
+    const isDemoProfile = SEATBELT_DEMO_PROFILE_NAMES.includes(
+      profile as (typeof SEATBELT_DEMO_PROFILE_NAMES)[number],
+    );
     let ensureError: unknown;
-    try {
-      await ensureSeatbeltDemoProfiles({
-        profileDir: params.cfg.seatbelt.profileDir,
-      });
-    } catch (error) {
-      ensureError = error;
+
+    if (isDemoProfile) {
+      try {
+        await ensureSeatbeltDemoProfiles({
+          profileDir: params.cfg.seatbelt.profileDir,
+        });
+      } catch (error) {
+        ensureError = error;
+      }
     }
 
     if (!(await hasProfile())) {

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -26,6 +26,18 @@ import type {
 } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
+const SEATBELT_PROFILE_NAME_PATTERN = /^[a-zA-Z0-9_-]+(?:\.sb)?$/;
+
+const RESERVED_SEATBELT_PARAM_KEYS = new Set([
+  "PROJECT_DIR",
+  "WORKSPACE_DIR",
+  "STATE_DIR",
+  "AGENT_ID",
+  "SEATBELT_PROFILE_DIR",
+  "WORKSPACE_ACCESS",
+  "TMPDIR",
+]);
+
 async function ensureSandboxWorkspaceLayout(params: {
   cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
   rawSessionKey: string;
@@ -127,6 +139,16 @@ async function resolveSeatbeltContextConfig(params: {
   if (!rawProfile) {
     return undefined;
   }
+  if (
+    rawProfile.includes("/") ||
+    rawProfile.includes("\\") ||
+    rawProfile.includes("..") ||
+    !SEATBELT_PROFILE_NAME_PATTERN.test(rawProfile)
+  ) {
+    throw new Error(
+      `Invalid seatbelt profile "${rawProfile}". Profile names must not contain path separators or ".." segments.`,
+    );
+  }
   const profile = rawProfile.endsWith(".sb") ? rawProfile.slice(0, -3) : rawProfile;
   const profileFile = `${profile}.sb`;
   const profilePath = path.join(params.cfg.seatbelt.profileDir, profileFile);
@@ -198,13 +220,19 @@ async function resolveSeatbeltContextConfig(params: {
     TMPDIR: "/tmp",
   };
 
+  const userParams = Object.fromEntries(
+    Object.entries(params.cfg.seatbelt.params ?? {}).filter(
+      ([key]) => !RESERVED_SEATBELT_PARAM_KEYS.has(key),
+    ),
+  );
+
   return {
     profileDir: params.cfg.seatbelt.profileDir,
     profile,
     profilePath,
     params: {
+      ...userParams,
       ...defaults,
-      ...(params.cfg.seatbelt.params ?? {}),
     },
   };
 }

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -15,6 +15,7 @@ import { createSandboxFsBridge } from "./fs-bridge.js";
 import { maybePruneSandboxes } from "./prune.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { createSeatbeltFsBridge } from "./seatbelt-fs-bridge.js";
+import { ensureSeatbeltDemoProfiles } from "./seatbelt-profiles.js";
 import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
 import type {
   SandboxContext,
@@ -112,12 +113,12 @@ function resolveSandboxSession(params: { config?: OpenClawConfig; sessionKey?: s
   return { rawSessionKey, runtime, cfg };
 }
 
-function resolveSeatbeltContextConfig(params: {
+async function resolveSeatbeltContextConfig(params: {
   cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
   workspaceDir: string;
   agentWorkspaceDir: string;
   agentId: string;
-}): SandboxSeatbeltContext | undefined {
+}): Promise<SandboxSeatbeltContext | undefined> {
   if (params.cfg.backend !== "seatbelt") {
     return undefined;
   }
@@ -127,6 +128,10 @@ function resolveSeatbeltContextConfig(params: {
   }
   const profile = rawProfile.endsWith(".sb") ? rawProfile.slice(0, -3) : rawProfile;
   const profileFile = `${profile}.sb`;
+
+  await ensureSeatbeltDemoProfiles({
+    profileDir: params.cfg.seatbelt.profileDir,
+  });
 
   const defaults = {
     PROJECT_DIR: params.workspaceDir,
@@ -171,7 +176,7 @@ export async function resolveSandboxContext(params: {
     workspaceDir: params.workspaceDir,
   });
 
-  const seatbelt = resolveSeatbeltContextConfig({
+  const seatbelt = await resolveSeatbeltContextConfig({
     cfg,
     workspaceDir,
     agentWorkspaceDir,

--- a/src/agents/sandbox/seatbelt-fs-bridge.test.ts
+++ b/src/agents/sandbox/seatbelt-fs-bridge.test.ts
@@ -10,6 +10,7 @@ function createSeatbeltSandbox(params: {
   workspaceDir: string;
   agentWorkspaceDir?: string;
   workspaceAccess?: SandboxContext["workspaceAccess"];
+  dockerBinds?: string[];
 }): SandboxContext {
   const profileDir = path.join(params.workspaceDir, "profiles");
   return createSandboxTestContext({
@@ -20,6 +21,9 @@ function createSeatbeltSandbox(params: {
       workspaceAccess: params.workspaceAccess ?? "rw",
       containerName: "",
       containerWorkdir: params.workspaceDir,
+      docker: {
+        binds: params.dockerBinds,
+      },
       seatbelt: {
         profileDir,
         profile: "demo-open",
@@ -56,6 +60,31 @@ describe("seatbelt fs bridge", () => {
 
       await bridge.remove({ filePath: "notes/todo.txt" });
       expect(await bridge.stat({ filePath: "notes/todo.txt" })).toBeNull();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores docker.binds mounts when resolving seatbelt fs paths", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-fs-binds-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    const externalDir = path.join(stateDir, "external");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(externalDir, { recursive: true });
+    await fs.writeFile(path.join(externalDir, "secret.txt"), "top-secret", "utf8");
+
+    try {
+      const bridge = createSeatbeltFsBridge({
+        sandbox: createSeatbeltSandbox({
+          workspaceDir,
+          workspaceAccess: "rw",
+          dockerBinds: [externalDir + ":/external:rw"],
+        }),
+      });
+
+      await expect(bridge.readFile({ filePath: "/external/secret.txt" })).rejects.toThrow(
+        /escapes allowed mounts|escapes sandbox root/,
+      );
     } finally {
       await fs.rm(stateDir, { recursive: true, force: true });
     }

--- a/src/agents/sandbox/seatbelt-fs-bridge.test.ts
+++ b/src/agents/sandbox/seatbelt-fs-bridge.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createSeatbeltFsBridge } from "./seatbelt-fs-bridge.js";
+import { createSandboxTestContext } from "./test-fixtures.js";
+import type { SandboxContext } from "./types.js";
+
+function createSeatbeltSandbox(params: {
+  workspaceDir: string;
+  agentWorkspaceDir?: string;
+  workspaceAccess?: SandboxContext["workspaceAccess"];
+}): SandboxContext {
+  const profileDir = path.join(params.workspaceDir, "profiles");
+  return createSandboxTestContext({
+    overrides: {
+      backend: "seatbelt",
+      workspaceDir: params.workspaceDir,
+      agentWorkspaceDir: params.agentWorkspaceDir ?? params.workspaceDir,
+      workspaceAccess: params.workspaceAccess ?? "rw",
+      containerName: "",
+      containerWorkdir: params.workspaceDir,
+      seatbelt: {
+        profileDir,
+        profile: "demo-open",
+        profilePath: path.join(profileDir, "demo-open.sb"),
+        params: {},
+      },
+    },
+  });
+}
+
+describe("seatbelt fs bridge", () => {
+  it("reads and writes files via native fs operations", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-fs-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    try {
+      const bridge = createSeatbeltFsBridge({
+        sandbox: createSeatbeltSandbox({ workspaceDir, workspaceAccess: "rw" }),
+      });
+
+      await bridge.writeFile({ filePath: "notes/todo.txt", data: "ship it" });
+
+      const resolved = bridge.resolvePath({ filePath: "notes/todo.txt" });
+      expect(resolved.hostPath).toBe(path.join(workspaceDir, "notes", "todo.txt"));
+      expect(await fs.readFile(resolved.hostPath, "utf8")).toBe("ship it");
+
+      const content = await bridge.readFile({ filePath: "notes/todo.txt" });
+      expect(content.toString("utf8")).toBe("ship it");
+
+      const stat = await bridge.stat({ filePath: "notes/todo.txt" });
+      expect(stat?.type).toBe("file");
+      expect(stat?.size).toBe("ship it".length);
+
+      await bridge.remove({ filePath: "notes/todo.txt" });
+      expect(await bridge.stat({ filePath: "notes/todo.txt" })).toBeNull();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("enforces read-only workspace access at the tool layer", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-fs-ro-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "README.md"), "hello");
+
+    try {
+      const bridge = createSeatbeltFsBridge({
+        sandbox: createSeatbeltSandbox({ workspaceDir, workspaceAccess: "ro" }),
+      });
+
+      const content = await bridge.readFile({ filePath: "README.md" });
+      expect(content.toString("utf8")).toBe("hello");
+
+      await expect(bridge.writeFile({ filePath: "new.txt", data: "denied" })).rejects.toThrow(
+        /read-only/,
+      );
+      await expect(bridge.mkdirp({ filePath: "nested" })).rejects.toThrow(/read-only/);
+      await expect(bridge.remove({ filePath: "README.md" })).rejects.toThrow(/read-only/);
+      await expect(bridge.rename({ from: "README.md", to: "README2.md" })).rejects.toThrow(
+        /read-only/,
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/sandbox/seatbelt-fs-bridge.ts
+++ b/src/agents/sandbox/seatbelt-fs-bridge.ts
@@ -32,7 +32,9 @@ class SeatbeltFsBridgeImpl implements SandboxFsBridge {
 
   constructor(sandbox: SandboxContext) {
     this.sandbox = sandbox;
-    this.mounts = buildSandboxFsMounts(sandbox);
+    // Seatbelt backend must not trust docker.binds here because bind specs are
+    // only validated for docker execution paths.
+    this.mounts = buildSandboxFsMounts(sandbox).filter((mount) => mount.source !== "bind");
     this.mountsByContainer = [...this.mounts].toSorted(
       (a, b) => b.containerRoot.length - a.containerRoot.length,
     );

--- a/src/agents/sandbox/seatbelt-fs-bridge.ts
+++ b/src/agents/sandbox/seatbelt-fs-bridge.ts
@@ -1,0 +1,216 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  PATH_ALIAS_POLICIES,
+  assertNoPathAliasEscape,
+  type PathAliasPolicy,
+} from "../../infra/path-alias-guards.js";
+import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.js";
+import {
+  buildSandboxFsMounts,
+  resolveSandboxFsPathWithMounts,
+  type SandboxFsMount,
+  type SandboxResolvedFsPath,
+} from "./fs-paths.js";
+import { isPathInsideContainerRoot, normalizeContainerPath } from "./path-utils.js";
+import type { SandboxContext, SandboxWorkspaceAccess } from "./types.js";
+
+type PathSafetyOptions = {
+  action: string;
+  aliasPolicy?: PathAliasPolicy;
+  requireWritable?: boolean;
+};
+
+export function createSeatbeltFsBridge(params: { sandbox: SandboxContext }): SandboxFsBridge {
+  return new SeatbeltFsBridgeImpl(params.sandbox);
+}
+
+class SeatbeltFsBridgeImpl implements SandboxFsBridge {
+  private readonly sandbox: SandboxContext;
+  private readonly mounts: ReturnType<typeof buildSandboxFsMounts>;
+  private readonly mountsByContainer: ReturnType<typeof buildSandboxFsMounts>;
+
+  constructor(sandbox: SandboxContext) {
+    this.sandbox = sandbox;
+    this.mounts = buildSandboxFsMounts(sandbox);
+    this.mountsByContainer = [...this.mounts].toSorted(
+      (a, b) => b.containerRoot.length - a.containerRoot.length,
+    );
+  }
+
+  resolvePath(params: { filePath: string; cwd?: string }): SandboxResolvedPath {
+    const target = this.resolveResolvedPath(params);
+    return {
+      hostPath: target.hostPath,
+      relativePath: target.relativePath,
+      containerPath: target.containerPath,
+    };
+  }
+
+  async readFile(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<Buffer> {
+    const target = this.resolveResolvedPath(params);
+    await this.assertPathSafety(target, { action: "read files" });
+    return fs.readFile(target.hostPath);
+  }
+
+  async writeFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "write files");
+    await this.assertPathSafety(target, { action: "write files", requireWritable: true });
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    if (params.mkdir !== false) {
+      await fs.mkdir(path.dirname(target.hostPath), { recursive: true });
+    }
+    await fs.writeFile(target.hostPath, buffer);
+  }
+
+  async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "create directories");
+    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await fs.mkdir(target.hostPath, { recursive: true });
+  }
+
+  async remove(params: {
+    filePath: string;
+    cwd?: string;
+    recursive?: boolean;
+    force?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "remove files");
+    await this.assertPathSafety(target, {
+      action: "remove files",
+      requireWritable: true,
+      aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
+    });
+    await fs.rm(target.hostPath, {
+      recursive: params.recursive ?? false,
+      force: params.force ?? false,
+    });
+  }
+
+  async rename(params: {
+    from: string;
+    to: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const from = this.resolveResolvedPath({ filePath: params.from, cwd: params.cwd });
+    const to = this.resolveResolvedPath({ filePath: params.to, cwd: params.cwd });
+    this.ensureWriteAccess(from, "rename files");
+    this.ensureWriteAccess(to, "rename files");
+    await this.assertPathSafety(from, {
+      action: "rename files",
+      requireWritable: true,
+      aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
+    });
+    await this.assertPathSafety(to, {
+      action: "rename files",
+      requireWritable: true,
+    });
+    await fs.mkdir(path.dirname(to.hostPath), { recursive: true });
+    await fs.rename(from.hostPath, to.hostPath);
+  }
+
+  async stat(params: {
+    filePath: string;
+    cwd?: string;
+    signal?: AbortSignal;
+  }): Promise<SandboxFsStat | null> {
+    const target = this.resolveResolvedPath(params);
+    await this.assertPathSafety(target, { action: "stat files" });
+    try {
+      const stats = await fs.stat(target.hostPath);
+      return {
+        type: coerceStatType(stats),
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ENOTDIR") {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async assertPathSafety(target: SandboxResolvedFsPath, options: PathSafetyOptions) {
+    const lexicalMount = this.resolveMountByContainerPath(target.containerPath);
+    if (!lexicalMount) {
+      throw new Error(
+        `Sandbox path escapes allowed mounts; cannot ${options.action}: ${target.containerPath}`,
+      );
+    }
+
+    await assertNoPathAliasEscape({
+      absolutePath: target.hostPath,
+      rootPath: lexicalMount.hostRoot,
+      boundaryLabel: "sandbox mount root",
+      policy: options.aliasPolicy,
+    });
+
+    if (options.requireWritable && !lexicalMount.writable) {
+      throw new Error(
+        `Sandbox path is read-only; cannot ${options.action}: ${target.containerPath}`,
+      );
+    }
+  }
+
+  private resolveMountByContainerPath(containerPath: string): SandboxFsMount | null {
+    const normalized = normalizeContainerPath(containerPath);
+    for (const mount of this.mountsByContainer) {
+      if (isPathInsideContainerRoot(normalizeContainerPath(mount.containerRoot), normalized)) {
+        return mount;
+      }
+    }
+    return null;
+  }
+
+  private ensureWriteAccess(target: SandboxResolvedFsPath, action: string) {
+    if (!allowsWrites(this.sandbox.workspaceAccess) || !target.writable) {
+      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+    }
+  }
+
+  private resolveResolvedPath(params: { filePath: string; cwd?: string }): SandboxResolvedFsPath {
+    return resolveSandboxFsPathWithMounts({
+      filePath: params.filePath,
+      cwd: params.cwd ?? this.sandbox.workspaceDir,
+      defaultWorkspaceRoot: this.sandbox.workspaceDir,
+      defaultContainerRoot: this.sandbox.containerWorkdir,
+      mounts: this.mounts,
+    });
+  }
+}
+
+function allowsWrites(access: SandboxWorkspaceAccess): boolean {
+  return access === "rw";
+}
+
+function coerceStatType(
+  stats: Awaited<ReturnType<typeof fs.stat>>,
+): "file" | "directory" | "other" {
+  if (stats.isDirectory()) {
+    return "directory";
+  }
+  if (stats.isFile()) {
+    return "file";
+  }
+  return "other";
+}

--- a/src/agents/sandbox/seatbelt-profiles.test.ts
+++ b/src/agents/sandbox/seatbelt-profiles.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import {
   ensureConfiguredSeatbeltDemoProfiles,
   ensureSeatbeltDemoProfiles,
+  resolveBundledSeatbeltProfilesDir,
   SEATBELT_DEMO_PROFILE_NAMES,
 } from "./seatbelt-profiles.js";
 
@@ -48,6 +49,27 @@ describe("seatbelt demo profile installer", () => {
 
     const persisted = await fs.readFile(markerPath, "utf8");
     expect(persisted).toBe(markerContents);
+  });
+
+  it("demo-open profile gates writes by WORKSPACE_ACCESS while keeping reads", async () => {
+    const bundledDir = resolveBundledSeatbeltProfilesDir();
+    expect(bundledDir).not.toBeNull();
+
+    const profile = await fs.readFile(path.join(bundledDir!, "demo-open.sb"), "utf8");
+    expect(profile).toContain('(allow file-read* (subpath (param "PROJECT_DIR")))');
+    expect(profile).toContain('(allow file-read* (subpath (param "WORKSPACE_DIR")))');
+    expect(profile).toContain(
+      '(if (string=? (param "WORKSPACE_ACCESS") "rw")\n  (allow file-write* (subpath (param "PROJECT_DIR")))',
+    );
+    expect(profile).toContain(
+      '(if (string=? (param "WORKSPACE_ACCESS") "rw")\n  (allow file-write* (subpath (param "WORKSPACE_DIR")))',
+    );
+    expect(profile).not.toContain(
+      '(allow file-read* file-write* (subpath (param "PROJECT_DIR")))',
+    );
+    expect(profile).not.toContain(
+      '(allow file-read* file-write* (subpath (param "WORKSPACE_DIR")))',
+    );
   });
 
   it("installs profiles for each configured seatbelt profileDir", async () => {

--- a/src/agents/sandbox/seatbelt-profiles.test.ts
+++ b/src/agents/sandbox/seatbelt-profiles.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  ensureConfiguredSeatbeltDemoProfiles,
+  ensureSeatbeltDemoProfiles,
+  SEATBELT_DEMO_PROFILE_NAMES,
+} from "./seatbelt-profiles.js";
+
+const PROFILE_FILES = SEATBELT_DEMO_PROFILE_NAMES.map((name) => `${name}.sb`);
+
+async function createDemoSourceDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-src-"));
+  for (const fileName of PROFILE_FILES) {
+    await fs.writeFile(path.join(dir, fileName), `; ${fileName}\n(version 1)\n`, "utf8");
+  }
+  return dir;
+}
+
+describe("seatbelt demo profile installer", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanupPaths.splice(0).map((target) => fs.rm(target, { recursive: true, force: true })),
+    );
+  });
+
+  it("copies bundled demo profiles when missing and does not overwrite existing files", async () => {
+    const sourceDir = await createDemoSourceDir();
+    const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-dest-"));
+    cleanupPaths.push(sourceDir, profileDir);
+
+    const first = await ensureSeatbeltDemoProfiles({ profileDir, sourceDir });
+    expect(first.copied.toSorted()).toEqual(PROFILE_FILES.toSorted());
+    expect(first.existing).toEqual([]);
+    expect(first.missingSource).toEqual([]);
+
+    const markerPath = path.join(profileDir, "demo-open.sb");
+    const markerContents = "; keep me\n(version 1)\n";
+    await fs.writeFile(markerPath, markerContents, "utf8");
+
+    const second = await ensureSeatbeltDemoProfiles({ profileDir, sourceDir });
+    expect(second.copied).toEqual([]);
+    expect(second.existing.toSorted()).toEqual(PROFILE_FILES.toSorted());
+
+    const persisted = await fs.readFile(markerPath, "utf8");
+    expect(persisted).toBe(markerContents);
+  });
+
+  it("installs profiles for each configured seatbelt profileDir", async () => {
+    const sourceDir = await createDemoSourceDir();
+    const defaultProfileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-main-"));
+    const workerProfileDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-seatbelt-worker-"));
+    cleanupPaths.push(sourceDir, defaultProfileDir, workerProfileDir);
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+              profileDir: defaultProfileDir,
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            sandbox: {
+              backend: "seatbelt",
+              seatbelt: {
+                profile: "demo-restricted",
+                profileDir: workerProfileDir,
+              },
+            },
+          },
+          {
+            id: "docker-only",
+            sandbox: {
+              backend: "docker",
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const summary = await ensureConfiguredSeatbeltDemoProfiles({
+      cfg,
+      sourceDir,
+      onWarn: vi.fn(),
+    });
+
+    expect(summary.profileDirs.toSorted()).toEqual(
+      [defaultProfileDir, workerProfileDir].toSorted(),
+    );
+    expect(summary.totalCopied).toBe(PROFILE_FILES.length * 2);
+
+    const mainFiles = await fs.readdir(defaultProfileDir);
+    const workerFiles = await fs.readdir(workerProfileDir);
+    expect(mainFiles.sort()).toEqual(PROFILE_FILES.toSorted());
+    expect(workerFiles.sort()).toEqual(PROFILE_FILES.toSorted());
+  });
+});

--- a/src/agents/sandbox/seatbelt-profiles.ts
+++ b/src/agents/sandbox/seatbelt-profiles.ts
@@ -1,0 +1,147 @@
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
+import { resolveSandboxConfigForAgent } from "./config.js";
+
+export const SEATBELT_DEMO_PROFILE_NAMES = [
+  "demo-open",
+  "demo-websearch",
+  "demo-restricted",
+] as const;
+
+export type SeatbeltDemoProfileName = (typeof SEATBELT_DEMO_PROFILE_NAMES)[number];
+
+export type EnsureSeatbeltDemoProfilesResult = {
+  profileDir: string;
+  sourceDir: string | null;
+  copied: string[];
+  existing: string[];
+  missingSource: string[];
+};
+
+export function resolveBundledSeatbeltProfilesDir(): string | null {
+  const packageRoot = resolveOpenClawPackageRootSync({
+    moduleUrl: import.meta.url,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+  });
+  if (!packageRoot) {
+    return null;
+  }
+  return path.join(packageRoot, "assets", "seatbelt-profiles");
+}
+
+export async function ensureSeatbeltDemoProfiles(params: {
+  profileDir: string;
+  sourceDir?: string;
+  onWarn?: (message: string) => void;
+}): Promise<EnsureSeatbeltDemoProfilesResult> {
+  const sourceDir = params.sourceDir ?? resolveBundledSeatbeltProfilesDir();
+  const copied: string[] = [];
+  const existing: string[] = [];
+  const missingSource: string[] = [];
+
+  await fs.mkdir(params.profileDir, { recursive: true });
+
+  if (!sourceDir) {
+    for (const profile of SEATBELT_DEMO_PROFILE_NAMES) {
+      missingSource.push(`${profile}.sb`);
+    }
+    params.onWarn?.(
+      `seatbelt: bundled demo profile source directory was not found; skipping demo profile install into ${params.profileDir}`,
+    );
+    return {
+      profileDir: params.profileDir,
+      sourceDir: null,
+      copied,
+      existing,
+      missingSource,
+    };
+  }
+
+  for (const profile of SEATBELT_DEMO_PROFILE_NAMES) {
+    const fileName = `${profile}.sb`;
+    const sourcePath = path.join(sourceDir, fileName);
+    const targetPath = path.join(params.profileDir, fileName);
+
+    try {
+      await fs.access(sourcePath);
+    } catch {
+      missingSource.push(fileName);
+      params.onWarn?.(`seatbelt: bundled demo profile missing at ${sourcePath}`);
+      continue;
+    }
+
+    try {
+      await fs.copyFile(sourcePath, targetPath, fsConstants.COPYFILE_EXCL);
+      copied.push(fileName);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") {
+        existing.push(fileName);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return {
+    profileDir: params.profileDir,
+    sourceDir,
+    copied,
+    existing,
+    missingSource,
+  };
+}
+
+export async function ensureConfiguredSeatbeltDemoProfiles(params: {
+  cfg: OpenClawConfig;
+  sourceDir?: string;
+  onWarn?: (message: string) => void;
+}): Promise<{
+  profileDirs: string[];
+  totalCopied: number;
+  results: EnsureSeatbeltDemoProfilesResult[];
+}> {
+  const profileDirs = collectConfiguredSeatbeltProfileDirs(params.cfg);
+  const results: EnsureSeatbeltDemoProfilesResult[] = [];
+  let totalCopied = 0;
+
+  for (const profileDir of profileDirs) {
+    const result = await ensureSeatbeltDemoProfiles({
+      profileDir,
+      sourceDir: params.sourceDir,
+      onWarn: params.onWarn,
+    });
+    totalCopied += result.copied.length;
+    results.push(result);
+  }
+
+  return {
+    profileDirs,
+    totalCopied,
+    results,
+  };
+}
+
+function collectConfiguredSeatbeltProfileDirs(cfg: OpenClawConfig): string[] {
+  const agentIds = new Set<string>(["main"]);
+  for (const entry of cfg.agents?.list ?? []) {
+    const id = entry.id?.trim();
+    if (id) {
+      agentIds.add(id);
+    }
+  }
+
+  const profileDirs = new Set<string>();
+  for (const agentId of agentIds) {
+    const sandbox = resolveSandboxConfigForAgent(cfg, agentId);
+    if (sandbox.backend === "seatbelt") {
+      profileDirs.add(sandbox.seatbelt.profileDir);
+    }
+  }
+
+  return Array.from(profileDirs).toSorted();
+}

--- a/src/agents/sandbox/test-fixtures.ts
+++ b/src/agents/sandbox/test-fixtures.ts
@@ -28,6 +28,7 @@ export function createSandboxTestContext(params?: {
 
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: "sandbox:test",
     workspaceDir: "/tmp/workspace",
     agentWorkspaceDir: "/tmp/workspace",

--- a/src/agents/sandbox/types.seatbelt.ts
+++ b/src/agents/sandbox/types.seatbelt.ts
@@ -1,0 +1,13 @@
+import type { SandboxSeatbeltSettings } from "../../config/types.sandbox.js";
+
+type RequiredSeatbeltConfigKeys = "profileDir";
+
+export type SandboxSeatbeltConfig = Omit<SandboxSeatbeltSettings, RequiredSeatbeltConfigKeys> &
+  Required<Pick<SandboxSeatbeltSettings, RequiredSeatbeltConfigKeys>>;
+
+export type SandboxSeatbeltContext = {
+  profileDir: string;
+  profile: string;
+  profilePath: string;
+  params: Record<string, string>;
+};

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -1,7 +1,10 @@
+import type { SandboxBackend } from "../../config/types.sandbox.js";
 import type { SandboxFsBridge } from "./fs-bridge.js";
 import type { SandboxDockerConfig } from "./types.docker.js";
+import type { SandboxSeatbeltConfig, SandboxSeatbeltContext } from "./types.seatbelt.js";
 
 export type { SandboxDockerConfig } from "./types.docker.js";
+export type { SandboxSeatbeltConfig, SandboxSeatbeltContext } from "./types.seatbelt.js";
 
 export type SandboxToolPolicy = {
   allow?: string[];
@@ -54,9 +57,11 @@ export type SandboxScope = "session" | "agent" | "shared";
 
 export type SandboxConfig = {
   mode: "off" | "non-main" | "all";
+  backend: SandboxBackend;
   scope: SandboxScope;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceRoot: string;
+  seatbelt: SandboxSeatbeltConfig;
   docker: SandboxDockerConfig;
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
@@ -71,6 +76,7 @@ export type SandboxBrowserContext = {
 
 export type SandboxContext = {
   enabled: boolean;
+  backend: SandboxBackend;
   sessionKey: string;
   workspaceDir: string;
   agentWorkspaceDir: string;
@@ -78,6 +84,7 @@ export type SandboxContext = {
   containerName: string;
   containerWorkdir: string;
   docker: SandboxDockerConfig;
+  seatbelt?: SandboxSeatbeltContext;
   tools: SandboxToolPolicy;
   browserAllowHostControl: boolean;
   browser?: SandboxBrowserContext;
@@ -85,6 +92,7 @@ export type SandboxContext = {
 };
 
 export type SandboxWorkspaceInfo = {
+  backend: SandboxBackend;
   workspaceDir: string;
   containerWorkdir: string;
 };

--- a/src/agents/test-helpers/pi-tools-sandbox-context.ts
+++ b/src/agents/test-helpers/pi-tools-sandbox-context.ts
@@ -18,6 +18,7 @@ export function createPiToolsSandboxContext(params: PiToolsSandboxContextParams)
   const workspaceDir = params.workspaceDir;
   return {
     enabled: true,
+    backend: "docker",
     sessionKey: params.sessionKey ?? "sandbox:test",
     workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir ?? workspaceDir,

--- a/src/config/config.sandbox-seatbelt.test.ts
+++ b/src/config/config.sandbox-seatbelt.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  try {
+    return fn();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(process, "platform", descriptor);
+    }
+  }
+}
+
+describe("sandbox seatbelt config", () => {
+  it("accepts seatbelt backend with a profile", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.backend).toBe("seatbelt");
+      expect(res.config.agents?.defaults?.sandbox?.seatbelt?.profile).toBe("demo-open");
+    }
+  });
+
+  it("requires seatbelt.profile when backend=seatbelt", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "seatbelt",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path.includes("seatbelt.profile") || issue.message.includes("seatbelt.profile"),
+        ),
+      ).toBe(true);
+      expect(res.issues.some((issue) => issue.message.includes("openclaw doctor"))).toBe(true);
+    }
+  });
+
+  it("rejects seatbelt backend on non-darwin platforms", () => {
+    const res = withPlatform("linux", () =>
+      validateConfigObject({
+        agents: {
+          defaults: {
+            sandbox: {
+              backend: "seatbelt",
+              seatbelt: {
+                profile: "demo-open",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.message.toLowerCase().includes("darwin"))).toBe(true);
+      expect(res.issues.some((issue) => issue.message.includes("openclaw doctor"))).toBe(true);
+    }
+  });
+});

--- a/src/config/config.sandbox-seatbelt.test.ts
+++ b/src/config/config.sandbox-seatbelt.test.ts
@@ -38,7 +38,7 @@ describe("sandbox seatbelt config", () => {
     }
   });
 
-  it("requires seatbelt.profile when backend=seatbelt", () => {
+  it("allows seatbelt backend without profile at parse time", () => {
     const res = validateConfigObject({
       agents: {
         defaults: {
@@ -49,16 +49,32 @@ describe("sandbox seatbelt config", () => {
       },
     });
 
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(
-        res.issues.some(
-          (issue) =>
-            issue.path.includes("seatbelt.profile") || issue.message.includes("seatbelt.profile"),
-        ),
-      ).toBe(true);
-      expect(res.issues.some((issue) => issue.message.includes("openclaw doctor"))).toBe(true);
-    }
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows agent seatbelt backend to inherit profile from defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "demo-open",
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            sandbox: {
+              backend: "seatbelt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
   });
 
   it("rejects seatbelt backend on non-darwin platforms", () => {

--- a/src/config/config.sandbox-seatbelt.test.ts
+++ b/src/config/config.sandbox-seatbelt.test.ts
@@ -38,7 +38,7 @@ describe("sandbox seatbelt config", () => {
     }
   });
 
-  it("allows seatbelt backend without profile at parse time", () => {
+  it("rejects defaults seatbelt backend without a resolved profile", () => {
     const res = validateConfigObject({
       agents: {
         defaults: {
@@ -49,7 +49,16 @@ describe("sandbox seatbelt config", () => {
       },
     });
 
-    expect(res.ok).toBe(true);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path.includes("agents.defaults.sandbox.seatbelt.profile") ||
+            issue.message.includes("sandbox.seatbelt.profile"),
+        ),
+      ).toBe(true);
+    }
   });
 
   it("allows agent seatbelt backend to inherit profile from defaults", () => {
@@ -75,6 +84,37 @@ describe("sandbox seatbelt config", () => {
     });
 
     expect(res.ok).toBe(true);
+  });
+
+  it("rejects agent seatbelt backend when profile is missing from agent and defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "docker",
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            sandbox: {
+              backend: "seatbelt",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path.includes("agents.list[0].sandbox.seatbelt.profile") ||
+            issue.message.includes("resolved profile"),
+        ),
+      ).toBe(true);
+    }
   });
 
   it("rejects traversal-like seatbelt profile names", () => {

--- a/src/config/config.sandbox-seatbelt.test.ts
+++ b/src/config/config.sandbox-seatbelt.test.ts
@@ -77,6 +77,32 @@ describe("sandbox seatbelt config", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("rejects traversal-like seatbelt profile names", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            backend: "seatbelt",
+            seatbelt: {
+              profile: "../../etc/evil",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path.includes("seatbelt.profile") ||
+            issue.message.toLowerCase().includes("profile name must use only"),
+        ),
+      ).toBe(true);
+    }
+  });
+
   it("rejects seatbelt backend on non-darwin platforms", () => {
     const res = withPlatform("linux", () =>
       validateConfigObject({

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -1,7 +1,9 @@
 import type {
+  SandboxBackend,
   SandboxBrowserSettings,
   SandboxDockerSettings,
   SandboxPruneSettings,
+  SandboxSeatbeltSettings,
 } from "./types.sandbox.js";
 
 export type AgentModelConfig =
@@ -28,6 +30,10 @@ export type AgentSandboxConfig = {
   /** Legacy alias for scope ("session" when true, "shared" when false). */
   perSession?: boolean;
   workspaceRoot?: string;
+  /** Sandbox runtime backend (default: docker). */
+  backend?: SandboxBackend;
+  /** Seatbelt-specific sandbox settings. */
+  seatbelt?: SandboxSeatbeltSettings;
   /** Docker-specific sandbox settings. */
   docker?: SandboxDockerSettings;
   /** Optional sandboxed browser settings. */

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -1,3 +1,5 @@
+export type SandboxBackend = "docker" | "seatbelt";
+
 export type SandboxDockerSettings = {
   /** Docker image to use for sandbox containers. */
   image?: string;
@@ -57,6 +59,15 @@ export type SandboxDockerSettings = {
    * Default behavior blocks container namespace joins to preserve sandbox isolation.
    */
   dangerouslyAllowContainerNamespaceJoin?: boolean;
+};
+
+export type SandboxSeatbeltSettings = {
+  /** Directory containing seatbelt profiles. */
+  profileDir?: string;
+  /** Logical profile name ("<name>.sb" resolved automatically). */
+  profile?: string;
+  /** Extra sandbox-exec -D params. */
+  params?: Record<string, string>;
 };
 
 export type SandboxBrowserSettings = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -494,17 +494,9 @@ export const AgentSandboxSchema = z
   .superRefine((data, ctx) => {
     const backend = data.backend ?? "docker";
     if (backend === "seatbelt") {
-      const profile = data.seatbelt?.profile?.trim();
-      if (!profile) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["seatbelt", "profile"],
-          message:
-            'Seatbelt sandbox requires sandbox.seatbelt.profile when sandbox.backend="seatbelt". ' +
-            'Example: sandbox: { backend: "seatbelt", seatbelt: { profile: "demo-open" } }. ' +
-            "Run `openclaw doctor` to validate and repair config issues.",
-        });
-      }
+      // Do not require seatbelt.profile at parse time: agent-specific sandbox config may
+      // intentionally inherit profile from defaults. Enforce after merge in
+      // resolveSandboxConfigForAgent().
       if (process.platform !== "darwin") {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -198,6 +198,15 @@ export const SandboxDockerSchema = z
   })
   .optional();
 
+export const SandboxSeatbeltSchema = z
+  .object({
+    profileDir: z.string().optional(),
+    profile: z.string().optional(),
+    params: z.record(z.string(), z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const SandboxBrowserSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -475,12 +484,39 @@ export const AgentSandboxSchema = z
     scope: z.union([z.literal("session"), z.literal("agent"), z.literal("shared")]).optional(),
     perSession: z.boolean().optional(),
     workspaceRoot: z.string().optional(),
+    backend: z.union([z.literal("docker"), z.literal("seatbelt")]).optional(),
+    seatbelt: SandboxSeatbeltSchema,
     docker: SandboxDockerSchema,
     browser: SandboxBrowserSchema,
     prune: SandboxPruneSchema,
   })
   .strict()
   .superRefine((data, ctx) => {
+    const backend = data.backend ?? "docker";
+    if (backend === "seatbelt") {
+      const profile = data.seatbelt?.profile?.trim();
+      if (!profile) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["seatbelt", "profile"],
+          message:
+            'Seatbelt sandbox requires sandbox.seatbelt.profile when sandbox.backend="seatbelt". ' +
+            'Example: sandbox: { backend: "seatbelt", seatbelt: { profile: "demo-open" } }. ' +
+            "Run `openclaw doctor` to validate and repair config issues.",
+        });
+      }
+      if (process.platform !== "darwin") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["backend"],
+          message:
+            "Seatbelt sandbox backend is only supported on macOS (darwin). Current platform: " +
+            process.platform +
+            ". Run `openclaw doctor` for remediation guidance.",
+        });
+      }
+    }
+
     const blockedBrowserNetworkReason = getBlockedNetworkModeReason({
       network: data.browser?.network,
       allowContainerNamespaceJoin: data.docker?.dangerouslyAllowContainerNamespaceJoin === true,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -201,7 +201,13 @@ export const SandboxDockerSchema = z
 export const SandboxSeatbeltSchema = z
   .object({
     profileDir: z.string().optional(),
-    profile: z.string().optional(),
+    profile: z
+      .string()
+      .regex(
+        /^[a-zA-Z0-9_-]+(?:\.sb)?$/,
+        "Seatbelt profile name must use only letters, numbers, '_' or '-' (optional .sb suffix).",
+      )
+      .optional(),
     params: z.record(z.string(), z.string()).optional(),
   })
   .strict()

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -9,6 +9,40 @@ export const AgentsSchema = z
     list: z.array(AgentEntrySchema).optional(),
   })
   .strict()
+  .superRefine((data, ctx) => {
+    const defaultsBackend = data.defaults?.sandbox?.backend;
+    const defaultsProfile = data.defaults?.sandbox?.seatbelt?.profile?.trim();
+
+    if (defaultsBackend === "seatbelt" && !defaultsProfile) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["defaults", "sandbox", "seatbelt", "profile"],
+        message:
+          'Seatbelt sandbox requires sandbox.seatbelt.profile when backend="seatbelt". ' +
+          "Set agents.defaults.sandbox.seatbelt.profile or provide an agent-specific override. " +
+          "Run `openclaw doctor` to validate and repair config issues.",
+      });
+    }
+
+    for (const [index, entry] of (data.list ?? []).entries()) {
+      const backend = entry.sandbox?.backend ?? defaultsBackend;
+      if (backend !== "seatbelt") {
+        continue;
+      }
+      const effectiveProfile = entry.sandbox?.seatbelt?.profile?.trim() ?? defaultsProfile;
+      if (effectiveProfile) {
+        continue;
+      }
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["list", index, "sandbox", "seatbelt", "profile"],
+        message:
+          `Seatbelt sandbox requires a resolved profile for agent "${entry.id}". ` +
+          "Set agents.defaults.sandbox.seatbelt.profile or this agent's sandbox.seatbelt.profile. " +
+          "Run `openclaw doctor` to validate and repair config issues.",
+      });
+    }
+  })
   .optional();
 
 export const BindingsSchema = z

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -8,6 +8,7 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
+import { ensureConfiguredSeatbeltDemoProfiles } from "../agents/sandbox/seatbelt-profiles.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
@@ -59,6 +60,15 @@ export async function startGatewaySidecars(params: {
     }
   } catch (err) {
     params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
+  }
+
+  try {
+    await ensureConfiguredSeatbeltDemoProfiles({
+      cfg: params.cfg,
+      onWarn: (message) => params.log.warn(message),
+    });
+  } catch (err) {
+    params.log.warn(`seatbelt demo profile install failed on startup: ${String(err)}`);
   }
 
   // Start OpenClaw browser control server (unless disabled via config).


### PR DESCRIPTION
## Summary

Implements a generic macOS seatbelt sandbox backend for OpenClaw exec runtime.

## Changes

- **Config & Schema**: Add seatbelt sandbox backend schema validation
- **Backend Scaffolding**: Add seatbelt backend config/context scaffolding
- **File Bridge**: Add seatbelt native fs bridge for sandbox host access
- **Sandbox Exec Runtime**: Add seatbelt sandbox-exec runtime path with allowlist/safebins enforcement
- **Profile Installation**: Install demo profiles into configured profile dirs
- **Documentation**: Document seatbelt profiles and allowlist rationale

## Tests

✅ Tests rerun by forge (post-53510506e): 40 files / 249 tests passing

## Related

Implements the generic seatbelt sandbox architecture for improved process isolation and security.