### PR TITLE
fix(web_fetch): discard non-textual error response bodies (CSS, images, fonts)

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -209,6 +209,27 @@ function looksLikeHtml(value: string): boolean {
   return head.startsWith("<!doctype html") || head.startsWith("<html");
 }
 
+/** Content types that are never useful as error detail text. */
+function isNonTextualContentType(ct: string): boolean {
+  return (
+    ct.includes("text/css") ||
+    ct.includes("image/") ||
+    ct.includes("font/") ||
+    ct.includes("audio/") ||
+    ct.includes("video/") ||
+    ct.includes("application/octet-stream") ||
+    ct.includes("application/wasm") ||
+    ct.includes("application/pdf") ||
+    ct.includes("application/zip")
+  );
+}
+
+/** Body-sniff for CSS when content-type header is missing or generic. */
+function looksLikeCss(value: string): boolean {
+  const head = value.trimStart().slice(0, 256);
+  return /^(@charset|@import|@font-face|@media|@keyframes)\b/.test(head);
+}
+
 function formatWebFetchErrorDetail(params: {
   detail: string;
   contentType?: string | null;
@@ -218,9 +239,13 @@ function formatWebFetchErrorDetail(params: {
   if (!detail) {
     return "";
   }
+  const ct = contentType?.toLowerCase() ?? "";
+  // CSS, images, fonts, and other binary types are never useful as error details
+  if (isNonTextualContentType(ct) || looksLikeCss(detail)) {
+    return "";
+  }
   let text = detail;
-  const contentTypeLower = contentType?.toLowerCase();
-  if (contentTypeLower?.includes("text/html") || looksLikeHtml(detail)) {
+  if (ct.includes("text/html") || looksLikeHtml(detail)) {
     const rendered = htmlToMarkdown(detail);
     const withTitle = rendered.title ? `${rendered.title}\n${rendered.text}` : rendered.text;
     text = markdownToText(withTitle);
@@ -584,7 +609,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         contentType: res.headers.get("content-type"),
         maxChars: DEFAULT_ERROR_MAX_CHARS,
       });
-      const wrappedDetail = wrapWebFetchContent(detail || res.statusText, DEFAULT_ERROR_MAX_CHARS);
+      const wrappedDetail = wrapWebFetchContent(
+        detail || res.statusText || "Error",
+        DEFAULT_ERROR_MAX_CHARS,
+      );
       throw new Error(`Web fetch failed (${res.status}): ${wrappedDetail.text}`);
     }
 

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -463,6 +463,63 @@ describe("web_fetch extraction fallbacks", () => {
     expect(message).toContain("Oops");
   });
 
+  it("discards CSS error responses and falls back to statusText", async () => {
+    const css = '@charset "UTF-8";.Modal-bg{background:#000000b3}body{margin:0}';
+    installMockFetch(
+      (input: RequestInfo | URL) =>
+        Promise.resolve(
+          errorHtmlResponse(css, 404, requestUrl(input), "text/css; charset=utf-8"),
+        ) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const message = await captureToolErrorMessage({
+      tool,
+      url: "https://example.com/style.css",
+    });
+
+    expect(message).toContain("Web fetch failed (404):");
+    // Should NOT contain raw CSS
+    expect(message).not.toContain("@charset");
+    expect(message).not.toContain(".Modal-bg");
+  });
+
+  it("discards image error responses via content-type", async () => {
+    const binary = "\x89PNG\r\n\x1a\nfake-image-bytes";
+    installMockFetch(
+      (input: RequestInfo | URL) =>
+        Promise.resolve(
+          errorHtmlResponse(binary, 404, requestUrl(input), "image/png"),
+        ) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const message = await captureToolErrorMessage({
+      tool,
+      url: "https://example.com/logo.png",
+    });
+
+    expect(message).toContain("Web fetch failed (404):");
+    expect(message).not.toContain("PNG");
+  });
+
+  it("detects CSS body when content-type header is missing", async () => {
+    const css = "@font-face { font-family: test; src: url(test.woff2); }";
+    installMockFetch(
+      (input: RequestInfo | URL) =>
+        Promise.resolve(errorHtmlResponse(css, 404, requestUrl(input), null)) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const message = await captureToolErrorMessage({
+      tool,
+      url: "https://example.com/fonts.css",
+    });
+
+    expect(message).toContain("Web fetch failed (404):");
+    expect(message).not.toContain("@font-face");
+  });
+
   it("wraps firecrawl error details", async () => {
     installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);


### PR DESCRIPTION
## Summary
- Adds content-type detection for CSS, images, fonts in web_fetch error responses
- Body-sniffing fallback for CSS when content-type header missing
- Falls back to HTTP statusText instead of raw CSS/binary
- 3 new test cases

Fixes #26953

🤖 Generated with [Claude Code](https://claude.com/claude-code)