### PR TITLE
Harden outbound payloads against internal trace leakage

### DIFF
--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1065,6 +1065,19 @@ describe("normalizeOutboundPayloadsForJson", () => {
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrl: null, mediaUrls: undefined }]);
   });
+
+  it("suppresses internal tool-trace envelopes", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      {
+        text: [
+          "NO_REPLY",
+          "assistant to=functions.memory_search comment json",
+          '{"query":"incident","maxResults":3}',
+        ].join("\n"),
+      },
+    ]);
+    expect(normalized).toEqual([]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {
@@ -1080,6 +1093,19 @@ describe("normalizeOutboundPayloads", () => {
       { text: "final answer" },
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrls: [] }]);
+  });
+
+  it("suppresses internal tool-trace envelopes", () => {
+    const normalized = normalizeOutboundPayloads([
+      {
+        text: [
+          "NO_REPLY",
+          "assistant to=functions.memory_search մեկնաբանություն json",
+          '{"query":"recent incident internal tool trace leaked into user chat happened today","maxResults":3}',
+        ].join("\n"),
+      },
+    ]);
+    expect(normalized).toEqual([]);
   });
 });
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1078,6 +1078,22 @@ describe("normalizeOutboundPayloadsForJson", () => {
     ]);
     expect(normalized).toEqual([]);
   });
+
+  it("does not suppress normal technical discussion messages", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      {
+        text: "Can you explain how function_call works in the OpenAI API and when to use functions.search?",
+      },
+    ]);
+    expect(normalized).toEqual([
+      {
+        text: "Can you explain how function_call works in the OpenAI API and when to use functions.search?",
+        mediaUrl: null,
+        mediaUrls: undefined,
+        channelData: undefined,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {
@@ -1106,6 +1122,15 @@ describe("normalizeOutboundPayloads", () => {
       },
     ]);
     expect(normalized).toEqual([]);
+  });
+
+  it("does not suppress normal messages mentioning functions.* identifiers", () => {
+    const normalized = normalizeOutboundPayloads([
+      { text: "The functions.memory_search endpoint is unavailable right now." },
+    ]);
+    expect(normalized).toEqual([
+      { text: "The functions.memory_search endpoint is unavailable right now.", mediaUrls: [] },
+    ]);
   });
 });
 

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1079,6 +1079,21 @@ describe("normalizeOutboundPayloadsForJson", () => {
     expect(normalized).toEqual([]);
   });
 
+  it("suppresses NO_REPLY reasoning-style leakage text", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      {
+        text: [
+          "NO_REPLY",
+          "user continues cron spam maybe expects no_reply unless new.",
+          "should output NO_REPLY if exact result already delivered in this same turn.",
+          "Need include reply tag first token.",
+          "Final.",
+        ].join("\n"),
+      },
+    ]);
+    expect(normalized).toEqual([]);
+  });
+
   it("does not suppress normal technical discussion messages", () => {
     const normalized = normalizeOutboundPayloadsForJson([
       {
@@ -1088,6 +1103,20 @@ describe("normalizeOutboundPayloadsForJson", () => {
     expect(normalized).toEqual([
       {
         text: "Can you explain how function_call works in the OpenAI API and when to use functions.search?",
+        mediaUrl: null,
+        mediaUrls: undefined,
+        channelData: undefined,
+      },
+    ]);
+  });
+
+  it("does not suppress benign mentions of NO_REPLY", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      { text: "In this protocol, NO_REPLY means skip auto-response output." },
+    ]);
+    expect(normalized).toEqual([
+      {
+        text: "In this protocol, NO_REPLY means skip auto-response output.",
         mediaUrl: null,
         mediaUrls: undefined,
         channelData: undefined,
@@ -1118,6 +1147,20 @@ describe("normalizeOutboundPayloads", () => {
           "NO_REPLY",
           "assistant to=functions.memory_search մեկնաբանություն json",
           '{"query":"recent incident internal tool trace leaked into user chat happened today","maxResults":3}',
+        ].join("\n"),
+      },
+    ]);
+    expect(normalized).toEqual([]);
+  });
+
+  it("suppresses NO_REPLY reasoning-style leakage text", () => {
+    const normalized = normalizeOutboundPayloads([
+      {
+        text: [
+          "NO_REPLY",
+          "should output NO_REPLY if exact result already delivered in this same turn.",
+          "This is a system instruction checkpoint.",
+          "Final.",
         ].join("\n"),
       },
     ]);

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -23,13 +23,38 @@ const INTERNAL_TRACE_ENVELOPE_PATTERNS = {
   assistantToFunctions: /(?:^|\n)[^\n]*\bassistant\s+to=functions\.[a-z0-9_]+\b/i,
 } as const;
 
+const INTERNAL_TRACE_REASONING_MARKERS: ReadonlyArray<RegExp> = [
+  /\bshould\s+output\s+no_reply\b/i,
+  /\b(system\s+message|system\s+instruction)\b/i,
+  /\bneed\s+include\s+reply\s+tag\b/i,
+  /\bexact\s+result\s+already\s+delivered\b/i,
+  /(?:^|\n)\s*Final\.\s*(?:$|\n)/im,
+];
+
+function isNoReplyReasoningLeak(text: string): boolean {
+  if (!INTERNAL_TRACE_ENVELOPE_PATTERNS.noReply.test(text)) {
+    return false;
+  }
+  let matchedMarkers = 0;
+  for (const marker of INTERNAL_TRACE_REASONING_MARKERS) {
+    if (marker.test(text)) {
+      matchedMarkers += 1;
+      if (matchedMarkers >= 2) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function isInternalTraceLeakText(text: string | undefined): boolean {
   if (!text) {
     return false;
   }
   return (
-    INTERNAL_TRACE_ENVELOPE_PATTERNS.noReply.test(text) &&
-    INTERNAL_TRACE_ENVELOPE_PATTERNS.assistantToFunctions.test(text)
+    (INTERNAL_TRACE_ENVELOPE_PATTERNS.noReply.test(text) &&
+      INTERNAL_TRACE_ENVELOPE_PATTERNS.assistantToFunctions.test(text)) ||
+    isNoReplyReasoningLeak(text)
   );
 }
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -18,17 +18,19 @@ export type OutboundPayloadJson = {
   channelData?: Record<string, unknown>;
 };
 
-const INTERNAL_TRACE_PATTERNS: ReadonlyArray<RegExp> = [
-  /\bassistant\s+to=functions\.[a-z0-9_]+\b/i,
-  /\bfunctions\.[a-z0-9_]+\b/i,
-  /\b(memory_search|tool_call|function_call)\b/i,
-];
+const INTERNAL_TRACE_ENVELOPE_PATTERNS = {
+  noReply: /(?:^|\n)\s*NO_REPLY\b/i,
+  assistantToFunctions: /(?:^|\n)[^\n]*\bassistant\s+to=functions\.[a-z0-9_]+\b/i,
+} as const;
 
 function isInternalTraceLeakText(text: string | undefined): boolean {
   if (!text) {
     return false;
   }
-  return INTERNAL_TRACE_PATTERNS.some((pattern) => pattern.test(text));
+  return (
+    INTERNAL_TRACE_ENVELOPE_PATTERNS.noReply.test(text) &&
+    INTERNAL_TRACE_ENVELOPE_PATTERNS.assistantToFunctions.test(text)
+  );
 }
 
 function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | undefined>): string[] {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -18,6 +18,19 @@ export type OutboundPayloadJson = {
   channelData?: Record<string, unknown>;
 };
 
+const INTERNAL_TRACE_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bassistant\s+to=functions\.[a-z0-9_]+\b/i,
+  /\bfunctions\.[a-z0-9_]+\b/i,
+  /\b(memory_search|tool_call|function_call)\b/i,
+];
+
+function isInternalTraceLeakText(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  return INTERNAL_TRACE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | undefined>): string[] {
   const seen = new Set<string>();
   const merged: string[] = [];
@@ -66,6 +79,9 @@ export function normalizeReplyPayloadsForDelivery(
       replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
       audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
     };
+    if (isInternalTraceLeakText(next.text)) {
+      return [];
+    }
     if (parsed.isSilent && mergedMedia.length === 0) {
       return [];
     }


### PR DESCRIPTION
## Summary
- suppress outbound text payloads that look like internal tool-call traces
- add a focused detector for leaked internal envelopes (e.g. `assistant to=functions...`, `memory_search`)
- add unit coverage for both JSON and channel outbound normalization paths

## Why
Users observed internal tool trace envelopes leaking into chat messages. These should never be user-visible.

## Validation
- `corepack pnpm vitest run --config vitest.unit.config.ts src/infra/outbound/outbound.test.ts`
