### PR TITLE
feat(control-ui): set document.title to active agent name

### DIFF
--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleDisconnected } from "./app-lifecycle.ts";
+import { handleDisconnected, handleUpdated, syncDocumentTitle } from "./app-lifecycle.ts";
 
 function createHost() {
   return {
@@ -40,5 +40,50 @@ describe("handleDisconnected", () => {
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(host.topbarObserver).toBeNull();
     removeSpy.mockRestore();
+  });
+});
+
+describe("syncDocumentTitle", () => {
+  it("sets base title when assistant name is the default", () => {
+    syncDocumentTitle("Assistant");
+    expect(document.title).toBe("OpenClaw Control");
+  });
+
+  it("sets base title when assistant name is empty", () => {
+    syncDocumentTitle("");
+    expect(document.title).toBe("OpenClaw Control");
+  });
+
+  it("includes agent name in title for named agents", () => {
+    syncDocumentTitle("Tony");
+    expect(document.title).toBe("OpenClaw \u2014 Tony");
+  });
+
+  it("includes agent name for non-default names", () => {
+    syncDocumentTitle("Claw");
+    expect(document.title).toBe("OpenClaw \u2014 Claw");
+  });
+});
+
+describe("handleUpdated", () => {
+  it("syncs document title when assistantName changes", () => {
+    const host = createHost();
+    host.assistantName = "Tony";
+    const changed = new Map<PropertyKey, unknown>([["assistantName", "OpenClaw"]]);
+
+    handleUpdated(host as unknown as Parameters<typeof handleUpdated>[0], changed);
+
+    expect(document.title).toBe("OpenClaw \u2014 Tony");
+  });
+
+  it("does not change title when assistantName is not in changed map", () => {
+    document.title = "Original";
+    const host = createHost();
+    host.assistantName = "Tony";
+    const changed = new Map<PropertyKey, unknown>([["chatLoading", true]]);
+
+    handleUpdated(host as unknown as Parameters<typeof handleUpdated>[0], changed);
+
+    expect(document.title).toBe("Original");
   });
 });

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -16,6 +16,7 @@ import {
   syncTabWithLocation,
   syncThemeWithSettings,
 } from "./app-settings.ts";
+import { DEFAULT_ASSISTANT_NAME } from "./assistant-identity.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
 
@@ -40,9 +41,24 @@ type LifecycleHost = {
   topbarObserver: ResizeObserver | null;
 };
 
+const BASE_TITLE = "OpenClaw Control";
+
+/** Update the browser tab title to reflect the active agent name. */
+export function syncDocumentTitle(assistantName: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  // Show "OpenClaw Control" when no custom agent name, otherwise "OpenClaw — AgentName".
+  if (!assistantName || assistantName === DEFAULT_ASSISTANT_NAME) {
+    document.title = BASE_TITLE;
+    return;
+  }
+  document.title = `OpenClaw \u2014 ${assistantName}`;
+}
+
 export function handleConnected(host: LifecycleHost) {
   host.basePath = inferBasePath();
-  void loadControlUiBootstrapConfig(host);
+  void loadControlUiBootstrapConfig(host).then(() => syncDocumentTitle(host.assistantName));
   applySettingsFromUrl(host as unknown as Parameters<typeof applySettingsFromUrl>[0]);
   syncTabWithLocation(host as unknown as Parameters<typeof syncTabWithLocation>[0], true);
   syncThemeWithSettings(host as unknown as Parameters<typeof syncThemeWithSettings>[0]);
@@ -76,6 +92,9 @@ export function handleDisconnected(host: LifecycleHost) {
 }
 
 export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unknown>) {
+  if (changed.has("assistantName")) {
+    syncDocumentTitle(host.assistantName);
+  }
   if (host.tab === "chat" && host.chatManualRefreshInFlight) {
     return;
   }


### PR DESCRIPTION
## Summary
- Dynamically update document.title based on active agent assistantName
- Shows "OpenClaw — AgentName" for named agents, "OpenClaw Control" for default
- Syncs on both initial load and session switching
- Closes #27027

## Test plan
- 4 unit tests for syncDocumentTitle function
- 2 tests for handleUpdated lifecycle hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)