### PR TITLE
fix(wizard): auto-add Tailscale origin to controlUi.allowedOrigins

### DIFF
--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   buildGatewayAuthConfig: vi.fn(),
   note: vi.fn(),
   randomToken: vi.fn(),
+  getTailnetHostname: vi.fn(),
 }));
 
 vi.mock("../config/config.js", async (importActual) => {
@@ -35,6 +36,7 @@ vi.mock("./configure.gateway-auth.js", () => ({
 
 vi.mock("../infra/tailscale.js", () => ({
   findTailscaleBinary: vi.fn(async () => undefined),
+  getTailnetHostname: mocks.getTailnetHostname,
 }));
 
 vi.mock("./onboard-helpers.js", async (importActual) => {
@@ -153,5 +155,70 @@ describe("promptGatewayConfig", () => {
     expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.tailscale?.mode).toBe("off");
     expect(result.config.gateway?.tailscale?.resetOnExit).toBe(false);
+  });
+
+  it("adds Tailscale origin to controlUi.allowedOrigins when tailscale serve is enabled", async () => {
+    mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
+    const { result } = await runGatewayPrompt({
+      // bind=loopback, auth=token, tailscale=serve
+      selectQueue: ["loopback", "token", "serve"],
+      textQueue: ["18789", "my-token"],
+      confirmResult: true,
+      authConfigFactory: ({ mode, token }) => ({ mode, token }),
+    });
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain(
+      "https://my-host.tail1234.ts.net",
+    );
+  });
+
+  it("adds Tailscale origin to controlUi.allowedOrigins when tailscale funnel is enabled", async () => {
+    mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
+    const { result } = await runGatewayPrompt({
+      // bind=loopback, auth=password (funnel requires password), tailscale=funnel
+      selectQueue: ["loopback", "password", "funnel"],
+      textQueue: ["18789", "my-password"],
+      confirmResult: true,
+      authConfigFactory: ({ mode, password }) => ({ mode, password }),
+    });
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toContain(
+      "https://my-host.tail1234.ts.net",
+    );
+  });
+
+  it("does not add Tailscale origin when getTailnetHostname fails", async () => {
+    mocks.getTailnetHostname.mockRejectedValue(new Error("not found"));
+    const { result } = await runGatewayPrompt({
+      selectQueue: ["loopback", "token", "serve"],
+      textQueue: ["18789", "my-token"],
+      confirmResult: true,
+      authConfigFactory: ({ mode, token }) => ({ mode, token }),
+    });
+    expect(result.config.gateway?.controlUi?.allowedOrigins).toBeUndefined();
+  });
+
+  it("does not duplicate Tailscale origin if already present", async () => {
+    mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
+    vi.clearAllMocks();
+    mocks.resolveGatewayPort.mockReturnValue(18789);
+    mocks.select.mockImplementation(async () => ["loopback", "token", "serve"].shift());
+    mocks.text.mockImplementation(async () => ["18789", "my-token"].shift());
+    mocks.randomToken.mockReturnValue("generated-token");
+    mocks.confirm.mockResolvedValue(true);
+    mocks.buildGatewayAuthConfig.mockImplementation((input) => input);
+    mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
+
+    const result = await promptGatewayConfig(
+      {
+        gateway: {
+          controlUi: {
+            allowedOrigins: ["https://my-host.tail1234.ts.net"],
+          },
+        },
+      },
+      makeRuntime(),
+    );
+    const origins = result.config.gateway?.controlUi?.allowedOrigins ?? [];
+    const tsOriginCount = origins.filter((o) => o === "https://my-host.tail1234.ts.net").length;
+    expect(tsOriginCount).toBe(1);
   });
 });

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -111,8 +111,10 @@ export async function promptGatewayConfig(
   );
 
   // Detect Tailscale binary before proceeding with serve/funnel setup.
+  // Persist the path so getTailnetHostname can reuse it for origin injection.
+  let tailscaleBin: string | null = null;
   if (tailscaleMode !== "off") {
-    const tailscaleBin = await findTailscaleBinary();
+    tailscaleBin = await findTailscaleBinary();
     if (!tailscaleBin) {
       note(TAILSCALE_MISSING_BIN_NOTE_LINES.join("\n"), "Tailscale Warning");
     }
@@ -288,7 +290,7 @@ export async function promptGatewayConfig(
   // Auto-add Tailscale origin to controlUi.allowedOrigins so the Control UI
   // is accessible via the Tailscale hostname without manual config.
   if (tailscaleMode === "serve" || tailscaleMode === "funnel") {
-    const tsOrigin = await getTailnetHostname()
+    const tsOrigin = await getTailnetHostname(undefined, tailscaleBin ?? undefined)
       .then((h) => `https://${h}`)
       .catch(() => null);
     if (tsOrigin) {

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -5,7 +5,7 @@ import {
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
-import { findTailscaleBinary } from "../infra/tailscale.js";
+import { findTailscaleBinary, getTailnetHostname } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 import { note } from "../terminal/note.js";
@@ -284,6 +284,29 @@ export async function promptGatewayConfig(
       },
     },
   };
+
+  // Auto-add Tailscale origin to controlUi.allowedOrigins so the Control UI
+  // is accessible via the Tailscale hostname without manual config.
+  if (tailscaleMode === "serve" || tailscaleMode === "funnel") {
+    const tsOrigin = await getTailnetHostname()
+      .then((h) => `https://${h}`)
+      .catch(() => null);
+    if (tsOrigin) {
+      const existing = next.gateway?.controlUi?.allowedOrigins ?? [];
+      if (!existing.some((o) => o.toLowerCase() === tsOrigin.toLowerCase())) {
+        next = {
+          ...next,
+          gateway: {
+            ...next.gateway,
+            controlUi: {
+              ...next.gateway?.controlUi,
+              allowedOrigins: [...existing, tsOrigin],
+            },
+          },
+        };
+      }
+    }
+  }
 
   return { config: next, port, token: gatewayToken };
 }

--- a/src/wizard/onboarding.gateway-config.test.ts
+++ b/src/wizard/onboarding.gateway-config.test.ts
@@ -5,6 +5,7 @@ import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
 
 const mocks = vi.hoisted(() => ({
   randomToken: vi.fn(),
+  getTailnetHostname: vi.fn(),
 }));
 
 vi.mock("../commands/onboard-helpers.js", async (importActual) => {
@@ -17,6 +18,7 @@ vi.mock("../commands/onboard-helpers.js", async (importActual) => {
 
 vi.mock("../infra/tailscale.js", () => ({
   findTailscaleBinary: vi.fn(async () => undefined),
+  getTailnetHostname: mocks.getTailnetHostname,
 }));
 
 import { configureGatewayForOnboarding } from "./onboarding.gateway-config.js";
@@ -135,5 +137,53 @@ describe("configureGatewayForOnboarding", () => {
       "http://localhost:18789",
       "http://127.0.0.1:18789",
     ]);
+  });
+
+  it("adds Tailscale origin to controlUi.allowedOrigins when tailscale serve is enabled", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+    mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
+
+    const prompter = createPrompter({
+      selectQueue: ["loopback", "token", "serve"],
+      textQueue: ["18789", undefined],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForOnboarding({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: createQuickstartGateway("token"),
+      prompter,
+      runtime,
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowedOrigins).toContain(
+      "https://my-host.tail1234.ts.net",
+    );
+  });
+
+  it("does not add Tailscale origin when getTailnetHostname fails", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+    mocks.getTailnetHostname.mockRejectedValue(new Error("not found"));
+
+    const prompter = createPrompter({
+      selectQueue: ["loopback", "token", "serve"],
+      textQueue: ["18789", undefined],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForOnboarding({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: createQuickstartGateway("token"),
+      prompter,
+      runtime,
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowedOrigins).toBeUndefined();
   });
 });

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -137,8 +137,10 @@ export async function configureGatewayForOnboarding(
         });
 
   // Detect Tailscale binary before proceeding with serve/funnel setup.
+  // Persist the path so getTailnetHostname can reuse it for origin injection.
+  let tailscaleBin: string | null = null;
   if (tailscaleMode !== "off") {
-    const tailscaleBin = await findTailscaleBinary();
+    tailscaleBin = await findTailscaleBinary();
     if (!tailscaleBin) {
       await prompter.note(TAILSCALE_MISSING_BIN_NOTE_LINES.join("\n"), "Tailscale Warning");
     }
@@ -256,7 +258,7 @@ export async function configureGatewayForOnboarding(
   // Auto-add Tailscale origin to controlUi.allowedOrigins so the Control UI
   // is accessible via the Tailscale hostname without manual config.
   if (tailscaleMode === "serve" || tailscaleMode === "funnel") {
-    const tsOrigin = await getTailnetHostname()
+    const tsOrigin = await getTailnetHostname(undefined, tailscaleBin ?? undefined)
       .then((h) => `https://${h}`)
       .catch(() => null);
     if (tsOrigin) {

--- a/src/wizard/onboarding.gateway-config.ts
+++ b/src/wizard/onboarding.gateway-config.ts
@@ -10,7 +10,7 @@ import {
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
-import { findTailscaleBinary } from "../infra/tailscale.js";
+import { findTailscaleBinary, getTailnetHostname } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 import type {
@@ -251,6 +251,29 @@ export async function configureGatewayForOnboarding(
         },
       },
     };
+  }
+
+  // Auto-add Tailscale origin to controlUi.allowedOrigins so the Control UI
+  // is accessible via the Tailscale hostname without manual config.
+  if (tailscaleMode === "serve" || tailscaleMode === "funnel") {
+    const tsOrigin = await getTailnetHostname()
+      .then((h) => `https://${h}`)
+      .catch(() => null);
+    if (tsOrigin) {
+      const existing = nextConfig.gateway?.controlUi?.allowedOrigins ?? [];
+      if (!existing.some((o) => o.toLowerCase() === tsOrigin.toLowerCase())) {
+        nextConfig = {
+          ...nextConfig,
+          gateway: {
+            ...nextConfig.gateway,
+            controlUi: {
+              ...nextConfig.gateway?.controlUi,
+              allowedOrigins: [...existing, tsOrigin],
+            },
+          },
+        };
+      }
+    }
   }
 
   // If this is a new gateway setup (no existing gateway settings), start with a


### PR DESCRIPTION
## Summary
- Auto-add Tailscale HTTPS origin to controlUi.allowedOrigins during gateway configure and onboarding
- Handles both serve and funnel modes, graceful failure, duplicate prevention
- Closes #27877

## Test plan
- [ ] Run configure with Tailscale serve → verify origin added
- [ ] Run with Tailscale off → verify no origin added
- [ ] Verify no duplicates when origin already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)