### PR TITLE
fix(cron): accept delivery mode none for sessionTarget main

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -129,7 +129,8 @@ function validateTelegramDeliveryTarget(to: string | undefined): string | undefi
 }
 
 function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
-  if (!job.delivery) {
+  // No delivery object or mode is "none" -- nothing to validate.
+  if (!job.delivery || job.delivery.mode === "none") {
     return;
   }
   if (job.delivery.mode === "webhook") {


### PR DESCRIPTION
## Summary
- Treat delivery: { mode: "none" } same as no delivery in assertDeliverySupport()
- Fixes validation rejecting mode:none for main session target
- Closes #27431

## Test plan
- Run pnpm vitest run src/cron/service.jobs.test.ts
- Verify 4 new delivery mode validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)