### PR TITLE
fix(sandbox): allow missing target in write/mkdir/rename operations

### DIFF
--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -114,7 +114,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "write files");
-    await this.assertPathSafety(target, { action: "write files", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "write files",
+      requireWritable: true,
+      allowMissingTarget: params.mkdir !== false,
+    });
     const buffer = Buffer.isBuffer(params.data)
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
@@ -132,7 +136,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create directories");
-    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "create directories",
+      requireWritable: true,
+      allowMissingTarget: true,
+    });
     await this.runCommand('set -eu; mkdir -p -- "$1"', {
       args: [target.containerPath],
       signal: params.signal,
@@ -181,6 +189,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     await this.assertPathSafety(to, {
       action: "rename files",
       requireWritable: true,
+      allowMissingTarget: true,
     });
     await this.runCommand(
       'set -eu; dir=$(dirname -- "$2"); if [ "$dir" != "." ]; then mkdir -p -- "$dir"; fi; mv -- "$1" "$2"',


### PR DESCRIPTION
## Summary

Fixes a regression from 2026.2.24 where creating new files in a sandboxed environment fails with:



## Root Cause

The  function was checking for file existence before allowing directory creation, but for new files the parent directory may not have the target file yet.

## Fix

Add  option to  calls for:
-  operation (when mkdir is enabled)
-  operation
-  operation

## Test

This fix was developed against the exact scenario described in issue #28734.

## Fixes

Fixes #28734