### PR TITLE
feat(slack): sticky thread routing — bypass @mention in active threads (rebased on main)

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -670,6 +670,8 @@ export const FIELD_HELP: Record<string, string> = {
     "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
   "channels.slack.thread.initialHistoryLimit":
     "Maximum number of existing Slack thread messages to fetch when starting a new thread session (default: 20, set to 0 to disable).",
+  "channels.slack.thread.stickyRouting":
+    "Route all thread messages to the bot without @mention after the bot first replies in the thread (default: true).",
   "channels.mattermost.botToken":
     "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
   "channels.mattermost.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -721,6 +721,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
   "channels.slack.thread.initialHistoryLimit": "Slack Thread Initial History Limit",
+  "channels.slack.thread.stickyRouting": "Slack Thread Sticky Routing",
   "channels.mattermost.botToken": "Mattermost Bot Token",
   "channels.mattermost.baseUrl": "Mattermost Base URL",
   "channels.mattermost.configWrites": "Mattermost Config Writes",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -77,6 +77,8 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
   /** Maximum number of thread messages to fetch as context when starting a new thread session (default: 20). Set to 0 to disable thread history fetching. */
   initialHistoryLimit?: number;
+  /** Route all thread messages to the bot without requiring @mention after the bot's first reply. Default: true. */
+  stickyRouting?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -623,6 +623,7 @@ export const SlackThreadSchema = z
     historyScope: z.enum(["thread", "channel"]).optional(),
     inheritParent: z.boolean().optional(),
     initialHistoryLimit: z.number().int().min(0).optional(),
+    stickyRouting: z.boolean().optional(),
   })
   .strict();
 

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -1,14 +1,15 @@
 import type { App } from "@slack/bolt";
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
-import { formatAllowlistMatchMeta } from "../../channels/allowlist-match.js";
 import type { OpenClawConfig, SlackReactionNotificationMode } from "../../config/config.js";
-import { resolveSessionKey, type SessionScope } from "../../config/sessions.js";
 import type { DmPolicy, GroupPolicy } from "../../config/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { SlackMessageEvent } from "../types.js";
+import type { StickyThreadTracker } from "./sticky-threads.js";
+import { formatAllowlistMatchMeta } from "../../channels/allowlist-match.js";
+import { resolveSessionKey, type SessionScope } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createDedupeCache } from "../../infra/dedupe.js";
 import { getChildLogger } from "../../logging.js";
-import type { RuntimeEnv } from "../../runtime.js";
-import type { SlackMessageEvent } from "../types.js";
 import { normalizeAllowList, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
 import type { SlackChannelConfigEntries } from "./channel-config.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
@@ -85,6 +86,8 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  stickyRouting: boolean;
+  stickyThreadTracker: StickyThreadTracker | null;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -147,6 +150,8 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  stickyRouting: boolean;
+  stickyThreadTracker: StickyThreadTracker | null;
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -410,6 +415,8 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    stickyRouting: params.stickyRouting,
+    stickyThreadTracker: params.stickyThreadTracker,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -413,6 +413,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
 
+  if (anyReplyDelivered && ctx.stickyThreadTracker) {
+    const threadToRecord = incomingThreadTs ?? (ctx.replyToMode !== "off" ? messageTs : undefined);
+    if (threadToRecord && message.channel) {
+      ctx.stickyThreadTracker.record(message.channel, threadToRecord);
+    }
+  }
+
   if (!anyReplyDelivered) {
     await draftStream.clear();
     if (prepared.isRoomish) {

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -90,7 +90,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const { statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
     message,
-    replyToMode: ctx.replyToMode,
+    replyToMode: prepared.replyToMode,
   });
 
   const messageTs = message.ts ?? message.event_ts;
@@ -101,7 +101,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   // mark this to ensure only the first reply is threaded.
   const hasRepliedRef = { value: false };
   const replyPlan = createSlackReplyDeliveryPlan({
-    replyToMode: ctx.replyToMode,
+    replyToMode: prepared.replyToMode,
     incomingThreadTs,
     messageTs,
     hasRepliedRef,
@@ -413,8 +413,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
 
-  if (anyReplyDelivered && ctx.stickyThreadTracker) {
-    const threadToRecord = incomingThreadTs ?? (ctx.replyToMode !== "off" ? messageTs : undefined);
+  if (anyReplyDelivered && ctx.stickyThreadTracker && !prepared.isDirectMessage) {
+    const threadToRecord =
+      incomingThreadTs ?? (prepared.replyToMode !== "off" ? messageTs : undefined);
     if (threadToRecord && message.channel) {
       ctx.stickyThreadTracker.record(message.channel, threadToRecord);
     }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -237,7 +237,8 @@ export async function prepareSlackMessage(params: {
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&
-    message.parent_user_id === ctx.botUserId,
+    (message.parent_user_id === ctx.botUserId ||
+      ctx.stickyThreadTracker?.isActive(message.channel, message.thread_ts)),
   );
 
   const sender = message.user ? await ctx.resolveUserName(message.user) : null;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -203,8 +203,14 @@ export async function prepareSlackMessage(params: {
     },
   });
 
+  const chatType = isDirectMessage ? "direct" : isRoom ? "channel" : "group";
+  const chatTypeReplyOverride =
+    account.replyToModeByChatType?.[chatType] ??
+    (isDirectMessage ? account.dm?.replyToMode : undefined);
+  const replyToMode = chatTypeReplyOverride ?? ctx.replyToMode;
+
   const baseSessionKey = route.sessionKey;
-  const threadContext = resolveSlackThreadContext({ message, replyToMode: ctx.replyToMode });
+  const threadContext = resolveSlackThreadContext({ message, replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
   const threadKeys = resolveThreadSessionKeys({
@@ -696,6 +702,7 @@ export async function prepareSlackMessage(params: {
     channelConfig,
     replyTarget,
     ctxPayload,
+    replyToMode,
     isDirectMessage,
     isRoomish,
     historyKey,

--- a/src/slack/monitor/message-handler/types.ts
+++ b/src/slack/monitor/message-handler/types.ts
@@ -13,6 +13,7 @@ export type PreparedSlackMessage = {
   channelConfig: SlackChannelConfigResolved | null;
   replyTarget: string;
   ctxPayload: FinalizedMsgContext;
+  replyToMode: "off" | "first" | "all";
   isDirectMessage: boolean;
   isRoomish: boolean;
   historyKey: string;

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -33,6 +33,7 @@ import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
+import { createStickyThreadTracker } from "./sticky-threads.js";
 import type { MonitorSlackOpts } from "./types.js";
 
 const slackBoltModule = SlackBolt as typeof import("@slack/bolt") & {
@@ -125,6 +126,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const stickyRouting = slackCfg.thread?.stickyRouting ?? true;
+  const stickyThreadTracker = stickyRouting ? createStickyThreadTracker() : null;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -223,6 +226,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    stickyRouting,
+    stickyThreadTracker,
     slashCommand,
     textLimit,
     ackReactionScope,

--- a/src/slack/monitor/sticky-threads.ts
+++ b/src/slack/monitor/sticky-threads.ts
@@ -36,9 +36,9 @@ export function createStickyThreadTracker(opts?: {
   return {
     record: (channelId, threadTs) => {
       const key = makeKey(channelId, threadTs);
-      cache.delete(key);
-      cache.set(key, Date.now());
-      prune(Date.now());
+      const now = Date.now();
+      cache.set(key, now);
+      prune(now);
     },
     isActive: (channelId, threadTs) => {
       const key = makeKey(channelId, threadTs);

--- a/src/slack/monitor/sticky-threads.ts
+++ b/src/slack/monitor/sticky-threads.ts
@@ -1,0 +1,60 @@
+export type StickyThreadTracker = {
+  record: (channelId: string, threadTs: string) => void;
+  isActive: (channelId: string, threadTs: string) => boolean;
+  size: () => number;
+  clear: () => void;
+};
+
+export function createStickyThreadTracker(opts?: {
+  ttlMs?: number;
+  maxSize?: number;
+}): StickyThreadTracker {
+  const ttlMs = Math.max(0, opts?.ttlMs ?? 24 * 60 * 60 * 1000);
+  const maxSize = Math.max(0, Math.floor(opts?.maxSize ?? 10_000));
+  const cache = new Map<string, number>();
+
+  const makeKey = (channelId: string, threadTs: string) => `${channelId}:${threadTs}`;
+
+  const prune = (now: number) => {
+    if (ttlMs > 0) {
+      const cutoff = now - ttlMs;
+      for (const [key, ts] of cache) {
+        if (ts < cutoff) {
+          cache.delete(key);
+        }
+      }
+    }
+    while (cache.size > maxSize) {
+      const oldestKey = cache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+  };
+
+  return {
+    record: (channelId, threadTs) => {
+      const key = makeKey(channelId, threadTs);
+      cache.delete(key);
+      cache.set(key, Date.now());
+      prune(Date.now());
+    },
+    isActive: (channelId, threadTs) => {
+      const key = makeKey(channelId, threadTs);
+      const ts = cache.get(key);
+      if (ts === undefined) {
+        return false;
+      }
+      if (ttlMs > 0 && Date.now() - ts >= ttlMs) {
+        cache.delete(key);
+        return false;
+      }
+      return true;
+    },
+    size: () => cache.size,
+    clear: () => {
+      cache.clear();
+    },
+  };
+}


### PR DESCRIPTION
This is a rebase of #16223 by @iamfuntime, rebased onto the latest main.

### Why this rebase?
The original branch was failing to build due to config validation errors - the newer main has added support for Slack config keys like `channels.slack.streaming`, `channels.slack.dmPolicy`, etc.

### Changes from rebase
- Rebase of @iamfuntime's work onto origin/main (commit bce643a0b)
- Resolved merge conflicts in `src/slack/monitor/context.ts` and `provider.ts`
- Removed `src/slack/monitor/message-handler/prepare.inbound-contract.test.ts` (deleted in upstream main)

### Original PR description
feat(slack): sticky thread routing — bypass @mention in active threads

### Testing
- Gateway builds successfully with `pnpm build`
- Gateway starts and runs without config validation errors
- RPC probe: ok, listening on 127.0.0.1:18789

Fixes #16223