### PR TITLE
fix(providers): auto-set authHeader for existing MiniMax provider configs

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -498,6 +498,14 @@ export function normalizeProviders(params: {
       normalizedProvider = antigravityNormalized;
     }
 
+    if (
+      (normalizedKey === "minimax" || normalizedKey === "minimax-portal") &&
+      normalizedProvider.authHeader === undefined
+    ) {
+      mutated = true;
+      normalizedProvider = { ...normalizedProvider, authHeader: true };
+    }
+
     next[key] = normalizedProvider;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** After upgrading to 2026.2.26, existing MiniMax provider configs return 401 authentication errors because they lack `authHeader: true`.
- **Why it matters:** All users with pre-existing MiniMax configs are broken after upgrading — the API now requires `Authorization: Bearer` but old configs still send `x-api-key`.
- **What changed:** Added a normalization step in `normalizeExplicitProviders` that auto-sets `authHeader: true` for `minimax` and `minimax-portal` providers when the field is not explicitly configured.
- **What did NOT change:** Implicit provider templates (already have `authHeader: true`), onboarding flow, or any other provider normalization logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28458

## User-visible / Behavior Changes

- Existing MiniMax provider configs now automatically use `Authorization: Bearer` header
- No more 401 errors after upgrading from pre-2026.2.26 versions

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — same API key, different header format
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any using MiniMax models

### Steps

1. Have an existing `openclaw.json` with `minimax` provider configured (no `authHeader` field)
2. Upgrade to 2026.2.26
3. Send a message using MiniMax model

### Expected

- Message sends successfully with `Authorization: Bearer` header

### Actual

- Before fix: HTTP 401 authentication error (`x-api-key` header sent instead of `Authorization: Bearer`)
- After fix: Works correctly (`Authorization: Bearer` header sent)

## Evidence

The normalization follows the same pattern as existing `google` and `google-antigravity` provider normalization in `normalizeExplicitProviders` (models-config.providers.ts L485-499). For configs that explicitly set `authHeader: false`, the normalization is skipped (only triggers on `undefined`).

## Human Verification (required)

- Verified scenarios: `authHeader` undefined → auto-set to `true`; `authHeader: true` already set → no change; `authHeader: false` explicitly set → no change
- Edge cases checked: Provider keys with leading/trailing whitespace (handled by existing `normalizedKey` trimming)
- What I did **not** verify: Live MiniMax API call (no MiniMax API key in test environment)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — runtime normalization, no config file mutation
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `src/agents/models-config.providers.ts`
- Known bad symptoms: If MiniMax API stops accepting `Authorization: Bearer` and requires `x-api-key`, users can set `authHeader: false` explicitly

## Risks and Mitigations

Low risk — only affects providers named `minimax` or `minimax-portal` with `authHeader === undefined`. Users who explicitly set `authHeader: false` are not affected.
