### PR TITLE
Fix TS2352 in pi embedded runner extra params test

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -872,7 +872,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
         compat: { supportsStore: false },
-      } as Model<"openai-responses">,
+      } as unknown as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });


### PR DESCRIPTION
## Summary
- fix TS2352 in `pi-embedded-runner-extraparams.test.ts` by using an explicit `unknown` bridge cast for the minimal mock model object

## Why
CI `check` was failing on this test-only type assertion after upstream model typing changes.

## Validation
- `corepack pnpm tsgo`
