### PR TITLE
fix(agents): disable developer role compatibility flag for vLLM provider

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -162,6 +162,19 @@ describe("normalizeModelCompat", () => {
     ).toBe(false);
   });
 
+  it("forces supportsDeveloperRole off for vLLM provider", () => {
+    const model = {
+      ...baseModel(),
+      provider: "vllm",
+      baseUrl: "http://127.0.0.1:8000/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
+
   it("leaves non-zai models untouched", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -46,7 +46,8 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     baseUrl.includes("moonshot.ai") ||
     baseUrl.includes("moonshot.cn");
   const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
-  if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(model)) {
+  const isVllm = model.provider === "vllm";
+  if ((!isZai && !isMoonshot && !isDashScope && !isVllm) || !isOpenAiCompletionsModel(model)) {
     return model;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** Local vLLM deployments (notably qwen variants) can reject requests containing `role=developer`, but vLLM was not included in OpenClaw compat normalization.
- **Why it matters:** Users on vLLM can hit immediate request failures or unusable chat flow despite valid model setup.
- **What changed:** In `src/agents/model-compat.ts`, added vLLM provider to `supportsDeveloperRole=false` normalization for `openai-completions` models. Added regression test in `src/agents/model-compat.test.ts`.
- **What did NOT change:** Other provider compat logic, model registry behavior, or non-openai-completions model handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28711

## User-visible / Behavior Changes

- vLLM provider models now apply `supportsDeveloperRole=false` compat normalization.
- Requests to developer-role-sensitive backends are shaped with safer compatibility defaults.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime: Node.js
- Integration/channel: model compatibility layer for `openai-completions`

### Steps

1. Configure model provider as `vllm` with `api: openai-completions`.
2. Normalize model compat and inspect resulting `compat` flags.

### Expected

- `supportsDeveloperRole` should be `false`.

### Actual

- Before fix: vLLM was not included in normalization and could keep developer-role behavior.
- After fix: vLLM follows same compat path as other known incompatible providers.

## Evidence

Automated checks passed:
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec vitest run src/agents/model-compat.test.ts`
- `pnpm -C /Users/sidqin/Desktop/openclaw-contrib exec tsc --noEmit --pretty false`

Added test:
- `forces supportsDeveloperRole off for vLLM provider`

## Human Verification (required)

- Verified scenarios: vLLM provider now sets `supportsDeveloperRole=false`.
- Edge cases checked: non-target providers remain unchanged; explicit false remains respected.
- What I did **not** verify: live vLLM endpoint request capture in reporter environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/agents/model-compat.ts`, `src/agents/model-compat.test.ts`
- Known bad symptoms: vLLM may again emit unsupported developer-role requests.

## Risks and Mitigations

Low risk. Change is provider-scoped (`provider === "vllm"`) and only in compatibility metadata normalization.
