### PR TITLE
fix(cron): force main-target system events onto main session

### DIFF
--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -509,7 +509,7 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("passes agentId + sessionKey to runHeartbeatOnce for main-session wakeMode now jobs", async () => {
+  it("passes agentId and resolves main session for wakeMode now main jobs", async () => {
     const runHeartbeatOnce = vi.fn(async () => ({ status: "ran" as const, durationMs: 1 }));
 
     const { store, cron, enqueueSystemEvent, requestHeartbeatNow } =
@@ -534,13 +534,13 @@ describe("CronService", () => {
       expect.objectContaining({
         reason: `cron:${job.id}`,
         agentId: "ops",
-        sessionKey,
+        sessionKey: undefined,
       }),
     );
     expect(requestHeartbeatNow).not.toHaveBeenCalled();
     expect(enqueueSystemEvent).toHaveBeenCalledWith(
       "hello",
-      expect.objectContaining({ agentId: "ops", sessionKey }),
+      expect.objectContaining({ agentId: "ops", sessionKey: undefined }),
     );
 
     cron.stop();
@@ -578,7 +578,7 @@ describe("CronService", () => {
     expect(requestHeartbeatNow).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: `cron:${job.id}`,
-        sessionKey,
+        sessionKey: undefined,
       }),
     );
     expect(job.state.lastStatus).toBe("ok");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -636,9 +636,12 @@ export async function executeJobCore(
             : 'main job requires payload.kind="systemEvent"',
       };
     }
+    // main-target cron jobs should always resolve via the agent's main session.
+    // Avoid forwarding persisted channel session keys from legacy records.
+    const targetMainSessionKey = undefined;
     state.deps.enqueueSystemEvent(text, {
       agentId: job.agentId,
-      sessionKey: job.sessionKey,
+      sessionKey: targetMainSessionKey,
       contextKey: `cron:${job.id}`,
     });
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
@@ -655,7 +658,7 @@ export async function executeJobCore(
         heartbeatResult = await state.deps.runHeartbeatOnce({
           reason,
           agentId: job.agentId,
-          sessionKey: job.sessionKey,
+          sessionKey: targetMainSessionKey,
         });
         if (
           heartbeatResult.status !== "skipped" ||
@@ -673,7 +676,7 @@ export async function executeJobCore(
           state.deps.requestHeartbeatNow({
             reason,
             agentId: job.agentId,
-            sessionKey: job.sessionKey,
+            sessionKey: targetMainSessionKey,
           });
           return { status: "ok", summary: text };
         }
@@ -694,7 +697,7 @@ export async function executeJobCore(
       state.deps.requestHeartbeatNow({
         reason: `cron:${job.id}`,
         agentId: job.agentId,
-        sessionKey: job.sessionKey,
+        sessionKey: targetMainSessionKey,
       });
       return { status: "ok", summary: text };
     }


### PR DESCRIPTION
## Summary

- **Problem:** For cron jobs configured with `sessionTarget: "main"` + `payload.kind: "systemEvent"`, persisted `sessionKey` could override main-session routing and create/send to unintended Telegram sessions after upgrades.
- **Why it matters:** Users don't receive cron output in their expected main chat; events land in wrong session context.
- **What changed:** Updated `src/cron/service/timer.ts` to ignore persisted `job.sessionKey` when `sessionTarget` is `main`, and always resolve through main-session path (`sessionKey: undefined` in enqueue/wake calls); updated regression expectations in `src/cron/service.runs-one-shot-main-job-disables-it.test.ts`.
- **What did NOT change:** Isolated cron jobs and non-main targeting behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28770

## User-visible / Behavior Changes

- Main-target cron system events now reliably route to agent main session.
- Legacy/persisted session keys no longer divert main-target jobs into separate chat sessions.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3 (dev), reporter environment Ubuntu/WSL + Telegram
- Runtime: Node.js + pnpm test runner
- Integration/channel: Cron + main session routing

### Steps

1. Create a cron job with `sessionTarget: "main"`, `payload.kind: "systemEvent"`, and a persisted channel-like `sessionKey`.
2. Trigger job run (`wakeMode: now`) and observe routing arguments.

### Expected

- Main-target job resolves to main session, not to persisted channel session key.

### Actual

- Before fix: persisted `sessionKey` could be forwarded and misroute events.
- After fix: main-target path ignores persisted `sessionKey` and uses main-session resolution.

## Evidence

- Updated regression test:
  - `src/cron/service.runs-one-shot-main-job-disables-it.test.ts`
- Test run (same patch before cherry-pick):
  - `pnpm --dir /Users/sidqin/Desktop/openclaw-contrib exec vitest src/cron/service.runs-one-shot-main-job-disables-it.test.ts`
  - Result: 1 file passed, 14 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Main-target wakeMode-now job with explicit `agentId` uses main-session resolution path.
  - Busy-heartbeat fallback path also keeps main-session resolution behavior.
- Edge cases checked:
  - Existing system-event execution flow remains intact for wake/run outcomes.
- What I did **not** verify:
  - Live Telegram E2E delivery in a real upgraded production instance.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/cron/service/timer.ts`, test expectation file.
- Known bad symptoms: Main-target cron jobs may again route into unintended sessions.

## Risks and Mitigations

- Risk: Deployments relying on non-main `sessionKey` overrides for main-target jobs may observe changed behavior.
- Mitigation: `sessionTarget: "main"` semantics are now strictly enforced and covered by regression test expectations.
