### PR TITLE
fix(discord): keep attachment metadata when media fetch is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Inbound media fallback: preserve attachment and sticker metadata when Discord CDN fetch/save fails by keeping URL-based media entries in context, with regression coverage for save failures and mixed success/failure ordering. Landed from contributor PR #28906 by @Sid-Qin. Thanks @Sid-Qin.
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.
 - Agents/Copilot token refresh: refresh GitHub Copilot runtime API tokens after auth-expiry failures and re-run with the renewed token so long-running embedded/subagent turns do not fail on mid-session 401 expiry. Landed from contributor PR #8805 by @Arthur742Ramos. Thanks @Arthur742Ramos.


### PR DESCRIPTION
## Summary

- **Problem:** When Discord media fetch fails (for example SSRF guard blocking CDN URLs), inbound attachment/sticker entries are silently dropped from agent context.
- **Why it matters:** Agents lose awareness of attached files/images even though Discord event payload includes valid metadata.
- **What changed:** In `src/discord/monitor/message-utils.ts`, added fallback behavior so failed media downloads still push metadata-only media entries (URL + placeholder + content type where available) for both attachments and stickers; added regression tests in `src/discord/monitor/message-utils.test.ts`.
- **What did NOT change:** Successful media download/save path is unchanged; no SSRF policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28816

## User-visible / Behavior Changes

- Discord inbound messages keep attachment/sticker hints even when file download is blocked.
- Agents can still reference files by URL/placeholder instead of receiving text-only context.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (fallback path only)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm + Vitest
- Integration/channel: Discord monitor inbound media handling

### Steps

1. Simulate Discord message with attachment/sticker metadata.
2. Force media fetch failure (e.g., SSRF blocked error).
3. Resolve media list for inbound context.

### Expected

- Media metadata remains present in resolved list despite fetch failure.

### Actual

- Before fix: failed downloads were logged and then dropped.
- After fix: metadata fallback entry is preserved.

## Evidence

- Updated tests:
  - `src/discord/monitor/message-utils.test.ts`
- Test run:
  - `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/discord/monitor/message-utils.test.ts`
  - Result: 1 file passed, 23 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Forwarded attachment fallback retains URL + content type + placeholder.
  - Direct attachment fallback retains metadata.
  - Sticker fallback retains CDN URL + sticker placeholder.
- Edge cases checked:
  - Fallback path does not call `saveMediaBuffer` when fetch fails.
- What I did **not** verify:
  - Live Discord VPN/proxy environment with real SSRF-blocked DNS.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/discord/monitor/message-utils.ts`.
- Known bad symptoms: Attachments may become invisible to agents again on fetch failure.

## Risks and Mitigations

- Risk: Fallback uses remote URLs instead of local stored file paths when download fails.
- Mitigation: This only applies to failure path and is strictly better than dropping context entirely.
