### PR TITLE
fix(discord): allowlist CDN hostnames in SSRF policy for inbound attachment and sticker downloads

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -94,6 +94,7 @@ describe("resolveForwardedMediaList", () => {
       filePathHint: attachment.filename,
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"] },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
@@ -168,6 +169,7 @@ describe("resolveForwardedMediaList", () => {
       filePathHint: "wave.png",
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"] },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
@@ -236,6 +238,7 @@ describe("resolveMediaList", () => {
       filePathHint: "hello.png",
       maxBytes: 512,
       fetchImpl: undefined,
+      ssrfPolicy: { hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"] },
     });
     expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
     expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -2,6 +2,8 @@ import type { ChannelType, Client, Message } from "@buape/carbon";
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { logVerbose } from "../../globals.js";
+import { type SsrFPolicy } from "../../infra/net/ssrf.js";
+import { logWarn } from "../../logger.js";
 import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 
@@ -46,6 +48,15 @@ type DiscordMessageSnapshot = {
 };
 
 const DISCORD_CHANNEL_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * SSRF policy that allows Discord CDN hostnames so that inbound attachment
+ * downloads succeed in VPN/proxy environments where cdn.discordapp.com and
+ * media.discordapp.net resolve to private/reserved IP ranges (e.g. 198.18.x.x).
+ */
+const DISCORD_CDN_SSRF_POLICY: SsrFPolicy = {
+  hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"],
+};
 const DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS = 30 * 1000;
 const DISCORD_CHANNEL_INFO_CACHE = new Map<
   string,
@@ -228,6 +239,7 @@ async function appendResolvedMediaFromAttachments(params: {
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
+        ssrfPolicy: DISCORD_CDN_SSRF_POLICY,
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -242,7 +254,7 @@ async function appendResolvedMediaFromAttachments(params: {
       });
     } catch (err) {
       const id = attachment.id ?? attachment.url;
-      logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+      logWarn(`${params.errorPrefix} ${id}: ${String(err)}`);
     }
   }
 }
@@ -320,6 +332,7 @@ async function appendResolvedMediaFromStickers(params: {
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
+          ssrfPolicy: DISCORD_CDN_SSRF_POLICY,
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,


### PR DESCRIPTION
## Summary

Fixes #28816

In VPN/proxy environments (e.g. TUN-mode VPN, regional proxies) where `cdn.discordapp.com` and `media.discordapp.net` resolve to private/reserved IP ranges such as `198.18.x.x` (RFC 2544 benchmark range), the SSRF guard was blocking inbound attachment and sticker downloads. The attachment was then silently dropped from the agent's inbound context — leaving the agent with no knowledge of the file.

## Root Cause

`appendResolvedMediaFromAttachments` and `appendResolvedMediaFromStickers` both call `fetchRemoteMedia` without an `ssrfPolicy`, so the default SSRF guard applies its full private-IP block. When a VPN's DNS returns a private IP for Discord CDN hostnames, the download throws `SsrFBlockedError` and the attachment is lost.

## Fix

Apply a `DISCORD_CDN_SSRF_POLICY` with `hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"]` to the `fetchRemoteMedia` calls in both functions. The SSRF hostname allowlist bypasses the downstream IP check for these two known-safe Discord CDN hosts, matching the pattern used for other provider-specific CDN allowlists in the codebase.

Additionally promotes `logVerbose` → `logWarn` for attachment download failures so errors are visible in gateway logs without verbose mode.

## Changes

- `src/discord/monitor/message-utils.ts`
  - Import `SsrFPolicy` and `logWarn`
  - Add `DISCORD_CDN_SSRF_POLICY` constant (hostnameAllowlist for both CDN domains)
  - Pass `ssrfPolicy: DISCORD_CDN_SSRF_POLICY` to `fetchRemoteMedia` in attachment downloads
  - Pass `ssrfPolicy: DISCORD_CDN_SSRF_POLICY` to `fetchRemoteMedia` in sticker downloads  
  - Promote `logVerbose` → `logWarn` for download failure catch block
- `src/discord/monitor/message-utils.test.ts`
  - Add `ssrfPolicy` to the three exact-match `toHaveBeenCalledWith` assertions