### PR TITLE
fix(auto-reply): discard entire message when NO_REPLY has trailing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway NO_REPLY suppression: discard the entire message when the model outputs `NO_REPLY` followed by trailing text on subsequent lines, preventing phantom messages from leaking through to conversation partners. (#28874) Thanks @ZenGardenDubai for reporting.
 - Telegram/DM allowlist runtime inheritance: enforce `dmPolicy: "allowlist"` `allowFrom` requirements using effective account-plus-parent config across account-capable channels (Telegram, Discord, Slack, Signal, iMessage, IRC, BlueBubbles, WhatsApp), and align `openclaw doctor` checks to the same inheritance logic so DM traffic is not silently dropped after upgrades. (#27936) Thanks @widingmarcus-cyber.
 - Delivery queue/recovery backoff: prevent retry starvation by persisting `lastAttemptAt` on failed sends and deferring recovery retries until each entry's `lastAttemptAt + backoff` window is eligible, while continuing to recover ready entries behind deferred ones. Landed from contributor PR #27710 by @Jimmy-xuzimo. Thanks @Jimmy-xuzimo.
 - Gemini OAuth/Auth flow: align OAuth project discovery metadata and endpoint fallback handling for Gemini CLI auth, including fallback coverage for environment-provided project IDs. (#16684) Thanks @vincentkoc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -21,9 +21,16 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText(text)).toBe(false);
   });
 
-  it("returns false for substantive text starting with token", () => {
+  it("returns false for substantive text starting with token on same line", () => {
     const text = "NO_REPLY but here is more content";
     expect(isSilentReplyText(text)).toBe(false);
+  });
+
+  it("returns true for token followed by trailing text on new lines (#28874)", () => {
+    expect(isSilentReplyText("NO_REPLY\n\nWhat's my favorite color?")).toBe(true);
+    expect(isSilentReplyText("NO_REPLY\nsome command")).toBe(true);
+    expect(isSilentReplyText("  NO_REPLY\n\nclear everything")).toBe(true);
+    expect(isSilentReplyText("NO_REPLY\n\n\nDelete Test User from contacts")).toBe(true);
   });
 
   it("returns false for token embedded in text", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -11,10 +11,11 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  // Match only the exact silent token with optional surrounding whitespace.
-  // This prevents
-  // substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return new RegExp(`^\\s*${escaped}\\s*$`).test(text);
+  // Match the silent token at the start (with optional leading whitespace) followed by
+  // either end-of-string or a newline. This suppresses the entire message when the model
+  // outputs e.g. "NO_REPLY\n\nsome trailing text" (#28874) while still allowing
+  // substantive replies that end with NO_REPLY to pass through (#19537).
+  return new RegExp(`^\\s*${escaped}\\s*$|^\\s*${escaped}\\s*\\n`).test(text);
 }
 
 export function isSilentReplyPrefixText(


### PR DESCRIPTION
## Summary

Fix gateway NO_REPLY suppression to discard the entire message when the model outputs `NO_REPLY` followed by trailing text on subsequent lines.

## Problem

When the agent model outputs `NO_REPLY` followed by additional text on new lines (e.g. `NO_REPLY\n\nWhat's my favorite color?`), the gateway only checks for an exact match of the `NO_REPLY` token. The trailing text leaks through and gets sent as a real message to the conversation partner, creating a self-amplifying feedback loop of phantom messages.

Fixes #28874

## Changes

- Updated `isSilentReplyText()` in `src/auto-reply/tokens.ts` to match `NO_REPLY` at the start of a message followed by a newline (not just exact match with optional whitespace)
- The regex now uses `^\s*NO_REPLY\s*$|^\s*NO_REPLY\s*\n` — matching either the exact token OR the token followed by a newline and any trailing content
- Preserves the #19537 fix: substantive text ending with `NO_REPLY` still passes through
- Preserves same-line continuation: `NO_REPLY but here is more content` still passes through (not silent)

## Test plan

- Added regression test case for `NO_REPLY\n\ntrailing text` variants (4 assertions)
- Renamed existing test to clarify it covers same-line continuation only
- All 11 token tests pass, plus 71 tests across related test files (followup-runner, dispatch-from-config, server-chat.agent-events, reply-state)
- `pnpm lint` and `pnpm format:check` pass clean

## Effect on User Experience

Before: `NO_REPLY\n\nWhat's my favorite color?` would send "What's my favorite color?" as a real message, causing phantom messages and feedback loops.

After: Any message starting with `NO_REPLY` on its own line is fully suppressed, regardless of trailing text. This eliminates the phantom message feedback loop described in #28874.
