### PR TITLE
feishu: send opus audio as voice bar instead of file attachment

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -36,7 +36,12 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-import { downloadImageFeishu, downloadMessageResourceFeishu, sendMediaFeishu } from "./media.js";
+import {
+  downloadImageFeishu,
+  downloadMessageResourceFeishu,
+  sendMediaFeishu,
+  sendVoiceFeishu,
+} from "./media.js";
 
 function expectPathIsolatedToTmpRoot(pathValue: string, key: string): void {
   expect(pathValue).not.toContain(key);
@@ -129,7 +134,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media for opus", async () => {
+  it("uses msg_type=audio for opus (voice bar)", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -145,7 +150,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });
@@ -275,5 +280,48 @@ describe("sendMediaFeishu msg_type routing", () => {
     ).rejects.toThrow("invalid file_key");
 
     expect(messageResourceGetMock).not.toHaveBeenCalled();
+  });
+
+  it("sendVoiceFeishu sends with msg_type=audio and file_type=opus", async () => {
+    await sendVoiceFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      audio: Buffer.from("opus-audio-data"),
+      duration: 5000,
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          file_type: "opus",
+          file_name: "voice.opus",
+          duration: 5000,
+        }),
+      }),
+    );
+
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
+  it("sendVoiceFeishu supports reply", async () => {
+    await sendVoiceFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      audio: Buffer.from("opus-audio-data"),
+      replyToMessageId: "om_parent",
+    });
+
+    expect(messageReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: { message_id: "om_parent" },
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -306,8 +306,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
-  msgType?: "file" | "media";
+  /** Use "audio" for voice messages (green bar), "media" for video, "file" for documents */
+  msgType?: "file" | "media" | "audio";
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
@@ -427,15 +427,51 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
+    // Feishu msg_type: "audio" = voice bar (green bar), "media" = video, "file" = document
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType,
       replyToMessageId,
       accountId,
     });
   }
+}
+
+/**
+ * Send a voice message as a voice bar (green bar) in Feishu.
+ * The audio must be in opus format. Feishu only supports opus for voice bars.
+ * The file is uploaded with file_type "opus" and sent with msg_type "audio".
+ */
+export async function sendVoiceFeishu(params: {
+  cfg: ClawdbotConfig;
+  to: string;
+  audio: Buffer | string; // Buffer or file path (must be opus-encoded)
+  fileName?: string;
+  duration?: number; // Duration in milliseconds (shown on the voice bar)
+  replyToMessageId?: string;
+  accountId?: string;
+}): Promise<SendMediaResult> {
+  const { cfg, to, audio, duration, replyToMessageId, accountId } = params;
+  const fileName = params.fileName ?? "voice.opus";
+
+  const { fileKey } = await uploadFileFeishu({
+    cfg,
+    file: audio,
+    fileName,
+    fileType: "opus",
+    duration,
+    accountId,
+  });
+
+  return sendFileFeishu({
+    cfg,
+    to,
+    fileKey,
+    msgType: "audio",
+    replyToMessageId,
+    accountId,
+  });
 }


### PR DESCRIPTION
## Summary

- Fix Feishu adapter to send opus audio files with `msg_type: "audio"` (voice message bar) instead of `msg_type: "media"` (file attachment)
- Add `sendVoiceFeishu()` convenience function for explicitly sending voice messages with duration support
- Update `sendFileFeishu()` to accept `"audio"` as a valid `msgType`

## Problem

Previously, opus audio files were sent using `msg_type: "media"`, which displayed them as downloadable file attachments in Feishu. The Feishu API supports `msg_type: "audio"` which renders audio as a native green voice message bar with inline playback — a much better user experience.

## Changes

**`extensions/feishu/src/media.ts`:**
- `sendFileFeishu`: expanded `msgType` to accept `"file" | "media" | "audio"`
- `sendMediaFeishu`: route `fileType === "opus"` to `msg_type: "audio"` (was `"media"`)
- Added `sendVoiceFeishu()` — dedicated function for sending voice bars with optional `duration` parameter

**`extensions/feishu/src/media.test.ts`:**
- Updated existing opus test to expect `msg_type: "audio"`
- Added tests for `sendVoiceFeishu` (send + reply)

## Message type routing (before → after)

| File type | Before | After | Effect |
|-----------|--------|-------|--------|
| `.opus` / `.ogg` | `msg_type: "media"` | `msg_type: "audio"` | **Green voice bar** |
| `.mp4` / `.mov` | `msg_type: "media"` | `msg_type: "media"` | No change |
| Other files | `msg_type: "file"` | `msg_type: "file"` | No change |

## Test plan

- [x] Updated unit test for opus routing (`msg_type: "audio"`)
- [x] Added unit tests for `sendVoiceFeishu` (direct send + reply)
- [ ] Manual test: send an opus file to a Feishu chat and verify it appears as a green voice bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)