### PR TITLE
fix: preserve error cause chain in MediaFetchError

### DIFF
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -15,8 +15,8 @@ export type MediaFetchErrorCode = "max_bytes" | "http_error" | "fetch_failed";
 export class MediaFetchError extends Error {
   readonly code: MediaFetchErrorCode;
 
-  constructor(code: MediaFetchErrorCode, message: string) {
-    super(message);
+  constructor(code: MediaFetchErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
     this.code = code;
     this.name = "MediaFetchError";
   }
@@ -107,7 +107,9 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
     finalUrl = result.finalUrl;
     release = result.release;
   } catch (err) {
-    throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}: ${String(err)}`);
+    throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}: ${String(err)}`, {
+      cause: err,
+    });
   }
 
   try {


### PR DESCRIPTION
## Summary

- Problem: `MediaFetchError` constructor doesn't accept `ErrorOptions`, so wrapping fetch failures loses the original error's stack trace and type
- Why it matters: Error reporters and debuggers can't trace the root cause of fetch failures through the error chain
- What changed: Added optional `ErrorOptions` parameter to constructor; pass `{ cause: err }` at the `fetch_failed` call site
- What did NOT change: Constructor signature is backward-compatible; all other call sites remain unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — error cause chain is an internal debugging aid

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Trigger a fetch failure in `fetchRemoteMedia` (e.g., network timeout)
2. Before: caught `MediaFetchError` has no `.cause`; original error stack is lost
3. After: caught `MediaFetchError.cause` contains the original error with full stack

### Expected

- Error chain is preserved for debugging

### Actual

- Original error was stringified and the stack/type was discarded

## Evidence

- [x] Failing test/log before + passing after: All 3 tests in `src/media/fetch.test.ts` pass

## Human Verification (required)

- Verified scenarios: All fetch tests pass; constructor backward-compatible
- Edge cases checked: Optional parameter doesn't affect existing callers
- What you did **not** verify: Live network failure scenarios

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/media/fetch.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure

By : [definable](https://definable.ai) ~ Anandesh Sharma