### PR TITLE
feat(memory): add structural memory load policy enforcement (v1.1)

### DIFF
--- a/governance/memory_load_policy_active.json
+++ b/governance/memory_load_policy_active.json
@@ -1,0 +1,6 @@
+{
+  "activePolicyPath": "governance/memory_load_policy_v1_1.json",
+  "version": "v1.1",
+  "enforce": false,
+  "reportOnly": true
+}

--- a/governance/memory_load_policy_active.json
+++ b/governance/memory_load_policy_active.json
@@ -1,6 +1,6 @@
 {
   "activePolicyPath": "governance/memory_load_policy_v1_1.json",
   "version": "v1.1",
-  "enforce": false,
-  "reportOnly": true
+  "enforce": true,
+  "reportOnly": false
 }

--- a/governance/memory_load_policy_v1_1.json
+++ b/governance/memory_load_policy_v1_1.json
@@ -1,0 +1,11 @@
+{
+  "version": "v1.1",
+  "entrypoint": "MEMORY.md",
+  "topicAllowlist": ["MEMORY.md", "memory/topics/*.md", "memory/*.md"],
+  "deepAllowlist": ["memory/mission_log.md", "memory/runbook.md", "memory/**/*.md"],
+  "hardDenies": ["**/.env*", "**/secrets/**"],
+  "escalation": {
+    "minConfidence": 0.6,
+    "missSignalThreshold": 1
+  }
+}

--- a/src/agents/pi-embedded-runner/memory-context-policy-guard.ts
+++ b/src/agents/pi-embedded-runner/memory-context-policy-guard.ts
@@ -1,0 +1,123 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import {
+  appendMemoryLoadTelemetry,
+  buildTelemetryRecord,
+  enforceMemoryLoadPolicy,
+  resolveMemoryLoadPolicy,
+} from "../tools/memory-load-policy.js";
+
+function extractText(msg: AgentMessage): string {
+  const m = msg as { content?: unknown };
+  if (typeof m.content === "string") {
+    return m.content;
+  }
+  if (!Array.isArray(m.content)) {
+    return "";
+  }
+  const chunks: string[] = [];
+  for (const block of m.content) {
+    if (block && typeof block === "object" && (block as { type?: unknown }).type === "text") {
+      const t = (block as { text?: unknown }).text;
+      if (typeof t === "string") {
+        chunks.push(t);
+      }
+    }
+  }
+  return chunks.join("\n");
+}
+
+function replaceText(msg: AgentMessage, text: string): AgentMessage {
+  const source = msg as Record<string, unknown>;
+  return {
+    ...source,
+    content: [{ type: "text", text }],
+  } as AgentMessage;
+}
+
+function extractCandidatePathsFromToolResultText(text: string): string[] {
+  const out = new Set<string>();
+  const pathRegex = /"path"\s*:\s*"([^"]+)"/g;
+  const citationRegex = /\b(memory\/[\w./-]+\.md|MEMORY\.md)\b/g;
+
+  let m: RegExpExecArray | null;
+  while ((m = pathRegex.exec(text)) !== null) {
+    if (m[1]) {
+      out.add(m[1]);
+    }
+  }
+  while ((m = citationRegex.exec(text)) !== null) {
+    if (m[1]) {
+      out.add(m[1]);
+    }
+  }
+  return [...out];
+}
+
+function isMemoryToolResult(msg: AgentMessage): boolean {
+  const anyMsg = msg as { role?: unknown; type?: unknown; toolName?: unknown };
+  const roleOk =
+    anyMsg.role === "toolResult" || anyMsg.role === "tool" || anyMsg.type === "toolResult";
+  const name = typeof anyMsg.toolName === "string" ? anyMsg.toolName : "";
+  return roleOk && (name === "memory_search" || name === "memory_get");
+}
+
+export async function sanitizeMemoryToolResultsByPolicy(params: {
+  messages: AgentMessage[];
+  sessionKey?: string;
+  taskId?: string;
+}): Promise<AgentMessage[]> {
+  if (!Array.isArray(params.messages) || params.messages.length === 0) {
+    return params.messages;
+  }
+
+  const runtime = await resolveMemoryLoadPolicy();
+  const out: AgentMessage[] = [];
+
+  for (const msg of params.messages) {
+    if (!isMemoryToolResult(msg)) {
+      out.push(msg);
+      continue;
+    }
+
+    const text = extractText(msg);
+    const candidatePaths = extractCandidatePathsFromToolResultText(text);
+    if (candidatePaths.length === 0) {
+      out.push(msg);
+      continue;
+    }
+
+    const decision = enforceMemoryLoadPolicy({
+      query: "pre_prompt_memory_context_guard",
+      candidatePaths,
+      confidence: 1,
+      missSignals: 0,
+      policy: runtime.policy,
+      mode: runtime.mode,
+    });
+
+    const denied = decision.deniedPaths.map((d) => d.path);
+    if (runtime.mode.enforce && denied.length > 0) {
+      const redacted = replaceText(
+        msg,
+        `[policy] memory snippet dropped by ${runtime.policy.version}; denied paths: ${denied.join(", ")}`,
+      );
+      out.push(redacted);
+      await appendMemoryLoadTelemetry(
+        buildTelemetryRecord({
+          sessionKey: params.sessionKey,
+          taskId: params.taskId,
+          policyVersion: runtime.policy.version,
+          query: "pre_prompt_memory_context_guard",
+          candidatePaths,
+          decision,
+          violationCode: "MEMORY_CONTEXT_POLICY_DROP",
+        }),
+      );
+      continue;
+    }
+
+    out.push(msg);
+  }
+
+  return out;
+}

--- a/src/agents/pi-embedded-runner/memory-context-policy-guard.ts
+++ b/src/agents/pi-embedded-runner/memory-context-policy-guard.ts
@@ -27,9 +27,11 @@ function extractText(msg: AgentMessage): string {
 }
 
 function replaceText(msg: AgentMessage, text: string): AgentMessage {
-  const source = msg as Record<string, unknown>;
+  if (typeof msg !== "object" || msg === null) {
+    return msg;
+  }
   return {
-    ...source,
+    ...msg,
     content: [{ type: "text", text }],
   } as AgentMessage;
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -87,6 +87,7 @@ import {
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
+import { sanitizeMemoryToolResultsByPolicy } from "../memory-context-policy-guard.js";
 import { buildModelAliasLines } from "../model.js";
 import {
   clearActiveEmbeddedRun,
@@ -881,9 +882,14 @@ export async function runEmbeddedAttempt(
         const limited = transcriptPolicy.repairToolUseResultPairing
           ? sanitizeToolUseResultPairing(truncated)
           : truncated;
-        cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0) {
-          activeSession.agent.replaceMessages(limited);
+        const memoryPolicySanitized = await sanitizeMemoryToolResultsByPolicy({
+          messages: limited,
+          sessionKey: params.sessionKey,
+          taskId: params.runId,
+        });
+        cacheTrace?.recordStage("session:limited", { messages: memoryPolicySanitized });
+        if (memoryPolicySanitized.length > 0) {
+          activeSession.agent.replaceMessages(memoryPolicySanitized);
         }
       } catch (err) {
         await flushPendingToolResultsAfterIdle({

--- a/src/agents/tools/memory-load-policy.enforcement.test.ts
+++ b/src/agents/tools/memory-load-policy.enforcement.test.ts
@@ -1,0 +1,254 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetMemoryToolMockState,
+  setMemoryReadFileImpl,
+} from "../../../test/helpers/memory-tool-manager-mock.js";
+import { resolveMemoryLoadPolicy } from "./memory-load-policy.js";
+import { createMemoryGetTool, createMemorySearchTool } from "./memory-tool.js";
+
+const ENV_KEYS = [
+  "OPENCLAW_MEMORY_POLICY_POINTER_PATH",
+  "OPENCLAW_MEMORY_POLICY_PATH",
+  "OPENCLAW_MEMORY_POLICY_ENFORCE",
+  "OPENCLAW_MEMORY_POLICY_REPORT_ONLY",
+] as const;
+
+async function mkTmpDir() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "oc-memory-policy-"));
+}
+
+function restoreEnv(snapshot: Record<string, string | undefined>) {
+  for (const k of ENV_KEYS) {
+    const v = snapshot[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+}
+
+describe("memory load policy structural enforcement", () => {
+  let envSnapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    envSnapshot = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    resetMemoryToolMockState();
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    vi.clearAllMocks();
+  });
+
+  it("policy file missing test: fail-closed blocks deep reads", async () => {
+    const tmp = await mkTmpDir();
+    process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH = path.join(tmp, "missing-pointer.json");
+
+    const readSpy = vi.fn(async (params: { relPath: string }) => ({
+      text: `read ${params.relPath}`,
+      path: params.relPath,
+    }));
+    setMemoryReadFileImpl(readSpy);
+
+    const tool = createMemoryGetTool({
+      config: { agents: { list: [{ id: "main", default: true }] } },
+    });
+    if (!tool) {
+      throw new Error("memory_get tool missing");
+    }
+
+    const result = await tool.execute("test-missing", {
+      path: "memory/mission_log.md",
+      from: 1,
+      lines: 10,
+    });
+
+    expect(result.details?.disabled).toBe(true);
+    expect(String(result.details?.error || "")).toContain("blocked by policy");
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("deep-read blocked test: enforce mode denies out-of-scope deep file", async () => {
+    const tmp = await mkTmpDir();
+    const policyPath = path.join(tmp, "policy.json");
+    const pointerPath = path.join(tmp, "pointer.json");
+
+    await fs.writeFile(
+      policyPath,
+      JSON.stringify({
+        version: "v1.1-test",
+        entrypoint: "MEMORY.md",
+        topicAllowlist: ["MEMORY.md", "memory/topics/*.md"],
+        deepAllowlist: [],
+        hardDenies: [],
+        escalation: { minConfidence: 0.6, missSignalThreshold: 1 },
+      }),
+    );
+    await fs.writeFile(
+      pointerPath,
+      JSON.stringify({
+        activePolicyPath: policyPath,
+        version: "v1.1-test",
+        enforce: true,
+        reportOnly: false,
+      }),
+    );
+
+    process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH = pointerPath;
+
+    const readSpy = vi.fn(async (params: { relPath: string }) => ({
+      text: `read ${params.relPath}`,
+      path: params.relPath,
+    }));
+    setMemoryReadFileImpl(readSpy);
+
+    const tool = createMemoryGetTool({
+      config: { agents: { list: [{ id: "main", default: true }] } },
+    });
+    if (!tool) {
+      throw new Error("memory_get tool missing");
+    }
+
+    const result = await tool.execute("test-deep-block", {
+      path: "memory/runbook.md",
+    });
+
+    expect(result.details?.disabled).toBe(true);
+    expect(String(result.details?.error || "")).toContain("blocked by policy");
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("allowed entrypoint read emits PASS telemetry", async () => {
+    const tmp = await mkTmpDir();
+    process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH = path.join(tmp, "missing-pointer.json");
+
+    const tool = createMemoryGetTool({
+      config: { agents: { list: [{ id: "main", default: true }] } },
+    });
+    if (!tool) {
+      throw new Error("memory_get tool missing");
+    }
+
+    const result = await tool.execute("test-entrypoint-pass", {
+      path: "MEMORY.md",
+    });
+
+    expect(result.details?.disabled).not.toBe(true);
+  });
+
+  it("memory_search filters denied paths and emits telemetry", async () => {
+    const tmp = await mkTmpDir();
+    const policyPath = path.join(tmp, "policy.json");
+    const pointerPath = path.join(tmp, "pointer.json");
+
+    await fs.writeFile(
+      policyPath,
+      JSON.stringify({
+        version: "v1.1-search",
+        entrypoint: "MEMORY.md",
+        topicAllowlist: ["MEMORY.md", "memory/topics/*.md"],
+        deepAllowlist: ["memory/mission_log.md"],
+        hardDenies: [],
+        escalation: { minConfidence: 0.6, missSignalThreshold: 1 },
+      }),
+    );
+    await fs.writeFile(
+      pointerPath,
+      JSON.stringify({
+        activePolicyPath: policyPath,
+        version: "v1.1-search",
+        enforce: true,
+        reportOnly: false,
+      }),
+    );
+
+    process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH = pointerPath;
+
+    resetMemoryToolMockState({
+      searchImpl: async () => [
+        {
+          path: "memory/topics/governance.md",
+          startLine: 1,
+          endLine: 3,
+          score: 0.9,
+          snippet: "ok",
+          source: "memory",
+        },
+        {
+          path: "memory/private.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.5,
+          snippet: "deny",
+          source: "memory",
+        },
+      ],
+    });
+
+    const tool = createMemorySearchTool({
+      config: { agents: { list: [{ id: "main", default: true }] } },
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+
+    const result = await tool.execute("test-search", { query: "governance" });
+    const rows = Array.isArray(result.details?.results) ? result.details?.results : [];
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.path).toBe("memory/topics/governance.md");
+  });
+
+  it("rollback pointer flip test: flip policy pointer and restore", async () => {
+    const tmp = await mkTmpDir();
+    const policyA = path.join(tmp, "policyA.json");
+    const policyB = path.join(tmp, "policyB.json");
+    const pointer = path.join(tmp, "pointer.json");
+
+    await fs.writeFile(policyA, JSON.stringify({ version: "v1.1-A" }));
+    await fs.writeFile(policyB, JSON.stringify({ version: "v1.1-B" }));
+
+    await fs.writeFile(
+      pointer,
+      JSON.stringify({
+        activePolicyPath: policyA,
+        version: "v1.1-A",
+        enforce: false,
+        reportOnly: true,
+      }),
+    );
+
+    process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH = pointer;
+
+    const first = await resolveMemoryLoadPolicy({ cwd: tmp });
+    expect(first.policy.version).toBe("v1.1-A");
+
+    await fs.writeFile(
+      pointer,
+      JSON.stringify({
+        activePolicyPath: policyB,
+        version: "v1.1-B",
+        enforce: false,
+        reportOnly: true,
+      }),
+    );
+    const second = await resolveMemoryLoadPolicy({ cwd: tmp });
+    expect(second.policy.version).toBe("v1.1-B");
+
+    // restore pointer (rollback)
+    await fs.writeFile(
+      pointer,
+      JSON.stringify({
+        activePolicyPath: policyA,
+        version: "v1.1-A",
+        enforce: false,
+        reportOnly: true,
+      }),
+    );
+    const restored = await resolveMemoryLoadPolicy({ cwd: tmp });
+    expect(restored.policy.version).toBe("v1.1-A");
+  });
+});

--- a/src/agents/tools/memory-load-policy.enforcement.test.ts
+++ b/src/agents/tools/memory-load-policy.enforcement.test.ts
@@ -6,6 +6,7 @@ import {
   resetMemoryToolMockState,
   setMemoryReadFileImpl,
 } from "../../../test/helpers/memory-tool-manager-mock.js";
+import type { MemoryPolicyResult } from "./memory-load-policy.js";
 import { resolveMemoryLoadPolicy } from "./memory-load-policy.js";
 import { createMemoryGetTool, createMemorySearchTool } from "./memory-tool.js";
 
@@ -29,6 +30,13 @@ function restoreEnv(snapshot: Record<string, string | undefined>) {
       process.env[k] = v;
     }
   }
+}
+
+function detailsAsPolicyResult(value: unknown): MemoryPolicyResult {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  return value as MemoryPolicyResult;
 }
 
 describe("memory load policy structural enforcement", () => {
@@ -67,8 +75,9 @@ describe("memory load policy structural enforcement", () => {
       lines: 10,
     });
 
-    expect(result.details?.disabled).toBe(true);
-    expect(String(result.details?.error || "")).toContain("blocked by policy");
+    const details = detailsAsPolicyResult(result.details);
+    expect(details.disabled).toBe(true);
+    expect(String(details.error || "")).toContain("blocked by policy");
     expect(readSpy).not.toHaveBeenCalled();
   });
 
@@ -117,8 +126,9 @@ describe("memory load policy structural enforcement", () => {
       path: "memory/runbook.md",
     });
 
-    expect(result.details?.disabled).toBe(true);
-    expect(String(result.details?.error || "")).toContain("blocked by policy");
+    const details = detailsAsPolicyResult(result.details);
+    expect(details.disabled).toBe(true);
+    expect(String(details.error || "")).toContain("blocked by policy");
     expect(readSpy).not.toHaveBeenCalled();
   });
 
@@ -137,7 +147,8 @@ describe("memory load policy structural enforcement", () => {
       path: "MEMORY.md",
     });
 
-    expect(result.details?.disabled).not.toBe(true);
+    const details = detailsAsPolicyResult(result.details);
+    expect(details.disabled).not.toBe(true);
   });
 
   it("memory_search filters denied paths and emits telemetry", async () => {
@@ -197,9 +208,10 @@ describe("memory load policy structural enforcement", () => {
     }
 
     const result = await tool.execute("test-search", { query: "governance" });
-    const rows = Array.isArray(result.details?.results) ? result.details?.results : [];
+    const details = detailsAsPolicyResult(result.details);
+    const rows = Array.isArray(details.results) ? details.results : [];
     expect(rows.length).toBe(1);
-    expect(rows[0]?.path).toBe("memory/topics/governance.md");
+    expect((rows[0] as { path?: string } | undefined)?.path).toBe("memory/topics/governance.md");
   });
 
   it("rollback pointer flip test: flip policy pointer and restore", async () => {

--- a/src/agents/tools/memory-load-policy.ts
+++ b/src/agents/tools/memory-load-policy.ts
@@ -1,0 +1,282 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type MemoryLoadPolicyConfig = {
+  version: string;
+  entrypoint: string;
+  topicAllowlist: string[];
+  deepAllowlist: string[];
+  hardDenies: string[];
+  escalation: {
+    minConfidence: number;
+    missSignalThreshold: number;
+  };
+};
+
+export type MemoryLoadRuntimeMode = {
+  enforce: boolean;
+  reportOnly: boolean;
+};
+
+export type MemoryLoadDecision = {
+  allowedPaths: string[];
+  deniedPaths: Array<{ path: string; reason: string }>;
+  escalated: boolean;
+  escalationReason?: string;
+  violation?: string;
+  mode: MemoryLoadRuntimeMode;
+  policyVersion: string;
+};
+
+export type MemoryTelemetryRecord = {
+  ts: string;
+  sessionKey?: string;
+  taskId?: string;
+  policyVersion: string;
+  queryClass: string;
+  entrypointLoaded: boolean;
+  filesConsidered: number;
+  topicFilesLoaded: string[];
+  deepFilesLoaded: string[];
+  deniedPaths: string[];
+  escalated: boolean;
+  escalationReason?: string;
+  recallConfidence: number;
+  missSignals: number;
+  promptTokensEst?: number;
+  policyViolation: boolean;
+  policyViolationCode?: string;
+  outcome: "PASS" | "BLOCK";
+};
+
+type PolicyPointer = {
+  activePolicyPath?: string;
+  version?: string;
+  enforce?: boolean;
+  reportOnly?: boolean;
+};
+
+const DEFAULT_POLICY: MemoryLoadPolicyConfig = {
+  version: "v1.1",
+  entrypoint: "MEMORY.md",
+  topicAllowlist: ["memory/topics/*.md", "memory/*.md", "MEMORY.md"],
+  deepAllowlist: ["memory/mission_log.md", "memory/runbook.md", "memory/**/*.md"],
+  hardDenies: ["**/.env*", "**/secrets/**"],
+  escalation: {
+    minConfidence: 0.6,
+    missSignalThreshold: 1,
+  },
+};
+
+function toPosix(relPath: string): string {
+  return relPath.replaceAll("\\", "/").replace(/^\/+/, "");
+}
+
+function wildcardToRegExp(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DOUBLE_STAR::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DOUBLE_STAR::/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesAny(relPath: string, patterns: string[]): boolean {
+  const normalized = toPosix(relPath);
+  return patterns.some((p) => wildcardToRegExp(toPosix(p)).test(normalized));
+}
+
+function classifyQuery(query: string): string {
+  const q = query.toLowerCase();
+  if (q.includes("govern") || q.includes("policy")) {
+    return "governance";
+  }
+  if (q.includes("revenue") || q.includes("monet")) {
+    return "monetization";
+  }
+  if (q.includes("pipeline") || q.includes("release")) {
+    return "pipelines";
+  }
+  if (q.includes("reliab") || q.includes("incident")) {
+    return "reliability";
+  }
+  return "general";
+}
+
+function isEntrypoint(relPath: string, entrypoint: string): boolean {
+  const p = toPosix(relPath).toLowerCase();
+  const e = toPosix(entrypoint).toLowerCase();
+  return p === e || p === `memory/${e}`;
+}
+
+function isDeepPath(relPath: string): boolean {
+  const p = toPosix(relPath).toLowerCase();
+  return p.includes("mission_log") || p.includes("runbook") || p.startsWith("memory/");
+}
+
+function shouldEscalate(
+  confidence: number,
+  missSignals: number,
+  policy: MemoryLoadPolicyConfig,
+): { escalated: boolean; reason?: string } {
+  if (confidence < policy.escalation.minConfidence) {
+    return { escalated: true, reason: "low_confidence" };
+  }
+  if (missSignals >= policy.escalation.missSignalThreshold) {
+    return { escalated: true, reason: "miss_signal_threshold" };
+  }
+  return { escalated: false };
+}
+
+export function enforceMemoryLoadPolicy(params: {
+  query: string;
+  candidatePaths: string[];
+  confidence?: number;
+  missSignals?: number;
+  policy: MemoryLoadPolicyConfig;
+  mode: MemoryLoadRuntimeMode;
+}): MemoryLoadDecision {
+  const confidence = params.confidence ?? 1;
+  const missSignals = params.missSignals ?? 0;
+  const { escalated, reason } = shouldEscalate(confidence, missSignals, params.policy);
+
+  const allowedPaths: string[] = [];
+  const deniedPaths: Array<{ path: string; reason: string }> = [];
+
+  for (const raw of params.candidatePaths) {
+    const relPath = toPosix(raw);
+    if (matchesAny(relPath, params.policy.hardDenies)) {
+      deniedPaths.push({ path: relPath, reason: "hard_deny" });
+      continue;
+    }
+    if (isEntrypoint(relPath, params.policy.entrypoint)) {
+      allowedPaths.push(relPath);
+      continue;
+    }
+    if (matchesAny(relPath, params.policy.topicAllowlist)) {
+      allowedPaths.push(relPath);
+      continue;
+    }
+    if (escalated && matchesAny(relPath, params.policy.deepAllowlist)) {
+      allowedPaths.push(relPath);
+      continue;
+    }
+    deniedPaths.push({ path: relPath, reason: "out_of_scope" });
+  }
+
+  const hasEntrypoint = allowedPaths.some((p) => isEntrypoint(p, params.policy.entrypoint));
+  if (!hasEntrypoint) {
+    allowedPaths.unshift(params.policy.entrypoint);
+  }
+
+  return {
+    allowedPaths,
+    deniedPaths,
+    escalated,
+    escalationReason: reason,
+    violation: undefined,
+    mode: params.mode,
+    policyVersion: params.policy.version,
+  };
+}
+
+export async function resolveMemoryLoadPolicy(params?: {
+  cwd?: string;
+}): Promise<{ policy: MemoryLoadPolicyConfig; mode: MemoryLoadRuntimeMode; pointerPath: string }> {
+  const cwd = params?.cwd ?? process.cwd();
+  const pointerPath = process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH
+    ? path.resolve(process.env.OPENCLAW_MEMORY_POLICY_POINTER_PATH)
+    : path.resolve(cwd, "governance", "memory_load_policy_active.json");
+
+  const fallbackPolicyPath = process.env.OPENCLAW_MEMORY_POLICY_PATH
+    ? path.resolve(process.env.OPENCLAW_MEMORY_POLICY_PATH)
+    : path.resolve(cwd, "governance", "memory_load_policy_v1_1.json");
+
+  const defaultMode: MemoryLoadRuntimeMode = {
+    enforce: process.env.OPENCLAW_MEMORY_POLICY_ENFORCE === "true",
+    reportOnly: process.env.OPENCLAW_MEMORY_POLICY_REPORT_ONLY !== "false",
+  };
+
+  try {
+    const raw = await fs.readFile(pointerPath, "utf8");
+    const pointer = JSON.parse(raw) as PolicyPointer;
+    const policyPath = pointer.activePolicyPath
+      ? path.resolve(cwd, pointer.activePolicyPath)
+      : fallbackPolicyPath;
+    const policyRaw = await fs.readFile(policyPath, "utf8");
+    const policy = {
+      ...DEFAULT_POLICY,
+      ...(JSON.parse(policyRaw) as Partial<MemoryLoadPolicyConfig>),
+      version: pointer.version ?? DEFAULT_POLICY.version,
+    };
+    return {
+      policy,
+      mode: {
+        enforce: pointer.enforce ?? defaultMode.enforce,
+        reportOnly: pointer.reportOnly ?? defaultMode.reportOnly,
+      },
+      pointerPath,
+    };
+  } catch {
+    // fail-closed mode if policy missing/invalid: block deep reads, allow entrypoint only.
+    return {
+      policy: {
+        ...DEFAULT_POLICY,
+        topicAllowlist: [DEFAULT_POLICY.entrypoint],
+        deepAllowlist: [],
+      },
+      mode: {
+        enforce: true,
+        reportOnly: false,
+      },
+      pointerPath,
+    };
+  }
+}
+
+export async function appendMemoryLoadTelemetry(record: MemoryTelemetryRecord, cwd?: string) {
+  const base = cwd ?? process.cwd();
+  const target = path.resolve(base, "logs", "memory_load_telemetry.jsonl");
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.appendFile(target, `${JSON.stringify(record)}\n`, "utf8");
+  return target;
+}
+
+export function buildTelemetryRecord(params: {
+  sessionKey?: string;
+  taskId?: string;
+  policyVersion: string;
+  query: string;
+  candidatePaths: string[];
+  decision: MemoryLoadDecision;
+  confidence?: number;
+  missSignals?: number;
+  promptTokensEst?: number;
+  violationCode?: string;
+}): MemoryTelemetryRecord {
+  const entrypointLoaded = params.decision.allowedPaths.some((p) =>
+    isEntrypoint(p, DEFAULT_POLICY.entrypoint),
+  );
+  const deepFilesLoaded = params.decision.allowedPaths.filter((p) => isDeepPath(p));
+  const topicFilesLoaded = params.decision.allowedPaths.filter((p) => !deepFilesLoaded.includes(p));
+  return {
+    ts: new Date().toISOString(),
+    sessionKey: params.sessionKey,
+    taskId: params.taskId,
+    policyVersion: params.policyVersion,
+    queryClass: classifyQuery(params.query),
+    entrypointLoaded,
+    filesConsidered: params.candidatePaths.length,
+    topicFilesLoaded,
+    deepFilesLoaded,
+    deniedPaths: params.decision.deniedPaths.map((d) => d.path),
+    escalated: params.decision.escalated,
+    escalationReason: params.decision.escalationReason,
+    recallConfidence: params.confidence ?? 1,
+    missSignals: params.missSignals ?? 0,
+    promptTokensEst: params.promptTokensEst,
+    policyViolation: Boolean(params.violationCode),
+    policyViolationCode: params.violationCode,
+    outcome: params.violationCode ? "BLOCK" : "PASS",
+  };
+}

--- a/src/agents/tools/memory-load-policy.ts
+++ b/src/agents/tools/memory-load-policy.ts
@@ -28,6 +28,13 @@ export type MemoryLoadDecision = {
   policyVersion: string;
 };
 
+export interface MemoryPolicyResult {
+  disabled?: boolean;
+  error?: string;
+  results?: unknown[];
+  policyVersion?: string;
+}
+
 export type MemoryTelemetryRecord = {
   ts: string;
   sessionKey?: string;

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -9,6 +9,12 @@ import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import {
+  appendMemoryLoadTelemetry,
+  buildTelemetryRecord,
+  enforceMemoryLoadPolicy,
+  resolveMemoryLoadPolicy,
+} from "./memory-load-policy.js";
 
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
@@ -56,6 +62,7 @@ export function createMemorySearchTool(options: {
       const query = readStringParam(params, "query", { required: true });
       const maxResults = readNumberParam(params, "maxResults");
       const minScore = readNumberParam(params, "minScore");
+      const policyRuntime = await resolveMemoryLoadPolicy();
       const { manager, error } = await getMemorySearchManager({
         cfg,
         agentId,
@@ -74,14 +81,53 @@ export function createMemorySearchTool(options: {
           minScore,
           sessionKey: options.agentSessionKey,
         });
+
+        const candidatePaths = rawResults.map((entry) => entry.path);
+        const decision = enforceMemoryLoadPolicy({
+          query,
+          candidatePaths,
+          confidence: 1,
+          missSignals: 0,
+          policy: policyRuntime.policy,
+          mode: policyRuntime.mode,
+        });
+
+        const filtered = rawResults.filter((entry) => decision.allowedPaths.includes(entry.path));
+        const violationCode =
+          policyRuntime.mode.enforce && filtered.length === 0
+            ? "MEMORY_POLICY_BLOCK_SEARCH"
+            : undefined;
+
         const status = manager.status();
-        const decorated = decorateCitations(rawResults, includeCitations);
+        const decorated = decorateCitations(filtered, includeCitations);
         const resolved = resolveMemoryBackendConfig({ cfg, agentId });
         const results =
           status.backend === "qmd"
             ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
             : decorated;
         const searchMode = (status.custom as { searchMode?: string } | undefined)?.searchMode;
+
+        await appendMemoryLoadTelemetry(
+          buildTelemetryRecord({
+            sessionKey: options.agentSessionKey,
+            taskId: _toolCallId,
+            policyVersion: policyRuntime.policy.version,
+            query,
+            candidatePaths,
+            decision,
+            violationCode,
+          }),
+        );
+
+        if (violationCode) {
+          return jsonResult({
+            results: [],
+            disabled: true,
+            error: "memory search blocked by policy",
+            policyVersion: policyRuntime.policy.version,
+          });
+        }
+
         return jsonResult({
           results,
           provider: status.provider,
@@ -89,6 +135,7 @@ export function createMemorySearchTool(options: {
           fallback: status.fallback,
           citations: citationsMode,
           mode: searchMode,
+          policyVersion: policyRuntime.policy.version,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -117,6 +164,47 @@ export function createMemoryGetTool(options: {
       const relPath = readStringParam(params, "path", { required: true });
       const from = readNumberParam(params, "from", { integer: true });
       const lines = readNumberParam(params, "lines", { integer: true });
+      const policyRuntime = await resolveMemoryLoadPolicy();
+      const decision = enforceMemoryLoadPolicy({
+        query: `memory_get:${relPath}`,
+        candidatePaths: [relPath],
+        confidence: 1,
+        missSignals: 0,
+        policy: policyRuntime.policy,
+        mode: policyRuntime.mode,
+      });
+      const normalizedRelPath = relPath.replaceAll("\\", "/");
+      const allowed = decision.allowedPaths.some(
+        (p) =>
+          p === normalizedRelPath ||
+          (p === "MEMORY.md" && /(^|\/)MEMORY\.md$/i.test(normalizedRelPath)),
+      );
+
+      const violationCode =
+        policyRuntime.mode.enforce && !allowed ? "MEMORY_POLICY_BLOCK_READ" : undefined;
+
+      await appendMemoryLoadTelemetry(
+        buildTelemetryRecord({
+          sessionKey: options.agentSessionKey,
+          taskId: _toolCallId,
+          policyVersion: policyRuntime.policy.version,
+          query: `memory_get:${relPath}`,
+          candidatePaths: [relPath],
+          decision,
+          violationCode,
+        }),
+      );
+
+      if (violationCode) {
+        return jsonResult({
+          path: relPath,
+          text: "",
+          disabled: true,
+          error: "memory read blocked by policy",
+          policyVersion: policyRuntime.policy.version,
+        });
+      }
+
       const { manager, error } = await getMemorySearchManager({
         cfg,
         agentId,
@@ -130,7 +218,7 @@ export function createMemoryGetTool(options: {
           from: from ?? undefined,
           lines: lines ?? undefined,
         });
-        return jsonResult(result);
+        return jsonResult({ ...result, policyVersion: policyRuntime.policy.version });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ path: relPath, text: "", disabled: true, error: message });

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -15,6 +15,7 @@ import {
   enforceMemoryLoadPolicy,
   resolveMemoryLoadPolicy,
 } from "./memory-load-policy.js";
+import type { MemoryPolicyResult } from "./memory-load-policy.js";
 
 const MemorySearchSchema = Type.Object({
   query: Type.String(),
@@ -120,12 +121,13 @@ export function createMemorySearchTool(options: {
         );
 
         if (violationCode) {
-          return jsonResult({
+          const blockedResult: MemoryPolicyResult = {
             results: [],
             disabled: true,
             error: "memory search blocked by policy",
             policyVersion: policyRuntime.policy.version,
-          });
+          };
+          return jsonResult(blockedResult);
         }
 
         return jsonResult({
@@ -196,12 +198,15 @@ export function createMemoryGetTool(options: {
       );
 
       if (violationCode) {
-        return jsonResult({
-          path: relPath,
-          text: "",
+        const blockedResult: MemoryPolicyResult = {
           disabled: true,
           error: "memory read blocked by policy",
           policyVersion: policyRuntime.policy.version,
+        };
+        return jsonResult({
+          path: relPath,
+          text: "",
+          ...blockedResult,
         });
       }
 
@@ -218,7 +223,7 @@ export function createMemoryGetTool(options: {
           from: from ?? undefined,
           lines: lines ?? undefined,
         });
-        return jsonResult({ ...result, policyVersion: policyRuntime.policy.version });
+        return jsonResult(result);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ path: relPath, text: "", disabled: true, error: message });


### PR DESCRIPTION
## Summary
Implements structural memory load policy enforcement (v1.1).
- Adds deterministic gate in memory_search and memory_get before disk reads
- Introduces fail-closed behavior when policy is missing or invalid
- Adds lightweight JSONL telemetry for policy decisions
- Enables versioned governance via active policy pointer config

This converts memory governance from advisory behavior into enforceable runtime boundaries.