### PR TITLE
fix(update): stop launchd gateway before detached restart

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -64,7 +64,10 @@ describe("restart-helper", () => {
       });
       expect(scriptPath.endsWith(".sh")).toBe(true);
       expect(content).toContain("#!/bin/sh");
-      expect(content).toContain("launchctl kickstart -k 'gui/501/ai.openclaw.gateway'");
+      expect(content).toContain("service=\"$domain/$label\"");
+      expect(content).toContain("launchctl bootout \"$service\" >/dev/null 2>&1 || true");
+      expect(content).toContain("launchctl bootstrap \"$domain\" \"$plist\" >/dev/null 2>&1 || true");
+      expect(content).toContain("launchctl kickstart -k \"$service\"");
       expect(content).toContain('rm -f "$0"');
       await cleanupScript(scriptPath);
     });
@@ -77,7 +80,7 @@ describe("restart-helper", () => {
         OPENCLAW_PROFILE: "default",
         OPENCLAW_LAUNCHD_LABEL: "com.custom.openclaw",
       });
-      expect(content).toContain("launchctl kickstart -k 'gui/501/com.custom.openclaw'");
+      expect(content).toContain("label='com.custom.openclaw'");
       await cleanupScript(scriptPath);
     });
 
@@ -124,7 +127,8 @@ describe("restart-helper", () => {
       const { scriptPath, content } = await prepareAndReadScript({
         OPENCLAW_PROFILE: "staging",
       });
-      expect(content).toContain("gui/502/ai.openclaw.staging");
+      expect(content).toContain("domain='gui/502'");
+      expect(content).toContain("label='ai.openclaw.staging'");
       await cleanupScript(scriptPath);
     });
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -86,7 +86,14 @@ rm -f "$0"
 # Standalone restart script — survives parent process termination.
 # Wait briefly to ensure file locks are released after update.
 sleep 1
-launchctl kickstart -k 'gui/${uid}/${escaped}'
+label='${escaped}'
+domain='gui/${uid}'
+service="$domain/$label"
+plist="$HOME/Library/LaunchAgents/$label.plist"
+# Stop old gateway process first, then bootstrap the updated plist and start.
+launchctl bootout "$service" >/dev/null 2>&1 || true
+launchctl bootstrap "$domain" "$plist" >/dev/null 2>&1 || true
+launchctl kickstart -k "$service"
 # Self-cleanup
 rm -f "$0"
 `;


### PR DESCRIPTION
## Summary

- **Problem:** During `openclaw update` on macOS, the detached restart script used `launchctl kickstart -k` directly, which can race while an old gateway process is still active.
- **Why it matters:** Updates may fail to bring up the new gateway cleanly when the old process still holds the gateway port.
- **What changed:** Updated the macOS detached restart script to run explicit stop/start sequence: `bootout` old service target, `bootstrap` plist, then `kickstart`. Added/updated assertions in `src/cli/update-cli/restart-helper.test.ts`.
- **What did NOT change:** Linux (`systemctl restart`) and Windows (`schtasks /End + /Run`) restart scripts are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28332

## User-visible / Behavior Changes

- `openclaw update` on macOS now uses a stricter detached restart path that stops the old LaunchAgent target before starting the refreshed one.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm + Vitest

### Steps

1. Run `openclaw update` on macOS with daemon restart enabled.
2. Observe generated detached restart script behavior.

### Expected

- Restart sequence stops old process before starting new process.

### Actual

- Before fix: detached script only `kickstart -k`.
- After fix: detached script performs `bootout -> bootstrap -> kickstart`.

## Evidence

- Updated file: `src/cli/update-cli/restart-helper.ts`
- Updated tests: `src/cli/update-cli/restart-helper.test.ts`
- Test run:
  - `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/cli/update-cli/restart-helper.test.ts`
  - Result: 1 file passed, 15 tests passed.

## Human Verification (required)

- Verified scenarios:
  - macOS restart script now contains explicit stop/start sequence.
  - launchd label/domain overrides remain supported.
- What I did **not** verify:
  - Full end-to-end daemon restart on a live macOS host with active old gateway process.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/cli/update-cli/restart-helper.ts`.

## Risks and Mitigations

- Risk: bootstrap may fail if LaunchAgent plist is missing.
- Mitigation: script remains best-effort and update health checks still surface restart diagnostics.
