### PR TITLE
fix: include actual buffer size in media overflow error message

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -298,7 +298,9 @@ export async function saveMediaBuffer(
   originalFilename?: string,
 ): Promise<SavedMedia> {
   if (buffer.byteLength > maxBytes) {
-    throw new Error(`Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`);
+    throw new Error(
+      `Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit (received ${(buffer.byteLength / (1024 * 1024)).toFixed(1)}MB)`,
+    );
   }
   const dir = path.join(resolveMediaDir(), subdir);
   await fs.mkdir(dir, { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## Summary

- Problem: When `saveMediaBuffer` rejects an oversized buffer, the error only shows the limit but not the actual buffer size
- Why it matters: Users and logs can't tell how much the payload exceeded the limit by
- What changed: Added the received buffer size (in MB) to the overflow error message
- What did NOT change: Error type, throw behavior, and size check logic remain identical

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

Error message now shows "Media exceeds 5MB limit (received 7.2MB)" instead of just "Media exceeds 5MB limit"

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Call `saveMediaBuffer` with a buffer larger than `maxBytes`
2. Before: error says "Media exceeds 5MB limit"
3. After: error says "Media exceeds 5MB limit (received 7.2MB)"

### Expected

- Error includes both limit and actual size

### Actual

- Error only showed the limit

## Evidence

- [x] Failing test/log before + passing after: All 18 tests in `src/media/store.test.ts` pass

## Human Verification (required)

- Verified scenarios: All store tests pass; size formatting is correct
- Edge cases checked: Fractional MB values display with one decimal place
- What you did **not** verify: Live oversized media uploads

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/media/store.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure
By : [definable](https://definable.ai) ~ Anandesh Sharma