### PR TITLE
fix: log errors instead of silently swallowing them in media cleanup

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { SafeOpenError, readLocalFileSafely } from "../infra/fs-safe.js";
 import { resolvePinnedHostname } from "../infra/net/ssrf.js";
+import { logDebug } from "../logger.js";
 import { resolveConfigDir } from "../utils.js";
 import { detectMime, extensionForMime } from "./mime.js";
 
@@ -99,7 +100,9 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS) {
           return;
         }
         if (now - stat.mtimeMs > ttlMs) {
-          await fs.rm(full).catch(() => {});
+          await fs.rm(full).catch((err) => {
+            logDebug(`media cleanup: failed to remove ${full}: ${err}`);
+          });
         }
       }),
     );
@@ -117,7 +120,9 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS) {
         return;
       }
       if (stat.isFile() && now - stat.mtimeMs > ttlMs) {
-        await fs.rm(full).catch(() => {});
+        await fs.rm(full).catch((err) => {
+          logDebug(`media cleanup: failed to remove ${full}: ${err}`);
+        });
       }
     }),
   );


### PR DESCRIPTION
## Summary

- Problem: `cleanOldMedia` in `src/media/store.ts` uses `.catch(() => {})` to silently discard all errors when removing expired media files
- Why it matters: Makes it impossible to diagnose filesystem issues (permission errors, locked files) during media cleanup
- What changed: Replaced empty catch handlers with `logDebug` calls that include file path and error details
- What did NOT change: Non-throwing behavior preserved; cleanup errors logged at debug level only

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Trigger media cleanup with a locked or permission-denied file in the media directory
2. Before: error silently swallowed, no trace in logs
3. After: error appears in debug log output

### Expected

- Cleanup errors are visible in debug logs

### Actual

- Cleanup errors were silently swallowed

## Evidence

- [x] Failing test/log before + passing after: All 18 tests in `src/media/store.test.ts` pass

## Human Verification (required)

- Verified scenarios: All existing store tests pass; import resolves correctly
- Edge cases checked: Both `fs.rm` call sites in nested and top-level cleanup
- What you did **not** verify: Live filesystem error scenarios (permission denied, locked files)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/media/store.ts`
- Known bad symptoms reviewers should watch for: Unexpected debug log noise from cleanup

## Risks and Mitigations

None

## Disclosure

By : [definable](https://definable.ai) ~ Anandesh Sharma