### PR TITLE
feat: add tools.nodes.enabled config to disable nodes tool

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentConfig } from "../config/group-policy.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
@@ -65,6 +66,8 @@ export function createOpenClawTools(options?: {
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
+  /** If true, omit the nodes tool from the tool list. */
+  disableNodesTool?: boolean;
   /** Trusted sender id from inbound context (not tool args). */
   requesterSenderId?: string | null;
   /** Whether the requesting sender is an owner. */
@@ -108,20 +111,32 @@ export function createOpenClawTools(options?: {
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         requesterSenderId: options?.requesterSenderId ?? undefined,
       });
+  const agentId = options?.agentSessionKey
+    ? resolveSessionAgentId(options.agentSessionKey)
+    : undefined;
+  const agentConfig =
+    options?.config && agentId ? resolveAgentConfig(options.config, agentId) : undefined;
+  const nodesDisabledByConfig =
+    agentConfig?.tools?.nodes?.enabled === false ||
+    options?.config?.tools?.nodes?.enabled === false;
+  const nodesTool =
+    (options?.disableNodesTool ?? nodesDisabledByConfig)
+      ? null
+      : createNodesTool({
+          agentSessionKey: options?.agentSessionKey,
+          agentChannel: options?.agentChannel,
+          agentAccountId: options?.agentAccountId,
+          currentChannelId: options?.currentChannelId,
+          currentThreadTs: options?.currentThreadTs,
+          config: options?.config,
+        });
   const tools: AnyAgentTool[] = [
     createBrowserTool({
       sandboxBridgeUrl: options?.sandboxBrowserBridgeUrl,
       allowHostControl: options?.allowHostBrowserControl,
     }),
     createCanvasTool({ config: options?.config }),
-    createNodesTool({
-      agentSessionKey: options?.agentSessionKey,
-      agentChannel: options?.agentChannel,
-      agentAccountId: options?.agentAccountId,
-      currentChannelId: options?.currentChannelId,
-      currentThreadTs: options?.currentThreadTs,
-      config: options?.config,
-    }),
+    ...(nodesTool ? [nodesTool] : []),
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
     }),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -444,6 +444,7 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          disableNodesTool: params.disableNodesTool,
         });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     const allowedToolNames = collectAllowedToolNames({

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -58,6 +58,8 @@ export type RunEmbeddedPiAgentParams = {
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
+  /** If true, omit the nodes tool from the tool list. */
+  disableNodesTool?: boolean;
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -234,6 +234,8 @@ export function createOpenClawCodingTools(options?: {
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
+  /** If true, omit the nodes tool from the tool list. */
+  disableNodesTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
 }): AnyAgentTool[] {
@@ -490,6 +492,7 @@ export function createOpenClawCodingTools(options?: {
       modelHasVision: options?.modelHasVision,
       requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
       disableMessageTool: options?.disableMessageTool,
+      disableNodesTool: options?.disableNodesTool,
       requesterAgentIdOverride: agentId,
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -518,6 +518,12 @@ export const AgentToolsSchema = z
     exec: AgentToolExecSchema,
     fs: ToolFsSchema,
     loopDetection: ToolLoopDetectionSchema,
+    nodes: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     sandbox: z
       .object({
         tools: ToolPolicySchema,
@@ -744,6 +750,12 @@ export const ToolsSchema = z
           })
           .strict()
           .optional(),
+      })
+      .strict()
+      .optional(),
+    nodes: z
+      .object({
+        enabled: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
Adds a config option to disable the nodes tool for agents without paired devices.

## Problem
On headless servers with no paired nodes (phones/screens), the LLM often incorrectly routes queries like "check for errors" to the `nodes` tool because of semantic matching. Since no nodes are paired, every call fails with `node required`.

## Solution
Add `tools.nodes.enabled` config option (default: `true`) that lets users disable the nodes tool:

```json
{
  "tools": {
    "nodes": { "enabled": false }
  }
}
```

Per-agent override via `agents.list[].tools.nodes.enabled` is also supported.

## Changes
- Add `disableNodesTool` option through the tool creation call chain
- Add `tools.nodes.enabled` to global `ToolsSchema` and per-agent `AgentToolsSchema`
- Check both global and per-agent config when creating the nodes tool

Fixes #29036

---
🤖 AI-assisted (Bartok via Clawdbot)