### PR TITLE
fix: prevent typing keepalive loop from restarting after stop

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -77,7 +77,8 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     keepaliveLoop.stop();
     clearTtlTimer();
     await fireStart();
-    if (startGuard.isTripped()) {
+    // Check closed again after async operation - fireStop may have been called during await
+    if (closed || startGuard.isTripped()) {
       return;
     }
     keepaliveLoop.start();


### PR DESCRIPTION
## Summary

Fixes a race condition in `createTypingCallbacks` where the keepalive loop was incorrectly restarted after `fireStop()` was called during an async operation. This caused Discord typing indicator to get stuck permanently after the bot sends a message.

## Root Cause

In `src/channels/typing.ts`, the `onReplyStart` function:

```typescript
const onReplyStart = async () => {
    if (closed) return;
    stopSent = false;
    keepaliveLoop.stop();
    await fireStart();    // <-- async operation
    keepaliveLoop.start(); // <-- BUG: could run after fireStop() was called
};
```

**Race condition:**
1. `onReplyStart` executes and reaches `await fireStart()`
2. During the async operation, `fireStop()` is called (sets `closed = true`, stops timer)
3. `await fireStart()` completes
4. `keepaliveLoop.start()` runs, **restarting the timer**
5. Timer keeps firing indefinitely since `closed` check in subsequent calls to `fireStart` just returns early

## Fix

Add a check for `closed` after the async operation before restarting the loop:

```typescript
await fireStart();
if (closed) return;  // <-- Don't restart if stop was called during await
keepaliveLoop.start();
```

## Testing

- The fix ensures that if `fireStop()` is called during the async `fireStart()` operation, the keepalive loop will not be restarted
- Typing indicator will properly stop when the bot finishes sending messages

Fixes #26891