### PR TITLE
security: Instruction Boundary Enforcement Layer (IBEL)

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -43,6 +43,7 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerHook() {},
     registerHttpRoute() {},
     registerCommand() {},
+    registerGuard() {},
     on() {},
     resolvePath: (p) => p,
     ...overrides,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -132,6 +132,56 @@ export async function runBeforeToolCallHook(args: {
     recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
   }
 
+  // ── IBEL Guard Pipeline ────────────────────────────────────────────────────
+  // Runs before plugin hooks. Guards can block, reprompt, or escalate to HITL.
+  // When no pipeline is initialized (no guards registered), this is a no-op.
+  try {
+    const { getGlobalGuardPipeline } = await import("../security/guard-pipeline.js");
+    const guardPipeline = getGlobalGuardPipeline();
+    if (guardPipeline) {
+      const { getToolMetadata } = await import("../security/tool-risk-registry.js");
+      const { buildExecutionContext } = await import("../security/execution-context.js");
+
+      const normalizedArgs = isPlainObject(params) ? (params as Record<string, unknown>) : {};
+
+      const toolMeta = getToolMetadata(toolName);
+      const context = buildExecutionContext({
+        agentId: args.ctx?.agentId,
+        sessionKey: args.ctx?.sessionKey,
+      });
+
+      const guardResult = await guardPipeline.validate(
+        { toolName, arguments: normalizedArgs, toolCallId: args.toolCallId },
+        context,
+        toolMeta,
+      );
+
+      if (guardResult.action === "block") {
+        return { blocked: true, reason: guardResult.reason };
+      }
+
+      if (guardResult.action === "reprompt") {
+        return { blocked: true, reason: `[REPROMPT] ${guardResult.agentInstruction}` };
+      }
+
+      if (guardResult.action === "escalate") {
+        const { handleEscalation } = await import("../security/hitl-escalation.js");
+        const { ExecApprovalManager } = await import("../gateway/exec-approval-manager.js");
+        // Use a dedicated approval manager instance for IBEL escalations.
+        const approvalManager = new ExecApprovalManager();
+        const escalationResult = await handleEscalation(guardResult, approvalManager, {
+          agentId: args.ctx?.agentId,
+          sessionKey: args.ctx?.sessionKey,
+        });
+        if (!escalationResult.approved) {
+          return { blocked: true, reason: escalationResult.reason };
+        }
+      }
+    }
+  } catch (err) {
+    log.warn(`IBEL guard pipeline failed: tool=${toolName} error=${String(err)}`);
+  }
+
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("before_tool_call")) {
     return { blocked: false, params: args.params };

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -2,6 +2,7 @@ import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { TaintTracker } from "../security/taint-tracker.js";
 import { isPlainObject } from "../utils.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -10,6 +11,8 @@ export type HookContext = {
   agentId?: string;
   sessionKey?: string;
   loopDetection?: ToolLoopDetectionConfig;
+  /** IBEL: explicit taint tracker for non-session flows. */
+  taintTracker?: TaintTracker;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };
@@ -80,12 +83,14 @@ export async function runBeforeToolCallHook(args: {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
 
+  let sessionState: import("../logging/diagnostic-session-state.js").SessionState | undefined;
+
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState } = await import("../logging/diagnostic-session-state.js");
     const { logToolLoopAction } = await import("../logging/diagnostic.js");
     const { detectToolCallLoop, recordToolCall } = await import("./tool-loop-detection.js");
 
-    const sessionState = getDiagnosticSessionState({
+    sessionState = getDiagnosticSessionState({
       sessionKey: args.ctx.sessionKey,
       sessionId: args.ctx?.agentId,
     });
@@ -144,10 +149,14 @@ export async function runBeforeToolCallHook(args: {
 
       const normalizedArgs = isPlainObject(params) ? (params as Record<string, unknown>) : {};
 
+      // Resolve taint tracker: explicit ctx > session state > none
+      const taintTracker = args.ctx?.taintTracker ?? sessionState?.taintTracker;
+
       const toolMeta = getToolMetadata(toolName);
       const context = buildExecutionContext({
         agentId: args.ctx?.agentId,
         sessionKey: args.ctx?.sessionKey,
+        taintTracker,
       });
 
       const guardResult = await guardPipeline.validate(
@@ -166,9 +175,13 @@ export async function runBeforeToolCallHook(args: {
 
       if (guardResult.action === "escalate") {
         const { handleEscalation } = await import("../security/hitl-escalation.js");
-        const { ExecApprovalManager } = await import("../gateway/exec-approval-manager.js");
-        // Use a dedicated approval manager instance for IBEL escalations.
-        const approvalManager = new ExecApprovalManager();
+        const { getGlobalExecApprovalManager } = await import(
+          "../security/exec-approval-global.js"
+        );
+        const approvalManager = getGlobalExecApprovalManager();
+        if (!approvalManager) {
+          return { blocked: true, reason: "HITL escalation unavailable (non-gateway context)" };
+        }
         const escalationResult = await handleEscalation(guardResult, approvalManager, {
           agentId: args.ctx?.agentId,
           sessionKey: args.ctx?.sessionKey,

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -7,6 +7,10 @@ import { sanitizeToolResultImages } from "../tool-images.js";
 // oxlint-disable-next-line typescript/no-explicit-any
 export type AnyAgentTool = AgentTool<any, unknown> & {
   ownerOnly?: boolean;
+  /** IBEL: intrinsic tool risk level. Optional — falls back to registry defaults. */
+  riskLevel?: "low" | "medium" | "high" | "critical";
+  /** IBEL: plain-English summary for HITL approval UIs. */
+  humanReadableSummary?: string;
 };
 
 export type StringParamOptions = {

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -10,7 +10,7 @@ export type AnyAgentTool = AgentTool<any, unknown> & {
   /** IBEL: intrinsic tool risk level. Optional — falls back to registry defaults. */
   riskLevel?: "low" | "medium" | "high" | "critical";
   /** IBEL: plain-English summary for HITL approval UIs. */
-  humanReadableSummary?: string;
+  humanReadableSummary?: string | ((args: unknown) => string);
 };
 
 export type StringParamOptions = {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -391,6 +391,17 @@ export async function startGatewayServer(
         coreGatewayHandlers,
         baseMethods,
       });
+
+  // ── IBEL: Register default tool execution guards ─────────────────────────
+  {
+    const { ensureGlobalGuardPipeline } = await import("../security/guard-pipeline.js");
+    const { TaintRiskGuard, CapabilityAllowlistGuard } =
+      await import("../security/tool-execution-guard.js");
+    const pipeline = ensureGlobalGuardPipeline();
+    pipeline.register(TaintRiskGuard);
+    pipeline.register(CapabilityAllowlistGuard);
+  }
+
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -64,6 +64,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { initializeGlobalExecApprovalManager } from "../security/exec-approval-global.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
@@ -684,6 +685,7 @@ export async function startGatewayServer(
   }
 
   const execApprovalManager = new ExecApprovalManager();
+  initializeGlobalExecApprovalManager(execApprovalManager);
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
     forwarder: execApprovalForwarder,

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -9,6 +9,8 @@ export type SessionState = {
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
+  /** IBEL: per-session taint tracker for instruction boundary enforcement. */
+  taintTracker?: import("../security/taint-tracker.js").TaintTracker;
 };
 
 export type ToolCallRecord = {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -8,6 +8,7 @@ import type {
 } from "../gateway/server-methods/types.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
+import { ensureGlobalGuardPipeline } from "../security/guard-pipeline.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -498,6 +499,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerService: (service) => registerService(record, service),
       registerCommand: (command) => registerCommand(record, command),
       resolvePath: (input: string) => resolveUserPath(input),
+      registerGuard: (guard) => {
+        ensureGlobalGuardPipeline().register(guard);
+      },
       on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts),
     };
   };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -13,6 +13,7 @@ import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { ToolExecutionGuard } from "../security/types.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
@@ -275,6 +276,8 @@ export type OpenClawPluginApi = {
    */
   registerCommand: (command: OpenClawPluginCommandDefinition) => void;
   resolvePath: (input: string) => string;
+  /** IBEL: Register a tool execution guard on the global guard pipeline. */
+  registerGuard: (guard: ToolExecutionGuard) => void;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(
     hookName: K,

--- a/src/security/exec-approval-global.ts
+++ b/src/security/exec-approval-global.ts
@@ -1,0 +1,34 @@
+/**
+ * Global ExecApprovalManager singleton for IBEL HITL escalations.
+ *
+ * Mirrors the hook-runner-global.ts pattern. The gateway initializes this
+ * during startup so that the guard pipeline can resolve escalations against
+ * the real approval manager instead of creating orphaned instances.
+ */
+
+import type { ExecApprovalManager } from "../gateway/exec-approval-manager.js";
+
+let globalExecApprovalManager: ExecApprovalManager | null = null;
+
+/**
+ * Store the gateway's ExecApprovalManager as a global singleton.
+ * Called once during gateway startup after the manager is created.
+ */
+export function initializeGlobalExecApprovalManager(manager: ExecApprovalManager): void {
+  globalExecApprovalManager = manager;
+}
+
+/**
+ * Get the global ExecApprovalManager.
+ * Returns null if the gateway hasn't initialized yet (non-gateway context).
+ */
+export function getGlobalExecApprovalManager(): ExecApprovalManager | null {
+  return globalExecApprovalManager;
+}
+
+/**
+ * Reset the global singleton (for testing).
+ */
+export function resetGlobalExecApprovalManager(): void {
+  globalExecApprovalManager = null;
+}

--- a/src/security/execution-context.test.ts
+++ b/src/security/execution-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildExecutionContext } from "./execution-context.js";
+import { TaintTracker } from "./taint-tracker.js";
+import { InstructionLevel } from "./types.js";
+
+describe("buildExecutionContext", () => {
+  it("defaults aggregateTaintLevel to SYSTEM when no tracker is attached", () => {
+    const ctx = buildExecutionContext({});
+    expect(ctx.aggregateTaintLevel).toBe(InstructionLevel.SYSTEM);
+    expect(ctx.fieldTaint).toBeUndefined();
+  });
+
+  it("uses taint tracker aggregate level when attached", () => {
+    const tracker = new TaintTracker();
+    tracker.tagField("args.url", InstructionLevel.EXTERNAL_CONTENT);
+
+    const ctx = buildExecutionContext({ taintTracker: tracker });
+    expect(ctx.aggregateTaintLevel).toBe(InstructionLevel.EXTERNAL_CONTENT);
+  });
+
+  it("provides fieldTaint accessor when tracker is attached", () => {
+    const tracker = new TaintTracker();
+    tracker.tagField("a", InstructionLevel.USER, "input");
+
+    const ctx = buildExecutionContext({ taintTracker: tracker });
+    expect(ctx.fieldTaint).toBeDefined();
+
+    const fields = ctx.fieldTaint!();
+    expect(fields).toHaveLength(1);
+    expect(fields[0].fieldPath).toBe("a");
+  });
+
+  it("passes through session metadata", () => {
+    const ctx = buildExecutionContext({
+      activeTask: "process-email",
+      sessionRole: "owner",
+      agentId: "agent-1",
+      sessionKey: "hook:gmail:inbox",
+      senderIsOwner: true,
+    });
+
+    expect(ctx.activeTask).toBe("process-email");
+    expect(ctx.sessionRole).toBe("owner");
+    expect(ctx.agentId).toBe("agent-1");
+    expect(ctx.sessionKey).toBe("hook:gmail:inbox");
+    expect(ctx.senderIsOwner).toBe(true);
+  });
+
+  it("handles tracker at SYSTEM level (no taint)", () => {
+    const tracker = new TaintTracker();
+    const ctx = buildExecutionContext({ taintTracker: tracker });
+    expect(ctx.aggregateTaintLevel).toBe(InstructionLevel.SYSTEM);
+    expect(ctx.fieldTaint!()).toEqual([]);
+  });
+});

--- a/src/security/execution-context.ts
+++ b/src/security/execution-context.ts
@@ -1,0 +1,40 @@
+/**
+ * IBEL Phase 1 — Execution context builder.
+ *
+ * Bridges taint tracking into the tool validation layer. The context carries
+ * aggregate taint level and optional field-level access for guards that need
+ * granularity.
+ */
+
+import type { TaintTracker } from "./taint-tracker.js";
+import { InstructionLevel } from "./types.js";
+import type { ExecutionContext, TaintField } from "./types.js";
+
+export type BuildExecutionContextParams = {
+  activeTask?: string;
+  sessionRole?: string;
+  agentId?: string;
+  sessionKey?: string;
+  senderIsOwner?: boolean;
+  taintTracker?: TaintTracker;
+};
+
+/**
+ * Build an ExecutionContext from session metadata and an optional taint tracker.
+ *
+ * When no taint tracker is attached, aggregateTaintLevel defaults to SYSTEM —
+ * this ensures backward compatibility (all guards return allow for untainted flows).
+ */
+export function buildExecutionContext(params: BuildExecutionContextParams): ExecutionContext {
+  const { activeTask, sessionRole, agentId, sessionKey, senderIsOwner, taintTracker } = params;
+
+  return {
+    activeTask,
+    sessionRole,
+    aggregateTaintLevel: taintTracker?.getAggregateLevel() ?? InstructionLevel.SYSTEM,
+    agentId,
+    sessionKey,
+    senderIsOwner,
+    fieldTaint: taintTracker ? () => taintTracker.getFields() : undefined,
+  };
+}

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "node:crypto";
+import { InstructionLevel } from "./types.js";
+import type { TaggedPayload } from "./types.js";
 
 /**
  * Security utilities for handling untrusted external content.
@@ -322,4 +324,22 @@ export function wrapWebContent(
   const includeWarning = source === "web_fetch";
   // Marker sanitization happens in wrapExternalContent
   return wrapExternalContent(content, { source, includeWarning });
+}
+
+/**
+ * IBEL: Tag external content with privilege metadata.
+ *
+ * Complements wrapExternalContent() — that function adds textual boundary
+ * markers for LLM context; this function produces a TaggedPayload for the
+ * guard pipeline's taint tracking system. Existing callers are unchanged.
+ */
+export function tagExternalContent(
+  content: unknown,
+  opts?: { source?: ExternalContentSource },
+): TaggedPayload {
+  return {
+    level: InstructionLevel.EXTERNAL_CONTENT,
+    content,
+    source: opts?.source,
+  };
 }

--- a/src/security/guard-pipeline.test.ts
+++ b/src/security/guard-pipeline.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  GuardPipeline,
+  ensureGlobalGuardPipeline,
+  getGlobalGuardPipeline,
+  resetGlobalGuardPipeline,
+} from "./guard-pipeline.js";
+import { InstructionLevel } from "./types.js";
+import type { ExecutionContext, ToolCall, ToolExecutionGuard, ValidationResult } from "./types.js";
+
+function makeContext(level: InstructionLevel = InstructionLevel.SYSTEM): ExecutionContext {
+  return { aggregateTaintLevel: level };
+}
+
+function makeCall(toolName: string = "test_tool"): ToolCall {
+  return { toolName, arguments: {} };
+}
+
+function makeGuard(
+  name: string,
+  priority: number,
+  result: ValidationResult = { action: "allow" },
+): ToolExecutionGuard {
+  return {
+    name,
+    priority,
+    validate: () => result,
+  };
+}
+
+describe("GuardPipeline", () => {
+  describe("register / unregister", () => {
+    it("registers guards sorted by priority descending", () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register(makeGuard("low", 10));
+      pipeline.register(makeGuard("high", 100));
+      pipeline.register(makeGuard("mid", 50));
+
+      expect(pipeline.guardNames()).toEqual(["high", "mid", "low"]);
+    });
+
+    it("replaces guard with same name", () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register(makeGuard("g", 10, { action: "allow" }));
+      pipeline.register(makeGuard("g", 20, { action: "block", reason: "updated" }));
+
+      expect(pipeline.size).toBe(1);
+      expect(pipeline.guardNames()).toEqual(["g"]);
+    });
+
+    it("unregisters by name", () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register(makeGuard("a", 10));
+      pipeline.register(makeGuard("b", 20));
+      pipeline.unregister("a");
+
+      expect(pipeline.guardNames()).toEqual(["b"]);
+    });
+  });
+
+  describe("validate", () => {
+    it("returns allow when no guards are registered", async () => {
+      const pipeline = new GuardPipeline();
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result).toEqual({ action: "allow" });
+    });
+
+    it("returns allow when all guards allow", async () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register(makeGuard("a", 100));
+      pipeline.register(makeGuard("b", 50));
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result).toEqual({ action: "allow" });
+    });
+
+    it("short-circuits on first non-allow result", async () => {
+      const calls: string[] = [];
+      const pipeline = new GuardPipeline();
+
+      pipeline.register({
+        name: "blocker",
+        priority: 100,
+        validate: () => {
+          calls.push("blocker");
+          return { action: "block", reason: "blocked" };
+        },
+      });
+
+      pipeline.register({
+        name: "after",
+        priority: 50,
+        validate: () => {
+          calls.push("after");
+          return { action: "allow" };
+        },
+      });
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result.action).toBe("block");
+      expect(calls).toEqual(["blocker"]);
+    });
+
+    it("runs guards in priority order (highest first)", async () => {
+      const calls: string[] = [];
+      const pipeline = new GuardPipeline();
+
+      pipeline.register({
+        name: "low",
+        priority: 10,
+        validate: () => {
+          calls.push("low");
+          return { action: "allow" };
+        },
+      });
+
+      pipeline.register({
+        name: "high",
+        priority: 100,
+        validate: () => {
+          calls.push("high");
+          return { action: "allow" };
+        },
+      });
+
+      await pipeline.validate(makeCall(), makeContext());
+      expect(calls).toEqual(["high", "low"]);
+    });
+
+    it("fail-closed: guard exception produces block result", async () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register({
+        name: "broken",
+        priority: 100,
+        validate: () => {
+          throw new Error("guard crashed");
+        },
+      });
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result.action).toBe("block");
+      if (result.action === "block") {
+        expect(result.reason).toContain("broken");
+        expect(result.reason).toContain("fail-closed");
+      }
+    });
+
+    it("handles async guards", async () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register({
+        name: "async-guard",
+        priority: 100,
+        validate: async () => {
+          return { action: "block", reason: "async block" };
+        },
+      });
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result.action).toBe("block");
+    });
+
+    it("passes reprompt results through", async () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register({
+        name: "reprompt-guard",
+        priority: 100,
+        validate: () => ({
+          action: "reprompt",
+          agentInstruction: "Ask the user",
+          reason: "needs confirmation",
+        }),
+      });
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result.action).toBe("reprompt");
+    });
+
+    it("passes escalate results through", async () => {
+      const pipeline = new GuardPipeline();
+      pipeline.register({
+        name: "escalate-guard",
+        priority: 100,
+        validate: () => ({
+          action: "escalate",
+          timeoutMs: 30_000,
+          hitlPayload: { toolName: "exec", summary: "test", riskLevel: "critical" },
+        }),
+      });
+
+      const result = await pipeline.validate(makeCall(), makeContext());
+      expect(result.action).toBe("escalate");
+    });
+  });
+});
+
+describe("global pipeline", () => {
+  afterEach(() => {
+    resetGlobalGuardPipeline();
+  });
+
+  it("returns null before initialization", () => {
+    expect(getGlobalGuardPipeline()).toBeNull();
+  });
+
+  it("ensureGlobalGuardPipeline creates and returns singleton", () => {
+    const a = ensureGlobalGuardPipeline();
+    const b = ensureGlobalGuardPipeline();
+    expect(a).toBe(b);
+    expect(getGlobalGuardPipeline()).toBe(a);
+  });
+
+  it("resetGlobalGuardPipeline clears the singleton", () => {
+    ensureGlobalGuardPipeline();
+    resetGlobalGuardPipeline();
+    expect(getGlobalGuardPipeline()).toBeNull();
+  });
+});

--- a/src/security/guard-pipeline.ts
+++ b/src/security/guard-pipeline.ts
@@ -1,0 +1,107 @@
+/**
+ * IBEL Phase 1 — Guard pipeline runner.
+ *
+ * Runs guards in priority order (highest first), short-circuits on the first
+ * non-allow result. Guard exceptions produce a block result (fail-closed).
+ */
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type {
+  ExecutionContext,
+  OpenClawToolMetadata,
+  ToolCall,
+  ToolExecutionGuard,
+  ValidationResult,
+} from "./types.js";
+
+const log = createSubsystemLogger("security/guard-pipeline");
+
+export class GuardPipeline {
+  private guards: ToolExecutionGuard[] = [];
+
+  /**
+   * Register a guard. Guards are kept sorted by priority descending.
+   */
+  register(guard: ToolExecutionGuard): void {
+    this.unregister(guard.name);
+    this.guards.push(guard);
+    this.guards.sort((a, b) => b.priority - a.priority);
+  }
+
+  /**
+   * Remove a guard by name.
+   */
+  unregister(name: string): void {
+    this.guards = this.guards.filter((g) => g.name !== name);
+  }
+
+  /**
+   * Run all guards in priority order. Short-circuits on first non-allow result.
+   * Guard exceptions produce a block result (fail-closed).
+   */
+  async validate(
+    call: ToolCall,
+    context: ExecutionContext,
+    toolMeta?: OpenClawToolMetadata,
+  ): Promise<ValidationResult> {
+    for (const guard of this.guards) {
+      try {
+        const result = await guard.validate(call, context, toolMeta);
+        if (result.action !== "allow") {
+          log.info(
+            `guard="${guard.name}" tool="${call.toolName}" action=${result.action}` +
+              ("reason" in result ? ` reason="${result.reason}"` : ""),
+          );
+          return result;
+        }
+      } catch (err) {
+        log.error(`guard="${guard.name}" tool="${call.toolName}" threw: ${String(err)}`);
+        return {
+          action: "block",
+          reason: `Guard "${guard.name}" failed with an exception (fail-closed)`,
+        };
+      }
+    }
+    return { action: "allow" };
+  }
+
+  /** Number of registered guards. */
+  get size(): number {
+    return this.guards.length;
+  }
+
+  /** Names of registered guards in execution order. */
+  guardNames(): string[] {
+    return this.guards.map((g) => g.name);
+  }
+}
+
+// ── Global Singleton ─────────────────────────────────────────────────────────
+
+let globalPipeline: GuardPipeline | null = null;
+
+/**
+ * Get the global guard pipeline singleton.
+ * Returns null if no pipeline has been initialized (no guards registered).
+ */
+export function getGlobalGuardPipeline(): GuardPipeline | null {
+  return globalPipeline;
+}
+
+/**
+ * Initialize and return the global guard pipeline.
+ * Creates a new pipeline if one doesn't exist.
+ */
+export function ensureGlobalGuardPipeline(): GuardPipeline {
+  if (!globalPipeline) {
+    globalPipeline = new GuardPipeline();
+  }
+  return globalPipeline;
+}
+
+/**
+ * Reset the global pipeline. Primarily for testing.
+ */
+export function resetGlobalGuardPipeline(): void {
+  globalPipeline = null;
+}

--- a/src/security/hitl-escalation.test.ts
+++ b/src/security/hitl-escalation.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExecApprovalManager } from "../gateway/exec-approval-manager.js";
+import { handleEscalation } from "./hitl-escalation.js";
+import type { EscalateResult } from "./types.js";
+
+function makeEscalateResult(overrides?: Partial<EscalateResult>): EscalateResult {
+  return {
+    action: "escalate",
+    timeoutMs: 5_000,
+    hitlPayload: {
+      toolName: "exec",
+      summary: "Execute command: rm -rf /",
+      riskLevel: "critical",
+    },
+    ...overrides,
+  };
+}
+
+describe("handleEscalation", () => {
+  it("returns approved:true when decision is allow-once", async () => {
+    const manager = new ExecApprovalManager();
+    const escalation = makeEscalateResult();
+
+    const promise = handleEscalation(escalation, manager, {
+      agentId: "agent-1",
+      sessionKey: "session-1",
+    });
+
+    // Simulate human approval — find the pending record and resolve it.
+    // The create() call returns the record synchronously, so we need a tick.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Find the pending approval by iterating (manager doesn't expose list,
+    // but we can resolve by inspecting the created record's ID).
+    // Instead, we can use a spy to capture the record ID.
+    // Re-approach: use a manager with known ID.
+    const manager2 = new ExecApprovalManager();
+    const record = manager2.create({ command: "test" }, 5_000, "known-id");
+    const decisionPromise = manager2.register(record, 5_000);
+
+    manager2.resolve("known-id", "allow-once");
+    const decision = await decisionPromise;
+    expect(decision).toBe("allow-once");
+  });
+
+  it("returns approved:true for allow-once decision", async () => {
+    const manager = new ExecApprovalManager();
+    const escalation = makeEscalateResult();
+
+    // Spy on create to capture the record ID
+    const createSpy = vi.spyOn(manager, "create");
+
+    const promise = handleEscalation(escalation, manager);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const record = createSpy.mock.results[0].value;
+    manager.resolve(record.id, "allow-once");
+
+    const result = await promise;
+    expect(result).toEqual({ approved: true });
+  });
+
+  it("returns approved:true for allow-always decision", async () => {
+    const manager = new ExecApprovalManager();
+    const escalation = makeEscalateResult();
+
+    const createSpy = vi.spyOn(manager, "create");
+    const promise = handleEscalation(escalation, manager);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const record = createSpy.mock.results[0].value;
+    manager.resolve(record.id, "allow-always");
+
+    const result = await promise;
+    expect(result).toEqual({ approved: true });
+  });
+
+  it("returns approved:false for deny decision", async () => {
+    const manager = new ExecApprovalManager();
+    const escalation = makeEscalateResult();
+
+    const createSpy = vi.spyOn(manager, "create");
+    const promise = handleEscalation(escalation, manager);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const record = createSpy.mock.results[0].value;
+    manager.resolve(record.id, "deny");
+
+    const result = await promise;
+    expect(result.approved).toBe(false);
+    if (!result.approved) {
+      expect(result.reason).toContain("denied");
+      expect(result.reason).toContain("exec");
+    }
+  });
+
+  it("returns approved:false on timeout (fail-closed)", async () => {
+    const manager = new ExecApprovalManager();
+    const escalation = makeEscalateResult({ timeoutMs: 50 });
+
+    const result = await handleEscalation(escalation, manager);
+
+    expect(result.approved).toBe(false);
+    if (!result.approved) {
+      expect(result.reason).toContain("timed out");
+      expect(result.reason).toContain("fail-closed");
+    }
+  });
+
+  it("passes agent metadata to approval request", async () => {
+    const manager = new ExecApprovalManager();
+    const createSpy = vi.spyOn(manager, "create");
+
+    const escalation = makeEscalateResult({ timeoutMs: 50 });
+    await handleEscalation(escalation, manager, {
+      agentId: "test-agent",
+      sessionKey: "hook:gmail:inbox",
+    });
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "Execute command: rm -rf /",
+        agentId: "test-agent",
+        sessionKey: "hook:gmail:inbox",
+      }),
+      50,
+    );
+  });
+});

--- a/src/security/hitl-escalation.test.ts
+++ b/src/security/hitl-escalation.test.ts
@@ -17,32 +17,6 @@ function makeEscalateResult(overrides?: Partial<EscalateResult>): EscalateResult
 }
 
 describe("handleEscalation", () => {
-  it("returns approved:true when decision is allow-once", async () => {
-    const manager = new ExecApprovalManager();
-    const escalation = makeEscalateResult();
-
-    const promise = handleEscalation(escalation, manager, {
-      agentId: "agent-1",
-      sessionKey: "session-1",
-    });
-
-    // Simulate human approval — find the pending record and resolve it.
-    // The create() call returns the record synchronously, so we need a tick.
-    await new Promise((r) => setTimeout(r, 10));
-
-    // Find the pending approval by iterating (manager doesn't expose list,
-    // but we can resolve by inspecting the created record's ID).
-    // Instead, we can use a spy to capture the record ID.
-    // Re-approach: use a manager with known ID.
-    const manager2 = new ExecApprovalManager();
-    const record = manager2.create({ command: "test" }, 5_000, "known-id");
-    const decisionPromise = manager2.register(record, 5_000);
-
-    manager2.resolve("known-id", "allow-once");
-    const decision = await decisionPromise;
-    expect(decision).toBe("allow-once");
-  });
-
   it("returns approved:true for allow-once decision", async () => {
     const manager = new ExecApprovalManager();
     const escalation = makeEscalateResult();

--- a/src/security/hitl-escalation.ts
+++ b/src/security/hitl-escalation.ts
@@ -1,0 +1,57 @@
+/**
+ * IBEL Phase 1 — HITL escalation adapter.
+ *
+ * Integrates the guard pipeline's "escalate" result with OpenClaw's existing
+ * ExecApprovalManager. Creates approval requests, awaits decisions, and
+ * maps outcomes back to allow/block.
+ *
+ * Fail-closed on timeout: if no human responds, the tool call is blocked.
+ */
+
+import type { ExecApprovalManager } from "../gateway/exec-approval-manager.js";
+import type { EscalateResult } from "./types.js";
+
+export type HitlEscalationResult = { approved: true } | { approved: false; reason: string };
+
+export type HitlEscalationMeta = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+/**
+ * Handle a guard pipeline "escalate" result by creating an approval request
+ * and waiting for a human decision.
+ */
+export async function handleEscalation(
+  result: EscalateResult,
+  approvalManager: ExecApprovalManager,
+  meta?: HitlEscalationMeta,
+): Promise<HitlEscalationResult> {
+  const record = approvalManager.create(
+    {
+      command: result.hitlPayload.summary,
+      agentId: meta?.agentId ?? null,
+      sessionKey: meta?.sessionKey ?? null,
+    },
+    result.timeoutMs,
+  );
+
+  const decision = await approvalManager.register(record, result.timeoutMs);
+
+  if (decision === null) {
+    return {
+      approved: false,
+      reason: `HITL escalation timed out for tool "${result.hitlPayload.toolName}" (fail-closed)`,
+    };
+  }
+
+  if (decision === "deny") {
+    return {
+      approved: false,
+      reason: `HITL escalation denied for tool "${result.hitlPayload.toolName}"`,
+    };
+  }
+
+  // "allow-once" or "allow-always"
+  return { approved: true };
+}

--- a/src/security/ibel-integration.test.ts
+++ b/src/security/ibel-integration.test.ts
@@ -1,0 +1,290 @@
+/**
+ * IBEL Phase 1 — Integration tests.
+ *
+ * End-to-end tests covering the full guard pipeline flow:
+ * guard registration → tool call validation → block/reprompt/escalate outcomes.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExecApprovalManager } from "../gateway/exec-approval-manager.js";
+import { buildExecutionContext } from "./execution-context.js";
+import { tagExternalContent } from "./external-content.js";
+import {
+  GuardPipeline,
+  ensureGlobalGuardPipeline,
+  getGlobalGuardPipeline,
+  resetGlobalGuardPipeline,
+} from "./guard-pipeline.js";
+import { handleEscalation } from "./hitl-escalation.js";
+import { deriveTaint } from "./taint-propagation.js";
+import { TaintTracker } from "./taint-tracker.js";
+import { TaintRiskGuard, CapabilityAllowlistGuard } from "./tool-execution-guard.js";
+import { getToolMetadata, resetToolRiskRegistry } from "./tool-risk-registry.js";
+import { InstructionLevel } from "./types.js";
+import type { ToolCall, ToolExecutionGuard, ValidationResult } from "./types.js";
+
+afterEach(() => {
+  resetGlobalGuardPipeline();
+  resetToolRiskRegistry();
+});
+
+describe("IBEL integration", () => {
+  describe("no guards registered = pass-through (backward compat)", () => {
+    it("returns allow when global pipeline is null", () => {
+      expect(getGlobalGuardPipeline()).toBeNull();
+    });
+
+    it("returns allow with an empty pipeline", async () => {
+      const pipeline = new GuardPipeline();
+      const call: ToolCall = { toolName: "exec", arguments: { command: "rm -rf /" } };
+      const ctx = buildExecutionContext({});
+      const result = await pipeline.validate(call, ctx);
+      expect(result).toEqual({ action: "allow" });
+    });
+  });
+
+  describe("default guards with tainted context", () => {
+    it("blocks dangerous tools via CapabilityAllowlistGuard when tainted", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+      pipeline.register(CapabilityAllowlistGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagField("args.command", InstructionLevel.EXTERNAL_CONTENT, "email");
+
+      const call: ToolCall = { toolName: "exec", arguments: { command: "rm -rf /" } };
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("exec"));
+
+      // TaintRiskGuard (priority 100) runs first and escalates for critical + external
+      expect(result.action).toBe("escalate");
+    });
+
+    it("reprompts for high-risk tools with EXTERNAL_CONTENT taint", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+      pipeline.register(CapabilityAllowlistGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagField("args.path", InstructionLevel.EXTERNAL_CONTENT, "web_fetch");
+
+      const call: ToolCall = { toolName: "fs_write", arguments: { path: "/etc/passwd" } };
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("fs_write"));
+
+      expect(result.action).toBe("reprompt");
+      if (result.action === "reprompt") {
+        expect(result.agentInstruction).toContain("untrusted external source");
+      }
+    });
+
+    it("allows low-risk tools even with EXTERNAL_CONTENT taint", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+      pipeline.register(CapabilityAllowlistGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagField("query", InstructionLevel.EXTERNAL_CONTENT);
+
+      const call: ToolCall = { toolName: "read", arguments: { path: "/tmp/safe" } };
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("read"));
+      expect(result).toEqual({ action: "allow" });
+    });
+
+    it("allows all tools when context is not tainted", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+      pipeline.register(CapabilityAllowlistGuard);
+
+      const call: ToolCall = { toolName: "exec", arguments: { command: "ls" } };
+      const ctx = buildExecutionContext({});
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("exec"));
+      expect(result).toEqual({ action: "allow" });
+    });
+  });
+
+  describe("guard priority ordering", () => {
+    it("higher priority guard runs first and short-circuits", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      const calls: string[] = [];
+
+      const highGuard: ToolExecutionGuard = {
+        name: "high",
+        priority: 200,
+        validate: () => {
+          calls.push("high");
+          return { action: "block", reason: "blocked by high" };
+        },
+      };
+
+      const lowGuard: ToolExecutionGuard = {
+        name: "low",
+        priority: 10,
+        validate: () => {
+          calls.push("low");
+          return { action: "allow" };
+        },
+      };
+
+      pipeline.register(lowGuard);
+      pipeline.register(highGuard);
+
+      const result = await pipeline.validate(
+        { toolName: "test", arguments: {} },
+        buildExecutionContext({}),
+      );
+
+      expect(result.action).toBe("block");
+      expect(calls).toEqual(["high"]);
+    });
+
+    it("guards run before plugin hooks (structural test)", () => {
+      // The integration in pi-tools.before-tool-call.ts places the guard pipeline
+      // invocation BEFORE the plugin hook runner call. This test verifies the guards
+      // are registered at higher structural priority.
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+      pipeline.register(CapabilityAllowlistGuard);
+
+      expect(pipeline.guardNames()).toEqual(["TaintRiskGuard", "CapabilityAllowlistGuard"]);
+    });
+  });
+
+  describe("HITL escalation flow", () => {
+    it("blocks on timeout (fail-closed)", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagArtifact(InstructionLevel.EXTERNAL_CONTENT);
+
+      const call: ToolCall = { toolName: "exec", arguments: { command: "danger" } };
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("exec"));
+      expect(result.action).toBe("escalate");
+
+      if (result.action === "escalate") {
+        const manager = new ExecApprovalManager();
+        const escalation = await handleEscalation({ ...result, timeoutMs: 50 }, manager);
+        expect(escalation.approved).toBe(false);
+        if (!escalation.approved) {
+          expect(escalation.reason).toContain("timed out");
+        }
+      }
+    });
+
+    it("allows when human approves", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagArtifact(InstructionLevel.EXTERNAL_CONTENT);
+
+      const call: ToolCall = { toolName: "exec", arguments: { command: "safe" } };
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+
+      const result = await pipeline.validate(call, ctx, getToolMetadata("exec"));
+      expect(result.action).toBe("escalate");
+
+      if (result.action === "escalate") {
+        const manager = new ExecApprovalManager();
+        const createSpy = vi.spyOn(manager, "create");
+
+        const promise = handleEscalation(result, manager, { agentId: "test" });
+
+        await new Promise((r) => setTimeout(r, 10));
+        const record = createSpy.mock.results[0].value;
+        manager.resolve(record.id, "allow-once");
+
+        const escalation = await promise;
+        expect(escalation.approved).toBe(true);
+      }
+    });
+  });
+
+  describe("taint propagation through the pipeline", () => {
+    it("deriveTaint preserves worst-case level for guard consumption", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+
+      const clean = tagExternalContent("safe data", { source: "web_search" });
+      const tainted = tagExternalContent("unsafe data", { source: "email" });
+      const combined = deriveTaint([clean, tainted]);
+
+      expect(combined.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+
+      const tracker = new TaintTracker();
+      tracker.tagArtifact(combined.level);
+
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+      const result = await pipeline.validate(
+        { toolName: "exec", arguments: {} },
+        ctx,
+        getToolMetadata("exec"),
+      );
+
+      expect(result.action).toBe("escalate");
+    });
+
+    it("taint tracker collapse preserves aggregate level", async () => {
+      const tracker = new TaintTracker({ explosionThreshold: 3 });
+
+      // Add fields until collapse
+      for (let i = 0; i < 4; i++) {
+        tracker.tagField(`field_${i}`, InstructionLevel.EXTERNAL_CONTENT);
+      }
+
+      expect(tracker.isCollapsed()).toBe(true);
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(CapabilityAllowlistGuard);
+
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+      const result = await pipeline.validate({ toolName: "sessions_spawn", arguments: {} }, ctx);
+
+      expect(result.action).toBe("block");
+    });
+  });
+
+  describe("tagExternalContent", () => {
+    it("produces TaggedPayload at EXTERNAL_CONTENT level", () => {
+      const payload = tagExternalContent("some data", { source: "email" });
+      expect(payload.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(payload.content).toBe("some data");
+      expect(payload.source).toBe("email");
+    });
+  });
+
+  describe("reprompt result formatting", () => {
+    it("reprompt reason includes tool name and taint level", async () => {
+      const pipeline = ensureGlobalGuardPipeline();
+      pipeline.register(TaintRiskGuard);
+
+      const tracker = new TaintTracker();
+      tracker.tagField("data", InstructionLevel.EXTERNAL_CONTENT);
+
+      const ctx = buildExecutionContext({ taintTracker: tracker });
+      const result = await pipeline.validate(
+        { toolName: "edit", arguments: {} },
+        ctx,
+        getToolMetadata("edit"),
+      );
+
+      expect(result.action).toBe("reprompt");
+      if (result.action === "reprompt") {
+        expect(result.reason).toContain("edit");
+        expect(result.reason).toContain("EXTERNAL_CONTENT");
+        // Verify the prefix convention used in before-tool-call integration
+        const prefixed = `[REPROMPT] ${result.agentInstruction}`;
+        expect(prefixed).toMatch(/^\[REPROMPT\] /);
+      }
+    });
+  });
+});

--- a/src/security/instruction-level.test.ts
+++ b/src/security/instruction-level.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { canOverride, isUntrusted, levelLabel, worstCaseLevel } from "./instruction-level.js";
+import { InstructionLevel } from "./types.js";
+
+describe("instruction-level", () => {
+  describe("canOverride", () => {
+    it("SYSTEM can override everything", () => {
+      expect(canOverride(InstructionLevel.SYSTEM, InstructionLevel.SYSTEM)).toBe(true);
+      expect(canOverride(InstructionLevel.SYSTEM, InstructionLevel.POLICY)).toBe(true);
+      expect(canOverride(InstructionLevel.SYSTEM, InstructionLevel.TASK)).toBe(true);
+      expect(canOverride(InstructionLevel.SYSTEM, InstructionLevel.USER)).toBe(true);
+      expect(canOverride(InstructionLevel.SYSTEM, InstructionLevel.EXTERNAL_CONTENT)).toBe(true);
+    });
+
+    it("EXTERNAL_CONTENT can only override itself", () => {
+      expect(canOverride(InstructionLevel.EXTERNAL_CONTENT, InstructionLevel.SYSTEM)).toBe(false);
+      expect(canOverride(InstructionLevel.EXTERNAL_CONTENT, InstructionLevel.POLICY)).toBe(false);
+      expect(canOverride(InstructionLevel.EXTERNAL_CONTENT, InstructionLevel.TASK)).toBe(false);
+      expect(canOverride(InstructionLevel.EXTERNAL_CONTENT, InstructionLevel.USER)).toBe(false);
+      expect(
+        canOverride(InstructionLevel.EXTERNAL_CONTENT, InstructionLevel.EXTERNAL_CONTENT),
+      ).toBe(true);
+    });
+
+    it("same level can override itself", () => {
+      expect(canOverride(InstructionLevel.TASK, InstructionLevel.TASK)).toBe(true);
+      expect(canOverride(InstructionLevel.USER, InstructionLevel.USER)).toBe(true);
+    });
+
+    it("lower privilege cannot override higher privilege", () => {
+      expect(canOverride(InstructionLevel.USER, InstructionLevel.POLICY)).toBe(false);
+      expect(canOverride(InstructionLevel.TASK, InstructionLevel.SYSTEM)).toBe(false);
+    });
+  });
+
+  describe("worstCaseLevel", () => {
+    it("returns SYSTEM for empty input", () => {
+      expect(worstCaseLevel()).toBe(InstructionLevel.SYSTEM);
+    });
+
+    it("returns the single input level", () => {
+      expect(worstCaseLevel(InstructionLevel.USER)).toBe(InstructionLevel.USER);
+    });
+
+    it("returns least privileged level", () => {
+      expect(worstCaseLevel(InstructionLevel.SYSTEM, InstructionLevel.EXTERNAL_CONTENT)).toBe(
+        InstructionLevel.EXTERNAL_CONTENT,
+      );
+    });
+
+    it("handles multiple levels", () => {
+      expect(
+        worstCaseLevel(InstructionLevel.POLICY, InstructionLevel.TASK, InstructionLevel.USER),
+      ).toBe(InstructionLevel.USER);
+    });
+  });
+
+  describe("isUntrusted", () => {
+    it("returns true for EXTERNAL_CONTENT", () => {
+      expect(isUntrusted(InstructionLevel.EXTERNAL_CONTENT)).toBe(true);
+    });
+
+    it("returns false for all other levels", () => {
+      expect(isUntrusted(InstructionLevel.SYSTEM)).toBe(false);
+      expect(isUntrusted(InstructionLevel.POLICY)).toBe(false);
+      expect(isUntrusted(InstructionLevel.TASK)).toBe(false);
+      expect(isUntrusted(InstructionLevel.USER)).toBe(false);
+    });
+  });
+
+  describe("levelLabel", () => {
+    it("returns human-readable labels", () => {
+      expect(levelLabel(InstructionLevel.SYSTEM)).toBe("SYSTEM");
+      expect(levelLabel(InstructionLevel.POLICY)).toBe("POLICY");
+      expect(levelLabel(InstructionLevel.TASK)).toBe("TASK");
+      expect(levelLabel(InstructionLevel.USER)).toBe("USER");
+      expect(levelLabel(InstructionLevel.EXTERNAL_CONTENT)).toBe("EXTERNAL_CONTENT");
+    });
+
+    it("handles unknown levels gracefully", () => {
+      expect(levelLabel(99 as InstructionLevel)).toBe("UNKNOWN(99)");
+    });
+  });
+});

--- a/src/security/instruction-level.ts
+++ b/src/security/instruction-level.ts
@@ -1,0 +1,53 @@
+/**
+ * IBEL Phase 1 — Instruction level hierarchy utilities.
+ */
+
+import { InstructionLevel } from "./types.js";
+
+const LEVEL_LABELS: Record<InstructionLevel, string> = {
+  [InstructionLevel.SYSTEM]: "SYSTEM",
+  [InstructionLevel.POLICY]: "POLICY",
+  [InstructionLevel.TASK]: "TASK",
+  [InstructionLevel.USER]: "USER",
+  [InstructionLevel.EXTERNAL_CONTENT]: "EXTERNAL_CONTENT",
+};
+
+/**
+ * Returns true if `source` has equal or higher privilege than `target`
+ * (i.e. source can override target).
+ */
+export function canOverride(source: InstructionLevel, target: InstructionLevel): boolean {
+  return source <= target;
+}
+
+/**
+ * Returns the least-privileged (highest numeric value) level from the inputs.
+ * This is the conservative choice: when combining data from multiple sources,
+ * the result inherits the worst-case privilege.
+ */
+export function worstCaseLevel(...levels: InstructionLevel[]): InstructionLevel {
+  if (levels.length === 0) {
+    return InstructionLevel.SYSTEM;
+  }
+  let worst = levels[0];
+  for (let i = 1; i < levels.length; i++) {
+    if (levels[i] > worst) {
+      worst = levels[i];
+    }
+  }
+  return worst;
+}
+
+/**
+ * Returns true if the level represents untrusted external content.
+ */
+export function isUntrusted(level: InstructionLevel): boolean {
+  return level === InstructionLevel.EXTERNAL_CONTENT;
+}
+
+/**
+ * Returns a human-readable label for the given instruction level.
+ */
+export function levelLabel(level: InstructionLevel): string {
+  return LEVEL_LABELS[level] ?? `UNKNOWN(${level})`;
+}

--- a/src/security/taint-propagation.ts
+++ b/src/security/taint-propagation.ts
@@ -1,0 +1,43 @@
+/**
+ * IBEL Phase 1 — Taint derivation from multiple sources.
+ *
+ * When an artifact is constructed from multiple tagged payloads,
+ * the result inherits the worst-case taint across all sources.
+ */
+
+import { worstCaseLevel } from "./instruction-level.js";
+import { InstructionLevel } from "./types.js";
+import type { TaggedPayload, TaintField } from "./types.js";
+
+/**
+ * Derive a combined taint from multiple source payloads.
+ * Returns a TaggedPayload with:
+ * - level: worst-case across all sources
+ * - fields: merged (worst-case per field path), omitted if any source lacks fields
+ */
+export function deriveTaint(sources: TaggedPayload[]): TaggedPayload {
+  if (sources.length === 0) {
+    return { level: InstructionLevel.SYSTEM, content: undefined };
+  }
+
+  const level = worstCaseLevel(...sources.map((s) => s.level));
+
+  // If any source lacks field-level taint, we can't provide field granularity.
+  const allHaveFields = sources.every((s) => s.fields != null);
+
+  let fields: TaintField[] | undefined;
+  if (allHaveFields) {
+    const merged = new Map<string, TaintField>();
+    for (const source of sources) {
+      for (const field of source.fields!) {
+        const existing = merged.get(field.fieldPath);
+        if (!existing || field.level > existing.level) {
+          merged.set(field.fieldPath, { ...field });
+        }
+      }
+    }
+    fields = [...merged.values()];
+  }
+
+  return { level, content: undefined, fields };
+}

--- a/src/security/taint-tracker.test.ts
+++ b/src/security/taint-tracker.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { deriveTaint } from "./taint-propagation.js";
+import { TaintTracker } from "./taint-tracker.js";
+import { InstructionLevel } from "./types.js";
+
+describe("TaintTracker", () => {
+  describe("initial state", () => {
+    it("starts at SYSTEM level with no fields", () => {
+      const tracker = new TaintTracker();
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.SYSTEM);
+      expect(tracker.fieldCount()).toBe(0);
+      expect(tracker.isCollapsed()).toBe(false);
+    });
+  });
+
+  describe("tagField", () => {
+    it("tags a field and raises aggregate level", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("args.url", InstructionLevel.EXTERNAL_CONTENT, "web_fetch");
+
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(tracker.fieldCount()).toBe(1);
+
+      const field = tracker.getFieldTaint("args.url");
+      expect(field).toBeDefined();
+      expect(field!.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(field!.source).toBe("web_fetch");
+    });
+
+    it("keeps worse taint when re-tagging same field at lower privilege", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("data", InstructionLevel.EXTERNAL_CONTENT);
+      tracker.tagField("data", InstructionLevel.USER);
+
+      const field = tracker.getFieldTaint("data");
+      expect(field!.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+
+    it("upgrades taint when re-tagging same field at worse privilege", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("data", InstructionLevel.USER);
+      tracker.tagField("data", InstructionLevel.EXTERNAL_CONTENT);
+
+      const field = tracker.getFieldTaint("data");
+      expect(field!.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+
+    it("tracks multiple independent fields", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("a", InstructionLevel.USER);
+      tracker.tagField("b", InstructionLevel.TASK);
+      tracker.tagField("c", InstructionLevel.EXTERNAL_CONTENT);
+
+      expect(tracker.fieldCount()).toBe(3);
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+  });
+
+  describe("explosion threshold", () => {
+    it("auto-collapses when field count exceeds threshold", () => {
+      const tracker = new TaintTracker({ explosionThreshold: 5 });
+
+      for (let i = 0; i < 6; i++) {
+        tracker.tagField(`field_${i}`, InstructionLevel.USER);
+      }
+
+      expect(tracker.isCollapsed()).toBe(true);
+      expect(tracker.fieldCount()).toBe(0);
+      expect(tracker.getFields()).toEqual([]);
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.USER);
+    });
+
+    it("stops tracking new fields after collapse", () => {
+      const tracker = new TaintTracker({ explosionThreshold: 2 });
+      tracker.tagField("a", InstructionLevel.USER);
+      tracker.tagField("b", InstructionLevel.USER);
+      tracker.tagField("c", InstructionLevel.USER); // triggers collapse
+
+      expect(tracker.isCollapsed()).toBe(true);
+
+      // New tags still update aggregate level
+      tracker.tagField("d", InstructionLevel.EXTERNAL_CONTENT);
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(tracker.getFieldTaint("d")).toBeUndefined();
+    });
+  });
+
+  describe("tagArtifact", () => {
+    it("collapses and sets aggregate level", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("a", InstructionLevel.USER);
+      tracker.tagArtifact(InstructionLevel.EXTERNAL_CONTENT);
+
+      expect(tracker.isCollapsed()).toBe(true);
+      expect(tracker.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(tracker.fieldCount()).toBe(0);
+    });
+  });
+
+  describe("merge", () => {
+    it("merges fields from another tracker (worst-case per field)", () => {
+      const a = new TaintTracker();
+      a.tagField("x", InstructionLevel.USER);
+
+      const b = new TaintTracker();
+      b.tagField("x", InstructionLevel.EXTERNAL_CONTENT);
+      b.tagField("y", InstructionLevel.TASK);
+
+      a.merge(b);
+
+      expect(a.fieldCount()).toBe(2);
+      expect(a.getFieldTaint("x")!.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(a.getFieldTaint("y")!.level).toBe(InstructionLevel.TASK);
+      expect(a.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+
+    it("collapses when merging a collapsed tracker", () => {
+      const a = new TaintTracker();
+      a.tagField("x", InstructionLevel.USER);
+
+      const b = new TaintTracker();
+      b.tagArtifact(InstructionLevel.EXTERNAL_CONTENT);
+
+      a.merge(b);
+
+      expect(a.isCollapsed()).toBe(true);
+      expect(a.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+
+    it("triggers collapse when merged field count exceeds threshold", () => {
+      const a = new TaintTracker({ explosionThreshold: 4 });
+      a.tagField("a1", InstructionLevel.USER);
+      a.tagField("a2", InstructionLevel.USER);
+
+      const b = new TaintTracker();
+      b.tagField("b1", InstructionLevel.TASK);
+      b.tagField("b2", InstructionLevel.TASK);
+      b.tagField("b3", InstructionLevel.TASK);
+
+      a.merge(b);
+
+      expect(a.isCollapsed()).toBe(true);
+    });
+
+    it("is a no-op for fields when receiver is already collapsed", () => {
+      const a = new TaintTracker();
+      a.tagArtifact(InstructionLevel.USER);
+
+      const b = new TaintTracker();
+      b.tagField("x", InstructionLevel.EXTERNAL_CONTENT);
+
+      a.merge(b);
+
+      expect(a.isCollapsed()).toBe(true);
+      expect(a.getAggregateLevel()).toBe(InstructionLevel.EXTERNAL_CONTENT);
+    });
+  });
+
+  describe("toTaggedPayload", () => {
+    it("produces payload with fields when not collapsed", () => {
+      const tracker = new TaintTracker();
+      tracker.tagField("a", InstructionLevel.USER, "input");
+
+      const payload = tracker.toTaggedPayload("content", "test");
+
+      expect(payload.level).toBe(InstructionLevel.USER);
+      expect(payload.content).toBe("content");
+      expect(payload.source).toBe("test");
+      expect(payload.fields).toHaveLength(1);
+      expect(payload.fields![0].fieldPath).toBe("a");
+    });
+
+    it("omits fields when collapsed", () => {
+      const tracker = new TaintTracker();
+      tracker.tagArtifact(InstructionLevel.EXTERNAL_CONTENT);
+
+      const payload = tracker.toTaggedPayload({ data: 1 });
+
+      expect(payload.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+      expect(payload.fields).toBeUndefined();
+    });
+  });
+});
+
+describe("deriveTaint", () => {
+  it("returns SYSTEM for empty sources", () => {
+    const result = deriveTaint([]);
+    expect(result.level).toBe(InstructionLevel.SYSTEM);
+  });
+
+  it("returns worst-case level across sources", () => {
+    const result = deriveTaint([
+      { level: InstructionLevel.USER, content: "a" },
+      { level: InstructionLevel.EXTERNAL_CONTENT, content: "b" },
+    ]);
+    expect(result.level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+  });
+
+  it("merges fields from all sources (worst-case per path)", () => {
+    const result = deriveTaint([
+      {
+        level: InstructionLevel.USER,
+        content: "a",
+        fields: [{ fieldPath: "x", level: InstructionLevel.USER }],
+      },
+      {
+        level: InstructionLevel.EXTERNAL_CONTENT,
+        content: "b",
+        fields: [{ fieldPath: "x", level: InstructionLevel.EXTERNAL_CONTENT }],
+      },
+    ]);
+
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields![0].level).toBe(InstructionLevel.EXTERNAL_CONTENT);
+  });
+
+  it("omits fields when any source lacks field-level taint", () => {
+    const result = deriveTaint([
+      {
+        level: InstructionLevel.USER,
+        content: "a",
+        fields: [{ fieldPath: "x", level: InstructionLevel.USER }],
+      },
+      { level: InstructionLevel.EXTERNAL_CONTENT, content: "b" },
+    ]);
+
+    expect(result.fields).toBeUndefined();
+  });
+});

--- a/src/security/taint-tracker.ts
+++ b/src/security/taint-tracker.ts
@@ -1,0 +1,143 @@
+/**
+ * IBEL Phase 1 — Field-level taint tracking engine.
+ *
+ * Tracks which fields within an artifact are derived from untrusted sources.
+ * Auto-collapses to full-artifact taint when field count exceeds the explosion
+ * threshold (256 by default) to prevent unbounded memory growth in long sessions.
+ */
+
+import { InstructionLevel } from "./types.js";
+import type { TaggedPayload, TaintField } from "./types.js";
+
+const DEFAULT_EXPLOSION_THRESHOLD = 256;
+
+export class TaintTracker {
+  private fields = new Map<string, TaintField>();
+  private aggregateLevel: InstructionLevel = InstructionLevel.SYSTEM;
+  private collapsed = false;
+  private readonly explosionThreshold: number;
+
+  constructor(options?: { explosionThreshold?: number }) {
+    this.explosionThreshold = options?.explosionThreshold ?? DEFAULT_EXPLOSION_THRESHOLD;
+  }
+
+  /**
+   * Tag a single field with a taint level.
+   * If the tracker has already collapsed, this is a no-op for field tracking
+   * but still updates the aggregate level.
+   */
+  tagField(path: string, level: InstructionLevel, source?: string): void {
+    this.updateAggregate(level);
+
+    if (this.collapsed) {
+      return;
+    }
+
+    const existing = this.fields.get(path);
+    if (existing && existing.level >= level) {
+      // Existing taint is already worse or equal — keep it.
+      return;
+    }
+
+    this.fields.set(path, {
+      fieldPath: path,
+      level,
+      source,
+      taggedAt: Date.now(),
+    });
+
+    if (this.fields.size > this.explosionThreshold) {
+      this.collapse();
+    }
+  }
+
+  /**
+   * Collapse to full-artifact taint. All field-level tracking is discarded;
+   * the entire artifact is treated at the aggregate taint level.
+   */
+  tagArtifact(level: InstructionLevel): void {
+    this.updateAggregate(level);
+    this.collapse();
+  }
+
+  /**
+   * Merge another tracker into this one (worst-case per field).
+   */
+  merge(other: TaintTracker): void {
+    this.updateAggregate(other.aggregateLevel);
+
+    if (this.collapsed) {
+      return;
+    }
+
+    if (other.collapsed) {
+      this.collapse();
+      return;
+    }
+
+    for (const [path, field] of other.fields) {
+      const existing = this.fields.get(path);
+      if (!existing || field.level > existing.level) {
+        this.fields.set(path, { ...field });
+      }
+    }
+
+    if (this.fields.size > this.explosionThreshold) {
+      this.collapse();
+    }
+  }
+
+  /** Current worst-case taint level across all tracked fields. */
+  getAggregateLevel(): InstructionLevel {
+    return this.aggregateLevel;
+  }
+
+  /** Whether field-level tracking has been collapsed to artifact-level. */
+  isCollapsed(): boolean {
+    return this.collapsed;
+  }
+
+  /** Number of individually tracked fields (0 if collapsed). */
+  fieldCount(): number {
+    return this.collapsed ? 0 : this.fields.size;
+  }
+
+  /** Snapshot of all tracked fields (empty array if collapsed). */
+  getFields(): TaintField[] {
+    if (this.collapsed) {
+      return [];
+    }
+    return [...this.fields.values()];
+  }
+
+  /** Get taint for a specific field path, or undefined if not tracked. */
+  getFieldTaint(path: string): TaintField | undefined {
+    if (this.collapsed) {
+      return undefined;
+    }
+    return this.fields.get(path);
+  }
+
+  /**
+   * Create a TaggedPayload snapshot for pipeline consumption.
+   */
+  toTaggedPayload(content: unknown, source?: string): TaggedPayload {
+    return {
+      level: this.aggregateLevel,
+      content,
+      source,
+      fields: this.collapsed ? undefined : this.getFields(),
+    };
+  }
+
+  private updateAggregate(level: InstructionLevel): void {
+    if (level > this.aggregateLevel) {
+      this.aggregateLevel = level;
+    }
+  }
+
+  private collapse(): void {
+    this.collapsed = true;
+    this.fields.clear();
+  }
+}

--- a/src/security/tool-execution-guard.test.ts
+++ b/src/security/tool-execution-guard.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { TaintRiskGuard, CapabilityAllowlistGuard } from "./tool-execution-guard.js";
+import { InstructionLevel } from "./types.js";
+import type { ExecutionContext, ToolCall, ValidationResult } from "./types.js";
+
+function makeContext(level: InstructionLevel): ExecutionContext {
+  return { aggregateTaintLevel: level };
+}
+
+function makeCall(toolName: string): ToolCall {
+  return { toolName, arguments: {} };
+}
+
+async function validate(
+  guard: typeof TaintRiskGuard | typeof CapabilityAllowlistGuard,
+  call: ToolCall,
+  context: ExecutionContext,
+  toolMeta?: Parameters<typeof TaintRiskGuard.validate>[2],
+): Promise<ValidationResult> {
+  return await guard.validate(call, context, toolMeta);
+}
+
+describe("TaintRiskGuard", () => {
+  it("allows when taint level is not EXTERNAL_CONTENT", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("exec"),
+      makeContext(InstructionLevel.USER),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+
+  it("allows unknown tools even with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("unknown_tool"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+
+  it("escalates for critical tools with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("exec"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result.action).toBe("escalate");
+    if (result.action === "escalate") {
+      expect(result.hitlPayload.toolName).toBe("exec");
+      expect(result.hitlPayload.riskLevel).toBe("critical");
+      expect(result.timeoutMs).toBe(120_000);
+    }
+  });
+
+  it("uses toolMeta humanReadableSummary when available", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      { toolName: "exec", arguments: { command: "rm -rf /" } },
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+      {
+        name: "exec",
+        description: "Execute command",
+        riskLevel: "critical",
+        humanReadableSummary: (args) => `Run: ${String((args as Record<string, unknown>).command)}`,
+      },
+    );
+    if (result.action === "escalate") {
+      expect(result.hitlPayload.summary).toBe("Run: rm -rf /");
+    }
+  });
+
+  it("reprompts for high-risk tools with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("fs_write"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result.action).toBe("reprompt");
+    if (result.action === "reprompt") {
+      expect(result.reason).toContain("fs_write");
+      expect(result.agentInstruction).toContain("untrusted external source");
+    }
+  });
+
+  it("allows medium-risk tools with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("web_fetch"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+
+  it("allows low-risk tools with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      TaintRiskGuard,
+      makeCall("read"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+});
+
+describe("CapabilityAllowlistGuard", () => {
+  it("allows all tools when taint is not EXTERNAL_CONTENT", async () => {
+    const result = await validate(
+      CapabilityAllowlistGuard,
+      makeCall("exec"),
+      makeContext(InstructionLevel.USER),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+
+  it.each([
+    "exec",
+    "gateway",
+    "sessions_spawn",
+    "sessions_send",
+    "cron",
+    "whatsapp_login",
+    "fs_delete",
+    "fs_move",
+  ])("blocks '%s' with EXTERNAL_CONTENT taint", async (toolName) => {
+    const result = await validate(
+      CapabilityAllowlistGuard,
+      makeCall(toolName),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result.action).toBe("block");
+    if (result.action === "block") {
+      expect(result.reason).toContain(toolName);
+    }
+  });
+
+  it("allows non-blocked tools with EXTERNAL_CONTENT taint", async () => {
+    const result = await validate(
+      CapabilityAllowlistGuard,
+      makeCall("fs_read"),
+      makeContext(InstructionLevel.EXTERNAL_CONTENT),
+    );
+    expect(result).toEqual({ action: "allow" });
+  });
+});

--- a/src/security/tool-execution-guard.ts
+++ b/src/security/tool-execution-guard.ts
@@ -1,0 +1,110 @@
+/**
+ * IBEL Phase 1 — Built-in tool execution guards.
+ *
+ * TaintRiskGuard (priority 100):
+ *   - critical tool + EXTERNAL_CONTENT taint → escalate (HITL)
+ *   - high tool + EXTERNAL_CONTENT taint → reprompt
+ *   - everything else → allow
+ *
+ * CapabilityAllowlistGuard (priority 90):
+ *   - EXTERNAL_CONTENT cannot invoke dangerous tools → block
+ *   - everything else → allow
+ */
+
+import { isUntrusted, levelLabel } from "./instruction-level.js";
+import { getToolRiskLevel } from "./tool-risk-registry.js";
+import { InstructionLevel } from "./types.js";
+import type {
+  ExecutionContext,
+  OpenClawToolMetadata,
+  ToolCall,
+  ToolExecutionGuard,
+  ValidationResult,
+} from "./types.js";
+
+const DEFAULT_HITL_TIMEOUT_MS = 120_000;
+
+// ── TaintRiskGuard ───────────────────────────────────────────────────────────
+
+export const TaintRiskGuard: ToolExecutionGuard = {
+  name: "TaintRiskGuard",
+  priority: 100,
+
+  validate(
+    call: ToolCall,
+    context: ExecutionContext,
+    toolMeta?: OpenClawToolMetadata,
+  ): ValidationResult {
+    if (!isUntrusted(context.aggregateTaintLevel)) {
+      return { action: "allow" };
+    }
+
+    const riskLevel = toolMeta?.riskLevel ?? getToolRiskLevel(call.toolName);
+    if (!riskLevel) {
+      return { action: "allow" };
+    }
+
+    if (riskLevel === "critical") {
+      const summary = toolMeta?.humanReadableSummary
+        ? toolMeta.humanReadableSummary(call.arguments)
+        : `${call.toolName} (critical risk)`;
+      return {
+        action: "escalate",
+        timeoutMs: DEFAULT_HITL_TIMEOUT_MS,
+        hitlPayload: {
+          toolName: call.toolName,
+          summary,
+          riskLevel: "critical",
+        },
+      };
+    }
+
+    if (riskLevel === "high") {
+      return {
+        action: "reprompt",
+        agentInstruction:
+          `The tool "${call.toolName}" is high-risk and the current context includes ` +
+          `data from an untrusted external source (taint level: ${levelLabel(context.aggregateTaintLevel)}). ` +
+          `Explain this risk to the user and ask for explicit confirmation before proceeding.`,
+        reason: `High-risk tool "${call.toolName}" invoked with ${levelLabel(context.aggregateTaintLevel)} tainted data`,
+      };
+    }
+
+    return { action: "allow" };
+  },
+};
+
+// ── CapabilityAllowlistGuard ─────────────────────────────────────────────────
+
+const BLOCKED_FOR_EXTERNAL_CONTENT = new Set([
+  "exec",
+  "gateway",
+  "sessions_spawn",
+  "sessions_send",
+  "cron",
+  "whatsapp_login",
+  "fs_delete",
+  "fs_move",
+]);
+
+export const CapabilityAllowlistGuard: ToolExecutionGuard = {
+  name: "CapabilityAllowlistGuard",
+  priority: 90,
+
+  validate(call: ToolCall, context: ExecutionContext): ValidationResult {
+    if (!isUntrusted(context.aggregateTaintLevel)) {
+      return { action: "allow" };
+    }
+
+    if (BLOCKED_FOR_EXTERNAL_CONTENT.has(call.toolName)) {
+      return {
+        action: "block",
+        reason:
+          `Tool "${call.toolName}" is not available when the execution context ` +
+          `is tainted with ${levelLabel(context.aggregateTaintLevel)} data`,
+      };
+    }
+
+    return { action: "allow" };
+  },
+};

--- a/src/security/tool-risk-registry.test.ts
+++ b/src/security/tool-risk-registry.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getToolMetadata,
+  getToolRiskLevel,
+  registerToolMetadata,
+  resetToolRiskRegistry,
+} from "./tool-risk-registry.js";
+
+describe("tool-risk-registry", () => {
+  afterEach(() => {
+    resetToolRiskRegistry();
+  });
+
+  describe("getToolRiskLevel", () => {
+    it("returns correct defaults for known tools", () => {
+      expect(getToolRiskLevel("exec")).toBe("critical");
+      expect(getToolRiskLevel("gateway")).toBe("critical");
+      expect(getToolRiskLevel("sessions_spawn")).toBe("critical");
+      expect(getToolRiskLevel("fs_write")).toBe("high");
+      expect(getToolRiskLevel("fs_delete")).toBe("high");
+      expect(getToolRiskLevel("edit")).toBe("high");
+      expect(getToolRiskLevel("browser_navigate")).toBe("medium");
+      expect(getToolRiskLevel("web_fetch")).toBe("medium");
+      expect(getToolRiskLevel("fs_read")).toBe("low");
+      expect(getToolRiskLevel("read")).toBe("low");
+      expect(getToolRiskLevel("list")).toBe("low");
+    });
+
+    it("returns undefined for unknown tools", () => {
+      expect(getToolRiskLevel("custom_tool")).toBeUndefined();
+    });
+  });
+
+  describe("getToolMetadata", () => {
+    it("returns default metadata for known tools", () => {
+      const meta = getToolMetadata("exec");
+      expect(meta).toBeDefined();
+      expect(meta!.name).toBe("exec");
+      expect(meta!.riskLevel).toBe("critical");
+      expect(meta!.humanReadableSummary({ command: "ls -la" })).toBe("Execute command: ls -la");
+    });
+
+    it("returns undefined for unknown tools", () => {
+      expect(getToolMetadata("unknown_tool")).toBeUndefined();
+    });
+
+    it("generates summary for tools without explicit templates", () => {
+      const meta = getToolMetadata("memory_search");
+      expect(meta).toBeDefined();
+      expect(meta!.humanReadableSummary({ query: "test" })).toBe("memory_search(query)");
+    });
+  });
+
+  describe("registerToolMetadata", () => {
+    it("allows registering custom tool metadata", () => {
+      registerToolMetadata({
+        name: "custom_tool",
+        description: "A custom tool",
+        riskLevel: "high",
+        humanReadableSummary: (args) =>
+          `Custom: ${String((args as Record<string, unknown>).action)}`,
+      });
+
+      const meta = getToolMetadata("custom_tool");
+      expect(meta).toBeDefined();
+      expect(meta!.riskLevel).toBe("high");
+      expect(meta!.humanReadableSummary({ action: "test" })).toBe("Custom: test");
+    });
+
+    it("overrides defaults when registering known tool", () => {
+      registerToolMetadata({
+        name: "exec",
+        description: "Sandboxed exec",
+        riskLevel: "medium",
+        humanReadableSummary: () => "sandboxed",
+      });
+
+      expect(getToolRiskLevel("exec")).toBe("medium");
+      expect(getToolMetadata("exec")!.humanReadableSummary({})).toBe("sandboxed");
+    });
+  });
+
+  describe("default summary templates", () => {
+    it("exec handles missing command", () => {
+      const meta = getToolMetadata("exec")!;
+      expect(meta.humanReadableSummary({})).toBe("Execute command: unknown");
+    });
+
+    it("fs_write uses path or file arg", () => {
+      const meta = getToolMetadata("fs_write")!;
+      expect(meta.humanReadableSummary({ path: "/tmp/x" })).toBe("Write file: /tmp/x");
+      expect(meta.humanReadableSummary({ file: "/tmp/y" })).toBe("Write file: /tmp/y");
+    });
+
+    it("web_fetch uses url arg", () => {
+      const meta = getToolMetadata("web_fetch")!;
+      expect(meta.humanReadableSummary({ url: "https://evil.com" })).toBe(
+        "Fetch URL: https://evil.com",
+      );
+    });
+  });
+});

--- a/src/security/tool-risk-registry.ts
+++ b/src/security/tool-risk-registry.ts
@@ -1,0 +1,127 @@
+/**
+ * IBEL Phase 1 — Tool risk metadata registry.
+ *
+ * Maps tool names to risk classifications and human-readable summary templates.
+ * Ships with defaults for known OpenClaw tools; plugins can register additional
+ * metadata at boot time.
+ */
+
+import type { OpenClawToolMetadata, RiskLevel } from "./types.js";
+
+// ── Default Risk Classifications ─────────────────────────────────────────────
+
+const DEFAULT_RISK_MAP: Record<string, RiskLevel> = {
+  // Critical — remote code execution, control-plane actions
+  exec: "critical",
+  gateway: "critical",
+  sessions_spawn: "critical",
+  // High — file mutation, persistent automation, cross-session messaging
+  fs_write: "high",
+  fs_delete: "high",
+  fs_move: "high",
+  apply_patch: "high",
+  write: "high",
+  edit: "high",
+  cron: "high",
+  sessions_send: "high",
+  // Medium — network access with side effects
+  browser_navigate: "medium",
+  web_fetch: "medium",
+  // Low — read-only
+  fs_read: "low",
+  read: "low",
+  list: "low",
+  memory_search: "low",
+};
+
+// ── Default Human-Readable Summary Templates ─────────────────────────────────
+
+type SummaryFn = (args: unknown) => string;
+
+function arg(args: unknown, key: string): unknown {
+  if (args && typeof args === "object") {
+    return (args as Record<string, unknown>)[key];
+  }
+  return undefined;
+}
+
+function argKeys(args: unknown): string[] {
+  if (args && typeof args === "object") {
+    return Object.keys(args as Record<string, unknown>);
+  }
+  return [];
+}
+
+const DEFAULT_SUMMARIES: Record<string, SummaryFn> = {
+  exec: (args) => `Execute command: ${String(arg(args, "command") ?? "unknown")}`,
+  gateway: (args) => `Gateway operation: ${String(arg(args, "action") ?? "unknown")}`,
+  sessions_spawn: (args) => `Spawn session: ${String(arg(args, "agentId") ?? "unknown")}`,
+  fs_write: (args) => `Write file: ${String(arg(args, "path") ?? arg(args, "file") ?? "unknown")}`,
+  fs_delete: (args) => `Delete: ${String(arg(args, "path") ?? arg(args, "file") ?? "unknown")}`,
+  fs_move: (args) =>
+    `Move ${String(arg(args, "source") ?? "unknown")} → ${String(arg(args, "destination") ?? "unknown")}`,
+  apply_patch: (args) =>
+    `Apply patch to: ${String(arg(args, "path") ?? arg(args, "file") ?? "unknown")}`,
+  write: (args) =>
+    `Write file: ${String(arg(args, "file_path") ?? arg(args, "path") ?? "unknown")}`,
+  edit: (args) => `Edit file: ${String(arg(args, "file_path") ?? arg(args, "path") ?? "unknown")}`,
+  cron: (args) => `Cron operation: ${String(arg(args, "action") ?? "unknown")}`,
+  sessions_send: (args) => `Send to session: ${String(arg(args, "sessionId") ?? "unknown")}`,
+  browser_navigate: (args) => `Navigate to: ${String(arg(args, "url") ?? "unknown")}`,
+  web_fetch: (args) => `Fetch URL: ${String(arg(args, "url") ?? "unknown")}`,
+};
+
+function defaultSummary(name: string): SummaryFn {
+  return (args) => `${name}(${argKeys(args).join(", ")})`;
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+
+const registry = new Map<string, OpenClawToolMetadata>();
+
+/**
+ * Register or update risk metadata for a tool.
+ */
+export function registerToolMetadata(meta: OpenClawToolMetadata): void {
+  registry.set(meta.name, meta);
+}
+
+/**
+ * Get full metadata for a tool. Falls back to defaults for known tools.
+ */
+export function getToolMetadata(toolName: string): OpenClawToolMetadata | undefined {
+  const explicit = registry.get(toolName);
+  if (explicit) {
+    return explicit;
+  }
+
+  const riskLevel = DEFAULT_RISK_MAP[toolName];
+  if (riskLevel) {
+    return {
+      name: toolName,
+      description: toolName,
+      riskLevel,
+      humanReadableSummary: DEFAULT_SUMMARIES[toolName] ?? defaultSummary(toolName),
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Get the risk level for a tool. Returns undefined for unknown tools.
+ */
+export function getToolRiskLevel(toolName: string): RiskLevel | undefined {
+  const meta = registry.get(toolName);
+  if (meta) {
+    return meta.riskLevel;
+  }
+  return DEFAULT_RISK_MAP[toolName];
+}
+
+/**
+ * Reset the registry to defaults only. Primarily for testing.
+ */
+export function resetToolRiskRegistry(): void {
+  registry.clear();
+}

--- a/src/security/tool-risk-registry.ts
+++ b/src/security/tool-risk-registry.ts
@@ -15,6 +15,7 @@ const DEFAULT_RISK_MAP: Record<string, RiskLevel> = {
   exec: "critical",
   gateway: "critical",
   sessions_spawn: "critical",
+  whatsapp_login: "critical",
   // High — file mutation, persistent automation, cross-session messaging
   fs_write: "high",
   fs_delete: "high",
@@ -56,6 +57,7 @@ const DEFAULT_SUMMARIES: Record<string, SummaryFn> = {
   exec: (args) => `Execute command: ${String(arg(args, "command") ?? "unknown")}`,
   gateway: (args) => `Gateway operation: ${String(arg(args, "action") ?? "unknown")}`,
   sessions_spawn: (args) => `Spawn session: ${String(arg(args, "agentId") ?? "unknown")}`,
+  whatsapp_login: () => "WhatsApp login operation",
   fs_write: (args) => `Write file: ${String(arg(args, "path") ?? arg(args, "file") ?? "unknown")}`,
   fs_delete: (args) => `Delete: ${String(arg(args, "path") ?? arg(args, "file") ?? "unknown")}`,
   fs_move: (args) =>

--- a/src/security/types.ts
+++ b/src/security/types.ts
@@ -1,0 +1,160 @@
+/**
+ * IBEL Phase 1 — Shared type definitions.
+ *
+ * Leaf module with no internal dependencies. All IBEL modules import from here.
+ */
+
+// ── Instruction Level Hierarchy ──────────────────────────────────────────────
+
+/**
+ * Privilege levels for instruction sources.
+ * Lower numeric value = higher privilege. A lower-privilege instruction
+ * cannot override a higher-privilege one.
+ */
+export enum InstructionLevel {
+  /** Framework internals, immutable at runtime. */
+  SYSTEM = 0,
+  /** Operator-defined governance rules. */
+  POLICY = 1,
+  /** Current task definition and constraints. */
+  TASK = 2,
+  /** End-user messages. */
+  USER = 3,
+  /** RAG results, tool outputs, scraped data. */
+  EXTERNAL_CONTENT = 4,
+}
+
+// ── Taint Tracking ───────────────────────────────────────────────────────────
+
+/** A single tainted field within an artifact. */
+export type TaintField = {
+  /** Dot-delimited path to the field (e.g. "args.url"). */
+  fieldPath: string;
+  /** Privilege level of the data that populated this field. */
+  level: InstructionLevel;
+  /** Optional provenance label (e.g. "web_fetch", "email"). */
+  source?: string;
+  /** Timestamp when the taint was applied. */
+  taggedAt?: number;
+};
+
+/**
+ * A content payload tagged with privilege metadata.
+ * Produced by TaintTracker.toTaggedPayload() or tagExternalContent().
+ */
+export type TaggedPayload = {
+  /** Worst-case privilege level across all fields. */
+  level: InstructionLevel;
+  /** The content (string, object, etc.). */
+  content: unknown;
+  /** Provenance label. */
+  source?: string;
+  /** Per-field taint when field-level tracking is active. */
+  fields?: TaintField[];
+  /** Arbitrary metadata for guards/telemetry. */
+  metadata?: Record<string, unknown>;
+};
+
+// ── Tool Risk ────────────────────────────────────────────────────────────────
+
+export type RiskLevel = "low" | "medium" | "high" | "critical";
+
+/** Risk metadata for a registered tool. */
+export type OpenClawToolMetadata<T = unknown> = {
+  name: string;
+  description: string;
+  riskLevel: RiskLevel;
+  /**
+   * Translates raw arguments into plain English for HITL approval UIs.
+   * Example: (args) => `Execute command: ${args.command}`
+   *
+   * SECURITY: Templates must be static/pre-validated — never interpolate
+   * tainted arguments directly (second-order injection vector).
+   */
+  humanReadableSummary: (args: T) => string;
+};
+
+// ── Execution Context ────────────────────────────────────────────────────────
+
+/**
+ * Security context passed to guards during tool validation.
+ * Bridges taint tracking into the guard pipeline.
+ */
+export type ExecutionContext = {
+  /** Current task identifier (e.g. job name). */
+  activeTask?: string;
+  /** Session role (e.g. "owner", "api"). */
+  sessionRole?: string;
+  /**
+   * Worst-case privilege level across all data used to construct this tool call.
+   * Defaults to SYSTEM when no taint tracker is attached (backward compat).
+   */
+  aggregateTaintLevel: InstructionLevel;
+  /** Agent identifier. */
+  agentId?: string;
+  /** Session key for correlation. */
+  sessionKey?: string;
+  /** Whether the sender is the session owner. */
+  senderIsOwner?: boolean;
+  /** Access per-field taint when granularity is needed. */
+  fieldTaint?: () => TaintField[];
+};
+
+// ── Tool Call ────────────────────────────────────────────────────────────────
+
+/** Represents a tool invocation to be validated by the guard pipeline. */
+export type ToolCall = {
+  toolName: string;
+  arguments: Record<string, unknown>;
+  toolCallId?: string;
+};
+
+// ── Validation Results ───────────────────────────────────────────────────────
+
+export type AllowResult = { action: "allow" };
+
+export type BlockResult = {
+  action: "block";
+  reason: string;
+};
+
+export type RepromptResult = {
+  action: "reprompt";
+  /**
+   * Instruction injected into the agent's context to guide recovery.
+   * MUST be static/template-safe — never interpolate tainted arguments.
+   */
+  agentInstruction: string;
+  reason: string;
+};
+
+export type EscalateResult = {
+  action: "escalate";
+  requiredRole?: string;
+  timeoutMs: number;
+  hitlPayload: {
+    toolName: string;
+    summary: string;
+    riskLevel: RiskLevel;
+  };
+};
+
+export type ValidationResult = AllowResult | BlockResult | RepromptResult | EscalateResult;
+
+// ── Guard Interface ──────────────────────────────────────────────────────────
+
+/**
+ * A guard that validates tool calls before execution.
+ * Guards run in priority order (highest first); the pipeline short-circuits
+ * on the first non-allow result.
+ */
+export type ToolExecutionGuard = {
+  readonly name: string;
+  /** Higher priority = runs first. */
+  readonly priority: number;
+  validate(
+    call: ToolCall,
+    context: ExecutionContext,
+    toolMeta?: OpenClawToolMetadata,
+  ): ValidationResult | Promise<ValidationResult>;
+};


### PR DESCRIPTION
## Summary

- Introduces formal privilege separation for agent security via an Instruction Boundary Enforcement Layer (IBEL)
- Adds instruction level hierarchy, taint tracking, guard pipeline, tool execution guards, and HITL escalation
- Wires the guard pipeline into the existing `beforeToolCall` hook, gateway startup, and plugin API

RFC discussion: #27770

## Details

**Core primitives** (`src/security/`):
- `InstructionLevel` enum (SYSTEM > POLICY > TASK > USER > EXTERNAL_CONTENT) with enforcement rules
- Taint tracker with per-field provenance and propagation logic
- Execution context builder for guard decision-making
- Composable guard pipeline with priority-ordered validation
- Tool risk registry with intrinsic risk levels
- Built-in guards: `TaintRiskGuard`, `CapabilityAllowlistGuard`
- HITL escalation handler with fail-closed timeout semantics

**Integration points**:
- `beforeToolCall` runs the guard pipeline before plugin hooks (block, reprompt, or escalate)
- Gateway startup registers default guards
- Plugin API exposes `registerGuard()` for extension-provided guards
- `tagExternalContent()` complements existing `wrapExternalContent()` with privilege metadata
- `AnyAgentTool` extended with optional `riskLevel` and `humanReadableSummary`

**Design**:
- Opt-in by default — zero-config baseline, no-op when no guards are registered
- Modular — each component is independent and testable
- Fail-open on pipeline errors (logged warning, does not block tool execution)

## Test plan

- [x] Unit tests for all new modules (instruction level, taint tracker, execution context, guard pipeline, tool risk registry, tool execution guard, HITL escalation)
- [x] Integration test covering end-to-end guard pipeline flow (`ibel-integration.test.ts`)
- [ ] Run full test suite (`pnpm test`)
- [ ] Verify build (`pnpm build`)
- [ ] Manual validation with a real gateway session