### PR TITLE
fix(docker): ensure agent directory permissions in docker-setup.sh

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -347,8 +347,14 @@ fi
 # it works regardless of the host uid and doesn't require host-side root.
 echo ""
 echo "==> Fixing data-directory permissions"
+# Use -xdev to restrict chown to the config-dir mount only — without it,
+# the recursive chown would cross into the workspace bind mount and rewrite
+# ownership of all user project files on Linux hosts.
+# After fixing the config dir, only the OpenClaw metadata subdirectory
+# (.openclaw/) inside the workspace gets chowned, not the user's project files.
 docker compose "${COMPOSE_ARGS[@]}" run --rm --user root --entrypoint sh openclaw-cli -c \
-  'chown -R node:node /home/node/.openclaw'
+  'find /home/node/.openclaw -xdev -exec chown node:node {} +; \
+   [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
 
 echo ""
 echo "==> Onboarding (interactive)"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -154,9 +154,11 @@ fi
 
 mkdir -p "$OPENCLAW_CONFIG_DIR"
 mkdir -p "$OPENCLAW_WORKSPACE_DIR"
-# Seed device-identity parent eagerly for Docker Desktop/Windows bind mounts
-# that reject creating new subdirectories from inside the container.
+# Seed directory tree eagerly so bind mounts work even on Docker Desktop/Windows
+# where the container (even as root) cannot create new host subdirectories.
 mkdir -p "$OPENCLAW_CONFIG_DIR/identity"
+mkdir -p "$OPENCLAW_CONFIG_DIR/agents/main/agent"
+mkdir -p "$OPENCLAW_CONFIG_DIR/agents/main/sessions"
 
 export OPENCLAW_CONFIG_DIR
 export OPENCLAW_WORKSPACE_DIR
@@ -337,6 +339,16 @@ else
     exit 1
   fi
 fi
+
+# Ensure bind-mounted data directories are writable by the container's `node`
+# user (uid 1000). Host-created dirs inherit the host user's uid which may
+# differ, causing EACCES when the container tries to mkdir/write.
+# Running a brief root container to chown is the portable Docker idiom --
+# it works regardless of the host uid and doesn't require host-side root.
+echo ""
+echo "==> Fixing data-directory permissions"
+docker compose "${COMPOSE_ARGS[@]}" run --rm --user root --entrypoint sh openclaw-cli -c \
+  'chown -R node:node /home/node/.openclaw'
 
 echo ""
 echo "==> Onboarding (interactive)"

--- a/src/docker-setup.test.ts
+++ b/src/docker-setup.test.ts
@@ -168,6 +168,30 @@ describe("docker-setup.sh", () => {
     expect(identityDirStat.isDirectory()).toBe(true);
   });
 
+  it("precreates agent data dirs to avoid EACCES in container", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    const configDir = join(activeSandbox.rootDir, "config-agent-dirs");
+    const workspaceDir = join(activeSandbox.rootDir, "workspace-agent-dirs");
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_CONFIG_DIR: configDir,
+      OPENCLAW_WORKSPACE_DIR: workspaceDir,
+    });
+
+    expect(result.status).toBe(0);
+    const agentDirStat = await stat(join(configDir, "agents", "main", "agent"));
+    expect(agentDirStat.isDirectory()).toBe(true);
+    const sessionsDirStat = await stat(join(configDir, "agents", "main", "sessions"));
+    expect(sessionsDirStat.isDirectory()).toBe(true);
+
+    // Verify that a root-user chown step runs before onboarding.
+    const log = await readFile(activeSandbox.logPath, "utf8");
+    const chownIdx = log.indexOf("--user root");
+    const onboardIdx = log.indexOf("onboard");
+    expect(chownIdx).toBeGreaterThanOrEqual(0);
+    expect(onboardIdx).toBeGreaterThan(chownIdx);
+  });
+
   it("reuses existing config token when OPENCLAW_GATEWAY_TOKEN is unset", async () => {
     const activeSandbox = requireSandbox(sandbox);
     const configDir = join(activeSandbox.rootDir, "config-token-reuse");


### PR DESCRIPTION
## Summary
- Pre-create agent data directories (agents/main/agent, agents/main/sessions) before container start
- Run chown -R as root inside container to fix bind-mount ownership for node user
- Prevents EACCES when onboarding tries to mkdir in bind-mounted dirs
- Closes #21489

## Test plan
- Run pnpm vitest run src/docker-setup.test.ts
- Verify pre-creation and chown ordering tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)