### PR TITLE
fix: prevent duplicate gateway when lock owner status is unknown

### DIFF
--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import * as pidAliveModule from "../shared/pid-alive.js";
 import { acquireGatewayLock, GatewayLockError, type GatewayLockOptions } from "./gateway-lock.js";
 
 let fixtureRoot = "";
@@ -83,10 +84,11 @@ function createLockPayload(params: { configPath: string; startTime: number; crea
   };
 }
 
-function mockProcStatRead(params: { onProcRead: () => string }) {
+function mockProcStatRead(params: { onProcRead: () => string; pid?: number }) {
   const readFileSync = fsSync.readFileSync;
+  const targetPid = params.pid ?? process.pid;
   return vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
-    if (filePath === `/proc/${process.pid}/stat`) {
+    if (filePath === `/proc/${targetPid}/stat`) {
       return params.onProcRead();
     }
     return readFileSync(filePath as never, encoding as never) as never;
@@ -284,6 +286,91 @@ describe("gateway lock", () => {
       env: { ...env, VITEST: "1" },
     });
     expect(lock).toBeNull();
+  });
+
+  it("retries unknown status before treating lock as stale", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const fakePid = 999998;
+    const { lockPath, configPath } = resolveLockPath(env);
+    const payload = createLockPayload({
+      configPath,
+      startTime: 111,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    payload.pid = fakePid;
+    await fs.writeFile(lockPath, JSON.stringify(payload), "utf8");
+
+    const aliveSpy = vi.spyOn(pidAliveModule, "isPidAlive").mockImplementation((pid) => {
+      if (pid === fakePid) {
+        return true;
+      }
+      return pidAliveModule.isPidAlive(pid);
+    });
+
+    let readCount = 0;
+    const spy = mockProcStatRead({
+      pid: fakePid,
+      onProcRead: () => {
+        readCount++;
+        if (readCount <= 2) {
+          throw new Error("EACCES");
+        }
+        return makeProcStat(fakePid, 111);
+      },
+    });
+
+    // Should NOT steal the lock because retries resolve to "alive"
+    const pending = acquireForTest(env, {
+      timeoutMs: 5000,
+      pollIntervalMs: 5,
+      staleMs: 1000,
+      platform: "linux",
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    spy.mockRestore();
+    aliveSpy.mockRestore();
+  });
+
+  it("treats unknown status as alive even when lock is stale", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const fakePid = 999999;
+    const { lockPath, configPath } = resolveLockPath(env);
+    const payload = createLockPayload({
+      configPath,
+      startTime: 111,
+      createdAt: new Date(Date.now() - 60_000).toISOString(), // very stale
+    });
+    payload.pid = fakePid;
+    await fs.writeFile(lockPath, JSON.stringify(payload), "utf8");
+
+    // All /proc reads fail → status stays "unknown" after retries
+    const procSpy = mockProcStatRead({
+      pid: fakePid,
+      onProcRead: () => {
+        throw new Error("EACCES");
+      },
+    });
+    const aliveSpy = vi.spyOn(pidAliveModule, "isPidAlive").mockImplementation((pid) => {
+      if (pid === fakePid) {
+        return true;
+      }
+      return pidAliveModule.isPidAlive(pid);
+    });
+
+    // Should NOT steal the lock — "unknown" is treated as "alive"
+    const pending = acquireForTest(env, {
+      timeoutMs: 2000,
+      pollIntervalMs: 5,
+      staleMs: 1000,
+      platform: "linux",
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    procSpy.mockRestore();
+    aliveSpy.mockRestore();
   });
 
   it("wraps unexpected fs errors as GatewayLockError", async () => {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -10,6 +10,8 @@ const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
 const DEFAULT_STALE_MS = 30_000;
 const DEFAULT_PORT_PROBE_TIMEOUT_MS = 1000;
+const UNKNOWN_STATUS_RETRIES = 3;
+const UNKNOWN_STATUS_RETRY_DELAY_MS = 200;
 
 type LockPayload = {
   pid: number;
@@ -253,14 +255,34 @@ export async function acquireGatewayLock(
 
       lastPayload = await readLockPayload(lockPath);
       const ownerPid = lastPayload?.pid;
-      const ownerStatus = ownerPid
+      let ownerStatus: LockOwnerStatus = ownerPid
         ? await resolveGatewayOwnerStatus(ownerPid, lastPayload, platform, port)
         : "unknown";
+
+      // Retry transient "unknown" status before making any stale decision.
+      // /proc reads can fail momentarily under load; retrying avoids
+      // incorrectly treating a live gateway as stale (see #28705).
+      if (ownerStatus === "unknown" && ownerPid) {
+        for (let attempt = 0; attempt < UNKNOWN_STATUS_RETRIES; attempt++) {
+          await new Promise((r) => setTimeout(r, UNKNOWN_STATUS_RETRY_DELAY_MS));
+          ownerStatus = await resolveGatewayOwnerStatus(ownerPid, lastPayload, platform, port);
+          if (ownerStatus !== "unknown") {
+            break;
+          }
+        }
+      }
+
       if (ownerStatus === "dead" && ownerPid) {
         await fs.rm(lockPath, { force: true });
         continue;
       }
-      if (ownerStatus !== "alive") {
+
+      // If status is still "unknown" after retries, the PID passed
+      // isPidAlive so a process with that PID exists. We cannot confirm
+      // it is the original gateway, but silently stealing the lock would
+      // allow duplicate gateways (see #28705). Treat "unknown" the same
+      // as "alive" — keep waiting for the lock to be released.
+      if (ownerStatus !== "alive" && ownerStatus !== "unknown") {
         let stale = false;
         if (lastPayload?.createdAt) {
           const createdAt = Date.parse(lastPayload.createdAt);


### PR DESCRIPTION
## Problem

When `resolveGatewayOwnerStatus()` returns `"unknown"` on Linux (e.g., `/proc/{pid}/stat` read fails due to permissions or race conditions), the lock acquisition code falls through to the stale-timer check. For any gateway running >30 seconds (i.e., all of them), the lock is deleted and a new one created — **while the original gateway is still running**.

This causes:
- Two gateway processes running simultaneously
- Resource contention (2x CPU, 2x memory)
- Message routing conflicts
- No warning to the user

Detailed reproduction and evidence in #28705.

## Fix

1. **Retry transient failures**: When status is `"unknown"`, retry `resolveGatewayOwnerStatus()` up to 3 times with 200ms delays. This handles momentary `/proc` read failures under load.

2. **Treat `"unknown"` as `"alive"`**: If retries don't resolve the status, treat it the same as `"alive"` — never steal the lock when we can't confirm the owner is dead. The PID passed `isPidAlive()`, so a process with that PID exists; the safe default is to wait.

## Tests

- **"retries unknown status before treating lock as stale"** — verifies that transient `/proc` failures are retried and a successful read on retry prevents lock theft
- **"treats unknown status as alive even when lock is stale"** — verifies that persistent `"unknown"` status does not allow lock theft, even when the lock is far past the stale threshold

All 11 gateway-lock tests pass.

Closes #28705