### PR TITLE
fix(telegram): auto-detect HTTPS_PROXY/HTTP_PROXY env vars (#28607)

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -13,7 +13,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeEnvProxyFetch, makeProxyFetch } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -134,8 +134,12 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     }
 
+    // Fall back to HTTPS_PROXY / HTTP_PROXY env vars when no explicit proxy is
+    // configured. Node.js 22's globalThis.fetch (undici) silently ignores
+    // these variables — wire the dispatcher manually. See: #28607
     const proxyFetch =
-      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+      opts.proxyFetch ??
+      (account.config.proxy ? makeProxyFetch(account.config.proxy) : makeEnvProxyFetch());
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -14,12 +14,7 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   return fetcher;
 }
 
-const ENV_PROXY_KEYS = [
-  "HTTPS_PROXY",
-  "HTTP_PROXY",
-  "https_proxy",
-  "http_proxy",
-] as const;
+const ENV_PROXY_KEYS = ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"] as const;
 
 function getEnvProxy(): string | undefined {
   for (const key of ENV_PROXY_KEYS) {

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -36,6 +36,8 @@ function getEnvProxy(): string | undefined {
  */
 export function makeEnvProxyFetch(): typeof fetch | undefined {
   const envProxy = getEnvProxy();
-  if (!envProxy) return undefined;
+  if (!envProxy) {
+    return undefined;
+  }
   return makeProxyFetch(envProxy);
 }

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -13,3 +13,34 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   // should opt into resolveFetch/wrapFetchWithAbortSignal once at the edge.
   return fetcher;
 }
+
+const ENV_PROXY_KEYS = [
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "https_proxy",
+  "http_proxy",
+] as const;
+
+function getEnvProxy(): string | undefined {
+  for (const key of ENV_PROXY_KEYS) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns a proxy fetch backed by the first `HTTPS_PROXY` / `HTTP_PROXY`
+ * (case-insensitive) env var that is set, or `undefined` when none are present.
+ *
+ * Node.js 22's built-in `globalThis.fetch` (undici) silently ignores these
+ * variables, so callers that want curl-compatible proxy behaviour should
+ * prefer this over bare `globalThis.fetch`.
+ */
+export function makeEnvProxyFetch(): typeof fetch | undefined {
+  const envProxy = getEnvProxy();
+  if (!envProxy) return undefined;
+  return makeProxyFetch(envProxy);
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,7 +27,7 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeEnvProxyFetch, makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
 import {
@@ -122,7 +122,11 @@ function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
   const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  // Fall back to HTTPS_PROXY / HTTP_PROXY env vars when no explicit proxy is
+  // configured. Node.js 22's globalThis.fetch (undici) silently ignores these
+  // variables, so we must wire the dispatcher manually — matching the behaviour
+  // users expect from curl and browsers. See: #28607
+  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : makeEnvProxyFetch();
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
     network: account.config.network,
   });


### PR DESCRIPTION
## Problem

Fixes #28607

Users behind system/corporate proxies (ClashX, Squid, etc.) who rely on `HTTPS_PROXY` or `HTTP_PROXY` environment variables see silent Telegram send failures with `"Network request for 'sendMessage' failed!"`. This is a regression introduced by Node.js 22, whose built-in `globalThis.fetch` (undici) **silently ignores** these proxy env vars — unlike `curl`, browsers, or any other HTTP client.

OpenClaw only activated a proxy dispatcher when `channels.telegram.proxy` was explicitly set in config. If it was not set, `undefined` was passed through, causing `globalThis.fetch` to make direct connections that the network silently dropped or rejected.

## Root Cause

**`src/telegram/send.ts` (outbound sends/reactions/edits):**
```typescript
// BEFORE — no env proxy fallback:
const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
```

**`src/telegram/monitor.ts` (polling/webhook bots):**
```typescript
// BEFORE — no env proxy fallback:
const proxyFetch = opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
```

## Fix

Adds `makeEnvProxyFetch()` to `src/telegram/proxy.ts`. It reads the four common proxy env var names (`HTTPS_PROXY`, `HTTP_PROXY`, `https_proxy`, `http_proxy`) in priority order and returns a `ProxyAgent`-backed undici fetch when any is set, or `undefined` if none are configured.

This fallback is wired into both call sites:
- `resolveTelegramClientOptions()` in `send.ts`
- `monitorTelegramAccount()` in `monitor.ts`

```typescript
// AFTER — env proxy auto-detected when no explicit config proxy:
const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : makeEnvProxyFetch();
```

**Priority:** explicit `channels.telegram.proxy` config > env vars > no proxy (identical to before when no env vars are set).

## Re-verify Evidence

The old bug pattern (`: undefined` fallback with no env proxy lookup) is confirmed gone from both affected files:

```
$ grep "account.config.proxy.*undefined" src/telegram/send.ts src/telegram/monitor.ts
(no output — pattern absent)
```

`makeEnvProxyFetch()` is exported from `proxy.ts` and imported in both `send.ts` and `monitor.ts`. The logic mirrors the pattern already used in `src/infra/net/fetch-guard.ts` (`hasEnvProxyConfigured()` + `EnvHttpProxyAgent`), keeping the approach consistent across the codebase.

When no proxy env vars are set, `makeEnvProxyFetch()` returns `undefined` and behaviour is byte-for-byte identical to before.