### PR TITLE
fix(gateway): honor browser profile from request body for node proxy calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Prompt spoofing hardening: stop injecting queued runtime events into user-role prompt text, route them through trusted system-prompt context, and neutralize inbound spoof markers like `[System Message]` and line-leading `System:` in untrusted message content. (#30448)
+- Gateway/Node browser proxy routing: honor `profile` from `browser.request` JSON body when query params omit it, while preserving query-profile precedence when both are present. (#28852) Thanks @Sid-Qin.
 - Browser/Remote CDP ownership checks: skip local-process ownership errors for non-loopback remote CDP profiles when HTTP is reachable but the websocket handshake fails, and surface the remote websocket attach/retry path instead. (#15582) Landed from contributor (#28780) Thanks @stubbi, @bsormagec, @unblockedgamesstudio and @vincentkoc.
 - Docker/Image health checks: add Dockerfile `HEALTHCHECK` that probes gateway `GET /healthz` so container runtimes can mark unhealthy instances without requiring auth credentials in the probe command. (#11478) Thanks @U-C4N and @vincentkoc.
 - Daemon/systemd checks in containers: treat missing `systemctl` invocations (including `spawn systemctl ENOENT`/`EACCES`) as unavailable service state during `is-enabled` checks, preventing container flows from failing with `Gateway service check failed` before install/status handling can continue. (#26089) Thanks @sahilsatralkar and @vincentkoc.

--- a/src/gateway/server-methods/browser.profile-from-body.test.ts
+++ b/src/gateway/server-methods/browser.profile-from-body.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadConfigMock, isNodeCommandAllowedMock, resolveNodeCommandAllowlistMock } = vi.hoisted(
+  () => ({
+    loadConfigMock: vi.fn(),
+    isNodeCommandAllowedMock: vi.fn(),
+    resolveNodeCommandAllowlistMock: vi.fn(),
+  }),
+);
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock("../node-command-policy.js", () => ({
+  isNodeCommandAllowed: isNodeCommandAllowedMock,
+  resolveNodeCommandAllowlist: resolveNodeCommandAllowlistMock,
+}));
+
+import { browserHandlers } from "./browser.js";
+
+type RespondCall = [boolean, unknown?, { code: number; message: string }?];
+
+function createContext() {
+  const invoke = vi.fn(async () => ({
+    ok: true,
+    payload: {
+      result: { ok: true },
+    },
+  }));
+  const listConnected = vi.fn(() => [
+    {
+      nodeId: "node-1",
+      caps: ["browser"],
+      commands: ["browser.proxy"],
+      platform: "linux",
+    },
+  ]);
+  return {
+    invoke,
+    listConnected,
+  };
+}
+
+async function runBrowserRequest(params: Record<string, unknown>) {
+  const respond = vi.fn();
+  const nodeRegistry = createContext();
+  await browserHandlers["browser.request"]({
+    params,
+    respond: respond as never,
+    context: { nodeRegistry } as never,
+    client: null,
+    req: { type: "req", id: "req-1", method: "browser.request" },
+    isWebchatConnect: () => false,
+  });
+  return { respond, nodeRegistry };
+}
+
+describe("browser.request profile selection", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReturnValue({
+      gateway: { nodes: { browser: { mode: "auto" } } },
+    });
+    resolveNodeCommandAllowlistMock.mockReturnValue([]);
+    isNodeCommandAllowedMock.mockReturnValue({ ok: true });
+  });
+
+  it("uses profile from request body when query profile is missing", async () => {
+    const { respond, nodeRegistry } = await runBrowserRequest({
+      method: "POST",
+      path: "/act",
+      body: { profile: "work", request: { action: "click", ref: "btn1" } },
+    });
+
+    expect(nodeRegistry.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "browser.proxy",
+        params: expect.objectContaining({
+          profile: "work",
+        }),
+      }),
+    );
+    const call = respond.mock.calls[0] as RespondCall | undefined;
+    expect(call?.[0]).toBe(true);
+  });
+
+  it("prefers query profile over body profile when both are present", async () => {
+    const { nodeRegistry } = await runBrowserRequest({
+      method: "POST",
+      path: "/act",
+      query: { profile: "chrome" },
+      body: { profile: "work", request: { action: "click", ref: "btn1" } },
+    });
+
+    expect(nodeRegistry.invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          profile: "chrome",
+        }),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/browser.ts
+++ b/src/gateway/server-methods/browser.ts
@@ -20,6 +20,25 @@ type BrowserRequestParams = {
   timeoutMs?: number;
 };
 
+function resolveRequestedProfile(params: {
+  query?: Record<string, unknown>;
+  body?: unknown;
+}): string | undefined {
+  const queryProfile =
+    typeof params.query?.profile === "string" ? params.query.profile.trim() : undefined;
+  if (queryProfile) {
+    return queryProfile;
+  }
+  if (!params.body || typeof params.body !== "object") {
+    return undefined;
+  }
+  const bodyProfile =
+    "profile" in params.body && typeof params.body.profile === "string"
+      ? params.body.profile.trim()
+      : undefined;
+  return bodyProfile || undefined;
+}
+
 type BrowserProxyFile = {
   path: string;
   base64: string;
@@ -187,7 +206,7 @@ export const browserHandlers: GatewayRequestHandlers = {
         query,
         body,
         timeoutMs,
-        profile: typeof query?.profile === "string" ? query.profile : undefined,
+        profile: resolveRequestedProfile({ query, body }),
       };
       const res = await context.nodeRegistry.invoke({
         nodeId: nodeTarget.nodeId,


### PR DESCRIPTION
## Summary

- **Problem:** Browser proxy requests in gateway only read `profile` from query params, so calls that pass `profile` in POST body silently lose it.
- **Why it matters:** Explicit `profile: "openclaw"` can be ignored and fall back to default profile (`chrome`), causing wrong runtime mode and startup errors.
- **What changed:** Added `resolveRequestedProfile()` in `src/gateway/server-methods/browser.ts` to resolve profile from `query.profile` first, then fallback to `body.profile`.
- **What did NOT change:** Browser routing, node command policy, profile selection logic outside request parsing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28687

## User-visible / Behavior Changes

- Browser requests that pass `profile` in POST body now correctly honor that profile.
- `profile` passed in query remains the highest-priority source.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux/macOS (gateway side)
- Runtime: Node.js
- Integration/channel: browser tool via gateway node proxy

### Steps

1. Send a browser proxy request with POST body containing `profile: "openclaw"` and no `query.profile`.
2. Observe node proxy receives params.

### Expected

- Node proxy receives `profile: "openclaw"`.

### Actual

- Before fix: `profile` was `undefined` unless put in query.
- After fix: `profile` resolved from body when query does not provide it.

## Evidence

Type-check passed after change:
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec tsc --noEmit --pretty false`

Core change in `src/gateway/server-methods/browser.ts`:
- old: `profile: typeof query?.profile === "string" ? query.profile : undefined`
- new: `profile: resolveRequestedProfile({ query, body })`

## Human Verification (required)

- Verified scenarios: query profile provided; body profile provided; both missing.
- Edge cases checked: whitespace-only profile values are trimmed and treated as empty.
- What I did **not** verify: Full e2e browser session against live extension relay.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/gateway/server-methods/browser.ts`
- Known bad symptoms: profile may again be ignored when only present in POST body.

## Risks and Mitigations

Low risk. Change is scoped to parsing profile input and keeps query precedence unchanged.
