### PR TITLE
fix(sanitizer): thread errorKind through pipeline to prevent false positives

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -123,6 +123,28 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  it("returns undefined for stale errorMessage metadata on non-error turns", () => {
+    const msg = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: "500 Internal Server Error",
+      content: [{ type: "text", text: "Recovered response" }],
+    });
+
+    expect(formatAssistantErrorText(msg)).toBeUndefined();
+  });
+
+  it("uses assistant text fallback for content-only role ordering errors", () => {
+    const msg = makeAssistantMessageFixture({
+      stopReason: "error",
+      errorMessage: "",
+      content: [{ type: "text", text: "400 Incorrect role information" }],
+    });
+
+    expect(
+      formatAssistantErrorText(msg, { assistantText: "400 Incorrect role information" }),
+    ).toContain("Message ordering conflict");
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext-errorkind.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext-errorkind.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { deriveErrorKind, sanitizeUserFacingText } from "./pi-embedded-helpers/errors.js";
+
+describe("sanitizeUserFacingText with errorKind", () => {
+  it("returns billing message when errorKind is billing", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "billing",
+    });
+    expect(result).toContain("billing error");
+  });
+
+  it("returns rate limit message when errorKind is rate_limit", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "rate_limit",
+    });
+    expect(result).toContain("rate limit");
+  });
+
+  it("returns overloaded message when errorKind is overloaded", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "overloaded",
+    });
+    expect(result).toContain("overloaded");
+  });
+
+  it("returns timeout message when errorKind is timeout", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "timeout",
+    });
+    expect(result).toBe("LLM request timed out.");
+  });
+
+  it("returns context overflow message when errorKind is context_overflow", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "context_overflow",
+    });
+    expect(result).toContain("Context overflow");
+  });
+
+  it("returns context overflow message when errorKind is compaction_failure", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "compaction_failure",
+    });
+    expect(result).toContain("Context overflow");
+  });
+
+  it("returns role ordering message when errorKind is role_ordering", () => {
+    const result = sanitizeUserFacingText("some unrelated text", {
+      errorContext: true,
+      errorKind: "role_ordering",
+    });
+    expect(result).toContain("Message ordering conflict");
+  });
+
+  it("returns auth message when errorKind is auth_permanent", () => {
+    const result = sanitizeUserFacingText("invalid api key", {
+      errorContext: true,
+      errorKind: "auth_permanent",
+    });
+    expect(result.toLowerCase()).toContain("authentication");
+  });
+
+  it("returns model not found message when errorKind is model_not_found", () => {
+    const result = sanitizeUserFacingText("model not found", {
+      errorContext: true,
+      errorKind: "model_not_found",
+    });
+    expect(result).toContain("model");
+    expect(result).toContain("not available");
+  });
+
+  it("returns session expired message when errorKind is session_expired", () => {
+    const result = sanitizeUserFacingText("session expired", {
+      errorContext: true,
+      errorKind: "session_expired",
+    });
+    expect(result).toContain("session");
+    expect(result).toContain("/new");
+  });
+
+  it("returns image size message when errorKind is image_size", () => {
+    const result = sanitizeUserFacingText("image exceeds 20 mb", {
+      errorContext: true,
+      errorKind: "image_size",
+    });
+    expect(result).toContain("image");
+    expect(result).toContain("smaller");
+  });
+
+  it("does not reclassify via regex for errorKind unknown", () => {
+    // Text contains billing keywords but errorKind says unknown — should NOT
+    // reclassify as billing. Formats as raw HTTP error instead.
+    const result = sanitizeUserFacingText("Error: 402 payment required", {
+      errorContext: true,
+      errorKind: "unknown",
+    });
+    expect(result).not.toContain("billing error");
+  });
+
+  it("does not reclassify via regex when errorKind is undefined", () => {
+    // Same: no regex reclassification without structured errorKind.
+    const result = sanitizeUserFacingText("Error: 402 payment required", {
+      errorContext: true,
+    });
+    expect(result).not.toContain("billing error");
+  });
+
+  it("prevents false positive: timeout errorKind with billing keywords returns timeout, not billing", () => {
+    // This is the core bug fix: a tool returning HTTP 402 should NOT be
+    // misclassified as an LLM billing error when errorKind says "timeout".
+    const result = sanitizeUserFacingText(
+      "Error: 402 payment required - upstream service billing issue",
+      { errorContext: true, errorKind: "timeout" },
+    );
+    expect(result).toBe("LLM request timed out.");
+    expect(result).not.toContain("billing");
+  });
+
+  it("does not use errorKind when errorContext is false", () => {
+    // errorKind only applies within the errorContext block
+    const text = "Hello world";
+    const result = sanitizeUserFacingText(text, {
+      errorContext: false,
+      errorKind: "billing",
+    });
+    expect(result).toBe("Hello world");
+  });
+});
+
+describe("deriveErrorKind", () => {
+  it("classifies role ordering payloads", () => {
+    expect(deriveErrorKind("400 Incorrect role information")).toBe("role_ordering");
+    expect(deriveErrorKind('messages: roles must alternate between "user" and "assistant"')).toBe(
+      "role_ordering",
+    );
+  });
+});

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -23,7 +23,10 @@ describe("sanitizeUserFacingText", () => {
   );
 
   it("sanitizes role ordering errors", () => {
-    const result = sanitizeUserFacingText("400 Incorrect role information", { errorContext: true });
+    const result = sanitizeUserFacingText("400 Incorrect role information", {
+      errorContext: true,
+      errorKind: "role_ordering",
+    });
     expect(result).toContain("Message ordering conflict");
   });
 
@@ -37,17 +40,17 @@ describe("sanitizeUserFacingText", () => {
     "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.",
     "Request size exceeds model context window",
   ])("sanitizes direct context-overflow error: %s", (text) => {
-    expect(sanitizeUserFacingText(text, { errorContext: true })).toContain(
-      "Context overflow: prompt too large for the model.",
-    );
+    expect(
+      sanitizeUserFacingText(text, { errorContext: true, errorKind: "context_overflow" }),
+    ).toContain("Context overflow: prompt too large for the model.");
   });
 
   it("sanitizes Ollama prompt-too-long payloads through the context-overflow path", () => {
     const text =
       'Ollama API error 400: {"StatusCode":400,"Status":"400 Bad Request","error":"prompt too long; exceeded max context length by 4 tokens"}';
-    expect(sanitizeUserFacingText(text, { errorContext: true })).toContain(
-      "Context overflow: prompt too large for the model.",
-    );
+    expect(
+      sanitizeUserFacingText(text, { errorContext: true, errorKind: "context_overflow" }),
+    ).toContain("Context overflow: prompt too large for the model.");
   });
 
   it.each([
@@ -70,9 +73,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
-  it("rewrites billing error-shaped text with errorContext", () => {
+  it("rewrites billing error-shaped text only when errorKind is billing", () => {
     const text = "billing: please upgrade your plan";
-    expect(sanitizeUserFacingText(text, { errorContext: true })).toContain("billing error");
+    // Without errorKind, regex-based reclassification is intentionally disabled.
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toBe(text);
+    // With errorKind: "billing", the structured path rewrites to a user-friendly message.
+    expect(sanitizeUserFacingText(text, { errorContext: true, errorKind: "billing" })).toContain(
+      "billing error",
+    );
   });
 
   it("sanitizes raw API error payloads", () => {
@@ -82,10 +90,13 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
-  it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
-    expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
-      "⚠️ API rate limit reached. Please try again later.",
-    );
+  it("returns a friendly message for rate limit errors", () => {
+    expect(
+      sanitizeUserFacingText("Error: 429 Rate limit exceeded", {
+        errorContext: true,
+        errorKind: "rate_limit",
+      }),
+    ).toBe("⚠️ API rate limit reached. Please try again later.");
   });
 
   it.each([

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -14,6 +14,7 @@ export {
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
+  deriveErrorKind,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,
   getApiErrorPayloadFingerprint,
@@ -39,6 +40,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isTransientProviderErrorMessage,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,
@@ -67,7 +69,11 @@ export {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "./pi-embedded-helpers/turns.js";
-export type { EmbeddedContextFile, FailoverReason } from "./pi-embedded-helpers/types.js";
+export type {
+  EmbeddedContextFile,
+  ErrorKind,
+  FailoverReason,
+} from "./pi-embedded-helpers/types.js";
 
 export type { ToolCallIdMode } from "./tool-call-id.js";
 export { isValidCloudCodeAssistToolId, sanitizeToolCallId } from "./tool-call-id.js";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -13,7 +13,7 @@ import {
   isTimeoutErrorMessage,
   matchesFormatErrorPattern,
 } from "./failover-matches.js";
-import type { FailoverReason } from "./types.js";
+import type { ErrorKind, FailoverReason } from "./types.js";
 
 export {
   isAuthErrorMessage,
@@ -42,6 +42,14 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
+const AUTH_ERROR_USER_MESSAGE =
+  "Authentication failed. Check your API key or provider credentials and try again.";
+const MODEL_NOT_FOUND_USER_MESSAGE =
+  "The selected model is not available. Choose a different model and try again.";
+const SESSION_EXPIRED_USER_MESSAGE =
+  "The provider session expired. Use /new to start a fresh session and try again.";
+const IMAGE_SIZE_USER_MESSAGE =
+  "The image is too large for this model. Send a smaller image and try again.";
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
@@ -63,6 +71,15 @@ function isReasoningConstraintErrorMessage(raw: string): boolean {
     lower.includes("reasoning is required") ||
     lower.includes("requires reasoning") ||
     (lower.includes("reasoning") && lower.includes("cannot be disabled"))
+  );
+}
+
+function isRoleOrderingErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return /incorrect role information|roles must alternate|400.*role|"message".*role.*information/i.test(
+    raw,
   );
 }
 
@@ -216,10 +233,6 @@ export function extractObservedOverflowTokenCount(errorMessage?: string): number
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error)(?:\s+\d{3})?[:\s-]+/i;
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
-const ERROR_PREFIX_RE =
-  /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
-const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
-  /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
@@ -392,6 +405,10 @@ export function isTransientHttpError(raw: string): boolean {
   return TRANSIENT_HTTP_ERROR_CODES.has(status.code);
 }
 
+export function isTransientProviderErrorMessage(raw: string): boolean {
+  return isTransientHttpError(raw) || isJsonApiInternalServerError(raw);
+}
+
 export function classifyFailoverReasonFromHttpStatus(
   status: number | undefined,
   message?: string,
@@ -494,18 +511,6 @@ function isLikelyHttpErrorText(raw: string): boolean {
   }
   const message = match[2].toLowerCase();
   return HTTP_ERROR_HINTS.some((hint) => message.includes(hint));
-}
-
-function shouldRewriteContextOverflowText(raw: string): boolean {
-  if (!isContextOverflowError(raw)) {
-    return false;
-  }
-  return (
-    isRawApiErrorPayload(raw) ||
-    isLikelyHttpErrorText(raw) ||
-    ERROR_PREFIX_RE.test(raw) ||
-    CONTEXT_OVERFLOW_ERROR_HEAD_RE.test(raw)
-  );
 }
 
 type ErrorPayload = Record<string, unknown>;
@@ -675,20 +680,28 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
 export function formatAssistantErrorText(
   msg: AssistantMessage,
-  opts?: { cfg?: OpenClawConfig; sessionKey?: string; provider?: string; model?: string },
+  opts?: {
+    cfg?: OpenClawConfig;
+    sessionKey?: string;
+    provider?: string;
+    model?: string;
+    assistantText?: string;
+  },
 ): string | undefined {
-  // Also format errors if errorMessage is present, even if stopReason isn't "error"
+  const isErrorTurn = msg.stopReason === "error";
   const raw = (msg.errorMessage ?? "").trim();
-  if (msg.stopReason !== "error" && !raw) {
+  if (!isErrorTurn) {
     return undefined;
   }
-  if (!raw) {
+  const fallbackAssistantText = opts?.assistantText?.trim();
+  const effectiveRaw = raw || fallbackAssistantText || "";
+  if (!effectiveRaw) {
     return "LLM request failed with an unknown error.";
   }
 
   const unknownTool =
-    raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
-    raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
+    effectiveRaw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
+    effectiveRaw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
   if (unknownTool?.[1]) {
     const rewritten = formatSandboxToolPolicyBlockedMessage({
       cfg: opts?.cfg,
@@ -700,14 +713,14 @@ export function formatAssistantErrorText(
     }
   }
 
-  if (isContextOverflowError(raw)) {
+  if (isContextOverflowError(effectiveRaw)) {
     return (
       "Context overflow: prompt too large for the model. " +
       "Try /reset (or /new) to start a fresh session, or use a larger-context model."
     );
   }
 
-  if (isReasoningConstraintErrorMessage(raw)) {
+  if (isReasoningConstraintErrorMessage(effectiveRaw)) {
     return (
       "Reasoning is required for this model endpoint. " +
       "Use /think minimal (or any non-off level) and try again."
@@ -715,18 +728,14 @@ export function formatAssistantErrorText(
   }
 
   // Catch role ordering errors - including JSON-wrapped and "400" prefix variants
-  if (
-    /incorrect role information|roles must alternate|400.*role|"message".*role.*information/i.test(
-      raw,
-    )
-  ) {
+  if (isRoleOrderingErrorMessage(effectiveRaw)) {
     return (
       "Message ordering conflict - please try again. " +
       "If this persists, use /new to start a fresh session."
     );
   }
 
-  if (isMissingToolCallInputError(raw)) {
+  if (isMissingToolCallInputError(effectiveRaw)) {
     return (
       "Session history looks corrupted (tool call input missing). " +
       "Use /new to start a fresh session. " +
@@ -734,36 +743,39 @@ export function formatAssistantErrorText(
     );
   }
 
-  const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
+  const invalidRequest = effectiveRaw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
-  const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
+  const transientCopy = formatRateLimitOrOverloadedErrorCopy(effectiveRaw);
   if (transientCopy) {
     return transientCopy;
   }
 
-  if (isTimeoutErrorMessage(raw)) {
+  if (isTimeoutErrorMessage(effectiveRaw)) {
     return "LLM request timed out.";
   }
 
-  if (isBillingErrorMessage(raw)) {
+  if (isBillingErrorMessage(effectiveRaw)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
-  if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
-    return formatRawAssistantErrorForUi(raw);
+  if (isLikelyHttpErrorText(effectiveRaw) || isRawApiErrorPayload(effectiveRaw)) {
+    return formatRawAssistantErrorForUi(effectiveRaw);
   }
 
   // Never return raw unhandled errors - log for debugging but return safe message
-  if (raw.length > 600) {
-    log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
+  if (effectiveRaw.length > 600) {
+    log.warn(`Long error truncated: ${effectiveRaw.slice(0, 200)}`);
   }
-  return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+  return effectiveRaw.length > 600 ? `${effectiveRaw.slice(0, 600)}…` : effectiveRaw;
 }
 
-export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boolean }): string {
+export function sanitizeUserFacingText(
+  text: string,
+  opts?: { errorContext?: boolean; errorKind?: ErrorKind },
+): string {
   if (!text) {
     return text;
   }
@@ -777,36 +789,42 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
   // Only apply error-pattern rewrites when the caller knows this text is an error payload.
   // Otherwise we risk swallowing legitimate assistant text that merely *mentions* these errors.
   if (errorContext) {
-    if (/incorrect role information|roles must alternate/i.test(trimmed)) {
-      return (
-        "Message ordering conflict - please try again. " +
-        "If this persists, use /new to start a fresh session."
-      );
-    }
-
-    if (shouldRewriteContextOverflowText(trimmed)) {
-      return (
-        "Context overflow: prompt too large for the model. " +
-        "Try /reset (or /new) to start a fresh session, or use a larger-context model."
-      );
-    }
-
-    if (isBillingErrorMessage(trimmed)) {
-      return BILLING_ERROR_USER_MESSAGE;
-    }
-
-    if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
-      return formatRawAssistantErrorForUi(trimmed);
-    }
-
-    if (ERROR_PREFIX_RE.test(trimmed)) {
-      const prefixedCopy = formatRateLimitOrOverloadedErrorCopy(trimmed);
-      if (prefixedCopy) {
-        return prefixedCopy;
-      }
-      if (isTimeoutErrorMessage(trimmed)) {
+    // Structured errorKind classification: the caller provides the error kind,
+    // preventing false positives (e.g. a tool returning HTTP 402 being
+    // misclassified as an LLM billing error).
+    switch (opts?.errorKind) {
+      case "billing":
+        return BILLING_ERROR_USER_MESSAGE;
+      case "rate_limit":
+        return RATE_LIMIT_ERROR_USER_MESSAGE;
+      case "overloaded":
+        return OVERLOADED_ERROR_USER_MESSAGE;
+      case "timeout":
         return "LLM request timed out.";
-      }
+      case "auth":
+      case "auth_permanent":
+        return AUTH_ERROR_USER_MESSAGE;
+      case "context_overflow":
+      case "compaction_failure":
+        return (
+          "Context overflow: prompt too large for the model. " +
+          "Try /reset (or /new) to start a fresh session, or use a larger-context model."
+        );
+      case "image_size":
+        return IMAGE_SIZE_USER_MESSAGE;
+      case "model_not_found":
+        return MODEL_NOT_FOUND_USER_MESSAGE;
+      case "role_ordering":
+        return (
+          "Message ordering conflict - please try again. " +
+          "If this persists, use /new to start a fresh session."
+        );
+      case "session_expired":
+        return SESSION_EXPIRED_USER_MESSAGE;
+    }
+
+    // For unclassified errors, format raw API payloads but don't reclassify via regex.
+    if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
       return formatRawAssistantErrorForUi(trimmed);
     }
   }
@@ -972,7 +990,33 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
     lower.includes("conversation id not found")
   );
 }
-
+export function deriveErrorKind(rawErrorMessage: string): ErrorKind {
+  if (isCompactionFailureError(rawErrorMessage)) {
+    return "compaction_failure";
+  }
+  if (isLikelyContextOverflowError(rawErrorMessage)) {
+    return "context_overflow";
+  }
+  if (isRoleOrderingErrorMessage(rawErrorMessage)) {
+    return "role_ordering";
+  }
+  // Check overloaded before classifyFailoverReason, which conflates it with rate_limit.
+  if (isOverloadedErrorMessage(rawErrorMessage)) {
+    return "overloaded";
+  }
+  if (isImageDimensionErrorMessage(rawErrorMessage) || isImageSizeError(rawErrorMessage)) {
+    return "image_size";
+  }
+  if (isTransientProviderErrorMessage(rawErrorMessage)) {
+    const status = extractLeadingHttpStatus(rawErrorMessage.trim());
+    return status?.code === 529 ? "overloaded" : "unknown";
+  }
+  const failoverReason = classifyFailoverReason(rawErrorMessage);
+  if (failoverReason && failoverReason !== "unknown") {
+    return failoverReason;
+  }
+  return "unknown";
+}
 export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isImageDimensionErrorMessage(raw)) {
     return null;

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -11,3 +11,19 @@ export type FailoverReason =
   | "model_not_found"
   | "session_expired"
   | "unknown";
+
+export type ErrorKind =
+  | "billing"
+  | "rate_limit"
+  | "timeout"
+  | "auth"
+  | "auth_permanent"
+  | "context_overflow"
+  | "overloaded"
+  | "format"
+  | "compaction_failure"
+  | "role_ordering"
+  | "image_size"
+  | "model_not_found"
+  | "session_expired"
+  | "unknown";

--- a/src/agents/pi-embedded-runner/run/payloads.errorkind.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errorkind.test.ts
@@ -1,0 +1,151 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedRunPayloads } from "./payloads.js";
+
+describe("buildEmbeddedRunPayloads errorKind derivation", () => {
+  const makeAssistant = (overrides: Partial<AssistantMessage>): AssistantMessage => ({
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    timestamp: 0,
+    stopReason: "error",
+    content: [],
+    ...overrides,
+  });
+
+  it("derives errorKind billing from a 402 error", () => {
+    const billingError =
+      '{"type":"error","error":{"type":"billing_error","message":"402 payment required"}}';
+    const lastAssistant = makeAssistant({ errorMessage: billingError });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    const errorPayload = payloads.find((p) => p.isError);
+    expect(errorPayload?.errorKind).toBe("billing");
+  });
+
+  it("derives errorKind rate_limit from rate limit error", () => {
+    const lastAssistant = makeAssistant({ errorMessage: "429 Too Many Requests" });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    const errorPayload = payloads.find((p) => p.isError);
+    expect(errorPayload?.errorKind).toBe("rate_limit");
+  });
+
+  it("derives errorKind timeout from timeout error", () => {
+    const lastAssistant = makeAssistant({ errorMessage: "Request timed out" });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    const errorPayload = payloads.find((p) => p.isError);
+    expect(errorPayload?.errorKind).toBe("timeout");
+  });
+
+  it("derives errorKind context_overflow from context overflow error", () => {
+    const lastAssistant = makeAssistant({ errorMessage: "context length exceeded" });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    const errorPayload = payloads.find((p) => p.isError);
+    expect(errorPayload?.errorKind).toBe("context_overflow");
+  });
+
+  it("does not set errorKind when assistant did not error", () => {
+    const lastAssistant = makeAssistant({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Hello" }],
+    });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: ["Hello"],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    expect(payloads.every((p) => p.errorKind === undefined)).toBe(true);
+  });
+
+  it("does not enqueue error payloads for non-error turns with stale errorMessage", () => {
+    const lastAssistant = makeAssistant({
+      stopReason: "stop",
+      errorMessage: "500 Internal Server Error",
+      content: [{ type: "text", text: "Recovered response" }],
+    });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: ["Recovered response"],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    expect(payloads.find((p) => p.isError)).toBeUndefined();
+    expect(payloads.some((p) => p.text === "Recovered response")).toBe(true);
+  });
+
+  it("emits one friendly payload for content-only role ordering errors", () => {
+    const lastAssistant = makeAssistant({
+      errorMessage: "",
+      content: [{ type: "text", text: "400 Incorrect role information" }],
+    });
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant,
+      sessionKey: "session:test",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+    });
+
+    expect(payloads.filter((p) => p.text?.includes("Message ordering conflict"))).toHaveLength(1);
+    expect(payloads.find((p) => p.isError)?.errorKind).toBe("role_ordering");
+    expect(payloads.some((p) => p.text === "LLM request failed with an unknown error.")).toBe(
+      false,
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -4,14 +4,17 @@ import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { extractTextFromChatContent } from "../../../shared/chat-content.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
+  deriveErrorKind,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
   getApiErrorPayloadFingerprint,
   isRawApiErrorPayload,
   normalizeTextForComparison,
 } from "../../pi-embedded-helpers.js";
+import type { ErrorKind } from "../../pi-embedded-helpers/types.js";
 import type { ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import {
   extractAssistantText,
@@ -110,6 +113,7 @@ export function buildEmbeddedRunPayloads(params: {
   replyToId?: string;
   isError?: boolean;
   isReasoning?: boolean;
+  errorKind?: ErrorKind;
   audioAsVoice?: boolean;
   replyToTag?: boolean;
   replyToCurrent?: boolean;
@@ -119,6 +123,7 @@ export function buildEmbeddedRunPayloads(params: {
     media?: string[];
     isError?: boolean;
     isReasoning?: boolean;
+    errorKind?: ErrorKind;
     audioAsVoice?: boolean;
     replyToId?: string;
     replyToTag?: boolean;
@@ -128,19 +133,32 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts = params.didSendDeterministicApprovalPrompt === true;
   const lastAssistantErrored = params.lastAssistant?.stopReason === "error";
-  const errorText =
-    params.lastAssistant && lastAssistantErrored
-      ? suppressAssistantArtifacts
-        ? undefined
-        : formatAssistantErrorText(params.lastAssistant, {
-            cfg: params.config,
-            sessionKey: params.sessionKey,
-            provider: params.provider,
-            model: params.model,
-          })
-      : undefined;
+  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
+  const fallbackRawAnswerText = params.lastAssistant
+    ? (extractTextFromChatContent(params.lastAssistant.content, {
+        joinWith: "\n",
+        normalizeText: (text) => text.trim(),
+      }) ?? "")
+    : "";
+  const effectiveErrorSource = lastAssistantErrored
+    ? params.lastAssistant?.errorMessage?.trim() || fallbackRawAnswerText.trim() || undefined
+    : undefined;
+  const errorText = params.lastAssistant
+    ? !lastAssistantErrored || suppressAssistantArtifacts
+      ? undefined
+      : formatAssistantErrorText(params.lastAssistant, {
+          cfg: params.config,
+          sessionKey: params.sessionKey,
+          provider: params.provider,
+          model: params.model,
+          assistantText: fallbackAnswerText,
+        })
+    : undefined;
   const rawErrorMessage = lastAssistantErrored
     ? params.lastAssistant?.errorMessage?.trim() || undefined
+    : undefined;
+  const errorKind: ErrorKind | undefined = effectiveErrorSource
+    ? deriveErrorKind(effectiveErrorSource)
     : undefined;
   const rawErrorFingerprint = rawErrorMessage
     ? getApiErrorPayloadFingerprint(rawErrorMessage)
@@ -158,7 +176,7 @@ export function buildEmbeddedRunPayloads(params: {
   const normalizedGenericBillingErrorText = normalizeTextForComparison(BILLING_ERROR_USER_MESSAGE);
   const genericErrorText = "The AI service returned an error. Please try again.";
   if (errorText) {
-    replyItems.push({ text: errorText, isError: true });
+    replyItems.push({ text: errorText, isError: true, errorKind });
   }
 
   const inlineToolResults =
@@ -198,7 +216,6 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
 
-  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;
@@ -212,7 +229,7 @@ export function buildEmbeddedRunPayloads(params: {
       if (normalized && normalizedErrorText && normalized === normalizedErrorText) {
         return true;
       }
-      if (trimmed === genericErrorText) {
+      if (trimmed === genericErrorText || trimmed === "LLM request failed with an unknown error.") {
         return true;
       }
       if (
@@ -229,6 +246,9 @@ export function buildEmbeddedRunPayloads(params: {
     if (formattedRawErrorMessage && trimmed === formattedRawErrorMessage) {
       return true;
     }
+    if (effectiveErrorSource && trimmed === effectiveErrorSource) {
+      return true;
+    }
     if (normalizedRawErrorText) {
       const normalized = normalizeTextForComparison(trimmed);
       if (normalized && normalized === normalizedRawErrorText) {
@@ -238,6 +258,17 @@ export function buildEmbeddedRunPayloads(params: {
     if (normalizedFormattedRawErrorMessage) {
       const normalized = normalizeTextForComparison(trimmed);
       if (normalized && normalized === normalizedFormattedRawErrorMessage) {
+        return true;
+      }
+    }
+    if (effectiveErrorSource) {
+      const normalized = normalizeTextForComparison(trimmed);
+      const normalizedEffectiveErrorSource = normalizeTextForComparison(effectiveErrorSource);
+      if (
+        normalized &&
+        normalizedEffectiveErrorSource &&
+        normalized === normalizedEffectiveErrorSource
+      ) {
         return true;
       }
     }
@@ -330,6 +361,7 @@ export function buildEmbeddedRunPayloads(params: {
       mediaUrls: item.media?.length ? item.media : undefined,
       mediaUrl: item.media?.[0],
       isError: item.isError,
+      errorKind: item.errorKind,
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -1,4 +1,5 @@
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
+import type { ErrorKind } from "../pi-embedded-helpers/types.js";
 import type { MessagingToolSend } from "../pi-embedded-messaging.js";
 
 export type EmbeddedPiAgentMeta = {
@@ -61,6 +62,7 @@ export type EmbeddedPiRunResult = {
     mediaUrls?: string[];
     replyToId?: string;
     isError?: boolean;
+    errorKind?: ErrorKind;
   }>;
   meta: EmbeddedPiRunMeta;
   // True if a messaging tool (telegram, whatsapp, discord, slack, sessions_send)

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -147,7 +147,45 @@ describe("extractAssistantText", () => {
     const result = extractAssistantText(msg);
     expect(result).toBe(responseText);
   });
+  it("ignores stale errorMessage metadata on non-error turns", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      errorMessage: "insufficient credits",
+      content: [
+        {
+          type: "text",
+          text: "Your billing issue is resolved and the deploy succeeded.",
+        },
+      ],
+      timestamp: Date.now(),
+    });
 
+    expect(extractAssistantText(msg)).toBe(
+      "Your billing issue is resolved and the deploy succeeded.",
+    );
+  });
+
+  it("classifies content-only role ordering errors for actual error turns", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      stopReason: "error",
+      content: [{ type: "text", text: "400 Incorrect role information" }],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toContain("Message ordering conflict");
+  });
+
+  it("classifies content-only context overflow errors for actual error turns", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      stopReason: "error",
+      content: [{ type: "text", text: "Request size exceeds model context window" }],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toContain("Context overflow");
+  });
   it("strips Minimax tool invocations with extra attributes", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -2,7 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
-import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
+import { deriveErrorKind, sanitizeUserFacingText } from "./pi-embedded-helpers/errors.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
 
 export function isAssistantMessage(msg: AgentMessage | undefined): msg is AssistantMessage {
@@ -248,7 +248,10 @@ export function extractAssistantText(msg: AssistantMessage): string {
   // Gate on stopReason only — a non-error response with an errorMessage set (e.g. from a
   // background tool failure) should not have its content rewritten (#13935).
   const errorContext = msg.stopReason === "error";
-  return sanitizeUserFacingText(extracted, { errorContext });
+  const trimmedErrorMessage = msg.errorMessage?.trim();
+  const errorSource = errorContext ? trimmedErrorMessage || extracted.trim() : undefined;
+  const errorKind = errorSource ? deriveErrorKind(errorSource) : undefined;
+  return sanitizeUserFacingText(extracted, { errorContext, errorKind });
 }
 
 export function extractAssistantThinking(msg: AssistantMessage): string {

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -30,7 +30,7 @@ export {
 } from "./sessions-resolution.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
-import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
+import { deriveErrorKind, sanitizeUserFacingText } from "../pi-embedded-helpers/errors.js";
 import {
   stripDowngradedToolCallText,
   stripMinimaxToolCallXml,
@@ -187,6 +187,13 @@ export function extractAssistantText(message: unknown): string | undefined {
   // Gate on stopReason only — a non-error response with a stale/background errorMessage
   // should not have its content rewritten with error templates (#13935).
   const errorContext = stopReason === "error";
+  const errorMessage = (message as { errorMessage?: unknown }).errorMessage;
 
-  return joined ? sanitizeUserFacingText(joined, { errorContext }) : undefined;
+  if (!joined) {
+    return undefined;
+  }
+  const trimmedErrorMessage = typeof errorMessage === "string" ? errorMessage.trim() : undefined;
+  const errorSource = errorContext ? trimmedErrorMessage || joined.trim() : undefined;
+  const errorKind = errorSource ? deriveErrorKind(errorSource) : undefined;
+  return sanitizeUserFacingText(joined, { errorContext, errorKind });
 }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -56,6 +56,9 @@ const installRegistry = async () => {
             blurb: "Discord test stub.",
           },
           capabilities: { chatTypes: ["direct", "channel", "thread"] },
+          messaging: {
+            resolveSessionTarget: ({ id }: { id: string }) => `channel:${id}`,
+          },
           config: {
             listAccountIds: () => ["default"],
             resolveAccount: () => ({}),
@@ -199,7 +202,6 @@ describe("extractAssistantText", () => {
       "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
     );
   });
-
   it("preserves successful turns with stale background errorMessage", () => {
     const message = {
       role: "assistant",
@@ -208,6 +210,23 @@ describe("extractAssistantText", () => {
       content: [{ type: "text", text: "Handle payment required errors in your API." }],
     };
     expect(extractAssistantText(message)).toBe("Handle payment required errors in your API.");
+  });
+  it("ignores stale errorMessage metadata on non-error turns", () => {
+    const message = {
+      role: "assistant",
+      errorMessage: "insufficient credits",
+      content: [{ type: "text", text: "Billing is fixed now; continue with the rollout." }],
+    };
+    expect(extractAssistantText(message)).toBe("Billing is fixed now; continue with the rollout.");
+  });
+
+  it("classifies content-only role ordering errors for actual error turns", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "error",
+      content: [{ type: "text", text: "400 Incorrect role information" }],
+    };
+    expect(extractAssistantText(message)).toContain("Message ordering conflict");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,13 +7,14 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
+  deriveErrorKind,
   isCompactionFailureError,
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
-  isTransientHttpError,
+  isTransientProviderErrorMessage,
   sanitizeUserFacingText,
-} from "../../agents/pi-embedded-helpers.js";
+} from "../../agents/pi-embedded-helpers/errors.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
@@ -179,6 +180,7 @@ export async function runAgentTurnWithFallback(params: {
         }
         const sanitized = sanitizeUserFacingText(text, {
           errorContext: Boolean(payload.isError),
+          errorKind: payload.errorKind,
         });
         if (!sanitized.trim()) {
           return { skip: true };
@@ -533,7 +535,7 @@ export async function runAgentTurnWithFallback(params: {
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
-      const isTransientHttp = isTransientHttpError(message);
+      const isTransientProviderError = isTransientProviderErrorMessage(message);
 
       if (
         isCompactionFailure &&
@@ -605,7 +607,7 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
-      if (isTransientHttp && !didRetryTransientHttpError) {
+      if (isTransientProviderError && !didRetryTransientHttpError) {
         didRetryTransientHttpError = true;
         // Retry the full runWithModelFallback() cycle — transient errors
         // (502/521/etc.) typically affect the whole provider, so falling
@@ -621,8 +623,9 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
+      const transientErrorKind = isTransientProviderError ? deriveErrorKind(message) : undefined;
+      const safeMessage = isTransientProviderError
+        ? sanitizeUserFacingText(message, { errorContext: true, errorKind: transientErrorKind })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1865,6 +1865,84 @@ describe("runReplyAgent transient HTTP retry", () => {
     const payload = Array.isArray(result) ? result[0] : result;
     expect(payload?.text).toContain("Recovered response");
   });
+
+  it("retries once after JSON internal server failure and then succeeds", async () => {
+    vi.useFakeTimers();
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(
+        new Error(
+          '{"type":"error","error":{"type":"api_error","message":"Internal server error"}}',
+        ),
+      )
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered response" }],
+        meta: {},
+      });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const runPromise = runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Transient HTTP provider error before reply"),
+    );
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered response");
+  });
 });
 
 describe("runReplyAgent billing error classification", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1549,6 +1549,22 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("preserves transient HTTP status context for pre-reply failures", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      throw new Error("503 Service Unavailable");
+    });
+
+    const { run } = createMinimalRun({});
+    const res = await run();
+
+    expect(res).toMatchObject({
+      text: expect.stringContaining("HTTP 503: Service Unavailable"),
+    });
+    expect(res).toMatchObject({
+      text: expect.not.stringContaining("LLM request timed out"),
+    });
+  });
+
   it("rewrites Bun socket errors into friendly text", async () => {
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
       payloads: [

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -109,7 +109,10 @@ export function normalizeReplyPayload(
   }
 
   if (text) {
-    text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    text = sanitizeUserFacingText(text, {
+      errorContext: Boolean(payload.isError),
+      errorKind: payload.errorKind,
+    });
   }
   if (
     !hasReplyContent({

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,4 +1,5 @@
 import type { ImageContent } from "@mariozechner/pi-ai";
+import type { ErrorKind } from "../agents/pi-embedded-helpers/types.js";
 import type { InteractiveReply } from "../interactive/payload.js";
 import type { TypingController } from "./reply/typing.js";
 
@@ -91,6 +92,7 @@ export type ReplyPayload = {
   /** Marks this payload as a reasoning/thinking block. Channels that do not
    *  have a dedicated reasoning lane (e.g. WhatsApp, web) should suppress it. */
   isReasoning?: boolean;
+  errorKind?: ErrorKind;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

- Adds structured `ErrorKind` type and `deriveErrorKind()` to classify errors at the source (runner payload layer) instead of regex-matching text content in `sanitizeUserFacingText`
- Threads `errorKind` through the sanitizer pipeline so `sanitizeUserFacingText` uses a `switch` on the caller-provided kind rather than regex matching the text body
- Prevents false positives where assistant text mentioning billing errors, context overflow, rate limits, etc. was being incorrectly rewritten to user-facing error messages

### Problem

`sanitizeUserFacingText` used regex patterns to detect error types in text content. This caused false positives: if an assistant reply *mentioned* a billing error (e.g. "check whether we need to re-enable billing") or context overflow, it would be silently rewritten to a canned error message like "billing error: please upgrade your plan".

### Solution

The caller now classifies the error once via `deriveErrorKind()` at the point where the raw error message is available, and passes the `errorKind` through to `sanitizeUserFacingText`. The sanitizer uses a structured `switch` on `errorKind` instead of regex matching, eliminating false positives entirely.

## Test plan

- [x] Added `sanitizeuserfacingtext-errorkind.test.ts` — tests structured errorKind dispatch in sanitizeUserFacingText
- [x] Added `payloads.errorkind.test.ts` — tests deriveErrorKind derivation in buildEmbeddedRunPayloads
- [x] Updated existing `sanitizeuserfacingtext.test.ts` to pass errorKind where needed
- [x] All 74 tests pass (`vitest run`)
- [x] Type-checks clean (no new errors introduced; 1 pre-existing error in `extraparams.test.ts` unrelated to this PR)
- [ ] Lightly tested with local OpenClaw instance

🤖 AI-assisted (Claude Code). I understand the code and have verified the changes are correct.