### PR TITLE
Usage: include archived reset/deleted transcripts in usage stats

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1276,6 +1276,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     public let utcoffset: String?
     public let limit: Int?
     public let includecontextweight: Bool?
+    public let includearchived: Bool?
 
     public init(
         key: String?,
@@ -1284,7 +1285,8 @@ public struct SessionsUsageParams: Codable, Sendable {
         mode: AnyCodable?,
         utcoffset: String?,
         limit: Int?,
-        includecontextweight: Bool?)
+        includecontextweight: Bool?,
+        includearchived: Bool?)
     {
         self.key = key
         self.startdate = startdate
@@ -1293,6 +1295,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         self.utcoffset = utcoffset
         self.limit = limit
         self.includecontextweight = includecontextweight
+        self.includearchived = includearchived
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1303,6 +1306,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         case utcoffset = "utcOffset"
         case limit
         case includecontextweight = "includeContextWeight"
+        case includearchived = "includeArchived"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1276,6 +1276,7 @@ public struct SessionsUsageParams: Codable, Sendable {
     public let utcoffset: String?
     public let limit: Int?
     public let includecontextweight: Bool?
+    public let includearchived: Bool?
 
     public init(
         key: String?,
@@ -1284,7 +1285,8 @@ public struct SessionsUsageParams: Codable, Sendable {
         mode: AnyCodable?,
         utcoffset: String?,
         limit: Int?,
-        includecontextweight: Bool?)
+        includecontextweight: Bool?,
+        includearchived: Bool?)
     {
         self.key = key
         self.startdate = startdate
@@ -1293,6 +1295,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         self.utcoffset = utcoffset
         self.limit = limit
         self.includecontextweight = includecontextweight
+        self.includearchived = includearchived
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1303,6 +1306,7 @@ public struct SessionsUsageParams: Codable, Sendable {
         case utcoffset = "utcOffset"
         case limit
         case includecontextweight = "includeContextWeight"
+        case includearchived = "includeArchived"
     }
 }
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -872,7 +872,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
         compat: { supportsStore: false },
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -126,6 +126,8 @@ export const SessionsUsageParamsSchema = Type.Object(
     limit: Type.Optional(Type.Integer({ minimum: 1 })),
     /** Include context weight breakdown (systemPromptReport). */
     includeContextWeight: Type.Optional(Type.Boolean()),
+    /** Include reset/deleted transcript archives in usage aggregation. */
+    includeArchived: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -29,29 +29,31 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
   );
   return {
     ...actual,
-    discoverAllSessions: vi.fn(async (params?: { agentId?: string }) => {
-      if (params?.agentId === "main") {
-        return [
-          {
-            sessionId: "s-main",
-            sessionFile: "/tmp/agents/main/sessions/s-main.jsonl",
-            mtime: 100,
-            firstUserMessage: "hello",
-          },
-        ];
-      }
-      if (params?.agentId === "opus") {
-        return [
-          {
-            sessionId: "s-opus",
-            sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
-            mtime: 200,
-            firstUserMessage: "hi",
-          },
-        ];
-      }
-      return [];
-    }),
+    discoverAllSessions: vi.fn(
+      async (params?: { agentId?: string; includeArchivedTranscripts?: boolean }) => {
+        if (params?.agentId === "main") {
+          return [
+            {
+              sessionId: "s-main",
+              sessionFile: "/tmp/agents/main/sessions/s-main.jsonl",
+              mtime: 100,
+              firstUserMessage: "hello",
+            },
+          ];
+        }
+        if (params?.agentId === "opus") {
+          return [
+            {
+              sessionId: "s-opus",
+              sessionFile: "/tmp/agents/opus/sessions/s-opus.jsonl",
+              mtime: 200,
+              firstUserMessage: "hi",
+            },
+          ];
+        }
+        return [];
+      },
+    ),
     loadSessionCostSummary: vi.fn(async () => ({
       input: 0,
       output: 0,
@@ -138,6 +140,12 @@ describe("sessions.usage", () => {
     expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.agentId).toBe("main");
     expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.agentId).toBe("opus");
+    expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.includeArchivedTranscripts).toBe(
+      true,
+    );
+    expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.includeArchivedTranscripts).toBe(
+      true,
+    );
 
     const sessions = expectSuccessfulSessionsUsage(respond);
     expect(sessions).toHaveLength(2);
@@ -147,6 +155,18 @@ describe("sessions.usage", () => {
     expect(sessions[0].agentId).toBe("opus");
     expect(sessions[1].key).toBe("agent:main:s-main");
     expect(sessions[1].agentId).toBe("main");
+  });
+
+  it("can opt out of archived transcripts via includeArchived=false", async () => {
+    await runSessionsUsage({ ...BASE_USAGE_RANGE, includeArchived: false });
+
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(discoverAllSessions).mock.calls[0]?.[0]?.includeArchivedTranscripts).toBe(
+      false,
+    );
+    expect(vi.mocked(discoverAllSessions).mock.calls[1]?.[0]?.includeArchivedTranscripts).toBe(
+      false,
+    );
   });
 
   it("resolves store entries by sessionId when queried via discovered agent-prefixed key", async () => {

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -158,4 +158,31 @@ describe("gateway usage helpers", () => {
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(1);
   });
+
+  it("loadCostUsageSummaryCached isolates cache entries by archive inclusion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    const config = {} as OpenClawConfig;
+    await __test.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      includeArchivedTranscripts: false,
+    });
+    await __test.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+      includeArchivedTranscripts: true,
+    });
+
+    expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(loadCostUsageSummary).mock.calls[0]?.[0]?.includeArchivedTranscripts).toBe(
+      false,
+    );
+    expect(vi.mocked(loadCostUsageSummary).mock.calls[1]?.[0]?.includeArchivedTranscripts).toBe(
+      true,
+    );
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -259,6 +259,7 @@ async function discoverAllSessionsForUsage(params: {
   config: ReturnType<typeof loadConfig>;
   startMs: number;
   endMs: number;
+  includeArchivedTranscripts?: boolean;
 }): Promise<DiscoveredSessionWithAgent[]> {
   const agents = listAgentsForGateway(params.config).agents;
   const results = await Promise.all(
@@ -267,6 +268,7 @@ async function discoverAllSessionsForUsage(params: {
         agentId: agent.id,
         startMs: params.startMs,
         endMs: params.endMs,
+        includeArchivedTranscripts: params.includeArchivedTranscripts,
       });
       return sessions.map((session) => ({ ...session, agentId: agent.id }));
     }),
@@ -278,8 +280,9 @@ async function loadCostUsageSummaryCached(params: {
   startMs: number;
   endMs: number;
   config: ReturnType<typeof loadConfig>;
+  includeArchivedTranscripts?: boolean;
 }): Promise<CostUsageSummary> {
-  const cacheKey = `${params.startMs}-${params.endMs}`;
+  const cacheKey = `${params.startMs}-${params.endMs}-${params.includeArchivedTranscripts ? "1" : "0"}`;
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
@@ -298,6 +301,7 @@ async function loadCostUsageSummaryCached(params: {
     startMs: params.startMs,
     endMs: params.endMs,
     config: params.config,
+    includeArchivedTranscripts: params.includeArchivedTranscripts,
   })
     .then((summary) => {
       costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
@@ -409,7 +413,14 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
-    const summary = await loadCostUsageSummaryCached({ startMs, endMs, config });
+    const includeArchivedTranscripts =
+      typeof params?.includeArchived === "boolean" ? params.includeArchived : true;
+    const summary = await loadCostUsageSummaryCached({
+      startMs,
+      endMs,
+      config,
+      includeArchivedTranscripts,
+    });
     respond(true, summary, undefined);
   },
   "sessions.usage": async ({ respond, params }) => {
@@ -435,6 +446,7 @@ export const usageHandlers: GatewayRequestHandlers = {
     });
     const limit = typeof p.limit === "number" && Number.isFinite(p.limit) ? p.limit : 50;
     const includeContextWeight = p.includeContextWeight ?? false;
+    const includeArchivedTranscripts = p.includeArchived ?? true;
     const specificKey = typeof p.key === "string" ? p.key.trim() : null;
 
     // Load session store for named sessions
@@ -510,6 +522,7 @@ export const usageHandlers: GatewayRequestHandlers = {
         config,
         startMs,
         endMs,
+        includeArchivedTranscripts,
       });
 
       // Build a map of sessionId -> store entry for quick lookup

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -231,6 +231,80 @@ describe("session cost usage", () => {
     });
   });
 
+  it("includes reset/deleted transcript archives when explicitly requested", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-archives-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const files = [
+      {
+        name: "sess-live.jsonl",
+        tokens: 10,
+      },
+      {
+        name: "sess-reset.jsonl.reset.2026-02-20T12-00-00.000Z",
+        tokens: 20,
+      },
+      {
+        name: "sess-deleted.jsonl.deleted.2026-02-20T13-00-00.000Z",
+        tokens: 30,
+      },
+    ];
+
+    for (const file of files) {
+      await fs.writeFile(
+        path.join(sessionsDir, file.name),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-20T12:00:00.000Z",
+          message: {
+            role: "assistant",
+            usage: { input: file.tokens, output: 0, totalTokens: file.tokens },
+          },
+        }),
+        "utf-8",
+      );
+    }
+
+    await withStateDir(root, async () => {
+      const withoutArchived = await loadCostUsageSummary({ days: 30 });
+      expect(withoutArchived.totals.totalTokens).toBe(10);
+
+      const withArchived = await loadCostUsageSummary({
+        days: 30,
+        includeArchivedTranscripts: true,
+      });
+      expect(withArchived.totals.totalTokens).toBe(60);
+    });
+  });
+
+  it("discovers archived transcripts when includeArchivedTranscripts is enabled", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-archives-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    await fs.writeFile(path.join(sessionsDir, "sess-live.jsonl"), "", "utf-8");
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-reset.jsonl.reset.2026-02-20T12-00-00.000Z"),
+      "",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-deleted.jsonl.deleted.2026-02-20T13-00-00.000Z"),
+      "",
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const withoutArchived = await discoverAllSessions();
+      expect(withoutArchived.map((session) => session.sessionId)).toEqual(["sess-live"]);
+
+      const withArchived = await discoverAllSessions({ includeArchivedTranscripts: true });
+      const discoveredIds = new Set(withArchived.map((session) => session.sessionId));
+      expect(discoveredIds).toEqual(new Set(["sess-live", "sess-reset", "sess-deleted"]));
+    });
+  });
+
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
     const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,6 +5,7 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { parseSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
@@ -66,6 +67,37 @@ const emptyTotals = (): CostUsageTotals => ({
   cacheWriteCost: 0,
   missingCostEntries: 0,
 });
+
+const TRANSCRIPT_SUFFIX = ".jsonl";
+const ARCHIVED_TRANSCRIPT_MARKER = `${TRANSCRIPT_SUFFIX}.`;
+const LEGACY_ARCHIVED_TRANSCRIPT_MARKER = `${TRANSCRIPT_SUFFIX}.archived-`;
+
+function isUsageTranscriptFileName(fileName: string, includeArchivedTranscripts: boolean): boolean {
+  if (fileName.endsWith(TRANSCRIPT_SUFFIX)) {
+    return true;
+  }
+  if (!includeArchivedTranscripts) {
+    return false;
+  }
+  if (parseSessionArchiveTimestamp(fileName, "reset") != null) {
+    return true;
+  }
+  if (parseSessionArchiveTimestamp(fileName, "deleted") != null) {
+    return true;
+  }
+  return fileName.includes(LEGACY_ARCHIVED_TRANSCRIPT_MARKER);
+}
+
+function extractSessionIdFromTranscriptFileName(fileName: string): string | undefined {
+  if (fileName.endsWith(TRANSCRIPT_SUFFIX)) {
+    return fileName.slice(0, -TRANSCRIPT_SUFFIX.length);
+  }
+  const markerIndex = fileName.indexOf(ARCHIVED_TRANSCRIPT_MARKER);
+  if (markerIndex <= 0) {
+    return undefined;
+  }
+  return fileName.slice(0, markerIndex);
+}
 
 const toFiniteNumber = (value: unknown): number | undefined => {
   if (typeof value !== "number") {
@@ -293,6 +325,7 @@ export async function loadCostUsageSummary(params?: {
   days?: number; // Deprecated, for backwards compatibility
   config?: OpenClawConfig;
   agentId?: string;
+  includeArchivedTranscripts?: boolean;
 }): Promise<CostUsageSummary> {
   const now = new Date();
   let sinceTime: number;
@@ -315,10 +348,14 @@ export async function loadCostUsageSummary(params?: {
 
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const includeArchivedTranscripts = params?.includeArchivedTranscripts ?? false;
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter(
+          (entry) =>
+            entry.isFile() && isUsageTranscriptFileName(entry.name, includeArchivedTranscripts),
+        )
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -386,14 +423,16 @@ export async function discoverAllSessions(params?: {
   agentId?: string;
   startMs?: number;
   endMs?: number;
+  includeArchivedTranscripts?: boolean;
 }): Promise<DiscoveredSession[]> {
   const sessionsDir = resolveSessionTranscriptsDirForAgent(params?.agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const includeArchivedTranscripts = params?.includeArchivedTranscripts ?? false;
 
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isUsageTranscriptFileName(entry.name, includeArchivedTranscripts)) {
       continue;
     }
 
@@ -409,8 +448,10 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    const sessionId = extractSessionIdFromTranscriptFileName(entry.name);
+    if (!sessionId) {
+      continue;
+    }
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;


### PR DESCRIPTION
Fixes #28973

## Summary
- include archived session transcripts in usage aggregation paths
- keep default behavior inclusive for dashboard usage endpoints, with optional opt-out via `includeArchived=false`
- keep cache correctness by scoping usage cache key to archive-inclusion mode

## Root Cause
Usage aggregation/discovery only scanned `*.jsonl` files, so archived transcripts created by reset/delete flows (`*.jsonl.reset.*`, `*.jsonl.deleted.*`) were excluded.

## Changes
- `src/infra/session-cost-usage.ts`
  - add transcript matcher that includes reset/deleted archive artifacts (plus legacy `*.jsonl.archived-*`)
  - add `includeArchivedTranscripts` option to `loadCostUsageSummary` and `discoverAllSessions`
  - extract stable session id from archived transcript filenames
- `src/gateway/server-methods/usage.ts`
  - pass archive inclusion through discovery and cost-summary paths
  - default `usage.cost` and `sessions.usage` to include archived transcripts
  - include archive mode in cache key
- `src/gateway/protocol/schema/sessions.ts`
  - add optional `includeArchived` for `sessions.usage`

## Tests
- `src/infra/session-cost-usage.test.ts`
  - archived transcripts are excluded by default and included when enabled
  - archived transcripts are discoverable when enabled
- `src/gateway/server-methods/usage.sessions-usage.test.ts`
  - verify default include behavior and opt-out wiring
- `src/gateway/server-methods/usage.test.ts`
  - verify cache isolation by archive inclusion mode

## Verification
- `pnpm test src/infra/session-cost-usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts src/gateway/server-methods/usage.test.ts`
