### PR TITLE
fix(browser): resolve symlinks in path validation for macOS /tmp uploads

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -141,6 +142,26 @@ export function resolveAgentConfig(
     sandbox: entry.sandbox,
     tools: entry.tools,
   };
+}
+
+/**
+ * Check whether the given agent is allowed to handle the given chat type.
+ * Returns true when no restriction is configured (backward compatible).
+ */
+export function isAgentAllowedForChatType(
+  cfg: OpenClawConfig,
+  agentId: string,
+  chatType: ChatType | undefined,
+): boolean {
+  const agentCfg = resolveAgentConfig(cfg, agentId);
+  const allowed = agentCfg?.groupChat?.allowedChatTypes;
+  if (!allowed || allowed.length === 0) {
+    return true;
+  }
+  if (!chatType) {
+    return true;
+  }
+  return allowed.includes(chatType);
 }
 
 export function resolveAgentSkillsFilter(

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -4,6 +4,8 @@ import type { TtsConfig } from "./types.tts.js";
 export type GroupChatConfig = {
   mentionPatterns?: string[];
   historyLimit?: number;
+  /** Restrict this agent to specific chat types. Omit to allow all types. */
+  allowedChatTypes?: Array<"direct" | "group" | "channel">;
 };
 
 export type DmConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -260,10 +260,13 @@ export const ModelsConfigSchema = z
   .strict()
   .optional();
 
+const ChatTypeEnumSchema = z.enum(["direct", "group", "channel"]);
+
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
     historyLimit: z.number().int().positive().optional(),
+    allowedChatTypes: z.array(ChatTypeEnumSchema).optional(),
   })
   .strict()
   .optional();

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -715,8 +715,12 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (isAgentAllowedForChatType(input.cfg, fallback.agentId, chatType)) {
         return fallback;
       }
+      // Default is also blocked; signal blocked using the default agent (not the
+      // binding-matched one) so the caller always sees the default as the
+      // "canonical" blocked identity when no agent is permitted.
+      return { ...fallback, blocked: true };
     }
-    // Default is also blocked (or was already the default); signal blocked.
+    // Was already the default agent; signal blocked.
     return { ...route, blocked: true };
   };
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,4 +1,4 @@
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { isAgentAllowedForChatType, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -54,6 +54,8 @@ export type ResolvedAgentRoute = {
     | "binding.account"
     | "binding.channel"
     | "default";
+  /** When true, the resolved agent is restricted from this chat type via allowedChatTypes. */
+  blocked?: boolean;
 };
 
 export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
@@ -695,6 +697,29 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     },
   ];
 
+  const chatType = normalizeChatType(peer?.kind);
+
+  // Check allowedChatTypes and fall back to default agent if blocked.
+  const withChatTypeGuard = (route: ResolvedAgentRoute): ResolvedAgentRoute => {
+    if (isAgentAllowedForChatType(input.cfg, route.agentId, chatType)) {
+      return route;
+    }
+    if (shouldLogDebug) {
+      logDebug(
+        `[routing] agent ${route.agentId} blocked for chatType=${chatType ?? "unknown"}; trying default`,
+      );
+    }
+    // Binding-matched agent is blocked — try the default agent.
+    if (route.matchedBy !== "default") {
+      const fallback = choose(resolveDefaultAgentId(input.cfg), "default");
+      if (isAgentAllowedForChatType(input.cfg, fallback.agentId, chatType)) {
+        return fallback;
+      }
+    }
+    // Default is also blocked (or was already the default); signal blocked.
+    return { ...route, blocked: true };
+  };
+
   for (const tier of tiers) {
     if (!tier.enabled) {
       continue;
@@ -711,9 +736,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      return withChatTypeGuard(choose(matched.binding.agentId, tier.matchedBy));
     }
   }
 
-  return choose(resolveDefaultAgentId(input.cfg), "default");
+  return withChatTypeGuard(choose(resolveDefaultAgentId(input.cfg), "default"));
 }


### PR DESCRIPTION
## Summary
- Resolve symlinks via tryRealpathSync() in resolvePathWithinRoot
- Fixes macOS /tmp -> /private/tmp mismatch causing upload path rejection
- Closes #23374

## Test plan
- Run pnpm vitest run src/browser/paths.test.ts
- Verify all 17 tests pass including new symlink tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)