### PR TITLE
fix(sandbox): allow mkdirp safety checks on existing directory targets

### DIFF
--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -23,6 +23,7 @@ type PathSafetyOptions = {
   aliasPolicy?: PathAliasPolicy;
   requireWritable?: boolean;
   allowMissingTarget?: boolean;
+  allowNonFileTarget?: boolean;
 };
 
 export type SandboxResolvedPath = {
@@ -132,7 +133,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveResolvedPath(params);
     this.ensureWriteAccess(target, "create directories");
-    await this.assertPathSafety(target, { action: "create directories", requireWritable: true });
+    await this.assertPathSafety(target, {
+      action: "create directories",
+      requireWritable: true,
+      allowNonFileTarget: true,
+    });
     await this.runCommand('set -eu; mkdir -p -- "$1"', {
       args: [target.containerPath],
       signal: params.signal,
@@ -260,7 +265,9 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       aliasPolicy: options.aliasPolicy,
     });
     if (!guarded.ok) {
-      if (guarded.reason !== "path" || options.allowMissingTarget === false) {
+      const allowedMissing = guarded.reason === "path" && options.allowMissingTarget !== false;
+      const allowedNonFile = guarded.reason === "validation" && options.allowNonFileTarget === true;
+      if (!allowedMissing && !allowedNonFile) {
         throw guarded.error instanceof Error
           ? guarded.error
           : new Error(


### PR DESCRIPTION
## Summary

- **Problem:** Sandbox boundary checks for directory creation use file-open validation semantics and can reject already-existing in-workspace directories as non-file.
- **Why it matters:** Write flows that prepare directories can fail with boundary-check errors even when path is valid and writable (`write` fails while `edit` works on same file path).
- **What changed:** In `src/agents/sandbox/fs-bridge.ts`, added `allowNonFileTarget` path-safety option and enabled it for `mkdirp`. `assertPathSafety` now allows `validation` failures for this specific mode while still enforcing canonical mount containment and writable mount checks.
- **What did NOT change:** Alias escape checks, canonical mount-root checks, writable mount enforcement, write/remove/rename safety behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28745

## User-visible / Behavior Changes

- `mkdir -p` style operations inside sandbox no longer fail on already-existing valid workspace directories.
- Subsequent write flows that depend on directory creation are consistent with edit behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux sandbox host
- Runtime: Docker-based sandbox bridge
- Integration/channel: tools.fs write/mkdir paths in sandbox mode

### Steps

1. Create an existing in-workspace directory path (e.g., `memory/state`).
2. Trigger sandbox `mkdirp` on the same path.

### Expected

- Path safety should pass and mkdirp should succeed/no-op.

### Actual

- Before fix: boundary check failed before mkdirp for existing directory target.
- After fix: mkdirp succeeds while mount-root and writable checks remain enforced.

## Evidence

Automated checks passed:
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec vitest run src/agents/sandbox/fs-bridge.test.ts`
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec tsc --noEmit --pretty false`

Added regression test:
- `allows mkdirp on an already-existing directory inside workspace` in `src/agents/sandbox/fs-bridge.test.ts`

## Human Verification (required)

- Verified scenarios: mkdirp on existing directory; baseline bridge operations still pass.
- Edge cases checked: path still must map inside canonical allowed mount and writable mount.
- What I did **not** verify: full live e2e with upstream reporter environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/agents/sandbox/fs-bridge.ts`, `src/agents/sandbox/fs-bridge.test.ts`
- Known bad symptoms: false-positive boundary rejections for valid existing directories may return.

## Risks and Mitigations

Low risk. Relaxation is scoped to `mkdirp` path precheck only, and canonical mount + writable checks still run for every call.
