### PR TITLE
fix(ui): align Config tab layout with other tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Config tab: remove negative margins and adjust viewport height calculation so the Config tab layout aligns with other tabs and respects the standard content-header section. (#28755)
 - Telegram/DM allowlist runtime inheritance: enforce `dmPolicy: "allowlist"` `allowFrom` requirements using effective account-plus-parent config across account-capable channels (Telegram, Discord, Slack, Signal, iMessage, IRC, BlueBubbles, WhatsApp), and align `openclaw doctor` checks to the same inheritance logic so DM traffic is not silently dropped after upgrades. (#27936) Thanks @widingmarcus-cyber.
 - Delivery queue/recovery backoff: prevent retry starvation by persisting `lastAttemptAt` on failed sends and deferring recovery retries until each entry's `lastAttemptAt + backoff` window is eligible, while continuing to recover ready entries behind deferred ones. Landed from contributor PR #27710 by @Jimmy-xuzimo. Thanks @Jimmy-xuzimo.
 - Gemini OAuth/Auth flow: align OAuth project discovery metadata and endpoint fallback handling for Gemini CLI auth, including fallback coverage for environment-provided project IDs. (#16684) Thanks @vincentkoc.

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -7,8 +7,7 @@
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
-  height: calc(100vh - 160px);
-  margin: -16px;
+  height: calc(100vh - 240px);
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Summary

Fixes the Config tab layout inconsistency in the Control UI by removing negative margins and adjusting the viewport height calculation.

## Problem

The Config tab was rendering with its own self-contained layout that used:
- Negative margins (`margin: -16px`)
- Full viewport height calculation (`height: calc(100vh - 160px)`)

This caused the Config tab to overlap with the standard `.content-header` section that all other tabs use, making it visually inconsistent.

## Changes

- Removed `margin: -16px` from `.config-layout` in `ui/src/styles/config.css`
- Adjusted height calculation from `calc(100vh - 160px)` to `calc(100vh - 240px)` to account for the content header space
- Updated CHANGELOG.md

## Test Plan

1. Verified formatting and linting pass
2. Checked that the Config tab now aligns with other tabs in the Control UI
3. Confirmed the layout respects the standard content-header section

## Effect on User Experience

The Config tab now has consistent spacing and alignment with all other tabs in the Control UI, providing a more cohesive user experience.

Fixes #28755