### PR TITLE
feat: include resolved date/time in system prompt time section

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -93,11 +93,16 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(params.userTime);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`, "");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -553,6 +558,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Summary
Adds the formatted user time to the system prompt's time section, giving agents an authoritative date anchor.

## Before
```
## Current Date & Time
Time zone: America/New_York
```

## After
```
## Current Date & Time
Thursday, February 27th, 2026 — 1:30 PM
Time zone: America/New_York
```

## Changes
- Modified `buildTimeSection` to accept optional `userTime` parameter
- Pass `params.userTime` (already computed by `buildSystemPromptParams`) to the section builder

## Why
- Agents currently need to run `date` or `session_status` to know what day it is
- Calendar/scheduling tasks are error-prone without a date anchor
- The timestamp in message metadata is buried in untrusted context blocks
- Having it in the system prompt makes it authoritative and impossible to miss

Fixes #28958

---
🤖 AI-assisted (Bartok via Clawdbot)