### PR TITLE
fix(discord): accept cid in agent component interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Agent component interactions: accept Components v2 `cid` payloads alongside legacy `componentId`, and safely decode percent-encoded IDs without throwing on malformed `%` sequences. Landed from contributor PR #29013 by @Jacky1n7. Thanks @Jacky1n7.
 - Discord/Inbound media fallback: preserve attachment and sticker metadata when Discord CDN fetch/save fails by keeping URL-based media entries in context, with regression coverage for save failures and mixed success/failure ordering. Landed from contributor PR #28906 by @Sid-Qin. Thanks @Sid-Qin.
 - Docs/Docker images: clarify the official GHCR image source and tag guidance (`main`, `latest`, `<version>`), and document that `OPENCLAW_IMAGE` skips local image builds but still uses the repo-local compose/setup flow. (#27214, #31180) Fixes #15655. Thanks @ipl31.
 - Agents/Model fallback: classify additional network transport errors (`ECONNREFUSED`, `ENETUNREACH`, `EHOSTUNREACH`, `ENETRESET`, `EAI_AGAIN`) as failover-worthy so fallback chains advance when primary providers are unreachable. Landed from contributor PR #19077 by @ayanesakura. Thanks @ayanesakura.

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -423,9 +423,26 @@ function parseAgentComponentData(data: ComponentData): {
       : (data as Record<string, unknown>).componentId) ??
     (data as Record<string, unknown>).componentId;
 
+  const decodeSafe = (value: string): string => {
+    // `cid` values may be raw (not URI-encoded). Guard against malformed % sequences.
+    // Only attempt decoding when it looks like it contains percent-encoding.
+    if (!value.includes("%")) {
+      return value;
+    }
+    // If it has a % but not a valid %XX sequence, skip decode.
+    if (!/%[0-9A-Fa-f]{2}/.test(value)) {
+      return value;
+    }
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  };
+
   const componentId =
     typeof raw === "string"
-      ? decodeURIComponent(raw)
+      ? decodeSafe(raw)
       : typeof raw === "number"
         ? String(raw)
         : null;

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -441,11 +441,7 @@ function parseAgentComponentData(data: ComponentData): {
   };
 
   const componentId =
-    typeof raw === "string"
-      ? decodeSafe(raw)
-      : typeof raw === "number"
-        ? String(raw)
-        : null;
+    typeof raw === "string" ? decodeSafe(raw) : typeof raw === "number" ? String(raw) : null;
 
   if (!componentId) {
     return null;

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -414,12 +414,22 @@ function parseAgentComponentData(data: ComponentData): {
   if (!data || typeof data !== "object") {
     return null;
   }
+
+  // Carbon parses "key:componentId=xxx" into { componentId: "xxx" }
+  // Components v2 / other builders may use { cid: "xxx" } (e.g. occomp:cid=xxx).
+  const raw =
+    ("cid" in data
+      ? (data as Record<string, unknown>).cid
+      : (data as Record<string, unknown>).componentId) ??
+    (data as Record<string, unknown>).componentId;
+
   const componentId =
-    typeof data.componentId === "string"
-      ? decodeURIComponent(data.componentId)
-      : typeof data.componentId === "number"
-        ? String(data.componentId)
+    typeof raw === "string"
+      ? decodeURIComponent(raw)
+      : typeof raw === "number"
+        ? String(raw)
         : null;
+
   if (!componentId) {
     return null;
   }

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -182,6 +182,44 @@ describe("agent components", () => {
     expect(reply).toHaveBeenCalledWith({ content: "✓" });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
   });
+
+  it("accepts cid payloads for agent button interactions", async () => {
+    const button = createAgentComponentButton({
+      cfg: createCfg(),
+      accountId: "default",
+      dmPolicy: "allowlist",
+      allowFrom: ["123456789"],
+    });
+    const { interaction, defer, reply } = createDmButtonInteraction();
+
+    await button.run(interaction, { cid: "hello_cid" } as ComponentData);
+
+    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("hello_cid"),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps malformed percent cid values without throwing", async () => {
+    const button = createAgentComponentButton({
+      cfg: createCfg(),
+      accountId: "default",
+      dmPolicy: "allowlist",
+      allowFrom: ["123456789"],
+    });
+    const { interaction, defer, reply } = createDmButtonInteraction();
+
+    await button.run(interaction, { cid: "hello%2G" } as ComponentData);
+
+    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("hello%2G"),
+      expect.any(Object),
+    );
+  });
 });
 
 describe("discord component interactions", () => {


### PR DESCRIPTION
背景：我们在 Discord Components v2 面板里点击按钮时，OpenClaw 日志出现：

- `agent button: failed to parse component data`
- `discord component button: failed to parse component data`

原因是某些组件的 customId 解析出来的字段是 `cid`（例如 `occomp:cid=...`），而 `parseAgentComponentData()` 只读取 `componentId`，导致 interaction 被判定为无效并回复 “This button is no longer valid.”

改动：`parseAgentComponentData()` 现在同时接受 `data.cid` 与 `data.componentId`。

效果：兼容 Components v2 / occomp 风格的交互数据，避免误判按钮失效。

备注：只改了一个函数，风险较低。
