### PR TITLE
fix(hooks): preserve plugin-registered hooks across gateway startup

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -13,11 +13,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
-import {
-  clearInternalHooks,
-  createInternalHookEvent,
-  triggerInternalHook,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
@@ -109,9 +105,9 @@ export async function startGatewaySidecars(params: {
   }
 
   // Load internal hook handlers from configuration and directory discovery.
+  // clearInternalHooks() moved to server.impl.ts (before plugin loading).
+  // loadInternalHooks() handles its own cleanup on hot-reload.
   try {
-    // Clear any previously registered hooks to ensure fresh loading
-    clearInternalHooks();
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
       params.logHooks.info(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -20,6 +20,7 @@ import {
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -381,6 +382,8 @@ export async function startGatewayServer(
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
+  // Clear hooks before plugins register theirs (#25859).
+  clearInternalHooks();
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -348,4 +348,80 @@ describe("loader", () => {
       expect(getRegisteredEventKeys()).not.toContain("command:new");
     });
   });
+
+  describe("hot-reload safety", () => {
+    it("should not duplicate file-based handlers when called twice", async () => {
+      const hookDir = path.join(tmpDir, "hooks", "test-dedup");
+      await fs.mkdir(hookDir, { recursive: true });
+      await fs.writeFile(
+        path.join(hookDir, "HOOK.md"),
+        [
+          "---",
+          "name: test-dedup",
+          "description: dedup test",
+          'metadata: {"openclaw":{"events":["command:new"]}}',
+          "---",
+          "",
+          "# Dedup Hook",
+        ].join("\n"),
+      );
+      await fs.writeFile(
+        path.join(hookDir, "handler.js"),
+        "export default async function(event) { event.messages.push('dedup-test'); }",
+      );
+
+      const cfg = createEnabledHooksConfig();
+
+      // Load twice (simulates hot-reload)
+      await loadInternalHooks(cfg, tmpDir);
+      await loadInternalHooks(cfg, tmpDir);
+
+      // Trigger and verify handler only fires once
+      const event = createInternalHookEvent("command", "new", "test-session", {});
+      await triggerInternalHook(event);
+      const dedupMessages = event.messages.filter((m) => m === "dedup-test");
+      expect(dedupMessages).toHaveLength(1);
+    });
+
+    it("should preserve plugin-registered hooks across reload", async () => {
+      const { registerInternalHook } = await import("./internal-hooks.js");
+
+      // Simulate a plugin hook registered via api.registerHook()
+      const pluginHandler = async (event: { messages: string[] }) => {
+        event.messages.push("plugin-hook");
+      };
+      registerInternalHook("command:new", pluginHandler);
+
+      // Set up a file-based hook
+      const hookDir = path.join(tmpDir, "hooks", "test-preserve");
+      await fs.mkdir(hookDir, { recursive: true });
+      await fs.writeFile(
+        path.join(hookDir, "HOOK.md"),
+        [
+          "---",
+          "name: test-preserve",
+          "description: preserve test",
+          'metadata: {"openclaw":{"events":["command:new"]}}',
+          "---",
+          "",
+          "# Preserve Hook",
+        ].join("\n"),
+      );
+      await fs.writeFile(
+        path.join(hookDir, "handler.js"),
+        "export default async function(event) { event.messages.push('file-hook'); }",
+      );
+
+      const cfg = createEnabledHooksConfig();
+
+      // Load file-based hooks (simulates startGatewaySidecars)
+      await loadInternalHooks(cfg, tmpDir);
+
+      // Trigger and verify both hooks fire
+      const event = createInternalHookEvent("command", "new", "test-session", {});
+      await triggerInternalHook(event);
+      expect(event.messages).toContain("plugin-hook");
+      expect(event.messages).toContain("file-hook");
+    });
+  });
 });

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -14,11 +14,14 @@ import { resolveHookConfig } from "./config.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildImportUrl } from "./import-url.js";
 import type { InternalHookHandler } from "./internal-hooks.js";
-import { registerInternalHook } from "./internal-hooks.js";
+import { registerInternalHook, unregisterInternalHook } from "./internal-hooks.js";
 import { resolveFunctionModuleExport } from "./module-loader.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
 
 const log = createSubsystemLogger("hooks:loader");
+
+// Tracks file-based handlers for cleanup on hot-reload.
+const fileRegisteredHandlers: Array<{ event: string; handler: InternalHookHandler }> = [];
 
 /**
  * Load and register all hook handlers
@@ -51,6 +54,12 @@ export async function loadInternalHooks(
   if (!cfg.hooks?.internal?.enabled) {
     return 0;
   }
+
+  // Clean up handlers from a previous call (hot-reload).
+  for (const { event, handler } of fileRegisteredHandlers) {
+    unregisterInternalHook(event, handler);
+  }
+  fileRegisteredHandlers.length = 0;
 
   let loadedCount = 0;
 
@@ -114,6 +123,7 @@ export async function loadInternalHooks(
 
         for (const event of events) {
           registerInternalHook(event, handler);
+          fileRegisteredHandlers.push({ event, handler });
         }
 
         log.info(
@@ -186,6 +196,7 @@ export async function loadInternalHooks(
       }
 
       registerInternalHook(handlerConfig.event, handler);
+      fileRegisteredHandlers.push({ event: handlerConfig.event, handler });
       log.info(
         `Registered hook (legacy): ${handlerConfig.event} -> ${modulePath}${exportName !== "default" ? `#${exportName}` : ""}`,
       );


### PR DESCRIPTION
## Summary

Fixes #25859

Plugin hooks registered via `api.registerHook()` during `loadGatewayPlugins()` were wiped by `clearInternalHooks()` in `startGatewaySidecars()`. File-based hooks survived because `loadInternalHooks()` re-loaded them from disk. Plugin hooks were never restored.

**Why it looked intermittent:** config file changes trigger plugin re-registration without calling `clearInternalHooks()`, so hooks came back until the next cold restart. Every restart always killed plugin hooks.

## Changes

- **`server.impl.ts`**: Move `clearInternalHooks()` before `loadGatewayPlugins()` so plugins register into a clean registry that stays intact
- **`server-startup.ts`**: Remove `clearInternalHooks()` from `startGatewaySidecars()`
- **`loader.ts`**: Track file-based handlers and clean them up before reloading (hot-reload safe without touching plugin hooks)
- **`loader.test.ts`**: Two new tests: no duplicate handlers on reload + plugin hook preservation

## Same bug as #20541, #26184, #26242

| | This PR | #20541 | #26184 | #26242 |
|---|---|---|---|---|
| Approach | Move clear before plugins + self-tracking loader | Move clear before plugins | Clear then re-register from registry | Separate pluginHandlers Map |
| Hot-reload safe | Yes (loader tracks its own handlers) | Needs follow-up | Yes | Yes (but unregister not synced) |
| New abstractions | None | None | `reregisterPluginInternalHooks()` | `registerPluginHook()` + second Map |
| Tests added | 2 (dedup + preserve) | 1 (integration) | 0 | 1 (unit) |