### PR TITLE
fix(telegram): preserve HTTP proxy when replacing global undici dispatcher

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -5,8 +5,8 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const AgentCtor = vi.hoisted(() =>
-  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
     this.options = options;
   }),
 );
@@ -28,7 +28,7 @@ vi.mock("node:dns", async () => {
 });
 
 vi.mock("undici", () => ({
-  Agent: AgentCtor,
+  EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
   setGlobalDispatcher,
 }));
 
@@ -39,7 +39,7 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
-  AgentCtor.mockClear();
+  EnvHttpProxyAgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -147,12 +147,12 @@ describe("resolveTelegramFetch", () => {
     expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
   });
 
-  it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
+  it("replaces global undici dispatcher with proxy-aware autoSelectFamily-enabled agent", async () => {
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenCalledWith({
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledWith({
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -174,13 +174,13 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(1, {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(2, {
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -45,8 +45,12 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
     try {
+      // Use EnvHttpProxyAgent instead of plain Agent to preserve HTTP_PROXY /
+      // HTTPS_PROXY support.  A plain Agent would overwrite the proxy-aware
+      // global dispatcher set by pi-ai's http-proxy.js, causing all
+      // globalThis.fetch calls (including Anthropic API) to bypass the proxy.
       setGlobalDispatcher(
-        new Agent({
+        new EnvHttpProxyAgent({
           connect: {
             autoSelectFamily: autoSelectDecision.value,
             autoSelectFamilyAttemptTimeout: 300,


### PR DESCRIPTION
## Summary

- The Telegram network workaround in `telegram/fetch.ts` calls `setGlobalDispatcher(new Agent({...}))` to apply `autoSelectFamily` settings
- This overwrites the `EnvHttpProxyAgent` previously set by pi-ai's `http-proxy.js`, causing all `globalThis.fetch()` calls to bypass `HTTP_PROXY` / `HTTPS_PROXY` env vars
- On networks where direct connections to upstream APIs (e.g. Anthropic) are geo-blocked, this results in **403 "Request not allowed"** errors
- Fix: replace `Agent` with `EnvHttpProxyAgent`, which accepts the same `connect` options while preserving proxy support

## Test plan

- [x] All 11 existing tests in `telegram/fetch.test.ts` pass
- [x] Verified with manual testing: `EnvHttpProxyAgent({ connect: { autoSelectFamily: true } })` correctly proxies requests while maintaining IPv4 fallback behavior
- [x] Confirmed fix resolves 403 errors for Anthropic API calls on proxy-dependent networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)