### PR TITLE
fix(daemon): align entrypoint candidate priority with program-args and always refresh after update

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -99,10 +99,10 @@ function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
     return [];
   }
   return [
-    path.join(root, "dist", "entry.js"),
-    path.join(root, "dist", "entry.mjs"),
     path.join(root, "dist", "index.js"),
     path.join(root, "dist", "index.mjs"),
+    path.join(root, "dist", "entry.js"),
+    path.join(root, "dist", "entry.mjs"),
   ];
 }
 
@@ -823,8 +823,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       const loaded = await resolveGatewayService().isLoaded({ env: process.env });
       if (loaded) {
         restartScriptPath = await prepareRestartScript(process.env);
-        refreshGatewayServiceEnv = true;
       }
+      // Always refresh service env after update so the LaunchAgent plist
+      // stays in sync with the current entrypoint, even when the service
+      // was not loaded at the time of update.
+      refreshGatewayServiceEnv = true;
     } catch {
       // Ignore errors during pre-check; fallback to standard restart
     }


### PR DESCRIPTION
## Summary

- **Problem:** After nightly macOS updates, `openclaw doctor` repeatedly reports entrypoint mismatch (`entry.js -> index.js`), requiring manual intervention every morning.
- **Why it matters:** Every macOS user running nightly updates has to manually run `openclaw doctor --fix` daily.
- **What changed:** Aligned entrypoint candidate priority in `resolveGatewayInstallEntrypointCandidates` (`index.js > entry.js`) to match `program-args.ts`, and made the update flow always refresh the LaunchAgent plist after updates regardless of whether the gateway was loaded.
- **What did NOT change:** Restart logic, doctor detection, or any other daemon management code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28423

## User-visible / Behavior Changes

- macOS LaunchAgent plist entrypoint is now always refreshed after updates
- No more daily `openclaw doctor` entrypoint mismatch warnings after nightly updates

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (any version with LaunchAgent support)
- Runtime: Node.js via npm global install
- Integration/channel: Any

### Steps

1. Install OpenClaw globally via npm on macOS
2. Run nightly auto-update that changes the entrypoint file (e.g. `entry.js` → `index.js`)
3. Run `openclaw doctor`

### Expected

- No entrypoint mismatch warnings after update

### Actual

- Before fix: `Gateway service entrypoint does not match the current install (entry.js -> index.js)` every morning
- After fix: No warning; plist is refreshed during update

## Evidence

`resolveGatewayInstallEntrypointCandidates` (update-command.ts L97-107) had `entry.js` first, while `appendDistCandidates` (program-args.ts L83-88) had `index.js` first. The update flow also skipped service env refresh when the service was not loaded at update time.

## Human Verification (required)

- Verified scenarios: Confirmed both code paths now use `index.js > entry.js` priority order
- Edge cases checked: Service not loaded at update time → plist still refreshed; both files present → `index.js` selected consistently
- What I did **not** verify: Live macOS nightly update cycle (no macOS CI available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `src/cli/update-cli/update-command.ts`
- Known bad symptoms: If `index.js` doesn't exist but `entry.js` does, the new priority may pick the wrong file — but this matches program-args.ts and doctor behavior

## Risks and Mitigations

`None` — aligns two existing code paths to use the same priority order.
