### PR TITLE
fix(test): add missing Model properties to extraparams test cast

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -870,7 +870,13 @@ describe("applyExtraParamsToAgent", () => {
         api: "openai-responses",
         provider: "azure-openai-responses",
         id: "gpt-4o",
+        name: "GPT-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 16_384,
         compat: { supportsStore: false },
       } as Model<"openai-responses">,
     });


### PR DESCRIPTION
## Summary

- Fix tsgo TS2352 type error in `pi-embedded-runner-extraparams.test.ts:869` where `Model<"openai-responses">` cast was missing required properties (`name`, `reasoning`, `input`, `cost`, `contextWindow`, `maxTokens`) introduced in pi-ai 0.55.1
- Adds the missing properties with sensible defaults matching the test's Azure OpenAI gpt-4o model context

## Test plan

- [x] `pnpm tsgo` passes with zero errors (previously failed on this file)
- [x] All 39 tests in `pi-embedded-runner-extraparams.test.ts` pass
- [x] `oxfmt --check` passes