### PR TITLE
feat(telegram): add link_preview_options support to message tool

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -198,6 +198,21 @@ function buildSendSchema(options: {
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),
     ),
+    linkPreviewOptions: Type.Optional(
+      Type.Object(
+        {
+          is_disabled: Type.Optional(Type.Boolean()),
+          url: Type.Optional(Type.String()),
+          prefer_small_media: Type.Optional(Type.Boolean()),
+          prefer_large_media: Type.Optional(Type.Boolean()),
+          show_above_text: Type.Optional(Type.Boolean()),
+        },
+        {
+          description:
+            "Telegram link preview options. Controls link unfurling behavior per message.",
+        },
+      ),
+    ),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
     buttons: Type.Optional(

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -223,6 +223,17 @@ export async function handleTelegramAction(
       integer: true,
     });
     const quoteText = readStringParam(params, "quoteText");
+    // Per-message link preview control (maps to Telegram API link_preview_options).
+    const linkPreviewOptions =
+      params.linkPreviewOptions != null && typeof params.linkPreviewOptions === "object"
+        ? (params.linkPreviewOptions as {
+            is_disabled?: boolean;
+            url?: string;
+            prefer_small_media?: boolean;
+            prefer_large_media?: boolean;
+            show_above_text?: boolean;
+          })
+        : undefined;
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(
@@ -240,6 +251,7 @@ export async function handleTelegramAction(
       quoteText: quoteText ?? undefined,
       asVoice: typeof params.asVoice === "boolean" ? params.asVoice : undefined,
       silent: typeof params.silent === "boolean" ? params.silent : undefined,
+      linkPreviewOptions,
     });
     return jsonResult({
       ok: true,

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -224,9 +224,10 @@ export async function handleTelegramAction(
     });
     const quoteText = readStringParam(params, "quoteText");
     // Per-message link preview control (maps to Telegram API link_preview_options).
+    const rawLinkPreviewOptions = params.linkPreviewOptions ?? params.link_preview_options;
     const linkPreviewOptions =
-      params.linkPreviewOptions != null && typeof params.linkPreviewOptions === "object"
-        ? (params.linkPreviewOptions as {
+      rawLinkPreviewOptions != null && typeof rawLinkPreviewOptions === "object"
+        ? (rawLinkPreviewOptions as {
             is_disabled?: boolean;
             url?: string;
             prefer_small_media?: boolean;

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -30,6 +30,10 @@ function readTelegramSendParams(params: Record<string, unknown>) {
   const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
   const silent = typeof params.silent === "boolean" ? params.silent : undefined;
   const quoteText = readStringParam(params, "quoteText");
+  const linkPreviewOptions =
+    params.linkPreviewOptions != null && typeof params.linkPreviewOptions === "object"
+      ? (params.linkPreviewOptions as Record<string, unknown>)
+      : undefined;
   return {
     to,
     content,
@@ -40,6 +44,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     asVoice,
     silent,
     quoteText: quoteText ?? undefined,
+    linkPreviewOptions,
   };
 }
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -30,9 +30,10 @@ function readTelegramSendParams(params: Record<string, unknown>) {
   const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
   const silent = typeof params.silent === "boolean" ? params.silent : undefined;
   const quoteText = readStringParam(params, "quoteText");
+  const rawLinkPreviewOptions = params.linkPreviewOptions ?? params.link_preview_options;
   const linkPreviewOptions =
-    params.linkPreviewOptions != null && typeof params.linkPreviewOptions === "object"
-      ? (params.linkPreviewOptions as Record<string, unknown>)
+    rawLinkPreviewOptions != null && typeof rawLinkPreviewOptions === "object"
+      ? (rawLinkPreviewOptions as Record<string, unknown>)
       : undefined;
   return {
     to,

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -329,6 +329,64 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("uses per-message linkPreviewOptions when provided", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 10, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    loadConfig.mockReturnValue({});
+    await sendMessageTelegram("123", "check https://example.com", {
+      token: "tok",
+      api,
+      linkPreviewOptions: { is_disabled: true },
+    });
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+  });
+
+  it("per-message linkPreviewOptions overrides config linkPreview", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 11, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    // Config disables link preview, but per-message opts enable with specific URL
+    loadConfig.mockReturnValue({
+      channels: { telegram: { linkPreview: false } },
+    });
+    await sendMessageTelegram("123", "check this out", {
+      token: "tok",
+      api,
+      linkPreviewOptions: { url: "https://example.com", prefer_small_media: true },
+    });
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        link_preview_options: { url: "https://example.com", prefer_small_media: true },
+      }),
+    );
+  });
+
+  it("falls back to config linkPreview when no per-message linkPreviewOptions", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 12, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    loadConfig.mockReturnValue({
+      channels: { telegram: { linkPreview: false } },
+    });
+    await sendMessageTelegram("123", "check this out", {
+      token: "tok",
+      api,
+    });
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+  });
+
   it("fails when Telegram text send returns no message_id", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chat: { id: "123" },

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -41,6 +41,15 @@ import { resolveTelegramVoiceSend } from "./voice.js";
 type TelegramApi = Bot["api"];
 type TelegramApiOverride = Partial<TelegramApi>;
 
+/** Per-message link preview options (maps to Telegram API link_preview_options). */
+type TelegramLinkPreviewOptions = {
+  is_disabled?: boolean;
+  url?: string;
+  prefer_small_media?: boolean;
+  prefer_large_media?: boolean;
+  show_above_text?: boolean;
+};
+
 type TelegramSendOpts = {
   cfg?: ReturnType<typeof loadConfig>;
   token?: string;
@@ -67,6 +76,8 @@ type TelegramSendOpts = {
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
   buttons?: TelegramInlineButtons;
+  /** Per-message link preview options. Overrides account-level linkPreview config. */
+  linkPreviewOptions?: TelegramLinkPreviewOptions;
 };
 
 type TelegramSendResult = {
@@ -504,9 +515,12 @@ export async function sendMessageTelegram(
   });
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
 
-  // Resolve link preview setting from config (default: enabled).
-  const linkPreviewEnabled = account.config.linkPreview ?? true;
-  const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
+  // Per-message link_preview_options override account-level linkPreview config.
+  const linkPreviewOptions: TelegramLinkPreviewOptions | undefined = opts.linkPreviewOptions
+    ? opts.linkPreviewOptions
+    : (account.config.linkPreview ?? true)
+      ? undefined
+      : { is_disabled: true };
 
   const sendTelegramText = async (
     rawText: string,


### PR DESCRIPTION
## Summary
- Added per-message link_preview_options to Telegram message tool
- Supports is_disabled, url, prefer_small_media, prefer_large_media, show_above_text
- Falls back to account-level linkPreview config when not specified
- 5 files changed, 3 new tests
- Closes #22754

## Test plan
- Test per-message linkPreviewOptions passthrough
- Test override of config linkPreview
- Test fallback to config when no per-message option

🤖 Generated with [Claude Code](https://claude.com/claude-code)