### PR TITLE
fix(doctor): avoid false warning for local memory search

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -143,6 +143,20 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("reports memory embeddings are ready");
   });
 
+  it("does not warn for local provider when gateway probe reports embeddings ready", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: true, ready: true },
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("uses model configure hint when gateway probe is unavailable and API key is missing", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "gemini",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -45,6 +45,13 @@ export async function noteMemorySearchHealth(
       if (hasLocalEmbeddings(resolved.local)) {
         return; // local model file exists
       }
+      // Some local embedding providers (e.g. node-llama-cpp) can resolve a model
+      // from their own on-disk cache even when no explicit modelPath is
+      // configured. If the running gateway reports embeddings ready, avoid a
+      // false-positive warning.
+      if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
+        return;
+      }
       note(
         [
           'Memory search provider is set to "local" but no local model file was found.',


### PR DESCRIPTION
Fixes #28944.

When memorySearch.provider=local and no explicit local.modelPath is configured, doctor previously warned that no model file was found. Some local providers (e.g. node-llama-cpp) resolve models from their own cache directories at runtime.

If the running gateway reports embeddings are ready, skip the warning to avoid a false positive.

Adds a unit test covering this case.