### PR TITLE
fix(model): strip @auth_profile suffix in parseModelRef to prevent 404

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -133,6 +133,27 @@ describe("model-selection", () => {
       expect(parseModelRef("anthropic/", "anthropic")).toBeNull();
       expect(parseModelRef("/model", "anthropic")).toBeNull();
     });
+
+    it("strips trailing @auth_profile suffix from provider/model refs", () => {
+      expect(parseModelRef("anthropic/claude-opus-4-6@anthropic:claude_max", "openai")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+    });
+
+    it("strips trailing @auth_profile suffix from bare model refs", () => {
+      expect(parseModelRef("claude-opus-4-6@myprofile", "anthropic")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+    });
+
+    it("strips trailing @auth_profile suffix from nested model refs", () => {
+      expect(parseModelRef("google/gemini-flash-latest@google:bevfresh", "anthropic")).toEqual({
+        provider: "google",
+        model: "gemini-flash-latest",
+      });
+    });
   });
 
   describe("inferUniqueProviderFromConfiguredModels", () => {
@@ -467,6 +488,24 @@ describe("model-selection", () => {
         defaultModel: "gpt-4",
       });
       expect(result).toEqual({ provider: "openai", model: "gpt-4" });
+    });
+
+    it("strips @auth_profile suffix from configured model primary", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6@anthropic:claude_max" },
+          },
+        },
+      };
+
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "openai",
+        defaultModel: "gpt-4",
+      });
+
+      expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
     });
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -160,12 +160,19 @@ export function parseModelRef(raw: string, defaultProvider: string): ModelRef | 
   if (!trimmed) {
     return null;
   }
-  const slash = trimmed.indexOf("/");
-  if (slash === -1) {
-    return normalizeModelRef(defaultProvider, trimmed);
+  // Strip trailing @auth_profile suffix before parsing provider/model so that
+  // config values like "anthropic/claude-opus-4-6@anthropic:claude_max" do not
+  // leak the auth profile into the model name sent to the API (#23042).
+  const { model: stripped } = splitTrailingAuthProfile(trimmed);
+  if (!stripped) {
+    return null;
   }
-  const providerRaw = trimmed.slice(0, slash).trim();
-  const model = trimmed.slice(slash + 1).trim();
+  const slash = stripped.indexOf("/");
+  if (slash === -1) {
+    return normalizeModelRef(defaultProvider, stripped);
+  }
+  const providerRaw = stripped.slice(0, slash).trim();
+  const model = stripped.slice(slash + 1).trim();
   if (!providerRaw || !model) {
     return null;
   }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -383,6 +383,43 @@ describe("resolveSessionModelRef", () => {
 
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
+
+  test("strips @auth_profile suffix from runtime model without modelProvider", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "at-suffix",
+      updatedAt: Date.now(),
+      model: "claude-opus-4-6@anthropic:claude_max",
+      modelProvider: undefined,
+    });
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+  });
+
+  test("strips @auth_profile suffix from modelOverride", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "at-override",
+      updatedAt: Date.now(),
+      modelOverride: "google/gemini-flash-latest@google:bevfresh",
+    });
+
+    expect(resolved).toEqual({ provider: "google", model: "gemini-flash-latest" });
+  });
 });
 
 describe("resolveSessionModelIdentityRef", () => {


### PR DESCRIPTION
## Summary
- Call splitTrailingAuthProfile in parseModelRef to strip @auth_profile suffixes
- Prevents 404 errors when model config includes auth profile annotations
- Closes #23042

## Test plan
- Run pnpm vitest run src/agents/model-selection.test.ts
- Run pnpm vitest run src/gateway/session-utils.test.ts
- Verify model refs with @suffix resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)