### PR TITLE
fix(paths): guard HOME against cross-platform mismatch on state path resolution

### DIFF
--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -35,6 +35,21 @@ describe("resolveEffectiveHomeDir", () => {
 
     expect(resolveEffectiveHomeDir(env)).toBe(path.resolve("/home/alice/svc"));
   });
+
+  it("falls back to system homedir when HOME looks cross-platform mismatched", () => {
+    const env = {
+      HOME: "/home/node",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env, () => "/Users/alice")).toBe(path.resolve("/Users/alice"));
+  });
+
+  it("still honors explicit OPENCLAW_HOME even if cross-platform-looking", () => {
+    const env = {
+      OPENCLAW_HOME: "/home/node/custom",
+      HOME: "/home/node",
+    } as NodeJS.ProcessEnv;
+    expect(resolveEffectiveHomeDir(env, () => "/Users/alice")).toBe(path.resolve("/home/node/custom"));
+  });
 });
 
 describe("resolveRequiredHomeDir", () => {


### PR DESCRIPTION
## Summary

- **Problem:** On macOS, inherited `HOME=/home/node` can make OpenClaw resolve state paths under Linux-style home and break Telegram state storage.
- **Why it matters:** Telegram plugin can fail immediately because the runtime tries to create/use invalid home-root paths on macOS.
- **What changed:** In `src/infra/home-dir.ts`, added cross-platform home-shape validation (`/home/*` vs `/Users/*`). When `HOME` mismatches system homedir shape, fallback to system homedir. Explicit `OPENCLAW_HOME` behavior remains unchanged.
- **What did NOT change:** Explicit home override semantics, config path precedence, or non-home path resolution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28664

## User-visible / Behavior Changes

- On mixed environments, macOS now avoids adopting Linux-style `HOME` and uses system homedir for state path resolution.
- Telegram offset/state paths resolve to platform-appropriate home path by default.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS/Linux mixed env simulations
- Runtime: Node.js
- Integration/channel: Telegram plugin state path resolution

### Steps

1. Simulate env with `HOME=/home/node` and system homedir `/Users/alice`.
2. Resolve effective home dir and state dir.

### Expected

- Uses `/Users/alice` (system homedir) instead of `/home/node` on mismatch.

### Actual

- Before fix: trusted `HOME=/home/node` directly.
- After fix: detects mismatch and falls back to system homedir.

## Evidence

Automated checks passed:
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec vitest run src/infra/home-dir.test.ts`
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec tsc --noEmit --pretty false`

Added tests in `src/infra/home-dir.test.ts`:
- mismatch fallback case
- explicit `OPENCLAW_HOME` precedence preserved

## Human Verification (required)

- Verified scenarios: HOME matches system shape; HOME mismatches system shape; OPENCLAW_HOME explicit override.
- Edge cases checked: no homedir source available still falls back per existing logic.
- What I did **not** verify: full Telegram e2e on physical macOS host.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/infra/home-dir.ts`, `src/infra/home-dir.test.ts`
- Known bad symptoms: Home resolution may again trust cross-platform HOME and regress plugin storage paths.

## Risks and Mitigations

Low risk. Guard is narrow and only applies when `HOME` and system homedir clearly disagree on `/home/*` vs `/Users/*` shape.
