### PR TITLE
fix(cron): migrate legacy schedule cron fields on load

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -138,6 +138,25 @@ describe("normalizeCronJobCreate", () => {
     expectNormalizedAtSchedule({ kind: "at", atMs: "2026-01-12T18:00:00" });
   });
 
+  it("migrates legacy schedule.cron into schedule.expr", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy-cron-field",
+      enabled: true,
+      schedule: { kind: "cron", cron: "*/10 * * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: {
+        kind: "systemEvent",
+        text: "tick",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    expect(schedule.expr).toBe("*/10 * * * *");
+    expect(schedule.cron).toBeUndefined();
+  });
+
   it("defaults cron stagger for recurring top-of-hour schedules", () => {
     const normalized = normalizeCronJobCreate({
       name: "hourly",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -25,6 +25,9 @@ function coerceSchedule(schedule: UnknownRecord) {
   const next: UnknownRecord = { ...schedule };
   const rawKind = typeof schedule.kind === "string" ? schedule.kind.trim().toLowerCase() : "";
   const kind = rawKind === "at" || rawKind === "every" || rawKind === "cron" ? rawKind : undefined;
+  const exprRaw = typeof schedule.expr === "string" ? schedule.expr.trim() : "";
+  const legacyCronRaw = typeof schedule.cron === "string" ? schedule.cron.trim() : "";
+  const normalizedExpr = exprRaw || legacyCronRaw;
   const atMsRaw = schedule.atMs;
   const atRaw = schedule.at;
   const atString = typeof atRaw === "string" ? atRaw.trim() : "";
@@ -48,7 +51,7 @@ function coerceSchedule(schedule: UnknownRecord) {
       next.kind = "at";
     } else if (typeof schedule.everyMs === "number") {
       next.kind = "every";
-    } else if (typeof schedule.expr === "string") {
+    } else if (normalizedExpr) {
       next.kind = "cron";
     }
   }
@@ -60,6 +63,15 @@ function coerceSchedule(schedule: UnknownRecord) {
   }
   if ("atMs" in next) {
     delete next.atMs;
+  }
+
+  if (normalizedExpr) {
+    next.expr = normalizedExpr;
+  } else if ("expr" in next) {
+    delete next.expr;
+  }
+  if ("cron" in next) {
+    delete next.cron;
   }
 
   const staggerMs = normalizeCronStaggerMs(schedule.staggerMs);

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -25,6 +25,19 @@ describe("cron schedule", () => {
     ).toThrow("invalid cron schedule: expr is required");
   });
 
+  it("supports legacy cron field when expr is missing", () => {
+    const nowMs = Date.parse("2025-12-13T00:00:00.000Z");
+    const next = computeNextRunAtMs(
+      {
+        kind: "cron",
+        cron: "0 9 * * 3",
+        tz: "America/Los_Angeles",
+      } as unknown as { kind: "cron"; expr: string; tz?: string },
+      nowMs,
+    );
+    expect(next).toBe(Date.parse("2025-12-17T17:00:00.000Z"));
+  });
+
   it("computes next run for every schedule", () => {
     const anchor = Date.parse("2025-12-13T00:00:00.000Z");
     const now = anchor + 10_000;

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -41,7 +41,8 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     return anchor + steps * everyMs;
   }
 
-  const exprSource = (schedule as { expr?: unknown }).expr;
+  const cronSchedule = schedule as { expr?: unknown; cron?: unknown };
+  const exprSource = typeof cronSchedule.expr === "string" ? cronSchedule.expr : cronSchedule.cron;
   if (typeof exprSource !== "string") {
     throw new Error("invalid cron schedule: expr is required");
   }

--- a/src/cron/service.store-migration.test.ts
+++ b/src/cron/service.store-migration.test.ts
@@ -148,4 +148,59 @@ describe("CronService store migrations", () => {
     cron.stop();
     await store.cleanup();
   });
+
+  it("migrates legacy cron fields (jobId + schedule.cron) and defaults wakeMode", async () => {
+    const store = await makeStorePath();
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              jobId: "legacy-cron-field-job",
+              name: "legacy cron field",
+              enabled: true,
+              createdAtMs: Date.parse("2026-02-01T12:00:00.000Z"),
+              updatedAtMs: Date.parse("2026-02-05T12:00:00.000Z"),
+              schedule: { kind: "cron", cron: "*/5 * * * *", tz: "UTC" },
+              payload: { kind: "systemEvent", text: "tick" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const cron = await createStartedCron(store.storePath).start();
+    const jobs = await cron.list({ includeDisabled: true });
+    const job = jobs.find((entry) => entry.id === "legacy-cron-field-job");
+    expect(job).toBeDefined();
+    expect(job?.wakeMode).toBe("now");
+    expect(job?.schedule.kind).toBe("cron");
+    if (job?.schedule.kind === "cron") {
+      expect(job.schedule.expr).toBe("*/5 * * * *");
+    }
+
+    const persisted = JSON.parse(await fs.readFile(store.storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    const persistedJob = persisted.jobs.find((entry) => entry.id === "legacy-cron-field-job");
+    expect(persistedJob).toBeDefined();
+    expect(persistedJob?.jobId).toBeUndefined();
+    expect(persistedJob?.wakeMode).toBe("now");
+    const persistedSchedule =
+      persistedJob?.schedule && typeof persistedJob.schedule === "object"
+        ? (persistedJob.schedule as Record<string, unknown>)
+        : null;
+    expect(persistedSchedule?.cron).toBeUndefined();
+    expect(persistedSchedule?.expr).toBe("*/5 * * * *");
+
+    cron.stop();
+    await store.cleanup();
+  });
 });


### PR DESCRIPTION
## Summary

- **Problem:** Legacy cron jobs created by older versions may still store `schedule.cron` and `jobId`, while current runtime expects `schedule.expr` and `id`, causing schedule evaluation errors and silent non-firing jobs.
- **Why it matters:** Existing production cron jobs can stop running right after upgrade, with users seeing no expected deliveries.
- **What changed:** Added load-time store migration in `src/cron/service/store.ts` for `jobId -> id`, `schedule.cron -> schedule.expr`, and canonical `wakeMode`; added defensive fallback for legacy `cron` field in `src/cron/schedule.ts`; normalized legacy `schedule.cron` in `src/cron/normalize.ts`; added regression tests.
- **What did NOT change:** No new cron syntax, no scheduler cadence changes beyond legacy-field compatibility.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28861

## User-visible / Behavior Changes

- Legacy jobs that still use `schedule.cron` now migrate automatically and continue running.
- Legacy jobs with `jobId` now normalize to `id` during load.
- Missing/invalid `wakeMode` on legacy records defaults to `now` during migration.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3 (dev), legacy repro from Ubuntu/docker issue report
- Runtime: Node.js + pnpm workspace tests
- Integration/channel: Cron service

### Steps

1. Prepare a legacy `jobs.json` entry with `schedule: { kind: "cron", cron: "*/5 * * * *" }` and `jobId` instead of `id`.
2. Start cron service and list jobs.

### Expected

- Job is loaded with canonical fields (`id`, `schedule.expr`) and keeps scheduling.

### Actual

- Before fix: schedule evaluation could fail due to missing `expr`, and legacy fields were not normalized.
- After fix: legacy fields are migrated on load and scheduling proceeds normally.

## Evidence

- Added regression tests:
  - `src/cron/service.store-migration.test.ts`
  - `src/cron/schedule.test.ts`
  - `src/cron/normalize.test.ts`
- Test run:
  - `pnpm --dir /Users/sidqin/Desktop/openclaw-contrib exec vitest src/cron/service.store-migration.test.ts src/cron/schedule.test.ts src/cron/normalize.test.ts`
  - Result: 3 files passed, 41 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Legacy store record with `schedule.cron` migrates to `schedule.expr`.
  - Legacy `jobId` migrates to canonical `id`.
  - Runtime schedule computation accepts legacy cron field defensively.
- Edge cases checked:
  - Existing canonical `expr` remains preferred.
  - Missing `wakeMode` is normalized consistently.
- What I did **not** verify:
  - Full end-to-end cron delivery against external chat providers in a live deployment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` (automatic load-time migration)

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit or redeploy previous build.
- Files/config to restore: `src/cron/service/store.ts`, `src/cron/schedule.ts`, `src/cron/normalize.ts`.
- Known bad symptoms: Legacy cron records may fail to fire again after rollback.

## Risks and Mitigations

- Risk: Mutating legacy store data on load can touch many records in one pass.
- Mitigation: Migration is deterministic, narrow in scope, and covered by focused regression tests.
