### PR TITLE
fix(export): restore template placeholders broken by formatter

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -43,7 +43,14 @@ if [ "${#lint_files[@]}" -gt 0 ]; then
 fi
 
 if [ "${#format_files[@]}" -gt 0 ]; then
-  "$RUN_NODE_TOOL" oxfmt --write -- "${format_files[@]}"
+  # oxfmt exits 2 ("Expected at least one target file") when all passed files
+  # fall inside ignorePatterns (e.g. export-html/). Tolerate that exit code.
+  "$RUN_NODE_TOOL" oxfmt --write -- "${format_files[@]}" || {
+    ec=$?
+    if [ "$ec" -ne 2 ]; then
+      exit "$ec"
+    fi
+  }
 fi
 
 git add -- "${files[@]}"

--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -59,30 +59,15 @@
     </script>
 
     <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <!-- prettier-ignore -->
+    <script>{{JS}}</script>
   </body>
 </html>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -79,6 +79,34 @@ function now() {
   return new Date("2026-02-24T00:00:00.000Z").toISOString();
 }
 
+describe("export html template placeholders", () => {
+  // Regression: a formatter once rewrote {{MARKED_JS}} into { { MARKED_JS; } },
+  // breaking generateHtml()'s .replace() calls and producing broken exports (#22595).
+  it("contains literal placeholder strings that generateHtml expects", () => {
+    for (const placeholder of ["{{CSS}}", "{{SESSION_DATA}}", "{{MARKED_JS}}", "{{HIGHLIGHT_JS}}", "{{JS}}"]) {
+      expect(templateHtml).toContain(placeholder);
+    }
+  });
+
+  it("replaces all placeholders with substitute content", () => {
+    const result = templateHtml
+      .replace("{{CSS}}", "/* css */")
+      .replace("{{SESSION_DATA}}", "BASE64DATA")
+      .replace("{{MARKED_JS}}", "var marked=1;")
+      .replace("{{HIGHLIGHT_JS}}", "var hljs=1;")
+      .replace("{{JS}}", "var app=1;");
+
+    // None of the placeholders should remain after replacement
+    for (const placeholder of ["{{CSS}}", "{{SESSION_DATA}}", "{{MARKED_JS}}", "{{HIGHLIGHT_JS}}", "{{JS}}"]) {
+      expect(result).not.toContain(placeholder);
+    }
+    // Substituted content should be present
+    expect(result).toContain("var marked=1;");
+    expect(result).toContain("var hljs=1;");
+    expect(result).toContain("var app=1;");
+  });
+});
+
 describe("export html security hardening", () => {
   it("escapes raw HTML from markdown blocks", () => {
     const attack = "<img src=x onerror=alert(1)>";


### PR DESCRIPTION
## Summary
- Restores {{MARKED_JS}}, {{HIGHLIGHT_JS}}, {{JS}} placeholders in export HTML template
- Adds prettier-ignore comments to prevent future formatter interference
- Fixes pre-commit hook tolerance for oxfmt exit code 2
- Regression tests for placeholder integrity

Fixes #22595

🤖 Generated with [Claude Code](https://claude.com/claude-code)