### PR TITLE
fix(slack): rename /status to /agentstatus for Slack slash commands

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -208,7 +208,8 @@ For actions/directory reads, user token can be preferred when configured. For wr
 
 - Native command auto-mode is **off** for Slack (`commands.native: "auto"` does not enable Slack native commands).
 - Enable native Slack command handlers with `channels.slack.commands.native: true` (or global `commands.native: true`).
-- When native commands are enabled, register matching slash commands in Slack (`/<command>` names).
+- When native commands are enabled, register matching slash commands in Slack (`/<command>` names), with one exception:
+  - register `/agentstatus` for the status command (Slack reserves `/status`)
 - If native commands are not enabled, you can run a single configured slash command via `channels.slack.slashCommand`.
 - Native arg menus now adapt their rendering strategy:
   - up to 5 options: button blocks

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -219,3 +219,4 @@ Notes:
   - Telegram: `telegram:slash:<userId>` (targets the chat session via `CommandTargetSessionKey`)
 - **`/stop`** targets the active chat session so it can abort the current run.
 - **Slack:** `channels.slack.slashCommand` is still supported for a single `/openclaw`-style command. If you enable `commands.native`, you must create one Slack slash command per built-in command (same names as `/help`). Command argument menus for Slack are delivered as ephemeral Block Kit buttons.
+  - Slack native exception: register `/agentstatus` (not `/status`) because Slack reserves `/status`. Text `/status` still works in Slack messages.

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -109,6 +109,16 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("tts", "discord")).toBeUndefined();
   });
 
+  it("renames status to agentstatus for slack", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack" },
+    );
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "status")).toBeFalsy();
+    expect(findCommandByNativeName("agentstatus", "slack")?.key).toBe("status");
+  });
+
   it("keeps discord native command specs within slash-command limits", () => {
     const native = listNativeCommandSpecsForConfig(
       { commands: { native: true } },

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -123,6 +123,11 @@ const NATIVE_NAME_OVERRIDES: Record<string, Record<string, string>> = {
   discord: {
     tts: "voice",
   },
+  slack: {
+    // Slack reserves /status — registering it returns "invalid name"
+    // and invalidates the entire slash_commands manifest array.
+    status: "agentstatus",
+  },
 };
 
 function resolveNativeName(command: ChatCommandDefinition, provider?: string): string | undefined {


### PR DESCRIPTION
## Problem

Slack reserves `/status` as a built-in command name. When users enable native Slack slash commands (`commands.native: true`) and try to register `/status` in their Slack app manifest, Slack returns an "invalid name" error that invalidates the entire `slash_commands` array — meaning no commands can be registered at all.

This makes `/status` (one of the most commonly used OpenClaw commands) unusable as a native Slack slash command.

## Fix

Add a Slack entry to `NATIVE_NAME_OVERRIDES` that maps `status` → `agentstatus`. This uses the same override system that Discord already uses to rename `tts` → `voice`.

When the Slack driver calls `listNativeCommandSpecsForConfig()` with `provider: "slack"`, the returned command name is `agentstatus` instead of `status`. The Bolt handler then registers as `/agentstatus`, which matches the manifest entry users can safely create.

## Changes

- `src/auto-reply/commands-registry.ts` — add `slack: { status: "agentstatus" }` to `NATIVE_NAME_OVERRIDES`
- `src/auto-reply/commands-registry.test.ts` — add test following the existing Discord override test pattern

## Context

Slack reserves several command names (`/help`, `/status`, `/send`, `/kill`, `/debug`, `/commands`, etc.) that cannot be registered as custom slash commands. This PR addresses the most impactful one — `/status`. Other reserved names can be added to the override map as needed in the future.

Users need to register `/agentstatus` (instead of `/status`) in their Slack app manifest for this to work.