### PR TITLE
feat(slack): socket mode reconnect loop

### DIFF
--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -58,6 +58,15 @@ export const getSlackHandlers = () =>
 
 export const getSlackClient = () => (globalThis as { __slackClient?: SlackClient }).__slackClient;
 
+type MockAppInstance = {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  __triggerError: (err?: Error) => void;
+};
+
+export const getSlackAppInstances = () =>
+  (globalThis as { __slackAppInstances?: MockAppInstance[] }).__slackAppInstances ?? [];
+
 export const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 export async function waitForSlackEvent(name: string) {
@@ -146,6 +155,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
     created: true,
   });
   getSlackHandlers()?.clear();
+  getSlackAppInstances().length = 0;
 }
 
 vi.mock("../config/config.js", async (importOriginal) => {
@@ -215,13 +225,25 @@ vi.mock("@slack/bolt", () => {
     },
   };
   (globalThis as { __slackClient?: typeof client }).__slackClient = client;
+  const appInstances: App[] = [];
+  (globalThis as { __slackAppInstances?: App[] }).__slackAppInstances = appInstances;
   class App {
     client = client;
+    private errorHandler?: (error: Error) => Promise<void>;
+    constructor() {
+      appInstances.push(this);
+    }
     event(name: string, handler: SlackHandler) {
       handlers.set(name, handler);
     }
     command() {
       /* no-op */
+    }
+    error(handler: (error: Error) => Promise<void>) {
+      this.errorHandler = handler;
+    }
+    __triggerError(err?: Error) {
+      return this.errorHandler?.(err ?? new Error("socket disconnected"));
     }
     start = vi.fn().mockResolvedValue(undefined);
     stop = vi.fn().mockResolvedValue(undefined);

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "../monitor.test-helpers.js";
+import {
+  flush,
+  getSlackAppInstances,
+  getSlackTestState,
+  resetSlackTestState,
+} from "../monitor.test-helpers.js";
+
+const { monitorSlackProvider } = await import("./provider.js");
+
+const FAST_RECONNECT = {
+  initialMs: 0,
+  maxMs: 0,
+  factor: 1,
+  jitter: 0,
+  maxAttempts: 3,
+};
+
+function makeOpts(overrides?: Record<string, unknown>) {
+  const controller = new AbortController();
+  return {
+    controller,
+    opts: {
+      botToken: "bot-token",
+      appToken: "app-token",
+      abortSignal: controller.signal,
+      tuning: {
+        sleep: () => Promise.resolve(),
+        reconnect: FAST_RECONNECT,
+      },
+      ...overrides,
+    },
+  };
+}
+
+afterEach(() => {
+  resetSlackTestState();
+});
+
+describe("slack socket mode reconnect", () => {
+  it("reconnects after socket disconnect", async () => {
+    const { controller, opts } = makeOpts();
+    const run = monitorSlackProvider(opts);
+
+    // Wait for first connection to establish.
+    await flush();
+    await flush();
+    const instances = getSlackAppInstances();
+    expect(instances.length).toBeGreaterThanOrEqual(1);
+
+    // Trigger disconnect on the connected instance (last one with error handler).
+    const connectedApp = instances[instances.length - 1];
+    connectedApp.__triggerError(new Error("socket closed"));
+
+    // Wait for reconnect attempt.
+    await flush();
+    await flush();
+
+    // Abort to exit the loop cleanly.
+    controller.abort();
+    await run;
+
+    // A second App instance should have been created for the reconnect.
+    expect(instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("stops after max reconnect attempts on start failure", async () => {
+    const { opts } = makeOpts();
+
+    // Make every App's start() reject.
+    const origInstances = getSlackAppInstances();
+    const startInterceptor = setInterval(() => {
+      for (const app of origInstances) {
+        if (!app.start.mock.results.length) {
+          app.start.mockRejectedValueOnce(new Error("connection refused"));
+        }
+      }
+    }, 0);
+
+    // Simpler: patch start before instances are created by hooking into the array.
+    clearInterval(startInterceptor);
+
+    // We need start to fail. The mock returns resolved by default.
+    // Override at the globalThis level: make every new App's start fail.
+    const tracker = getSlackAppInstances();
+    const origPush = tracker.push.bind(tracker);
+    let pushCount = 0;
+    tracker.push = function (...apps) {
+      for (const app of apps) {
+        pushCount += 1;
+        app.start.mockRejectedValue(new Error("connection refused"));
+      }
+      return origPush(...apps);
+    };
+
+    const run = monitorSlackProvider(opts);
+    await run;
+
+    tracker.push = origPush;
+    // probe app + placeholder ctx app + maxAttempts reconnect apps
+    expect(pushCount).toBe(FAST_RECONNECT.maxAttempts + 2);
+  });
+
+  it("aborts cleanly during backoff sleep", async () => {
+    const { controller, opts } = makeOpts({
+      tuning: {
+        sleep: async (_ms: number, signal?: AbortSignal) => {
+          controller.abort();
+          if (signal?.aborted) {
+            throw new Error("aborted");
+          }
+        },
+        reconnect: FAST_RECONNECT,
+      },
+    });
+
+    // Make start fail so we enter backoff.
+    const tracker = getSlackAppInstances();
+    const origPush = tracker.push.bind(tracker);
+    tracker.push = function (...apps) {
+      for (const app of apps) {
+        app.start.mockRejectedValue(new Error("connection refused"));
+      }
+      return origPush(...apps);
+    };
+
+    const run = monitorSlackProvider(opts);
+    await run;
+
+    tracker.push = origPush;
+    // Should stop after first failed attempt + abort during sleep.
+    // probe + placeholder + 1 reconnect = 3 total
+    const instances = getSlackAppInstances();
+    expect(instances.length).toBe(3);
+  });
+
+  it("HTTP mode has no reconnect loop", async () => {
+    const state = getSlackTestState();
+    state.config = {
+      ...state.config,
+      channels: {
+        slack: {
+          signingSecret: "test-secret",
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+        },
+      },
+    };
+    const { controller, opts } = makeOpts({ mode: "http" });
+
+    const run = monitorSlackProvider(opts);
+    await flush();
+    controller.abort();
+    await run;
+
+    // HTTP mode creates apps but never enters the reconnect loop.
+    // Verify no start() was called (HTTP mode doesn't call app.start).
+    const instances = getSlackAppInstances();
+    for (const app of instances) {
+      expect(app.start).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -18,6 +18,8 @@ import {
 } from "../../config/runtime-group-policy.js";
 import type { SessionScope } from "../../config/sessions.js";
 import { warn } from "../../globals.js";
+import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
+import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
@@ -46,6 +48,14 @@ const { App, HTTPReceiver } = slackBolt;
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+const SLACK_SOCKET_RECONNECT_POLICY = {
+  initialMs: 2_000,
+  maxMs: 30_000,
+  factor: 1.8,
+  jitter: 0.25,
+  maxAttempts: 12,
+};
 
 function parseApiAppIdFromAppToken(raw?: string) {
   const token = raw?.trim();
@@ -131,63 +141,40 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
 
-  const receiver =
-    slackMode === "http"
-      ? new HTTPReceiver({
-          signingSecret: signingSecret ?? "",
-          endpoints: slackWebhookPath,
-        })
-      : null;
   const clientOptions = resolveSlackWebClientOptions();
-  const app = new App(
-    slackMode === "socket"
-      ? {
-          token: botToken,
-          appToken,
-          socketMode: true,
-          clientOptions,
-        }
-      : {
-          token: botToken,
-          receiver: receiver ?? undefined,
-          clientOptions,
-        },
-  );
-  const slackHttpHandler =
-    slackMode === "http" && receiver
-      ? async (req: IncomingMessage, res: ServerResponse) => {
-          const guard = installRequestBodyLimitGuard(req, res, {
-            maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
-            timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
-            responseFormat: "text",
-          });
-          if (guard.isTripped()) {
-            return;
-          }
-          try {
-            await Promise.resolve(receiver.requestListener(req, res));
-          } catch (err) {
-            if (!guard.isTripped()) {
-              throw err;
-            }
-          } finally {
-            guard.dispose();
-          }
-        }
-      : null;
-  let unregisterHttpHandler: (() => void) | null = null;
+  const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
 
+  // Resolve auth once — reused across reconnect iterations for socket mode.
   let botUserId = "";
   let teamId = "";
   let apiAppId = "";
-  const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
-  try {
-    const auth = await app.client.auth.test({ token: botToken });
-    botUserId = auth.user_id ?? "";
-    teamId = auth.team_id ?? "";
-    apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
-  } catch {
-    // auth test failing is non-fatal; message handler falls back to regex mentions.
+
+  const createAppInstance = () =>
+    new App(
+      slackMode === "socket"
+        ? { token: botToken, appToken, socketMode: true, clientOptions }
+        : {
+            token: botToken,
+            receiver: new HTTPReceiver({
+              signingSecret: signingSecret ?? "",
+              endpoints: slackWebhookPath,
+            }),
+            clientOptions,
+          },
+    );
+
+  // Run auth.test once to populate botUserId/teamId/apiAppId.
+  {
+    const probe = createAppInstance();
+    try {
+      const auth = await probe.client.auth.test({ token: botToken });
+      botUserId = auth.user_id ?? "";
+      teamId = auth.team_id ?? "";
+      apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
+    } catch {
+      // auth test failing is non-fatal; message handler falls back to regex mentions.
+    }
+    await probe.stop().catch(() => undefined);
   }
 
   if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
@@ -196,11 +183,13 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     );
   }
 
+  // Shared context — survives reconnect iterations. Event handlers close over `ctx`,
+  // so a new App instance with fresh handlers still reads the latest allowlist data.
   const ctx = createSlackMonitorContext({
     cfg,
     accountId: account.accountId,
     botToken,
-    app,
+    app: createAppInstance(), // placeholder; replaced per-iteration for socket mode
     runtime,
     botUserId,
     teamId,
@@ -230,19 +219,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     removeAckAfterReply,
   });
 
-  const handleSlackMessage = createSlackMessageHandler({ ctx, account });
-
-  registerSlackMonitorEvents({ ctx, account, handleSlackMessage });
-  await registerSlackMonitorSlashCommands({ ctx, account });
-  if (slackMode === "http" && slackHttpHandler) {
-    unregisterHttpHandler = registerSlackHttpHandler({
-      path: slackWebhookPath,
-      handler: slackHttpHandler,
-      log: runtime.log,
-      accountId: account.accountId,
-    });
-  }
-
+  // Background allowlist resolution — runs once, mutates ctx.channelsConfig / ctx.allowFrom.
   if (resolveToken) {
     void (async () => {
       if (opts.abortSignal?.aborted) {
@@ -341,32 +318,153 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     })();
   }
 
-  const stopOnAbort = () => {
-    if (opts.abortSignal?.aborted && slackMode === "socket") {
-      void app.stop();
-    }
-  };
-  opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+  // ── HTTP mode: no reconnect loop ──────────────────────────────────────
+  if (slackMode === "http") {
+    const app = createAppInstance();
+    ctx.app = app;
+    const receiver = (app as unknown as { receiver?: { requestListener?: unknown } }).receiver as
+      | InstanceType<typeof HTTPReceiver>
+      | undefined;
 
-  try {
-    if (slackMode === "socket") {
-      await app.start();
-      runtime.log?.("slack socket mode connected");
-    } else {
-      runtime.log?.(`slack http mode listening at ${slackWebhookPath}`);
+    const handleSlackMessage = createSlackMessageHandler({ ctx, account });
+    registerSlackMonitorEvents({ ctx, account, handleSlackMessage });
+    await registerSlackMonitorSlashCommands({ ctx, account });
+
+    const slackHttpHandler = receiver
+      ? async (req: IncomingMessage, res: ServerResponse) => {
+          const guard = installRequestBodyLimitGuard(req, res, {
+            maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
+            timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
+            responseFormat: "text",
+          });
+          if (guard.isTripped()) {
+            return;
+          }
+          try {
+            await Promise.resolve(receiver.requestListener(req, res));
+          } catch (err) {
+            if (!guard.isTripped()) {
+              throw err;
+            }
+          } finally {
+            guard.dispose();
+          }
+        }
+      : null;
+
+    let unregisterHttpHandler: (() => void) | null = null;
+    if (slackHttpHandler) {
+      unregisterHttpHandler = registerSlackHttpHandler({
+        path: slackWebhookPath,
+        handler: slackHttpHandler,
+        log: runtime.log,
+        accountId: account.accountId,
+      });
     }
-    if (opts.abortSignal?.aborted) {
+
+    runtime.log?.(`slack http mode listening at ${slackWebhookPath}`);
+    try {
+      if (opts.abortSignal?.aborted) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        opts.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+    } finally {
+      unregisterHttpHandler?.();
+      await app.stop().catch(() => undefined);
+    }
+    return;
+  }
+
+  // ── Socket mode: reconnect loop ───────────────────────────────────────
+  const policy = {
+    ...SLACK_SOCKET_RECONNECT_POLICY,
+    ...opts.tuning?.reconnect,
+  };
+  const sleep = opts.tuning?.sleep ?? sleepWithAbort;
+  let attempts = 0;
+
+  while (!opts.abortSignal?.aborted) {
+    const app = createAppInstance();
+    ctx.app = app;
+
+    const handleSlackMessage = createSlackMessageHandler({ ctx, account });
+    registerSlackMonitorEvents({ ctx, account, handleSlackMessage });
+    await registerSlackMonitorSlashCommands({ ctx, account });
+
+    // Detect socket disconnect via Bolt's error handler.
+    let resolveDisconnect: () => void;
+    const disconnectPromise = new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    });
+    app.error(async () => {
+      resolveDisconnect();
+    });
+
+    // Attempt connection.
+    try {
+      await app.start();
+    } catch (err) {
+      attempts += 1;
+      if (attempts >= policy.maxAttempts) {
+        runtime.error?.(
+          `slack socket mode failed after ${attempts} attempts: ${String(err)}; giving up.`,
+        );
+        return;
+      }
+      const delayMs = computeBackoff(policy, attempts);
+      const delay = formatDurationPrecise(delayMs);
+      runtime.log?.(
+        `slack socket mode start failed (attempt ${attempts}): ${String(err)}; retrying in ${delay}.`,
+      );
+      try {
+        await sleep(delayMs, opts.abortSignal);
+      } catch {
+        if (opts.abortSignal?.aborted) {
+          return;
+        }
+        throw err;
+      }
+      continue;
+    }
+
+    runtime.log?.("slack socket mode connected");
+    attempts = 0;
+
+    // Wait for either abort or disconnect.
+    const abortPromise = new Promise<"abort">((resolve) => {
+      opts.abortSignal?.addEventListener("abort", () => resolve("abort"), { once: true });
+    });
+    const reason = await Promise.race([
+      disconnectPromise.then(() => "disconnect" as const),
+      abortPromise,
+    ]);
+
+    await app.stop().catch(() => undefined);
+
+    if (reason === "abort") {
       return;
     }
-    await new Promise<void>((resolve) => {
-      opts.abortSignal?.addEventListener("abort", () => resolve(), {
-        once: true,
-      });
-    });
-  } finally {
-    opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-    unregisterHttpHandler?.();
-    await app.stop().catch(() => undefined);
+
+    // Disconnected — backoff and retry.
+    attempts += 1;
+    if (attempts >= policy.maxAttempts) {
+      runtime.error?.(`slack socket mode disconnected ${attempts} times; giving up.`);
+      return;
+    }
+    const delayMs = computeBackoff(policy, attempts);
+    const delay = formatDurationPrecise(delayMs);
+    runtime.log?.(
+      `slack socket mode disconnected; reconnecting in ${delay} (attempt ${attempts}).`,
+    );
+    try {
+      await sleep(delayMs, opts.abortSignal);
+    } catch {
+      if (opts.abortSignal?.aborted) {
+        return;
+      }
+    }
   }
 }
 

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -1,6 +1,12 @@
 import type { OpenClawConfig, SlackSlashCommandConfig } from "../../config/config.js";
+import type { BackoffPolicy } from "../../infra/backoff.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { SlackFile, SlackMessageEvent } from "../types.js";
+
+export type SlackMonitorTuning = {
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  reconnect?: Partial<BackoffPolicy & { maxAttempts: number }>;
+};
 
 export type MonitorSlackOpts = {
   botToken?: string;
@@ -12,6 +18,7 @@ export type MonitorSlackOpts = {
   abortSignal?: AbortSignal;
   mediaMaxMb?: number;
   slashCommand?: SlackSlashCommandConfig;
+  tuning?: SlackMonitorTuning;
 };
 
 export type SlackReactionEvent = {


### PR DESCRIPTION
## Summary

- Add reconnect loop with exponential backoff to `monitorSlackProvider` for socket mode
- Fresh `App` instance per iteration, disconnect detection via `app.error()` callback
- Follows Telegram monitor pattern using existing `computeBackoff`/`sleepWithAbort` infrastructure
- HTTP mode unchanged (no reconnect loop)

Closes #27077

## Test plan

- [x] New reconnect test suite (4 tests): reconnect after disconnect, max attempts, abort during backoff, HTTP mode unaffected
- [x] All 34 existing slack test files pass (278 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)