### PR TITLE
fix(ui): align config tab styling with other Control UI tabs

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -7,11 +7,12 @@
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
   gap: 0;
-  height: calc(100vh - 160px);
-  margin: -16px;
-  border-radius: var(--radius-xl);
+  min-height: 0;
+  max-height: calc(100vh - 200px);
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   background: var(--panel);
+  animation: rise 0.35s var(--ease-out) backwards;
 }
 
 /* ===========================================


### PR DESCRIPTION
## Summary

- **Problem:** The Config tab in Control UI overlaps with adjacent sections (negative margin) and lacks the entrance animation that all other tabs share.
- **Why it matters:** Inconsistent tab appearance confuses users and breaks visual hierarchy.
- **What changed:** Removed `margin: -16px`, replaced fixed `height: calc(100vh - 160px)` with flexible `min-height: 0; max-height: calc(100vh - 200px)`, matched `border-radius` to `.card` (`radius-lg`), and added the `rise` entrance animation.
- **What did NOT change:** Config tab grid layout (sidebar + content), form fields, functionality, or mobile responsive breakpoints.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28755

## User-visible / Behavior Changes

- Config tab no longer overlaps with adjacent sections
- Config tab now has the same `rise` entrance animation as Chat, Overview, and other tabs
- Config tab border-radius matches `.card` class (`radius-lg` instead of `radius-xl`)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (WSL 2/Ubuntu in original report)
- Runtime: Browser (Control UI)
- Integration/channel: Control UI Config tab

### Steps

1. Open Control UI
2. Switch between tabs (Overview → Chat → Config)

### Expected

- Config tab has the same animation and alignment as other tabs

### Actual

- Before fix: Config tab overlaps adjacent sections, no entrance animation, different border-radius
- After fix: Config tab is flush with container, has `rise` animation, consistent `radius-lg`

## Evidence

```css
/* Before (config.css L6-15) */
.config-layout {
  height: calc(100vh - 160px);
  margin: -16px;              /* overlap */
  border-radius: var(--radius-xl);
  /* no animation */
}

/* After */
.config-layout {
  min-height: 0;
  max-height: calc(100vh - 200px);
  border-radius: var(--radius-lg);   /* matches .card */
  animation: rise 0.35s var(--ease-out) backwards;  /* matches .card */
}
```

Other tabs use `.card` (components.css L36-49) which includes `animation: rise 0.35s var(--ease-out) backwards` and `border-radius: var(--radius-lg)`.

## Human Verification (required)

- Verified scenarios: Config tab loads with animation; sidebar + content grid layout preserved; mobile breakpoints unchanged
- Edge cases checked: Very tall content → `max-height` prevents overflow; very short content → `min-height: 0` allows shrink
- What I did **not** verify: Visual comparison across all screen sizes (no automated visual regression)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `ui/src/styles/config.css`
- Known bad symptoms: If `max-height` is too restrictive on some screens, the config content may need scrolling — but `overflow-y: auto` on `.config-content` already handles this

## Risks and Mitigations

`None` — CSS-only change affecting a single UI tab.
