### PR TITLE
feat(telegram): default heartbeat showOk to true for better feedback

### DIFF
--- a/src/infra/heartbeat-visibility.test.ts
+++ b/src/infra/heartbeat-visibility.test.ts
@@ -41,10 +41,28 @@ describe("resolveHeartbeatVisibility", () => {
     const result = resolveHeartbeatVisibility({ cfg, channel: "telegram" });
 
     expect(result).toEqual({
-      showOk: false,
+      showOk: true,
       showAlerts: true,
       useIndicator: true,
     });
+  });
+
+  it("telegram defaults showOk to true (built-in channel default)", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = resolveHeartbeatVisibility({ cfg, channel: "telegram" });
+    expect(result.showOk).toBe(true);
+  });
+
+  it("non-telegram channels default showOk to false", () => {
+    const cfg = {} as OpenClawConfig;
+    const result = resolveHeartbeatVisibility({ cfg, channel: "discord" });
+    expect(result.showOk).toBe(false);
+  });
+
+  it("config channel defaults override telegram built-in default", () => {
+    const cfg = createChannelDefaultsHeartbeatConfig({ showOk: false });
+    const result = resolveHeartbeatVisibility({ cfg, channel: "telegram" });
+    expect(result.showOk).toBe(false);
   });
 
   it("uses channel defaults when provided", () => {

--- a/src/infra/heartbeat-visibility.ts
+++ b/src/infra/heartbeat-visibility.ts
@@ -14,6 +14,13 @@ const DEFAULT_VISIBILITY: ResolvedHeartbeatVisibility = {
   useIndicator: true, // Emit indicator events
 };
 
+/** Per-channel built-in defaults that override DEFAULT_VISIBILITY. */
+const CHANNEL_VISIBILITY_DEFAULTS: Partial<
+  Record<GatewayMessageChannel, Partial<ResolvedHeartbeatVisibility>>
+> = {
+  telegram: { showOk: true }, // Telegram users expect visual heartbeat feedback
+};
+
 /**
  * Resolve heartbeat visibility settings for a channel.
  * Supports both deliverable channels (telegram, signal, etc.) and webchat.
@@ -52,22 +59,28 @@ export function resolveHeartbeatVisibility(params: {
   const accountCfg = accountId ? channelCfg?.accounts?.[accountId] : undefined;
   const perAccount = accountCfg?.heartbeat;
 
-  // Precedence: per-account > per-channel > channel-defaults > global defaults
+  // Built-in per-channel defaults (between config defaults and global defaults)
+  const builtinChannelDefaults = CHANNEL_VISIBILITY_DEFAULTS[channel];
+
+  // Precedence: per-account > per-channel > channel-defaults > built-in channel defaults > global defaults
   return {
     showOk:
       perAccount?.showOk ??
       perChannel?.showOk ??
       channelDefaults?.showOk ??
+      builtinChannelDefaults?.showOk ??
       DEFAULT_VISIBILITY.showOk,
     showAlerts:
       perAccount?.showAlerts ??
       perChannel?.showAlerts ??
       channelDefaults?.showAlerts ??
+      builtinChannelDefaults?.showAlerts ??
       DEFAULT_VISIBILITY.showAlerts,
     useIndicator:
       perAccount?.useIndicator ??
       perChannel?.useIndicator ??
       channelDefaults?.useIndicator ??
+      builtinChannelDefaults?.useIndicator ??
       DEFAULT_VISIBILITY.useIndicator,
   };
 }


### PR DESCRIPTION
## Summary
- Adds CHANNEL_VISIBILITY_DEFAULTS layer to heartbeat visibility resolution
- Telegram defaults showOk to true; other channels unaffected
- Closes #21952

## Test plan
- Verify Telegram heartbeat defaults showOk=true
- Verify non-Telegram channels still default showOk=false
- Verify config overrides still take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)