### PR TITLE
fix(agents): harden NVIDIA MiniMax payload compatibility (#28516)

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -171,6 +171,36 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
+  it("applies NVIDIA MiniMax compat defaults on provider fallback models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          nvidia: {
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("nvidia", "minimaxai/minimax-m2.5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "nvidia",
+      id: "minimaxai/minimax-m2.5",
+      api: "openai-completions",
+      compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        supportsUsageInStreaming: false,
+        maxTokensField: "max_tokens",
+      },
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `provider=nvidia` with model IDs like `minimaxai/minimax-m2.5` can fail with `400 'str object' has no attribute 'items'` because OpenClaw sends OpenAI fields that NVIDIA MiniMax endpoints do not reliably accept.
- Why it matters: basic `openclaw tui` chat fails for affected NVIDIA MiniMax setups, blocking normal usage.
- What changed: added NVIDIA+MiniMax compat defaults to disable unsupported OpenAI payload fields (`reasoning_effort`, `store`, `stream_options`) and force `max_tokens` over `max_completion_tokens`; applied both in provider normalization and runtime model-compat fallback paths.
- What did NOT change (scope boundary): no provider catalog expansion, no auth flow changes, no unrelated model routing logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28516
- Related #

## User-visible / Behavior Changes

- NVIDIA MiniMax sessions now avoid unsupported OpenAI-format request fields by default, which prevents 400 errors for affected configs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS (issue report), validated in repo tests
- Runtime/container: OpenClaw 2026.2.26
- Model/provider: `nvidia` + `minimaxai/minimax-m2.5`
- Integration/channel (if any): TUI / embedded PI runner
- Relevant config (redacted): `models.providers.nvidia` with MiniMax model ID

### Steps

1. Configure/use provider `nvidia` with model `minimaxai/minimax-m2.5`.
2. Start `openclaw tui`.
3. Send a simple prompt like `hi`.

### Expected

- Basic chat completes successfully.

### Actual

- Request fails with `400 'str object' has no attribute 'items'`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted unit tests for provider normalization, runtime compatibility normalization, and resolveModel fallback behavior now all pass.
- Edge cases checked: explicit compat overrides remain preserved; non-NVIDIA/MiniMax models remain unaffected.
- What you did **not** verify: live NVIDIA endpoint invocation in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `97f0307e4`.
- Files/config to restore: `src/agents/model-compat.ts`, `src/agents/models-config.providers.ts`.
- Known bad symptoms reviewers should watch for: NVIDIA MiniMax requests unexpectedly using `reasoning_effort` or `max_completion_tokens` again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some NVIDIA MiniMax deployments may actually support newer fields and lose optional behavior.
  - Mitigation: defaults only apply when compat fields are undefined; explicit model compat overrides are preserved.
