### PR TITLE
fix: use gateway label field for session dropdown — removes hardcoded group ID

### DIFF
--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -70,6 +70,7 @@ struct SessionRow: Identifiable {
     let id: String
     let key: String
     let kind: SessionKind
+    let label: String?
     let displayName: String?
     let provider: String?
     let subject: String?
@@ -88,8 +89,8 @@ struct SessionRow: Identifiable {
         relativeAge(from: self.updatedAt)
     }
 
-    var label: String {
-        self.displayName ?? self.key
+    var displayLabel: String {
+        self.label ?? self.displayName ?? self.key
     }
 
     var flagLabels: [String] {
@@ -145,6 +146,7 @@ extension SessionRow {
                 id: "direct-1",
                 key: "user@example.com",
                 kind: .direct,
+                label: nil,
                 displayName: nil,
                 provider: nil,
                 subject: nil,
@@ -162,6 +164,7 @@ extension SessionRow {
                 id: "group-1",
                 key: "discord:channel:release-squad",
                 kind: .group,
+                label: nil,
                 displayName: "discord:#release-squad",
                 provider: "discord",
                 subject: nil,
@@ -179,6 +182,7 @@ extension SessionRow {
                 id: "global",
                 key: "global",
                 kind: .global,
+                label: nil,
                 displayName: nil,
                 provider: nil,
                 subject: nil,
@@ -302,6 +306,7 @@ enum SessionLoader {
                 id: entry.key,
                 key: entry.key,
                 kind: SessionKind.from(key: entry.key),
+                label: entry.label,
                 displayName: entry.displayName,
                 provider: entry.provider,
                 subject: entry.subject,

--- a/apps/macos/Sources/OpenClaw/SessionData.swift
+++ b/apps/macos/Sources/OpenClaw/SessionData.swift
@@ -9,6 +9,7 @@ struct GatewaySessionDefaultsRecord: Codable {
 struct GatewaySessionEntryRecord: Codable {
     let key: String
     let displayName: String?
+    let label: String?
     let provider: String?
     let subject: String?
     let room: String?

--- a/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
@@ -1,7 +1,14 @@
 import SwiftUI
 
+private struct MenuItemHighlightedKey: EnvironmentKey {
+    nonisolated(unsafe) static let defaultValue: Bool = false
+}
+
 extension EnvironmentValues {
-    @Entry var menuItemHighlighted: Bool = false
+    var menuItemHighlighted: Bool {
+        get { self[MenuItemHighlightedKey.self] }
+        set { self[MenuItemHighlightedKey.self] = newValue }
+    }
 }
 
 struct SessionMenuLabelView: View {

--- a/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
+++ b/apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift
@@ -36,7 +36,7 @@ struct SessionMenuLabelView: View {
                 height: self.barHeight)
 
             HStack(alignment: .firstTextBaseline, spacing: 2) {
-                Text(self.row.label)
+                Text(self.row.displayLabel)
                     .font(.caption.weight(self.row.key == "main" ? .semibold : .regular))
                     .foregroundStyle(self.primaryTextColor)
                     .lineLimit(1)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -103,7 +103,7 @@ struct OpenClawChatComposer: View {
                 set: { next in self.viewModel.switchSession(to: next) }))
         {
             ForEach(self.viewModel.sessionChoices, id: \.key) { session in
-                Text(session.displayName ?? session.key)
+                Text(session.preferredLabel)
                     .font(.system(.caption, design: .monospaced))
                     .tag(session.key)
             }
@@ -225,8 +225,9 @@ struct OpenClawChatComposer: View {
 
     private var activeSessionLabel: String {
         let match = self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey }
-        let trimmed = match?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? self.viewModel.sessionKey : trimmed
+        return OpenClawChatSessionEntry.preferredLabel(
+            forKey: self.viewModel.sessionKey,
+            displayName: match?.displayName)
     }
 
     private var editorOverlay: some View {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -227,6 +227,7 @@ struct OpenClawChatComposer: View {
         let match = self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey }
         return OpenClawChatSessionEntry.preferredLabel(
             forKey: self.viewModel.sessionKey,
+            label: match?.label,
             displayName: match?.displayName)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -38,3 +38,46 @@ public struct OpenClawChatSessionsListResponse: Codable, Sendable {
     public let defaults: OpenClawChatSessionsDefaults?
     public let sessions: [OpenClawChatSessionEntry]
 }
+
+// MARK: - Session labels
+
+public extension OpenClawChatSessionEntry {
+    /// Preferred label for showing this session in UI.
+    ///
+    /// Rules:
+    /// - Prefer explicit `displayName` when present.
+    /// - If missing, disambiguate Telegram forum topic sessions for Aj's group.
+    /// - Otherwise fall back to `key`.
+    var preferredLabel: String {
+        return Self.preferredLabel(forKey: self.key, displayName: self.displayName)
+    }
+
+    static func preferredLabel(forKey key: String, displayName: String?) -> String {
+        let trimmed = (displayName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+
+        if let topicId = Self.telegramTopicIdIfKnownGroup(from: key) {
+            switch topicId {
+            case 1: return "General"
+            case 3: return "Config & Setup"
+            case 5: return "Tasks"
+            case 7: return "Memory"
+            case 9: return "Notes"
+            case 11: return "Coding Projects"
+            case 199: return "Cron Jobs"
+            default: return "Topic \(topicId)"
+            }
+        }
+
+        return key
+    }
+
+    private static func telegramTopicIdIfKnownGroup(from sessionKey: String) -> Int? {
+        // Example: agent:main:telegram:group:-1003818623107:topic:5
+        let marker = "telegram:group:-1003818623107:topic:"
+        guard let range = sessionKey.range(of: marker) else { return nil }
+        let remainder = sessionKey[range.upperBound...]
+        guard let idStr = remainder.split(separator: ":").first else { return nil }
+        return Int(idStr)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -10,6 +10,7 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
 
     public let key: String
     public let kind: String?
+    public let label: String?
     public let displayName: String?
     public let surface: String?
     public let subject: String?
@@ -44,40 +45,20 @@ public struct OpenClawChatSessionsListResponse: Codable, Sendable {
 public extension OpenClawChatSessionEntry {
     /// Preferred label for showing this session in UI.
     ///
-    /// Rules:
-    /// - Prefer explicit `displayName` when present.
-    /// - If missing, disambiguate Telegram forum topic sessions for Aj's group.
-    /// - Otherwise fall back to `key`.
+    /// Resolution order:
+    /// 1. `label` — explicit label set in gateway config or sessions store (most specific)
+    /// 2. `displayName` — channel-derived display name
+    /// 3. `key` — raw session key as last resort
     var preferredLabel: String {
-        return Self.preferredLabel(forKey: self.key, displayName: self.displayName)
+        return Self.preferredLabel(forKey: self.key, label: self.label, displayName: self.displayName)
     }
 
-    static func preferredLabel(forKey key: String, displayName: String?) -> String {
+    static func preferredLabel(forKey key: String, label: String? = nil, displayName: String?) -> String {
+        if let label = label?.trimmingCharacters(in: .whitespacesAndNewlines), !label.isEmpty {
+            return label
+        }
         let trimmed = (displayName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty { return trimmed }
-
-        if let topicId = Self.telegramTopicIdIfKnownGroup(from: key) {
-            switch topicId {
-            case 1: return "General"
-            case 3: return "Config & Setup"
-            case 5: return "Tasks"
-            case 7: return "Memory"
-            case 9: return "Notes"
-            case 11: return "Coding Projects"
-            case 199: return "Cron Jobs"
-            default: return "Topic \(topicId)"
-            }
-        }
-
         return key
-    }
-
-    private static func telegramTopicIdIfKnownGroup(from sessionKey: String) -> Int? {
-        // Example: agent:main:telegram:group:-1003818623107:topic:5
-        let marker = "telegram:group:-1003818623107:topic:"
-        guard let range = sessionKey.range(of: marker) else { return nil }
-        let remainder = sessionKey[range.upperBound...]
-        guard let idStr = remainder.split(separator: ":").first else { return nil }
-        return Int(idStr)
     }
 }


### PR DESCRIPTION
Supersedes #27623 / closes the Greptile concern about hardcoded group IDs.

## Problem

The previous fix (#27623) hardcoded a Telegram group ID (`-1003818623107`) in shared library code (`OpenClawKit`) to resolve topic names. This couples the shared library to a specific user's configuration and won't work for anyone else.

## Solution

The gateway already sends a `label` field in the sessions list response (set via `sessions.json` or gateway config). Simply decode and use it — no hardcoding needed.

## Changes

- **ChatSessions.swift**: Add `label: String?` to `OpenClawChatSessionEntry`; `preferredLabel()` resolves `label > displayName > key`; removes hardcoded group ID and topic-name switch entirely
- **ChatComposer.swift**: Pass `label` through to `preferredLabel()` in `activeSessionLabel`
- **SessionData.swift**: Add `label: String?` to `SessionRow`; `displayLabel` computed var uses `label > displayName > key`; maps `entry.label` on init
- **SessionMenuLabelView.swift**: Use `displayLabel` (the computed var) instead of `label` (now the raw optional stored property)

## Also fixes

The **menu bar session list** (`SessionMenuLabelView` → `SessionRow.displayLabel`) which the previous PR did not cover — flagged by Greptile.