### PR TITLE
Media: clean URL temp files on failed saves

### DIFF
--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -5,7 +5,7 @@ import { PassThrough } from "node:stream";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinnedLookup } from "../infra/net/ssrf.js";
 import { captureEnv } from "../test-utils/env.js";
-import { saveMediaSource, setMediaStoreNetworkDepsForTest } from "./store.js";
+import { MEDIA_MAX_BYTES, saveMediaSource, setMediaStoreNetworkDepsForTest } from "./store.js";
 
 const HOME = path.join(os.tmpdir(), "openclaw-home-redirect");
 const mockRequest = vi.fn();
@@ -23,7 +23,7 @@ function createMockHttpExchange() {
       return req;
     },
     end: () => undefined,
-    destroy: () => res.destroy(),
+    destroy: (err?: Error) => res.destroy(err),
   } as const;
   return { req, res };
 }
@@ -107,5 +107,26 @@ describe("media store redirects", () => {
       "Redirect loop or missing Location header",
     );
     expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans temp files when oversized downloads fail", async () => {
+    mockRequest.mockImplementationOnce((_url, _opts, cb) => {
+      const { req, res } = createMockHttpExchange();
+      res.statusCode = 200;
+      res.headers = { "content-type": "application/octet-stream" };
+      setImmediate(() => {
+        cb(res as unknown);
+        res.write(Buffer.alloc(MEDIA_MAX_BYTES + 1_024, 1));
+        res.end();
+      });
+      return req;
+    });
+
+    await expect(saveMediaSource("https://example.com/oversized")).rejects.toThrow(
+      "Media exceeds 5MB limit",
+    );
+    const mediaDir = path.join(HOME, "media");
+    const entries = await fs.readdir(mediaDir);
+    expect(entries.some((entry) => entry.endsWith(".tmp"))).toBe(false);
   });
 });

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -261,17 +261,23 @@ export async function saveMediaSource(
   const baseId = crypto.randomUUID();
   if (looksLikeUrl(source)) {
     const tempDest = path.join(dir, `${baseId}.tmp`);
-    const { headerMime, sniffBuffer, size } = await downloadToFile(source, tempDest, headers);
-    const mime = await detectMime({
-      buffer: sniffBuffer,
-      headerMime,
-      filePath: source,
-    });
-    const ext = extensionForMime(mime) ?? path.extname(new URL(source).pathname);
-    const id = ext ? `${baseId}${ext}` : baseId;
-    const finalDest = path.join(dir, id);
-    await fs.rename(tempDest, finalDest);
-    return { id, path: finalDest, size, contentType: mime };
+    try {
+      const { headerMime, sniffBuffer, size } = await downloadToFile(source, tempDest, headers);
+      const mime = await detectMime({
+        buffer: sniffBuffer,
+        headerMime,
+        filePath: source,
+      });
+      const ext = extensionForMime(mime) ?? path.extname(new URL(source).pathname);
+      const id = ext ? `${baseId}${ext}` : baseId;
+      const finalDest = path.join(dir, id);
+      await fs.rename(tempDest, finalDest);
+      return { id, path: finalDest, size, contentType: mime };
+    } catch (err) {
+      // Best-effort cleanup so failed URL saves do not leave stale temp files behind.
+      await fs.rm(tempDest, { force: true }).catch(() => {});
+      throw err;
+    }
   }
   // local path
   try {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `saveMediaSource()` writes URL downloads to `{uuid}.tmp`, but failures after write start (for example oversize payload rejection) can leave stale temp files in the media directory.
- Why it matters: Repeated failed downloads can accumulate orphaned temp files and create avoidable disk churn/noise.
- What changed: Wrapped URL save path in `try/catch` and added best-effort temp cleanup (`fs.rm(tempDest, { force: true })`) before rethrowing errors.
- What did NOT change (scope boundary): No MIME detection changes, no media size limit changes, and no local-file save path behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Failed URL media saves no longer leave `.tmp` artifacts in the media directory.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Media URL download path
- Relevant config (redacted): `OPENCLAW_STATE_DIR` set in test harness

### Steps

1. Run `pnpm vitest run src/media/store.redirect.test.ts src/media/store.test.ts`.
2. Run `pnpm build`.
3. Run full validation (`pnpm check`, `pnpm test`) to verify repo baseline.

### Expected

- Targeted media tests pass and include regression coverage for temp file cleanup.
- Build passes.
- Full check/test should pass when repository baseline is green.

### Actual

- Targeted media tests passed.
- `pnpm build` passed.
- `pnpm check` currently fails on unrelated baseline type error in `src/agents/pi-embedded-runner-extraparams.test.ts`.
- `pnpm test` currently fails on unrelated baseline tests (`src/docker-setup.test.ts`, `test/git-hooks-pre-commit.test.ts`, `test/scripts/ios-team-id.test.ts`, and `src/slack/monitor/events/interactions.test.ts`).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added regression test that forces an oversized URL download and asserts no `.tmp` files remain.
- Edge cases checked: Request destroy path now forwards error in mock transport to mirror runtime behavior under oversize abort.
- What you did **not** verify: Live network download against external URLs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/media/store.ts`, `src/media/store.redirect.test.ts`.
- Known bad symptoms reviewers should watch for: `.tmp` media artifacts reappearing after failed URL saves.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Cleanup could accidentally remove a non-temp file if path derivation is incorrect.
  - Mitigation: Cleanup targets only the request-specific `{uuid}.tmp` path generated within this function and uses best-effort remove on error path only.
