### PR TITLE
fix: increase streaming throttle to 300ms for MiniMax compatibility

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -297,7 +297,11 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
-    if (now - last < 150) {
+    // Increase throttle to 300ms to buffer short fragments from MiniMax M2.5,
+    // which sends very short chunks (single chars/words) that would otherwise
+    // be sent as separate Telegram messages. This allows the chunker to collect
+    // more meaningful text before sending.
+    if (now - last < 300) {
       return;
     }
     chatRunState.deltaSentAt.set(clientRunId, now);


### PR DESCRIPTION
## Description

Fixes #14936

### Problem
MiniMax M2.5 sends very short message fragments (single characters or words) to Telegram, resulting in multiple separate messages instead of one cohesive message.

### Root Cause
The streaming throttle in `server-chat.ts` is set to 150ms, which fires before the message chunker can buffer meaningful text. This causes each tiny fragment from MiniMax to be sent as a separate Telegram message immediately upon arrival.

### Solution
Increased the throttle from 150ms to 300ms in the chat streaming handler. This gives the chunker more time to collect short fragments from MiniMax before sending them to Telegram, allowing for more natural, consolidated messages.

### Changes
- Updated the throttle check in `src/gateway/server-chat.ts` from 150ms to 300ms
- Added explanatory comment documenting why this change is necessary for MiniMax compatibility

### Testing
The change is minimal and focused on timing. It should:
- Continue to work normally for other providers
- Improve message consolidation for MiniMax M2.5
- Not introduce any compilation issues

### Notes
- This is a provider-agnostic fix that benefits all providers that send short fragments
- No provider-specific files were modified
- The change is backward compatible