### PR TITLE
fix(telegram): track sent messages for reactionNotifications own mode

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -20,6 +20,7 @@ import {
   replySpy,
   sendMessageSpy,
   setMyCommandsSpy,
+  useSpy,
   wasSentByBot,
 } from "./bot.create-telegram-bot.test-harness.js";
 import { createTelegramBot } from "./bot.js";
@@ -1376,6 +1377,16 @@ describe("createTelegramBot", () => {
     });
 
     expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(expectedEnqueueCalls);
+  });
+
+  it("registers sent-message-recording transformer on bot.api.config", () => {
+    useSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+
+    // The throttler is the first transformer, and the sent-message-recording transformer is the second.
+    // useSpy captures all bot.api.config.use() calls.
+    expect(useSpy).toHaveBeenCalledTimes(2);
+    expect(typeof useSpy.mock.calls[1]?.[0]).toBe("function");
   });
 
   it("skips reaction when reactionNotifications is off", async () => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,9 +1,11 @@
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
+import { type Message, type UserFromGetMe } from "@grammyjs/types";
 import type { ApiClientOptions } from "grammy";
 import { Bot, webhookCallback } from "grammy";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
+import { isAbortRequestText } from "../auto-reply/reply/abort.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/reply/history.js";
 import {
   isNativeCommandsExplicitlyDisabled,
@@ -32,10 +34,14 @@ import {
   resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
-import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
+import {
+  buildTelegramGroupPeerId,
+  resolveTelegramForumThreadId,
+  resolveTelegramStreamMode,
+} from "./bot/helpers.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
+import { recordSentMessage } from "./sent-message-cache.js";
 
 export type TelegramBotOptions = {
   token: string;
@@ -58,7 +64,55 @@ export type TelegramBotOptions = {
   };
 };
 
-export { getTelegramSequentialKey };
+export function getTelegramSequentialKey(ctx: {
+  chat?: { id?: number };
+  me?: UserFromGetMe;
+  message?: Message;
+  channelPost?: Message;
+  editedChannelPost?: Message;
+  update?: {
+    message?: Message;
+    edited_message?: Message;
+    channel_post?: Message;
+    edited_channel_post?: Message;
+    callback_query?: { message?: Message };
+    message_reaction?: { chat?: { id?: number } };
+  };
+}): string {
+  // Handle reaction updates
+  const reaction = ctx.update?.message_reaction;
+  if (reaction?.chat?.id) {
+    return `telegram:${reaction.chat.id}`;
+  }
+  const msg =
+    ctx.message ??
+    ctx.channelPost ??
+    ctx.editedChannelPost ??
+    ctx.update?.message ??
+    ctx.update?.edited_message ??
+    ctx.update?.channel_post ??
+    ctx.update?.edited_channel_post ??
+    ctx.update?.callback_query?.message;
+  const chatId = msg?.chat?.id ?? ctx.chat?.id;
+  const rawText = msg?.text ?? msg?.caption;
+  const botUsername = ctx.me?.username;
+  if (isAbortRequestText(rawText, botUsername ? { botUsername } : undefined)) {
+    if (typeof chatId === "number") {
+      return `telegram:${chatId}:control`;
+    }
+    return "telegram:control";
+  }
+  const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
+  const messageThreadId = msg?.message_thread_id;
+  const isForum = msg?.chat?.is_forum;
+  const threadId = isGroup
+    ? resolveTelegramForumThreadId({ isForum, messageThreadId })
+    : messageThreadId;
+  if (typeof chatId === "number") {
+    return threadId != null ? `telegram:${chatId}:topic:${threadId}` : `telegram:${chatId}`;
+  }
+  return "telegram:unknown";
+}
 
 export function createTelegramBot(opts: TelegramBotOptions) {
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
@@ -90,6 +144,41 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
   const bot = new Bot(opts.token, client ? { client } : undefined);
   bot.api.config.use(apiThrottler());
+
+  // Intercept outgoing API calls to record sent messages for reaction "own" mode filtering.
+  // Without this, wasSentByBot() never returns true because the gateway sends via bot.api
+  // directly, bypassing sendMessageTelegram() which normally calls recordSentMessage().
+  const SEND_METHODS = new Set([
+    "sendMessage",
+    "sendPhoto",
+    "sendAudio",
+    "sendDocument",
+    "sendVideo",
+    "sendAnimation",
+    "sendVoice",
+    "sendVideoNote",
+    "sendSticker",
+    "sendLocation",
+    "sendVenue",
+    "sendContact",
+    "sendPoll",
+    "sendDice",
+    "forwardMessage",
+    "copyMessage",
+  ]);
+  bot.api.config.use(async (prev, method, payload, signal) => {
+    const result = await prev(method, payload, signal);
+    if (SEND_METHODS.has(method) && result.ok) {
+      const p = payload as Record<string, unknown>;
+      const chatId = p.chat_id;
+      const messageId = (result.result as Record<string, unknown> | undefined)?.message_id;
+      if (chatId != null && typeof messageId === "number") {
+        recordSentMessage(chatId as number | string, messageId);
+      }
+    }
+    return result;
+  });
+
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));

--- a/src/telegram/sent-message-cache.test.ts
+++ b/src/telegram/sent-message-cache.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearSentMessageCache, recordSentMessage, wasSentByBot } from "./sent-message-cache.js";
+
+describe("sent-message-cache", () => {
+  afterEach(() => {
+    clearSentMessageCache();
+  });
+
+  it("records and retrieves a sent message", () => {
+    recordSentMessage(123, 42);
+    expect(wasSentByBot(123, 42)).toBe(true);
+  });
+
+  it("returns false for unrecorded messages", () => {
+    expect(wasSentByBot(123, 42)).toBe(false);
+  });
+
+  it("returns false for wrong chat id", () => {
+    recordSentMessage(123, 42);
+    expect(wasSentByBot(456, 42)).toBe(false);
+  });
+
+  it("returns false for wrong message id", () => {
+    recordSentMessage(123, 42);
+    expect(wasSentByBot(123, 99)).toBe(false);
+  });
+
+  it("handles string and number chat ids consistently", () => {
+    recordSentMessage(123, 42);
+    expect(wasSentByBot("123", 42)).toBe(true);
+
+    recordSentMessage("-1001234567890", 55);
+    expect(wasSentByBot(-1001234567890, 55)).toBe(true);
+  });
+
+  it("expires entries after TTL", () => {
+    vi.useFakeTimers();
+    try {
+      recordSentMessage(123, 42);
+      expect(wasSentByBot(123, 42)).toBe(true);
+
+      // Advance past 24h TTL
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+
+      expect(wasSentByBot(123, 42)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears all entries", () => {
+    recordSentMessage(123, 42);
+    recordSentMessage(456, 99);
+    clearSentMessageCache();
+
+    expect(wasSentByBot(123, 42)).toBe(false);
+    expect(wasSentByBot(456, 99)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add grammY transformer to intercept outgoing send methods and record message IDs
- Implement in-memory sent-message cache with 24h TTL for wasSentByBot() checks
- Fixes reactionNotifications 'own' mode silently dropping all reactions
- Closes #24679

## Test plan
- Run pnpm vitest run src/telegram/sent-message-cache.test.ts src/telegram/bot.test.ts
- Verify 7 cache tests + transformer registration test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)