### PR TITLE
fix(telegram): treat text_mention links as explicit bot mentions

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramForumThreadId,
 } from "./helpers.js";
@@ -65,6 +66,54 @@ describe("thread id normalization", () => {
     },
   ])("normalizes thread ids to integers", ({ build, expected }) => {
     expect(build()).toEqual(expected);
+  });
+});
+
+describe("hasBotMention", () => {
+  it("matches classic @username mentions", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "hello @MyBot",
+          entities: [{ type: "mention", offset: 6, length: 6 }],
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        { botUsername: "mybot", botId: 123 },
+      ),
+    ).toBe(true);
+  });
+
+  it("matches text_mention entities by bot id", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "hello bot",
+          entities: [
+            {
+              type: "text_mention",
+              offset: 6,
+              length: 3,
+              user: { id: 123, username: "mybot" },
+            },
+          ],
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        { botUsername: "mybot", botId: 123 },
+      ),
+    ).toBe(true);
+  });
+
+  it("matches tg://user text_link mention entities by bot id", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "mention",
+          entities: [{ type: "text_link", offset: 0, length: 7, url: "tg://user?id=123" }],
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        { botUsername: "mybot", botId: 123 },
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem:** Telegram group mention gating only treated `@username` mention entities as explicit bot mentions, missing other privacy-mode mention forms.
- **Why it matters:** In privacy mode, some clients deliver bot mentions via `text_mention` or `tg://user?id=...` link entities; those were not recognized and messages were dropped as non-mentions.
- **What changed:** Extended `hasBotMention` and mention pre-signals to recognize `text_mention` and `text_link` (`tg://user?id=...`) as explicit mentions by bot id, while preserving existing `@username` behavior. Added regression tests in `src/telegram/bot/helpers.test.ts`.
- **What did NOT change:** Group policy/allowlist behavior and command authorization logic remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28085

## User-visible / Behavior Changes

- Telegram group messages that mention the bot using `text_mention`/`tg://user?id=...` now pass mention gating under privacy mode.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime: Node.js + pnpm + Vitest

### Steps

1. Send Telegram group messages mentioning bot via different entity formats.
2. Evaluate explicit mention detection result.

### Expected

- `mention`, `text_mention`, and `tg://user?id=...` mention forms all count as explicit mention for target bot.

### Actual

- Before fix: only `@username` mention path was guaranteed.
- After fix: all major explicit mention entity forms are recognized.

## Evidence

- Updated files:
  - `src/telegram/bot/helpers.ts`
  - `src/telegram/bot-message-context.ts`
  - `src/telegram/bot/helpers.test.ts`
- Test run:
  - `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/telegram/bot/helpers.test.ts src/telegram/bot-message-context.sender-prefix.test.ts src/telegram/bot-message-context.audio-transcript.test.ts src/telegram/bot-message-context.dm-threads.test.ts src/telegram/bot-message-context.dm-topic-threadid.test.ts`
  - Result: 5 files passed, 52 tests passed.

## Human Verification (required)

- Verified scenarios:
  - Classic `@username` mentions still match.
  - `text_mention` with bot id matches.
  - `text_link` with `tg://user?id=<botId>` matches.
- What I did **not** verify:
  - Live Telegram privacy-mode behavior across all mobile client variants.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: Telegram mention helper/context files listed above.

## Risks and Mitigations

- Risk: Over-matching non-bot text_link entities.
- Mitigation: text_link mention path requires exact `tg://user?id=<botId>` match.
