### PR TITLE
fix(discord): expose EventQueue listenerTimeout as configurable option

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -300,6 +300,20 @@ export type DiscordAccountConfig = {
   activityType?: 0 | 1 | 2 | 3 | 4 | 5;
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */
   activityUrl?: string;
+  /**
+   * Carbon EventQueue configuration. Controls how Discord gateway events are processed.
+   * The most important option is `listenerTimeout` which defaults to 30s in Carbon --
+   * too short for LLM calls with extended thinking. Set a higher value (e.g. 120000)
+   * to prevent the event queue from killing long-running message handlers.
+   */
+  eventQueue?: {
+    /** Max time (ms) a single listener can run before being killed. Default: 120000. */
+    listenerTimeout?: number;
+    /** Max events queued before backpressure is applied. Default: 10000. */
+    maxQueueSize?: number;
+    /** Max concurrent event processing operations. Default: 50. */
+    maxConcurrency?: number;
+  };
 };
 
 export type DiscordConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -514,6 +514,14 @@ export const DiscordAccountSchema = z
       .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3), z.literal(4), z.literal(5)])
       .optional(),
     activityUrl: z.string().url().optional(),
+    eventQueue: z
+      .object({
+        listenerTimeout: z.number().int().positive().optional(),
+        maxQueueSize: z.number().int().positive().optional(),
+        maxConcurrency: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -515,6 +515,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     if (voiceEnabled) {
       clientPlugins.push(new VoicePlugin());
     }
+    // Pass eventQueue config to Carbon so the listener timeout can be tuned.
+    // Default listenerTimeout is 120s (Carbon defaults to 30s which is too short for LLM calls).
+    const eventQueueOpts = {
+      listenerTimeout: 120_000,
+      ...discordCfg.eventQueue,
+    };
     const client = new Client(
       {
         baseUrl: "http://localhost",
@@ -523,6 +529,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         publicKey: "a",
         token,
         autoDeploy: false,
+        eventQueue: eventQueueOpts,
       },
       {
         commands,


### PR DESCRIPTION
## Summary
- Expose Carbon EventQueue listenerTimeout/maxQueueSize/maxConcurrency as configurable discord.eventQueue options
- Default listenerTimeout raised from 30s to 120s to prevent extended thinking timeouts
- Closes #24458

## Test plan
- [ ] Verify default 120s timeout applied when no custom config
- [ ] Verify custom eventQueue config overrides defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)