### PR TITLE
fix: increase VERIFY_TIMEOUT_MS to 2 minutes for local LLMs

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -220,7 +220,7 @@ describe("promptCustomApiConfig", () => {
 
     const promise = runPromptCustomApi(prompter);
 
-    await vi.advanceTimersByTimeAsync(10000);
+    await vi.advanceTimersByTimeAsync(120000);
     await promise;
 
     expect(prompter.text).toHaveBeenCalledTimes(6);

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,7 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 10000;
+const VERIFY_TIMEOUT_MS = 120000; // 2 minutes for local LLMs
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -28,14 +28,17 @@ function isLocalEndpoint(url: string): boolean {
   try {
     const parsed = new URL(url);
     const host = parsed.hostname.toLowerCase();
+    // Handle IPv6 localhost: URL.hostname returns "[::1]" for ::1
+    const normalizedHost = host.replace(/^\[|\]$/g, "");
     return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host.startsWith("192.168.") ||
-      host.startsWith("10.") ||
-      host.startsWith("172.16.") ||
-      host.endsWith(".local")
+      normalizedHost === "localhost" ||
+      normalizedHost === "127.0.0.1" ||
+      normalizedHost === "::1" ||
+      normalizedHost.startsWith("192.168.") ||
+      normalizedHost.startsWith("10.") ||
+      // RFC1918 172.16.0.0/12 covers 172.16.x.x through 172.31.x.x
+      /^172\.(1[6-9]|2[0-9]|3[01])\./.test(normalizedHost) ||
+      normalizedHost.endsWith(".local")
     );
   } catch {
     return false;

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,37 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 120000; // 2 minutes for local LLMs
+const VERIFY_TIMEOUT_MS = 10000; // 10 seconds for remote APIs
+const VERIFY_TIMEOUT_LOCAL_MS = 120000; // 2 minutes for local LLMs
+
+/**
+ * Check if a URL points to a local endpoint (localhost, 127.0.0.1, etc.)
+ */
+function isLocalEndpoint(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host.startsWith("192.168.") ||
+      host.startsWith("10.") ||
+      host.startsWith("172.16.") ||
+      host.endsWith(".local")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get appropriate verification timeout based on endpoint type.
+ * Local LLMs need more time; remote APIs should fail fast.
+ */
+function getVerifyTimeoutMs(endpoint: string): number {
+  return isLocalEndpoint(endpoint) ? VERIFY_TIMEOUT_LOCAL_MS : VERIFY_TIMEOUT_MS;
+}
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.
@@ -282,6 +312,7 @@ async function requestVerification(params: {
   headers: Record<string, string>;
   body: Record<string, unknown>;
 }): Promise<VerificationResult> {
+  const timeoutMs = getVerifyTimeoutMs(params.endpoint);
   try {
     const res = await fetchWithTimeout(
       params.endpoint,
@@ -293,7 +324,7 @@ async function requestVerification(params: {
         },
         body: JSON.stringify(params.body),
       },
-      VERIFY_TIMEOUT_MS,
+      timeoutMs,
     );
     return { ok: res.ok, status: res.status };
   } catch (error) {


### PR DESCRIPTION
## Summary

Increases the model verification timeout from 10 seconds to 2 minutes (120 seconds) to accommodate local LLMs running on consumer hardware.

## Problem

Local LLMs running on laptops with small GPUs (e.g., Qwen3 14B with llama.cpp) often take more than 10 seconds to generate a verification response. The current 10-second timeout causes the verification step to fail unnecessarily.

## Solution

Change `VERIFY_TIMEOUT_MS` from 10000ms (10s) to 120000ms (2 minutes).

This change:
- Allows local models sufficient time to respond
- Does not negatively impact cloud API users (just a longer fallback timeout)
- Improves user experience for self-hosted model users

## Testing

- The change is a simple constant modification
- No functional behavior changes other than timeout duration

Fixes #28972