### PR TITLE
fix(failover): classify connection errors as timeout for model failover

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -532,4 +532,14 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+  it("classifies connection errors as timeout for failover (e.g. MiniMax)", () => {
+    expect(classifyFailoverReason("Connection error.")).toBe("timeout");
+    expect(classifyFailoverReason("connection error")).toBe("timeout");
+    expect(classifyFailoverReason("connect error")).toBe("timeout");
+    expect(classifyFailoverReason("connect ECONNREFUSED 127.0.0.1:443")).toBe("timeout");
+    expect(classifyFailoverReason("connect ECONNRESET")).toBe("timeout");
+    expect(classifyFailoverReason("getaddrinfo ENOTFOUND api.minimax.chat")).toBe("timeout");
+    expect(classifyFailoverReason("connect ENETUNREACH 2001:db8::1:443")).toBe("timeout");
+    expect(classifyFailoverReason("connect EHOSTUNREACH 10.0.0.1:443")).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -644,6 +644,14 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*abort\b/i,
     /\breason:\s*abort\b/i,
     /\bunhandled stop reason:\s*abort\b/i,
+    // Transient TCP/DNS connection failures (e.g. MiniMax "Connection error.")
+    "connection error",
+    "connect error",
+    /\beconnrefused\b/i,
+    /\beconnreset\b/i,
+    /\benotfound\b/i,
+    /\benetunreach\b/i,
+    /\behostunreach\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
## Summary
- Add connection error patterns (ECONNREFUSED, ECONNRESET, ENOTFOUND, etc.) to ERROR_PATTERNS.timeout
- Fixes MiniMax and other providers' connection errors not triggering model failover
- Closes #20931

## Test plan
- Run pnpm vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
- Verify all 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)