### PR TITLE
fix(cron): guard invalid model aliases + auto fallback on model-not-found

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -13,6 +13,7 @@ import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { describeFailoverError } from "../../agents/failover-error.js";
 import {
   getModelRefStatus,
   isCliProvider,
@@ -86,6 +87,22 @@ export type RunCronAgentTurnResult = {
   deliveryAttempted?: boolean;
 } & CronRunOutcome &
   CronRunTelemetry;
+
+const CRON_KNOWN_GOOD_MODEL =
+  process.env.OPENCLAW_CRON_FALLBACK_MODEL?.trim() || "sonnet";
+
+function resolveCronModelFallbacks(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  requestedModel: string;
+}): string[] {
+  const configured = resolveAgentModelFallbacksOverride(params.cfg, params.agentId) ?? [];
+  const requested = params.requestedModel.trim();
+  const candidates = [...configured, CRON_KNOWN_GOOD_MODEL]
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry !== requested);
+  return Array.from(new Set(candidates));
+}
 
 export async function runCronIsolatedAgentTurn(params: {
   cfg: OpenClawConfig;
@@ -422,7 +439,19 @@ export async function runCronIsolatedAgentTurn(params: {
       provider,
       model,
       agentDir,
-      fallbacksOverride: resolveAgentModelFallbacksOverride(params.cfg, agentId),
+      fallbacksOverride: resolveCronModelFallbacks({
+        cfg: params.cfg,
+        agentId,
+        requestedModel: model,
+      }),
+      onError: ({ provider: failedProvider, model: failedModel, error, attempt, total }) => {
+        const described = describeFailoverError(error);
+        if (described.reason === "model_not_found" && attempt < total) {
+          logWarn(
+            `cron: model-not-found for ${failedProvider}/${failedModel}; auto-fallback continuing (${attempt}/${total})`,
+          );
+        }
+      },
       run: (providerOverride, modelOverride) => {
         if (abortSignal?.aborted) {
           throw new Error(abortReason());

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,3 +1,6 @@
+import { resolveConfiguredModelRef, resolveAllowedModelRef } from "../../agents/model-selection.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { loadConfig } from "../../config/config.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   readCronRunLogEntriesPage,
@@ -19,7 +22,36 @@ import {
   validateCronUpdateParams,
   validateWakeParams,
 } from "../protocol/index.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+
+async function validateCronAgentTurnModelOverride(params: {
+  context: GatewayRequestContext;
+  modelRaw: string;
+}): Promise<string | undefined> {
+  const modelInput = params.modelRaw.trim();
+  if (!modelInput) {
+    return "invalid cron payload.model: empty";
+  }
+
+  const cfg = loadConfig();
+  const configured = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  const catalog = await params.context.loadGatewayModelCatalog();
+  const resolved = resolveAllowedModelRef({
+    cfg,
+    catalog,
+    raw: modelInput,
+    defaultProvider: configured.provider,
+    defaultModel: configured.model,
+  });
+  if ("error" in resolved) {
+    return `invalid cron payload.model '${modelInput}': ${resolved.error}`;
+  }
+  return undefined;
+}
 
 export const cronHandlers: GatewayRequestHandlers = {
   wake: ({ params, respond, context }) => {
@@ -102,6 +134,19 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const jobCreate = normalized as unknown as CronJobCreate;
+    if (jobCreate.sessionTarget === "isolated" && jobCreate.payload.kind === "agentTurn") {
+      const modelRaw = jobCreate.payload.model;
+      if (typeof modelRaw === "string") {
+        const modelValidationError = await validateCronAgentTurnModelOverride({
+          context,
+          modelRaw,
+        });
+        if (modelValidationError) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, modelValidationError));
+          return;
+        }
+      }
+    }
     const timestampValidation = validateScheduleTimestamp(jobCreate.schedule);
     if (!timestampValidation.ok) {
       respond(
@@ -146,6 +191,16 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
     const patch = p.patch as unknown as CronJobPatch;
+    if (patch.payload?.kind === "agentTurn" && typeof patch.payload.model === "string") {
+      const modelValidationError = await validateCronAgentTurnModelOverride({
+        context,
+        modelRaw: patch.payload.model,
+      });
+      if (modelValidationError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, modelValidationError));
+        return;
+      }
+    }
     if (patch.schedule) {
       const timestampValidation = validateScheduleTimestamp(patch.schedule);
       if (!timestampValidation.ok) {


### PR DESCRIPTION
## Summary
This ships three reliability fixes for cron isolated `agentTurn` jobs:

1. **Save-time model guardrail**
   - `cron.add` / `cron.update` now validate `payload.model` against configured aliases + allowed model catalog.
   - Invalid/unavailable strings (e.g. `qwen3:32b`) are rejected up front instead of being saved and failing at runtime.

2. **Runtime model-not-found fallback**
   - Cron isolated runs now always append a known-good fallback model (`sonnet` by default) to the fallback chain.
   - Override supported via `OPENCLAW_CRON_FALLBACK_MODEL`.

3. **Fallback event logging**
   - When the provider returns `model_not_found` and cron auto-falls back, emit a clear warning log for observability.

## Files changed
- `src/gateway/server-methods/cron.ts`
  - Added save-time `payload.model` validation for `cron.add` and `cron.update`.
- `src/cron/isolated-agent/run.ts`
  - Added cron-specific fallback chain helper (appends known-good fallback)
  - Added model-not-found fallback warning logs.

## Notes
- This is backwards compatible for valid model refs.
- Rollback switch for fallback behavior: set `OPENCLAW_CRON_FALLBACK_MODEL` to a preferred model (or revert this PR).
