### PR TITLE
chore: remove dead gateway.sigterm.test.ts stub

### DIFF
--- a/src/cli/gateway.sigterm.test.ts
+++ b/src/cli/gateway.sigterm.test.ts
@@ -1,8 +1,0 @@
-import { describe, it } from "vitest";
-
-describe("gateway SIGTERM", () => {
-  it.skip("covered by runGatewayLoop signal tests in src/cli/gateway-cli/run-loop.test.ts", () => {
-    // Kept as a placeholder to document why the old child-process integration
-    // case was retired: it duplicated run-loop signal coverage at high runtime cost.
-  });
-});


### PR DESCRIPTION
## Summary

- Problem: `src/cli/gateway.sigterm.test.ts` contains a single `it.skip` with a comment explaining that signal coverage was moved to `run-loop.test.ts`
- Why it matters: Dead test files add noise to test output, confuse code search results, and increase cognitive overhead for new contributors
- What changed: Removed the dead test file entirely
- What did NOT change: No logic or coverage affected; the actual signal tests live in `src/cli/gateway-cli/run-loop.test.ts`

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. `grep -r "it.skip" src/` — the only skipped test was in this file
2. The skip comment references `src/cli/gateway-cli/run-loop.test.ts` which contains the actual signal tests

### Expected

- No dead test stubs remain in the codebase

### Actual

- A single-test file with only a skipped placeholder existed

## Evidence

- [x] Full test suite runs without this file; no test references this file

## Human Verification (required)

- Verified scenarios: The referenced `run-loop.test.ts` contains the actual SIGTERM/signal tests
- Edge cases checked: No imports or references to this file exist elsewhere
- What you did **not** verify: N/A — simple file deletion

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/cli/gateway.sigterm.test.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None

## Disclosure

This contribution was developed with AI assistance.
All changes have been reviewed and tested before submission.