### PR TITLE
fix: emit signoff event when parseReplyDirectives strips silent tokens

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,6 +1,6 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { SILENT_REPLY_TOKEN, HEARTBEAT_TOKEN, isSilentReplyText } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -202,6 +202,22 @@ export function handleMessageUpdate(
     let deltaText = "";
     if (!cleanedText && !hasMedia && !hasAudio) {
       shouldEmit = false;
+      // parseReplyDirectives strips silent reply tokens (NO_REPLY, HEARTBEAT_OK) from
+      // the text, which prevents downstream sign-off detection (e.g. reply-chain-enforcer).
+      // When the raw cumulative text IS a silent reply token but cleanedText is empty,
+      // emit a "signoff" event so consumers can detect the agent intentionally signed off.
+      // See: https://github.com/openclaw/openclaw/issues/28693
+      const trimmedNext = next.trim();
+      if (
+        isSilentReplyText(trimmedNext, SILENT_REPLY_TOKEN) ||
+        isSilentReplyText(trimmedNext, HEARTBEAT_TOKEN)
+      ) {
+        emitAgentEvent({
+          runId: ctx.params.runId,
+          stream: "signoff",
+          data: { token: trimmedNext },
+        });
+      }
     } else if (previousCleaned && !cleanedText.startsWith(previousCleaned)) {
       shouldEmit = false;
     } else {


### PR DESCRIPTION
## Summary

`parseReplyDirectives` in `pi-embedded-subscribe.handlers.messages.ts` strips silent reply tokens (`NO_REPLY`, `HEARTBEAT_OK`) from cumulative text before the `shouldEmit` check. This means **no event is emitted at all** for silent reply turns, preventing downstream consumers from detecting agent sign-off.

## The Bug

1. Model outputs `NO_REPLY` → streaming tokenizes into chunks (`"NO"`, `"_REPLY"`)
2. First chunk: cumulative `"NO"` → `parseReplyDirectives("NO")` → `{ text: "NO" }` → assistant event emitted
3. Second chunk: cumulative `"NO_REPLY"` → `parseReplyDirectives("NO_REPLY")` → `{ text: "" }` → `shouldEmit = false` → **no event**
4. The `normalizeStreamingText` code in `agent-runner-execution.ts` (lines 150-154) is designed to pass full tokens through for sign-off detection, but it never sees the full token because this layer strips it first
5. `emitChatFinal` receives only the leaked `"NO"` prefix → `hasSignoff: false` → no sign-off event emitted

## Fix

When `parseReplyDirectives` cleans the text to empty AND the raw cumulative text is a known silent reply token, emit a `stream: "signoff"` event.

One file changed, 17 lines added.

## Impact

Without this fix, any downstream consumer relying on lifecycle events (sign-off detection, session cleanup, delivery coordination) cannot distinguish between "agent produced no output" and "agent explicitly signed off with a silent token." The signoff event is the only reliable signal that the agent intentionally ended its turn silently.

Fixes #28693

---
🤖 **AI-assisted** (Claude Opus/Sonnet via OpenClaw agent). Fully tested in production.