### PR TITLE
fix: increase onboard verify timeout to 120s for local LLMs

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,7 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 10000;
+const VERIFY_TIMEOUT_MS = 120_000;
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.


### PR DESCRIPTION
## Summary
Increases the verification timeout from 10s to 120s to accommodate slower local LLM setups.

## Problem
Local models running on modest hardware (e.g. Qwen3 14B on a laptop GPU with llama.cpp) can take longer than 10 seconds to generate a verification response, causing the onboarding to fail.

## Solution
Increase `VERIFY_TIMEOUT_MS` from 10,000ms to 120,000ms (2 minutes). This doesn't hurt faster models but allows slower local setups to complete verification.

Fixes #28972

---
🤖 AI-assisted (Bartok via Clawdbot)