### PR TITLE
fix: prevent endless tool retries by enabling loop detection by default

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -207,7 +207,7 @@ describe("tool-loop-detection", () => {
   });
 
   describe("detectToolCallLoop", () => {
-    it("is disabled by default", () => {
+    it("warns on repeated calls by default", () => {
       const state = createState();
 
       for (let i = 0; i < 20; i += 1) {
@@ -215,7 +215,10 @@ describe("tool-loop-detection", () => {
       }
 
       const loopResult = detectToolCallLoop(state, "read", { path: "/same.txt" });
-      expect(loopResult.stuck).toBe(false);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+      }
     });
 
     it("does not flag unique tool calls", () => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -29,7 +29,7 @@ export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
+  enabled: true,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -440,7 +440,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.exec.applyPatch.allowModels":
     'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
   "tools.loopDetection.enabled":
-    "Enable repetitive tool-call loop detection and backoff safety checks (default: false).",
+    "Enable repetitive tool-call loop detection and backoff safety checks (default: true).",
   "tools.loopDetection.historySize": "Tool history window size for loop detection (default: 30).",
   "tools.loopDetection.warningThreshold":
     "Warning threshold for repetitive patterns when detector is enabled (default: 10).",


### PR DESCRIPTION
Fixes #28576

## Summary
- enable `tools.loopDetection` by default so repeated no-progress tool calls are detected without extra config
- keep existing thresholds/detectors unchanged
- update help text to reflect the new default
- update loop-detection tests for the new default behavior

## Validation
- `pnpm vitest src/agents/tool-loop-detection.test.ts src/agents/pi-tools.before-tool-call.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`
