### PR TITLE
fix: retry Telegram sendPhoto network wrapper failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -872,7 +872,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
         compat: { supportsStore: false },
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });

--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -39,9 +39,9 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("treats grammY network-request failures as recoverable in send context", () => {
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
 
     const undiciSnippetErr = new Error("Undici: socket failure");

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -40,6 +40,8 @@ const RECOVERABLE_MESSAGE_SNIPPETS = [
   "timed out", // grammY getUpdates returns "timed out after X seconds" (not matched by "timeout")
 ];
 
+const GRAMMY_NETWORK_REQUEST_FAILED_RE = /^network request for '.+' failed!?$/i;
+
 function normalizeCode(code?: string): string {
   return code?.trim().toUpperCase() ?? "";
 }
@@ -140,6 +142,12 @@ export function isRecoverableTelegramNetworkError(
 
     const message = formatErrorMessage(candidate).trim().toLowerCase();
     if (message && ALWAYS_RECOVERABLE_MESSAGES.has(message)) {
+      return true;
+    }
+    // grammY wraps failed API requests with messages like:
+    // "Network request for 'sendPhoto' failed!"
+    // Treat these as recoverable in send context too so upload sends can retry.
+    if (message && GRAMMY_NETWORK_REQUEST_FAILED_RE.test(message)) {
       return true;
     }
     if (allowMessageMatch && message) {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -363,6 +363,34 @@ describe("sendMessageTelegram", () => {
     ).rejects.toThrow(/returned no message_id/i);
   });
 
+  it("retries sendPhoto network request failures for media sends", async () => {
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/png",
+      fileName: "photo.png",
+    });
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network request for 'sendPhoto' failed!"))
+      .mockResolvedValueOnce({
+        message_id: 77,
+        chat: { id: "123" },
+      });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    const result = await sendMessageTelegram("123", "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.png",
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ messageId: "77", chatId: "123" });
+  });
+
   it("uses native fetch for BAN compatibility when api is omitted", async () => {
     const originalFetch = globalThis.fetch;
     const originalBun = (globalThis as { Bun?: unknown }).Bun;


### PR DESCRIPTION
Title
fix: retry Telegram sendPhoto network wrapper failures

Severity Assessment
Medium. This is a user-visible reliability regression on Telegram media sends in normal workflows.

Impact
Telegram image sends could fail with `Network request for 'sendPhoto' failed!` and not recover, even though the same transient class should be retriable. Text sends continued to work, creating an inconsistent channel experience.

Affected Component
- `src/telegram/network-errors.ts`
- `src/telegram/send.ts` retry path behavior for media sends
- Telegram send/network error tests

Technical Reproduction
1. Configure Telegram channel and invoke message tool with `action=send` and an image `path`.
2. During send, force grammY-style wrapper error text: `Network request for 'sendPhoto' failed!`.
3. Observe that send fails instead of retrying this transient wrapper error.

Demonstrated Impact
- Before fix: send-context classification treated this wrapper as non-recoverable, so media send could fail immediately.
- After fix: wrapper error is classified recoverable; media send retries and succeeds on transient failure.
- Added coverage:
  - `src/telegram/network-errors.test.ts` validates recoverable classification in send context.
  - `src/telegram/send.test.ts` validates `sendPhoto` retries and succeeds after transient wrapper failure.

Environment
- OpenClaw: current `main` plus this PR
- Runtime: Node 22+, pnpm
- Channel: Telegram (grammY API client)

Remediation Advice
Treat grammY `Network request for '...' failed!` wrapper messages as recoverable transient network errors in send paths so media sends (`sendPhoto` and peers) retry consistently with other transient network failures.

Closes #28981
Co Authored with codex