### PR TITLE
Telegram: avoid process-wide undici dispatcher mutation

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -872,7 +872,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
         compat: { supportsStore: false },
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -5,11 +5,6 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const AgentCtor = vi.hoisted(() =>
-  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
-    this.options = options;
-  }),
-);
 
 vi.mock("node:net", async () => {
   const actual = await vi.importActual<typeof import("node:net")>("node:net");
@@ -28,7 +23,6 @@ vi.mock("node:dns", async () => {
 });
 
 vi.mock("undici", () => ({
-  Agent: AgentCtor,
   setGlobalDispatcher,
 }));
 
@@ -39,7 +33,6 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
-  AgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -147,44 +140,11 @@ describe("resolveTelegramFetch", () => {
     expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
   });
 
-  it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenCalledWith({
-      connect: {
-        autoSelectFamily: true,
-        autoSelectFamilyAttemptTimeout: 300,
-      },
-    });
-  });
-
-  it("sets global dispatcher only once across repeated equal decisions", async () => {
-    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
-
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-  });
-
-  it("updates global dispatcher when autoSelectFamily decision changes", async () => {
+  it("does not mutate global undici dispatcher", async () => {
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
-      connect: {
-        autoSelectFamily: true,
-        autoSelectFamilyAttemptTimeout: 300,
-      },
-    });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
-      connect: {
-        autoSelectFamily: false,
-        autoSelectFamilyAttemptTimeout: 300,
-      },
-    });
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,5 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -11,7 +10,6 @@ import {
 
 let appliedAutoSelectFamily: boolean | null = null;
 let appliedDnsResultOrder: string | null = null;
-let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 
 // Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
@@ -30,33 +28,6 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
       } catch {
         // ignore if unsupported by the runtime
       }
-    }
-  }
-
-  // Node 22's built-in globalThis.fetch uses undici's internal Agent whose
-  // connect options are frozen at construction time. Calling
-  // net.setDefaultAutoSelectFamily() after that agent is created has no
-  // effect on it. Replace the global dispatcher with one that carries the
-  // current autoSelectFamily setting so subsequent globalThis.fetch calls
-  // inherit the same decision.
-  // See: https://github.com/openclaw/openclaw/issues/25676
-  if (
-    autoSelectDecision.value !== null &&
-    autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
-  ) {
-    try {
-      setGlobalDispatcher(
-        new Agent({
-          connect: {
-            autoSelectFamily: autoSelectDecision.value,
-            autoSelectFamilyAttemptTimeout: 300,
-          },
-        }),
-      );
-      appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-      log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
-    } catch {
-      // ignore if setGlobalDispatcher is unavailable
     }
   }
 
@@ -97,5 +68,4 @@ export function resolveTelegramFetch(
 export function resetTelegramFetchStateForTests(): void {
   appliedAutoSelectFamily = null;
   appliedDnsResultOrder = null;
-  appliedGlobalDispatcherAutoSelectFamily = null;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: #25676 fixed the original Telegram Node 22 fetch regression by replacing undici's global dispatcher (#25682), but that process-wide mutation still leaks Telegram networking decisions into unrelated outbound fetch clients.
- Why it matters: in shared gateway processes, non-Telegram requests can regress after Telegram initialization (for example provider/API calls that rely on different dispatcher/proxy behavior).
- What changed: removed Telegram's `setGlobalDispatcher(new Agent(...))` path and kept existing `net.setDefaultAutoSelectFamily` / `dns.setDefaultResultOrder` decision flow.
- What did NOT change (scope boundary): Telegram proxy wiring, DNS result-order logic, and fetch wrapping behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #25676
- Related #25682
- Related #23600

## User-visible / Behavior Changes

- Telegram no longer rewrites the process-global undici dispatcher.
- Telegram setup no longer changes dispatcher state for unrelated fetch consumers in the same process.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node 24 local dev runtime
- Model/provider: N/A
- Integration/channel (if any): Telegram + gateway outbound API fetch
- Relevant config (redacted): Telegram `network.autoSelectFamily` enabled path

### Steps

1. Start gateway with Telegram channel enabled.
2. Trigger Telegram setup path that calls `resolveTelegramFetch`.
3. Observe outbound fetch behavior for non-Telegram callers in the same process.

### Expected

- Telegram setup should not mutate global dispatcher state used by unrelated fetch clients.

### Actual

- Before this patch, Telegram path replaced global undici dispatcher.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing after patch:

- `pnpm exec vitest run --config vitest.unit.config.ts src/telegram/fetch.test.ts src/telegram/send.proxy.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Telegram fetch resolution with and without `autoSelectFamily` overrides.
- Edge cases checked: repeated calls and decision changes do not call `setGlobalDispatcher`.
- What you did **not** verify: full live Telegram E2E in this upstream clone.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/telegram/fetch.ts`, `src/telegram/fetch.test.ts`
- Known bad symptoms reviewers should watch for: Telegram requests failing on IPv6-broken networks if no alternative path provides IPv4 fallback.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: removing global dispatcher mutation may reduce Telegram-specific fallback effectiveness in environments that relied on that side effect.
  - Mitigation: existing `net.setDefaultAutoSelectFamily` and `dnsResultOrder` decisions remain, and this change avoids process-wide regressions for unrelated fetch callers.
