### PR TITLE
fix(tools): honor tools.fs.workspaceOnly=false for host write/edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- FS tools/workspaceOnly: honor `tools.fs.workspaceOnly=false` for host write and edit operations so FS tools can access paths outside the workspace when sandbox is off. (#28763) Thanks @cjscld for reporting.
 - Telegram/DM allowlist runtime inheritance: enforce `dmPolicy: "allowlist"` `allowFrom` requirements using effective account-plus-parent config across account-capable channels (Telegram, Discord, Slack, Signal, iMessage, IRC, BlueBubbles, WhatsApp), and align `openclaw doctor` checks to the same inheritance logic so DM traffic is not silently dropped after upgrades. (#27936) Thanks @widingmarcus-cyber.
 - Delivery queue/recovery backoff: prevent retry starvation by persisting `lastAttemptAt` on failed sends and deferring recovery retries until each entry's `lastAttemptAt + backoff` window is eligible, while continuing to recover ready entries behind deferred ones. Landed from contributor PR #27710 by @Jimmy-xuzimo. Thanks @Jimmy-xuzimo.
 - Gemini OAuth/Auth flow: align OAuth project discovery metadata and endpoint fallback handling for Gemini CLI auth, including fallback coverage for environment-provided project IDs. (#16684) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- FS tools/workspaceOnly: honor `tools.fs.workspaceOnly=false` for host write and edit operations so FS tools can access paths outside the workspace when sandbox is off. (#28763) Thanks @cjscld for reporting.
+- FS tools/workspaceOnly: honor `tools.fs.workspaceOnly=false` for host write and edit operations so FS tools can access paths outside the workspace when sandbox is off. (#28822) thanks @lailoo. Fixes #28763. Thanks @cjscld for reporting.
 - Telegram/DM allowlist runtime inheritance: enforce `dmPolicy: "allowlist"` `allowFrom` requirements using effective account-plus-parent config across account-capable channels (Telegram, Discord, Slack, Signal, iMessage, IRC, BlueBubbles, WhatsApp), and align `openclaw doctor` checks to the same inheritance logic so DM traffic is not silently dropped after upgrades. (#27936) Thanks @widingmarcus-cyber.
 - Delivery queue/recovery backoff: prevent retry starvation by persisting `lastAttemptAt` on failed sends and deferring recovery retries until each entry's `lastAttemptAt + backoff` window is eligible, while continuing to recover ready entries behind deferred ones. Landed from contributor PR #27710 by @Jimmy-xuzimo. Thanks @Jimmy-xuzimo.
 - Gemini OAuth/Auth flow: align OAuth project discovery metadata and endpoint fallback handling for Gemini CLI auth, including fallback coverage for environment-provided project IDs. (#16684) Thanks @vincentkoc.

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -359,14 +359,14 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceWriteTool(workspaceRoot);
+      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceEditTool(workspaceRoot);
+      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     return [tool];

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+describe("FS tools with workspaceOnly=false", () => {
+  let tmpDir: string;
+  let workspaceDir: string;
+  let outsideFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    workspaceDir = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspaceDir);
+    outsideFile = path.join(tmpDir, "outside.txt");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should allow write outside workspace when workspaceOnly=false", async () => {
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: false,
+          },
+        },
+      },
+    });
+
+    const writeTool = tools.find((t) => t.name === "write");
+    expect(writeTool).toBeDefined();
+
+    const result = await writeTool!.execute("test-call-1", {
+      path: outsideFile,
+      content: "test content",
+    });
+
+    // Check if the operation succeeded (no error in content)
+    const hasError = result.content.some(
+      (c) => c.type === "text" && c.text.toLowerCase().includes("error"),
+    );
+    expect(hasError).toBe(false);
+    const content = await fs.readFile(outsideFile, "utf-8");
+    expect(content).toBe("test content");
+  });
+
+  it("should allow edit outside workspace when workspaceOnly=false", async () => {
+    await fs.writeFile(outsideFile, "old content");
+
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: false,
+          },
+        },
+      },
+    });
+
+    const editTool = tools.find((t) => t.name === "edit");
+    expect(editTool).toBeDefined();
+
+    const result = await editTool!.execute("test-call-2", {
+      path: outsideFile,
+      oldText: "old content",
+      newText: "new content",
+    });
+
+    // Check if the operation succeeded (no error in content)
+    const hasError = result.content.some(
+      (c) => c.type === "text" && c.text.toLowerCase().includes("error"),
+    );
+    expect(hasError).toBe(false);
+    const content = await fs.readFile(outsideFile, "utf-8");
+    expect(content).toBe("new content");
+  });
+
+  it("should allow read outside workspace when workspaceOnly=false", async () => {
+    await fs.writeFile(outsideFile, "test read content");
+
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: false,
+          },
+        },
+      },
+    });
+
+    const readTool = tools.find((t) => t.name === "read");
+    expect(readTool).toBeDefined();
+
+    const result = await readTool!.execute("test-call-3", {
+      path: outsideFile,
+    });
+
+    // Check if the operation succeeded (no error in content)
+    const hasError = result.content.some(
+      (c) => c.type === "text" && c.text.toLowerCase().includes("error"),
+    );
+    expect(hasError).toBe(false);
+  });
+
+  it("should block write outside workspace when workspaceOnly=true", async () => {
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: true,
+          },
+        },
+      },
+    });
+
+    const writeTool = tools.find((t) => t.name === "write");
+    expect(writeTool).toBeDefined();
+
+    // When workspaceOnly=true, the guard throws an error
+    await expect(
+      writeTool!.execute("test-call-4", {
+        path: outsideFile,
+        content: "test content",
+      }),
+    ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #28763 by honoring the `tools.fs.workspaceOnly=false` configuration for host write and edit operations.

## Problem

After upgrading to 2026.2.26, FS tools remained restricted to the agent workspace even when `tools.fs.workspaceOnly=false` was set with sandbox mode off. The issue was that while the workspace guard wrapper was conditionally applied based on the config, the underlying host operations (`createHostWriteOperations` and `createHostEditOperations`) always called `toRelativePathInRoot`, which throws an error for paths outside the workspace.

## Changes

- Modified `createHostWriteOperations` and `createHostEditOperations` to accept a `workspaceOnly` parameter
- When `workspaceOnly=false`, these functions now use direct file operations instead of enforcing workspace boundaries
- When `workspaceOnly=true` (default), the original workspace boundary enforcement is preserved
- Updated `createHostWorkspaceWriteTool` and `createHostWorkspaceEditTool` to pass the `workspaceOnly` option
- Updated the tool creation in `pi-tools.ts` to pass the `workspaceOnly` config to the host operations

## Test Plan

Added comprehensive test coverage in `src/agents/pi-tools.workspace-only-false.test.ts`:
- ✅ Write outside workspace when `workspaceOnly=false`
- ✅ Edit outside workspace when `workspaceOnly=false`
- ✅ Read outside workspace when `workspaceOnly=false`
- ✅ Block write outside workspace when `workspaceOnly=true`

All tests pass. Existing tests remain passing.

## Effect on User Experience

Users who set `tools.fs.workspaceOnly=false` with sandbox off can now use FS tools (read, write, edit) to access files outside the workspace as expected. The default behavior (workspace-only) remains unchanged for security.