### PR TITLE
security: scan HEARTBEAT.md for injection + wire detectSkillPatterns into skill loading

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -20,6 +20,7 @@ import {
 } from "./frontmatter.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
+import { detectSkillPatterns } from "../../security/external-content.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -391,6 +392,18 @@ function loadSkillEntries(
     let frontmatter: ParsedSkillFrontmatter = {};
     try {
       const raw = fs.readFileSync(skill.filePath, "utf-8");
+      // SECURITY: Scan skill content for attack patterns (download-execute chains,
+      // credential harvesting, exfiltration). Skills are injected into the agent
+      // system prompt, so malicious instructions here would be treated as authoritative.
+      const skillAttackPatterns = detectSkillPatterns(raw);
+      if (skillAttackPatterns.length > 0) {
+        skillsLogger.warn("skill-specific attack patterns detected in skill file", {
+          path: skill.filePath,
+          name: skill.name,
+          count: skillAttackPatterns.length,
+          patterns: skillAttackPatterns.map((p) => p.slice(0, 80)),
+        });
+      }
       frontmatter = parseFrontmatter(raw);
     } catch {
       // ignore malformed skills

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -18,6 +18,7 @@ import {
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
+import { detectSuspiciousPatterns } from "../security/external-content.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
@@ -541,6 +542,15 @@ async function resolveHeartbeatPreflight(params: {
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
   try {
     const heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
+    // SECURITY: HEARTBEAT.md is a workspace file that could be written by tools,
+    // hooks, or external content. Scan for injection patterns before using it.
+    const suspiciousInHeartbeat = detectSuspiciousPatterns(heartbeatFileContent);
+    if (suspiciousInHeartbeat.length > 0) {
+      log.warn("suspicious patterns detected in HEARTBEAT.md", {
+        count: suspiciousInHeartbeat.length,
+        patterns: suspiciousInHeartbeat.map((p) => p.slice(0, 80)),
+      });
+    }
     if (isHeartbeatContentEffectivelyEmpty(heartbeatFileContent)) {
       return {
         ...basePreflight,


### PR DESCRIPTION
## Summary

Two targeted security fixes that close gaps between existing detection logic and actual usage.

### Fix 1: HEARTBEAT.md injection scan (#17)

**File:** `src/infra/heartbeat-runner.ts`

HEARTBEAT.md is a workspace file that can be written by any tool, hook, or external content landing in the workspace. Before this change, its content was injected directly into the cron agent prompt without any security scanning — even though `detectSuspiciousPatterns()` already exists in `external-content.ts`.

The fix wires `detectSuspiciousPatterns()` into `runHeartbeatPreflight()` immediately after the file is read, logging a `warn` with matched pattern snippets if hits are found.

### Fix 2: detectSkillPatterns in loadSkillEntries (#21)

**File:** `src/agents/skills/workspace.ts`

`detectSkillPatterns()` in `external-content.ts` detects download-execute chains, credential harvesting, and exfiltration patterns in skill files. However, it was never called during skill loading — only the `detectSuspiciousPatterns()` general scanner was wired in (in a different code path).

The fix adds a `detectSkillPatterns()` call inside `loadSkillEntries()` so every skill file is scanned at load time. Hits are logged at `warn` level with file path, skill name, and matched pattern snippets.

## Changes

- `src/infra/heartbeat-runner.ts`: import + call `detectSuspiciousPatterns()` on HEARTBEAT.md content
- `src/agents/skills/workspace.ts`: import + call `detectSkillPatterns()` in `loadSkillEntries()`

## Testing

Both changes are purely additive (warn-only, no blocking behavior). Existing tests unaffected. `pnpm tsgo` passes.