### PR TITLE
fix: add TTL-based cleanup for agent run context maps

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -96,6 +96,9 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const nextSeq = (seqByRun.get(event.runId) ?? 0) + 1;
   seqByRun.set(event.runId, nextSeq);
   const context = runContextById.get(event.runId);
+  if (context) {
+    context.lastActiveAt = Date.now();
+  }
   const sessionKey =
     typeof event.sessionKey === "string" && event.sessionKey.trim()
       ? event.sessionKey

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -20,7 +20,33 @@ export type AgentRunContext = {
 // Keep per-run counters so streams stay strictly monotonic per runId.
 const seqByRun = new Map<string, number>();
 const listeners = new Set<(evt: AgentEventPayload) => void>();
-const runContextById = new Map<string, AgentRunContext>();
+const runContextById = new Map<string, AgentRunContext & { lastActiveAt: number }>();
+
+/** Maximum age (ms) before an idle run context is pruned. */
+const RUN_CONTEXT_TTL_MS = 30 * 60_000; // 30 minutes
+/** How often the TTL sweep runs. */
+const RUN_CONTEXT_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
+let runContextSweepTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureRunContextSweep() {
+  if (runContextSweepTimer) {
+    return;
+  }
+  runContextSweepTimer = setInterval(() => {
+    const cutoff = Date.now() - RUN_CONTEXT_TTL_MS;
+    for (const [runId, ctx] of runContextById) {
+      if (ctx.lastActiveAt < cutoff) {
+        runContextById.delete(runId);
+        seqByRun.delete(runId);
+      }
+    }
+    if (runContextById.size === 0) {
+      clearInterval(runContextSweepTimer!);
+      runContextSweepTimer = null;
+    }
+  }, RUN_CONTEXT_SWEEP_INTERVAL_MS);
+  runContextSweepTimer.unref?.();
+}
 
 export function registerAgentRunContext(runId: string, context: AgentRunContext) {
   if (!runId) {
@@ -28,9 +54,11 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   }
   const existing = runContextById.get(runId);
   if (!existing) {
-    runContextById.set(runId, { ...context });
+    runContextById.set(runId, { ...context, lastActiveAt: Date.now() });
+    ensureRunContextSweep();
     return;
   }
+  existing.lastActiveAt = Date.now();
   if (context.sessionKey && existing.sessionKey !== context.sessionKey) {
     existing.sessionKey = context.sessionKey;
   }
@@ -43,15 +71,25 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
 }
 
 export function getAgentRunContext(runId: string) {
-  return runContextById.get(runId);
+  const ctx = runContextById.get(runId);
+  if (ctx) {
+    ctx.lastActiveAt = Date.now();
+  }
+  return ctx;
 }
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {
   runContextById.clear();
+  seqByRun.clear();
+  if (runContextSweepTimer) {
+    clearInterval(runContextSweepTimer);
+    runContextSweepTimer = null;
+  }
 }
 
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {


### PR DESCRIPTION
## Summary
- Adds a periodic sweep (every 5 min) that prunes `runContextById` and `seqByRun` entries idle for more than 30 minutes
- Tracks `lastActiveAt` timestamp on each run context entry, refreshed on register and get
- Cleans up `seqByRun` in `clearAgentRunContext()` to prevent orphaned sequence counters
- Sweep timer self-stops when the map is empty and uses `.unref()` to avoid keeping the process alive

## Test plan
- [ ] Verify agent events still emit correctly with sequence numbers
- [ ] Confirm `resetAgentRunContextForTest()` properly clears sweep timer
- [ ] Test that idle contexts are pruned after TTL expiration
- [ ] Run existing agent event tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)