### PR TITLE
fix(subagents): forward parent images through sessions_spawn

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -59,6 +59,8 @@ export function createOpenClawTools(options?: {
   hasRepliedRef?: { value: boolean };
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
+  /** Current turn images (from inbound attachments) for sessions_spawn forwarding. */
+  currentImages?: Array<{ type: "image"; data: string; mimeType: string }>;
   /** Explicit agent ID override for cron/hook sessions. */
   requesterAgentIdOverride?: string;
   /** Require explicit message targets (no implicit last-route sends). */
@@ -160,6 +162,7 @@ export function createOpenClawTools(options?: {
       agentGroupId: options?.agentGroupId,
       agentGroupChannel: options?.agentGroupChannel,
       agentGroupSpace: options?.agentGroupSpace,
+      agentImages: options?.currentImages,
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -441,6 +441,7 @@ export async function runEmbeddedAttempt(
           replyToMode: params.replyToMode,
           hasRepliedRef: params.hasRepliedRef,
           modelHasVision,
+          currentImages: params.images,
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -230,6 +230,8 @@ export function createOpenClawCodingTools(options?: {
   hasRepliedRef?: { value: boolean };
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
+  /** Current turn images from inbound attachments. */
+  currentImages?: Array<{ type: "image"; data: string; mimeType: string }>;
   /** Require explicit message targets (no implicit last-route sends). */
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
@@ -488,6 +490,7 @@ export function createOpenClawCodingTools(options?: {
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
       modelHasVision: options?.modelHasVision,
+      currentImages: options?.currentImages,
       requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
       disableMessageTool: options?.disableMessageTool,
       requesterAgentIdOverride: agentId,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -115,4 +115,24 @@ describe("sessions_spawn tool", () => {
     );
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
+
+  it("forwards parent images to subagent spawn context", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentImages: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+    });
+
+    await tool.execute("call-images", {
+      task: "analyze parent image",
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze parent image",
+      }),
+      expect.objectContaining({
+        agentImages: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+      }),
+    );
+  });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -33,6 +33,7 @@ export function createSessionsSpawnTool(opts?: {
   agentGroupId?: string | null;
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
+  agentImages?: Array<{ type: "image"; data: string; mimeType: string }>;
   sandboxed?: boolean;
   /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
   requesterAgentIdOverride?: string;
@@ -109,6 +110,7 @@ export function createSessionsSpawnTool(opts?: {
                 agentGroupId: opts?.agentGroupId,
                 agentGroupChannel: opts?.agentGroupChannel,
                 agentGroupSpace: opts?.agentGroupSpace,
+                agentImages: opts?.agentImages,
                 requesterAgentIdOverride: opts?.requesterAgentIdOverride,
               },
             );


### PR DESCRIPTION
## Summary

- **Problem:** `sessions_spawn` starts subagent runs without parent-turn images, so vision subagents cannot see images that were attached to the requester turn.
- **Why it matters:** Multi-agent image workflows break unless users manually copy files into subagent workspaces.
- **What changed:** Added image forwarding path from current run context into `sessions_spawn` and `spawnSubagentDirect`, then attached forwarded images to the child `agent` request. Updated tests in `src/agents/tools/sessions-spawn-tool.test.ts` and `src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`.
- **What did NOT change:** ACP runtime behavior and non-image spawn flow remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28772

## User-visible / Behavior Changes

- Subagents spawned via `sessions_spawn` now receive parent image attachments in their initial run.
- Vision subagents can process parent turn images without manual workspace copy steps.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm + Vitest
- Integration/channel: sessions_spawn / subagent runtime

### Steps

1. Send a turn with one or more images.
2. Trigger `sessions_spawn` to start a subagent for image analysis.
3. Inspect child `agent` request payload.

### Expected

- Child request includes image attachments, and subagent can access them.

### Actual

- Before fix: child request had no attachments.
- After fix: child request carries forwarded image attachments.

## Evidence

- Updated tests:
  - `src/agents/tools/sessions-spawn-tool.test.ts`
  - `src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- Test run:
  - `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/agents/tools/sessions-spawn-tool.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
  - Result: 2 files passed, 13 tests passed.

## Human Verification (required)

- Verified scenarios:
  - sessions_spawn tool context forwards parent images.
  - Child `agent` call contains normalized image attachments.
- Edge cases checked:
  - Empty/malformed image entries are filtered.
- What I did **not** verify:
  - End-to-end live Telegram/Discord image spawn flow against production channels.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/agents/subagent-spawn.ts` and spawn tool plumbing files.
- Known bad symptoms: Subagents may again miss parent images.

## Risks and Mitigations

- Risk: Larger parent images increase spawn payload size.
- Mitigation: Only already-sanitized current-turn image blocks are forwarded; invalid entries are dropped.
