### PR TITLE
fix: add resource safeguards — polling, pending caps, reconnect guard

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -40,6 +40,7 @@ const reattachPending = new Set()
 // Reconnect state for exponential backoff.
 let reconnectAttempt = 0
 let reconnectTimer = null
+let reconnectScheduled = false
 
 function nowStack() {
   try {
@@ -223,6 +224,7 @@ function scheduleReconnect() {
     reconnectTimer = null
   }
 
+  reconnectScheduled = true
   const delay = reconnectDelayMs(reconnectAttempt)
   reconnectAttempt++
 
@@ -230,6 +232,7 @@ function scheduleReconnect() {
 
   reconnectTimer = setTimeout(async () => {
     reconnectTimer = null
+    reconnectScheduled = false
     try {
       await ensureRelayConnection()
       reconnectAttempt = 0
@@ -251,6 +254,7 @@ function cancelReconnect() {
     clearTimeout(reconnectTimer)
     reconnectTimer = null
   }
+  reconnectScheduled = false
   reconnectAttempt = 0
 }
 
@@ -901,7 +905,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 
   // If relay is down and no reconnect is in progress, trigger one.
   if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
-    if (!relayConnectPromise && !reconnectTimer) {
+    if (!relayConnectPromise && !reconnectTimer && !reconnectScheduled) {
       console.log('Keepalive: WebSocket unhealthy, triggering reconnect')
       await ensureRelayConnection().catch(() => {
         // ensureRelayConnection may throw without triggering onRelayClosed

--- a/extensions/msteams/src/pending-uploads.ts
+++ b/extensions/msteams/src/pending-uploads.ts
@@ -22,11 +22,17 @@ const pendingUploads = new Map<string, PendingUpload>();
 /** TTL for pending uploads: 5 minutes */
 const PENDING_UPLOAD_TTL_MS = 5 * 60 * 1000;
 
+/** Maximum number of pending uploads to prevent unbounded memory growth */
+const MAX_PENDING_UPLOADS = 1000;
+
 /**
  * Store a file pending user consent.
  * Returns the upload ID to include in the FileConsentCard context.
  */
 export function storePendingUpload(upload: Omit<PendingUpload, "id" | "createdAt">): string {
+  if (pendingUploads.size >= MAX_PENDING_UPLOADS) {
+    throw new Error(`Too many pending uploads (limit: ${MAX_PENDING_UPLOADS})`);
+  }
   const id = crypto.randomUUID();
   const entry: PendingUpload = {
     ...upload,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -7,6 +7,9 @@ import type {
 // Grace period to keep resolved entries for late awaitDecision calls
 const RESOLVED_ENTRY_GRACE_MS = 15_000;
 
+// Maximum number of pending approval requests to prevent unbounded growth
+const MAX_PENDING_APPROVALS = 1000;
+
 export type ExecApprovalRequestPayload = InfraExecApprovalRequestPayload;
 
 export type ExecApprovalRecord = {
@@ -57,6 +60,9 @@ export class ExecApprovalManager {
    */
   register(record: ExecApprovalRecord, timeoutMs: number): Promise<ExecApprovalDecision | null> {
     const existing = this.pending.get(record.id);
+    if (!existing && this.pending.size >= MAX_PENDING_APPROVALS) {
+      throw new Error(`Too many pending approval requests (limit: ${MAX_PENDING_APPROVALS})`);
+    }
     if (existing) {
       // Idempotent: return existing promise if still pending
       if (existing.record.resolvedAtMs === undefined) {

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -15,7 +15,11 @@ export function startNodesPolling(host: PollingHost) {
     return;
   }
   host.nodesPollInterval = window.setInterval(
-    () => void loadNodes(host as unknown as OpenClawApp, { quiet: true }),
+    () => {
+      if (document.visibilityState === 'visible') {
+        void loadNodes(host as unknown as OpenClawApp, { quiet: true });
+      }
+    },
     5000,
   );
 }
@@ -33,6 +37,9 @@ export function startLogsPolling(host: PollingHost) {
     return;
   }
   host.logsPollInterval = window.setInterval(() => {
+    if (document.visibilityState !== 'visible') {
+      return;
+    }
     if (host.tab !== "logs") {
       return;
     }
@@ -53,6 +60,9 @@ export function startDebugPolling(host: PollingHost) {
     return;
   }
   host.debugPollInterval = window.setInterval(() => {
+    if (document.visibilityState !== 'visible') {
+      return;
+    }
     if (host.tab !== "debug") {
       return;
     }


### PR DESCRIPTION
## Summary
- Pause dashboard polling intervals when browser tab is not visible (`document.visibilityState`) to reduce unnecessary server load
- Cap `ExecApprovalManager` pending map at 1000 entries to prevent unbounded memory growth
- Cap MS Teams `pendingUploads` map at 1000 entries to prevent unbounded memory growth
- Add `reconnectScheduled` guard in Chrome extension to prevent dual-path reconnection storms from keepalive alarm and `onRelayClosed` competing

## Test plan
- [ ] Verify dashboard polling pauses when tab is backgrounded and resumes when foregrounded
- [ ] Verify exec-approval-manager throws when pending limit reached
- [ ] Verify MS Teams pending-uploads throws when limit reached  
- [ ] Verify Chrome extension reconnection does not duplicate attempts when relay goes down

🤖 Generated with [Claude Code](https://claude.com/claude-code)