### PR TITLE
fix(config): add missing params field to AgentEntrySchema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -703,6 +703,8 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    /** Per-agent stream params (e.g. cacheRetention, temperature). */
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary
- Add params: z.record(z.string(), z.unknown()).optional() to AgentEntrySchema
- Aligns Zod validation with TypeScript AgentConfig type
- Closes #27173

## Test plan
- Run pnpm build (confirms no TS errors)
- Run pnpm test (full suite passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)