### PR TITLE
feat(config): add agents.defaults.reasoningDefault for reasoning visibility

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -350,6 +350,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??
@@ -391,13 +392,16 @@ export async function resolveReplyDirectives(params: {
   provider = modelState.provider;
   model = modelState.model;
 
-  // When neither directive nor session set reasoning, default to model capability
-  // (e.g. OpenRouter with reasoning: true). Skip auto-enabling when thinking is
-  // active, including model-inferred defaults, or internal thinking blocks can
-  // be emitted as visible "Reasoning:" messages.
+  // When neither directive, session, nor config default set reasoning, fall back
+  // to model capability (e.g. OpenRouter with reasoning: true). Config
+  // reasoningDefault takes precedence over model-inferred default so operators
+  // can lock visibility to "off" globally. Skip auto-enabling when thinking is
+  // active, or internal thinking blocks can be emitted as visible "Reasoning:"
+  // messages.
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
+    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null) ||
+    agentCfg?.reasoningDefault !== undefined;
   const effectiveThinkingForReasoning =
     resolvedThinkLevel ?? (await modelState.resolveDefaultThinkingLevel());
   const thinkingActive = effectiveThinkingForReasoning !== "off";

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -250,6 +250,30 @@ describe("buildStatusMessage", () => {
     expect(optionsLine).not.toContain("elevated");
   });
 
+  it("shows reasoning level from reasoningDefault config", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5", reasoningDefault: "stream" },
+      sessionEntry: { sessionId: "r1", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Reasoning: stream");
+  });
+
+  it("defaults reasoning to off when no reasoningDefault is set", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: { sessionId: "r2", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).not.toContain("Reasoning:");
+  });
+
   it("shows selected model and active runtime model when they differ", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -508,7 +508,11 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ??
+    (args.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    args.agent?.reasoningDefault ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -164,6 +164,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning visibility level when no /reasoning directive is present. Suppresses the auto-default from model capability. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -110,6 +110,7 @@ export const AgentDefaultsSchema = z
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
     blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     blockStreamingChunk: BlockStreamingChunkSchema.optional(),


### PR DESCRIPTION
## Summary

Adds `reasoningDefault` config option to `agents.defaults` for controlling reasoning visibility without disabling model reasoning capability.

**Problem:** After OpenClaw 2026.2.22 (#22513), `resolveReasoningDefault()` returns `"on"` for any model with `reasoning: true` in the catalog. Setting `reasoning: false` on models breaks Claude (extended thinking is mandatory for Opus). There's no way to decouple visibility from capability — operators can't suppress reasoning traces for cron/automated agents while keeping the model's reasoning capability intact.

**Fix:** Add `reasoningDefault` to the agent defaults config, following the existing pattern of `thinkingDefault`, `verboseDefault`, and `elevatedDefault`. Resolution chain: `directive > session > config default > model capability`.

## Changes

| File | Change |
|------|--------|
| `src/config/types.agent-defaults.ts` | Add `reasoningDefault?: "off" \| "on" \| "stream"` type |
| `src/config/zod-schema.agent-defaults.ts` | Add Zod validation |
| `src/auto-reply/reply/get-reply-directives.ts` | Wire into resolution chain + explicitly-set guard |
| `src/auto-reply/status.ts` | Show `reasoningDefault` in `/status` output |
| `src/auto-reply/status.test.ts` | 2 tests for status display |

## Production Validation

Running this exact patch on a production OpenClaw instance for **3+ weeks**:
- **Hardware:** Lenovo ThinkStation PGX (NVIDIA Grace Blackwell GB10)
- **Agents:** 11 cron jobs (~85 runs/day) — Email Classifier, Calendar Monitor, Vision Monitor, Supervisor, Email Responder, CRM Steward, etc.
- **Models:** Kimi K2.5 (10 agents) + Sonnet 4.6 (1 agent), both `reasoning: true` in catalog
- **Config:** `"agents": { "defaults": { "reasoningDefault": "off" } }`
- **Verified:** Reasoning traces suppressed across all agents. `/reasoning on` directive override works. No regressions.

## Related

Closes #13607. See also #24132, #25094, #14474, #25164 (overlapping implementations).

## Test plan

- [x] 2 new status display tests added
- [x] `reasoningDefault: "stream"` shows in `/status` output
- [x] No `reasoningDefault` set → no "Reasoning:" line in `/status`
- [x] Production-validated for 3+ weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)