### PR TITLE
ci: fix CONTRIBUTING.md oxfmt formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary
Fix formatting issues in CONTRIBUTING.md that cause CI to fail on all PRs.

## Changes
- Remove trailing blank line after Jonathan Taylor entry  
- Escape underscore in @jlehman_ X handle

## Testing
- Ran `npx oxfmt --check CONTRIBUTING.md` locally - passes

Fixes #29039

---
🤖 AI-assisted (Bartok via Clawdbot)