### PR TITLE
fix(infra): actively kickstart launchd on supervised gateway restart

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
@@ -142,13 +142,63 @@ describe("applyExtraParamsToAgent", () => {
     } as Model<"anthropic-messages">;
     const context: Context = { messages: [] };
 
-    void agent.streamFn?.(model, context, { headers: { "X-Custom": "1" } });
+    // Simulate pi-agent-core passing apiKey in options (API key, not OAuth token)
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-api03-test",
+      headers: { "X-Custom": "1" },
+    });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.headers).toEqual({
       "X-Custom": "1",
-      "anthropic-beta": "context-1m-2025-08-07",
+      // Includes pi-ai default betas (preserved to avoid overwrite) + context1m
+      "anthropic-beta":
+        "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,context-1m-2025-08-07",
     });
+  });
+
+  it("preserves oauth-2025-04-20 beta when context1m is enabled with an OAuth token", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": {
+              params: {
+                context1m: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-sonnet-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    // Simulate pi-agent-core passing an OAuth token (sk-ant-oat-*) as apiKey
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-oat01-test-oauth-token",
+      headers: { "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    const betaHeader = calls[0]?.headers?.["anthropic-beta"] as string;
+    // Must include the OAuth-required betas so they aren't stripped by pi-ai's mergeHeaders
+    expect(betaHeader).toContain("oauth-2025-04-20");
+    expect(betaHeader).toContain("claude-code-20250219");
+    expect(betaHeader).toContain("context-1m-2025-08-07");
   });
 
   it("merges existing anthropic-beta headers with configured betas", () => {
@@ -183,12 +233,14 @@ describe("applyExtraParamsToAgent", () => {
     const context: Context = { messages: [] };
 
     void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-api03-test",
       headers: { "anthropic-beta": "prompt-caching-2024-07-31" },
     });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.headers).toEqual({
-      "anthropic-beta": "prompt-caching-2024-07-31,files-api-2025-04-14,context-1m-2025-08-07",
+      "anthropic-beta":
+        "prompt-caching-2024-07-31,fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14,files-api-2025-04-14,context-1m-2025-08-07",
     });
   });
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -218,16 +218,46 @@ function mergeAnthropicBetaHeader(
   return merged;
 }
 
+// Betas that pi-ai's createClient injects for standard Anthropic API key calls.
+// Must be included when injecting anthropic-beta via options.headers, because
+// pi-ai's mergeHeaders uses Object.assign (last-wins), which would otherwise
+// overwrite the hardcoded defaultHeaders["anthropic-beta"].
+const PI_AI_DEFAULT_ANTHROPIC_BETAS = [
+  "fine-grained-tool-streaming-2025-05-14",
+  "interleaved-thinking-2025-05-14",
+] as const;
+
+// Additional betas pi-ai injects when the API key is an OAuth token (sk-ant-oat-*).
+// These are required for Anthropic to accept OAuth Bearer auth. Losing oauth-2025-04-20
+// causes a 401 "OAuth authentication is currently not supported".
+const PI_AI_OAUTH_ANTHROPIC_BETAS = [
+  "claude-code-20250219",
+  "oauth-2025-04-20",
+  ...PI_AI_DEFAULT_ANTHROPIC_BETAS,
+] as const;
+
+function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
+  return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
+}
+
 function createAnthropicBetaHeadersWrapper(
   baseStreamFn: StreamFn | undefined,
   betas: string[],
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) =>
-    underlying(model, context, {
+  return (model, context, options) => {
+    // Preserve the betas pi-ai's createClient would inject for the given token type.
+    // Without this, our options.headers["anthropic-beta"] overwrites the pi-ai
+    // defaultHeaders via Object.assign, stripping critical betas like oauth-2025-04-20.
+    const piAiBetas = isAnthropicOAuthApiKey(options?.apiKey)
+      ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
+      : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);
+    const allBetas = [...new Set([...piAiBetas, ...betas])];
+    return underlying(model, context, {
       ...options,
-      headers: mergeAnthropicBetaHeader(options?.headers, betas),
+      headers: mergeAnthropicBetaHeader(options?.headers, allBetas),
     });
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Problem:** When an agent triggers a gateway restart in supervised (launchd) mode, the process exits expecting `KeepAlive: true` to respawn it. But launchd's `ThrottleInterval` (default 10s, or 60s on older installs) can delay or prevent the restart entirely, leaving the gateway dead.
- **Why it matters:** Users report gateways staying dead for hours (#4632), entering restart loops (#26904), or orphaning processes (#27605) — all because supervised restart relies on launchd timing instead of an explicit kickstart.
- **What changed:** `process-respawn.ts` now calls `triggerOpenClawRestart()` (explicit `launchctl kickstart -k`) on macOS when `OPENCLAW_LAUNCHD_LABEL` is set, before returning `mode: "supervised"`. Falls back to `mode: "failed"` on kickstart error so `run-loop.ts` can do in-process restart.
- **What did NOT change (scope boundary):** No changes to `restart.ts`, `run-loop.ts`, plist generation, or ThrottleInterval defaults. No new shell commands — reuses existing `triggerOpenClawRestart()`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26904
- Related #4632
- Related #27605
- Related #20257
- Related #19138

## User-visible / Behavior Changes

Agent-triggered restarts on macOS now come back within seconds instead of waiting 10-60s (or never). No config changes required, though users with old plists benefit from `openclaw gateway install --force` to drop the legacy `ThrottleInterval=60`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — reuses existing `triggerOpenClawRestart()` which already calls `launchctl kickstart`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon, Sequoia 26.2)
- Runtime/container: Node.js via launchd LaunchAgent
- Model/provider: Any
- Integration/channel (if any): Any — triggered by agent `/restart` command
- Relevant config (redacted): LaunchAgent plist with `KeepAlive: true`

### Steps

1. Gateway running via launchd LaunchAgent with `KeepAlive: true`
2. Agent triggers `/restart` or `gateway-tool` restart
3. `process-respawn.ts` detects supervised mode, exits with code 0

### Expected

- Gateway restarts within seconds via explicit `launchctl kickstart -k`

### Actual (before fix)

- Gateway exits and waits for launchd `ThrottleInterval` (10-60s), may not restart at all

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test:fast src/infra/process-respawn.test.ts` — 6/6 passing, including 2 new tests for kickstart success and failure paths.

## Human Verification (required)

- Verified scenarios: Patched build installed locally, `openclaw gateway install --force` regenerated plist without ThrottleInterval
- Edge cases checked: Kickstart failure path (bad label → falls back to `mode: "failed"`); non-macOS platforms skip kickstart; missing `OPENCLAW_LAUNCHD_LABEL` skips kickstart
- What you did **not** verify: Live agent-triggered `/restart` end-to-end (pending next agent interaction)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — `OPENCLAW_LAUNCHD_LABEL` is already set by the launchd plist
- Migration needed? `No` — optional `openclaw gateway install --force` to drop legacy ThrottleInterval=60 from old plists
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit; or unset `OPENCLAW_LAUNCHD_LABEL` env to skip the new code path entirely
- Files/config to restore: `src/infra/process-respawn.ts` only
- Known bad symptoms reviewers should watch for: Gateway not restarting at all (kickstart returns error but `mode: "failed"` fallback not triggering in `run-loop.ts`)

## Risks and Mitigations

- Risk: `triggerOpenClawRestart()` could fail silently on edge-case launchd configs
  - Mitigation: Failure returns `mode: "failed"` with detail string; `run-loop.ts` already handles this with in-process restart fallback + warning log