### PR TITLE
fix(control-ui): allow nav section collapse when current page is inside section

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -347,6 +347,22 @@
   transform: rotate(-90deg);
 }
 
+/* Highlight section label when collapsed but contains the active tab */
+.nav-group--collapsed.nav-group--has-active .nav-label {
+  color: var(--text-strong);
+}
+
+.nav-group--collapsed.nav-group--has-active .nav-label__text::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
 /* Nav items */
 .nav-item {
   position: relative;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -265,7 +265,7 @@ export function renderApp(state: AppViewState) {
           const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
           const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
           return html`
-            <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
+            <div class="nav-group ${isGroupCollapsed ? "nav-group--collapsed" : ""} ${hasActiveTab ? "nav-group--has-active" : ""}">
               <button
                 class="nav-label"
                 @click=${() => {

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -185,4 +185,41 @@ describe("control UI routing", () => {
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.hash).toBe("");
   });
+
+  it("collapses a nav section even when the active tab is inside it", async () => {
+    const app = mountApp("/overview");
+    await app.updateComplete;
+
+    expect(app.tab).toBe("overview");
+
+    // Find the nav-group containing the active tab (overview is in the "control" group)
+    const navGroups = app.querySelectorAll<HTMLElement>(".nav-group");
+    let activeGroup: HTMLElement | null = null;
+    for (const group of navGroups) {
+      if (group.querySelector('a.nav-item[href="/overview"]')) {
+        activeGroup = group;
+        break;
+      }
+    }
+    expect(activeGroup).not.toBeNull();
+
+    // Section should not be collapsed initially
+    expect(activeGroup?.classList.contains("nav-group--collapsed")).toBe(false);
+
+    // Click the section toggle to collapse
+    const toggleBtn = activeGroup?.querySelector<HTMLButtonElement>(".nav-label");
+    expect(toggleBtn).not.toBeNull();
+    toggleBtn?.click();
+    await app.updateComplete;
+
+    // Section should now be collapsed and show the active indicator
+    expect(activeGroup?.classList.contains("nav-group--collapsed")).toBe(true);
+    expect(activeGroup?.classList.contains("nav-group--has-active")).toBe(true);
+
+    // Click the section toggle again to expand
+    toggleBtn?.click();
+    await app.updateComplete;
+
+    expect(activeGroup?.classList.contains("nav-group--collapsed")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Removed hasActiveTab guard preventing nav section collapse
- Added accent dot indicator when collapsed section contains active page
- Closes #22831

## Test plan
- Browser test verifying toggle collapse/expand with active tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)