### PR TITLE
fix(gateway): check URL path before HTTP method in control UI handler

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -342,15 +342,27 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("does not intercept POST to non-control-UI paths (webhook passthrough)", async () => {
+  it("does not intercept POST to non-control-UI paths with basePath (webhook passthrough)", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        // With basePath: POST to a webhook path outside the UI prefix should pass through
         const { handled } = runControlUiRequest({
-          url: "/line/fulla",
+          url: "/line/webhook",
           method: "POST",
           rootPath: tmp,
           basePath: "/openclaw",
+        });
+        expect(handled).toBe(false);
+      },
+    });
+  });
+
+  it("does not intercept POST to non-control-UI paths without basePath (webhook passthrough)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled } = runControlUiRequest({
+          url: "/line/webhook",
+          method: "POST",
+          rootPath: tmp,
         });
         expect(handled).toBe(false);
       },

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -42,7 +42,7 @@ describe("handleControlUiHttpRequest", () => {
 
   function runControlUiRequest(params: {
     url: string;
-    method: "GET" | "HEAD";
+    method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
   }) {
@@ -136,7 +136,12 @@ describe("handleControlUiHttpRequest", () => {
             root: { kind: "resolved", path: tmp },
             config: {
               agents: { defaults: { workspace: tmp } },
-              ui: { assistant: { name: "</script><script>alert(1)//", avatar: "evil.png" } },
+              ui: {
+                assistant: {
+                  name: "</script><script>alert(1)//",
+                  avatar: "evil.png",
+                },
+              },
             },
           },
         );
@@ -151,13 +156,21 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const { res, end } = makeMockHttpResponse();
         const handled = handleControlUiHttpRequest(
-          { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
+          {
+            url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+            method: "GET",
+          } as IncomingMessage,
           res,
           {
             root: { kind: "resolved", path: tmp },
             config: {
               agents: { defaults: { workspace: tmp } },
-              ui: { assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" } },
+              ui: {
+                assistant: {
+                  name: "</script><script>alert(1)//",
+                  avatar: "</script>.png",
+                },
+              },
             },
           },
         );
@@ -176,7 +189,10 @@ describe("handleControlUiHttpRequest", () => {
       fn: async (tmp) => {
         const { res, end } = makeMockHttpResponse();
         const handled = handleControlUiHttpRequest(
-          { url: `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, method: "GET" } as IncomingMessage,
+          {
+            url: `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
+            method: "GET",
+          } as IncomingMessage,
           res,
           {
             basePath: "/openclaw",
@@ -322,6 +338,21 @@ describe("handleControlUiHttpRequest", () => {
         } finally {
           await fs.rm(outsideDir, { recursive: true, force: true });
         }
+      },
+    });
+  });
+
+  it("does not intercept POST to non-control-UI paths (webhook passthrough)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        // With basePath: POST to a webhook path outside the UI prefix should pass through
+        const { handled } = runControlUiRequest({
+          url: "/line/fulla",
+          method: "POST",
+          rootPath: tmp,
+          basePath: "/openclaw",
+        });
+        expect(handled).toBe(false);
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -297,6 +297,10 @@ export function handleControlUiHttpRequest(
       respondNotFound(res);
       return true;
     }
+    // No basePath and not a /ui path — let other handlers (webhooks, etc.) handle it
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      return false;
+    }
   }
 
   if (basePath) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -118,7 +118,10 @@ function isValidAgentId(agentId: string): boolean {
 export function handleControlUiAvatarRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  opts: { basePath?: string; resolveAvatar: (agentId: string) => ControlUiAvatarResolution },
+  opts: {
+    basePath?: string;
+    resolveAvatar: (agentId: string) => ControlUiAvatarResolution;
+  },
 ): boolean {
   const urlRaw = req.url;
   if (!urlRaw) {
@@ -275,19 +278,21 @@ export function handleControlUiHttpRequest(
   if (!urlRaw) {
     return false;
   }
-  if (req.method !== "GET" && req.method !== "HEAD") {
-    res.statusCode = 405;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end("Method Not Allowed");
-    return true;
-  }
 
+  // Parse URL and check path BEFORE method — non-control-UI paths must pass through
+  // so webhook handlers (LINE, etc.) can process POST requests.
   const url = new URL(urlRaw, "http://localhost");
   const basePath = normalizeControlUiBasePath(opts?.basePath);
   const pathname = url.pathname;
 
   if (!basePath) {
     if (pathname === "/ui" || pathname.startsWith("/ui/")) {
+      if (req.method !== "GET" && req.method !== "HEAD") {
+        res.statusCode = 405;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Method Not Allowed");
+        return true;
+      }
       applyControlUiSecurityHeaders(res);
       respondNotFound(res);
       return true;
@@ -296,6 +301,12 @@ export function handleControlUiHttpRequest(
 
   if (basePath) {
     if (pathname === basePath) {
+      if (req.method !== "GET" && req.method !== "HEAD") {
+        res.statusCode = 405;
+        res.setHeader("Content-Type", "text/plain; charset=utf-8");
+        res.end("Method Not Allowed");
+        return true;
+      }
       applyControlUiSecurityHeaders(res);
       res.statusCode = 302;
       res.setHeader("Location", `${basePath}/${url.search}`);
@@ -305,6 +316,14 @@ export function handleControlUiHttpRequest(
     if (!pathname.startsWith(`${basePath}/`)) {
       return false;
     }
+  }
+
+  // Path matches a control UI route — only allow GET/HEAD
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.statusCode = 405;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Method Not Allowed");
+    return true;
   }
 
   applyControlUiSecurityHeaders(res);


### PR DESCRIPTION
## Summary

- **Problem:** `handleControlUiHttpRequest` checks HTTP method before URL path, causing all POST requests to return 405 Method Not Allowed when control UI is enabled — breaking webhook-based channels that use the plugin HTTP route system
- **Why:** The method check (`req.method !== "GET"`) intercepts every non-GET/HEAD request before path matching can determine if the request is actually for the control UI
- **Fix:** Move URL parsing and path matching before the method check so non-control-UI paths pass through to their handlers
- **Scope:** Only `handleControlUiHttpRequest` logic ordering; no API or config changes

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway

## Affected channels

Channels using plugin HTTP routes (go through the gateway HTTP chain) are affected:
- LINE, Zalo, Feishu (HTTP mode), Google Chat, Synology Chat, Nextcloud Talk, BlueBubbles, Voice Call, MS Teams

Not affected (own HTTP server or non-webhook):
- Telegram (separate HTTP server), Slack (separate handler), Discord (WebSocket), Signal (SSE), Matrix, IRC, iMessage, WhatsApp Web

## User-visible changes

POST requests to non-control-UI paths are no longer intercepted with 405 when control UI is enabled. Plugin-route webhook channels work correctly again.

## Security impact

No new permissions, secrets, network calls, or data access. The 405 response is preserved for actual control UI paths — only non-UI paths are affected.

## Evidence

Added test: POST to a webhook path with basePath configured returns `false` (not handled by control UI), confirming webhook passthrough.

## Human verification

- `pnpm build` — passes
- `pnpm check` — passes
- `pnpm test -- --run src/gateway/` — 952 passed, 1 pre-existing failure in `server.canvas-auth.test.ts` (unrelated)