### PR TITLE
fix: include URL in protocol validation error for easier debugging

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -145,7 +145,9 @@ async function downloadToFile(
       return;
     }
     if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-      reject(new Error(`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP/HTTPS allowed.`));
+      reject(
+        new Error(`Invalid URL protocol: ${parsedUrl.protocol} (${url}). Only HTTP/HTTPS allowed.`),
+      );
       return;
     }
     const requestImpl = parsedUrl.protocol === "https:" ? httpsRequestImpl : httpRequestImpl;


### PR DESCRIPTION
## Summary

- Problem: When `downloadToFile` rejects a URL with an unsupported protocol, the error shows the protocol but not the full URL
- Why it matters: Harder to trace back to the source of the bad URL in logs or error reports
- What changed: Included the full URL in the protocol validation error message
- What did NOT change: Error type and validation logic remain identical

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None — error messages are internal (not surfaced to end users)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Pass a URL with unsupported protocol (e.g., `ftp://example.com/file`) to `downloadToFile`
2. Before: "Invalid URL protocol: ftp:. Only HTTP/HTTPS allowed."
3. After: "Invalid URL protocol: ftp: (ftp://example.com/file). Only HTTP/HTTPS allowed."

### Expected

- Error includes both the protocol and the full URL

### Actual

- Error only showed the protocol

## Evidence

- [x] Failing test/log before + passing after: All 18 tests in `src/media/store.test.ts` pass

## Human Verification (required)

- Verified scenarios: All store tests pass; lint passes
- Edge cases checked: URL is included after successful URL parse (so it's always valid)
- What you did **not** verify: Live unsupported-protocol scenarios

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/media/store.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure
By : [definable](https://definable.ai) ~ Anandesh Sharma
