### PR TITLE
Fix session store lock queue timeout handling

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -9,6 +9,7 @@ import {
   mergeSessionEntry,
   resolveAndPersistSessionFile,
   updateSessionStore,
+  withSessionStoreLockForTest,
 } from "../sessions.js";
 import type { SessionConfig } from "../types.base.js";
 import {
@@ -215,6 +216,32 @@ describe("session store lock (Promise chain mutex)", () => {
 
     const store = loadSessionStore(storePath);
     expect(store[key]?.modelOverride).toBe("recovered");
+  });
+
+  it("enforces timeout while waiting in the in-process queue", { timeout: 10_000 }, async () => {
+    const { storePath } = await makeTmpStore({
+      "agent:main:timeout": { sessionId: "s1", updatedAt: 100 },
+    });
+
+    const slow = withSessionStoreLockForTest(
+      storePath,
+      async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return "slow";
+      },
+      { timeoutMs: 1000 },
+    );
+
+    const startedAt = Date.now();
+    const fast = withSessionStoreLockForTest(storePath, async () => "fast", { timeoutMs: 50 });
+    const fastExpectation = expect(fast).rejects.toThrow(/timeout waiting for session store lock/);
+
+    await fastExpectation;
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(40);
+    expect(elapsedMs).toBeLessThan(500);
+
+    await expect(slow).resolves.toBe("slow");
   });
 
   it("clears stale runtime provider when model is patched without provider", () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -172,6 +172,11 @@ export function clearSessionStoreCacheForTest(): void {
   SESSION_STORE_CACHE.clear();
   for (const queue of LOCK_QUEUES.values()) {
     for (const task of queue.pending) {
+      task.done = true;
+      if (task.timer) {
+        clearTimeout(task.timer);
+        task.timer = undefined;
+      }
       task.reject(new Error("session store queue cleared for test"));
     }
   }
@@ -890,6 +895,10 @@ type SessionStoreLockTask = {
   reject: (reason: unknown) => void;
   timeoutMs?: number;
   staleMs: number;
+  enqueuedAt: number;
+  started: boolean;
+  done: boolean;
+  timer?: NodeJS.Timeout;
 };
 
 type SessionStoreLockQueue = {
@@ -925,11 +934,30 @@ async function drainSessionStoreLockQueue(storePath: string): Promise<void> {
       if (!task) {
         continue;
       }
+      if (task.done) {
+        continue;
+      }
 
-      const remainingTimeoutMs = task.timeoutMs ?? Number.POSITIVE_INFINITY;
+      // Timeout accounting includes time spent waiting in the in-process queue.
+      // Otherwise callers can hang for unbounded time under contention even when
+      // providing a small timeout.
+      const elapsedMs = Date.now() - task.enqueuedAt;
+      const remainingTimeoutMs =
+        task.timeoutMs == null ? Number.POSITIVE_INFINITY : task.timeoutMs - elapsedMs;
       if (task.timeoutMs != null && remainingTimeoutMs <= 0) {
+        task.done = true;
+        if (task.timer) {
+          clearTimeout(task.timer);
+          task.timer = undefined;
+        }
         task.reject(lockTimeoutError(storePath));
         continue;
+      }
+
+      task.started = true;
+      if (task.timer) {
+        clearTimeout(task.timer);
+        task.timer = undefined;
       }
 
       let lock: { release: () => Promise<void> } | undefined;
@@ -949,6 +977,7 @@ async function drainSessionStoreLockQueue(storePath: string): Promise<void> {
       } finally {
         await lock?.release().catch(() => undefined);
       }
+      task.done = true;
       if (hasFailure) {
         task.reject(failed);
         continue;
@@ -992,7 +1021,29 @@ async function withSessionStoreLock<T>(
       reject,
       timeoutMs: hasTimeout ? timeoutMs : undefined,
       staleMs,
+      enqueuedAt: Date.now(),
+      started: false,
+      done: false,
     };
+
+    if (hasTimeout) {
+      task.timer = setTimeout(() => {
+        // If we haven't started yet, remove from the pending queue and reject.
+        if (task.done || task.started) {
+          return;
+        }
+        task.done = true;
+        const idx = queue.pending.indexOf(task);
+        if (idx >= 0) {
+          queue.pending.splice(idx, 1);
+        }
+        reject(lockTimeoutError(storePath));
+        if (!queue.running && queue.pending.length === 0) {
+          LOCK_QUEUES.delete(storePath);
+        }
+      }, timeoutMs);
+      task.timer.unref?.();
+    }
 
     queue.pending.push(task);
     void drainSessionStoreLockQueue(storePath);


### PR DESCRIPTION
### Problem
OpenClaw’s in-process session store mutex (`withSessionStoreLock`) accepted a per-call `timeoutMs`, but the timeout only applied once a task reached the front of the queue. Under contention, callers could block far longer than their timeout, which looked like a gateway hang.

### Fix
- Track enqueue time + started/done state per lock task.
- Enforce timeouts while waiting in the queue (proactively via a timer, and defensively when dequeued).
- Pass the *remaining* timeout to `acquireSessionWriteLock` so lock contention respects the caller’s overall deadline.
- Ensure test cleanup clears any outstanding timers.

### Tests
- Added a unit test that holds the lock briefly, then asserts a second queued call with a small timeout rejects quickly (without waiting for the first to finish).

### Notes
This keeps the existing Promise-chain queue semantics but prevents unbounded waiting time under load.