### PR TITLE
fix: atomic JSON file writes to prevent crash corruption

### DIFF
--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -18,6 +19,23 @@ export function saveJsonFile(pathname: string, data: unknown) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  // Atomic write: write to a temp file in the same directory, then rename.
+  // rename() is atomic on the same filesystem, preventing corruption on crash.
+  const tmpPath = path.join(
+    dir,
+    `.${path.basename(pathname)}.${crypto.randomBytes(4).toString("hex")}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tmpPath, content, { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, pathname);
+  } catch (err) {
+    // Clean up the temp file if rename failed.
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary

- **Problem:** `saveJsonFile()` writes directly to the target path with `writeFileSync()`. A crash mid-write corrupts the file — affecting subagent registry, config, and other persisted JSON state.
- **What changed:** Write to a temp file in the same directory, then `renameSync()` atomically. The target is always either the old or new complete version — never partial.
- **What did NOT change:** `loadJsonFile()` is unchanged. No new dependencies.

## Change Type
- [x] Bug fix

## Scope
- [x] Memory / storage

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations
- Risk: Temp files left behind if process killed between write and rename (e.g., `SIGKILL`).
  - Mitigation: Temp files use a `.tmp` suffix and random hex — easily identified and cleaned. The rename itself is atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)