### PR TITLE
Gateway: interrupt active tool execution on stop/abort/restart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,8 @@ Welcome to the lobster tank! 🦞
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
   - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
-    
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman_](https://x.com/jlehman_)
+  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -703,6 +703,7 @@ export async function runEmbeddedAttempt(
               sessionKey: params.sessionKey,
               loopDetection: clientToolLoopDetection,
             },
+            { abortSignal: runAbortController.signal },
           )
         : [];
 

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -48,6 +48,19 @@ export function abortEmbeddedPiRun(sessionId: string): boolean {
   return true;
 }
 
+export function abortAllEmbeddedPiRuns(): number {
+  if (ACTIVE_EMBEDDED_RUNS.size === 0) {
+    return 0;
+  }
+  let aborted = 0;
+  for (const [sessionId, handle] of ACTIVE_EMBEDDED_RUNS) {
+    diag.debug(`aborting run: sessionId=${sessionId} reason=gateway_shutdown`);
+    handle.abort();
+    aborted += 1;
+  }
+  return aborted;
+}
+
 export function isEmbeddedPiRunActive(sessionId: string): boolean {
   const active = ACTIVE_EMBEDDED_RUNS.has(sessionId);
   if (active) {

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -97,4 +97,32 @@ describe("pi tool definition adapter", () => {
     expect(result.content[0]).toMatchObject({ type: "text" });
     expect((result.content[0] as { text?: string }).text).toContain('"count"');
   });
+
+  it("throws AbortError before executing when signal is already aborted", async () => {
+    let executed = false;
+    const execute = async () => {
+      executed = true;
+      return { content: [], details: { ok: true } };
+    };
+    const tool = {
+      name: "read",
+      label: "Read",
+      description: "reads",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AgentTool;
+
+    const defs = toToolDefinitions([tool]);
+    const def = defs[0];
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      def.execute("call-aborted", {}, abortController.signal, undefined, extensionContext),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(executed).toBe(false);
+  });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -42,6 +42,54 @@ function isAbortSignal(value: unknown): value is AbortSignal {
   return typeof value === "object" && value !== null && "aborted" in value;
 }
 
+function isNativeAbortSignal(value: unknown): value is AbortSignal {
+  return value instanceof AbortSignal;
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+}
+
+function makeAbortError(signal: AbortSignal): Error {
+  const reason = getAbortReason(signal);
+  const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw makeAbortError(signal);
+}
+
+function combineAbortSignals(a?: AbortSignal, b?: AbortSignal): AbortSignal | undefined {
+  if (!a && !b) {
+    return undefined;
+  }
+  if (a && !b) {
+    return a;
+  }
+  if (b && !a) {
+    return b;
+  }
+  if (a?.aborted) {
+    return a;
+  }
+  if (b?.aborted) {
+    return b;
+  }
+  if (typeof AbortSignal.any === "function" && isNativeAbortSignal(a) && isNativeAbortSignal(b)) {
+    return AbortSignal.any([a, b]);
+  }
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  a?.addEventListener("abort", onAbort, { once: true });
+  b?.addEventListener("abort", onAbort, { once: true });
+  return controller.signal;
+}
+
 function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteArgsLegacy {
   const third = args[2];
   const fifth = args[4];
@@ -150,6 +198,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
         try {
+          throwIfAborted(signal);
           if (!beforeHookWrapped) {
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
@@ -161,6 +210,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             }
             executeParams = hookOutcome.params;
           }
+          throwIfAborted(signal);
           const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
           const result = normalizeToolExecutionResult({
             toolName: normalizedName,
@@ -248,6 +298,7 @@ export function toClientToolDefinitions(
   tools: ClientToolDefinition[],
   onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
   hookContext?: HookContext,
+  options?: { abortSignal?: AbortSignal },
 ): ToolDefinition[] {
   return tools.map((tool) => {
     const func = tool.function;
@@ -257,7 +308,9 @@ export function toClientToolDefinitions(
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params } = splitToolExecuteArgs(args);
+        const { toolCallId, params, signal } = splitToolExecuteArgs(args);
+        const combinedSignal = combineAbortSignals(signal, options?.abortSignal);
+        throwIfAborted(combinedSignal);
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
           params,
@@ -267,6 +320,7 @@ export function toClientToolDefinitions(
         if (outcome.blocked) {
           throw new Error(outcome.reason);
         }
+        throwIfAborted(combinedSignal);
         const adjustedParams = outcome.params;
         const paramsRecord = isPlainObject(adjustedParams) ? adjustedParams : {};
         // Notify handler that a client tool was called

--- a/src/agents/pi-tools.before-tool-call.integration.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.test.ts
@@ -234,4 +234,63 @@ describe("before_tool_call hook integration for client tools", () => {
       extra: true,
     });
   });
+
+  it("blocks client tool execution when the run abort signal is already aborted", async () => {
+    const onClientToolCall = vi.fn();
+    const abortController = new AbortController();
+    abortController.abort();
+    const [tool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: { value: { type: "string" } } },
+          },
+        },
+      ],
+      onClientToolCall,
+      { agentId: "main", sessionKey: "main" },
+      { abortSignal: abortController.signal },
+    );
+    const extensionContext = {} as Parameters<typeof tool.execute>[4];
+
+    await expect(
+      tool.execute("client-call-aborted", { value: "ok" }, undefined, undefined, extensionContext),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(onClientToolCall).not.toHaveBeenCalled();
+  });
+
+  it("blocks client tool execution when per-call signal is aborted", async () => {
+    const onClientToolCall = vi.fn();
+    const [tool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: { value: { type: "string" } } },
+          },
+        },
+      ],
+      onClientToolCall,
+      { agentId: "main", sessionKey: "main" },
+    );
+    const extensionContext = {} as Parameters<typeof tool.execute>[4];
+    const callAbortController = new AbortController();
+    callAbortController.abort();
+
+    await expect(
+      tool.execute(
+        "client-call-aborted-per-call",
+        { value: "ok" },
+        callAbortController.signal,
+        undefined,
+        extensionContext,
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(onClientToolCall).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -123,8 +123,9 @@ export function createGatewayTool(opts?: {
           `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"})`,
         );
         const scheduled = scheduleGatewaySigusr1Restart({
-          delayMs,
+          delayMs: delayMs ?? 0,
           reason,
+          force: true,
         });
         return jsonResult(scheduled);
       }

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -458,7 +458,7 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
   }
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
   if (hasSigusr1Listener) {
-    scheduleGatewaySigusr1Restart({ reason: "/restart" });
+    scheduleGatewaySigusr1Restart({ reason: "/restart", delayMs: 0, force: true });
     return {
       shouldContinue: false,
       reply: {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -10,12 +10,11 @@ const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
 const getActiveTaskCount = vi.fn(() => 0);
 const markGatewayDraining = vi.fn();
-const waitForActiveTasks = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
-const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
+const FORCE_RESTART_LOG = "forcing restart with 2 active task(s); cancelling in-flight runs";
 const gatewayLog = {
   info: vi.fn(),
   warn: vi.fn(),
@@ -39,7 +38,6 @@ vi.mock("../../infra/process-respawn.js", () => ({
 vi.mock("../../process/command-queue.js", () => ({
   getActiveTaskCount: () => getActiveTaskCount(),
   markGatewayDraining: () => markGatewayDraining(),
-  waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
 }));
 
@@ -158,12 +156,11 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration", async () => {
+  it("restarts after SIGUSR1 and resets lanes for the new iteration", async () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async () => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
-      waitForActiveTasks.mockResolvedValueOnce({ drained: false });
 
       type StartServer = () => Promise<{
         close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
@@ -214,9 +211,8 @@ describe("runGatewayLoop", () => {
       expect(start).toHaveBeenCalledTimes(2);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(30_000);
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
-      expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(FORCE_RESTART_LOG);
       expect(closeFirst).toHaveBeenCalledWith({
         reason: "gateway restarting",
         restartExpectedMs: 1500,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -9,6 +9,7 @@ const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
 const getActiveTaskCount = vi.fn(() => 0);
+const waitForActiveTasks = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const markGatewayDraining = vi.fn();
 const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
@@ -37,6 +38,7 @@ vi.mock("../../infra/process-respawn.js", () => ({
 
 vi.mock("../../process/command-queue.js", () => ({
   getActiveTaskCount: () => getActiveTaskCount(),
+  waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   markGatewayDraining: () => markGatewayDraining(),
   resetAllLanes: () => resetAllLanes(),
 }));
@@ -231,6 +233,26 @@ describe("runGatewayLoop", () => {
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("exits when non-abortable lane tasks fail to drain for in-process restart", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      getActiveTaskCount.mockReturnValueOnce(1).mockReturnValueOnce(1);
+      waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+
+      const { start, runtime, exited } = await createSignaledLoopHarness();
+      process.emit("SIGUSR1");
+
+      await expect(exited).resolves.toBe(1);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(waitForActiveTasks).toHaveBeenCalledWith(10_000);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "in-process restart cancelled; non-abortable lane tasks are still active after 10000ms",
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -11,7 +11,6 @@ import {
   getActiveTaskCount,
   markGatewayDraining,
   resetAllLanes,
-  waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
 import type { defaultRuntime } from "../../runtime.js";
@@ -88,7 +87,7 @@ export async function runGatewayLoop(params: {
     exitProcess(0);
   };
 
-  const DRAIN_TIMEOUT_MS = 30_000;
+  const FORCED_RESTART_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = 5_000;
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
@@ -100,8 +99,9 @@ export async function runGatewayLoop(params: {
     const isRestart = action === "restart";
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
 
-    // Allow extra time for draining active turns on restart.
-    const forceExitMs = isRestart ? DRAIN_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
+    // Allow extra time for forced cancellation on restart.
+    const forceExitMs =
+      isRestart ? FORCED_RESTART_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
       exitProcess(0);
@@ -109,23 +109,14 @@ export async function runGatewayLoop(params: {
 
     void (async () => {
       try {
-        // On restart, wait for in-flight agent turns to finish before
-        // tearing down the server so buffered messages are delivered.
         if (isRestart) {
-          // Reject new enqueues immediately during the drain window so
-          // sessions get an explicit restart error instead of silent task loss.
+          // Reject new enqueues immediately and force active runs to cancel in close().
           markGatewayDraining();
           const activeTasks = getActiveTaskCount();
           if (activeTasks > 0) {
-            gatewayLog.info(
-              `draining ${activeTasks} active task(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
+            gatewayLog.warn(
+              `forcing restart with ${activeTasks} active task(s); cancelling in-flight runs`,
             );
-            const { drained } = await waitForActiveTasks(DRAIN_TIMEOUT_MS);
-            if (drained) {
-              gatewayLog.info("all active tasks drained");
-            } else {
-              gatewayLog.warn("drain timeout reached; proceeding with restart");
-            }
           }
         }
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -11,6 +11,7 @@ import {
   getActiveTaskCount,
   markGatewayDraining,
   resetAllLanes,
+  waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
 import type { defaultRuntime } from "../../runtime.js";
@@ -79,6 +80,20 @@ export async function runGatewayLoop(params: {
     if (hadLock && !(await reacquireLockForInProcessRestart())) {
       return;
     }
+    const remainingLaneTasks = getActiveTaskCount();
+    if (remainingLaneTasks > 0) {
+      gatewayLog.info(
+        `waiting for ${remainingLaneTasks} non-abortable lane task(s) before in-process restart (timeout ${IN_PROCESS_RESTART_DRAIN_TIMEOUT_MS}ms)`,
+      );
+      const { drained } = await waitForActiveTasks(IN_PROCESS_RESTART_DRAIN_TIMEOUT_MS);
+      if (!drained) {
+        gatewayLog.error(
+          `in-process restart cancelled; non-abortable lane tasks are still active after ${IN_PROCESS_RESTART_DRAIN_TIMEOUT_MS}ms`,
+        );
+        exitProcess(1);
+        return;
+      }
+    }
     shuttingDown = false;
     restartResolver?.();
   };
@@ -88,6 +103,7 @@ export async function runGatewayLoop(params: {
   };
 
   const FORCED_RESTART_TIMEOUT_MS = 30_000;
+  const IN_PROCESS_RESTART_DRAIN_TIMEOUT_MS = 10_000;
   const SHUTDOWN_TIMEOUT_MS = 5_000;
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
@@ -100,8 +116,9 @@ export async function runGatewayLoop(params: {
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
 
     // Allow extra time for forced cancellation on restart.
-    const forceExitMs =
-      isRestart ? FORCED_RESTART_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
+    const forceExitMs = isRestart
+      ? FORCED_RESTART_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS
+      : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
       exitProcess(0);

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGatewayCloseHandler } from "./server-close.js";
+
+describe("gateway close handler", () => {
+  it("aborts active chat runs and embedded runs during shutdown", async () => {
+    const chatAbortController = new AbortController();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller: chatAbortController,
+          sessionId: "session-1",
+          sessionKey: "main",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const abortAllEmbeddedRuns = vi.fn(() => 1);
+    const broadcast = vi.fn();
+    const tickInterval = setInterval(() => {}, 60_000);
+    const healthInterval = setInterval(() => {}, 60_000);
+    const dedupeCleanup = setInterval(() => {}, 60_000);
+
+    const close = createGatewayCloseHandler({
+      bonjourStop: null,
+      tailscaleCleanup: null,
+      canvasHost: null,
+      canvasHostServer: null,
+      stopChannel: vi.fn(async () => {}),
+      pluginServices: null,
+      cron: { stop: vi.fn() },
+      heartbeatRunner: {
+        stop: vi.fn(),
+        updateConfig: vi.fn(),
+      },
+      updateCheckStop: null,
+      nodePresenceTimers: new Map(),
+      chatAbortControllers,
+      abortAllEmbeddedRuns,
+      broadcast,
+      tickInterval,
+      healthInterval,
+      dedupeCleanup,
+      agentUnsub: null,
+      heartbeatUnsub: null,
+      chatRunState: { clear: vi.fn() },
+      clients: new Set(),
+      configReloader: { stop: vi.fn(async () => {}) },
+      browserControl: null,
+      wss: {
+        close: (cb: () => void) => cb(),
+      } as never,
+      httpServer: {
+        closeIdleConnections: vi.fn(),
+        close: (cb: (err?: Error) => void) => cb(),
+      } as never,
+    });
+
+    await close({ reason: "gateway restarting", restartExpectedMs: 1500 });
+
+    expect(chatAbortController.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+    expect(abortAllEmbeddedRuns).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith("shutdown", {
+      reason: "gateway restarting",
+      restartExpectedMs: 1500,
+    });
+  });
+});

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -5,6 +5,7 @@ import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
@@ -17,6 +18,8 @@ export function createGatewayCloseHandler(params: {
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  abortAllEmbeddedRuns: () => number;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   tickInterval: ReturnType<typeof setInterval>;
   healthInterval: ReturnType<typeof setInterval>;
@@ -80,6 +83,23 @@ export function createGatewayCloseHandler(params: {
       clearInterval(timer);
     }
     params.nodePresenceTimers.clear();
+    for (const active of params.chatAbortControllers.values()) {
+      try {
+        active.controller.abort(new Error(reason));
+      } catch {
+        try {
+          active.controller.abort();
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    params.chatAbortControllers.clear();
+    try {
+      params.abortAllEmbeddedRuns();
+    } catch {
+      /* ignore */
+    }
     params.broadcast("shutdown", {
       reason,
       restartExpectedMs,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+import {
+  abortAllEmbeddedPiRuns,
+  getActiveEmbeddedRunCount,
+} from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
@@ -894,6 +897,8 @@ export async function startGatewayServer(
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,
     nodePresenceTimers,
+    chatAbortControllers,
+    abortAllEmbeddedRuns: abortAllEmbeddedPiRuns,
     broadcast,
     tickInterval,
     healthInterval,

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -368,6 +368,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   delayMs?: number;
   reason?: string;
   audit?: RestartAuditInfo;
+  force?: boolean;
 }): ScheduledRestart {
   const delayMsRaw =
     typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
@@ -378,6 +379,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
     typeof opts?.reason === "string" && opts.reason.trim()
       ? opts.reason.trim().slice(0, 200)
       : undefined;
+  const force = opts?.force === true;
   const mode = process.listenerCount("SIGUSR1") > 0 ? "emit" : "signal";
   const nowMs = Date.now();
   const cooldownMsApplied = Math.max(0, lastRestartEmittedAt + RESTART_COOLDOWN_MS - nowMs);
@@ -432,7 +434,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       pendingRestartDueAt = 0;
       pendingRestartReason = undefined;
       const pendingCheck = preRestartCheck;
-      if (!pendingCheck) {
+      if (force || !pendingCheck) {
         emitGatewayRestart();
         return;
       }


### PR DESCRIPTION
## Summary
- enforce abort checks between tool calls during a single run, including client tool definitions
- wire run abort signals into client tool execution so mid-turn `/stop` and abort requests interrupt ongoing chains
- force gateway shutdown/restart to cancel active chat sessions and embedded PI runs immediately
- update restart flow to avoid waiting for active task drain and allow explicit restart commands to bypass defer checks
- add and update tests for abort propagation and gateway close cancellation behavior

## Testing
- `bun test src/gateway/server-close.test.ts` *(fails in this environment due missing deps: `Cannot find package 'chalk'`)*
- attempted install: `npx -y pnpm@10.23.0 install` *(failed: `EAI_AGAIN registry.npmjs.org`)*

Closes #29034.
