### PR TITLE
fix(sandbox): allow write mkdir step on existing workspace directories

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -173,6 +173,28 @@ describe("sandbox fs bridge shell compatibility", () => {
     expect(mockedExecDockerRaw).not.toHaveBeenCalled();
   });
 
+  it("allows mkdirp on an already-existing in-workspace directory", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fs-bridge-mkdirp-"));
+    const workspaceDir = path.join(stateDir, "workspace");
+    const nestedDir = path.join(workspaceDir, "memory", "state");
+    await fs.mkdir(nestedDir, { recursive: true });
+
+    const bridge = createSandboxFsBridge({
+      sandbox: createSandbox({
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+      }),
+    });
+
+    await expect(
+      bridge.mkdirp({ filePath: path.join(workspaceDir, "memory", "state") }),
+    ).resolves.toBeUndefined();
+    const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+    expect(mkdirCall).toBeDefined();
+    expect(getDockerPathArg(mkdirCall?.[0] ?? [])).toBe("/workspace/memory/state");
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
   it("rejects pre-existing host symlink escapes before docker exec", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fs-bridge-"));
     const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -23,6 +23,7 @@ type PathSafetyOptions = {
   aliasPolicy?: PathAliasPolicy;
   requireWritable?: boolean;
   allowMissingTarget?: boolean;
+  allowExistingDirectoryTarget?: boolean;
 };
 
 export type SandboxResolvedPath = {
@@ -132,7 +133,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create directories");
-    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "create directories",
+      requireWritable: true,
+      allowExistingDirectoryTarget: true,
+    });
     await this.runCommand('set -eu; mkdir -p -- "$1"', {
       args: [target.containerPath],
       signal: params.signal,
@@ -260,12 +265,18 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       aliasPolicy: options.aliasPolicy,
     });
     if (!guarded.ok) {
-      if (guarded.reason !== "path" || options.allowMissingTarget === false) {
-        throw guarded.error instanceof Error
-          ? guarded.error
-          : new Error(
-              `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
-            );
+      const existingDirectoryAllowed =
+        guarded.reason === "validation" &&
+        options.allowExistingDirectoryTarget === true &&
+        this.isExistingDirectoryPath(target.hostPath);
+      if (!existingDirectoryAllowed) {
+        if (guarded.reason !== "path" || options.allowMissingTarget === false) {
+          throw guarded.error instanceof Error
+            ? guarded.error
+            : new Error(
+                `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
+              );
+        }
       }
     } else {
       fs.closeSync(guarded.fd);
@@ -333,6 +344,14 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   private ensureWriteAccess(target: SandboxResolvedFsPath, action: string) {
     if (!allowsWrites(this.sandbox.workspaceAccess) || !target.writable) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+    }
+  }
+
+  private isExistingDirectoryPath(hostPath: string): boolean {
+    try {
+      return fs.lstatSync(hostPath).isDirectory();
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes a sandbox regression where `write` failed on existing in-workspace paths because the internal mkdir boundary guard treated existing directories as invalid non-file targets.

Closes #28745

## Root cause
`SandboxFsBridge.assertPathSafety()` uses `openBoundaryFile()`, which validates **files** only. During `mkdirp`, when the target directory already existed, this returned a `validation` failure and was surfaced as a sandbox boundary error even though the path was inside an allowed writable mount.

## Changes
- Allow `create directories` safety checks to accept an already-existing directory target.
- Keep canonical container-path enforcement and mount writability checks unchanged.
- Add a regression test covering `mkdirp` on an existing in-workspace directory.

## Validation
- `pnpm vitest src/agents/sandbox/fs-bridge.test.ts`
- `pnpm vitest src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts`

## Risk
Low: behavior change is narrowly scoped to directory-creation safety checks and still enforces mount/boundary constraints.