### PR TITLE
fix(skills): surface YAML parse errors in skills discovery

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -7,13 +7,14 @@ import {
   hasBinary,
   isBundledSkillAllowed,
   isConfigPathTruthy,
-  loadWorkspaceSkillEntries,
+  loadWorkspaceSkillEntriesWithDiagnostics,
   resolveBundledAllowlist,
   resolveSkillConfig,
   resolveSkillsInstallPreferences,
   type SkillEntry,
   type SkillEligibilityContext,
   type SkillInstallSpec,
+  type SkillLoadDiagnostic,
   type SkillsInstallPreferences,
 } from "./skills.js";
 import { resolveBundledSkillsContext } from "./skills/bundled-context.js";
@@ -52,6 +53,8 @@ export type SkillStatusReport = {
   workspaceDir: string;
   managedSkillsDir: string;
   skills: SkillStatusEntry[];
+  /** Diagnostics from skill loading (e.g. YAML parse errors in SKILL.md files). */
+  diagnostics: SkillLoadDiagnostic[];
 };
 
 function resolveSkillKey(entry: SkillEntry): string {
@@ -230,18 +233,27 @@ export function buildWorkspaceSkillStatus(
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     entries?: SkillEntry[];
+    /** Pre-computed diagnostics; only used when entries are provided externally. */
+    diagnostics?: SkillLoadDiagnostic[];
     eligibility?: SkillEligibilityContext;
   },
 ): SkillStatusReport {
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
   const bundledContext = resolveBundledSkillsContext();
-  const skillEntries =
-    opts?.entries ??
-    loadWorkspaceSkillEntries(workspaceDir, {
+  let skillEntries: SkillEntry[];
+  let loadDiagnostics: SkillLoadDiagnostic[];
+  if (opts?.entries) {
+    skillEntries = opts.entries;
+    loadDiagnostics = opts.diagnostics ?? [];
+  } else {
+    const result = loadWorkspaceSkillEntriesWithDiagnostics(workspaceDir, {
       config: opts?.config,
       managedSkillsDir,
       bundledSkillsDir: bundledContext.dir,
     });
+    skillEntries = result.entries;
+    loadDiagnostics = result.diagnostics;
+  }
   const prefs = resolveSkillsInstallPreferences(opts?.config);
   return {
     workspaceDir,
@@ -249,5 +261,6 @@ export function buildWorkspaceSkillStatus(
     skills: skillEntries.map((entry) =>
       buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility, bundledContext.names),
     ),
+    diagnostics: loadDiagnostics,
   };
 }

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -20,6 +20,7 @@ export type {
   SkillCommandSpec,
   SkillEntry,
   SkillInstallSpec,
+  SkillLoadDiagnostic,
   SkillSnapshot,
   SkillsInstallPreferences,
 } from "./skills/types.js";
@@ -29,6 +30,7 @@ export {
   buildWorkspaceSkillCommandSpecs,
   filterWorkspaceSkillEntries,
   loadWorkspaceSkillEntries,
+  loadWorkspaceSkillEntriesWithDiagnostics,
   resolveSkillsPromptForRun,
   syncSkillsToWorkspace,
 } from "./skills/workspace.js";

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -79,6 +79,16 @@ export type SkillEligibilityContext = {
   };
 };
 
+/** A diagnostic from skill loading (e.g. YAML parse error in SKILL.md). */
+export type SkillLoadDiagnostic = {
+  type: "warning" | "error";
+  message: string;
+  /** Absolute path to the skill file that triggered the diagnostic. */
+  path?: string;
+  /** Source label for the skill directory (e.g. "openclaw-managed"). */
+  source?: string;
+};
+
 export type SkillSnapshot = {
   prompt: string;
   skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -25,6 +25,7 @@ import type {
   SkillEligibilityContext,
   SkillCommandSpec,
   SkillEntry,
+  SkillLoadDiagnostic,
   SkillSnapshot,
 } from "./types.js";
 
@@ -205,28 +206,58 @@ function resolveNestedSkillsRoot(
   return { baseDir: dir };
 }
 
-function unwrapLoadedSkills(loaded: unknown): Skill[] {
+type UnwrappedSkills = {
+  skills: Skill[];
+  diagnostics: SkillLoadDiagnostic[];
+};
+
+function unwrapLoadedSkills(loaded: unknown, source?: string): UnwrappedSkills {
   if (Array.isArray(loaded)) {
-    return loaded as Skill[];
+    return { skills: loaded as Skill[], diagnostics: [] };
   }
-  if (loaded && typeof loaded === "object" && "skills" in loaded) {
-    const skills = (loaded as { skills?: unknown }).skills;
-    if (Array.isArray(skills)) {
-      return skills as Skill[];
+  if (loaded && typeof loaded === "object") {
+    const obj = loaded as Record<string, unknown>;
+    const skills = Array.isArray(obj.skills) ? (obj.skills as Skill[]) : [];
+    const rawDiags = Array.isArray(obj.diagnostics) ? obj.diagnostics : [];
+    // Convert pi-coding-agent ResourceDiagnostic[] to our SkillLoadDiagnostic[].
+    // Only surface diagnostics for skills that were NOT successfully loaded (i.e. parse errors).
+    const loadedPaths = new Set(skills.map((s) => s.filePath));
+    const diagnostics: SkillLoadDiagnostic[] = [];
+    for (const d of rawDiags) {
+      if (d && typeof d === "object" && "message" in d) {
+        const diag = d as { type?: string; message: string; path?: string };
+        // Skip diagnostics for successfully loaded skills (name-mismatch warnings, etc.)
+        if (diag.path && loadedPaths.has(diag.path)) {
+          continue;
+        }
+        diagnostics.push({
+          type: diag.type === "error" ? "error" : "warning",
+          message: diag.message,
+          path: typeof diag.path === "string" ? diag.path : undefined,
+          source,
+        });
+      }
     }
+    return { skills, diagnostics };
   }
-  return [];
+  return { skills: [], diagnostics: [] };
 }
 
-function loadSkillEntries(
+type LoadSkillEntriesResult = {
+  entries: SkillEntry[];
+  diagnostics: SkillLoadDiagnostic[];
+};
+
+function loadSkillEntriesInternal(
   workspaceDir: string,
   opts?: {
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
   },
-): SkillEntry[] {
+): LoadSkillEntriesResult {
   const limits = resolveSkillsLimits(opts?.config);
+  const allDiagnostics: SkillLoadDiagnostic[] = [];
 
   const loadSkills = (params: { dir: string; source: string }): Skill[] => {
     const resolved = resolveNestedSkillsRoot(params.dir, {
@@ -253,7 +284,9 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
-      return unwrapLoadedSkills(loaded);
+      const result = unwrapLoadedSkills(loaded, params.source);
+      allDiagnostics.push(...result.diagnostics);
+      return result.skills;
     }
 
     const childDirs = listChildDirectories(baseDir);
@@ -304,7 +337,9 @@ function loadSkillEntries(
       }
 
       const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
-      loadedSkills.push(...unwrapLoadedSkills(loaded));
+      const result = unwrapLoadedSkills(loaded, params.source);
+      loadedSkills.push(...result.skills);
+      allDiagnostics.push(...result.diagnostics);
 
       if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
         break;
@@ -402,7 +437,19 @@ function loadSkillEntries(
       invocation: resolveSkillInvocationPolicy(frontmatter),
     };
   });
-  return skillEntries;
+  return { entries: skillEntries, diagnostics: allDiagnostics };
+}
+
+/** Backward-compatible wrapper: returns only entries, discards diagnostics. */
+function loadSkillEntries(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+  },
+): SkillEntry[] {
+  return loadSkillEntriesInternal(workspaceDir, opts).entries;
 }
 
 function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawConfig }): {
@@ -545,6 +592,18 @@ export function loadWorkspaceSkillEntries(
   },
 ): SkillEntry[] {
   return loadSkillEntries(workspaceDir, opts);
+}
+
+/** Like loadWorkspaceSkillEntries but also returns diagnostics (e.g. YAML parse errors). */
+export function loadWorkspaceSkillEntriesWithDiagnostics(
+  workspaceDir: string,
+  opts?: {
+    config?: OpenClawConfig;
+    managedSkillsDir?: string;
+    bundledSkillsDir?: string;
+  },
+): { entries: SkillEntry[]; diagnostics: SkillLoadDiagnostic[] } {
+  return loadSkillEntriesInternal(workspaceDir, opts);
 }
 
 function resolveUniqueSyncedSkillDirName(base: string, used: Set<string>): string {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -49,6 +49,7 @@ describe("registerSkillsCli", () => {
     workspaceDir: "/tmp/workspace",
     managedSkillsDir: "/tmp/workspace/.skills",
     skills: [],
+    diagnostics: [],
   };
 
   async function runCli(args: string[]) {

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,4 +1,5 @@
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
+import type { SkillLoadDiagnostic } from "../agents/skills.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
@@ -27,19 +28,19 @@ function appendClawHubHint(output: string, json?: boolean): string {
 
 function formatSkillStatus(skill: SkillStatusEntry): string {
   if (skill.eligible) {
-    return theme.success("✓ ready");
+    return theme.success("\u2713 ready");
   }
   if (skill.disabled) {
-    return theme.warn("⏸ disabled");
+    return theme.warn("\u23F8 disabled");
   }
   if (skill.blockedByAllowlist) {
-    return theme.warn("🚫 blocked");
+    return theme.warn("\uD83D\uDEAB blocked");
   }
-  return theme.error("✗ missing");
+  return theme.error("\u2717 missing");
 }
 
 function formatSkillName(skill: SkillStatusEntry): string {
-  const emoji = skill.emoji ?? "📦";
+  const emoji = skill.emoji ?? "\uD83D\uDCE6";
   return `${emoji} ${theme.command(skill.name)}`;
 }
 
@@ -63,8 +64,23 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   return missing.join("; ");
 }
 
+/** Derive a short name from a diagnostic's file path (parent dir name or filename). */
+function diagnosticSkillName(diag: SkillLoadDiagnostic): string {
+  if (!diag.path) {
+    return "(unknown)";
+  }
+  const parts = diag.path.split("/");
+  const fileName = parts[parts.length - 1] ?? "";
+  // For SKILL.md, use the parent directory name as the skill identifier.
+  if (fileName.toLowerCase() === "skill.md" && parts.length >= 2) {
+    return parts[parts.length - 2] ?? "(unknown)";
+  }
+  return fileName;
+}
+
 export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOptions): string {
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
+  const diagnostics = report.diagnostics ?? [];
 
   if (opts.json) {
     const jsonReport = {
@@ -83,11 +99,21 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
         homepage: s.homepage,
         missing: s.missing,
       })),
+      ...(diagnostics.length > 0
+        ? {
+            diagnostics: diagnostics.map((d) => ({
+              type: d.type,
+              message: d.message,
+              path: d.path,
+              source: d.source,
+            })),
+          }
+        : {}),
     };
     return JSON.stringify(jsonReport, null, 2);
   }
 
-  if (skills.length === 0) {
+  if (skills.length === 0 && diagnostics.length === 0) {
     const message = opts.eligible
       ? `No eligible skills found. Run \`${formatCliCommand("openclaw skills list")}\` to see all skills.`
       : "No skills found.";
@@ -106,6 +132,18 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
       Missing: missing ? theme.warn(missing) : "",
     };
   });
+
+  // Append diagnostic rows for skills that failed to load (e.g. YAML parse errors).
+  for (const diag of diagnostics) {
+    const name = diagnosticSkillName(diag);
+    rows.push({
+      Status: theme.warn("!! parse error"),
+      Skill: theme.warn(name),
+      Description: theme.warn(diag.message),
+      Source: diag.source ?? "",
+      Missing: "",
+    });
+  }
 
   const columns = [
     { key: "Status", header: "Status", minWidth: 10 },
@@ -154,14 +192,14 @@ export function formatSkillInfo(
   }
 
   const lines: string[] = [];
-  const emoji = skill.emoji ?? "📦";
+  const emoji = skill.emoji ?? "\uD83D\uDCE6";
   const status = skill.eligible
-    ? theme.success("✓ Ready")
+    ? theme.success("\u2713 Ready")
     : skill.disabled
-      ? theme.warn("⏸ Disabled")
+      ? theme.warn("\u23F8 Disabled")
       : skill.blockedByAllowlist
-        ? theme.warn("🚫 Blocked by allowlist")
-        : theme.error("✗ Missing requirements");
+        ? theme.warn("\uD83D\uDEAB Blocked by allowlist")
+        : theme.error("\u2717 Missing requirements");
 
   lines.push(`${emoji} ${theme.heading(skill.name)} ${status}`);
   lines.push("");
@@ -191,7 +229,7 @@ export function formatSkillInfo(
     if (skill.requirements.bins.length > 0) {
       const binsStatus = skill.requirements.bins.map((bin) => {
         const missing = skill.missing.bins.includes(bin);
-        return missing ? theme.error(`✗ ${bin}`) : theme.success(`✓ ${bin}`);
+        return missing ? theme.error(`\u2717 ${bin}`) : theme.success(`\u2713 ${bin}`);
       });
       lines.push(`${theme.muted("  Binaries:")} ${binsStatus.join(", ")}`);
     }
@@ -199,28 +237,28 @@ export function formatSkillInfo(
       const anyBinsMissing = skill.missing.anyBins.length > 0;
       const anyBinsStatus = skill.requirements.anyBins.map((bin) => {
         const missing = anyBinsMissing;
-        return missing ? theme.error(`✗ ${bin}`) : theme.success(`✓ ${bin}`);
+        return missing ? theme.error(`\u2717 ${bin}`) : theme.success(`\u2713 ${bin}`);
       });
       lines.push(`${theme.muted("  Any binaries:")} ${anyBinsStatus.join(", ")}`);
     }
     if (skill.requirements.env.length > 0) {
       const envStatus = skill.requirements.env.map((env) => {
         const missing = skill.missing.env.includes(env);
-        return missing ? theme.error(`✗ ${env}`) : theme.success(`✓ ${env}`);
+        return missing ? theme.error(`\u2717 ${env}`) : theme.success(`\u2713 ${env}`);
       });
       lines.push(`${theme.muted("  Environment:")} ${envStatus.join(", ")}`);
     }
     if (skill.requirements.config.length > 0) {
       const configStatus = skill.requirements.config.map((cfg) => {
         const missing = skill.missing.config.includes(cfg);
-        return missing ? theme.error(`✗ ${cfg}`) : theme.success(`✓ ${cfg}`);
+        return missing ? theme.error(`\u2717 ${cfg}`) : theme.success(`\u2713 ${cfg}`);
       });
       lines.push(`${theme.muted("  Config:")} ${configStatus.join(", ")}`);
     }
     if (skill.requirements.os.length > 0) {
       const osStatus = skill.requirements.os.map((osName) => {
         const missing = skill.missing.os.includes(osName);
-        return missing ? theme.error(`✗ ${osName}`) : theme.success(`✓ ${osName}`);
+        return missing ? theme.error(`\u2717 ${osName}`) : theme.success(`\u2713 ${osName}`);
       });
       lines.push(`${theme.muted("  OS:")} ${osStatus.join(", ")}`);
     }
@@ -230,7 +268,7 @@ export function formatSkillInfo(
     lines.push("");
     lines.push(theme.heading("Install options:"));
     for (const inst of skill.install) {
-      lines.push(`  ${theme.warn("→")} ${inst.label}`);
+      lines.push(`  ${theme.warn("\u2192")} ${inst.label}`);
     }
   }
 
@@ -244,6 +282,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   const missingReqs = report.skills.filter(
     (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
   );
+  const diagnostics = report.diagnostics ?? [];
 
   if (opts.json) {
     return JSON.stringify(
@@ -254,6 +293,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           disabled: disabled.length,
           blocked: blocked.length,
           missingRequirements: missingReqs.length,
+          parseErrors: diagnostics.length,
         },
         eligible: eligible.map((s) => s.name),
         disabled: disabled.map((s) => s.name),
@@ -263,6 +303,15 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
           missing: s.missing,
           install: s.install,
         })),
+        ...(diagnostics.length > 0
+          ? {
+              parseErrors: diagnostics.map((d) => ({
+                message: d.message,
+                path: d.path,
+                source: d.source,
+              })),
+            }
+          : {}),
       },
       null,
       2,
@@ -273,16 +322,23 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   lines.push(theme.heading("Skills Status Check"));
   lines.push("");
   lines.push(`${theme.muted("Total:")} ${report.skills.length}`);
-  lines.push(`${theme.success("✓")} ${theme.muted("Eligible:")} ${eligible.length}`);
-  lines.push(`${theme.warn("⏸")} ${theme.muted("Disabled:")} ${disabled.length}`);
-  lines.push(`${theme.warn("🚫")} ${theme.muted("Blocked by allowlist:")} ${blocked.length}`);
-  lines.push(`${theme.error("✗")} ${theme.muted("Missing requirements:")} ${missingReqs.length}`);
+  lines.push(`${theme.success("\u2713")} ${theme.muted("Eligible:")} ${eligible.length}`);
+  lines.push(`${theme.warn("\u23F8")} ${theme.muted("Disabled:")} ${disabled.length}`);
+  lines.push(
+    `${theme.warn("\uD83D\uDEAB")} ${theme.muted("Blocked by allowlist:")} ${blocked.length}`,
+  );
+  lines.push(
+    `${theme.error("\u2717")} ${theme.muted("Missing requirements:")} ${missingReqs.length}`,
+  );
+  if (diagnostics.length > 0) {
+    lines.push(`${theme.warn("!!")} ${theme.muted("Parse errors:")} ${diagnostics.length}`);
+  }
 
   if (eligible.length > 0) {
     lines.push("");
     lines.push(theme.heading("Ready to use:"));
     for (const skill of eligible) {
-      const emoji = skill.emoji ?? "📦";
+      const emoji = skill.emoji ?? "\uD83D\uDCE6";
       lines.push(`  ${emoji} ${skill.name}`);
     }
   }
@@ -291,9 +347,23 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     lines.push("");
     lines.push(theme.heading("Missing requirements:"));
     for (const skill of missingReqs) {
-      const emoji = skill.emoji ?? "📦";
+      const emoji = skill.emoji ?? "\uD83D\uDCE6";
       const missing = formatSkillMissingSummary(skill);
       lines.push(`  ${emoji} ${skill.name} ${theme.muted(`(${missing})`)}`);
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    lines.push("");
+    lines.push(theme.heading("Parse errors:"));
+    lines.push(
+      theme.muted("  These skills failed to load due to YAML/frontmatter errors in SKILL.md."),
+    );
+    lines.push(theme.muted("  Tip: wrap description values containing `: ` in quotes."));
+    for (const diag of diagnostics) {
+      const name = diagnosticSkillName(diag);
+      const pathHint = diag.path ? ` ${theme.muted(`(${shortenHomePath(diag.path)})`)}` : "";
+      lines.push(`  ${theme.warn("!!")} ${name}: ${diag.message}${pathHint}`);
     }
   }
 

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -29,11 +29,15 @@ function createMockSkill(overrides: Partial<SkillStatusEntry> = {}): SkillStatus
   };
 }
 
-function createMockReport(skills: SkillStatusEntry[]): SkillStatusReport {
+function createMockReport(
+  skills: SkillStatusEntry[],
+  diagnostics: SkillStatusReport["diagnostics"] = [],
+): SkillStatusReport {
   return {
     workspaceDir: "/workspace",
     managedSkillsDir: "/managed",
     skills,
+    diagnostics,
   };
 }
 
@@ -93,6 +97,42 @@ describe("skills-cli", () => {
       expect(output).toContain("missing");
       expect(output).toContain("anyBins");
       expect(output).toContain("os:");
+    });
+
+    it("shows parse error diagnostics as warning rows", () => {
+      const report = createMockReport(
+        [createMockSkill({ name: "good-skill", eligible: true })],
+        [
+          {
+            type: "warning",
+            message: "Nested mappings are not allowed in compact mappings",
+            path: "/home/user/.openclaw/skills/bad-skill/SKILL.md",
+            source: "openclaw-managed",
+          },
+        ],
+      );
+      const output = formatSkillsList(report, {});
+      expect(output).toContain("parse error");
+      expect(output).toContain("bad-skill");
+      expect(output).toContain("Nested mappings");
+    });
+
+    it("includes diagnostics in JSON output", () => {
+      const report = createMockReport(
+        [],
+        [
+          {
+            type: "warning",
+            message: "YAML parse error",
+            path: "/tmp/skills/broken/SKILL.md",
+            source: "openclaw-extra",
+          },
+        ],
+      );
+      const output = formatSkillsList(report, { json: true });
+      const parsed = JSON.parse(output);
+      expect(parsed.diagnostics).toHaveLength(1);
+      expect(parsed.diagnostics[0].message).toBe("YAML parse error");
     });
 
     it("filters to eligible only with --eligible flag", () => {
@@ -169,6 +209,43 @@ describe("skills-cli", () => {
       expect(output).toContain("not-ready");
       expect(output).toContain("go"); // missing binary
       expect(output).toContain("npx clawhub");
+    });
+
+    it("shows parse errors section in check output", () => {
+      const report = createMockReport(
+        [createMockSkill({ name: "ready-1", eligible: true })],
+        [
+          {
+            type: "warning",
+            message: "failed to parse skill file",
+            path: "/tmp/broken-skill/SKILL.md",
+            source: "openclaw-workspace",
+          },
+        ],
+      );
+      const output = formatSkillsCheck(report, {});
+      expect(output).toContain("Parse errors:");
+      expect(output).toContain("broken-skill");
+      expect(output).toContain("failed to parse skill file");
+      expect(output).toContain("Tip:");
+    });
+
+    it("includes parseErrors in check JSON output", () => {
+      const report = createMockReport(
+        [],
+        [
+          {
+            type: "warning",
+            message: "bad yaml",
+            path: "/tmp/x/SKILL.md",
+            source: "openclaw-managed",
+          },
+        ],
+      );
+      const output = formatSkillsCheck(report, { json: true });
+      const parsed = JSON.parse(output);
+      expect(parsed.summary.parseErrors).toBe(1);
+      expect(parsed.parseErrors).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Extracts diagnostics from loadSkillsFromDir() result
- Shows parse error rows in skills list and skills check output
- 4 new test cases covering list/check formats

Fixes #22134

🤖 Generated with [Claude Code](https://claude.com/claude-code)