### PR TITLE
fix: improve gateway upgrade diagnostics and recovery

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -131,6 +131,29 @@ Common signatures:
 - `refusing to bind gateway ... without auth` → non-loopback bind without token/password.
 - `another gateway instance is already listening` / `EADDRINUSE` → port conflict.
 
+### PM2 + NVM ghost crash
+
+If `openclaw gateway` works in foreground but PM2 restarts fail instantly with no logs,
+PM2 likely started without your shell init and lost Node/NPM paths from NVM.
+
+Use a wrapper script that sources your shell environment:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source ~/.bashrc
+export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH"
+exec openclaw gateway
+```
+
+Then run PM2 with that wrapper (or set an absolute interpreter path in ecosystem config).
+
+For external dashboard access, prefer SSH local forwarding over cloud web proxies:
+
+```bash
+ssh -N -L 18789:127.0.0.1:18789 <user>@<host>
+```
+
 Related:
 
 - [/gateway/background-process](/gateway/background-process)

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -92,3 +92,20 @@ Enable it:
 ```
 systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```
+
+## PM2 with NVM
+
+When PM2 manages OpenClaw on NVM-based hosts, PM2 may not load your shell init
+on restart. That can drop `PATH` entries and cause instant process exits.
+
+Use a wrapper script that sources your shell env before launching:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+source ~/.bashrc
+export PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH"
+exec openclaw gateway
+```
+
+Start PM2 with this wrapper (or set an absolute Node interpreter path in PM2).

--- a/openclaw-gateway.mjs
+++ b/openclaw-gateway.mjs
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
 
-// Dedicated gateway entrypoint for shim launchers where invocation name
-// is not preserved in process.argv.
-if (process.argv[2] !== "gateway") {
-  process.argv.splice(2, 0, "gateway");
-}
-
+// Keep this wrapper side-effect free. The gateway subcommand rewrite happens in
+// run-main after entry-level profile parsing.
 await import("./openclaw.mjs");

--- a/openclaw-gateway.mjs
+++ b/openclaw-gateway.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+// Dedicated gateway entrypoint for shim launchers where invocation name
+// is not preserved in process.argv.
+if (process.argv[2] !== "gateway") {
+  process.argv.splice(2, 0, "gateway");
+}
+
+await import("./openclaw.mjs");

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "git+https://github.com/openclaw/openclaw.git"
   },
   "bin": {
-    "openclaw": "openclaw.mjs"
+    "openclaw": "openclaw.mjs",
+    "openclaw-gateway": "openclaw.mjs"
   },
   "directories": {
     "doc": "docs",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "bin": {
     "openclaw": "openclaw.mjs",
-    "openclaw-gateway": "openclaw.mjs"
+    "openclaw-gateway": "openclaw-gateway.mjs"
   },
   "directories": {
     "doc": "docs",
@@ -24,6 +24,7 @@
   "files": [
     "CHANGELOG.md",
     "LICENSE",
+    "openclaw-gateway.mjs",
     "openclaw.mjs",
     "README-header.png",
     "README.md",

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -870,8 +870,15 @@ describe("applyExtraParamsToAgent", () => {
         api: "openai-responses",
         provider: "azure-openai-responses",
         id: "gpt-4o",
+        name: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-        compat: { supportsStore: false },
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4096,
+        // pi-ai currently types OpenAIResponsesCompat as an empty interface.
+        compat: { supportsStore: false } as unknown as Model<"openai-responses">["compat"],
       } as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -10,6 +10,7 @@ import { findBundledPluginByNpmSpec } from "../plugins/bundled-sources.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
 import { recordPluginInstall } from "../plugins/installs.js";
+import { resolvePluginMissingDependencyHint } from "../plugins/load-error-hints.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import type { PluginRecord } from "../plugins/registry.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
@@ -777,6 +778,13 @@ export function registerPluginsCli(program: Command) {
         lines.push(theme.error("Plugin errors:"));
         for (const entry of errors) {
           lines.push(`- ${entry.id}: ${entry.error ?? "failed to load"} (${entry.source})`);
+          const hint = resolvePluginMissingDependencyHint({
+            message: entry.error ?? "",
+            pluginId: entry.id,
+          });
+          if (hint) {
+            lines.push(`  ${theme.muted(`Hint: ${hint}`)}`);
+          }
         }
       }
       if (diags.length > 0) {
@@ -787,6 +795,13 @@ export function registerPluginsCli(program: Command) {
         for (const diag of diags) {
           const target = diag.pluginId ? `${diag.pluginId}: ` : "";
           lines.push(`- ${target}${diag.message}`);
+          const hint = resolvePluginMissingDependencyHint({
+            message: diag.message,
+            pluginId: diag.pluginId,
+          });
+          if (hint) {
+            lines.push(`  ${theme.muted(`Hint: ${hint}`)}`);
+          }
         }
       }
       const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -62,6 +62,9 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
     expect(
       rewriteLegacyGatewayBinaryArgv(["node", "/usr/local/bin/openclaw-gateway.mjs", "run"]),
     ).toEqual(["node", "/usr/local/bin/openclaw-gateway.mjs", "gateway", "run"]);
+    expect(rewriteLegacyGatewayBinaryArgv(["node", "/usr/local/bin/openclaw-gateway.mjs"])).toEqual(
+      ["node", "/usr/local/bin/openclaw-gateway.mjs", "gateway"],
+    );
   });
 
   it("keeps modern argv untouched", () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -77,6 +77,14 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
     const argv = ["node", "/usr/local/bin/openclaw-gateway", "gateway", "status"];
     expect(rewriteLegacyGatewayBinaryArgv(argv)).toBe(argv);
   });
+
+  it("keeps root update invocations untouched for gateway binaries", () => {
+    const updateArgv = ["node", "/usr/local/bin/openclaw-gateway", "update", "--yes"];
+    expect(rewriteLegacyGatewayBinaryArgv(updateArgv)).toBe(updateArgv);
+
+    const updateFlagArgv = ["node", "/usr/local/bin/openclaw-gateway", "--update", "--json"];
+    expect(rewriteLegacyGatewayBinaryArgv(updateFlagArgv)).toBe(updateFlagArgv);
+  });
 });
 
 describe("syncProcessArgvForNormalizedArgs", () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   rewriteLegacyGatewayBinaryArgv,
   rewriteUpdateFlagArgv,
+  syncProcessArgvForNormalizedArgs,
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
   shouldSkipPluginCommandRegistration,
@@ -75,6 +76,33 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
   it("avoids double-prefixing when gateway is already present", () => {
     const argv = ["node", "/usr/local/bin/openclaw-gateway", "gateway", "status"];
     expect(rewriteLegacyGatewayBinaryArgv(argv)).toBe(argv);
+  });
+});
+
+describe("syncProcessArgvForNormalizedArgs", () => {
+  it("syncs global argv when normalization started from process.argv", () => {
+    const current = ["node", "/usr/local/bin/openclaw-gateway", "discover"];
+    const normalized = rewriteLegacyGatewayBinaryArgv(current);
+    expect(
+      syncProcessArgvForNormalizedArgs({
+        sourceArgv: current,
+        normalizedArgv: normalized,
+        currentArgv: current,
+      }),
+    ).toEqual(["node", "/usr/local/bin/openclaw-gateway", "gateway", "discover"]);
+  });
+
+  it("leaves process argv untouched when runCli receives a custom argv input", () => {
+    const source = ["node", "/usr/local/bin/openclaw-gateway", "discover"];
+    const current = ["node", "/usr/local/bin/openclaw", "status"];
+    const normalized = rewriteLegacyGatewayBinaryArgv(source);
+    expect(
+      syncProcessArgvForNormalizedArgs({
+        sourceArgv: source,
+        normalizedArgv: normalized,
+        currentArgv: current,
+      }),
+    ).toBe(current);
   });
 });
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -58,6 +58,12 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
     ).toEqual(["node", "/usr/local/bin/openclaw-gateway", "gateway", "--port", "18789"]);
   });
 
+  it("rewrites legacy gateway wrapper invocations launched through node", () => {
+    expect(
+      rewriteLegacyGatewayBinaryArgv(["node", "/usr/local/bin/openclaw-gateway.mjs", "run"]),
+    ).toEqual(["node", "/usr/local/bin/openclaw-gateway.mjs", "gateway", "run"]);
+  });
+
   it("keeps modern argv untouched", () => {
     const argv = ["node", "/usr/local/bin/openclaw", "gateway", "status"];
     expect(rewriteLegacyGatewayBinaryArgv(argv)).toBe(argv);

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  rewriteLegacyGatewayBinaryArgv,
   rewriteUpdateFlagArgv,
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
@@ -37,6 +38,34 @@ describe("rewriteUpdateFlagArgv", () => {
       "update",
       "--json",
     ]);
+  });
+});
+
+describe("rewriteLegacyGatewayBinaryArgv", () => {
+  it("rewrites legacy openclaw-gateway invocations to the gateway command path", () => {
+    expect(rewriteLegacyGatewayBinaryArgv(["node", "/usr/local/bin/openclaw-gateway"])).toEqual([
+      "node",
+      "/usr/local/bin/openclaw-gateway",
+      "gateway",
+    ]);
+    expect(
+      rewriteLegacyGatewayBinaryArgv([
+        "node",
+        "/usr/local/bin/openclaw-gateway",
+        "--port",
+        "18789",
+      ]),
+    ).toEqual(["node", "/usr/local/bin/openclaw-gateway", "gateway", "--port", "18789"]);
+  });
+
+  it("keeps modern argv untouched", () => {
+    const argv = ["node", "/usr/local/bin/openclaw", "gateway", "status"];
+    expect(rewriteLegacyGatewayBinaryArgv(argv)).toBe(argv);
+  });
+
+  it("avoids double-prefixing when gateway is already present", () => {
+    const argv = ["node", "/usr/local/bin/openclaw-gateway", "gateway", "status"];
+    expect(rewriteLegacyGatewayBinaryArgv(argv)).toBe(argv);
   });
 });
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -100,6 +100,14 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
     expect(rewriteLegacyGatewayBinaryArgv(withLogLevel)).toBe(withLogLevel);
   });
 
+  it("keeps root version alias untouched for gateway binaries", () => {
+    const rootAlias = ["node", "/usr/local/bin/openclaw-gateway", "-v"];
+    expect(rewriteLegacyGatewayBinaryArgv(rootAlias)).toBe(rootAlias);
+
+    const withLogLevel = ["node", "/usr/local/bin/openclaw-gateway", "--log-level", "debug", "-v"];
+    expect(rewriteLegacyGatewayBinaryArgv(withLogLevel)).toBe(withLogLevel);
+  });
+
   it("injects gateway after known root flags for normal gateway command paths", () => {
     expect(
       rewriteLegacyGatewayBinaryArgv([

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -85,6 +85,31 @@ describe("rewriteLegacyGatewayBinaryArgv", () => {
     const updateFlagArgv = ["node", "/usr/local/bin/openclaw-gateway", "--update", "--json"];
     expect(rewriteLegacyGatewayBinaryArgv(updateFlagArgv)).toBe(updateFlagArgv);
   });
+
+  it("keeps --update untouched when root flags appear before it", () => {
+    const withNoColor = ["node", "/usr/local/bin/openclaw-gateway", "--no-color", "--update"];
+    expect(rewriteLegacyGatewayBinaryArgv(withNoColor)).toBe(withNoColor);
+
+    const withLogLevel = [
+      "node",
+      "/usr/local/bin/openclaw-gateway",
+      "--log-level",
+      "debug",
+      "--update",
+    ];
+    expect(rewriteLegacyGatewayBinaryArgv(withLogLevel)).toBe(withLogLevel);
+  });
+
+  it("injects gateway after known root flags for normal gateway command paths", () => {
+    expect(
+      rewriteLegacyGatewayBinaryArgv([
+        "node",
+        "/usr/local/bin/openclaw-gateway",
+        "--no-color",
+        "discover",
+      ]),
+    ).toEqual(["node", "/usr/local/bin/openclaw-gateway", "--no-color", "gateway", "discover"]);
+  });
 });
 
 describe("syncProcessArgvForNormalizedArgs", () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -50,6 +50,18 @@ export function rewriteLegacyGatewayBinaryArgv(argv: string[]): string[] {
   return next;
 }
 
+export function syncProcessArgvForNormalizedArgs(params: {
+  sourceArgv: string[];
+  normalizedArgv: string[];
+  currentArgv?: string[];
+}): string[] {
+  const currentArgv = params.currentArgv ?? process.argv;
+  if (params.sourceArgv !== currentArgv) {
+    return currentArgv;
+  }
+  return params.normalizedArgv;
+}
+
 export function shouldRegisterPrimarySubcommand(argv: string[]): boolean {
   return !hasHelpOrVersion(argv);
 }
@@ -90,6 +102,7 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
 
 export async function runCli(argv: string[] = process.argv) {
   const normalizedArgv = rewriteLegacyGatewayBinaryArgv(normalizeWindowsArgv(argv));
+  process.argv = syncProcessArgvForNormalizedArgs({ sourceArgv: argv, normalizedArgv });
   loadDotEnv({ quiet: true });
   normalizeEnv();
   if (shouldEnsureCliPath(normalizedArgv)) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadDotEnv } from "../infra/dotenv.js";
@@ -20,6 +21,31 @@ export function rewriteUpdateFlagArgv(argv: string[]): string[] {
 
   const next = [...argv];
   next.splice(index, 1, "update");
+  return next;
+}
+
+function isLegacyGatewayBinary(entryPath: string | undefined): boolean {
+  if (!entryPath) {
+    return false;
+  }
+  const base = path.basename(entryPath).toLowerCase();
+  return (
+    base === "openclaw-gateway" ||
+    base === "openclaw-gateway.cmd" ||
+    base === "openclaw-gateway.ps1" ||
+    base === "openclaw-gateway.exe"
+  );
+}
+
+export function rewriteLegacyGatewayBinaryArgv(argv: string[]): string[] {
+  if (!isLegacyGatewayBinary(argv[1])) {
+    return argv;
+  }
+  if (argv[2] === "gateway") {
+    return argv;
+  }
+  const next = [...argv];
+  next.splice(2, 0, "gateway");
   return next;
 }
 
@@ -62,7 +88,7 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
 }
 
 export async function runCli(argv: string[] = process.argv) {
-  const normalizedArgv = normalizeWindowsArgv(argv);
+  const normalizedArgv = rewriteLegacyGatewayBinaryArgv(normalizeWindowsArgv(argv));
   loadDotEnv({ quiet: true });
   normalizeEnv();
   if (shouldEnsureCliPath(normalizedArgv)) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -40,6 +40,16 @@ function isLegacyGatewayBinary(entryPath: string | undefined): boolean {
 
 const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
 const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
+const LEGACY_GATEWAY_PASSTHROUGH_TOKENS = new Set([
+  "gateway",
+  "update",
+  "--update",
+  "-h",
+  "--help",
+  "-v",
+  "-V",
+  "--version",
+]);
 
 function resolveLegacyGatewayCommandToken(argv: string[]): {
   commandToken: string | undefined;
@@ -74,7 +84,7 @@ export function rewriteLegacyGatewayBinaryArgv(argv: string[]): string[] {
     return argv;
   }
   const { commandToken, commandIndex } = resolveLegacyGatewayCommandToken(argv);
-  if (commandToken === "gateway" || commandToken === "update" || commandToken === "--update") {
+  if (commandToken && LEGACY_GATEWAY_PASSTHROUGH_TOKENS.has(commandToken)) {
     return argv;
   }
   const next = [...argv];

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -38,15 +38,47 @@ function isLegacyGatewayBinary(entryPath: string | undefined): boolean {
   );
 }
 
+const ROOT_BOOLEAN_FLAGS = new Set(["--dev", "--no-color"]);
+const ROOT_VALUE_FLAGS = new Set(["--profile", "--log-level"]);
+
+function resolveLegacyGatewayCommandToken(argv: string[]): {
+  commandToken: string | undefined;
+  commandIndex: number;
+} {
+  let index = 2;
+  while (index < argv.length) {
+    const token = argv[index];
+    if (!token) {
+      index += 1;
+      continue;
+    }
+    if (ROOT_BOOLEAN_FLAGS.has(token)) {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--profile=") || token.startsWith("--log-level=")) {
+      index += 1;
+      continue;
+    }
+    if (ROOT_VALUE_FLAGS.has(token)) {
+      index += 2;
+      continue;
+    }
+    break;
+  }
+  return { commandToken: argv[index], commandIndex: index };
+}
+
 export function rewriteLegacyGatewayBinaryArgv(argv: string[]): string[] {
   if (!isLegacyGatewayBinary(argv[1])) {
     return argv;
   }
-  if (argv[2] === "gateway" || argv[2] === "update" || argv[2] === "--update") {
+  const { commandToken, commandIndex } = resolveLegacyGatewayCommandToken(argv);
+  if (commandToken === "gateway" || commandToken === "update" || commandToken === "--update") {
     return argv;
   }
   const next = [...argv];
-  next.splice(2, 0, "gateway");
+  next.splice(commandIndex, 0, "gateway");
   return next;
 }
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -31,6 +31,7 @@ function isLegacyGatewayBinary(entryPath: string | undefined): boolean {
   const base = path.basename(entryPath).toLowerCase();
   return (
     base === "openclaw-gateway" ||
+    base === "openclaw-gateway.mjs" ||
     base === "openclaw-gateway.cmd" ||
     base === "openclaw-gateway.ps1" ||
     base === "openclaw-gateway.exe"

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -42,7 +42,7 @@ export function rewriteLegacyGatewayBinaryArgv(argv: string[]): string[] {
   if (!isLegacyGatewayBinary(argv[1])) {
     return argv;
   }
-  if (argv[2] === "gateway") {
+  if (argv[2] === "gateway" || argv[2] === "update" || argv[2] === "--update") {
     return argv;
   }
   const next = [...argv];

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -88,26 +88,40 @@ function resolveNonceRecoveryContext(params: {
   closeReason?: string | null;
   gatewayUrl?: string | null;
   fallbackPort: number;
+  listenerPortConfigured: boolean;
 }): {
   loopbackUrl: boolean;
   tunnelPort: number;
 } | null {
   const resolveTunnelPort = (): number => {
     const raw = params.gatewayUrl;
-    // Recovery guidance should target the gateway listener directly. For
-    // non-loopback URLs we may be looking at a reverse-proxy edge port (e.g. 443),
-    // so prefer configured gateway port unless the probe itself is loopback.
-    if (!raw || !isLoopbackWsUrl(raw)) {
+    if (!raw) {
       return params.fallbackPort;
     }
     try {
       const parsed = new URL(raw);
-      if ((parsed.protocol === "ws:" || parsed.protocol === "wss:") && parsed.port) {
+      if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+        return params.fallbackPort;
+      }
+
+      const loopback = isLoopbackWsUrl(raw);
+      let parsedPort: number | null = null;
+      if (parsed.port) {
         const numeric = Number.parseInt(parsed.port, 10);
         if (Number.isFinite(numeric) && numeric > 0 && numeric <= 65_535) {
-          return numeric;
+          parsedPort = numeric;
         }
       }
+
+      if (loopback) {
+        return parsedPort ?? params.fallbackPort;
+      }
+      // For non-loopback URLs, prefer explicit listener settings; otherwise use
+      // the probed URL port when available.
+      if (params.listenerPortConfigured) {
+        return params.fallbackPort;
+      }
+      return parsedPort ?? params.fallbackPort;
     } catch {
       // Use configured fallback below.
     }
@@ -132,6 +146,24 @@ function resolveNonceRecoveryContext(params: {
     loopbackUrl: isLoopbackWsUrl(params.gatewayUrl),
     tunnelPort: resolveTunnelPort(),
   };
+}
+
+function resolveExplicitGatewayPort(
+  cfg: { gateway?: { port?: number } } | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): number | null {
+  const envRaw = env.OPENCLAW_GATEWAY_PORT?.trim() || env.CLAWDBOT_GATEWAY_PORT?.trim();
+  if (envRaw) {
+    const parsed = Number.parseInt(envRaw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  const configPort = cfg?.gateway?.port;
+  if (typeof configPort === "number" && Number.isFinite(configPort) && configPort > 0) {
+    return configPort;
+  }
+  return null;
 }
 
 export async function statusCommand(
@@ -286,8 +318,10 @@ export async function statusCommand(
 
   const tableWidth = Math.max(60, (process.stdout.columns ?? 120) - 1);
 
+  const explicitGatewayPort = resolveExplicitGatewayPort(cfg);
+  const configuredGatewayPort = explicitGatewayPort ?? resolveGatewayPort(cfg);
+
   const dashboard = (() => {
-    const configuredGatewayPort = resolveGatewayPort(cfg);
     const controlUiEnabled = cfg.gateway?.controlUi?.enabled ?? true;
     if (!controlUiEnabled) {
       return "disabled";
@@ -336,7 +370,8 @@ export async function statusCommand(
     error: gatewayProbe?.error ?? null,
     closeReason: gatewayProbe?.close?.reason ?? null,
     gatewayUrl: gatewayProbe?.url ?? gatewayConnection.url,
-    fallbackPort: resolveGatewayPort(cfg),
+    fallbackPort: configuredGatewayPort,
+    listenerPortConfigured: explicitGatewayPort !== null,
   });
 
   const agentsValue = (() => {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -64,6 +64,48 @@ function resolvePairingRecoveryContext(params: {
   return { requestId: requestId || null };
 }
 
+function isLoopbackWsUrl(url?: string | null): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+      return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function resolveNonceRecoveryContext(params: {
+  error?: string | null;
+  closeReason?: string | null;
+  gatewayUrl?: string | null;
+}): {
+  loopbackUrl: boolean;
+} | null {
+  const source = [params.error, params.closeReason]
+    .filter((part) => typeof part === "string" && part.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+  if (!source) {
+    return null;
+  }
+  const hasNonceHandshakeFailure =
+    source.includes("device nonce required") ||
+    source.includes("device nonce mismatch") ||
+    source.includes("connect challenge missing nonce");
+  if (!hasNonceHandshakeFailure) {
+    return null;
+  }
+  return {
+    loopbackUrl: isLoopbackWsUrl(params.gatewayUrl),
+  };
+}
+
 export async function statusCommand(
   opts: {
     json?: boolean;
@@ -261,6 +303,11 @@ export async function statusCommand(
     error: gatewayProbe?.error ?? null,
     closeReason: gatewayProbe?.close?.reason ?? null,
   });
+  const nonceRecovery = resolveNonceRecoveryContext({
+    error: gatewayProbe?.error ?? null,
+    closeReason: gatewayProbe?.close?.reason ?? null,
+    gatewayUrl: gatewayProbe?.url ?? gatewayConnection.url,
+  });
 
   const agentsValue = (() => {
     const pending =
@@ -442,6 +489,26 @@ export async function statusCommand(
     }
     runtime.log(theme.muted(`Fallback: ${formatCliCommand("openclaw devices approve --latest")}`));
     runtime.log(theme.muted(`Inspect: ${formatCliCommand("openclaw devices list")}`));
+  }
+
+  if (nonceRecovery) {
+    runtime.log("");
+    runtime.log(theme.warn("Gateway device nonce handshake failed."));
+    runtime.log(
+      theme.muted(
+        "If this dashboard is behind a cloud proxy/WSS forwarder, it may strip handshake data.",
+      ),
+    );
+    if (!nonceRecovery.loopbackUrl) {
+      runtime.log(theme.muted("Use a local SSH tunnel instead of a provider web proxy."));
+    }
+    runtime.log(theme.muted("Tunnel: ssh -L 18789:127.0.0.1:18789 <user>@<host>"));
+    runtime.log(theme.muted("Then open: http://127.0.0.1:18789"));
+    runtime.log(
+      theme.muted(
+        "If you must stay behind a reverse proxy, configure gateway auth mode as trusted-proxy.",
+      ),
+    );
   }
 
   runtime.log("");

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -90,11 +90,14 @@ function resolveNonceRecoveryContext(params: {
   tunnelPort: number;
 } | null {
   const resolveTunnelPort = (): number => {
+    const raw = params.gatewayUrl;
+    // Recovery guidance should target the gateway listener directly. For
+    // non-loopback URLs we may be looking at a reverse-proxy edge port (e.g. 443),
+    // so prefer configured gateway port unless the probe itself is loopback.
+    if (!raw || !isLoopbackWsUrl(raw)) {
+      return params.fallbackPort;
+    }
     try {
-      const raw = params.gatewayUrl;
-      if (!raw) {
-        return params.fallbackPort;
-      }
       const parsed = new URL(raw);
       if ((parsed.protocol === "ws:" || parsed.protocol === "wss:") && parsed.port) {
         const numeric = Number.parseInt(parsed.port, 10);

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -74,7 +74,10 @@ function isLoopbackWsUrl(url?: string | null): boolean {
       return false;
     }
     const host = parsed.hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+    const normalizedHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+    return (
+      normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1"
+    );
   } catch {
     return false;
   }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -84,9 +84,30 @@ function resolveNonceRecoveryContext(params: {
   error?: string | null;
   closeReason?: string | null;
   gatewayUrl?: string | null;
+  fallbackPort: number;
 }): {
   loopbackUrl: boolean;
+  tunnelPort: number;
 } | null {
+  const resolveTunnelPort = (): number => {
+    try {
+      const raw = params.gatewayUrl;
+      if (!raw) {
+        return params.fallbackPort;
+      }
+      const parsed = new URL(raw);
+      if ((parsed.protocol === "ws:" || parsed.protocol === "wss:") && parsed.port) {
+        const numeric = Number.parseInt(parsed.port, 10);
+        if (Number.isFinite(numeric) && numeric > 0 && numeric <= 65_535) {
+          return numeric;
+        }
+      }
+    } catch {
+      // Use configured fallback below.
+    }
+    return params.fallbackPort;
+  };
+
   const source = [params.error, params.closeReason]
     .filter((part) => typeof part === "string" && part.trim().length > 0)
     .join(" ")
@@ -103,6 +124,7 @@ function resolveNonceRecoveryContext(params: {
   }
   return {
     loopbackUrl: isLoopbackWsUrl(params.gatewayUrl),
+    tunnelPort: resolveTunnelPort(),
   };
 }
 
@@ -259,12 +281,13 @@ export async function statusCommand(
   const tableWidth = Math.max(60, (process.stdout.columns ?? 120) - 1);
 
   const dashboard = (() => {
+    const configuredGatewayPort = resolveGatewayPort(cfg);
     const controlUiEnabled = cfg.gateway?.controlUi?.enabled ?? true;
     if (!controlUiEnabled) {
       return "disabled";
     }
     const links = resolveControlUiLinks({
-      port: resolveGatewayPort(cfg),
+      port: configuredGatewayPort,
       bind: cfg.gateway?.bind,
       customBindHost: cfg.gateway?.customBindHost,
       basePath: cfg.gateway?.controlUi?.basePath,
@@ -307,6 +330,7 @@ export async function statusCommand(
     error: gatewayProbe?.error ?? null,
     closeReason: gatewayProbe?.close?.reason ?? null,
     gatewayUrl: gatewayProbe?.url ?? gatewayConnection.url,
+    fallbackPort: resolveGatewayPort(cfg),
   });
 
   const agentsValue = (() => {
@@ -502,8 +526,12 @@ export async function statusCommand(
     if (!nonceRecovery.loopbackUrl) {
       runtime.log(theme.muted("Use a local SSH tunnel instead of a provider web proxy."));
     }
-    runtime.log(theme.muted("Tunnel: ssh -L 18789:127.0.0.1:18789 <user>@<host>"));
-    runtime.log(theme.muted("Then open: http://127.0.0.1:18789"));
+    runtime.log(
+      theme.muted(
+        `Tunnel: ssh -L ${nonceRecovery.tunnelPort}:127.0.0.1:${nonceRecovery.tunnelPort} <user>@<host>`,
+      ),
+    );
+    runtime.log(theme.muted(`Then open: http://127.0.0.1:${nonceRecovery.tunnelPort}`));
     runtime.log(
       theme.muted(
         "If you must stay behind a reverse proxy, configure gateway auth mode as trusted-proxy.",

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -114,11 +114,15 @@ function resolveNonceRecoveryContext(params: {
         return parsedPort ?? params.fallbackPort;
       }
       // For non-loopback URLs, prefer explicit listener settings; otherwise use
-      // the probed URL port when available.
+      // the probed URL port when available. If URL omits the port, use the
+      // scheme default because that's the only concrete remote listener hint.
       if (params.listenerPortConfigured) {
         return params.fallbackPort;
       }
-      return parsedPort ?? params.fallbackPort;
+      if (parsedPort !== null) {
+        return parsedPort;
+      }
+      return parsed.protocol === "wss:" ? 443 : 80;
     } catch {
       // Use configured fallback below.
     }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
 import { resolveGatewayPort } from "../config/config.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import { isLoopbackHost } from "../gateway/net.js";
 import { info } from "../globals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
@@ -73,11 +74,7 @@ function isLoopbackWsUrl(url?: string | null): boolean {
     if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
       return false;
     }
-    const host = parsed.hostname.toLowerCase();
-    const normalizedHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
-    return (
-      normalizedHost === "localhost" || normalizedHost === "127.0.0.1" || normalizedHost === "::1"
-    );
+    return isLoopbackHost(parsed.hostname);
   } catch {
     return false;
   }

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -568,7 +568,7 @@ describe("statusCommand", () => {
     expect(joined).toContain("devices approve req-close-456");
   });
 
-  it("prints nonce recovery guidance when handshake nonce is missing behind proxy", async () => {
+  it("uses wss default port for nonce guidance when non-loopback URL omits port", async () => {
     mocks.probeGateway.mockResolvedValueOnce({
       ok: false,
       url: "wss://forward.example.com",
@@ -586,9 +586,29 @@ describe("statusCommand", () => {
     const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
     expect(joined).toContain("Gateway device nonce handshake failed.");
     expect(joined).toContain("cloud proxy/WSS forwarder");
-    expect(joined).toContain("ssh -L 18789:127.0.0.1:18789 <user>@<host>");
-    expect(joined).toContain("http://127.0.0.1:18789");
+    expect(joined).toContain("ssh -L 443:127.0.0.1:443 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:443");
     expect(joined).toContain("trusted-proxy");
+  });
+
+  it("uses ws default port for nonce guidance when non-loopback URL omits port", async () => {
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: false,
+      url: "ws://forward.example.com",
+      connectLatencyMs: null,
+      error: "connect failed: device nonce required",
+      close: { code: 1008, reason: "connect failed" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    runtimeLogMock.mockClear();
+    await statusCommand({}, runtime as never);
+    const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(joined).toContain("ssh -L 80:127.0.0.1:80 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:80");
   });
 
   it("uses probe URL port for nonce guidance when listener port is not configured", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -589,6 +589,26 @@ describe("statusCommand", () => {
     expect(joined).toContain("trusted-proxy");
   });
 
+  it("uses probed gateway port in nonce tunnel guidance", async () => {
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://forward.example.com:24444",
+      connectLatencyMs: null,
+      error: "connect failed: device nonce required",
+      close: { code: 1008, reason: "connect failed" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    runtimeLogMock.mockClear();
+    await statusCommand({}, runtime as never);
+    const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:24444");
+  });
+
   it("includes sessions across agents in JSON output", async () => {
     const originalAgents = mocks.listAgentsForGateway.getMockImplementation();
     const originalResolveStorePath = mocks.resolveStorePath.getMockImplementation();

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -589,10 +589,30 @@ describe("statusCommand", () => {
     expect(joined).toContain("trusted-proxy");
   });
 
-  it("uses probed gateway port in nonce tunnel guidance", async () => {
+  it("uses configured gateway port for nonce guidance when probe URL is proxy-facing", async () => {
     mocks.probeGateway.mockResolvedValueOnce({
       ok: false,
       url: "wss://forward.example.com:24444",
+      connectLatencyMs: null,
+      error: "connect failed: device nonce required",
+      close: { code: 1008, reason: "connect failed" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    runtimeLogMock.mockClear();
+    await statusCommand({}, runtime as never);
+    const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(joined).toContain("ssh -L 18789:127.0.0.1:18789 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:18789");
+  });
+
+  it("uses loopback probe URL port in nonce guidance when URL is direct gateway", async () => {
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: false,
+      url: "ws://127.0.0.1:24444",
       connectLatencyMs: null,
       error: "connect failed: device nonce required",
       close: { code: 1008, reason: "connect failed" },

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -661,6 +661,37 @@ describe("statusCommand", () => {
     expect(joined).toContain("http://127.0.0.1:24444");
   });
 
+  it("treats other IPv4 loopback probe URLs as direct gateway endpoints", async () => {
+    const previousGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
+    process.env.OPENCLAW_GATEWAY_PORT = "18789";
+    try {
+      mocks.probeGateway.mockResolvedValueOnce({
+        ok: false,
+        url: "ws://127.0.0.2:24444",
+        connectLatencyMs: null,
+        error: "connect failed: device nonce required",
+        close: { code: 1008, reason: "connect failed" },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      });
+
+      runtimeLogMock.mockClear();
+      await statusCommand({}, runtime as never);
+      const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+      expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
+      expect(joined).toContain("http://127.0.0.1:24444");
+      expect(joined).not.toContain("Use a local SSH tunnel instead of a provider web proxy.");
+    } finally {
+      if (previousGatewayPort === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PORT;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PORT = previousGatewayPort;
+      }
+    }
+  });
+
   it("treats bracketed IPv6 loopback probe URLs as direct gateway endpoints", async () => {
     mocks.probeGateway.mockResolvedValueOnce({
       ok: false,
@@ -680,6 +711,37 @@ describe("statusCommand", () => {
     expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
     expect(joined).toContain("http://127.0.0.1:24444");
     expect(joined).not.toContain("Use a local SSH tunnel instead of a provider web proxy.");
+  });
+
+  it("treats IPv4-mapped IPv6 loopback probe URLs as direct gateway endpoints", async () => {
+    const previousGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
+    process.env.OPENCLAW_GATEWAY_PORT = "18789";
+    try {
+      mocks.probeGateway.mockResolvedValueOnce({
+        ok: false,
+        url: "ws://[::ffff:127.0.0.1]:24444",
+        connectLatencyMs: null,
+        error: "connect failed: device nonce required",
+        close: { code: 1008, reason: "connect failed" },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      });
+
+      runtimeLogMock.mockClear();
+      await statusCommand({}, runtime as never);
+      const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+      expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
+      expect(joined).toContain("http://127.0.0.1:24444");
+      expect(joined).not.toContain("Use a local SSH tunnel instead of a provider web proxy.");
+    } finally {
+      if (previousGatewayPort === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PORT;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PORT = previousGatewayPort;
+      }
+    }
   });
 
   it("includes sessions across agents in JSON output", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -566,6 +566,29 @@ describe("statusCommand", () => {
     expect(joined).toContain("devices approve req-close-456");
   });
 
+  it("prints nonce recovery guidance when handshake nonce is missing behind proxy", async () => {
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://forward.example.com",
+      connectLatencyMs: null,
+      error: "connect failed: device nonce required",
+      close: { code: 1008, reason: "connect failed" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    runtimeLogMock.mockClear();
+    await statusCommand({}, runtime as never);
+    const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(joined).toContain("Gateway device nonce handshake failed.");
+    expect(joined).toContain("cloud proxy/WSS forwarder");
+    expect(joined).toContain("ssh -L 18789:127.0.0.1:18789 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:18789");
+    expect(joined).toContain("trusted-proxy");
+  });
+
   it("includes sessions across agents in JSON output", async () => {
     const originalAgents = mocks.listAgentsForGateway.getMockImplementation();
     const originalResolveStorePath = mocks.resolveStorePath.getMockImplementation();

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -629,6 +629,27 @@ describe("statusCommand", () => {
     expect(joined).toContain("http://127.0.0.1:24444");
   });
 
+  it("treats bracketed IPv6 loopback probe URLs as direct gateway endpoints", async () => {
+    mocks.probeGateway.mockResolvedValueOnce({
+      ok: false,
+      url: "ws://[::1]:24444",
+      connectLatencyMs: null,
+      error: "connect failed: device nonce required",
+      close: { code: 1008, reason: "connect failed" },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    runtimeLogMock.mockClear();
+    await statusCommand({}, runtime as never);
+    const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+    expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:24444");
+    expect(joined).not.toContain("Use a local SSH tunnel instead of a provider web proxy.");
+  });
+
   it("includes sessions across agents in JSON output", async () => {
     const originalAgents = mocks.listAgentsForGateway.getMockImplementation();
     const originalResolveStorePath = mocks.resolveStorePath.getMockImplementation();

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -5,8 +5,10 @@ import { captureEnv } from "../test-utils/env.js";
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 beforeAll(() => {
-  envSnapshot = captureEnv(["OPENCLAW_PROFILE"]);
+  envSnapshot = captureEnv(["OPENCLAW_PROFILE", "OPENCLAW_GATEWAY_PORT", "CLAWDBOT_GATEWAY_PORT"]);
   process.env.OPENCLAW_PROFILE = "isolated";
+  delete process.env.OPENCLAW_GATEWAY_PORT;
+  delete process.env.CLAWDBOT_GATEWAY_PORT;
 });
 
 afterAll(() => {
@@ -589,7 +591,7 @@ describe("statusCommand", () => {
     expect(joined).toContain("trusted-proxy");
   });
 
-  it("uses configured gateway port for nonce guidance when probe URL is proxy-facing", async () => {
+  it("uses probe URL port for nonce guidance when listener port is not configured", async () => {
     mocks.probeGateway.mockResolvedValueOnce({
       ok: false,
       url: "wss://forward.example.com:24444",
@@ -605,8 +607,38 @@ describe("statusCommand", () => {
     runtimeLogMock.mockClear();
     await statusCommand({}, runtime as never);
     const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
-    expect(joined).toContain("ssh -L 18789:127.0.0.1:18789 <user>@<host>");
-    expect(joined).toContain("http://127.0.0.1:18789");
+    expect(joined).toContain("ssh -L 24444:127.0.0.1:24444 <user>@<host>");
+    expect(joined).toContain("http://127.0.0.1:24444");
+  });
+
+  it("uses configured listener port for nonce guidance when probe URL is non-loopback", async () => {
+    const previousGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
+    process.env.OPENCLAW_GATEWAY_PORT = "18789";
+    try {
+      mocks.probeGateway.mockResolvedValueOnce({
+        ok: false,
+        url: "wss://forward.example.com:24444",
+        connectLatencyMs: null,
+        error: "connect failed: device nonce required",
+        close: { code: 1008, reason: "connect failed" },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      });
+
+      runtimeLogMock.mockClear();
+      await statusCommand({}, runtime as never);
+      const joined = runtimeLogMock.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+      expect(joined).toContain("ssh -L 18789:127.0.0.1:18789 <user>@<host>");
+      expect(joined).toContain("http://127.0.0.1:18789");
+    } finally {
+      if (previousGatewayPort === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PORT;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PORT = previousGatewayPort;
+      }
+    }
   });
 
   it("uses loopback probe URL port in nonce guidance when URL is direct gateway", async () => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -13,6 +13,7 @@ import { attachChildProcessBridge } from "./process/child-process-bridge.js";
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
   { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
+  { wrapperBasename: "openclaw-gateway.mjs", entryBasename: "entry.js" },
 ] as const;
 
 function shouldForceReadOnlyAuthStore(argv: string[]): boolean {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -57,4 +57,37 @@ describe("loadGatewayPlugins", () => {
     );
     expect(log.warn).not.toHaveBeenCalled();
   });
+
+  test("adds actionable hint for missing plugin dependencies", () => {
+    const diagnostics: PluginDiagnostic[] = [
+      {
+        level: "error",
+        pluginId: "feishu",
+        source: "/tmp/feishu/index.ts",
+        message: "failed to load plugin: Error: Cannot find module '@larksuiteoapi/node-sdk'",
+      },
+    ];
+    loadOpenClawPlugins.mockReturnValue(createRegistry(diagnostics));
+
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log,
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Hint: Missing dependency "@larksuiteoapi/node-sdk". If this plugin was installed from npm, run "openclaw plugins update feishu".',
+      ),
+    );
+  });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -1,4 +1,5 @@
 import type { loadConfig } from "../config/config.js";
+import { resolvePluginMissingDependencyHint } from "../plugins/load-error-hints.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 
@@ -38,10 +39,18 @@ export function loadGatewayPlugins(params: {
       const message = details
         ? `[plugins] ${diag.message} (${details})`
         : `[plugins] ${diag.message}`;
+      const hint =
+        diag.level === "error"
+          ? resolvePluginMissingDependencyHint({
+              message: diag.message,
+              pluginId: diag.pluginId,
+            })
+          : null;
+      const finalMessage = hint ? `${message} Hint: ${hint}` : message;
       if (diag.level === "error") {
-        params.log.error(message);
+        params.log.error(finalMessage);
       } else {
-        params.log.info(message);
+        params.log.info(finalMessage);
       }
     }
   }

--- a/src/gateway/server.auth.test.ts
+++ b/src/gateway/server.auth.test.ts
@@ -258,6 +258,7 @@ async function sendRawConnectReq(
       details?: {
         code?: string;
         reason?: string;
+        hint?: string;
       };
     };
   }>(ws, isConnectResMessage(params.id));
@@ -646,6 +647,30 @@ describe("gateway server auth/connect", () => {
         ConnectErrorDetailCodes.DEVICE_AUTH_NONCE_REQUIRED,
       );
       expect(connectRes.error?.details?.reason).toBe("device-nonce-missing");
+      await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    });
+
+    test("includes reverse proxy hint for nonce errors on non-local host", async () => {
+      const ws = await openWs(port, { host: "forward.example.com" });
+      const token = resolveGatewayTokenOrEnv();
+      const nonce = await readConnectChallengeNonce(ws);
+      const { device } = await createSignedDevice({
+        token,
+        scopes: ["operator.admin"],
+        clientId: TEST_OPERATOR_CLIENT.id,
+        clientMode: TEST_OPERATOR_CLIENT.mode,
+        nonce,
+      });
+
+      const connectRes = await sendRawConnectReq(ws, {
+        id: "c-blank-nonce-proxy",
+        token,
+        device: { ...device, nonce: "   " },
+      });
+      expect(connectRes.ok).toBe(false);
+      expect(connectRes.error?.message ?? "").toContain("device nonce required");
+      expect(connectRes.error?.message ?? "").toContain("proxy/tunnel may strip connect.challenge");
+      expect(connectRes.error?.details?.hint).toContain("SSH tunnel");
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
     });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -90,6 +90,8 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const DEVICE_SIGNATURE_SKEW_MS = 2 * 60 * 1000;
 const BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP = "198.18.0.1";
+const NONCE_PROXY_HINT =
+  "proxy/tunnel may strip connect.challenge; use SSH tunnel or gateway.auth.mode=trusted-proxy";
 
 type HandshakeBrowserSecurityContext = {
   hasBrowserOriginHeader: boolean;
@@ -619,6 +621,12 @@ export function attachGatewayWsMessageHandler(params: {
         }
         if (device) {
           const rejectDeviceAuthInvalid = (reason: string, message: string) => {
+            const proxyHint =
+              (reason === "device-nonce-missing" || reason === "device-nonce-mismatch") &&
+              (hasProxyHeaders || !hostIsLocalish)
+                ? NONCE_PROXY_HINT
+                : undefined;
+            const responseMessage = proxyHint ? `${message} (${proxyHint})` : message;
             setHandshakeState("failed");
             setCloseCause("device-auth-invalid", {
               reason,
@@ -629,14 +637,15 @@ export function attachGatewayWsMessageHandler(params: {
               type: "res",
               id: frame.id,
               ok: false,
-              error: errorShape(ErrorCodes.INVALID_REQUEST, message, {
+              error: errorShape(ErrorCodes.INVALID_REQUEST, responseMessage, {
                 details: {
                   code: resolveDeviceAuthConnectErrorDetailCode(reason),
                   reason,
+                  ...(proxyHint ? { hint: proxyHint } : {}),
                 },
               }),
             });
-            close(1008, message);
+            close(1008, truncateCloseReason(responseMessage));
           };
           const derivedId = deriveDeviceIdFromPublicKey(device.publicKey);
           if (!derivedId || derivedId !== device.id) {

--- a/src/infra/infra-parsing.test.ts
+++ b/src/infra/infra-parsing.test.ts
@@ -68,6 +68,20 @@ describe("infra parsing", () => {
       ).toBe(true);
     });
 
+    it("returns true for dist/entry.js when launched via openclaw-gateway.mjs wrapper", () => {
+      expect(
+        isMainModule({
+          currentFile: "/repo/dist/entry.js",
+          argv: ["node", "/repo/openclaw-gateway.mjs"],
+          cwd: "/repo",
+          env: {},
+          wrapperEntryPairs: [
+            { wrapperBasename: "openclaw-gateway.mjs", entryBasename: "entry.js" },
+          ],
+        }),
+      ).toBe(true);
+    });
+
     it("returns false for wrapper launches when wrapper pair is not configured", () => {
       expect(
         isMainModule({

--- a/src/plugins/load-error-hints.test.ts
+++ b/src/plugins/load-error-hints.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolvePluginMissingDependencyHint } from "./load-error-hints.js";
+
+describe("resolvePluginMissingDependencyHint", () => {
+  it("returns a fix hint for missing package dependencies", () => {
+    expect(
+      resolvePluginMissingDependencyHint({
+        pluginId: "feishu",
+        message: "failed to load plugin: Error: Cannot find module '@larksuiteoapi/node-sdk'",
+      }),
+    ).toBe(
+      'Missing dependency "@larksuiteoapi/node-sdk". If this plugin was installed from npm, run "openclaw plugins update feishu". Otherwise reinstall the plugin or run "npm install --omit=dev" in the plugin directory.',
+    );
+  });
+
+  it("returns placeholder update command when plugin id is unknown", () => {
+    expect(
+      resolvePluginMissingDependencyHint({
+        message:
+          "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod' imported from /tmp/plugin.js",
+      }),
+    ).toContain('"openclaw plugins update <plugin-id>"');
+  });
+
+  it("ignores relative-path module misses", () => {
+    expect(
+      resolvePluginMissingDependencyHint({
+        pluginId: "example",
+        message: "Error: Cannot find module './helpers.js'",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for unrelated load failures", () => {
+    expect(
+      resolvePluginMissingDependencyHint({
+        pluginId: "example",
+        message: "failed to load plugin: boom",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/plugins/load-error-hints.ts
+++ b/src/plugins/load-error-hints.ts
@@ -1,0 +1,56 @@
+export type PluginMissingDependencyHintParams = {
+  message: string;
+  pluginId?: string;
+};
+
+function extractMissingModuleSpecifier(message: string): string | null {
+  const patterns = [
+    /Cannot find module ['"]([^'"]+)['"]/i,
+    /Cannot find package ['"]([^'"]+)['"]/i,
+    /ERR_MODULE_NOT_FOUND[\s\S]*?['"]([^'"]+)['"]/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(message);
+    if (!match) {
+      continue;
+    }
+    const spec = match[1]?.trim();
+    if (spec) {
+      return spec;
+    }
+  }
+  return null;
+}
+
+function isLikelyDependencySpecifier(spec: string): boolean {
+  if (!spec) {
+    return false;
+  }
+  if (spec.startsWith(".") || spec.startsWith("/")) {
+    return false;
+  }
+  if (spec.startsWith("file:")) {
+    return false;
+  }
+  if (/^[a-z]:[\\/]/i.test(spec)) {
+    return false;
+  }
+  return true;
+}
+
+export function resolvePluginMissingDependencyHint(
+  params: PluginMissingDependencyHintParams,
+): string | null {
+  const specifier = extractMissingModuleSpecifier(params.message);
+  if (!specifier || !isLikelyDependencySpecifier(specifier)) {
+    return null;
+  }
+  const updateCommand = params.pluginId
+    ? `openclaw plugins update ${params.pluginId}`
+    : "openclaw plugins update <plugin-id>";
+  return (
+    `Missing dependency "${specifier}". If this plugin was installed from npm, run "${updateCommand}". ` +
+    'Otherwise reinstall the plugin or run "npm install --omit=dev" in the plugin directory.'
+  );
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: upgrades in PM2/NVM and proxy-forwarded setups could fail in multiple ways (legacy `openclaw-gateway` launch mismatch, opaque plugin dependency failures, and unclear nonce-handshake recovery guidance).
- Why it matters: operators could be blocked on startup/connectivity and receive recovery commands that did not match their actual deployment port/path.
- What changed:
  - Added a dedicated `openclaw-gateway` wrapper entrypoint and hardened legacy argv normalization in `run-main`.
  - Synced normalized gateway argv into `process.argv` so preAction/config-guard/lazy command registration all see the same command path.
  - Added explicit passthroughs for root update/version/help aliases (`update`, `--update`, `-v`, `-V`, `--version`, `-h`, `--help`) and made rewrite logic root-flag aware (`--no-color`, `--log-level`, `--profile`, `--dev`).
  - Added plugin missing-dependency hints (`gateway` startup + `openclaw plugins doctor`) with actionable install guidance.
  - Added nonce/proxy handshake diagnostics plus smarter tunnel port selection:
    - explicit listener port (env/config) wins for non-loopback URLs,
    - otherwise non-loopback probe URL ports are used when available,
    - loopback detection now covers broader local forms (including `127/8` and IPv4-mapped IPv6 loopback).
  - Added/updated Linux troubleshooting docs for PM2/NVM wrapper behavior and recovery.
- What did NOT change (scope boundary): no auth/pairing trust model was loosened; this PR focuses on compatibility, diagnostics, and operator guidance.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26252

## User-visible / Behavior Changes

- `openclaw-gateway` legacy launch paths are now compatible across shim/wrapper variants.
- `openclaw-gateway` root update/version/help invocations now remain valid even with leading root flags.
- Plugin startup failures now include dependency-specific install hints.
- `openclaw status` nonce recovery guidance now provides more accurate tunnel commands across loopback, custom-port, and proxy-facing scenarios.
- Linux troubleshooting docs include PM2/NVM wrapper recovery guidance.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - CLI dispatch behavior for legacy gateway entrypoints changed. Mitigation: regression tests cover rewrite/passthrough cases and command-path consistency.

## Repro + Verification

### Environment

- OS: macOS 14.x (local verification), Linux PM2/NVM behavior covered by docs + command-path tests
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Feishu dependency hint path
- Relevant config (redacted): gateway local mode, proxy/nonce failure scenarios

### Steps

1. Verify legacy gateway argv normalization (`openclaw-gateway ...`) and root passthrough behavior.
2. Verify nonce recovery messaging for loopback/non-loopback/proxy-facing URL variants.
3. Verify plugin load-error hints and doctor output guidance.
4. Run tests + checks.

### Expected

- Legacy gateway launch/update/version paths remain valid.
- Nonce recovery guidance uses correct tunnel target/port context.
- Plugin missing dependencies produce actionable hints.
- Checks pass.

### Actual

- Matches expected after this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/cli/run-main.test.ts`
  - `pnpm exec vitest run src/commands/status.test.ts`
  - `pnpm exec vitest run src/infra/infra-parsing.test.ts`
  - `pnpm check`
- Edge cases checked:
  - root-flag-ordered gateway update passthrough (`--no-color --update`, `--log-level debug --update`)
  - root version alias passthrough for gateway wrapper (`-v`)
  - loopback URL variants (`127.0.0.1`, `127.0.0.2`, `[::1]`, `[::ffff:127.0.0.1]`)
  - non-loopback nonce tunnel guidance with and without explicit listener port
- What you did **not** verify:
  - Live remote PM2/NVM deployment and live proxy appliance behavior in this PR run.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commits and republish.
- Files/config to restore:
  - `src/cli/run-main.ts`
  - `src/commands/status.command.ts`
  - `src/plugins/load-error-hints.ts`
  - `src/gateway/server/ws-connection/message-handler.ts`
  - `src/gateway/server-plugins.ts`
- Known bad symptoms reviewers should watch for:
  - `openclaw-gateway` commands mapping to invalid `gateway update` paths
  - wrong nonce tunnel port hints on loopback/custom-port URLs
  - missing plugin dependency remediation hints on startup

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: argv rewrite could alter root command semantics for gateway wrapper paths.
  - Mitigation: root passthrough set + root-flag-aware command detection + targeted rewrite tests.
- Risk: nonce guidance could prefer incorrect port in mixed proxy/direct deployments.
  - Mitigation: explicit listener-port precedence + URL-port fallback + loopback variant tests.
- Risk: plugin hints could become stale if dependency error signatures change.
  - Mitigation: hint logic constrained to known missing-module signatures and covered by unit tests.
