### PR TITLE
fix(cron): recompute nextRunAtMs when schedule timezone is changed

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -270,6 +270,10 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
     const now = state.deps.nowMs();
+    // Snapshot before patch so we can detect any schedule change, including
+    // timezone-only edits that the old `patch.schedule !== undefined` check
+    // could miss (#27996).
+    const prevScheduleSnapshot = JSON.stringify(job.schedule);
     applyJobPatch(job, patch, { defaultAgentId: state.deps.defaultAgentId });
     if (job.schedule.kind === "every") {
       const anchor = job.schedule.anchorMs;
@@ -287,7 +291,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
         };
       }
     }
-    const scheduleChanged = patch.schedule !== undefined;
+    const scheduleChanged = JSON.stringify(job.schedule) !== prevScheduleSnapshot;
     const enabledChanged = patch.enabled !== undefined;
 
     job.updatedAtMs = now;


### PR DESCRIPTION
## Summary

Fixes a bug where editing only the timezone of a cron job does not recompute `nextRunAtMs`, causing the job to continue firing at the old timezone.

Closes #27996.

### Problem

In `src/cron/service/ops.ts`, the schedule change detection was:
```typescript
const scheduleChanged = patch.schedule !== undefined;
```
This checks whether the patch *included* a schedule field, but after `applyJobPatch()` has already mutated the job in place. More importantly, it can miss timezone-only edits depending on how the patch is constructed. The result: users change a cron job timezone, but it keeps firing at the old time.

### Fix

Snapshot the schedule via `JSON.stringify(job.schedule)` **before** applying the patch, then compare to the post-patch schedule. This catches any semantic change — timezone, expression, stagger, kind — regardless of how the patch was structured.

```typescript
const prevScheduleSnapshot = JSON.stringify(job.schedule);
applyJobPatch(job, patch);
// ...
const scheduleChanged = JSON.stringify(job.schedule) !== prevScheduleSnapshot;
```

### Changes

**`src/cron/service/ops.ts`** — 1 file, +5 / -1 lines

### Testing

- [x] `pnpm build` passes
- [x] Existing tests unaffected
- [x] AI-assisted (Claude Code) — fully reviewed and understood
