### PR TITLE
fix(memory): truncate query text before embedding to prevent 400 errors

### DIFF
--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -8,7 +8,8 @@ import {
 } from "./batch-openai.js";
 import { type VoyageBatchRequest, runVoyageEmbeddingBatches } from "./batch-voyage.js";
 import { enforceEmbeddingMaxInputTokens } from "./embedding-chunk-limits.js";
-import { estimateUtf8Bytes } from "./embedding-input-limits.js";
+import { estimateUtf8Bytes, splitTextToUtf8ByteLimit } from "./embedding-input-limits.js";
+import { resolveEmbeddingMaxInputTokens } from "./embedding-model-limits.js";
 import {
   chunkMarkdown,
   hashText,
@@ -549,10 +550,21 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!this.provider) {
       throw new Error("Cannot embed query in FTS-only mode (no embedding provider)");
     }
+    // Truncate query text to the embedding model's input limit to prevent 400 errors.
+    const maxInputTokens = resolveEmbeddingMaxInputTokens(this.provider);
+    let truncated = text;
+    if (estimateUtf8Bytes(text) > maxInputTokens) {
+      const parts = splitTextToUtf8ByteLimit(text, maxInputTokens);
+      truncated = parts[0] ?? text;
+      log.debug("memory embeddings: query truncated", {
+        originalBytes: estimateUtf8Bytes(text),
+        maxInputTokens,
+      });
+    }
     const timeoutMs = this.resolveEmbeddingTimeout("query");
     log.debug("memory embeddings: query start", { provider: this.provider.id, timeoutMs });
     return await this.withTimeout(
-      this.provider.embedQuery(text),
+      this.provider.embedQuery(truncated),
       timeoutMs,
       `memory embeddings query timed out after ${Math.round(timeoutMs / 1000)}s`,
     );


### PR DESCRIPTION
## Summary
- `embedQueryWithTimeout()` passes query text to the embedding provider without enforcing input token limits
- When auto-recall sends long prompts (e.g. from hooks or large conversation contexts), the OpenAI API returns `400 This model's maximum context length is 8192 tokens` and the recall silently fails
- Uses the existing `resolveEmbeddingMaxInputTokens()` and `splitTextToUtf8ByteLimit()` utilities — already applied during indexing — to truncate query text before sending it to the embedding API
- Only the first chunk (up to the model's token limit) is used for the query embedding, with a debug log when truncation occurs

## Reproduction
Configure `memory-lancedb` with `text-embedding-3-small` (8192 token limit) and trigger auto-recall with a long prompt (e.g. a large hook messageTemplate). The gateway log will show:
```
memory-lancedb: recall failed: Error: 400 This model's maximum context length is 8192 tokens, however you requested N tokens
```

## Test plan
- [ ] Verify memory recall works with short queries (no truncation)
- [ ] Verify memory recall succeeds with queries exceeding 8192 tokens (truncated, no 400 error)
- [ ] Confirm debug log appears when truncation occurs
- [ ] Run existing memory manager tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)