### PR TITLE
fix(ui): clear stale update banner after successful update.run

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -371,4 +371,52 @@ describe("runUpdate", () => {
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
     });
   });
+
+  it("clears stale updateAvailable after successful update.run", async () => {
+    const request = vi.fn().mockResolvedValue({ result: { status: "ok" } });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.updateAvailable = {
+      currentVersion: "2026.2.23",
+      latestVersion: "2026.2.26",
+      channel: "latest",
+    };
+
+    await runUpdate(state);
+
+    expect(state.updateAvailable).toBeNull();
+  });
+
+  it("keeps updateAvailable when update.run reports failure", async () => {
+    const request = vi.fn().mockResolvedValue({ result: { status: "error" } });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.updateAvailable = {
+      currentVersion: "2026.2.23",
+      latestVersion: "2026.2.26",
+      channel: "latest",
+    };
+
+    await runUpdate(state);
+
+    expect(state.updateAvailable).not.toBeNull();
+  });
+
+  it("keeps updateAvailable when update.run is skipped", async () => {
+    const request = vi.fn().mockResolvedValue({ result: { status: "skipped" } });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.updateAvailable = {
+      currentVersion: "2026.2.23",
+      latestVersion: "2026.2.26",
+      channel: "latest",
+    };
+
+    await runUpdate(state);
+
+    expect(state.updateAvailable).not.toBeNull();
+  });
 });

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -1,5 +1,10 @@
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { ConfigSchemaResponse, ConfigSnapshot, ConfigUiHints } from "../types.ts";
+import type {
+  ConfigSchemaResponse,
+  ConfigSnapshot,
+  ConfigUiHints,
+  UpdateAvailable,
+} from "../types.ts";
 import type { JsonSchema } from "../views/config-form.shared.ts";
 import { coerceFormValues } from "./config/form-coerce.ts";
 import {
@@ -21,6 +26,7 @@ export type ConfigState = {
   configSaving: boolean;
   configApplying: boolean;
   updateRunning: boolean;
+  updateAvailable?: UpdateAvailable | null;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown;
   configSchemaVersion: string | null;
@@ -194,6 +200,12 @@ export async function runUpdate(state: ConfigState) {
       const status = res.result?.status ?? "error";
       const reason = res.result?.reason ?? "Update failed.";
       state.lastError = `Update ${status}: ${reason}`;
+    }
+    // Only clear the banner when the update truly applied (status "ok").
+    // update.run also resolves for "skipped" (already up-to-date, git dirty)
+    // and "error" (package-manager failure), so check the inner status.
+    if (res?.result?.status === "ok" && "updateAvailable" in state) {
+      state.updateAvailable = null;
     }
   } catch (err) {
     state.lastError = String(err);


### PR DESCRIPTION
## Summary
- fix stale "Update available" banner in Control UI after `update.run` succeeds
- optimistically clear `state.updateAvailable` on successful update request
- add controller test coverage for this behavior

## Why
Fixes a UX bug where users can update successfully but still see the old upgrade prompt until a full gateway snapshot refresh/restart arrives.

## Testing
- Added: `runUpdate` test asserting stale `updateAvailable` is cleared after success
- Local run note: UI browser test runner requires Playwright browsers in this environment (`pnpm exec playwright install`)

Closes #28938
