### PR TITLE
fix(models): include primary model in allowlist when adding fallbacks

### DIFF
--- a/src/commands/models.set.e2e.test.ts
+++ b/src/commands/models.set.e2e.test.ts
@@ -96,7 +96,28 @@ describe("models set + fallbacks", () => {
           primary: "openai/gpt-4.1-mini",
           fallbacks: ["anthropic/claude-opus-4-6"],
         },
-        models: { "anthropic/claude-opus-4-6": {} },
+        models: { "anthropic/claude-opus-4-6": {}, "openai/gpt-4.1-mini": {} },
+      },
+    });
+  });
+
+  it("includes primary model in allowlist when adding fallback with object model config", async () => {
+    mockConfigSnapshot({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+    });
+    const runtime = makeRuntime();
+
+    await modelsFallbacksAddCommand("openai/o3", runtime);
+
+    expect(writeConfigFile).toHaveBeenCalledTimes(1);
+    const written = getWrittenConfig();
+    expect(written.agents).toEqual({
+      defaults: {
+        model: {
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["openai/o3"],
+        },
+        models: { "openai/o3": {}, "anthropic/claude-opus-4-6": {} },
       },
     });
   });

--- a/src/commands/models/fallbacks-shared.ts
+++ b/src/commands/models/fallbacks-shared.ts
@@ -1,7 +1,11 @@
 import { buildModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
-import { resolveAgentModelFallbackValues, toAgentModelListLike } from "../../config/model-input.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+  toAgentModelListLike,
+} from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { loadModelsConfig } from "./load-config.js";
 import {
@@ -83,6 +87,16 @@ export async function addFallbackCommand(
     const nextModels = { ...cfg.agents?.defaults?.models } as Record<string, unknown>;
     if (!nextModels[targetKey]) {
       nextModels[targetKey] = {};
+    }
+    // Ensure the current primary model stays in the allowlist so it isn't
+    // silently blocked when `models` is populated for the first time.
+    const primaryRaw = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.[params.key]);
+    if (primaryRaw) {
+      const primaryResolved = resolveModelTarget({ raw: primaryRaw, cfg });
+      const primaryKey = modelKey(primaryResolved.provider, primaryResolved.model);
+      if (!nextModels[primaryKey]) {
+        nextModels[primaryKey] = {};
+      }
     }
     const existing = getFallbacks(cfg, params.key);
     const existingKeys = resolveModelKeysFromEntries({ cfg, entries: existing });


### PR DESCRIPTION
## Summary
- Resolve primary model from config and add to allowlist alongside fallback
- Prevents primary model from being silently excluded when adding first fallback
- Closes #20265

## Test plan
- Run pnpm vitest run src/commands/models.set.test.ts
- Verify updated and new fallback allowlist tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)