### PR TITLE
fix(config): add showDoctorHint option to suppress doctor hint in restart notifications

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -100,6 +100,47 @@ describe("gateway tool", () => {
     }
   });
 
+  it("suppresses doctorHint when showDoctorHint is false", async () => {
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_PROFILE: "isolated" },
+        async () => {
+          const tool = createOpenClawTools({
+            config: {
+              commands: {
+                restart: true,
+                restartNotification: { showDoctorHint: false },
+              },
+            },
+          }).find((candidate) => candidate.name === "gateway");
+          expect(tool).toBeDefined();
+
+          await tool!.execute("call-no-hint", {
+            action: "restart",
+            delayMs: 0,
+          });
+
+          const sentinelPath = path.join(stateDir, "restart-sentinel.json");
+          const raw = await fs.readFile(sentinelPath, "utf-8");
+          const parsed = JSON.parse(raw) as {
+            payload?: { doctorHint?: string | null };
+          };
+          expect(parsed.payload?.doctorHint).toBeNull();
+
+          await vi.runAllTimersAsync();
+        },
+      );
+    } finally {
+      kill.mockRestore();
+      vi.useRealTimers();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("passes config.apply through gateway call", async () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { isRestartEnabled } from "../../config/commands.js";
+import { isDoctorHintEnabled, isRestartEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
@@ -108,7 +108,7 @@ export function createGatewayTool(opts?: {
           deliveryContext,
           threadId,
           message: note ?? reason ?? null,
-          doctorHint: formatDoctorNonInteractiveHint(),
+          doctorHint: isDoctorHintEnabled(opts?.config) ? formatDoctorNonInteractiveHint() : null,
           stats: {
             mode: "gateway.restart",
             reason,

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isCommandFlagEnabled,
+  isDoctorHintEnabled,
   isRestartEnabled,
   isNativeCommandsExplicitlyDisabled,
   resolveNativeCommandsEnabled,
@@ -130,5 +131,36 @@ describe("isCommandFlagEnabled", () => {
         "bash",
       ),
     ).toBe(false);
+  });
+});
+
+describe("isDoctorHintEnabled", () => {
+  it("defaults to true when config is undefined", () => {
+    expect(isDoctorHintEnabled(undefined)).toBe(true);
+  });
+
+  it("defaults to true when commands is empty", () => {
+    expect(isDoctorHintEnabled({})).toBe(true);
+    expect(isDoctorHintEnabled({ commands: {} })).toBe(true);
+  });
+
+  it("defaults to true when restartNotification is empty", () => {
+    expect(isDoctorHintEnabled({ commands: { restartNotification: {} } })).toBe(true);
+  });
+
+  it("returns false when explicitly disabled", () => {
+    expect(
+      isDoctorHintEnabled({
+        commands: { restartNotification: { showDoctorHint: false } },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when explicitly enabled", () => {
+    expect(
+      isDoctorHintEnabled({
+        commands: { restartNotification: { showDoctorHint: true } },
+      }),
+    ).toBe(true);
   });
 });

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -88,3 +88,8 @@ export function isCommandFlagEnabled(
 export function isRestartEnabled(config?: { commands?: unknown }): boolean {
   return getOwnCommandFlagValue(config, "restart") !== false;
 }
+
+/** Whether the "Run: openclaw doctor --non-interactive" hint should appear in restart notifications. */
+export function isDoctorHintEnabled(config?: { commands?: CommandsConfig }): boolean {
+  return config?.commands?.restartNotification?.showDoctorHint !== false;
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -986,6 +986,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional secret used to HMAC hash owner IDs when ownerDisplay=hash. Prefer env substitution.",
   "commands.allowFrom":
     "Defines elevated command allow rules by channel and sender for owner-level command surfaces. Use narrow provider-specific identities so privileged commands are not exposed to broad chat audiences.",
+  "commands.restartNotification":
+    "Controls the content of restart notification messages sent after gateway restarts.",
+  "commands.restartNotification.showDoctorHint":
+    'Whether to include the "Run: openclaw doctor --non-interactive" hint in restart notification messages (default: true). Disable if you run doctor automatically after restarts.',
   session:
     "Global session routing, reset, delivery policy, and maintenance controls for conversation history behavior. Keep defaults unless you need stricter isolation, retention, or delivery constraints.",
   "session.scope":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -452,6 +452,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "commands.ownerDisplay": "Owner ID Display",
   "commands.ownerDisplaySecret": "Owner ID Hash Secret",
   "commands.allowFrom": "Command Elevated Access Rules",
+  "commands.restartNotification": "Restart Notification",
+  "commands.restartNotification.showDoctorHint": "Show Doctor Hint",
   ui: "UI",
   "ui.seamColor": "Accent Color",
   "ui.assistant": "Assistant Appearance",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -166,6 +166,11 @@ export type CommandsConfig = {
    * Example: { "*": ["user1"], discord: ["user:123"] }
    */
   allowFrom?: CommandAllowFrom;
+  /** Controls what appears in restart notification messages. */
+  restartNotification?: {
+    /** Include "Run: openclaw doctor --non-interactive" hint in restart messages (default: true). */
+    showDoctorHint?: boolean;
+  };
 };
 
 export type ProviderCommandsConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -206,6 +206,12 @@ export const CommandsSchema = z
     ownerDisplay: z.enum(["raw", "hash"]).optional().default("raw"),
     ownerDisplaySecret: z.string().optional().register(sensitive),
     allowFrom: ElevatedAllowFromSchema.optional(),
+    restartNotification: z
+      .object({
+        showDoctorHint: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional()

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -182,8 +182,9 @@ function buildConfigRestartSentinelPayload(params: {
   deliveryContext: ReturnType<typeof extractDeliveryInfo>["deliveryContext"];
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
   note: string | undefined;
+  config: OpenClawConfig;
 }): RestartSentinelPayload {
-  const config = loadConfig();
+  const { config } = params;
   return {
     kind: params.kind,
     status: "ok",
@@ -373,6 +374,7 @@ export const configHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       note,
+      config: validated.config,
     });
     const sentinelPath = await tryWriteRestartSentinelPayload(payload);
     const restart = scheduleGatewaySigusr1Restart({
@@ -433,6 +435,7 @@ export const configHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       note,
+      config: parsed.config,
     });
     const sentinelPath = await tryWriteRestartSentinelPayload(payload);
     const restart = scheduleGatewaySigusr1Restart({

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,5 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { isDoctorHintEnabled } from "../../config/commands.js";
 import {
   CONFIG_PATH,
   loadConfig,
@@ -182,6 +183,7 @@ function buildConfigRestartSentinelPayload(params: {
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
   note: string | undefined;
 }): RestartSentinelPayload {
+  const config = loadConfig();
   return {
     kind: params.kind,
     status: "ok",
@@ -190,7 +192,7 @@ function buildConfigRestartSentinelPayload(params: {
     deliveryContext: params.deliveryContext,
     threadId: params.threadId,
     message: params.note ?? null,
-    doctorHint: formatDoctorNonInteractiveHint(),
+    doctorHint: isDoctorHintEnabled(config) ? formatDoctorNonInteractiveHint() : null,
     stats: {
       mode: params.mode,
       root: CONFIG_PATH,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -30,9 +30,9 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? Math.max(1000, Math.floor(timeoutMsRaw))
         : undefined;
 
+    const config = loadConfig();
     let result: Awaited<ReturnType<typeof runGatewayUpdate>>;
     try {
-      const config = loadConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
       const root =
         (await resolveOpenClawPackageRoot({

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,3 +1,4 @@
+import { isDoctorHintEnabled } from "../../config/commands.js";
 import { loadConfig } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
@@ -63,7 +64,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       message: note ?? null,
-      doctorHint: formatDoctorNonInteractiveHint(),
+      doctorHint: isDoctorHintEnabled(config) ? formatDoctorNonInteractiveHint() : null,
       stats: {
         mode: result.mode,
         root: result.root ?? undefined,

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -100,6 +100,31 @@ describe("restart sentinel", () => {
     expect(trimmed?.startsWith("…")).toBe(true);
   });
 
+  it("formatRestartSentinelMessage omits doctorHint when null", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      doctorHint: null,
+      stats: { mode: "config.patch" },
+    };
+    const result = formatRestartSentinelMessage(payload);
+    expect(result).toContain("Gateway restart");
+    expect(result).not.toContain("doctor");
+  });
+
+  it("formatRestartSentinelMessage includes doctorHint when present", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      doctorHint: "Run: openclaw doctor --non-interactive",
+      stats: { mode: "config.patch" },
+    };
+    const result = formatRestartSentinelMessage(payload);
+    expect(result).toContain("doctor");
+  });
+
   it("formats restart messages without volatile timestamps", () => {
     const payloadA = {
       kind: "restart" as const,


### PR DESCRIPTION
## Summary
- Adds commands.restartNotification.showDoctorHint config option (default: true)
- When false, suppresses the "Run: openclaw doctor" hint in restart notification messages
- Includes zod schema, help text, labels, and full test coverage
- Closes #27019

## Test plan
- Verify doctorHint suppressed when showDoctorHint=false
- Verify default behavior unchanged (hint shown)
- Verify config schema validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)