### PR TITLE
fix(feishu): stop typing reaction keepalive spam

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -66,6 +66,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         action: "stop",
         error: err,
       }),
+    // Feishu typing indicator uses reaction APIs; periodic keepalive can
+    // generate excessive reaction writes and consume quota quickly.
+    keepaliveIntervalMs: 0,
   });
 
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(cfg, "feishu", accountId, {


### PR DESCRIPTION
## Summary

- **Problem:** Feishu reply typing indicator uses reaction APIs with periodic keepalive, causing repeated `POST /messages/{id}/reactions` and rapid API quota exhaustion.
- **Why it matters:** Long-running replies can burn tens of thousands of Feishu API calls in a few days, degrading channel availability.
- **What changed:** In `extensions/feishu/src/reply-dispatcher.ts`, disabled periodic typing keepalive (`keepaliveIntervalMs: 0`) for reaction-based Feishu typing indicator; added regression coverage in `extensions/feishu/src/reply-dispatcher.test.ts` to ensure typing reactions are not re-fired on timer ticks.
- **What did NOT change:** Normal reply sending, card rendering, and final typing cleanup behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28759

## User-visible / Behavior Changes

- Feishu typing indicator no longer repeatedly writes reaction keepalives.
- API quota usage is reduced during long responses.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (reduced frequency only)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm workspace tests
- Integration/channel: Feishu provider

### Steps

1. Create Feishu reply dispatcher with `replyToMessageId` present.
2. Trigger typing start and advance virtual time.

### Expected

- Typing reaction is added once, not repeatedly every keepalive interval.

### Actual

- Before fix: keepalive loop could repeatedly call reaction create API.
- After fix: only initial typing reaction is sent for the reply lifecycle.

## Evidence

- Updated tests:
  - `extensions/feishu/src/reply-dispatcher.test.ts`
- Test run:
  - `pnpm --dir /tmp/openclaw-28770-pr exec vitest extensions/feishu/src/reply-dispatcher.test.ts`
  - Result: 1 file passed, 3 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Auto-mode plain text and markdown card paths still pass existing tests.
  - Typing start does not repeatedly invoke reaction creation under timer advance.
- Edge cases checked:
  - Typing API mock continues supporting start/stop lifecycle.
- What I did **not** verify:
  - Live Feishu tenant-level API metrics over long-running production traffic.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `extensions/feishu/src/reply-dispatcher.ts`.
- Known bad symptoms: If reverted, typing reaction writes may spike again.

## Risks and Mitigations

- Risk: Without keepalive, typing indicator may appear less persistent for very long replies.
- Mitigation: This is acceptable trade-off to avoid quota exhaustion; final reply UX remains intact.
