### PR TITLE
fix(cron): guard list sorting against malformed legacy jobs

### DIFF
--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { listPage } from "./service/ops.js";
+import { createMockCronStateForJobs } from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+function createBaseJob(overrides?: Partial<CronJob>): CronJob {
+  return {
+    id: "job-1",
+    name: "job",
+    enabled: true,
+    schedule: { kind: "cron", expr: "*/5 * * * *", tz: "UTC" },
+    sessionTarget: "main",
+    wakeMode: "now",
+    payload: { kind: "systemEvent", text: "tick" },
+    state: { nextRunAtMs: Date.parse("2026-02-27T15:30:00.000Z") },
+    createdAtMs: Date.parse("2026-02-27T15:00:00.000Z"),
+    updatedAtMs: Date.parse("2026-02-27T15:05:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("cron listPage sort guards", () => {
+  it("does not throw when sorting by name with malformed name fields", async () => {
+    const jobs = [
+      createBaseJob({ id: "job-a", name: undefined as unknown as string }),
+      createBaseJob({ id: "job-b", name: "beta" }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { sortBy: "name", sortDir: "asc" });
+    expect(page.jobs).toHaveLength(2);
+  });
+
+  it("does not throw when tie-break sorting encounters missing ids", async () => {
+    const nextRunAtMs = Date.parse("2026-02-27T15:30:00.000Z");
+    const jobs = [
+      createBaseJob({
+        id: undefined as unknown as string,
+        name: "alpha",
+        state: { nextRunAtMs },
+      }),
+      createBaseJob({
+        id: undefined as unknown as string,
+        name: "alpha",
+        state: { nextRunAtMs },
+      }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { sortBy: "nextRunAtMs", sortDir: "asc" });
+    expect(page.jobs).toHaveLength(2);
+  });
+});

--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { listPage } from "./service/ops.js";
 import { createMockCronStateForJobs } from "./service.test-harness.js";
+import { listPage } from "./service/ops.js";
 import type { CronJob } from "./types.js";
 
 function createBaseJob(overrides?: Partial<CronJob>): CronJob {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -164,7 +164,9 @@ function sortJobs(jobs: CronJob[], sortBy: CronJobsSortBy, sortDir: CronSortDir)
   return jobs.toSorted((a, b) => {
     let cmp = 0;
     if (sortBy === "name") {
-      cmp = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+      const aName = typeof a.name === "string" ? a.name : "";
+      const bName = typeof b.name === "string" ? b.name : "";
+      cmp = aName.localeCompare(bName, undefined, { sensitivity: "base" });
     } else if (sortBy === "updatedAtMs") {
       cmp = a.updatedAtMs - b.updatedAtMs;
     } else {
@@ -183,7 +185,9 @@ function sortJobs(jobs: CronJob[], sortBy: CronJobsSortBy, sortDir: CronSortDir)
     if (cmp !== 0) {
       return cmp * dir;
     }
-    return a.id.localeCompare(b.id);
+    const aId = typeof a.id === "string" ? a.id : "";
+    const bId = typeof b.id === "string" ? b.id : "";
+    return aId.localeCompare(bId);
   });
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** Cron list APIs can throw `TypeError: Cannot read properties of undefined (reading 'localeCompare')` when legacy/corrupted records are missing `name` or `id`.
- **Why it matters:** Users lose cron visibility in UI/CLI and cannot inspect or manage jobs after upgrade/data drift.
- **What changed:** Hardened `sortJobs` in `src/cron/service/ops.ts` to safely normalize missing `name`/`id` before `localeCompare`; added regression tests in `src/cron/service.list-page-sort-guards.test.ts`.
- **What did NOT change:** No behavior changes for valid jobs, no scheduling logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28862

## User-visible / Behavior Changes

- `cron.list`/`cron.listPage` no longer crash on malformed entries missing `name`/`id`.
- Listing returns stable output instead of throwing runtime errors.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm test runner
- Integration/channel: Cron service list/read ops

### Steps

1. Prepare cron in-memory/store data with missing `name` or missing `id` fields.
2. Call list-page sorting by `name` or with tied sort requiring id tie-break.

### Expected

- List APIs return jobs without throwing.

### Actual

- Before fix: `localeCompare` could be called on `undefined` and throw.
- After fix: sorting uses safe string fallbacks, no crash.

## Evidence

- Added regression tests:
  - `src/cron/service.list-page-sort-guards.test.ts`
- Test run:
  - `pnpm --dir /Users/sidqin/Desktop/openclaw-contrib exec vitest src/cron/service.list-page-sort-guards.test.ts`
  - Result: 1 file passed, 2 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Missing `name` does not break `sortBy: "name"`.
  - Missing `id` does not break tie-break sorting path.
- Edge cases checked:
  - Both malformed entries still return deterministic page results.
- What I did **not** verify:
  - Full UI E2E list rendering against a live gateway instance.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/cron/service/ops.ts`.
- Known bad symptoms: Cron list operations may throw again on malformed data.

## Risks and Mitigations

- Risk: Fallback sorting for malformed records may group unnamed/unidentified jobs together.
- Mitigation: Only affects invalid data; valid records keep existing ordering behavior.
