### PR TITLE
feat(models): add Qwen 3.5 Plus model to Qwen provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -677,6 +677,15 @@ function buildQwenPortalProvider(): ProviderConfig {
     api: "openai-completions",
     models: [
       {
+        id: "qwen3.5-plus",
+        name: "Qwen 3.5 Plus",
+        reasoning: true,
+        input: ["text"],
+        cost: QWEN_PORTAL_DEFAULT_COST,
+        contextWindow: QWEN_PORTAL_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: QWEN_PORTAL_DEFAULT_MAX_TOKENS,
+      },
+      {
         id: "coder-model",
         name: "Qwen Coder",
         reasoning: false,


### PR DESCRIPTION
## Summary
- Added qwen3.5-plus model entry to buildQwenPortalProvider()
- Reasoning-capable model with 128K context, 8192 max tokens
- Closes #20848

## Test plan
- All 61 model selection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)