### PR TITLE
fix(doctor): validate fallback model providers are defined

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { TSchema } from "@sinclair/typebox";
 import { type ExecHost, maxAsk, minSecurity } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
@@ -155,10 +156,7 @@ async function validateScriptFileForShellBleed(params: {
   }
 }
 
-export function createExecTool(
-  defaults?: ExecToolDefaults,
-  // oxlint-disable-next-line typescript/no-explicit-any
-): AgentTool<any, ExecToolDetails> {
+export function createExecTool(defaults?: ExecToolDefaults): AgentTool<TSchema, ExecToolDetails> {
   const defaultBackgroundMs = clampWithDefault(
     defaults?.backgroundMs ?? readEnvInt("PI_BASH_YIELD_MS"),
     10_000,
@@ -609,8 +607,7 @@ export function createExecTool(
     },
   };
 
-  // oxlint-disable-next-line typescript/no-explicit-any
-  return patchToolSchemaForClaudeCompatibility(baseTool) as AgentTool<any, ExecToolDetails>;
+  return patchToolSchemaForClaudeCompatibility(baseTool) as AgentTool<TSchema, ExecToolDetails>;
 }
 
 export const execTool = createExecTool();

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -43,6 +43,13 @@ import {
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import {
+  CLAUDE_PARAM_GROUPS,
+  assertRequiredParams,
+  normalizeToolParams,
+  patchToolSchemaForClaudeCompatibility,
+} from "./pi-tools.read.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 
 export type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -200,14 +207,23 @@ export function createExecTool(
     defaults?.agentId ??
     (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
 
-  return {
+  // Build the base tool, then patch schema to accept `cmd` as alias for `command`,
+  // mirroring how read/write/edit accept `file_path` alongside `path`.
+  const baseTool: AnyAgentTool = {
     name: "exec",
     label: "exec",
     description:
       "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
     parameters: execSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
-      const params = args as {
+      // Normalize aliases (cmd → command) before validation, matching the
+      // pattern used by read/write/edit for file_path → path.
+      const normalized = normalizeToolParams(args);
+      const record =
+        normalized ??
+        (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+      assertRequiredParams(record, CLAUDE_PARAM_GROUPS.exec, "exec");
+      const params = (normalized ?? args) as {
         command: string;
         workdir?: string;
         env?: Record<string, string>;
@@ -592,6 +608,9 @@ export function createExecTool(
       });
     },
   };
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  return patchToolSchemaForClaudeCompatibility(baseTool) as AgentTool<any, ExecToolDetails>;
 }
 
 export const execTool = createExecTool();

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -575,6 +575,45 @@ describe("exec notifyOnExit", () => {
   it.each<NotifyNoopCase>(NOOP_NOTIFY_CASES)("$label", runNotifyNoopCase);
 });
 
+describe("exec cmd alias", () => {
+  useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
+  it("accepts cmd as alias for command", async () => {
+    const result = await executeExecTool(execTool, {
+      cmd: COMMAND_ECHO_HELLO,
+    } as ExecToolArgs);
+    const text = readNormalizedTextContent(result.content);
+    expect(text).toContain("hello");
+  });
+
+  it("prefers command over cmd when both are provided", async () => {
+    const result = await executeExecTool(execTool, {
+      command: COMMAND_ECHO_HELLO,
+      cmd: shellEcho(OUTPUT_NOPE),
+    } as ExecToolArgs);
+    const text = readNormalizedTextContent(result.content);
+    expect(text).toContain("hello");
+    expect(text).not.toContain(OUTPUT_NOPE);
+  });
+
+  it("rejects when neither command nor cmd is provided", async () => {
+    await expect(executeExecTool(execTool, {} as ExecToolArgs)).rejects.toThrow(
+      /Missing required parameter.*command/,
+    );
+  });
+
+  it("exposes cmd in the exec tool schema", () => {
+    const schema = execTool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.properties?.cmd).toBeDefined();
+    expect(schema.properties?.command).toBeDefined();
+    // command should not be required (alias makes it optional at schema level)
+    expect(schema.required ?? []).not.toContain("command");
+  });
+});
+
 describe("exec PATH handling", () => {
   useCapturedEnv([...PATH_SHELL_ENV_KEYS], applyDefaultShellEnv);
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -920,6 +920,31 @@ export function buildKilocodeProvider(): ProviderConfig {
   };
 }
 
+/**
+ * All provider IDs that {@link resolveImplicitProviders} may produce at runtime
+ * when matching credentials/env vars are present. Used by doctor validation to
+ * avoid false "undefined provider" warnings for implicit providers.
+ */
+export const IMPLICIT_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  "byteplus",
+  "byteplus-plan",
+  "cloudflare-ai-gateway",
+  "kilocode",
+  "minimax-portal",
+  "moonshot",
+  "nvidia",
+  "ollama",
+  "qianfan",
+  "qwen-portal",
+  "synthetic",
+  "together",
+  "venice",
+  "vllm",
+  "volcengine",
+  "volcengine-plan",
+  "xiaomi",
+]);
+
 export async function resolveImplicitProviders(params: {
   agentDir: string;
   explicitProviders?: Record<string, ProviderConfig> | null;

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -104,6 +104,61 @@ describe("createOpenClawCodingTools", () => {
       expect(params.required ?? []).not.toContain("file_path");
     });
 
+    it("adds cmd alias to exec schema without dropping command", () => {
+      const base: AgentTool = {
+        name: "exec",
+        label: "exec",
+        description: "test",
+        parameters: Type.Object({
+          command: Type.String({ description: "Shell command" }),
+          workdir: Type.Optional(Type.String()),
+        }),
+        execute: vi.fn(),
+      };
+
+      const patched = __testing.patchToolSchemaForClaudeCompatibility(base);
+      const params = patched.parameters as {
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      const props = params.properties ?? {};
+
+      expect(props.cmd).toEqual(props.command);
+      expect(params.required ?? []).not.toContain("command");
+    });
+
+    it("normalizes cmd to command at runtime for exec tool", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool: AgentTool = {
+        name: "exec",
+        label: "exec",
+        description: "test",
+        parameters: Type.Object({
+          command: Type.String(),
+        }),
+        execute,
+      };
+
+      const wrapped = __testing.wrapToolParamNormalization(tool, [
+        { keys: ["command", "cmd"], label: "command (command or cmd)" },
+      ]);
+
+      await wrapped.execute("tool-exec-1", { cmd: "ls -la" });
+      expect(execute).toHaveBeenCalledWith(
+        "tool-exec-1",
+        { command: "ls -la" },
+        undefined,
+        undefined,
+      );
+
+      await expect(wrapped.execute("tool-exec-2", {})).rejects.toThrow(
+        /Missing required parameter.*command/,
+      );
+      await expect(wrapped.execute("tool-exec-2", {})).rejects.toThrow(
+        /Supply correct parameters before retrying\./,
+      );
+    });
+
     it("normalizes file_path to path and enforces required groups at runtime", async () => {
       const execute = vi.fn(async (_id, args) => args);
       const tool: AgentTool = {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -13,26 +13,10 @@ import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
-import { wrapHostEditToolWithPostWriteRecovery } from "./pi-tools.host-edit.js";
-import {
-  CLAUDE_PARAM_GROUPS,
-  assertRequiredParams,
-  normalizeToolParams,
-  patchToolSchemaForClaudeCompatibility,
-  wrapToolParamNormalization,
-} from "./pi-tools.params.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
-
-export {
-  CLAUDE_PARAM_GROUPS,
-  assertRequiredParams,
-  normalizeToolParams,
-  patchToolSchemaForClaudeCompatibility,
-  wrapToolParamNormalization,
-} from "./pi-tools.params.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
 // to normalize payloads and sanitize oversized images before they hit providers.
@@ -350,6 +334,237 @@ async function normalizeReadImageResult(
   return { ...result, content: nextContent };
 }
 
+type RequiredParamGroup = {
+  keys: readonly string[];
+  allowEmpty?: boolean;
+  label?: string;
+};
+
+const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
+
+function parameterValidationError(message: string): Error {
+  return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
+}
+
+export const CLAUDE_PARAM_GROUPS = {
+  read: [{ keys: ["path", "file_path"], label: "path (path or file_path)" }],
+  write: [
+    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    { keys: ["content"], label: "content" },
+  ],
+  edit: [
+    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    {
+      keys: ["oldText", "old_string"],
+      label: "oldText (oldText or old_string)",
+    },
+    {
+      keys: ["newText", "new_string"],
+      label: "newText (newText or new_string)",
+      allowEmpty: true,
+    },
+  ],
+  exec: [{ keys: ["command", "cmd"], label: "command (command or cmd)" }],
+} as const;
+
+function extractStructuredText(value: unknown, depth = 0): string | undefined {
+  if (depth > 6) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((entry) => extractStructuredText(entry, depth + 1))
+      .filter((entry): entry is string => typeof entry === "string");
+    return parts.length > 0 ? parts.join("") : undefined;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+  if (typeof record.content === "string") {
+    return record.content;
+  }
+  if (Array.isArray(record.content)) {
+    return extractStructuredText(record.content, depth + 1);
+  }
+  if (Array.isArray(record.parts)) {
+    return extractStructuredText(record.parts, depth + 1);
+  }
+  if (typeof record.value === "string" && record.value.length > 0) {
+    const type = typeof record.type === "string" ? record.type.toLowerCase() : "";
+    const kind = typeof record.kind === "string" ? record.kind.toLowerCase() : "";
+    if (type.includes("text") || kind === "text") {
+      return record.value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
+  const value = record[key];
+  if (typeof value === "string") {
+    return;
+  }
+  const extracted = extractStructuredText(value);
+  if (typeof extracted === "string") {
+    record[key] = extracted;
+  }
+}
+
+// Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
+// Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
+// This prevents models trained on Claude Code from getting stuck in tool-call loops.
+export function normalizeToolParams(params: unknown): Record<string, unknown> | undefined {
+  if (!params || typeof params !== "object") {
+    return undefined;
+  }
+  const record = params as Record<string, unknown>;
+  const normalized = { ...record };
+  // file_path → path (read, write, edit)
+  if ("file_path" in normalized && !("path" in normalized)) {
+    normalized.path = normalized.file_path;
+    delete normalized.file_path;
+  }
+  // old_string → oldText (edit)
+  if ("old_string" in normalized && !("oldText" in normalized)) {
+    normalized.oldText = normalized.old_string;
+    delete normalized.old_string;
+  }
+  // new_string → newText (edit)
+  if ("new_string" in normalized && !("newText" in normalized)) {
+    normalized.newText = normalized.new_string;
+    delete normalized.new_string;
+  }
+  // cmd → command (exec)
+  if ("cmd" in normalized && !("command" in normalized)) {
+    normalized.command = normalized.cmd;
+    delete normalized.cmd;
+  }
+  // Some providers/models emit text payloads as structured blocks instead of raw strings.
+  // Normalize these for write/edit so content matching and writes stay deterministic.
+  normalizeTextLikeParam(normalized, "content");
+  normalizeTextLikeParam(normalized, "oldText");
+  normalizeTextLikeParam(normalized, "newText");
+  return normalized;
+}
+
+export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAgentTool {
+  const schema =
+    tool.parameters && typeof tool.parameters === "object"
+      ? (tool.parameters as Record<string, unknown>)
+      : undefined;
+
+  if (!schema || !schema.properties || typeof schema.properties !== "object") {
+    return tool;
+  }
+
+  const properties = { ...(schema.properties as Record<string, unknown>) };
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((key): key is string => typeof key === "string")
+    : [];
+  let changed = false;
+
+  const aliasPairs: Array<{ original: string; alias: string }> = [
+    { original: "path", alias: "file_path" },
+    { original: "oldText", alias: "old_string" },
+    { original: "newText", alias: "new_string" },
+    { original: "command", alias: "cmd" },
+  ];
+
+  for (const { original, alias } of aliasPairs) {
+    if (!(original in properties)) {
+      continue;
+    }
+    if (!(alias in properties)) {
+      properties[alias] = properties[original];
+      changed = true;
+    }
+    const idx = required.indexOf(original);
+    if (idx !== -1) {
+      required.splice(idx, 1);
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    parameters: {
+      ...schema,
+      properties,
+      required,
+    },
+  };
+}
+
+export function assertRequiredParams(
+  record: Record<string, unknown> | undefined,
+  groups: readonly RequiredParamGroup[],
+  toolName: string,
+): void {
+  if (!record || typeof record !== "object") {
+    throw parameterValidationError(`Missing parameters for ${toolName}`);
+  }
+
+  const missingLabels: string[] = [];
+  for (const group of groups) {
+    const satisfied = group.keys.some((key) => {
+      if (!(key in record)) {
+        return false;
+      }
+      const value = record[key];
+      if (typeof value !== "string") {
+        return false;
+      }
+      if (group.allowEmpty) {
+        return true;
+      }
+      return value.trim().length > 0;
+    });
+
+    if (!satisfied) {
+      const label = group.label ?? group.keys.join(" or ");
+      missingLabels.push(label);
+    }
+  }
+
+  if (missingLabels.length > 0) {
+    const joined = missingLabels.join(", ");
+    const noun = missingLabels.length === 1 ? "parameter" : "parameters";
+    throw parameterValidationError(`Missing required ${noun}: ${joined}`);
+  }
+}
+
+// Generic wrapper to normalize parameters for any tool
+export function wrapToolParamNormalization(
+  tool: AnyAgentTool,
+  requiredParamGroups?: readonly RequiredParamGroup[],
+): AnyAgentTool {
+  const patched = patchToolSchemaForClaudeCompatibility(tool);
+  return {
+    ...patched,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const normalized = normalizeToolParams(params);
+      const record =
+        normalized ??
+        (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
+      if (requiredParamGroups?.length) {
+        assertRequiredParams(record, requiredParamGroups, tool.name);
+      }
+      return tool.execute(toolCallId, normalized ?? params, signal, onUpdate);
+    },
+  };
+}
+
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
 }
@@ -476,8 +691,7 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
-  const withRecovery = wrapHostEditToolWithPostWriteRecovery(base, root);
-  return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
+  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
 }
 
 export function createOpenClawReadTool(
@@ -556,12 +770,6 @@ function createSandboxEditOperations(params: SandboxToolParams) {
   } as const;
 }
 
-async function writeHostFile(absolutePath: string, content: string) {
-  const resolved = path.resolve(absolutePath);
-  await fs.mkdir(path.dirname(resolved), { recursive: true });
-  await fs.writeFile(resolved, content, "utf-8");
-}
-
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
@@ -572,7 +780,12 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
         const resolved = path.resolve(dir);
         await fs.mkdir(resolved, { recursive: true });
       },
-      writeFile: writeHostFile,
+      writeFile: async (absolutePath: string, content: string) => {
+        const resolved = path.resolve(absolutePath);
+        const dir = path.dirname(resolved);
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(resolved, content, "utf-8");
+      },
     } as const;
   }
 
@@ -606,7 +819,12 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         const resolved = path.resolve(absolutePath);
         return await fs.readFile(resolved);
       },
-      writeFile: writeHostFile,
+      writeFile: async (absolutePath: string, content: string) => {
+        const resolved = path.resolve(absolutePath);
+        const dir = path.dirname(resolved);
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(resolved, content, "utf-8");
+      },
       access: async (absolutePath: string) => {
         const resolved = path.resolve(absolutePath);
         await fs.access(resolved);

--- a/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
+++ b/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from "vitest";
+import { withTempHomeConfig } from "../config/test-helpers.js";
+import { collectFallbackProviderWarnings } from "./doctor-config-flow.js";
+
+const { noteSpy } = vi.hoisted(() => ({
+  noteSpy: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: noteSpy,
+}));
+
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+
+describe("collectFallbackProviderWarnings", () => {
+  it("returns no warnings when fallbacks use built-in providers", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["google/gemini-2.5-pro", "openai/gpt-4.5"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns no warnings when fallbacks use explicitly defined providers", () => {
+    const warnings = collectFallbackProviderWarnings({
+      models: {
+        providers: {
+          "my-custom-provider": {
+            baseUrl: "https://example.com/v1",
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["my-custom-provider/my-model"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns when a fallback references an undefined provider", () => {
+    const warnings = collectFallbackProviderWarnings({
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            models: [],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["unknown-provider/some-model"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("agents.defaults.model.fallbacks[0]");
+    expect(warnings[0].entry).toBe("unknown-provider/some-model");
+    expect(warnings[0].provider).toBe("unknown-provider");
+  });
+
+  it("warns for undefined providers in imageModel fallbacks", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["nonexistent/image-model"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("agents.defaults.imageModel.fallbacks[0]");
+    expect(warnings[0].provider).toBe("nonexistent");
+  });
+
+  it("warns for undefined providers in per-agent fallbacks", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        list: [
+          {
+            id: "my-agent",
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["fake-provider/model-x"],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("agents.list[my-agent].model.fallbacks[0]");
+    expect(warnings[0].provider).toBe("fake-provider");
+  });
+
+  it("warns for undefined providers in subagent model fallbacks", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          subagents: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["missing-provider/sub-model"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("agents.defaults.subagents.model.fallbacks[0]");
+    expect(warnings[0].provider).toBe("missing-provider");
+  });
+
+  it("does not warn for CLI backend providers", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          cliBackends: {
+            "my-cli": {
+              command: "/usr/bin/my-cli",
+            },
+          },
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["my-cli/default"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("handles provider id normalization (z.ai -> zai)", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["z.ai/grok-3"],
+          },
+        },
+      },
+    });
+
+    // z.ai normalizes to zai which is a built-in provider
+    expect(warnings).toEqual([]);
+  });
+
+  it("handles empty or missing fallback arrays gracefully", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-6",
+        },
+        list: [{ id: "agent-no-fallbacks" }],
+      },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("reports multiple warnings across different scopes", () => {
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["bad-provider-1/model-a"],
+          },
+          imageModel: {
+            primary: "openai/gpt-4.5",
+            fallbacks: ["bad-provider-2/model-b"],
+          },
+        },
+        list: [
+          {
+            id: "agent-x",
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["bad-provider-3/model-c"],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(warnings).toHaveLength(3);
+    expect(warnings.map((w) => w.provider)).toEqual([
+      "bad-provider-1",
+      "bad-provider-2",
+      "bad-provider-3",
+    ]);
+  });
+});
+
+describe("doctor config flow fallback provider integration", () => {
+  it("surfaces fallback provider warnings during doctor scan", async () => {
+    noteSpy.mockReset();
+
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["undefined-provider/some-model"],
+            },
+          },
+        },
+      },
+      async () => {
+        await loadAndMaybeMigrateDoctorConfig({
+          options: { nonInteractive: true },
+          confirm: async () => false,
+        });
+      },
+    );
+
+    const fallbackWarnings = noteSpy.mock.calls.filter(
+      (call: unknown[]) => call[1] === "Fallback provider warnings",
+    );
+    expect(fallbackWarnings.length).toBeGreaterThan(0);
+    expect(String(fallbackWarnings[0][0])).toContain("undefined-provider");
+    expect(String(fallbackWarnings[0][0])).toContain("models.providers");
+  });
+
+  it("does not surface fallback warnings when all providers are known", async () => {
+    noteSpy.mockReset();
+
+    await withTempHomeConfig(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["google/gemini-2.5-pro"],
+            },
+          },
+        },
+      },
+      async () => {
+        await loadAndMaybeMigrateDoctorConfig({
+          options: { nonInteractive: true },
+          confirm: async () => false,
+        });
+      },
+    );
+
+    const fallbackWarnings = noteSpy.mock.calls.filter(
+      (call: unknown[]) => call[1] === "Fallback provider warnings",
+    );
+    expect(fallbackWarnings).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
+++ b/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
@@ -169,6 +169,42 @@ describe("collectFallbackProviderWarnings", () => {
     expect(warnings).toEqual([]);
   });
 
+  it("does not warn for implicit providers (resolved via env/credentials at runtime)", () => {
+    // These providers are discovered by resolveImplicitProviders and should
+    // not trigger false "undefined provider" warnings.
+    const implicitProviderRefs = [
+      "moonshot/moonshot-v1-128k",
+      "qwen-portal/qwen-max",
+      "volcengine/doubao-pro-32k",
+      "byteplus/doubao-pro-32k",
+      "venice/llama-3.3-70b",
+      "ollama/llama3",
+      "vllm/my-model",
+      "together/meta-llama/Llama-3-70b",
+      "nvidia/meta/llama-3.1-70b-instruct",
+      "kilocode/my-model",
+      "qianfan/ernie-4.0-8k",
+      "synthetic/synth-1",
+      "xiaomi/miai-model",
+      "minimax-portal/abab6-chat",
+      "cloudflare-ai-gateway/my-model",
+      "volcengine-plan/doubao-pro-32k",
+      "byteplus-plan/doubao-pro-32k",
+    ];
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: implicitProviderRefs,
+          },
+        },
+      },
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
   it("handles empty or missing fallback arrays gracefully", () => {
     const warnings = collectFallbackProviderWarnings({
       agents: {

--- a/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
+++ b/src/commands/doctor-config-flow.fallback-provider-warnings.test.ts
@@ -250,6 +250,70 @@ describe("collectFallbackProviderWarnings", () => {
       "bad-provider-3",
     ]);
   });
+
+  it("derives default provider from primary model for providerless fallbacks", () => {
+    // When the primary model is "openai/gpt-4.5", providerless fallback entries
+    // like "gpt-4o" should be treated as "openai/gpt-4o" (not "anthropic/gpt-4o").
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.5",
+            fallbacks: ["gpt-4o"],
+          },
+        },
+      },
+    });
+
+    // "openai" is a built-in provider, so no warnings expected.
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns for providerless fallback when primary uses a custom provider", () => {
+    // When the primary model uses a custom provider not in the known set,
+    // providerless fallbacks inherit that provider and should trigger a warning.
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "my-custom/my-model",
+            fallbacks: ["fallback-model"],
+          },
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].provider).toBe("my-custom");
+    expect(warnings[0].entry).toBe("fallback-model");
+  });
+
+  it("derives per-agent default provider from the agent model primary", () => {
+    // Per-agent fallbacks should use the agent's own primary model provider
+    // as the default, not the global default provider.
+    const warnings = collectFallbackProviderWarnings({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+          },
+        },
+        list: [
+          {
+            id: "openai-agent",
+            model: {
+              primary: "openai/gpt-4.5",
+              fallbacks: ["gpt-4o"],
+            },
+          },
+        ],
+      },
+    });
+
+    // "gpt-4o" should be resolved as "openai/gpt-4o" (from agent primary),
+    // not "anthropic/gpt-4o" (from global default).
+    expect(warnings).toEqual([]);
+  });
 });
 
 describe("doctor config flow fallback provider integration", () => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1844,12 +1844,14 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   }
 
   // Check agents.defaults.imageModel fallbacks.
+  // Runtime image failover (resolveImageFallbackCandidates) always uses DEFAULT_PROVIDER
+  // for providerless entries, not the text model's provider.
   const defaultImageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
   for (let i = 0; i < defaultImageFallbacks.length; i++) {
     checkFallback(
       `agents.defaults.imageModel.fallbacks[${i}]`,
       defaultImageFallbacks[i],
-      effectiveDefaultProvider,
+      DEFAULT_PROVIDER,
     );
   }
 
@@ -1864,8 +1866,9 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   }
 
   // Check per-agent fallbacks.
-  // Each agent may override the primary model, so derive its effective default
-  // provider from its own model primary (falling back to the global default).
+  // Runtime (resolveFallbackCandidates) always derives the default provider from
+  // the GLOBAL configured primary model, not the per-agent primary. Use the global
+  // effectiveDefaultProvider so validation matches runtime behavior.
   const agentList = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
   for (const agent of agentList) {
     if (!agent || typeof agent !== "object") {
@@ -1873,28 +1876,12 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
     }
     const agentId = typeof agent.id === "string" ? agent.id : "?";
 
-    // Derive per-agent default provider: if the agent specifies a model with an
-    // explicit provider prefix, use that; otherwise fall back to the global default.
-    const agentModelPrimary = (() => {
-      const raw =
-        typeof agent.model === "string"
-          ? agent.model.trim()
-          : agent.model && typeof agent.model === "object"
-            ? (agent.model.primary ?? "").trim()
-            : "";
-      if (!raw) {
-        return null;
-      }
-      return parseModelRef(raw, effectiveDefaultProvider);
-    })();
-    const agentDefaultProvider = agentModelPrimary?.provider ?? effectiveDefaultProvider;
-
     const agentFallbacks = resolveAgentModelFallbackValues(agent.model);
     for (let i = 0; i < agentFallbacks.length; i++) {
       checkFallback(
         `agents.list[${agentId}].model.fallbacks[${i}]`,
         agentFallbacks[i],
-        agentDefaultProvider,
+        effectiveDefaultProvider,
       );
     }
     const subagentModelFallbacks = resolveAgentModelFallbackValues(agent.subagents?.model);
@@ -1902,7 +1889,7 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
       checkFallback(
         `agents.list[${agentId}].subagents.model.fallbacks[${i}]`,
         subagentModelFallbacks[i],
-        agentDefaultProvider,
+        effectiveDefaultProvider,
       );
     }
   }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZodIssue } from "zod";
+import { normalizeProviderId, parseModelRef } from "../agents/model-selection.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
@@ -9,12 +10,16 @@ import {
 import { fetchTelegramChatId } from "../channels/telegram/api.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { CONFIG_PATH, migrateLegacyConfig, readConfigFileSnapshot } from "../config/config.js";
+import {
+  OpenClawSchema,
+  CONFIG_PATH,
+  migrateLegacyConfig,
+  readConfigFileSnapshot,
+} from "../config/config.js";
 import { collectProviderDangerousNameMatchingScopes } from "../config/dangerous-name-matching.js";
-import { formatConfigIssueLines } from "../config/issue-format.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { parseToolsBySenderTypedKey } from "../config/types.tools.js";
-import { OpenClawSchema } from "../config/zod-schema.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
 import {
   listInterpreterLikeSafeBins,
@@ -26,16 +31,7 @@ import {
   normalizeTrustedSafeBinDirs,
 } from "../infra/exec-safe-bin-trust.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
-import {
-  formatChannelAccountsDefaultPath,
-  formatSetExplicitDefaultInstruction,
-  formatSetExplicitDefaultToConfiguredInstruction,
-} from "../routing/default-account-warnings.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  normalizeAccountId,
-  normalizeOptionalAccountId,
-} from "../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import {
   isDiscordMutableAllowEntry,
   isGoogleChatMutableAllowEntry,
@@ -224,21 +220,15 @@ function normalizeBindingChannelKey(raw?: string | null): string {
   return (raw ?? "").trim().toLowerCase();
 }
 
-type ChannelMissingDefaultAccountContext = {
-  channelKey: string;
-  channel: Record<string, unknown>;
-  normalizedAccountIds: string[];
-};
-
-function collectChannelsMissingDefaultAccount(
-  cfg: OpenClawConfig,
-): ChannelMissingDefaultAccountContext[] {
+export function collectMissingDefaultAccountBindingWarnings(cfg: OpenClawConfig): string[] {
   const channels = asObjectRecord(cfg.channels);
   if (!channels) {
     return [];
   }
 
-  const contexts: ChannelMissingDefaultAccountContext[] = [];
+  const bindings = Array.isArray(cfg.bindings) ? cfg.bindings : [];
+  const warnings: string[] = [];
+
   for (const [channelKey, rawChannel] of Object.entries(channels)) {
     const channel = asObjectRecord(rawChannel);
     if (!channel) {
@@ -255,20 +245,10 @@ function collectChannelsMissingDefaultAccount(
           .map((accountId) => normalizeAccountId(accountId))
           .filter(Boolean),
       ),
-    ).toSorted((a, b) => a.localeCompare(b));
+    );
     if (normalizedAccountIds.length === 0 || normalizedAccountIds.includes(DEFAULT_ACCOUNT_ID)) {
       continue;
     }
-    contexts.push({ channelKey, channel, normalizedAccountIds });
-  }
-  return contexts;
-}
-
-export function collectMissingDefaultAccountBindingWarnings(cfg: OpenClawConfig): string[] {
-  const bindings = Array.isArray(cfg.bindings) ? cfg.bindings : [];
-  const warnings: string[] = [];
-
-  for (const { channelKey, normalizedAccountIds } of collectChannelsMissingDefaultAccount(cfg)) {
     const accountIdSet = new Set(normalizedAccountIds);
     const channelPattern = normalizeBindingChannelKey(channelKey);
 
@@ -316,43 +296,13 @@ export function collectMissingDefaultAccountBindingWarnings(cfg: OpenClawConfig)
     }
     if (coveredAccountIds.size > 0) {
       warnings.push(
-        `- channels.${channelKey}: accounts.default is missing and account bindings only cover a subset of configured accounts. Uncovered accounts: ${uncoveredAccountIds.join(", ")}. Add bindings[].match.accountId for uncovered accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
+        `- channels.${channelKey}: accounts.default is missing and account bindings only cover a subset of configured accounts. Uncovered accounts: ${uncoveredAccountIds.join(", ")}. Add bindings[].match.accountId for uncovered accounts (or "*"), or add channels.${channelKey}.accounts.default.`,
       );
       continue;
     }
 
     warnings.push(
-      `- channels.${channelKey}: accounts.default is missing and no valid account-scoped binding exists for configured accounts (${normalizedAccountIds.join(", ")}). Channel-only bindings (no accountId) match only default. Add bindings[].match.accountId for one of these accounts (or "*"), or add ${formatChannelAccountsDefaultPath(channelKey)}.`,
-    );
-  }
-
-  return warnings;
-}
-
-export function collectMissingExplicitDefaultAccountWarnings(cfg: OpenClawConfig): string[] {
-  const warnings: string[] = [];
-  for (const { channelKey, channel, normalizedAccountIds } of collectChannelsMissingDefaultAccount(
-    cfg,
-  )) {
-    if (normalizedAccountIds.length < 2) {
-      continue;
-    }
-
-    const preferredDefault = normalizeOptionalAccountId(
-      typeof channel.defaultAccount === "string" ? channel.defaultAccount : undefined,
-    );
-    if (preferredDefault) {
-      if (normalizedAccountIds.includes(preferredDefault)) {
-        continue;
-      }
-      warnings.push(
-        `- channels.${channelKey}: defaultAccount is set to "${preferredDefault}" but does not match configured accounts (${normalizedAccountIds.join(", ")}). ${formatSetExplicitDefaultToConfiguredInstruction({ channelKey })} to avoid fallback routing.`,
-      );
-      continue;
-    }
-
-    warnings.push(
-      `- channels.${channelKey}: multiple accounts are configured but no explicit default is set. ${formatSetExplicitDefaultInstruction(channelKey)} to avoid fallback routing.`,
+      `- channels.${channelKey}: accounts.default is missing and no valid account-scoped binding exists for configured accounts (${normalizedAccountIds.join(", ")}). Channel-only bindings (no accountId) match only default. Add bindings[].match.accountId for one of these accounts (or "*"), or add channels.${channelKey}.accounts.default.`,
     );
   }
 
@@ -1778,6 +1728,134 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
   return changes;
 }
 
+// Well-known providers built into pi-ai's model registry. These always have
+// model routing available without requiring explicit models.providers entries.
+const PI_BUILTIN_PROVIDERS = new Set([
+  "amazon-bedrock",
+  "anthropic",
+  "azure-openai-responses",
+  "cerebras",
+  "github-copilot",
+  "google",
+  "google-antigravity",
+  "google-gemini-cli",
+  "google-vertex",
+  "groq",
+  "huggingface",
+  "kimi-coding",
+  "minimax",
+  "minimax-cn",
+  "mistral",
+  "openai",
+  "openai-codex",
+  "opencode",
+  "openrouter",
+  "vercel-ai-gateway",
+  "xai",
+  "zai",
+]);
+
+type FallbackProviderWarning = {
+  /** Config path label (e.g. "agents.defaults.model.fallbacks[0]"). */
+  path: string;
+  /** The raw fallback entry string. */
+  entry: string;
+  /** The resolved (normalized) provider id. */
+  provider: string;
+  /** Defined provider ids for the hint message. */
+  definedProviders: string[];
+};
+
+/**
+ * Scan all fallback references in the config and flag any that reference
+ * providers not defined in models.providers and not a known built-in.
+ */
+export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackProviderWarning[] {
+  const explicitProviders = cfg.models?.providers;
+  const cliBackends = cfg.agents?.defaults?.cliBackends;
+
+  // Build the set of known provider ids (normalized).
+  const definedProviderIds = new Set(PI_BUILTIN_PROVIDERS);
+  if (explicitProviders) {
+    for (const key of Object.keys(explicitProviders)) {
+      definedProviderIds.add(normalizeProviderId(key));
+    }
+  }
+  if (cliBackends) {
+    for (const key of Object.keys(cliBackends)) {
+      definedProviderIds.add(normalizeProviderId(key));
+    }
+  }
+  // claude-cli and codex-cli are recognized CLI providers.
+  definedProviderIds.add("claude-cli");
+  definedProviderIds.add("codex-cli");
+
+  const definedList = [...definedProviderIds].toSorted();
+  const warnings: FallbackProviderWarning[] = [];
+
+  const DEFAULT_PROVIDER = "anthropic";
+
+  const checkFallback = (pathLabel: string, entry: string) => {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      return;
+    }
+    const ref = parseModelRef(trimmed, DEFAULT_PROVIDER);
+    if (!ref) {
+      return;
+    }
+    const normalized = normalizeProviderId(ref.provider);
+    if (!definedProviderIds.has(normalized)) {
+      warnings.push({
+        path: pathLabel,
+        entry: trimmed,
+        provider: normalized,
+        definedProviders: definedList,
+      });
+    }
+  };
+
+  // Check agents.defaults.model fallbacks.
+  const defaultModelFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
+  for (let i = 0; i < defaultModelFallbacks.length; i++) {
+    checkFallback(`agents.defaults.model.fallbacks[${i}]`, defaultModelFallbacks[i]);
+  }
+
+  // Check agents.defaults.imageModel fallbacks.
+  const defaultImageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
+  for (let i = 0; i < defaultImageFallbacks.length; i++) {
+    checkFallback(`agents.defaults.imageModel.fallbacks[${i}]`, defaultImageFallbacks[i]);
+  }
+
+  // Check agents.defaults.subagents.model fallbacks.
+  const subagentFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.subagents?.model);
+  for (let i = 0; i < subagentFallbacks.length; i++) {
+    checkFallback(`agents.defaults.subagents.model.fallbacks[${i}]`, subagentFallbacks[i]);
+  }
+
+  // Check per-agent fallbacks.
+  const agentList = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  for (const agent of agentList) {
+    if (!agent || typeof agent !== "object") {
+      continue;
+    }
+    const agentId = typeof agent.id === "string" ? agent.id : "?";
+    const agentFallbacks = resolveAgentModelFallbackValues(agent.model);
+    for (let i = 0; i < agentFallbacks.length; i++) {
+      checkFallback(`agents.list[${agentId}].model.fallbacks[${i}]`, agentFallbacks[i]);
+    }
+    const subagentModelFallbacks = resolveAgentModelFallbackValues(agent.subagents?.model);
+    for (let i = 0; i < subagentModelFallbacks.length; i++) {
+      checkFallback(
+        `agents.list[${agentId}].subagents.model.fallbacks[${i}]`,
+        subagentModelFallbacks[i],
+      );
+    }
+  }
+
+  return warnings;
+}
+
 export async function loadAndMaybeMigrateDoctorConfig(params: {
   options: DoctorOptions;
   confirm: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
@@ -1809,13 +1887,13 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
   const warnings = snapshot.warnings ?? [];
   if (warnings.length > 0) {
-    const lines = formatConfigIssueLines(warnings, "-").join("\n");
+    const lines = warnings.map((issue) => `- ${issue.path}: ${issue.message}`).join("\n");
     note(lines, "Config warnings");
   }
 
   if (snapshot.legacyIssues.length > 0) {
     note(
-      formatConfigIssueLines(snapshot.legacyIssues, "-").join("\n"),
+      snapshot.legacyIssues.map((issue) => `- ${issue.path}: ${issue.message}`).join("\n"),
       "Compatibility config keys detected",
     );
     const { config: migrated, changes } = migrateLegacyConfig(snapshot.parsed);
@@ -1866,10 +1944,6 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     collectMissingDefaultAccountBindingWarnings(candidate);
   if (missingDefaultAccountBindingWarnings.length > 0) {
     note(missingDefaultAccountBindingWarnings.join("\n"), "Doctor warnings");
-  }
-  const missingExplicitDefaultWarnings = collectMissingExplicitDefaultAccountWarnings(candidate);
-  if (missingExplicitDefaultWarnings.length > 0) {
-    note(missingExplicitDefaultWarnings.join("\n"), "Doctor warnings");
   }
 
   if (shouldRepair) {
@@ -2096,6 +2170,17 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   noteOpencodeProviderOverrides(cfg);
+
+  const fallbackProviderWarnings = collectFallbackProviderWarnings(cfg);
+  if (fallbackProviderWarnings.length > 0) {
+    const lines = fallbackProviderWarnings.map((w) => {
+      const definedHint =
+        w.definedProviders.length > 0 ? ` Defined providers: ${w.definedProviders.join(", ")}` : "";
+      return `- ${w.path}: "${w.entry}" references undefined provider "${w.provider}".${definedHint}`;
+    });
+    lines.push("- Fix: add the missing provider to models.providers or check for typos.");
+    note(lines.join("\n"), "Fallback provider warnings");
+  }
 
   return {
     cfg,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -3,9 +3,10 @@ import path from "node:path";
 import type { ZodIssue } from "zod";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
+  buildModelAliasIndex,
   normalizeProviderId,
-  parseModelRef,
   resolveConfiguredModelRef,
+  resolveModelRefFromString,
 } from "../agents/model-selection.js";
 import { IMPLICIT_PROVIDER_IDS } from "../agents/models-config.providers.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
@@ -1813,16 +1814,31 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   });
   const effectiveDefaultProvider = primaryRef.provider;
 
+  // Build the alias index so that fallback entries referencing model aliases
+  // (e.g. "backup") are resolved to their target provider, matching the runtime
+  // behavior in resolveFallbackCandidates / resolveModelRefFromString.
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: effectiveDefaultProvider,
+  });
+
   const checkFallback = (pathLabel: string, entry: string, defaultProvider: string) => {
     const trimmed = entry.trim();
     if (!trimmed) {
       return;
     }
-    const ref = parseModelRef(trimmed, defaultProvider);
-    if (!ref) {
+    // Use alias-aware resolution to match runtime behavior: if the entry is a
+    // configured model alias, resolve it to its target provider rather than
+    // treating it as a bare model name under the default provider.
+    const resolved = resolveModelRefFromString({
+      raw: trimmed,
+      defaultProvider,
+      aliasIndex,
+    });
+    if (!resolved) {
       return;
     }
-    const normalized = normalizeProviderId(ref.provider);
+    const normalized = normalizeProviderId(resolved.ref.provider);
     if (!definedProviderIds.has(normalized)) {
       warnings.push({
         path: pathLabel,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZodIssue } from "zod";
 import { normalizeProviderId, parseModelRef } from "../agents/model-selection.js";
+import { IMPLICIT_PROVIDER_IDS } from "../agents/models-config.providers.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import {
   isNumericTelegramUserId,
@@ -1775,7 +1776,10 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   const cliBackends = cfg.agents?.defaults?.cliBackends;
 
   // Build the set of known provider ids (normalized).
-  const definedProviderIds = new Set(PI_BUILTIN_PROVIDERS);
+  // Include built-in providers and implicit providers (those discovered at
+  // runtime via env/credentials in resolveImplicitProviders) so that valid
+  // fallback refs for implicitly available providers don't trigger false warnings.
+  const definedProviderIds = new Set([...PI_BUILTIN_PROVIDERS, ...IMPLICIT_PROVIDER_IDS]);
   if (explicitProviders) {
     for (const key of Object.keys(explicitProviders)) {
       definedProviderIds.add(normalizeProviderId(key));

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ZodIssue } from "zod";
-import { normalizeProviderId, parseModelRef } from "../agents/model-selection.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import {
+  normalizeProviderId,
+  parseModelRef,
+  resolveConfiguredModelRef,
+} from "../agents/model-selection.js";
 import { IMPLICIT_PROVIDER_IDS } from "../agents/models-config.providers.js";
 import { normalizeChatChannelId } from "../channels/registry.js";
 import {
@@ -1797,14 +1802,23 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   const definedList = [...definedProviderIds].toSorted();
   const warnings: FallbackProviderWarning[] = [];
 
-  const DEFAULT_PROVIDER = "anthropic";
+  // Derive the effective default provider from the configured primary model,
+  // matching the runtime behavior in resolveFallbackCandidates (model-fallback.ts).
+  // This ensures providerless fallback entries like "fallback-model" are validated
+  // against the same provider that the runtime would infer, not a hardcoded "anthropic".
+  const primaryRef = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const effectiveDefaultProvider = primaryRef.provider;
 
-  const checkFallback = (pathLabel: string, entry: string) => {
+  const checkFallback = (pathLabel: string, entry: string, defaultProvider: string) => {
     const trimmed = entry.trim();
     if (!trimmed) {
       return;
     }
-    const ref = parseModelRef(trimmed, DEFAULT_PROVIDER);
+    const ref = parseModelRef(trimmed, defaultProvider);
     if (!ref) {
       return;
     }
@@ -1822,37 +1836,73 @@ export function collectFallbackProviderWarnings(cfg: OpenClawConfig): FallbackPr
   // Check agents.defaults.model fallbacks.
   const defaultModelFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
   for (let i = 0; i < defaultModelFallbacks.length; i++) {
-    checkFallback(`agents.defaults.model.fallbacks[${i}]`, defaultModelFallbacks[i]);
+    checkFallback(
+      `agents.defaults.model.fallbacks[${i}]`,
+      defaultModelFallbacks[i],
+      effectiveDefaultProvider,
+    );
   }
 
   // Check agents.defaults.imageModel fallbacks.
   const defaultImageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
   for (let i = 0; i < defaultImageFallbacks.length; i++) {
-    checkFallback(`agents.defaults.imageModel.fallbacks[${i}]`, defaultImageFallbacks[i]);
+    checkFallback(
+      `agents.defaults.imageModel.fallbacks[${i}]`,
+      defaultImageFallbacks[i],
+      effectiveDefaultProvider,
+    );
   }
 
   // Check agents.defaults.subagents.model fallbacks.
   const subagentFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.subagents?.model);
   for (let i = 0; i < subagentFallbacks.length; i++) {
-    checkFallback(`agents.defaults.subagents.model.fallbacks[${i}]`, subagentFallbacks[i]);
+    checkFallback(
+      `agents.defaults.subagents.model.fallbacks[${i}]`,
+      subagentFallbacks[i],
+      effectiveDefaultProvider,
+    );
   }
 
   // Check per-agent fallbacks.
+  // Each agent may override the primary model, so derive its effective default
+  // provider from its own model primary (falling back to the global default).
   const agentList = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
   for (const agent of agentList) {
     if (!agent || typeof agent !== "object") {
       continue;
     }
     const agentId = typeof agent.id === "string" ? agent.id : "?";
+
+    // Derive per-agent default provider: if the agent specifies a model with an
+    // explicit provider prefix, use that; otherwise fall back to the global default.
+    const agentModelPrimary = (() => {
+      const raw =
+        typeof agent.model === "string"
+          ? agent.model.trim()
+          : agent.model && typeof agent.model === "object"
+            ? (agent.model.primary ?? "").trim()
+            : "";
+      if (!raw) {
+        return null;
+      }
+      return parseModelRef(raw, effectiveDefaultProvider);
+    })();
+    const agentDefaultProvider = agentModelPrimary?.provider ?? effectiveDefaultProvider;
+
     const agentFallbacks = resolveAgentModelFallbackValues(agent.model);
     for (let i = 0; i < agentFallbacks.length; i++) {
-      checkFallback(`agents.list[${agentId}].model.fallbacks[${i}]`, agentFallbacks[i]);
+      checkFallback(
+        `agents.list[${agentId}].model.fallbacks[${i}]`,
+        agentFallbacks[i],
+        agentDefaultProvider,
+      );
     }
     const subagentModelFallbacks = resolveAgentModelFallbackValues(agent.subagents?.model);
     for (let i = 0; i < subagentModelFallbacks.length; i++) {
       checkFallback(
         `agents.list[${agentId}].subagents.model.fallbacks[${i}]`,
         subagentModelFallbacks[i],
+        agentDefaultProvider,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Add collectFallbackProviderWarnings() to doctor config flow
- Warns when fallback models reference undefined providers
- Covers defaults, per-agent, subagent, and imageModel fallback scopes
- Closes #20909

## Test plan
- [ ] Run openclaw doctor with undefined fallback providers → see warnings
- [ ] Run with valid providers → no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)