### PR TITLE
fix(agents): skip Ollama discovery when explicit models configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Ollama: skip model discovery when explicit models are configured, preserving the `api: "ollama"` default for the provider. (#28762) Thanks @autoeverything for reporting.
 - Telegram/DM allowlist runtime inheritance: enforce `dmPolicy: "allowlist"` `allowFrom` requirements using effective account-plus-parent config across account-capable channels (Telegram, Discord, Slack, Signal, iMessage, IRC, BlueBubbles, WhatsApp), and align `openclaw doctor` checks to the same inheritance logic so DM traffic is not silently dropped after upgrades. (#27936) Thanks @widingmarcus-cyber.
 - Delivery queue/recovery backoff: prevent retry starvation by persisting `lastAttemptAt` on failed sends and deferring recovery retries until each entry's `lastAttemptAt + backoff` window is eligible, while continuing to recover ready entries behind deferred ones. Landed from contributor PR #27710 by @Jimmy-xuzimo. Thanks @Jimmy-xuzimo.
 - Gemini OAuth/Auth flow: align OAuth project discovery metadata and endpoint fallback handling for Gemini CLI auth, including fallback coverage for environment-provided project IDs. (#16684) Thanks @vincentkoc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 

--- a/src/agents/models-config.providers.ollama.test.ts
+++ b/src/agents/models-config.providers.ollama.test.ts
@@ -85,4 +85,40 @@ describe("Ollama provider", () => {
     // Native Ollama provider does not need streaming: false workaround
     expect(mockOllamaModel).not.toHaveProperty("params");
   });
+
+  it("should skip discovery when explicit models are configured", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    process.env.OLLAMA_API_KEY = "test-key";
+
+    try {
+      const explicitModels = [
+        {
+          id: "gpt-oss:20b",
+          name: "GPT-OSS 20B",
+          reasoning: false,
+          input: ["text"] as ("text" | "image")[],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 81920,
+        },
+      ];
+
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          ollama: {
+            baseUrl: "http://remote-ollama:11434",
+            api: "ollama",
+            models: explicitModels,
+          },
+        },
+      });
+
+      // Should use explicit models, not run discovery
+      expect(providers?.ollama?.models).toEqual(explicitModels);
+      expect(providers?.ollama?.baseUrl).toBe("http://remote-ollama:11434");
+    } finally {
+      delete process.env.OLLAMA_API_KEY;
+    }
+  });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -872,7 +872,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
         compat: { supportsStore: false },
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });


### PR DESCRIPTION
## Summary

Skip Ollama model discovery when explicit models are already configured in `models.providers.ollama`, preventing unnecessary 5s timeout delays at startup for remote Ollama hosts.

## Problem

When users configure explicit models in `models.providers.ollama` (e.g. for a remote Ollama host), `resolveImplicitProviders` still calls `discoverOllamaModels()` which makes an HTTP request to the Ollama API with a 5s timeout. For remote hosts that may be unreachable at startup, this adds a guaranteed 5s delay. The docs state that explicit config should skip auto-discovery, but the code didn't honor this.

## Changes

- `src/agents/models-config.providers.ts`: Check if `explicitProviders.ollama.models` is non-empty before running discovery. When explicit models exist, use them directly instead of calling `discoverOllamaModels()`.
- `src/agents/models-config.providers.ollama.test.ts`: Add regression test verifying that explicit models are preserved and discovery is skipped.

## Test plan

- Added test: "should skip discovery when explicit models are configured" — passes explicit models via `explicitProviders.ollama.models` and asserts they are returned as-is without discovery.
- All existing Ollama provider tests continue to pass.
- `pnpm format:check` and `pnpm lint` pass.

## Effect on User Experience

Users with explicit Ollama model configs (especially remote hosts) no longer experience a 5s startup delay from unnecessary model discovery. No behavior change for users relying on auto-discovery (no explicit models configured).

Closes #28762
