### PR TITLE
fix: include URL context in downloadToFile error messages

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -141,7 +141,7 @@ async function downloadToFile(
     try {
       parsedUrl = new URL(url);
     } catch {
-      reject(new Error("Invalid URL"));
+      reject(new Error(`Invalid URL: ${url}`));
       return;
     }
     if (!["http:", "https:"].includes(parsedUrl.protocol)) {
@@ -164,7 +164,7 @@ async function downloadToFile(
             return;
           }
           if (!res.statusCode || res.statusCode >= 400) {
-            reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
+            reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media from ${url}`));
             return;
           }
           let total = 0;


### PR DESCRIPTION
## Summary

- Problem: Error messages in `downloadToFile` (`src/media/store.ts`) are generic — "Invalid URL" and "HTTP {status} downloading media" — without the URL that caused the failure
- Why it matters: Makes it difficult to trace which URL failed in logs or error reports
- What changed: Added the URL string to both error messages
- What did NOT change: Error types and throw behavior remain identical

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — error messages are internal (not surfaced to end users)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Pass an invalid or failing URL to `downloadToFile`
2. Before: error says "Invalid URL" or "HTTP 404 downloading media"
3. After: error says "Invalid URL: ftp://example.com" or "HTTP 404 downloading media from https://example.com/file"

### Expected

- Error messages include the URL for debugging

### Actual

- Error messages were generic without URL context

## Evidence

- [x] Failing test/log before + passing after: All 18 tests in `src/media/store.test.ts` pass

## Human Verification (required)

- Verified scenarios: All existing store tests pass; lint passes
- Edge cases checked: Both error paths (URL parse failure and HTTP error)
- What you did **not** verify: Live network error scenarios

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/media/store.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure

By : [definable](https://definable.ai) ~ Anandesh Sharma