### PR TITLE
fix(control-ui): enable Save for default agent model/fallback edits

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -812,27 +812,30 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "model"];
+                  const cfgTyped = configValue as {
+                    agents?: { list?: unknown[]; defaults?: { model?: unknown } };
+                  };
+                  const list = cfgTyped.agents?.list;
+                  const index = Array.isArray(list)
+                    ? list.findIndex(
+                        (entry) =>
+                          entry &&
+                          typeof entry === "object" &&
+                          "id" in entry &&
+                          (entry as { id?: string }).id === agentId,
+                      )
+                    : -1;
+                  const isListEntry = index >= 0;
+                  const basePath = isListEntry
+                    ? ["agents", "list", index, "model"]
+                    : ["agents", "defaults", "model"];
                   if (!modelId) {
                     removeConfigFormValue(state, basePath);
                     return;
                   }
-                  const entry = list[index] as { model?: unknown };
-                  const existing = entry?.model;
+                  const existing = isListEntry
+                    ? (list![index] as { model?: unknown })?.model
+                    : cfgTyped.agents?.defaults?.model;
                   if (existing && typeof existing === "object" && !Array.isArray(existing)) {
                     const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
                     const next = {
@@ -848,24 +851,27 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
+                  const cfgTyped = configValue as {
+                    agents?: { list?: unknown[]; defaults?: { model?: unknown } };
+                  };
+                  const list = cfgTyped.agents?.list;
+                  const index = Array.isArray(list)
+                    ? list.findIndex(
+                        (entry) =>
+                          entry &&
+                          typeof entry === "object" &&
+                          "id" in entry &&
+                          (entry as { id?: string }).id === agentId,
+                      )
+                    : -1;
+                  const isListEntry = index >= 0;
+                  const basePath = isListEntry
+                    ? ["agents", "list", index, "model"]
+                    : ["agents", "defaults", "model"];
+                  const existing = isListEntry
+                    ? (list![index] as { model?: unknown }).model
+                    : cfgTyped.agents?.defaults?.model;
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -826,6 +826,12 @@ export function renderApp(state: AppViewState) {
                       )
                     : -1;
                   const isListEntry = index >= 0;
+                  // Only fall through to defaults for the actual default agent;
+                  // unknown non-default agents are a no-op to avoid overwriting globals.
+                  const defaultId = state.agentsList?.defaultId ?? null;
+                  if (!isListEntry && agentId !== defaultId) {
+                    return;
+                  }
                   const basePath = isListEntry
                     ? ["agents", "list", index, "model"]
                     : ["agents", "defaults", "model"];
@@ -865,11 +871,17 @@ export function renderApp(state: AppViewState) {
                       )
                     : -1;
                   const isListEntry = index >= 0;
+                  // Only fall through to defaults for the actual default agent;
+                  // unknown non-default agents are a no-op to avoid overwriting globals.
+                  const defaultId = state.agentsList?.defaultId ?? null;
+                  if (!isListEntry && agentId !== defaultId) {
+                    return;
+                  }
                   const basePath = isListEntry
                     ? ["agents", "list", index, "model"]
                     : ["agents", "defaults", "model"];
                   const existing = isListEntry
-                    ? (list![index] as { model?: unknown }).model
+                    ? (list![index] as { model?: unknown })?.model
                     : cfgTyped.agents?.defaults?.model;
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
                   const resolvePrimary = () => {


### PR DESCRIPTION
## Summary
- Fix Save button remaining disabled when editing model/fallbacks for a default agent (no agents.list)
- Both onModelChange and onModelFallbacksChange now handle the agents.defaults path
- Closes #20924

## Test plan
- [ ] Create config with only agents.defaults.model (no agents.list)
- [ ] Open control UI, change model → verify Save enables
- [ ] Change fallbacks → verify Save enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)