### PR TITLE
fix(slack): session-based sticky routing + context bloat fixes

### DIFF
--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -62,6 +62,7 @@ export type SlackMonitorContext = {
   runtime: RuntimeEnv;
 
   botUserId: string;
+  botId?: string;
   teamId: string;
   apiAppId: string;
 
@@ -125,6 +126,7 @@ export function createSlackMonitorContext(params: {
   runtime: RuntimeEnv;
 
   botUserId: string;
+  botId?: string;
   teamId: string;
   apiAppId: string;
 
@@ -389,6 +391,7 @@ export function createSlackMonitorContext(params: {
     app: params.app,
     runtime: params.runtime,
     botUserId: params.botUserId,
+    botId: params.botId,
     teamId: params.teamId,
     apiAppId: params.apiAppId,
     historyLimit: params.historyLimit,

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -52,6 +52,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       app: { client: params.appClient ?? {} } as App,
       runtime: {} as RuntimeEnv,
       botUserId: "B1",
+      botId: "BID1",
       teamId: "T1",
       apiAppId: "A1",
       historyLimit: 0,
@@ -596,6 +597,51 @@ describe("slack prepareSlackMessage inbound contract", () => {
         text: "following up",
         ts: "101.000",
         thread_ts: "100.000",
+        parent_user_id: "U2",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+  });
+
+  it("accepts first unmentioned thread follow-up when Slack history only has bot_id messages", async () => {
+    const { storePath } = makeTmpStorePath();
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        { text: "thread root", user: "U2", ts: "300.000" },
+        { text: "bot reply", bot_id: "BID1", ts: "300.500" },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true, groupPolicy: "open" } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as App["client"],
+      defaultRequireMention: true,
+      replyToMode: "all",
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      {
+        ...createThreadAccount(),
+        config: {
+          ...createThreadAccount().config,
+          thread: { initialHistoryLimit: 0 },
+        },
+      },
+      createThreadReplyMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "following up",
+        ts: "301.000",
+        thread_ts: "300.000",
         parent_user_id: "U2",
       }),
     );

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -559,6 +559,105 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(replies).toHaveBeenCalledTimes(1);
   });
 
+  it("accepts first unmentioned thread follow-up when Slack thread history shows prior bot reply", async () => {
+    const { storePath } = makeTmpStorePath();
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        { text: "thread root", user: "U2", ts: "100.000" },
+        { text: "bot reply", user: "B1", ts: "100.500" },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true, groupPolicy: "open" } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as App["client"],
+      defaultRequireMention: true,
+      replyToMode: "all",
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      {
+        ...createThreadAccount(),
+        config: {
+          ...createThreadAccount().config,
+          thread: { initialHistoryLimit: 0 },
+        },
+      },
+      createThreadReplyMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "following up",
+        ts: "101.000",
+        thread_ts: "100.000",
+        parent_user_id: "U2",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.WasMentioned).toBe(true);
+  });
+
+  it("keeps mention gating thread-scoped when only base channel session is warm", async () => {
+    const { storePath } = makeTmpStorePath();
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, groupPolicy: "open" } },
+    } as OpenClawConfig;
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "slack",
+      accountId: "default",
+      teamId: "T1",
+      peer: { kind: "channel", id: "C123" },
+    });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({ [route.sessionKey]: { updatedAt: Date.now() } }, null, 2),
+    );
+
+    const replies = vi.fn().mockResolvedValue({
+      messages: [{ text: "thread root", user: "U2", ts: "200.000" }],
+      response_metadata: { next_cursor: "" },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg,
+      appClient: { conversations: { replies } } as App["client"],
+      defaultRequireMention: true,
+      replyToMode: "all",
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      {
+        ...createThreadAccount(),
+        config: {
+          ...createThreadAccount().config,
+          thread: { initialHistoryLimit: 0 },
+        },
+      },
+      createThreadReplyMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: "U1",
+        text: "unmentioned reply",
+        ts: "201.000",
+        thread_ts: "200.000",
+        parent_user_id: "U2",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+  });
+
   it("includes thread_ts and parent_user_id metadata in thread replies", async () => {
     const message = createSlackMessage({
       text: "this is a reply",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -110,9 +110,10 @@ async function hasSlackBotParticipatedInThread(params: {
   channelId: string;
   threadTs: string;
   botUserId: string;
+  botId?: string;
   currentMessageTs?: string;
 }): Promise<boolean> {
-  const cacheKey = `${params.channelId}:${params.threadTs}:${params.botUserId}`;
+  const cacheKey = `${params.channelId}:${params.threadTs}:${params.botUserId}:${params.botId ?? ""}`;
   const cached = readThreadParticipationCache(cacheKey);
   if (cached !== undefined) {
     return cached;
@@ -150,7 +151,9 @@ async function hasSlackBotParticipatedInThread(params: {
       });
       const participated =
         response.messages?.some(
-          (reply) => reply.bot_id === params.botUserId || reply.user === params.botUserId,
+          (reply) =>
+            reply.user === params.botUserId ||
+            Boolean(params.botId && reply.bot_id === params.botId),
         ) === true;
       if (participated) {
         writeThreadParticipationCache(cacheKey, true);
@@ -357,6 +360,7 @@ export async function prepareSlackMessage(params: {
       channelId: message.channel,
       threadTs,
       botUserId: ctx.botUserId,
+      botId: ctx.botId,
       currentMessageTs: message.ts,
     });
   }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -50,6 +50,125 @@ import {
 import { resolveSlackRoomContextHints } from "../room-context.js";
 import type { PreparedSlackMessage } from "./types.js";
 
+type SlackThreadParticipationCacheEntry = {
+  participated: boolean;
+  updatedAt: number;
+};
+
+type SlackRepliesProbeMessage = {
+  user?: string;
+  bot_id?: string;
+};
+
+type SlackRepliesProbeResponse = {
+  messages?: SlackRepliesProbeMessage[];
+  response_metadata?: { next_cursor?: string };
+};
+
+const THREAD_PARTICIPATION_CACHE_TTL_MS = 60_000;
+const THREAD_PARTICIPATION_CACHE_MAX = 500;
+const THREAD_PARTICIPATION_MAX_PAGES = 4;
+const THREAD_PARTICIPATION_FETCH_LIMIT = 200;
+const THREAD_PARTICIPATION_CACHE = new Map<string, SlackThreadParticipationCacheEntry>();
+
+function pruneThreadParticipationCache() {
+  while (THREAD_PARTICIPATION_CACHE.size > THREAD_PARTICIPATION_CACHE_MAX) {
+    const oldestKey = THREAD_PARTICIPATION_CACHE.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    THREAD_PARTICIPATION_CACHE.delete(oldestKey);
+  }
+}
+
+function readThreadParticipationCache(cacheKey: string): boolean | undefined {
+  const entry = THREAD_PARTICIPATION_CACHE.get(cacheKey);
+  if (!entry) {
+    return undefined;
+  }
+  const now = Date.now();
+  if (now - entry.updatedAt > THREAD_PARTICIPATION_CACHE_TTL_MS) {
+    THREAD_PARTICIPATION_CACHE.delete(cacheKey);
+    return undefined;
+  }
+  THREAD_PARTICIPATION_CACHE.delete(cacheKey);
+  THREAD_PARTICIPATION_CACHE.set(cacheKey, { ...entry, updatedAt: now });
+  return entry.participated;
+}
+
+function writeThreadParticipationCache(cacheKey: string, participated: boolean) {
+  THREAD_PARTICIPATION_CACHE.delete(cacheKey);
+  THREAD_PARTICIPATION_CACHE.set(cacheKey, {
+    participated,
+    updatedAt: Date.now(),
+  });
+  pruneThreadParticipationCache();
+}
+
+async function hasSlackBotParticipatedInThread(params: {
+  client: SlackMonitorContext["app"]["client"];
+  channelId: string;
+  threadTs: string;
+  botUserId: string;
+  currentMessageTs?: string;
+}): Promise<boolean> {
+  const cacheKey = `${params.channelId}:${params.threadTs}:${params.botUserId}`;
+  const cached = readThreadParticipationCache(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const conversations = params.client.conversations as
+    | {
+        replies?: (args: {
+          channel: string;
+          ts: string;
+          limit: number;
+          inclusive: boolean;
+          latest?: string;
+          cursor?: string;
+        }) => Promise<SlackRepliesProbeResponse>;
+      }
+    | undefined;
+  const fetchReplies = conversations?.replies;
+  if (!fetchReplies) {
+    writeThreadParticipationCache(cacheKey, false);
+    return false;
+  }
+
+  let cursor: string | undefined;
+  let pageCount = 0;
+  try {
+    do {
+      const response = await fetchReplies({
+        channel: params.channelId,
+        ts: params.threadTs,
+        limit: THREAD_PARTICIPATION_FETCH_LIMIT,
+        inclusive: true,
+        ...(params.currentMessageTs ? { latest: params.currentMessageTs } : {}),
+        ...(cursor ? { cursor } : {}),
+      });
+      const participated =
+        response.messages?.some(
+          (reply) => reply.bot_id === params.botUserId || reply.user === params.botUserId,
+        ) === true;
+      if (participated) {
+        writeThreadParticipationCache(cacheKey, true);
+        return true;
+      }
+      const next = response.response_metadata?.next_cursor;
+      cursor = typeof next === "string" && next.trim() ? next.trim() : undefined;
+      pageCount += 1;
+    } while (cursor && pageCount < THREAD_PARTICIPATION_MAX_PAGES);
+  } catch {
+    writeThreadParticipationCache(cacheKey, false);
+    return false;
+  }
+
+  writeThreadParticipationCache(cacheKey, false);
+  return false;
+}
+
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
@@ -85,6 +204,9 @@ export async function prepareSlackMessage(params: {
         defaultRequireMention: ctx.defaultRequireMention,
       })
     : null;
+  const shouldRequireMention = isRoom
+    ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
+    : false;
 
   const allowBots =
     channelConfig?.allowBots ??
@@ -212,30 +334,32 @@ export async function prepareSlackMessage(params: {
       }));
   // Treat as an implicit mention when:
   // (a) the bot authored the thread root message (original behaviour), OR
-  // (b) the bot has previously replied in this thread (session already exists).
-  //     This covers scenario where the bot joined a thread via @mention but is
-  //     NOT the parent_user_id, so follow-up replies without @mention still
-  //     reach the bot (fixes: #25760).
+  // (b) thread-scoped session activity indicates prior participation, OR
+  // (c) Slack thread history confirms prior bot participation.
   //
-  // Thread session participation check: For thread replies, check both:
-  // 1. The thread-specific session (if bot has previously replied in this thread)
-  // 2. The base channel session (handles routing discontinuity)
-  //
-  // Why check the base session: Thread sessions are deferred during prepare
-  // (PR #19083). When the bot replies to the first @mention in a thread:
-  // - Internally: Gateway routes the response to the CHANNEL session (thread
-  //   session doesn't exist yet due to deferred creation)
-  // - On Slack: Bot's reply displays as a THREAD message (correct UI)
-  //
-  // This creates a discontinuity: the bot's participation exists in the channel
-  // session internally, but appears as a thread message externally. We check
-  // both sessions to bridge this gap.
-  const botParticipatedInThread =
+  // We intentionally avoid base channel session fallback to prevent cross-thread
+  // false positives in requireMention channels.
+  const hasThreadSessionActivity =
+    isThreadReply && Boolean(readSessionUpdatedAt({ storePath, sessionKey }));
+  const shouldProbeThreadParticipation =
     isThreadReply &&
-    Boolean(
-      readSessionUpdatedAt({ storePath, sessionKey }) ||
-      readSessionUpdatedAt({ storePath, sessionKey: baseSessionKey }),
-    );
+    isRoom &&
+    shouldRequireMention &&
+    Boolean(ctx.botUserId) &&
+    Boolean(threadTs) &&
+    !hasThreadSessionActivity &&
+    !wasMentioned &&
+    message.parent_user_id !== ctx.botUserId;
+  let botParticipatedInThread = hasThreadSessionActivity;
+  if (shouldProbeThreadParticipation && threadTs && ctx.botUserId) {
+    botParticipatedInThread = await hasSlackBotParticipatedInThread({
+      client: ctx.app.client,
+      channelId: message.channel,
+      threadTs,
+      botUserId: ctx.botUserId,
+      currentMessageTs: message.ts,
+    });
+  }
   const implicitMention = Boolean(
     !isDirectMessage &&
     ctx.botUserId &&
@@ -305,10 +429,6 @@ export async function prepareSlackMessage(params: {
     });
     return null;
   }
-
-  const shouldRequireMention = isRoom
-    ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
-    : false;
 
   // Allow "control commands" to bypass mention gating if sender is authorized.
   const canDetectMention = Boolean(ctx.botUserId) || mentionRegexes.length > 0;

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -187,6 +187,12 @@ export async function prepareSlackMessage(params: {
   const historyKey =
     isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
 
+  // Resolve storePath early so it can be used for both the implicitMention check
+  // (thread participation) and the later session-recording steps.
+  const storePath = resolveStorePath(ctx.cfg.session?.store, {
+    agentId: route.agentId,
+  });
+
   const mentionRegexes = buildMentionRegexes(cfg, route.agentId);
   const hasAnyMention = /<@[^>]+>/.test(message.text ?? "");
   const explicitlyMentioned = Boolean(
@@ -204,11 +210,37 @@ export async function prepareSlackMessage(params: {
           canResolveExplicit: Boolean(ctx.botUserId),
         },
       }));
+  // Treat as an implicit mention when:
+  // (a) the bot authored the thread root message (original behaviour), OR
+  // (b) the bot has previously replied in this thread (session already exists).
+  //     This covers scenario where the bot joined a thread via @mention but is
+  //     NOT the parent_user_id, so follow-up replies without @mention still
+  //     reach the bot (fixes: #25760).
+  //
+  // Thread session participation check: For thread replies, check both:
+  // 1. The thread-specific session (if bot has previously replied in this thread)
+  // 2. The base channel session (handles routing discontinuity)
+  //
+  // Why check the base session: Thread sessions are deferred during prepare
+  // (PR #19083). When the bot replies to the first @mention in a thread:
+  // - Internally: Gateway routes the response to the CHANNEL session (thread
+  //   session doesn't exist yet due to deferred creation)
+  // - On Slack: Bot's reply displays as a THREAD message (correct UI)
+  //
+  // This creates a discontinuity: the bot's participation exists in the channel
+  // session internally, but appears as a thread message externally. We check
+  // both sessions to bridge this gap.
+  const botParticipatedInThread =
+    isThreadReply &&
+    Boolean(
+      readSessionUpdatedAt({ storePath, sessionKey }) ||
+      readSessionUpdatedAt({ storePath, sessionKey: baseSessionKey }),
+    );
   const implicitMention = Boolean(
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&
-    message.parent_user_id === ctx.botUserId,
+    (message.parent_user_id === ctx.botUserId || botParticipatedInThread),
   );
 
   const sender = message.user ? await ctx.resolveUserName(message.user) : null;
@@ -403,9 +435,14 @@ export async function prepareSlackMessage(params: {
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  // Add simple sender preamble for context (who is speaking in the thread)
-  // This is important for multi-human threads so the LLM can track participants
-  enqueueSystemEvent(`Slack message from ${senderName}`, {
+  // Add sender preamble with thread context
+  // For threads, indicate it's a multi-user conversation so the LLM knows to be selective
+  // about whether to participate or NO_REPLY when the message is directed at someone else
+  const isThread = isThreadReply && threadTs;
+  const senderNote = isThread
+    ? `Slack message detected on thread: ${senderName} speaking`
+    : `Slack message from ${senderName}`;
+  enqueueSystemEvent(senderNote, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
   });
@@ -422,9 +459,6 @@ export async function prepareSlackMessage(params: {
       ? ` thread_ts: ${threadTs}${message.parent_user_id ? ` parent_user_id: ${message.parent_user_id}` : ""}`
       : "";
   const textWithId = `${rawBody}\n[slack message id: ${message.ts} channel: ${message.channel}${threadInfo}]`;
-  const storePath = resolveStorePath(ctx.cfg.session?.store, {
-    agentId: route.agentId,
-  });
   const envelopeOptions = resolveEnvelopeFormatOptions(ctx.cfg);
   const previousTimestamp = readSessionUpdatedAt({
     storePath,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -395,17 +395,17 @@ export async function prepareSlackMessage(params: {
       : null;
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
+  // Keep preview for logging/debugging
   const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
-  const inboundLabel = isDirectMessage
-    ? `Slack DM from ${senderName}`
-    : `Slack message in ${roomLabel} from ${senderName}`;
   const slackFrom = isDirectMessage
     ? `slack:${message.user}`
     : isRoom
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+  // Add simple sender preamble for context (who is speaking in the thread)
+  // This is important for multi-human threads so the LLM can track participants
+  enqueueSystemEvent(`Slack message from ${senderName}`, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
   });
@@ -513,7 +513,8 @@ export async function prepareSlackMessage(params: {
       storePath,
       sessionKey, // Thread-specific session key
     });
-    if (threadInitialHistoryLimit > 0) {
+    // Only fetch thread history for NEW sessions (when there's no previous timestamp)
+    if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
       const threadHistory = await resolveSlackThreadHistory({
         channelId: message.channel,
         threadTs,
@@ -601,7 +602,8 @@ export async function prepareSlackMessage(params: {
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
     ParentSessionKey: threadKeys.parentSessionKey,
-    ThreadStarterBody: threadStarterBody,
+    // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
+    ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadHistoryBody: threadHistoryBody,
     IsFirstThreadTurn:
       isThreadReply && threadTs && !threadSessionPreviousTimestamp ? true : undefined,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -178,12 +178,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let unregisterHttpHandler: (() => void) | null = null;
 
   let botUserId = "";
+  let botId = "";
   let teamId = "";
   let apiAppId = "";
   const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
   try {
     const auth = await app.client.auth.test({ token: botToken });
     botUserId = auth.user_id ?? "";
+    botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
   } catch {
@@ -203,6 +205,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     app,
     runtime,
     botUserId,
+    botId,
     teamId,
     apiAppId,
     historyLimit,


### PR DESCRIPTION
- **Problem**: In Slack channels with `requireMention: true`, follow-up replies in threads are dropped when users don't re-@mention the bot; even after the bot has already participated. Additionally, thread history was being fetched on every message, causing **significant token bloat**. See #27609 for bloat example
- **Why it matters**: Users have to repeatedly @mention the bot in ongoing conversations, breaking the natural flow. Token bloat increases costs and latency.
- **What changed**: 
  - Session-based check for thread participation (bot replies = implicit @mention for follow-ups)
  - Thread history only fetched for NEW sessions (existing sessions already have conversation in transcript)
  - Thread-aware sender preamble helps LLM understand multi-human thread context
- **What did NOT change**: Bot behavior in non-thread conversations, @mention requirement for first contact in threads

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24816, #25760
- Related #24760, #16133
- Combines work from #25781, #27609, #27654
- Alternative approach to #16223 / #28902

## User-visible / Behavior Changes

Once the bot replies in a Slack thread, subsequent messages from any user (without @mention) will be routed to the bot. Thread context is no longer redundantly included in messages (reduces token usage).

**Config changes**: None (zero new config options)

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: We now check using the slack API if the bot account replied to a thread as a fallback if we do not find an agent session matching the thread on which a new message arrived. This adds a few API calls to slack

## Repro + Verification

### Environment

- OS: Linux (Amazon Linux 2023)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: Slack
- Relevant config: `channels.slack.requireMention: true`

### Steps

1. Start a Slack thread (user posts message, not from bot)
2. User @mentions bot → bot replies
3. Another user replies in thread WITHOUT @mention

### Expected

Bot receives and responds to the follow-up message (session-based check passes)

### Actual

Before fix: Message was silently dropped (only `parent_user_id === botUserId` was checked)
After fix: Bot receives message (session exists from previous reply)

## Evidence

- [x] All 33 Slack test files pass (274 tests)
- [x] TypeScript type check passes
- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Session-based sticky routing works after bot reply; context bloat is reduced (thread history not re-fetched)
- Edge cases checked: DMs excluded from thread logic; non-thread messages unchanged
- What you did **not** verify: I did not test it with requireMention: false

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change: Revert PR; bot returns to requiring @mention on every thread message
- Files/config to restore: `src/slack/monitor/message-handler/prepare.ts`
- Known bad symptoms reviewers should watch for: Bot not receiving messages it should; or receiving messages it shouldn't

## Risks and Mitigations

This whole part of the codebase needs a real hard look. Why even bother with a slack channel session if the replyToMode is `all`? the dichotomy between openclaw sessions and how they are presented Slack threads makes it hard for Devs and agents to work in this piece and may be unnecessary. We might consider to get rid of the channel session entirely and spawn per response sessions until `replyToMode` is `off` (no threading)