### PR TITLE
fix: harden extension relay with auth and CDP event allowlist

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -355,7 +355,9 @@ describe("chrome extension relay server", () => {
     await waitForOpen(ext2);
     await ext1Closed;
 
-    const status = (await fetch(`${cdpUrl}/extension/status`).then((r) => r.json())) as {
+    const status = (await fetch(`${cdpUrl}/extension/status`, {
+      headers: relayAuthHeaders(cdpUrl),
+    }).then((r) => r.json())) as {
       connected?: boolean;
     };
     expect(status.connected).toBe(true);
@@ -712,7 +714,9 @@ describe("chrome extension relay server", () => {
       cdpUrl = `http://127.0.0.1:${port}`;
       const relay = await ensureChromeExtensionRelayServer({ cdpUrl });
       expect(relay.port).toBe(port);
-      const status = (await fetch(`${cdpUrl}/extension/status`).then((r) => r.json())) as {
+      const status = (await fetch(`${cdpUrl}/extension/status`, {
+        headers: relayAuthHeaders(cdpUrl),
+      }).then((r) => r.json())) as {
         connected?: boolean;
       };
       expect(status.connected).toBe(false);

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -85,6 +85,47 @@ const RELAY_AUTH_HEADER = "x-openclaw-relay-token";
 const DEFAULT_EXTENSION_RECONNECT_GRACE_MS = 5_000;
 const DEFAULT_EXTENSION_COMMAND_RECONNECT_WAIT_MS = 3_000;
 
+/**
+ * Allowlist of CDP event method prefixes that the extension relay may forward.
+ * Events outside this set are silently dropped to prevent a compromised
+ * extension from injecting arbitrary CDP events into connected clients.
+ */
+const ALLOWED_CDP_EVENT_PREFIXES: readonly string[] = [
+  "Target.",
+  "Page.",
+  "Runtime.",
+  "Network.",
+  "DOM.",
+  "CSS.",
+  "Debugger.",
+  "Log.",
+  "Console.",
+  "Performance.",
+  "Security.",
+  "Overlay.",
+  "Emulation.",
+  "Input.",
+  "Fetch.",
+  "Accessibility.",
+  "Animation.",
+  "Audits.",
+  "BackgroundService.",
+  "DOMStorage.",
+  "HeadlessExperimental.",
+  "Inspector.",
+  "LayerTree.",
+  "Media.",
+  "ServiceWorker.",
+  "Storage.",
+  "Tethering.",
+  "Tracing.",
+  "WebAuthn.",
+];
+
+function isAllowedCdpEventMethod(method: string): boolean {
+  return ALLOWED_CDP_EVENT_PREFIXES.some((prefix) => method.startsWith(prefix));
+}
+
 function headerValue(value: string | string[] | undefined): string | undefined {
   if (!value) {
     return undefined;
@@ -517,6 +558,12 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
 
       if (path === "/extension/status") {
+        const token = getRelayAuthTokenFromRequest(req, url);
+        if (!token || !relayAuthTokens.has(token)) {
+          res.writeHead(401);
+          res.end("Unauthorized");
+          return;
+        }
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ connected: extensionConnected() }));
         return;
@@ -726,6 +773,11 @@ export async function ensureChromeExtensionRelayServer(opts: {
           const params = evt.params?.params;
           const sessionId = evt.params?.sessionId;
           if (!method || typeof method !== "string") {
+            return;
+          }
+
+          // Drop events outside the allowlist to prevent event injection attacks.
+          if (!isAllowedCdpEventMethod(method)) {
             return;
           }
 


### PR DESCRIPTION
## Summary
- Adds auth token verification to the `/extension/status` endpoint (was previously unauthenticated, unlike all other relay endpoints)
- Introduces a CDP event method allowlist covering 28 standard Chrome DevTools Protocol domains
- Events from methods outside the allowlist are silently dropped, preventing a compromised extension from injecting arbitrary CDP events into connected clients

## Test plan
- [ ] Verify `/extension/status` returns 401 without a valid auth token
- [ ] Verify `/extension/status` returns 200 with a valid token
- [ ] Confirm standard CDP events (Page, Network, DOM, Runtime, etc.) are forwarded normally
- [ ] Confirm events with unknown method prefixes are silently dropped
- [ ] Run existing extension relay tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)