### PR TITLE
fix(mattermost): trust configured baseUrl hostname for media fetch SSRF policy

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -236,7 +236,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   // would otherwise be blocked by SSRF protection. Since the user has
   // explicitly configured this host, we allow media downloads from it.
   const baseHostname = new URL(client.baseUrl).hostname;
-  const mediaSsrfPolicy = { hostnameAllowlist: [baseHostname] };
+  const mediaSsrfPolicy = { allowedHostnames: [baseHostname] };
 
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -231,6 +231,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     log: (message) => logVerboseMessage(message),
   });
 
+  // Trust the configured Mattermost baseUrl hostname for media fetching.
+  // Self-hosted Mattermost servers typically resolve to private IPs, which
+  // would otherwise be blocked by SSRF protection. Since the user has
+  // explicitly configured this host, we allow media downloads from it.
+  const baseHostname = new URL(client.baseUrl).hostname;
+  const mediaSsrfPolicy = { hostnameAllowlist: [baseHostname] };
+
   const resolveMattermostMedia = async (
     fileIds?: string[] | null,
   ): Promise<MattermostMediaInfo[]> => {
@@ -250,6 +257,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           },
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
+          ssrfPolicy: mediaSsrfPolicy,
         });
         const saved = await core.channel.media.saveMediaBuffer(
           fetched.buffer,


### PR DESCRIPTION
## Summary

Self-hosted Mattermost servers typically resolve to private or special-use IP addresses (e.g. `10.x.x.x`, `192.168.x.x`, `198.18.x.x` via internal DNS). The SSRF protection in `fetchRemoteMedia()` blocks these by default, which prevents all image and file downloads from working.

This PR adds the configured Mattermost `baseUrl` hostname to the SSRF policy `hostnameAllowlist` when downloading files, so media fetching works for self-hosted instances on private networks.

## Problem

When a user sends an image via Mattermost DM, the monitor tries to download the file from the Mattermost API:
```
https://<mattermost-host>/api/v4/files/<fileId>
```

If `<mattermost-host>` resolves to a private/special-use IP, `fetchRemoteMedia()` throws:
```
SsrFBlockedError: Blocked: resolves to private/internal/special-use IP address
```

Text messages are unaffected since the WebSocket connection is established separately.

## Fix

Since the user has already explicitly configured `baseUrl` in their OpenClaw config (meaning they trust this host), we extract the hostname and pass it as a `hostnameAllowlist` entry in the `ssrfPolicy` parameter of `fetchRemoteMedia()`.

This is a minimal, targeted change — only the already-trusted Mattermost host is allowlisted, not all private networks.

## Changes

- `extensions/mattermost/src/mattermost/monitor.ts`
  - Extract `baseHostname` from `client.baseUrl`
  - Create `mediaSsrfPolicy` with `hostnameAllowlist: [baseHostname]`
  - Pass `ssrfPolicy: mediaSsrfPolicy` to `fetchRemoteMedia()`

## Testing

- Self-hosted Mattermost on private network (`10.x.x.x`) — images now download successfully
- No impact on public Mattermost instances (hostname allowlist is additive)

Fixes #28723