### PR TITLE
fix(qmd): resolve ensureCollections path+pattern conflict between agents

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -606,6 +606,120 @@ describe("QmdMemoryManager", () => {
     );
   });
 
+  it("resolves path+pattern conflict by removing the conflicting collection and retrying", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    const removeCalls: string[] = [];
+    const addCalls: string[] = [];
+    // Simulate: qmd has "memory-root-other" occupying the same path+pattern as "memory-root-main".
+    // collection list returns nothing (simulating a fresh or unknown state) so ensureCollections
+    // tries to add the managed collection. The first add fails with a "Name: memory-root-other"
+    // conflict message; after resolveCollectionConflict removes the conflicting collection,
+    // the retry succeeds.
+    let conflictResolved = false;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", JSON.stringify([]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "remove") {
+        const child = createMockChild({ autoClose: false });
+        removeCalls.push(args[2] ?? "");
+        conflictResolved = true;
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        const child = createMockChild({ autoClose: false });
+        const name = args[args.indexOf("--name") + 1] ?? "";
+        addCalls.push(name);
+        // First attempt for memory-root-main fails with conflict (another agent's collection)
+        if (name === "memory-root-main" && !conflictResolved) {
+          emitAndClose(
+            child,
+            "stderr",
+            "A collection already exists for this path and pattern:\n  Name: memory-root-other (qmd://memory-root-other/)\n  Pattern: MEMORY.md",
+            1,
+          );
+          return child;
+        }
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    // The conflicting collection should have been removed
+    expect(removeCalls).toContain("memory-root-other");
+    // And the desired collection should have been retried (appears twice in addCalls)
+    const memoryRootAdds = addCalls.filter((n) => n === "memory-root-main");
+    expect(memoryRootAdds.length).toBe(2);
+  });
+
+  it("skips conflict resolution when already-exists error names the same collection", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    const removeCalls: string[] = [];
+    // Simulate: the "already exists" error names the same collection we're trying to add.
+    // This means the collection truly exists and we should skip without removing anything.
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", JSON.stringify([]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "remove") {
+        const child = createMockChild({ autoClose: false });
+        removeCalls.push(args[2] ?? "");
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        const child = createMockChild({ autoClose: false });
+        const name = args[args.indexOf("--name") + 1] ?? "";
+        // The error message names the same collection => true duplicate, not a conflict
+        emitAndClose(
+          child,
+          "stderr",
+          `A collection already exists for this path and pattern:\n  Name: ${name} (qmd://${name}/)\n  Pattern: MEMORY.md`,
+          1,
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    // No conflict resolution should have been attempted
+    expect(removeCalls).toEqual([]);
+  });
+
   it("times out qmd update during sync when configured", async () => {
     vi.useFakeTimers();
     cfg = {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -335,6 +335,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (this.isCollectionAlreadyExistsError(message)) {
+          // Check whether the conflict is with the same collection name (safe to skip)
+          // or a different name occupying the same path+pattern (must resolve).
+          const conflicting = this.extractConflictingCollectionName(message);
+          if (conflicting && conflicting !== collection.name) {
+            try {
+              await this.resolveCollectionConflict(conflicting, collection);
+            } catch (resolveErr) {
+              log.warn(
+                `qmd collection conflict resolution failed for ${collection.name}: ${resolveErr instanceof Error ? resolveErr.message : String(resolveErr)}`,
+              );
+            }
+          }
           continue;
         }
         log.warn(`qmd collection add failed for ${collection.name}: ${message}`);
@@ -415,6 +427,40 @@ export class QmdMemoryManager implements MemorySearchManager {
   private isCollectionAlreadyExistsError(message: string): boolean {
     const lower = message.toLowerCase();
     return lower.includes("already exists") || lower.includes("exists");
+  }
+
+  /**
+   * Extract the conflicting collection name from a qmd "already exists" error.
+   * qmd emits messages like:
+   *   "A collection already exists for this path and pattern:\n  Name: foo-bar (...)"
+   * Returns the conflicting name, or null if we can't parse it.
+   */
+  private extractConflictingCollectionName(message: string): string | null {
+    const match = /Name:\s*(\S+)/i.exec(message);
+    return match?.[1]?.replace(/\s*\(.*$/, "") ?? null;
+  }
+
+  /**
+   * Handle a path+pattern conflict: another collection occupies the same slot
+   * under a different name. Remove the conflicting collection and retry the add.
+   */
+  private async resolveCollectionConflict(
+    conflictingName: string,
+    collection: ManagedCollection,
+  ): Promise<void> {
+    log.debug(
+      `qmd collection "${collection.name}" conflicts with existing "${conflictingName}" at same path+pattern; removing conflicting collection`,
+    );
+    try {
+      await this.removeCollection(conflictingName);
+    } catch (removeErr) {
+      const removeMessage = removeErr instanceof Error ? removeErr.message : String(removeErr);
+      if (!this.isCollectionMissingError(removeMessage)) {
+        log.warn(`qmd collection remove failed for ${conflictingName}: ${removeMessage}`);
+        return;
+      }
+    }
+    await this.addCollection(collection.path, collection.name, collection.pattern);
   }
 
   private isCollectionMissingError(message: string): boolean {
@@ -597,7 +643,19 @@ export class QmdMemoryManager implements MemorySearchManager {
         await this.addCollection(collection.path, collection.name, collection.pattern);
       } catch (addErr) {
         const addMessage = addErr instanceof Error ? addErr.message : String(addErr);
-        if (!this.isCollectionAlreadyExistsError(addMessage)) {
+        if (this.isCollectionAlreadyExistsError(addMessage)) {
+          // Path+pattern conflict with a differently-named collection; resolve it.
+          const conflicting = this.extractConflictingCollectionName(addMessage);
+          if (conflicting && conflicting !== collection.name) {
+            try {
+              await this.resolveCollectionConflict(conflicting, collection);
+            } catch (resolveErr) {
+              log.warn(
+                `qmd collection conflict resolution failed for ${collection.name}: ${resolveErr instanceof Error ? resolveErr.message : String(resolveErr)}`,
+              );
+            }
+          }
+        } else {
           log.warn(`qmd collection add failed for ${collection.name}: ${addMessage}`);
         }
       }


### PR DESCRIPTION
## Summary
- Fix qmd collection creation failure when multiple agents share a workspace
- Extract conflicting collection name from error and auto-resolve by removing stale collection
- Add tests for conflict resolution and same-name duplicate handling
- Closes #25496

## Test plan
- Run pnpm vitest run src/memory/qmd-manager.test.ts
- Verify conflict resolution and duplicate detection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)