### PR TITLE
style: fix oxfmt formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary

- Fix trailing whitespace and unescaped underscore in the Josh Lehman entry (added by 2916152f8) that breaks `oxfmt --check` for every open PR

The `check` CI job fails on the `format:check` step for all PRs since this commit was merged. Confirmed by checking CI logs across multiple unrelated open PRs (#29050, #25045, #28993, #26821, #29011, #29031).

## Test plan

- [x] `oxfmt --check CONTRIBUTING.md` passes after this change

🤖 AI-assisted (Claude Code). Fully tested — single `oxfmt` formatting fix.