### PR TITLE
fix: remove trailing whitespace in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
+
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
   - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
 


### PR DESCRIPTION
Removes 4 trailing spaces on a blank line (line 61) that cause `oxfmt --check` to fail on every PR — including #15051, which has nothing to do with this file.

One-character fix, zero logic change.