### PR TITLE
fix(config): add thinkingDefault to AgentEntrySchema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -713,6 +713,16 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+      ])
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Adds thinkingDefault field to AgentEntrySchema (per-agent config)
- Mirrors existing field in AgentDefaultsSchema
- Runtime code already reads agentCfg?.thinkingDefault

Fixes #21097

🤖 Generated with [Claude Code](https://claude.com/claude-code)