### PR TITLE
docs: add Windows native (non-WSL2) setup guide

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -18,7 +18,7 @@ Already followed [Getting Started](/start/getting-started)? You're all set — t
 - `pnpm` only if you build from source
 
 <Note>
-On Windows, we strongly recommend running OpenClaw under [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
+On Windows, OpenClaw runs natively (Node.js + PowerShell) or under [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install). See the [Windows platform page](/platforms/windows) for both paths.
 </Note>
 
 ## Install methods

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -13,7 +13,7 @@ Bun is not recommended for the Gateway (WhatsApp/Telegram bugs).
 
 Companion apps exist for macOS (menu bar app) and mobile nodes (iOS/Android). Windows and
 Linux companion apps are planned, but the Gateway is fully supported today.
-Native companion apps for Windows are also planned; the Gateway is recommended via WSL2.
+On Windows, the Gateway runs natively (Node.js + PowerShell) or via WSL2.
 
 ## Choose your OS
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -1,105 +1,354 @@
 ---
-summary: "Windows (WSL2) support + companion app status"
+summary: "Windows support: native (PowerShell) and WSL2 install paths, auto-start, and gateway config"
 read_when:
   - Installing OpenClaw on Windows
+  - Running OpenClaw natively on Windows without WSL2
   - Looking for Windows companion app status
-title: "Windows (WSL2)"
+  - Setting up auto-start on Windows
+title: "Windows"
 ---
 
-# Windows (WSL2)
+# Windows
 
-OpenClaw on Windows is recommended **via WSL2** (Ubuntu recommended). The
-CLI + Gateway run inside Linux, which keeps the runtime consistent and makes
-tooling far more compatible (Node/Bun/pnpm, Linux binaries, skills). Native
-Windows might be trickier. WSL2 gives you the full Linux experience — one command
-to install: `wsl --install`.
+OpenClaw runs on Windows in two ways:
 
-Native Windows companion apps are planned.
+- **Native Windows** -- Node.js + PowerShell, no WSL2 needed. Simpler setup, works on any Windows 10+ machine.
+- **WSL2** -- runs inside a Linux VM. Better compatibility with Linux-only tooling and skills.
 
-## Install (WSL2)
+Both paths use the same Gateway, config format, and channels.
 
-- [Getting Started](/start/getting-started) (use inside WSL)
-- [Install & updates](/install/updating)
-- Official WSL2 guide (Microsoft): [https://learn.microsoft.com/windows/wsl/install](https://learn.microsoft.com/windows/wsl/install)
+<Tip>
+If you just want OpenClaw running quickly and do not need Linux-specific tools, **native Windows** is the easiest path.
+</Tip>
 
-## Gateway
+---
+
+## Native Windows (no WSL2)
+
+### 1) Install Node.js
+
+Download and install [Node.js 22+](https://nodejs.org/) (LTS recommended). The installer adds `node` and `npm` to your PATH automatically.
+
+Verify in PowerShell:
+
+```powershell
+node -v    # should print v22.x or higher
+npm -v
+```
+
+### 2) Install OpenClaw
+
+<Tabs>
+  <Tab title="Installer script (recommended)">
+    ```powershell
+    iwr -useb https://openclaw.ai/install.ps1 | iex
+    ```
+
+    To skip onboarding and just install the binary:
+
+    ```powershell
+    & ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -NoOnboard
+    ```
+
+    For all flags, see [Installer internals](/install/installer).
+
+  </Tab>
+  <Tab title="npm">
+    ```powershell
+    npm install -g openclaw@latest
+    openclaw onboard
+    ```
+  </Tab>
+</Tabs>
+
+After install, verify:
+
+```powershell
+openclaw --version
+openclaw doctor
+```
+
+<Accordion title="openclaw not found after install">
+  If `openclaw` is not recognized, the npm global bin directory is not in your PATH.
+
+Find it:
+
+```powershell
+npm prefix -g
+```
+
+Add the output path to your system PATH (System Properties > Environment Variables > Path > Edit > New).
+
+Then open a new PowerShell window and retry.
+</Accordion>
+
+### 3) Configure the Gateway
+
+```powershell
+openclaw config set gateway.mode local
+```
+
+Or run the interactive wizard:
+
+```powershell
+openclaw configure
+```
+
+Config file location: `%USERPROFILE%\.openclaw\openclaw.json`
 
 - [Gateway runbook](/gateway)
 - [Configuration](/gateway/configuration)
 
-## Gateway service install (CLI)
+### 4) Start the Gateway
+
+```powershell
+openclaw gateway run
+```
+
+To run the gateway in the background (detached), see [Auto-start on Windows](#auto-start-on-windows) below.
+
+Verify:
+
+```powershell
+openclaw status
+openclaw gateway status
+```
+
+### Auto-start on Windows
+
+There is no systemd on native Windows, so use one of these approaches to keep the gateway running after login.
+
+#### Task Scheduler (recommended)
+
+Task Scheduler is built into Windows and is the most reliable option.
+
+<Steps>
+  <Step title="Create a wrapper script">
+    Save the following as `%USERPROFILE%\openclaw-gateway.cmd`:
+
+    ```batch
+    @echo off
+    openclaw gateway run --port 18789
+    ```
+
+  </Step>
+  <Step title="Create a scheduled task (PowerShell as Administrator)">
+    ```powershell
+    $Action = New-ScheduledTaskAction -Execute "cmd.exe" `
+      -Argument "/c `"$env:USERPROFILE\openclaw-gateway.cmd`"" `
+      -WorkingDirectory $env:USERPROFILE
+
+    $Trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+    $Settings = New-ScheduledTaskSettingsSet `
+      -AllowStartIfOnBatteries `
+      -DontStopIfGoingOnBatteries `
+      -RestartCount 3 `
+      -RestartInterval (New-TimeSpan -Minutes 1) `
+      -MultipleInstances IgnoreNew
+
+    Register-ScheduledTask -TaskName "OpenClaw Gateway" `
+      -Action $Action -Trigger $Trigger -Settings $Settings `
+      -Description "OpenClaw Gateway auto-start" -RunLevel Limited
+    ```
+
+  </Step>
+  <Step title="Verify">
+    ```powershell
+    Get-ScheduledTask -TaskName "OpenClaw Gateway"
+    ```
+
+    Reboot or manually start the task to confirm.
+
+  </Step>
+</Steps>
+
+To remove:
+
+```powershell
+Unregister-ScheduledTask -TaskName "OpenClaw Gateway" -Confirm:$false
+```
+
+#### Startup folder shortcut
+
+For a simpler (but less robust) approach, place a shortcut in the Startup folder:
+
+```powershell
+$WshShell = New-Object -ComObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut(
+  "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\OpenClaw Gateway.lnk"
+)
+$Shortcut.TargetPath = "cmd.exe"
+$Shortcut.Arguments = "/c openclaw gateway run --port 18789"
+$Shortcut.WorkingDirectory = $env:USERPROFILE
+$Shortcut.WindowStyle = 7  # minimized
+$Shortcut.Save()
+```
+
+This starts the gateway at login but does not restart it if it crashes.
+
+#### NSSM (Windows service)
+
+[NSSM](https://nssm.cc/) wraps any program as a Windows service. This is useful for headless servers or when you need the gateway running before anyone logs in.
+
+```powershell
+# Install NSSM (e.g. via Chocolatey)
+choco install nssm -y
+
+# Find the full path to openclaw
+(Get-Command openclaw).Source
+
+# Install the service (adjust the path)
+nssm install OpenClawGateway "C:\Program Files\nodejs\openclaw.cmd" "gateway" "run" "--port" "18789"
+nssm set OpenClawGateway AppDirectory $env:USERPROFILE
+nssm set OpenClawGateway AppStdout "$env:USERPROFILE\.openclaw\gateway-stdout.log"
+nssm set OpenClawGateway AppStderr "$env:USERPROFILE\.openclaw\gateway-stderr.log"
+nssm start OpenClawGateway
+```
+
+<Warning>
+Task Scheduler and NSSM can conflict if both are configured. Use one or the other.
+</Warning>
+
+### PowerShell gotchas
+
+PowerShell syntax differs from bash in ways that cause silent failures if you copy Linux examples directly.
+
+**No `&&` operator (PowerShell 5.x).**
+PowerShell 5.x (the version shipped with Windows) does not support `&&`. Use `;` to run commands sequentially, or run them as separate lines:
+
+```powershell
+# Wrong (fails silently in PS 5.x):
+openclaw gateway run && openclaw status
+
+# Correct:
+openclaw gateway run; openclaw status
+
+# Or just run them separately:
+openclaw gateway run
+openclaw status
+```
+
+<Note>
+PowerShell 7+ (installed separately via `winget install Microsoft.PowerShell`) does support `&&`.
+</Note>
+
+**Port conflict guard.**
+Before starting the gateway, check whether the port is already in use to avoid duplicate instances:
+
+```powershell
+$Port = 18789
+$InUse = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
+if ($InUse) {
+  Write-Host "Port $Port is already in use. Gateway may already be running."
+} else {
+  openclaw gateway run --port $Port
+}
+```
+
+**Execution policy.**
+If PowerShell blocks script execution, allow it for the current user:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+### Windows Firewall
+
+If you bind the gateway to a non-loopback address (for LAN or remote access), allow the port through Windows Firewall:
+
+```powershell
+New-NetFirewallRule -DisplayName "OpenClaw Gateway" -Direction Inbound `
+  -Protocol TCP -LocalPort 18789 -Action Allow
+```
+
+---
+
+## WSL2
+
+WSL2 gives you a full Linux environment on Windows. This is recommended if you rely on Linux-only tools, skills, or build chains (Bun, pnpm patches, etc.).
+
+### Install WSL2 + Ubuntu
+
+Open PowerShell (Admin):
+
+```powershell
+wsl --install
+# Or pick a distro explicitly:
+wsl --list --online
+wsl --install -d Ubuntu-24.04
+```
+
+Reboot if Windows asks.
+
+### Enable systemd (required for gateway service)
+
+In your WSL terminal:
+
+```bash
+sudo tee /etc/wsl.conf >/dev/null <<'EOF'
+[boot]
+systemd=true
+EOF
+```
+
+Then from PowerShell:
+
+```powershell
+wsl --shutdown
+```
+
+Re-open Ubuntu, then verify:
+
+```bash
+systemctl --user status
+```
+
+### Install OpenClaw (inside WSL)
+
+Follow the Linux Getting Started flow inside WSL:
+
+<Tabs>
+  <Tab title="Installer script">
+    ```bash
+    curl -fsSL https://openclaw.ai/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="From source">
+    ```bash
+    git clone https://github.com/openclaw/openclaw.git
+    cd openclaw
+    pnpm install
+    pnpm ui:build
+    pnpm build
+    openclaw onboard
+    ```
+  </Tab>
+</Tabs>
+
+Full guide: [Getting Started](/start/getting-started)
+
+### Gateway service install (WSL2)
 
 Inside WSL2:
 
-```
+```bash
 openclaw onboard --install-daemon
 ```
 
 Or:
 
-```
+```bash
 openclaw gateway install
 ```
-
-Or:
-
-```
-openclaw configure
-```
-
-Select **Gateway service** when prompted.
 
 Repair/migrate:
 
-```
+```bash
 openclaw doctor
 ```
 
-## Gateway auto-start before Windows login
-
-For headless setups, ensure the full boot chain runs even when no one logs into
-Windows.
-
-### 1) Keep user services running without login
-
-Inside WSL:
-
-```bash
-sudo loginctl enable-linger "$(whoami)"
-```
-
-### 2) Install the OpenClaw gateway user service
-
-Inside WSL:
-
-```bash
-openclaw gateway install
-```
-
-### 3) Start WSL automatically at Windows boot
-
-In PowerShell as Administrator:
-
-```powershell
-schtasks /create /tn "WSL Boot" /tr "wsl.exe -d Ubuntu --exec /bin/true" /sc onstart /ru SYSTEM
-```
-
-Replace `Ubuntu` with your distro name from:
-
-```powershell
-wsl --list --verbose
-```
-
-### Verify startup chain
-
-After a reboot (before Windows sign-in), check from WSL:
-
-```bash
-systemctl --user is-enabled openclaw-gateway
-systemctl --user status openclaw-gateway --no-pager
-```
-
-## Advanced: expose WSL services over LAN (portproxy)
+### Expose WSL services over LAN (portproxy)
 
 WSL has its own virtual network. If another machine needs to reach a service
 running **inside WSL** (SSH, a local TTS server, or the Gateway), you must
@@ -144,60 +393,14 @@ Notes:
 - If you want this automatic, register a Scheduled Task to run the refresh
   step at login.
 
-## Step-by-step WSL2 install
+---
 
-### 1) Install WSL2 + Ubuntu
+## Common links
 
-Open PowerShell (Admin):
-
-```powershell
-wsl --install
-# Or pick a distro explicitly:
-wsl --list --online
-wsl --install -d Ubuntu-24.04
-```
-
-Reboot if Windows asks.
-
-### 2) Enable systemd (required for gateway install)
-
-In your WSL terminal:
-
-```bash
-sudo tee /etc/wsl.conf >/dev/null <<'EOF'
-[boot]
-systemd=true
-EOF
-```
-
-Then from PowerShell:
-
-```powershell
-wsl --shutdown
-```
-
-Re-open Ubuntu, then verify:
-
-```bash
-systemctl --user status
-```
-
-### 3) Install OpenClaw (inside WSL)
-
-Follow the Linux Getting Started flow inside WSL:
-
-```bash
-git clone https://github.com/openclaw/openclaw.git
-cd openclaw
-pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
-openclaw onboard
-```
-
-Full guide: [Getting Started](/start/getting-started)
+- [Gateway runbook](/gateway)
+- [Configuration](/gateway/configuration)
+- [Install & updates](/install/updating)
 
 ## Windows companion app
 
-We do not have a Windows companion app yet. Contributions are welcome if you want
-contributions to make it happen.
+There is no Windows companion app yet. Contributions are welcome.


### PR DESCRIPTION
## Summary
- Major rewrite of docs/platforms/windows.md adding native Windows setup
- Covers auto-start (Task Scheduler, NSSM), PowerShell gotchas, firewall config
- Updated platforms/index.md and install/index.md to reflect native Windows support
- Closes #23178

## Test plan
- Documentation-only change
- Mintlify link conventions followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)