### PR TITLE
Switch to cheaper default LLMs

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -1,6 +1,6 @@
 // Defaults for agent metadata when upstream does not supply them.
 // Model id uses pi-ai's built-in Anthropic catalog.
 export const DEFAULT_PROVIDER = "anthropic";
-export const DEFAULT_MODEL = "claude-opus-4-6";
+export const DEFAULT_MODEL = "claude-sonnet-4-6";
 // Conservative fallback used when model metadata is unavailable.
 export const DEFAULT_CONTEXT_TOKENS = 200_000;

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -51,7 +51,7 @@ export const AUTO_IMAGE_KEY_PROVIDERS = [
 export const AUTO_VIDEO_KEY_PROVIDERS = ["google", "moonshot"] as const;
 export const DEFAULT_IMAGE_MODELS: Record<string, string> = {
   openai: "gpt-5-mini",
-  anthropic: "claude-opus-4-6",
+  anthropic: "claude-haiku-4-5",
   google: "gemini-3-flash-preview",
   minimax: "MiniMax-VL-01",
   zai: "glm-4.6v",


### PR DESCRIPTION
## Summary
- Default agent model: `claude-opus-4-6` → `claude-sonnet-4-6`
- Anthropic image understanding: `claude-opus-4-6` → `claude-haiku-4-5`
- Subagents already configured via `openclaw.json` to use `haiku-4-5`

Reduces cost without meaningful quality loss for typical gateway workloads.

## Test plan
- [ ] Verify gateway starts with new defaults
- [ ] Confirm agent responses are acceptable with sonnet-4-6
- [ ] Confirm image understanding works with haiku-4-5