### PR TITLE
fix(browser): avoid extension profile startup deadlock in browser start

### DIFF
--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -291,22 +291,15 @@ function createProfileContext(
     if (isExtension) {
       if (!httpReachable) {
         await ensureChromeExtensionRelayServer({ cdpUrl: profile.cdpUrl });
-        if (await isHttpReachable(1200)) {
-          // continue: we still need the extension to connect for CDP websocket.
-        } else {
+        if (!(await isHttpReachable(1200))) {
           throw new Error(
             `Chrome extension relay for profile "${profile.name}" is not reachable at ${profile.cdpUrl}.`,
           );
         }
       }
-
-      if (await isReachable(600)) {
-        return;
-      }
-      // Relay server is up, but no attached tab yet. Prompt user to attach.
-      throw new Error(
-        `Chrome extension relay is running, but no tab is connected. Click the OpenClaw Chrome extension icon on a tab to attach it (profile "${profile.name}").`,
-      );
+      // Browser startup should only ensure relay availability.
+      // Tab attachment is checked when a tab is actually required.
+      return;
     }
 
     if (!httpReachable) {


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw browser start --profile=chrome` can fail when relay is up but no tab is attached yet, creating a startup deadlock.
- **Why it matters:** Extension users cannot reliably start browser control unless a tab was already attached, which is the wrong startup dependency.
- **What changed:** In `src/browser/server-context.ts`, extension profile startup now requires only relay HTTP reachability in `ensureBrowserAvailable()`. Tab-attachment checks are deferred to `ensureTabAvailable()` when an actual tab action is requested.
- **What did NOT change:** Non-extension profile behavior, tab-selection logic, extension relay startup mechanism.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28701

## User-visible / Behavior Changes

- `browser start --profile=chrome` succeeds once relay server is reachable.
- Missing attached tabs are now reported only when a tab-dependent action runs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS/Linux
- Runtime: Node.js
- Integration/channel: browser extension relay profile (`driver=extension`)

### Steps

1. Run `openclaw browser start --profile=chrome` with no tab attached yet.
2. Trigger tab action later (e.g., list/open target).

### Expected

- Start succeeds when relay is reachable.
- Tab requirement is enforced only for tab actions.

### Actual

- Before fix: start failed with “relay running, but no tab is connected”.
- After fix: start succeeds; tab errors appear only in tab-dependent path.

## Evidence

Type-check passed:
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec tsc --noEmit --pretty false`

Key logic change in `ensureBrowserAvailable()` extension branch:
- removed startup-time websocket/tab enforcement
- retained relay reachability checks (`isHttpReachable`)

## Human Verification (required)

- Verified scenarios: extension profile with reachable relay and no attached tab.
- Edge cases checked: relay not reachable still throws clear startup error.
- What I did **not** verify: live Chrome extension attach flow on a real GUI session.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/browser/server-context.ts`
- Known bad symptoms: startup may again fail before users can attach tabs.

## Risks and Mitigations

Low risk. Change is isolated to extension startup gating and preserves existing tab checks in `ensureTabAvailable()`.
