### PR TITLE
test(subagent): add threadId forwarding regression tests for Telegram forums

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1012,6 +1012,100 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBe("42");
   });
 
+  it.each([
+    {
+      testName: "forwards numeric threadId as string on completion direct-send",
+      threadId: 42 as string | number,
+      expectedThreadId: "42",
+    },
+    {
+      testName: "forwards string threadId unchanged on completion direct-send",
+      threadId: "99" as string | number,
+      expectedThreadId: "99",
+    },
+    {
+      testName: "forwards threadId 0 (Telegram General topic) on completion direct-send",
+      threadId: 0 as string | number,
+      expectedThreadId: "0",
+    },
+  ] as const)("$testName", async (testCase) => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: `child-session-thread-edge-${testCase.expectedThreadId}`,
+      },
+      "agent:main:main": {
+        sessionId: `requester-session-thread-edge-${testCase.expectedThreadId}`,
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: `run-thread-edge-${testCase.expectedThreadId}`,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "telegram:-100123456789",
+        threadId: testCase.threadId,
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).not.toHaveBeenCalled();
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("telegram:-100123456789");
+    // threadId must be stringified and forwarded to the send call so
+    // Telegram delivers the announcement to the correct forum topic (#21162).
+    expect(call?.params?.threadId).toBe(testCase.expectedThreadId);
+  });
+
+  it("omits threadId from completion direct-send when origin has no thread", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-no-thread",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-no-thread",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-no-thread",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "telegram:-100123456789",
+        // No threadId -- message was sent to a non-forum group or DM.
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).not.toHaveBeenCalled();
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("telegram:-100123456789");
+    expect(call?.params?.threadId).toBeUndefined();
+  });
+
   it("uses hook-provided thread target across requester thread variants", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -809,6 +809,8 @@ async function sendSubagentAnnounceDirectly(params: {
       }
 
       if (shouldSendCompletionDirectly) {
+        // Forward threadId so Telegram forum topic announcements land in the
+        // originating thread rather than the General topic (#21162).
         const completionThreadId =
           completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
             ? String(completionDirectOrigin.threadId)


### PR DESCRIPTION
## Summary
- Add regression tests for threadId edge cases on completion direct-send path
- Tests cover numeric, string, zero (General topic), and missing threadId
- Documents threadId forwarding importance for Telegram forum topics
- Closes #21162

## Test plan
- Run pnpm vitest run src/agents/subagent-announce.format.test.ts
- Verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)