### PR TITLE
fix: include port value in gateway invalid port error messages

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -178,12 +178,12 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const cfg = loadConfig();
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
-    defaultRuntime.error("Invalid port");
+    defaultRuntime.error(`Invalid port: ${JSON.stringify(opts.port)}`);
     defaultRuntime.exit(1);
   }
   const port = portOverride ?? resolveGatewayPort(cfg);
   if (!Number.isFinite(port) || port <= 0) {
-    defaultRuntime.error("Invalid port");
+    defaultRuntime.error(`Invalid port: ${port}`);
     defaultRuntime.exit(1);
   }
   if (opts.force) {


### PR DESCRIPTION
## Summary

- Problem: The gateway `run` command prints "Invalid port" without showing the actual value that was rejected
- Why it matters: Makes it harder to debug configuration issues, especially when the port comes from config files or env vars
- What changed: Included the offending port value in both error paths using `JSON.stringify` (safe for `unknown` type)
- What did NOT change: Error flow and exit behavior remain identical

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

Error message now shows the invalid port value (e.g., "Invalid port: \"abc\"" instead of "Invalid port")

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Run `openclaw gateway run --port abc`
2. Before: "Invalid port"
3. After: "Invalid port: \"abc\""

### Expected

- Error message includes the rejected port value

### Actual

- Error message was generic

## Evidence

- [x] Lint passes via `scripts/committer`

## Human Verification (required)

- Verified scenarios: Lint passes; both error paths updated
- Edge cases checked: `unknown` type handled via `JSON.stringify`; `number` type handled via template literal
- What you did **not** verify: No test file exists for this module

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/cli/gateway-cli/run.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure

By : [definable](https://definable.ai) ~ Anandesh Sharma