### PR TITLE
feat: TGCC supervisor integration

### DIFF
--- a/docs/SPEC-SUBAGENT-OBSERVABILITY.md
+++ b/docs/SPEC-SUBAGENT-OBSERVABILITY.md
@@ -1,0 +1,242 @@
+# Subagent Observability Spec
+
+**Problem:** When OpenClaw spawns a CC task (via TGCC or directly), the caller agent has zero visibility until the task completes or fails. No progress, no errors, no way to check status. But streaming all events into the caller's context would exhaust it — a single CC task can produce hundreds of events.
+
+**Goal:** Find the balance between visibility and context efficiency. Push only critical alerts; let the caller pull details on demand.
+
+## Design Principles
+
+1. **Context is precious** — every line injected into the caller's context costs tokens and attention
+2. **Pull > Push** — let the caller decide when and how much to see
+3. **Treat transcripts like files** — offset, limit, grep, just like reading code
+4. **CC can talk back** — give spawned CC an explicit way to message its parent
+
+---
+
+## 1. Push Notifications (automatic, into caller context)
+
+Only inject into the caller's context when something needs attention:
+
+| Event | When | Context cost |
+|-------|------|-------------|
+| ✅ Completion | Task finished (result text) | ~100-500 tokens |
+| ❌ Error | API error, crash, permission block | ~50-100 tokens |
+| ⚠️ Stuck | No progress for N minutes (configurable) | ~30 tokens |
+| 💰 Budget | Cost exceeded threshold | ~30 tokens |
+| 💬 CC message | CC used `notify_parent` MCP tool | Variable |
+
+**Format:** Short, actionable, one message per event:
+```
+[subagent:sentinella] ❌ API error: rate limited (retry 2/5)
+[subagent:sentinella] ⚠️ No progress for 5 minutes (last: editing bridge.ts)
+[subagent:sentinella] 💰 $0.50 spent (budget: $1.00)
+[subagent:sentinella] 💬 "Build fails — missing dep X. Install it?"
+```
+
+### TGCC Implementation
+
+TGCC tracks these conditions per-process and emits supervisor events:
+
+```jsonc
+// Error event (already exists, extend with detail)
+{"type":"event", "event":"api_error", "agentId":"sentinella", "message":"rate limited", "retry":"2/5"}
+
+// Stuck event (new)
+{"type":"event", "event":"stuck", "agentId":"sentinella", "silentMs":300000, "lastActivity":"editing bridge.ts"}
+
+// Budget event (new)  
+{"type":"event", "event":"budget_alert", "agentId":"sentinella", "costUsd":0.50, "budgetUsd":1.00}
+
+// CC notify_parent (new, via MCP tool → supervisor event)
+{"type":"event", "event":"cc_message", "agentId":"sentinella", "text":"Build fails — missing dep X. Install it?"}
+```
+
+### OpenClaw Implementation
+
+`TgccSupervisorClient` receives events → injects as system messages into the requester's session.
+
+---
+
+## 2. Pull: `subagents log` (on-demand transcript access)
+
+Treat the CC transcript as a seekable, filterable file.
+
+### Tool Interface (OpenClaw)
+
+```
+subagents log <target>                              # last 50 lines
+subagents log <target> --offset 100 --limit 20      # specific range  
+subagents log <target> --grep "error|fail"           # filter by pattern
+subagents log <target> --grep "tool_use" --limit 10  # last 10 tool calls
+subagents log <target> --since 5m                    # last 5 minutes
+subagents log <target> --summary                     # compressed summary (cheap model)
+```
+
+Parameters:
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target` | string | required | Subagent label or run ID |
+| `offset` | number | 0 | Line offset from start (0-indexed) |
+| `limit` | number | 50 | Max lines to return |
+| `grep` | string | none | Regex filter on line content |
+| `since` | string | none | Time filter (e.g. "5m", "1h") |
+| `summary` | boolean | false | Return compressed summary instead of raw lines |
+| `type` | string | none | Filter by event type: "text", "tool", "error", "thinking" |
+
+### TGCC Implementation: `get_log` command
+
+TGCC buffers CC output events in memory (ring buffer, configurable max size). Supervisor can query:
+
+```jsonc
+// Request
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "get_log",
+  "params": {
+    "agentId": "sentinella",
+    "offset": 0,          // optional
+    "limit": 50,           // optional
+    "grep": "error|fail",  // optional, regex
+    "since": 300000,       // optional, ms ago
+    "type": "tool"         // optional, event type filter
+  }
+}
+
+// Response
+{
+  "type": "response",
+  "requestId": "...",
+  "result": {
+    "totalLines": 247,
+    "returnedLines": 12,
+    "offset": 235,
+    "lines": [
+      {"ts": 1772211918087, "type": "tool", "text": "✅ Bash (2.1s)\ncd /home/fonz/Botverse/sentinella && git log --oneline -3"},
+      {"ts": 1772211918282, "type": "text", "text": "Here are the last 3 commits:"},
+      ...
+    ]
+  }
+}
+```
+
+### Log Line Types
+
+| Type | Source | Content |
+|------|--------|---------|
+| `text` | CC assistant text output | The response text |
+| `thinking` | CC thinking blocks | Thinking content (truncated) |
+| `tool` | Tool use + result | Tool name, duration, summary |
+| `error` | API errors, crashes | Error message |
+| `system` | Init, compact, takeover | System event description |
+| `user` | User/supervisor messages sent | The input text + source |
+
+---
+
+## 3. Pull: `subagents status` (enhanced)
+
+Already partially exists. Enhance with more detail:
+
+```jsonc
+// subagents status sentinella
+{
+  "agentId": "sentinella",
+  "state": "active",
+  "runtime": "12m",
+  "sessionId": "abc-123",
+  "costUsd": 0.34,
+  "tokensIn": 45000,
+  "tokensOut": 12000,
+  "toolsUsed": 8,
+  "lastActivity": "editing src/bridge.ts",
+  "lastActivityAge": "30s ago"
+}
+```
+
+### TGCC Implementation
+
+Extend `status` response with per-process stats. TGCC already tracks cost via `result` events — accumulate per-process.
+
+---
+
+## 4. CC → Parent: `notify_parent` MCP Tool
+
+Give CC an explicit way to message the parent agent. This is an MCP tool provided by TGCC's MCP bridge:
+
+```typescript
+// MCP tool definition
+{
+  name: "notify_parent",
+  description: "Send a message to the orchestrator/parent that spawned this task. Use for: asking questions, reporting blockers, progress updates on long tasks, or when you need a decision.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      message: { type: "string", description: "Message to send to the parent" },
+      priority: { type: "string", enum: ["info", "question", "blocker"], default: "info" }
+    },
+    required: ["message"]
+  }
+}
+```
+
+### Flow
+
+```
+CC uses notify_parent("Build fails, should I install dep X?", priority="question")
+  → MCP bridge receives tool call
+  → TGCC emits supervisor event: {event: "cc_message", agentId, text, priority}
+  → OpenClaw receives event → injects into caller's context
+  → Caller responds via subagents steer
+  → TGCC forwards to CC stdin
+  → CC continues
+```
+
+### When CC Should Use This
+- **question** — needs a decision from the parent ("fix A or B?")
+- **blocker** — can't proceed without help ("missing credentials")
+- **info** — progress update on long tasks ("Phase 1 done, starting Phase 2")
+
+### When CC Should NOT Use This
+- Routine progress — handled by pull-based `subagents log`
+- Completion — handled by `result` event
+- Errors — handled by error push notifications
+
+---
+
+## 5. Implementation Phases
+
+### Phase A: Pull basics
+- TGCC: ring buffer for CC events, `get_log` command with offset/limit/grep
+- OpenClaw: `subagents log` tool with params, `subagents status` enhancement
+
+### Phase B: Push alerts
+- TGCC: stuck detection, budget tracking, emit alert events
+- OpenClaw: event handlers for alerts, inject as system messages
+
+### Phase C: CC → Parent
+- TGCC: `notify_parent` MCP tool, forward as supervisor event
+- OpenClaw: `cc_message` event handler, inject into caller context
+
+---
+
+## 6. Inventory
+
+### TGCC
+| What | Phase |
+|------|-------|
+| Event ring buffer (per-process, configurable max) | A |
+| `get_log` supervisor command | A |
+| Enhanced `status` with per-process stats | A |
+| Stuck detection (configurable silence threshold) | B |
+| Budget tracking per-process | B |
+| `stuck` and `budget_alert` supervisor events | B |
+| `notify_parent` MCP tool | C |
+| `cc_message` supervisor event | C |
+
+### OpenClaw
+| What | Phase |
+|------|-------|
+| `subagents log` tool (offset/limit/grep/since/type) | A |
+| Enhanced `subagents status` display | A |
+| Error/stuck/budget event handlers → system message injection | B |
+| `cc_message` event handler → system message injection | C |

--- a/docs/SPEC-SUPERVISOR-PROTOCOL.md
+++ b/docs/SPEC-SUPERVISOR-PROTOCOL.md
@@ -1,0 +1,1050 @@
+# TGCC ↔ OpenClaw Supervisor Protocol
+
+> Full specification for bidirectional communication between TGCC (Telegram ↔ Claude Code bridge) and OpenClaw (agent orchestrator).
+
+### Color Legend (all diagrams)
+
+| Color | Meaning |
+|-------|---------|
+| 🔵 Blue | Existing OpenClaw component |
+| 🟢 Green | **New** OpenClaw component |
+| 🟠 Orange | Existing TGCC component |
+| 🔴 Red | **New** TGCC component |
+
+## 1. Overview
+
+TGCC is the **single CC process manager**. It owns all Claude Code processes — whether triggered by Telegram users, CLI clients, or OpenClaw. OpenClaw never spawns CC directly; it always goes through TGCC.
+
+OpenClaw participates in two ways:
+
+1. **Subscriber to existing agents** — steer sentinella, kyo, saemem while Fnz also uses them via Telegram. Everyone sees everything.
+2. **Spawner of ephemeral agents** — create a temporary agent for a one-off CC task in any repo, with no Telegram bot. OpenClaw manages its lifecycle.
+
+The protocol runs over a persistent Unix socket connection using NDJSON (newline-delimited JSON).
+
+```mermaid
+graph TB
+    classDef ocExist fill:#4A90D9,stroke:#2C6FAC,color:#fff
+    classDef ocNew fill:#27AE60,stroke:#1E8449,color:#fff
+    classDef tgExist fill:#E67E22,stroke:#BA6418,color:#fff
+    classDef tgNew fill:#E74C3C,stroke:#C0392B,color:#fff
+    classDef external fill:#95A5A6,stroke:#7F8C8D,color:#fff
+
+    subgraph OpenClaw["OpenClaw Gateway"]
+        OC_Agent["BossBot (main agent)"]:::ocExist
+        OC_Tools["sessions_send / subagents / sessions_spawn"]:::ocExist
+        OC_Client["TgccSupervisorClient 🟢"]:::ocNew
+        OC_Exec["Host Executor 🟢"]:::ocNew
+    end
+
+    subgraph TGCC["TGCC Bridge Process"]
+        CTL["Ctl Server<br/>/tmp/tgcc/ctl/tgcc.sock"]:::tgExist
+        Bridge["Bridge + ProcessRegistry"]:::tgExist
+        subgraph Persistent["Persistent Agents (TG bots)"]
+            KYO["kyobot<br/>@fonzkyobot"]:::tgExist
+            SENT["sentinella<br/>@fonzsentinellabot"]:::tgExist
+            SAE["saemem<br/>@saemembot"]:::tgExist
+        end
+        subgraph Ephemeral["Ephemeral Agents (no TG) 🔴"]
+            E1["oc-spawn-a7f<br/>repo: KYO"]:::tgNew
+            E2["oc-spawn-b3c<br/>repo: tgcc"]:::tgNew
+        end
+        subgraph CC["CC Processes (1 per session)"]
+            CC_S["CC sess-001<br/>sentinella repo"]:::tgExist
+            CC_K["CC sess-002<br/>KYO repo"]:::tgExist
+            CC_E["CC sess-003<br/>KYO repo"]:::tgExist
+        end
+    end
+
+    Fnz["Fnz (Telegram)"]:::external
+
+    OC_Agent --> OC_Tools
+    OC_Tools --> OC_Client
+    OC_Client <-->|"Unix Socket<br/>NDJSON"| CTL
+    CTL <--> Bridge
+    Bridge --> Persistent
+    Bridge --> Ephemeral
+    Persistent --> CC
+    Ephemeral --> CC
+    Fnz <-->|"Telegram"| Persistent
+```
+
+## 2. Key Concepts
+
+### 2.1 CC Process = 1 Session
+
+A Claude Code process is bound to one session at spawn time (`--resume <id>` or `--continue`). You cannot switch sessions within a running process. To work on a different session, you need a different process.
+
+### 2.2 Agent State Model
+
+Each agent has exactly **one state**: a repo and (optionally) a running CC process. Agents don't know about users — `allowedUsers` is a system-level ACL that gates who can talk to the TG bot, not an agent concept.
+
+```
+Agent "sentinella":
+  repo: /home/fonz/Botverse/sentinella   # agent-level, required
+  model: claude-sonnet-4-20250514              # agent-level default
+  ccProcess: <CCProcess | null>
+    └─ sessionId: abc-123                 # lives on the process
+    └─ spawned with: --continue or --resume <id>
+```
+
+Multiple message sources can interact with the same agent:
+
+```mermaid
+graph LR
+    classDef tgExist fill:#E67E22,stroke:#BA6418,color:#fff
+    classDef tgNew fill:#E74C3C,stroke:#C0392B,color:#fff
+    classDef ocNew fill:#27AE60,stroke:#1E8449,color:#fff
+
+    subgraph "Agent: sentinella"
+        CC["CC Process<br/>stdin / stdout"]:::tgExist
+        TG["Telegram<br/>(Fnz via bot)"]:::tgExist
+        SUP["Supervisor<br/>(OpenClaw) 🟢"]:::ocNew
+        CTL["CLI attach"]:::tgExist
+    end
+
+    TG -->|"stdin"| CC
+    SUP -->|"stdin"| CC
+    CTL -->|"stdin"| CC
+    CC -->|"result, stream, events"| TG
+    CC -->|"result, stream, events"| SUP
+    CC -->|"result, stream, events"| CTL
+```
+
+All sources share the same process. When the supervisor sends a message, TG sees a system notification (`🦞 OpenClaw: ...`). When TG sends a message and the supervisor is subscribed, it receives the message event. **No CC spawn without a repo** — hard requirement.
+
+### 2.3 Two Agent Types
+
+| | Persistent Agent | Ephemeral Agent |
+|---|---|---|
+| **Created by** | Config file (`~/.tgcc/config.json`) | Supervisor `create_agent` command |
+| **Telegram bot** | Yes | No |
+| **Lifetime** | Until TGCC restarts or config changes | Until task completes, killed, or timeout |
+| **Message sources** | Telegram + supervisor + CLI | Supervisor only |
+| **Example** | sentinella, kyobot, saemem | oc-spawn-a7f |
+| **In config** | Always | Never persisted |
+
+### 2.4 OpenClaw Tool Mapping
+
+How OpenClaw's existing tools route through TGCC:
+
+```mermaid
+graph TD
+    classDef ocExist fill:#4A90D9,stroke:#2C6FAC,color:#fff
+    classDef ocNew fill:#27AE60,stroke:#1E8449,color:#fff
+    classDef tgExist fill:#E67E22,stroke:#BA6418,color:#fff
+    classDef tgNew fill:#E74C3C,stroke:#C0392B,color:#fff
+
+    subgraph "OpenClaw Tools"
+        SS["sessions_spawn<br/>mode=claude-code"]:::ocExist
+        SEND["sessions_send<br/>target=sentinella"]:::ocExist
+        SUB_L["subagents list"]:::ocExist
+        SUB_S["subagents steer"]:::ocExist
+        SUB_K["subagents kill"]:::ocExist
+        SH["sessions_history"]:::ocExist
+        SST["session_status"]:::ocExist
+    end
+
+    subgraph "New Routing Layer 🟢"
+        ROUTE["TGCC Agent Resolver"]:::ocNew
+    end
+
+    subgraph "Supervisor Commands"
+        CA["create_agent 🔴"]:::tgNew
+        SM["send_message 🔴"]:::tgNew
+        SC["send_to_cc 🔴"]:::tgNew
+        ST["status 🟠"]:::tgExist
+        KC["kill_cc 🟠"]:::tgExist
+        GH["get_session_history 🔴"]:::tgNew
+        SUB_CMD["subscribe 🔴"]:::tgNew
+    end
+
+    SS --> ROUTE
+    SEND --> ROUTE
+    SUB_L --> ROUTE
+    SUB_S --> ROUTE
+    SUB_K --> ROUTE
+    SH --> ROUTE
+    SST --> ROUTE
+
+    ROUTE -->|"New repo task"| CA
+    ROUTE -->|"Existing agent"| SM
+    ROUTE -->|"Active CC steer"| SC
+    ROUTE -->|"List"| ST
+    ROUTE -->|"Kill"| KC
+    ROUTE -->|"History"| GH
+
+    SM -.->|"Auto-subscribes<br/>supervisor"| SUB_CMD
+```
+
+## 3. Connection Lifecycle
+
+```mermaid
+sequenceDiagram
+    box rgb(39, 174, 96) OpenClaw (new)
+        participant OC as TgccSupervisorClient 🟢
+    end
+    box rgb(226, 125, 34) TGCC (existing)
+        participant TGCC as Ctl Server 🟠
+    end
+
+    Note over OC: Gateway starts
+    OC->>TGCC: connect(/tmp/tgcc/ctl/tgcc.sock)
+    OC->>TGCC: register_supervisor {agentId:"openclaw", capabilities:["exec","notify"]}
+    TGCC-->>OC: {type:"registered", agentId:"openclaw"}
+
+    Note over OC,TGCC: Persistent bidirectional connection
+
+    loop Heartbeat (30s)
+        OC->>TGCC: command: ping 🔴
+        TGCC-->>OC: response: pong 🔴
+    end
+
+    Note over TGCC: Socket drops (TGCC restart, crash)
+    OC->>OC: Detect via heartbeat timeout or socket error
+    OC->>OC: Exponential backoff (1s → 2s → 4s → ... → 30s max)
+    OC->>TGCC: Reconnect + register_supervisor again
+    OC->>TGCC: command: status 🟠 (re-sync state)
+    OC->>OC: Reconcile subagent registry with TGCC state
+```
+
+### Connection Rules
+
+- **One supervisor per TGCC instance.** New registrations replace existing.
+- **Connect to `tgcc.sock`** (the main bridge socket), not per-agent sockets. The bridge handles all agents.
+- **On reconnect**: query `status` to rebuild knowledge of running agents/sessions.
+- **Socket not found**: TGCC isn't running. Log, retry with backoff. Don't crash.
+
+## 4. Protocol Wire Format
+
+Both sides exchange NDJSON lines. Three message types:
+
+```typescript
+// ── Request something from the other side ──
+interface Command {
+  type: 'command';
+  requestId: string;        // UUID, sender generates
+  action: string;
+  params?: Record<string, unknown>;
+}
+
+// ── Reply to a command ──
+interface Response {
+  type: 'response';
+  requestId: string;        // matches the command's requestId
+  result?: unknown;
+  error?: string;           // mutually exclusive with result
+}
+
+// ── Fire-and-forget notification (no response expected) ──
+interface Event {
+  type: 'event';
+  event: string;
+  [key: string]: unknown;
+}
+```
+
+## 5. Commands: OpenClaw → TGCC
+
+### 5.1 `create_agent` ✨ NEW
+
+Create an ephemeral agent for a one-off CC task. No Telegram bot.
+
+```mermaid
+sequenceDiagram
+    box rgb(39, 174, 96) OpenClaw (new)
+        participant OC as TgccSupervisorClient 🟢
+    end
+    box rgb(231, 76, 60) TGCC (new)
+        participant TGCC as Ephemeral Agent Handler 🔴
+    end
+
+    OC->>TGCC: command: create_agent 🔴
+    Note right of TGCC: Create in-memory agent<br/>No TG bot, no config write
+    TGCC-->>OC: response: {agentId, state:"idle"}
+    OC->>TGCC: command: send_message 🔴 {agentId, text}
+    Note right of TGCC: Spawn CC process
+    TGCC-->>OC: response: {sessionId, state:"active"}
+    Note over TGCC: CC works...
+    TGCC->>OC: event: result 🔴 {agentId, text, cost}
+    OC->>TGCC: command: destroy_agent 🔴 {agentId}
+    TGCC-->>OC: response: {destroyed: true}
+```
+
+```jsonc
+// Request
+{
+  "type": "command",
+  "requestId": "abc-123",
+  "action": "create_agent",
+  "params": {
+    "agentId": "oc-spawn-a7f3",     // optional: OC picks ID, or TGCC generates
+    "repo": "/home/fonz/Botverse/KYO",     // required — no CC spawn without a repo
+    "model": "opus",                        // optional
+    "permissionMode": "bypassPermissions",
+    "timeoutMs": 300000                     // optional: auto-kill after 5 min
+  }
+}
+
+// Response
+{
+  "type": "response",
+  "requestId": "abc-123",
+  "result": {
+    "agentId": "oc-spawn-a7f3",
+    "state": "idle"
+  }
+}
+```
+
+**Implementation:** TGCC creates an `AgentInstance` in memory (no TG bot, no config write). Ephemeral agents have no TG bot — only the supervisor can send messages.
+
+### 5.2 `destroy_agent` ✨ NEW
+
+Tear down an ephemeral agent (kills CC process if running, cleans up).
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "destroy_agent",
+  "params": { "agentId": "oc-spawn-a7f3" }
+}
+```
+
+Only works on ephemeral agents. Persistent agents (with TG bots) cannot be destroyed via supervisor.
+
+### 5.3 `send_message` ✨ NEW
+
+Send a message to any agent (persistent or ephemeral). If no CC process is active, spawns one using the agent's repo (`--continue` by default, or `--resume <id>` if specified). The message goes to the agent's single shared process — all subscribers (TG, supervisor, CLI) see the output.
+
+For persistent agents with a TG bot, a system message (`🦞 OpenClaw: <text>`) is sent to the TG chat so the user knows the supervisor injected something.
+
+```jsonc
+// Request
+{
+  "type": "command",
+  "requestId": "def-456",
+  "action": "send_message",
+  "params": {
+    "agentId": "sentinella",         // any agent ID
+    "text": "Check tile coverage",
+    "sessionId": "sess-001",         // optional: --resume this session instead of --continue
+    "subscribe": true                // optional, default true: get result events back
+  }
+}
+
+// Response (immediate — doesn't wait for CC to finish)
+{
+  "type": "response",
+  "requestId": "def-456",
+  "result": {
+    "sessionId": "sess-001",        // from the process (may differ if --continue picked a different one)
+    "state": "active",
+    "subscribed": true
+  }
+}
+```
+
+**What `subscribe: true` does:** Registers the supervisor as a subscriber on this agent's process. All `result`, `stream_event`, `assistant`, `compact`, `api_error`, `process_exit` events get forwarded to the supervisor.
+
+**Implementation:** Use the agent's single `ccProcess` — if active, write to stdin; if idle/null, spawn via agent's repo. No userId involved.
+
+### 5.4 `send_to_cc` ✨ NEW
+
+Send a follow-up to an already-running CC process (steer). Does NOT spawn a new process.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "ghi-789",
+  "action": "send_to_cc",
+  "params": {
+    "agentId": "sentinella",
+    "text": "Actually, focus only on the Ibiza tiles"
+  }
+}
+
+// Response
+{
+  "type": "response",
+  "requestId": "ghi-789",
+  "result": { "sent": true }
+}
+
+// Error: no active process
+{
+  "type": "response",
+  "requestId": "ghi-789",
+  "error": "No active CC process for agent sentinella"
+}
+```
+
+### 5.5 `subscribe` ✨ NEW
+
+Subscribe to an agent's events without sending a message. Subscribes to whatever process the agent currently has (or will have next).
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "subscribe",
+  "params": {
+    "agentId": "sentinella"
+  }
+}
+```
+
+Use case: Fnz starts a sentinella task via Telegram. OpenClaw wants to observe (for later summarization, cross-agent coordination, etc.) without sending any message.
+
+### 5.6 `unsubscribe` ✨ NEW
+
+Stop receiving events for an agent's CC process.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "unsubscribe",
+  "params": { "agentId": "sentinella" }
+}
+```
+
+### 5.7 `status` ✅ EXISTS
+
+Query agent and session status.
+
+```jsonc
+// Request
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "status",
+  "params": { "agentId": "sentinella" }  // optional: all if omitted
+}
+
+// Response
+{
+  "type": "response",
+  "requestId": "...",
+  "result": {
+    "agents": [
+      {
+        "id": "kyobot",
+        "type": "persistent",            // persistent | ephemeral
+        "state": "idle",                 // idle (no process) | active (process running)
+        "repo": "/home/fonz/Botverse/KYO",
+        "process": null,                 // no active CC process
+        "supervisorSubscribed": false
+      },
+      {
+        "id": "sentinella",
+        "type": "persistent",
+        "state": "active",
+        "repo": "/home/fonz/Botverse/sentinella",
+        "process": {                     // active CC process
+          "sessionId": "sess-001",
+          "model": "claude-sonnet-4-20250514"
+        },
+        "supervisorSubscribed": true
+      },
+      {
+        "id": "oc-spawn-a7f3",
+        "type": "ephemeral",
+        "state": "active",
+        "repo": "/home/fonz/Botverse/KYO",
+        "process": {
+          "sessionId": "sess-003",
+          "model": "opus"
+        },
+        "supervisorSubscribed": true
+      }
+    ]
+  }
+}
+```
+
+### 5.8 `kill_cc` ✅ EXISTS
+
+Kill a running CC process.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "kill_cc",
+  "params": { "agentId": "sentinella" }
+}
+```
+
+### 5.9 `get_session_history` ✨ NEW
+
+Read a CC session's JSONL transcript.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "get_session_history",
+  "params": {
+    "agentId": "sentinella",
+    "sessionId": "sess-001",   // optional: current if omitted
+    "limit": 20                // optional: last N messages
+  }
+}
+```
+
+### 5.10 `ping` ✨ NEW (trivial)
+
+Heartbeat probe.
+
+```jsonc
+{"type": "command", "requestId": "...", "action": "ping"}
+// → {"type": "response", "requestId": "...", "result": {"pong": true, "uptime": 3600}}
+```
+
+## 6. Commands: TGCC → OpenClaw
+
+Things CC bots need from the host that they can't do themselves.
+
+```mermaid
+sequenceDiagram
+    box rgb(226, 125, 34) TGCC (existing)
+        participant CC as CC Process (saemem) 🟠
+    end
+    box rgb(231, 76, 60) TGCC (new)
+        participant TGCC as MCP Supervisor Tools 🔴
+    end
+    box rgb(39, 174, 96) OpenClaw (new)
+        participant OC as Exec Handler + Safety Gate 🟢
+    end
+
+    Note over CC: "I edited TGCC source,<br/>need it rebuilt and restarted"
+
+    CC->>TGCC: MCP tool: supervisor_exec 🔴
+    TGCC->>OC: command: exec {command: "cd ~/Botverse/tgcc && npm run build"}
+    OC->>OC: Safety check 🟢 → allowPattern matches
+    OC->>OC: Execute command
+    OC-->>TGCC: response: {exitCode: 0, stdout: "..."}
+    TGCC-->>CC: Tool result returned
+
+    TGCC->>OC: command: restart_service 🔴
+    OC->>OC: Kill old TGCC, start new one
+    Note over OC: TGCC restarts, supervisor reconnects
+```
+
+### 6.1 `exec` ✨ NEW
+
+Run a command on the host machine.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "exec",
+  "params": {
+    "command": "cd ~/Botverse/tgcc && npm run build",
+    "cwd": "/home/fonz",
+    "timeoutMs": 60000,
+    "agentId": "saemem"       // who's asking (for audit)
+  }
+}
+
+// Response
+{
+  "type": "response",
+  "requestId": "...",
+  "result": {
+    "exitCode": 0,
+    "stdout": "Build complete.",
+    "stderr": ""
+  }
+}
+```
+
+### 6.2 `restart_service` ✨ NEW
+
+Restart a known service.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "restart_service",
+  "params": {
+    "service": "tgcc",
+    "agentId": "saemem"
+  }
+}
+```
+
+OpenClaw maps service names to restart procedures in config.
+
+### 6.3 `notify` ✨ NEW
+
+Send a message to an OpenClaw agent or Telegram user.
+
+```jsonc
+{
+  "type": "command",
+  "requestId": "...",
+  "action": "notify",
+  "params": {
+    "target": "main",           // OpenClaw agent ID
+    "message": "Sentinella deploy complete.",
+    "urgency": "medium"
+  }
+}
+```
+
+### 6.4 How CC triggers supervisor commands
+
+CC processes don't know about the supervisor protocol. They need a bridge. Two options:
+
+**Option A — MCP Tool (recommended):**
+TGCC's MCP bridge already provides tools to CC. Add a `supervisor_exec` and `supervisor_notify` tool that CC can call. The bridge translates these to supervisor commands and returns the response.
+
+```mermaid
+sequenceDiagram
+    box rgb(226, 125, 34) TGCC (existing)
+        participant CC as CC Process
+        participant MCP as MCP Bridge 🟠
+    end
+    box rgb(231, 76, 60) TGCC (new)
+        participant Bridge as Supervisor Forwarder 🔴
+    end
+    box rgb(39, 174, 96) OpenClaw (new)
+        participant OC as Exec Handler 🟢
+    end
+
+    CC->>MCP: tool_call: supervisor_exec {command: "npm run build"}
+    MCP->>Bridge: route to supervisor
+    Bridge->>OC: command: exec {command: "npm run build"}
+    OC-->>Bridge: response: {exitCode: 0, stdout: "..."}
+    Bridge-->>MCP: tool result
+    MCP-->>CC: tool_result: {exitCode: 0, stdout: "..."}
+```
+
+**Option B — Message convention:**
+CC writes a specially-formatted message like `@supervisor exec: npm run build`. TGCC parses it and routes. Fragile, not recommended.
+
+## 7. Events: TGCC → OpenClaw
+
+Pushed to the supervisor when it's subscribed to a process. No response expected.
+
+### Event Catalog
+
+| Event | Status | Payload | When |
+|-------|--------|---------|------|
+| `result` | ✨ NEW | `{agentId, sessionId, text, cost_usd, duration_ms, is_error}` | CC finished and returned a result |
+| `assistant_message` | ✨ NEW | `{agentId, sessionId, text}` | CC sent a non-result assistant message |
+| `compact` | ✅ EXISTS | `{agentId, sessionId, trigger, preTokens}` | Context was compacted |
+| `api_error` | ✅ EXISTS | `{agentId, sessionId, message}` | CC hit an API error |
+| `process_exit` | ✅ EXISTS | `{agentId, sessionId, exitCode}` | CC process exited (normal or error) |
+| `session_takeover` | ✨ NEW | `{agentId, sessionId, exitCode}` | Another client (e.g. VS Code) stole the session — CC was killed externally. Fires *instead of* `process_exit` so OpenClaw can distinguish takeover from normal exit. |
+| `task_started` | ✨ NEW | `{agentId, sessionId, toolName}` | CC began a tool use |
+| `task_completed` | ✨ NEW | `{agentId, sessionId, toolName, duration_ms}` | CC finished a tool use |
+| `agent_created` | ✨ NEW | `{agentId, type, repo}` | Ephemeral agent was created |
+| `agent_destroyed` | ✨ NEW | `{agentId}` | Ephemeral agent was torn down |
+| `bridge_started` | ✨ NEW | `{agents: string[], uptime: 0}` | TGCC bridge (re)started — supervisor should re-sync state |
+| `cc_spawned` | ✨ NEW | `{agentId, sessionId, source}` | CC process spawned (source: "telegram", "supervisor", "cli") |
+| `cc_message` | ✨ NEW | `{agentId, text, priority}` | CC used `notify_parent` MCP tool to message parent |
+| `state_changed` | ✨ NEW | `{agentId, field, oldValue, newValue, source}` | Agent repo/session/model changed (from TG command or supervisor) |
+| `build_result` | ✨ NEW | `{agentId, command, passed, errors, summary}` | Build/test command completed (from HighSignalDetector) |
+| `git_commit` | ✨ NEW | `{agentId, message}` | CC committed code (from HighSignalDetector) |
+| `context_pressure` | ✨ NEW | `{agentId, percent, tokens}` | Context window at 50%/75%/90% threshold |
+| `subagent_spawn` | ✨ NEW | `{agentId, count}` | CC spawned sub-agents via Task tool |
+| `failure_loop` | ✨ NEW | `{agentId, consecutiveFailures, lastTool, lastError}` | 3+ consecutive tool failures |
+| `stuck` | ✨ NEW | `{agentId, silentMs, lastActivity}` | No CC output for 5+ minutes |
+| `budget_alert` | ✨ NEW | `{agentId, costUsd, budgetUsd}` | Cost exceeded configured threshold |
+| `task_milestone` | ✨ NEW | `{agentId, task, status, progress}` | CC created/completed a todo item |
+
+### Subscription Model
+
+```mermaid
+graph TD
+    classDef tgExist fill:#E67E22,stroke:#BA6418,color:#fff
+    classDef tgNew fill:#E74C3C,stroke:#C0392B,color:#fff
+    classDef ocNew fill:#27AE60,stroke:#1E8449,color:#fff
+
+    subgraph "Event Routing"
+        CC["CC Process"]:::tgExist
+        CC -->|"All events"| TG["Telegram Subscriber<br/>(Fnz via bot)"]:::tgExist
+        CC -->|"All events"| CTL["Ctl Subscriber<br/>(CLI attach)"]:::tgExist
+        CC -->|"All events<br/>if subscribed"| SUP["Supervisor Forwarder 🔴"]:::tgNew
+    end
+
+    subgraph "OpenClaw Receives 🟢"
+        SUP --> R["result 🔴"]:::tgNew
+        SUP --> AM["assistant_message 🔴"]:::tgNew
+        SUP --> CO["compact 🟠"]:::tgExist
+        SUP --> AE["api_error 🟠"]:::tgExist
+        SUP --> PE["process_exit 🟠"]:::tgExist
+    end
+
+    R --> OCH["Result Event Handler 🟢"]:::ocNew
+    AM --> OCH
+    CO --> OCH
+    AE --> OCH
+    PE --> OCH
+```
+
+Events are only forwarded to the supervisor for processes it's subscribed to (via `send_message(subscribe:true)` or explicit `subscribe` command). Global lifecycle events (`agent_created`, `agent_destroyed`) are always sent.
+
+## 8. End-to-End Flows
+
+### Flow 1: OpenClaw steers existing sentinella session
+
+Fnz started a task via Telegram. BossBot wants to add context.
+
+```mermaid
+sequenceDiagram
+    box rgb(149, 165, 166) External
+        participant Fnz as Fnz (Telegram)
+    end
+    box rgb(226, 125, 34) TGCC (existing)
+        participant SENT as sentinella bot 🟠
+        participant TGCC as Bridge 🟠
+        participant CC as CC Process 🟠
+    end
+    box rgb(74, 144, 217) OpenClaw (existing)
+        participant OC as BossBot 🔵
+    end
+
+    Fnz->>SENT: "Check tile coverage for Ibiza"
+    SENT->>TGCC: Message from TG
+    TGCC->>CC: Spawn CC, send message
+    Note over CC: Working...
+
+    Fnz->>OC: "Also tell sentinella to compare with last month"
+    OC->>TGCC: command: send_to_cc 🔴 {agentId:"sentinella"}
+    TGCC->>CC: Write to stdin
+    TGCC-->>OC: response: {sent: true}
+
+    Note over CC: Incorporates new instruction...
+
+    CC-->>TGCC: Result
+    TGCC->>SENT: Send to Telegram (Fnz sees in sentinella chat)
+    TGCC->>OC: event: result 🔴 {text:"Coverage: 98.2%..."}
+    OC-->>Fnz: "Sentinella reports: Coverage 98.2%, up from 95.1%..."
+```
+
+### Flow 2: OpenClaw spawns ephemeral agent
+
+BossBot needs a CC task in the KYO repo but doesn't want to disturb Fnz's kyobot session.
+
+```mermaid
+sequenceDiagram
+    box rgb(39, 174, 96) OpenClaw (new routing)
+        participant OC as BossBot + TgccClient 🟢
+    end
+    box rgb(231, 76, 60) TGCC (new)
+        participant TGCC as Ephemeral Agent Handler 🔴
+    end
+    box rgb(226, 125, 34) TGCC (existing)
+        participant CC as CC Process 🟠
+    end
+
+    OC->>TGCC: command: create_agent 🔴 {repo: KYO}
+    TGCC-->>OC: response: {agentId:"oc-kyo-fix", state:"idle"}
+
+    OC->>TGCC: command: send_message 🔴 {agentId:"oc-kyo-fix", text:"Fix the seed endpoint timeout"}
+    TGCC->>CC: Spawn CC in KYO repo
+    TGCC-->>OC: response: {sessionId:"new-sess", state:"active"}
+
+    Note over CC: Works on the fix...
+
+    TGCC->>OC: event: result 🔴 {text:"Fixed timeout in seed endpoint..."}
+
+    OC->>TGCC: command: destroy_agent 🔴 {agentId:"oc-kyo-fix"}
+    TGCC-->>OC: response: {destroyed: true}
+```
+
+### Flow 3: CC requests host action (self-update)
+
+saemem bot modifies TGCC source and needs it rebuilt.
+
+```mermaid
+sequenceDiagram
+    box rgb(149, 165, 166) External
+        participant Fnz as Fnz (Telegram)
+    end
+    box rgb(226, 125, 34) TGCC (existing)
+        participant TGCC as Bridge 🟠
+        participant CC as CC (saemem) 🟠
+    end
+    box rgb(39, 174, 96) OpenClaw (new)
+        participant OC as Exec Handler + Safety Gate 🟢
+    end
+
+    Fnz->>TGCC: "Add a /health command to TGCC"
+    TGCC->>CC: Send to CC
+
+    Note over CC: Edits ~/Botverse/tgcc/src/bridge.ts
+
+    CC->>TGCC: MCP: supervisor_exec 🔴
+    TGCC->>OC: command: exec {command:"npm run build", agentId:"saemem"}
+    OC->>OC: Safety gate 🟢 → allowed
+    OC->>OC: Run command
+    OC-->>TGCC: response: {exitCode:0, stdout:"Built successfully"}
+    TGCC-->>CC: Tool result: success
+
+    CC->>TGCC: MCP: supervisor_restart 🔴
+    TGCC->>OC: command: restart_service {service:"tgcc"}
+    OC->>OC: Restart TGCC via tmux 🟢
+
+    Note over TGCC: Process dies
+
+    Note over OC: Detects socket drop
+    OC->>OC: Reconnect with backoff 🟢
+    OC->>TGCC: register_supervisor
+    TGCC-->>OC: registered
+
+    OC-->>Fnz: "saemem rebuilt TGCC and it's been restarted."
+```
+
+### Flow 4: Cross-bot coordination via OpenClaw
+
+```mermaid
+sequenceDiagram
+    box rgb(39, 174, 96) OpenClaw (new routing)
+        participant OC as BossBot + TgccClient 🟢
+    end
+    box rgb(226, 125, 34) TGCC (existing)
+        participant TGCC as Bridge 🟠
+        participant K as CC (kyobot) 🟠
+        participant S as CC (sentinella) 🟠
+    end
+
+    OC->>TGCC: send_message 🔴 {agentId:"kyobot", text:"Export coords as GeoJSON"}
+    TGCC->>K: Spawn/resume CC
+    K-->>TGCC: Result
+    TGCC->>OC: event: result 🔴 {text:"Exported 5 properties"}
+
+    OC->>TGCC: send_message 🔴 {agentId:"sentinella", text:"Import from /tmp/kyo-props.geojson"}
+    TGCC->>S: Spawn/resume CC
+    S-->>TGCC: Result
+    TGCC->>OC: event: result 🔴 {text:"Imported 5 zones"}
+
+    OC->>OC: Synthesize for user
+```
+
+## 9. OpenClaw Integration
+
+### 9.1 Configuration
+
+```yaml
+# openclaw.json
+agents:
+  defaults:
+    subagents:
+      claudeCode:
+        tgccSupervisor:
+          socket: /tmp/tgcc/ctl/tgcc.sock
+          # Agents discovered from TGCC status (60s TTL cache), no static config
+```
+
+### 9.2 Tool Routing Changes
+
+**`sessions_spawn(mode="claude-code")`** — currently:
+```
+OpenClaw → import CCProcess from @fonz/tgcc → spawn CC directly
+```
+Becomes:
+```
+OpenClaw → supervisor: create_agent + send_message → TGCC spawns CC
+```
+
+**`sessions_send(target="sentinella")`** — currently:
+```
+Not supported (no routing to external agents)
+```
+Becomes:
+```
+OpenClaw → resolve as TGCC agent → supervisor: send_message or send_to_cc
+```
+
+**`subagents list`** — currently:
+```
+Only shows OpenClaw-spawned subagents
+```
+Becomes:
+```
+Merges local registry + supervisor:status → shows all CC processes
+```
+
+### 9.3 Subagent Registry Integration
+
+When OpenClaw sends a message to a TGCC agent, it registers a subagent run:
+
+```typescript
+// Actual implementation — keyed by agentId only (no sessionId)
+registerSubagentRun({
+  childSessionKey: "tgcc:sentinella",    // simplified: tgcc:{agentId}
+  requesterSessionKey: currentSession,
+  task: "Check tile coverage",
+  transport: "tgcc-supervisor",
+  tgccAgentId: "sentinella",
+});
+```
+
+> **Design decision:** Subagent runs are keyed as `tgcc:{agentId}` not `tgcc:{agentId}:{sessionId}`. One active run per agent. Simpler correlation — session IDs aren't needed since TGCC manages session selection internally.
+
+When a `result` or `process_exit` event arrives from TGCC:
+```typescript
+// Lookup by tgcc:{agentId}, mark complete, trigger announce
+markExternalSubagentRunComplete("tgcc:sentinella", {
+  text: resultText,
+  cost: costUsd,
+});
+// Triggers runSubagentAnnounceFlow() → delivers result to requester session
+```
+
+This way `subagents list`, `steer`, `kill` all work the same as for direct CC spawns.
+
+## 10. Security Model
+
+```mermaid
+graph TD
+    classDef tgNew fill:#E74C3C,stroke:#C0392B,color:#fff
+    classDef ocNew fill:#27AE60,stroke:#1E8449,color:#fff
+    classDef neutral fill:#95A5A6,stroke:#7F8C8D,color:#fff
+
+    subgraph "TGCC → OpenClaw (Reverse Commands)"
+        EXEC["exec 🔴"]:::tgNew --> GATE{"Safety Gate 🟢"}:::ocNew
+        RESTART["restart_service 🔴"]:::tgNew --> GATE
+        NOTIFY["notify 🔴"]:::tgNew --> PASS["Always allowed"]:::ocNew
+    end
+
+    GATE -->|"allowPattern match"| ALLOW["Execute 🟢"]:::ocNew
+    GATE -->|"denyPattern match"| DENY["Reject + Log"]:::neutral
+    GATE -->|"No match"| DENY
+    GATE -->|"requireApproval=true"| ASK["Ask Human via TG"]:::neutral
+
+    ALLOW --> AUDIT["Audit Log 🟢"]:::ocNew
+    DENY --> AUDIT
+    ASK --> AUDIT
+    PASS --> AUDIT
+```
+
+### Principles
+
+1. **Least privilege**: TGCC bots can only exec commands matching allowPatterns
+2. **No shell expansion**: Validate commands for injection (`$(...)`, backticks, pipes)
+3. **Audit everything**: Every command logged with `{agentId, command, result, timestamp}`
+4. **Deny by default**: Unmatched commands are rejected
+5. **Timeouts**: Hard timeout on all exec commands
+6. **Ephemeral agents are sandboxed**: Same restrictions as persistent agents for reverse commands
+
+## 11. Domain Boundaries
+
+The Unix socket + NDJSON protocol is the **only** interface between TGCC and OpenClaw.
+
+| Domain | Owns | Does NOT own |
+|--------|------|-------------|
+| **TGCC** | CC process lifecycle, agent state (repo, process), TG bots, MCP bridge, ctl socket server, session JSONL | Subagent tracking, user-facing delivery, tool routing, safety gating |
+| **OpenClaw** | Tool routing (`sessions_send`, `subagents`), subagent registry, announce flow, safety gate for reverse commands | CC processes, TG bots, ctl socket server, session persistence |
+
+OpenClaw connects to TGCC. TGCC never connects to OpenClaw.
+
+## 12. Implementation Plan
+
+### Phase 1: Send + Subscribe (in progress)
+
+**TGCC:**
+1. 🔧 **Agent-level state refactor** — the blocker. Collapse per-userId model to per-agent. See section 13.
+2. ✅ Supervisor commands: `send_message`, `send_to_cc`, `subscribe`, `unsubscribe`, `ping` (built, need updating after refactor)
+3. ✅ Event forwarding: `result`, `session_takeover`, `process_exit` (built)
+4. ❌ `state_changed` event on repo/session changes
+5. ❌ TG system messages when supervisor acts (`🦞 OpenClaw: ...`)
+
+**OpenClaw:** ✅ All Phase 1 done — `TgccSupervisorClient`, tool routing, event handlers, agent cache, auto-start, status display. Needs minor updates after TGCC refactor.
+
+### Phase 2: Ephemeral Agents
+
+**TGCC scope 🔴:**
+1. `create_agent` command → in-memory `AgentInstance` creation (no TG bot)
+2. `destroy_agent` command → cleanup
+3. `agent_created` / `agent_destroyed` events
+4. Timeout-based auto-destroy for orphaned ephemeral agents
+
+**OpenClaw scope 🟢:**
+1. Replace `CCProcess` library import with supervisor `create_agent` + `send_message`
+2. Map `sessions_spawn(mode="claude-code")` to ephemeral agent flow
+3. Lifecycle: destroy on completion/timeout, cleanup subagent registry
+
+**Result:** OpenClaw no longer imports `@fonz/tgcc` as a library. All CC goes through TGCC.
+
+### Phase 3: Reverse Commands
+
+**TGCC scope 🔴:**
+1. MCP tools: `supervisor_exec`, `supervisor_notify`, `supervisor_restart` in `mcp-bridge.ts`
+2. Route MCP tool calls → supervisor commands via `sendToSupervisor` + `supervisorPendingRequests`
+3. Return supervisor responses as tool results to CC
+
+**OpenClaw scope 🟢:**
+1. Handle incoming `exec` commands with safety gating (allowPatterns/denyPatterns)
+2. Handle `restart_service` with service registry from config
+3. Handle `notify` by injecting into agent sessions
+4. Audit logging for all reverse commands
+
+**Result:** CC bots can request host actions through OpenClaw.
+
+## 13. Current State (2026-02-27)
+
+### What Works
+- Supervisor registration, ping/heartbeat, reconnect with backoff
+- `sessions_send` → TGCC agent → CC → result → announce back to requester
+- Agent list from TGCC `status` (60s TTL cache, no static config)
+- `subagents list/steer/kill` routed through supervisor
+- Auto-start TGCC via systemd on first connection failure
+
+### Blocker: Agent-Level State Refactor
+
+TGCC currently tracks state per-userId (processes, repo, session). The supervisor gets a separate process from the TG user. **The fix** (in progress): refactor to per-agent state as described in section 2.2. See section 12 Phase 1.
+
+### OpenClaw Config
+
+```yaml
+agents:
+  defaults:
+    subagents:
+      claudeCode:
+        tgccSupervisor:
+          socket: /tmp/tgcc/ctl/tgcc.sock
+          # Agents discovered from TGCC status, no static config
+```
+
+### OpenClaw Subagent Keying
+Runs keyed as `tgcc:{agentId}` (no sessionId — one run per agent, TGCC manages sessions internally).
+
+## 14. Inventory
+
+### Phase 1 — TGCC
+| What | Status |
+|------|--------|
+| Agent-level state refactor (`bridge.ts`, `session.ts`) | 🔧 In progress |
+| Supervisor commands (`send_message`, `send_to_cc`, `subscribe`, `unsubscribe`, `ping`) | ✅ Built (updating for refactor) |
+| Event forwarding (`result`, `session_takeover`, `process_exit`) | ✅ Built |
+| `state_changed` event on repo/session changes | ❌ |
+| TG system messages when supervisor acts | ❌ |
+
+### Phase 1 — OpenClaw
+| What | Status |
+|------|--------|
+| `TgccSupervisorClient` (connect, register, reconnect, heartbeat) | ✅ |
+| Tool routing (`sessions_send`, `subagents`, `agents_list`) | ✅ |
+| Event handlers (result → announce, exit, takeover) | ✅ |
+| Agent cache from `status` (60s TTL) | ✅ |
+
+### Phase 2 — Ephemeral Agents
+| What | Status |
+|------|--------|
+| `create_agent` / `destroy_agent` commands (TGCC) | ❌ |
+| Replace `@fonz/tgcc` library import with supervisor (OpenClaw) | ❌ |
+
+### Phase 3 — Reverse Commands
+| What | Status |
+|------|--------|
+| MCP tools: `supervisor_exec`, `supervisor_notify`, `supervisor_restart` (TGCC) | ❌ |
+| Exec handler + safety gate (OpenClaw) | ❌ |

--- a/skills/tgcc-agents/SKILL.md
+++ b/skills/tgcc-agents/SKILL.md
@@ -1,8 +1,26 @@
 ---
 name: tgcc-agents
 description: 'Interact with TGCC-managed agents (sentinella, kyobot, saemem) via the supervisor protocol. Use when: routing tasks to persistent Telegram bots managed by TGCC, checking TGCC agent status, or coordinating across TGCC-managed CC sessions. NOT for: spawning new CC sessions (use coding-agent skill), direct Telegram bot interaction, or tasks that don't involve TGCC agents.'
+homepage: https://github.com/botverse/tgcc
 metadata:
-  { "openclaw": { "emoji": "🔌" } }
+  {
+    "openclaw":
+      {
+        "emoji": "🔌",
+        "requires": { "bins": ["tgcc"], "sockets": ["/tmp/tgcc/ctl/tgcc.sock"] },
+        "install":
+          [
+            {
+              "id": "npm",
+              "kind": "npm",
+              "package": "@fonz/tgcc",
+              "bins": ["tgcc"],
+              "label": "Install TGCC (npm)",
+            },
+          ],
+        "setup": "After install, run `tgcc init` to configure agents and `tgcc install` to start as a service. Then add `tgccSupervisor.socket` to your OpenClaw config.",
+      },
+  }
 ---
 
 # TGCC Agents — Supervisor Protocol Integration

--- a/skills/tgcc-agents/SKILL.md
+++ b/skills/tgcc-agents/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: tgcc-agents
+description: 'Interact with TGCC-managed agents (sentinella, kyobot, saemem) via the supervisor protocol. Use when: routing tasks to persistent Telegram bots managed by TGCC, checking TGCC agent status, or coordinating across TGCC-managed CC sessions. NOT for: spawning new CC sessions (use coding-agent skill), direct Telegram bot interaction, or tasks that don't involve TGCC agents.'
+metadata:
+  { "openclaw": { "emoji": "🔌" } }
+---
+
+# TGCC Agents — Supervisor Protocol Integration
+
+Talk to **persistent TGCC agents** (sentinella, kyobot, saemem, etc.) directly from OpenClaw via the supervisor protocol. Messages route through a Unix socket to TGCC, which manages the actual Claude Code processes.
+
+## Key Concepts
+
+### TGCC vs Direct CC Spawn
+
+| | TGCC Agents | Direct CC Spawn |
+|---|---|---|
+| **What** | Persistent bots with Telegram integration | Ephemeral CC sessions |
+| **How** | `sessions_send` → supervisor protocol → TGCC | `sessions_spawn` or coding-agent skill |
+| **Agents** | sentinella, kyobot, saemem (auto-discovered) | Created on demand |
+| **Shared** | Fnz can also talk to them via Telegram | Only OpenClaw sees them |
+| **Lifecycle** | TGCC manages process start/stop | OpenClaw manages lifecycle |
+
+### Auto-Discovery
+
+TGCC agents are **auto-discovered** — no static config needed beyond the socket path:
+
+```yaml
+# openclaw.json — only config needed
+agents:
+  defaults:
+    subagents:
+      claudeCode:
+        tgccSupervisor:
+          socket: /tmp/tgcc/ctl/tgcc.sock
+```
+
+On connect, OpenClaw queries TGCC for available agents and caches them (60s TTL). The `agents_list` tool shows them automatically.
+
+## Sending Messages to TGCC Agents
+
+Use `sessions_send` with the agent name as the label:
+
+```
+sessions_send(label="sentinella", message="Check tile coverage for Ibiza")
+```
+
+This routes through the supervisor protocol:
+1. OpenClaw detects "sentinella" is a known TGCC agent
+2. Sends `send_message` command via Unix socket to TGCC
+3. TGCC spawns or resumes a CC process for that agent
+4. CC works on the task
+5. When done, TGCC sends a `result` event back
+6. OpenClaw's announce flow delivers the result to the requester
+
+**Important:** The CC process is shared. If Fnz is also talking to sentinella via Telegram, both see the same session. OpenClaw auto-subscribes to events.
+
+## Monitoring & Control
+
+### List active agents
+
+```
+subagents list
+```
+
+TGCC-backed runs show with a `[tgcc]` prefix. Untracked TGCC agents with active CC processes also appear at the bottom.
+
+### Steer an active TGCC agent
+
+```
+subagents steer target="sentinella" message="Also compare with last month's data"
+```
+
+Routes `send_to_cc` through the supervisor — writes directly to the running CC process's stdin. Does NOT spawn a new process.
+
+### Kill a TGCC agent's CC process
+
+```
+subagents kill target="sentinella"
+```
+
+Routes `kill_cc` through the supervisor.
+
+## Status
+
+`session_status` shows TGCC connection state:
+
+```
+🔌 TGCC: connected (3 agents)
+```
+
+Or when disconnected:
+```
+🔌 TGCC: reconnecting
+```
+
+## How It Works Under the Hood
+
+```
+OpenClaw                    TGCC Bridge                CC Process
+  │                            │                          │
+  │─── send_message ──────────►│                          │
+  │    {agentId, text}         │─── spawn/resume CC ─────►│
+  │◄── response ──────────────│    {sessionId, state}     │
+  │                            │                          │
+  │    (CC works...)           │                          │
+  │                            │◄── result ───────────────│
+  │◄── event: result ─────────│    {text, cost}           │
+  │                            │                          │
+  │─── announce to requester   │                          │
+```
+
+- **Protocol:** NDJSON over Unix socket (`/tmp/tgcc/ctl/tgcc.sock`)
+- **Registration:** OpenClaw registers as `openclaw` supervisor on connect
+- **Heartbeat:** Ping/pong every 30s, reconnect with exponential backoff on failure
+- **Auto-start:** If configured, attempts `systemctl --user start tgcc.service` on first connection failure
+
+## Subagent Registry Integration
+
+TGCC runs are tracked in the subagent registry with:
+- `childSessionKey`: `tgcc:{agentId}` (e.g., `tgcc:sentinella`)
+- `transport`: `"tgcc-supervisor"`
+- `tgccAgentId`: the TGCC agent name
+
+One active run per agent — TGCC manages sessions internally.
+
+## When NOT to Use This
+
+- **New coding tasks in a repo:** Use the coding-agent skill to spawn a fresh CC session
+- **Tasks that need isolation:** TGCC agents share sessions with Telegram users
+- **Quick one-off edits:** Use the `edit` tool directly

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1162,6 +1162,48 @@ export function listDescendantRunsForRequester(rootSessionKey: string): Subagent
   );
 }
 
+export function findSubagentRunByChildSessionKey(
+  childSessionKey: string,
+): SubagentRunRecord | null {
+  const runIds = findRunIdsByChildSessionKey(childSessionKey);
+  for (const runId of runIds) {
+    const entry = subagentRuns.get(runId);
+    if (entry && typeof entry.endedAt !== "number") {
+      return entry;
+    }
+  }
+  // Fall back to any run (even ended) for correlation.
+  for (const runId of runIds) {
+    const entry = subagentRuns.get(runId);
+    if (entry) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+export function markExternalSubagentRunComplete(params: {
+  runId: string;
+  outcome: SubagentRunOutcome;
+  endedAt?: number;
+}): void {
+  const entry = subagentRuns.get(params.runId);
+  if (!entry) {return;}
+
+  const endedAt = typeof params.endedAt === "number" ? params.endedAt : Date.now();
+  void completeSubagentRun({
+    runId: params.runId,
+    endedAt,
+    outcome: params.outcome,
+    reason: params.outcome.status === "error"
+      ? SUBAGENT_ENDED_REASON_ERROR
+      : SUBAGENT_ENDED_REASON_COMPLETE,
+    sendFarewell: true,
+    accountId: entry.requesterOrigin?.accountId,
+    triggerCleanup: true,
+  });
+}
+
 export function initSubagentRegistry() {
   restoreSubagentRunsOnce();
 }

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -32,4 +32,8 @@ export type SubagentRunRecord = {
   endedReason?: SubagentLifecycleEndedReason;
   /** Set after the subagent_ended hook has been emitted successfully once. */
   endedHookEmittedAt?: number;
+  /** Transport type for externally-managed runs (e.g. "tgcc-supervisor"). */
+  transport?: string;
+  /** TGCC agent ID for runs managed via the TGCC supervisor protocol. */
+  tgccAgentId?: string;
 };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -15,8 +15,14 @@ import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
+import { countActiveRunsForSession, listSubagentRunsForRequester, registerSubagentRun } from "./subagent-registry.js";
 import { readStringParam } from "./tools/common.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  getTgccSupervisorClient,
+  isTgccSupervisorConnected,
+  buildTgccChildSessionKey,
+} from "./tgcc-supervisor/index.js";
 import {
   resolveDisplaySessionKey,
   resolveInternalSessionKey,
@@ -32,6 +38,7 @@ export type SpawnSubagentParams = {
   agentId?: string;
   model?: string;
   thinking?: string;
+  cwd?: string;
   runTimeoutSeconds?: number;
   thread?: boolean;
   mode?: SpawnSubagentMode;
@@ -79,6 +86,101 @@ export function splitModelRef(ref?: string) {
     return { provider, model };
   }
   return { provider: undefined, model: trimmed };
+}
+
+/**
+ * Attempt to route a subagent spawn through TGCC supervisor.
+ * Returns null if TGCC routing is not applicable (fallback to normal spawn).
+ */
+async function trySpawnViaTgcc(
+  params: SpawnSubagentParams,
+  ctx: SpawnSubagentContext,
+): Promise<SpawnSubagentResult | null> {
+  // Only route through TGCC when connected and a cwd (repo) is specified
+  if (!isTgccSupervisorConnected()) return null;
+  
+  // Mode must be "run" (or unspecified, which defaults to "run")
+  // Session mode needs thread binding which TGCC doesn't support
+  if (params.mode === "session" || params.thread === true) return null;
+
+  const tgccClient = getTgccSupervisorClient();
+  if (!tgccClient?.isConnected()) return null;
+
+  const task = params.task;
+  const label = params.label?.trim() || "";
+  const shortUuid = crypto.randomUUID().slice(0, 8);
+  const agentId = label ? `oc-${label.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 20)}-${shortUuid}` : `oc-spawn-${shortUuid}`;
+
+  // Resolve requester session key for tracking
+  const cfg = loadConfig();
+  const { mainKey, alias } = resolveMainSessionAlias(cfg);
+  const requesterInternalKey = ctx.agentSessionKey
+    ? resolveInternalSessionKey({ key: ctx.agentSessionKey, alias, mainKey })
+    : alias;
+  const requesterDisplayKey = resolveDisplaySessionKey({ key: requesterInternalKey, alias, mainKey });
+
+  // Resolve repo from cwd or config
+  const repo = params.cwd?.trim() || undefined;
+  if (!repo) {
+    // No repo specified — fall back to normal spawn
+    // TGCC requires a repo for ephemeral agents
+    return null;
+  }
+
+  try {
+    // Create ephemeral agent
+    const createResult = await tgccClient.createAgent({
+      agentId,
+      repo,
+      model: params.model,
+      permissionMode: "bypassPermissions",
+      timeoutMs: params.runTimeoutSeconds ? params.runTimeoutSeconds * 1000 : undefined,
+    });
+
+    // Send the task message to the agent
+    await tgccClient.sendMessage(createResult.agentId, task, { subscribe: true });
+
+    // Register subagent run
+    const childKey = buildTgccChildSessionKey(createResult.agentId);
+    const runId = crypto.randomUUID();
+    registerSubagentRun({
+      runId,
+      childSessionKey: childKey,
+      requesterSessionKey: requesterInternalKey,
+      requesterDisplayKey,
+      task: task.slice(0, 200),
+      cleanup: params.cleanup ?? "keep",
+      label: label || createResult.agentId,
+      model: params.model,
+      spawnMode: "run",
+      runTimeoutSeconds: params.runTimeoutSeconds,
+      expectsCompletionMessage: params.expectsCompletionMessage,
+    });
+
+    // Patch the run with TGCC transport info
+    const runs = listSubagentRunsForRequester(requesterInternalKey);
+    const tgccRun = runs.find((r) => r.runId === runId);
+    if (tgccRun) {
+      tgccRun.transport = "tgcc-supervisor";
+      tgccRun.tgccAgentId = createResult.agentId;
+    }
+
+    return {
+      status: "accepted",
+      childSessionKey: childKey,
+      runId,
+      mode: "run",
+      note: "Spawned via TGCC supervisor. Results auto-announce on completion.",
+      modelApplied: !!params.model,
+    };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    // If TGCC spawn fails, fall back to normal spawn
+    // (don't error out completely, just let the normal path handle it)
+    const tgccLog = createSubsystemLogger("tgcc-supervisor");
+    tgccLog.warn(`TGCC ephemeral spawn failed, falling back to normal: ${errMsg}`);
+    return null;
+  }
 }
 
 function resolveSpawnMode(params: {
@@ -167,6 +269,13 @@ export async function spawnSubagentDirect(
   params: SpawnSubagentParams,
   ctx: SpawnSubagentContext,
 ): Promise<SpawnSubagentResult> {
+  // ── TGCC ephemeral agent routing ─────────────────────────────────
+  // When TGCC supervisor is connected and the spawn has a cwd (repo),
+  // route through TGCC to create an ephemeral agent instead of spawning
+  // an OpenClaw-managed subagent session.
+  const tgccResult = await trySpawnViaTgcc(params, ctx);
+  if (tgccResult) return tgccResult;
+
   const task = params.task;
   const label = params.label?.trim() || "";
   const requestedAgentId = params.agentId;

--- a/src/agents/tgcc-supervisor/client.ts
+++ b/src/agents/tgcc-supervisor/client.ts
@@ -8,6 +8,7 @@
  */
 
 import crypto from "node:crypto";
+import { exec as cpExec } from "node:child_process";
 import net from "node:net";
 import { EventEmitter } from "node:events";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -225,6 +226,57 @@ export class TgccSupervisorClient extends EventEmitter {
     return this.sendCommand("unsubscribe", { agentId });
   }
 
+  // ── Phase 2: Ephemeral agent management ──────────────────────────────
+
+  /** Create an ephemeral agent for a one-off CC task. No Telegram bot. */
+  async createAgent(params: {
+    agentId?: string;
+    repo: string;
+    model?: string;
+    permissionMode?: string;
+    timeoutMs?: number;
+  }): Promise<{ agentId: string; state: string }> {
+    const result = await this.sendCommand("create_agent", {
+      agentId: params.agentId,
+      repo: params.repo,
+      model: params.model,
+      permissionMode: params.permissionMode,
+      timeoutMs: params.timeoutMs,
+    });
+    return result as { agentId: string; state: string };
+  }
+
+  /** Destroy an ephemeral agent (kills CC process if running, cleans up). */
+  async destroyAgent(agentId: string): Promise<{ destroyed: boolean }> {
+    const result = await this.sendCommand("destroy_agent", { agentId });
+    return result as { destroyed: boolean };
+  }
+
+  /** Query the event log for an agent's CC process (ring buffer). */
+  async getLog(
+    agentId: string,
+    opts?: { offset?: number; limit?: number; grep?: string; since?: number; type?: string },
+  ): Promise<{
+    totalLines: number;
+    returnedLines: number;
+    offset: number;
+    lines: Array<{ ts: number; type: string; text: string }>;
+  }> {
+    const params: Record<string, unknown> = { agentId };
+    if (opts?.offset != null) params.offset = opts.offset;
+    if (opts?.limit != null) params.limit = opts.limit;
+    if (opts?.grep) params.grep = opts.grep;
+    if (opts?.since != null) params.since = opts.since;
+    if (opts?.type) params.type = opts.type;
+    const result = await this.sendCommand("get_log", params);
+    return result as {
+      totalLines: number;
+      returnedLines: number;
+      offset: number;
+      lines: Array<{ ts: number; type: string; text: string }>;
+    };
+  }
+
   // ── Connection management ────────────────────────────────────────────
 
   private connect(): void {
@@ -377,8 +429,7 @@ export class TgccSupervisorClient extends EventEmitter {
     } else if (msg.type === "event") {
       this.handleEvent(msg);
     } else if (msg.type === "command") {
-      // Phase 3: reverse commands from TGCC → OpenClaw
-      log.info(`received reverse command: ${msg.action} (not yet implemented)`);
+      void this.handleReverseCommand(msg);
     }
   }
 
@@ -443,6 +494,36 @@ export class TgccSupervisorClient extends EventEmitter {
         void this.syncStateAfterConnect();
         break;
 
+      // Phase 2: lifecycle events
+      case "bridge_started":
+        this.emit("tgcc:bridge_started", msg);
+        break;
+      case "cc_spawned":
+        this.emit("tgcc:cc_spawned", msg);
+        break;
+      case "agent_created":
+        this.emit("tgcc:agent_created", msg);
+        break;
+      case "agent_destroyed":
+        this.emit("tgcc:agent_destroyed", msg);
+        break;
+      case "state_changed":
+        this.emit("tgcc:state_changed", msg);
+        break;
+
+      // Phase 2: high-signal observability events
+      case "build_result":
+      case "git_commit":
+      case "context_pressure":
+      case "failure_loop":
+      case "stuck":
+      case "task_milestone":
+      case "cc_message":
+      case "subagent_spawn":
+      case "budget_alert":
+        this.emit(`tgcc:${eventName}`, msg);
+        break;
+
       default:
         this.emit(`tgcc:${eventName}`, msg);
         break;
@@ -456,6 +537,132 @@ export class TgccSupervisorClient extends EventEmitter {
     } catch (err) {
       log.warn(`failed to sync state after connect: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  // ── Reverse command handling (TGCC → OpenClaw) ───────────────────────
+
+  private static readonly EXEC_DENY_PATTERNS = [
+    /rm\s+(-[a-z]*f[a-z]*\s+)?\//i,
+    /\bsudo\b/,
+    /\bmkfs\b/,
+    /\bdd\b.*\bof=\//,
+    /:\(\)\{/,
+    /\bchmod\s+777\s+\//,
+    /\bchown\b.*\//,
+    /\|\s*sh\b/,
+    /\$\(/,
+    /`[^`]*`/,
+  ];
+
+  private async handleReverseCommand(msg: SupervisorCommand): Promise<void> {
+    const { requestId, action, params } = msg;
+    log.info(`reverse command: ${action} (requestId=${requestId})`);
+
+    try {
+      switch (action) {
+        case "exec":
+          await this.handleExecCommand(requestId, params ?? {});
+          break;
+        case "restart_service":
+          await this.handleRestartServiceCommand(requestId, params ?? {});
+          break;
+        case "notify":
+          await this.handleNotifyCommand(requestId, params ?? {});
+          break;
+        default:
+          this.sendResponse(requestId, undefined, `Unknown reverse command: ${action}`);
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn(`reverse command ${action} failed: ${errMsg}`);
+      this.sendResponse(requestId, undefined, errMsg);
+    }
+  }
+
+  private async handleExecCommand(requestId: string, params: Record<string, unknown>): Promise<void> {
+    const command = typeof params.command === "string" ? params.command : "";
+    const agentId = typeof params.agentId === "string" ? params.agentId : "unknown";
+    const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : 60_000;
+
+    if (!command.trim()) {
+      this.sendResponse(requestId, undefined, "Empty command");
+      return;
+    }
+
+    // Safety check
+    for (const pattern of TgccSupervisorClient.EXEC_DENY_PATTERNS) {
+      if (pattern.test(command)) {
+        log.warn(`reverse exec DENIED (agent=${agentId}): ${command}`);
+        this.sendResponse(requestId, undefined, `Command denied by safety gate: ${command.slice(0, 100)}`);
+        return;
+      }
+    }
+
+    log.info(`reverse exec (agent=${agentId}): ${command.slice(0, 200)}`);
+
+    return new Promise<void>((resolve) => {
+      cpExec(command, {
+        timeout: timeoutMs,
+        maxBuffer: 1024 * 1024,
+        cwd: typeof params.cwd === "string" ? params.cwd : undefined,
+      }, (err, stdout, stderr) => {
+        const exitCode = err && "code" in err ? (err as { code?: number }).code ?? 1 : err ? 1 : 0;
+        this.sendResponse(requestId, {
+          exitCode,
+          stdout: stdout.slice(0, 50_000),
+          stderr: stderr.slice(0, 50_000),
+        });
+        resolve();
+      });
+    });
+  }
+
+  private async handleRestartServiceCommand(requestId: string, params: Record<string, unknown>): Promise<void> {
+    const service = typeof params.service === "string" ? params.service : "";
+    const agentId = typeof params.agentId === "string" ? params.agentId : "unknown";
+
+    log.info(`reverse restart_service (agent=${agentId}, service=${service})`);
+
+    if (service === "tgcc") {
+      return new Promise<void>((resolve) => {
+        cpExec(
+          `tmux send-keys -t tgcc C-c '' Enter; sleep 1; tmux send-keys -t tgcc 'cd ~/Botverse/tgcc && node dist/cli.js run' Enter`,
+          { timeout: 15_000 },
+          (err) => {
+            if (err) {
+              this.sendResponse(requestId, undefined, `Failed to restart tgcc: ${err.message}`);
+            } else {
+              this.sendResponse(requestId, { restarted: true, service });
+            }
+            resolve();
+          },
+        );
+      });
+    }
+
+    this.sendResponse(requestId, undefined, `Unknown service: ${service}`);
+  }
+
+  private handleNotifyCommand(requestId: string, params: Record<string, unknown>): void {
+    const message = typeof params.message === "string" ? params.message : "";
+    const target = typeof params.target === "string" ? params.target : "";
+
+    if (!message.trim()) {
+      this.sendResponse(requestId, undefined, "Empty notification message");
+      return;
+    }
+
+    // Emit as event so index.ts can inject it via callGateway
+    this.emit("tgcc:reverse_notify", { target, message });
+    this.sendResponse(requestId, { notified: true });
+  }
+
+  private sendResponse(requestId: string, result?: unknown, error?: string): void {
+    this.sendRaw({
+      type: "response",
+      requestId,
+      ...(error ? { error } : { result }),
+    });
   }
 
   // ── Command sending ──────────────────────────────────────────────────

--- a/src/agents/tgcc-supervisor/client.ts
+++ b/src/agents/tgcc-supervisor/client.ts
@@ -1,0 +1,525 @@
+/**
+ * TgccSupervisorClient — Unix socket client for the TGCC Supervisor Protocol.
+ *
+ * Connects to TGCC's ctl socket, registers as a supervisor, and provides
+ * async methods for interacting with TGCC-managed agents and CC processes.
+ *
+ * Phase 1: send_message, send_to_cc, status, kill_cc, subscribe, unsubscribe, ping
+ */
+
+import crypto from "node:crypto";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("tgcc-supervisor");
+
+// ---------------------------------------------------------------------------
+// Wire protocol types
+// ---------------------------------------------------------------------------
+
+export interface SupervisorCommand {
+  type: "command";
+  requestId: string;
+  action: string;
+  params?: Record<string, unknown>;
+}
+
+export interface SupervisorResponse {
+  type: "response";
+  requestId: string;
+  result?: unknown;
+  error?: string;
+}
+
+export interface SupervisorEvent {
+  type: "event";
+  event: string;
+  [key: string]: unknown;
+}
+
+type WireMessage = SupervisorCommand | SupervisorResponse | SupervisorEvent;
+
+// ---------------------------------------------------------------------------
+// Status response types
+// ---------------------------------------------------------------------------
+
+export interface TgccAgentStatus {
+  id: string;
+  type: "persistent" | "ephemeral";
+  state: "idle" | "active";
+  sessionId: string | null;
+  repo: string;
+  supervisorSubscribed: boolean;
+}
+
+export interface TgccStatusResult {
+  agents: TgccAgentStatus[];
+  sessions?: Array<{
+    id: string;
+    agentId: string;
+    messageCount?: number;
+    totalCostUsd?: number;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Event types emitted by the client
+// ---------------------------------------------------------------------------
+
+export interface TgccResultEvent {
+  agentId: string;
+  sessionId: string;
+  text: string;
+  cost_usd?: number;
+  duration_ms?: number;
+  is_error?: boolean;
+}
+
+export interface TgccProcessExitEvent {
+  agentId: string;
+  sessionId: string;
+  exitCode: number | null;
+}
+
+export interface TgccSessionTakeoverEvent {
+  agentId: string;
+  sessionId: string;
+  exitCode: number | null;
+}
+
+export interface TgccApiErrorEvent {
+  agentId: string;
+  sessionId: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface TgccSupervisorClientConfig {
+  socket: string;
+  reconnectInitialMs?: number;
+  reconnectMaxMs?: number;
+  heartbeatMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pending request tracking
+// ---------------------------------------------------------------------------
+
+interface PendingRequest {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_RECONNECT_INITIAL_MS = 1_000;
+const DEFAULT_RECONNECT_MAX_MS = 30_000;
+const DEFAULT_HEARTBEAT_MS = 30_000;
+const HEARTBEAT_PONG_TIMEOUT_MS = 5_000;
+const COMMAND_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class TgccSupervisorClient extends EventEmitter {
+  private config: Required<TgccSupervisorClientConfig>;
+  private socket: net.Socket | null = null;
+  private connected = false;
+  private destroyed = false;
+  private reconnectDelay: number;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private pongTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingRequests = new Map<string, PendingRequest>();
+  private lineBuffer = "";
+
+  constructor(config: TgccSupervisorClientConfig) {
+    super();
+    this.config = {
+      socket: config.socket,
+      reconnectInitialMs: config.reconnectInitialMs ?? DEFAULT_RECONNECT_INITIAL_MS,
+      reconnectMaxMs: config.reconnectMaxMs ?? DEFAULT_RECONNECT_MAX_MS,
+      heartbeatMs: config.heartbeatMs ?? DEFAULT_HEARTBEAT_MS,
+    };
+    this.reconnectDelay = this.config.reconnectInitialMs;
+  }
+
+  // ── Public lifecycle ─────────────────────────────────────────────────
+
+  /** Start connecting to the TGCC ctl socket. */
+  start(): void {
+    if (this.destroyed) {return;}
+    this.connect();
+  }
+
+  /** Disconnect and stop reconnecting. */
+  stop(): void {
+    this.destroyed = true;
+    this.clearTimers();
+    this.rejectAllPending("Client stopped");
+    if (this.socket) {
+      this.socket.removeAllListeners();
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.connected = false;
+  }
+
+  /** Whether the client is currently connected and registered. */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  // ── Public API methods ───────────────────────────────────────────────
+
+  /**
+   * Send a message to any TGCC agent. Spawns CC if not running.
+   * Returns the immediate response (sessionId, state), not the CC result.
+   */
+  async sendMessage(
+    agentId: string,
+    text: string,
+    opts?: { sessionId?: string; subscribe?: boolean },
+  ): Promise<{ sessionId: string; state: string; subscribed?: boolean }> {
+    const result = await this.sendCommand("send_message", {
+      agentId,
+      text,
+      sessionId: opts?.sessionId,
+      subscribe: opts?.subscribe ?? true,
+    });
+    return result as { sessionId: string; state: string; subscribed?: boolean };
+  }
+
+  /** Send a follow-up to an already-running CC process. */
+  async sendToCC(agentId: string, text: string): Promise<{ sent: boolean }> {
+    const result = await this.sendCommand("send_to_cc", { agentId, text });
+    return result as { sent: boolean };
+  }
+
+  /** Query agent and session status. */
+  async getStatus(agentId?: string): Promise<TgccStatusResult> {
+    const params: Record<string, unknown> = {};
+    if (agentId) {params.agentId = agentId;}
+    const result = await this.sendCommand("status", params);
+    return result as TgccStatusResult;
+  }
+
+  /** Kill a running CC process. */
+  async killCC(agentId: string): Promise<unknown> {
+    return this.sendCommand("kill_cc", { agentId });
+  }
+
+  /** Subscribe to an agent's CC process events. */
+  async subscribe(agentId: string, sessionId?: string): Promise<unknown> {
+    const params: Record<string, unknown> = { agentId };
+    if (sessionId) {params.sessionId = sessionId;}
+    return this.sendCommand("subscribe", params);
+  }
+
+  /** Unsubscribe from an agent's CC process events. */
+  async unsubscribe(agentId: string): Promise<unknown> {
+    return this.sendCommand("unsubscribe", { agentId });
+  }
+
+  // ── Connection management ────────────────────────────────────────────
+
+  private connect(): void {
+    if (this.destroyed) {return;}
+
+    log.info(`connecting to TGCC ctl socket: ${this.config.socket}`);
+
+    const sock = net.createConnection({ path: this.config.socket });
+    this.socket = sock;
+
+    sock.on("connect", () => {
+      log.info("connected to TGCC ctl socket");
+      this.connected = true;
+      this.reconnectDelay = this.config.reconnectInitialMs;
+      this.lineBuffer = "";
+      this.register();
+      this.startHeartbeat();
+      this.emit("connected");
+    });
+
+    sock.on("data", (data: Buffer) => {
+      this.handleData(data);
+    });
+
+    sock.on("error", (err: Error) => {
+      log.warn(`TGCC socket error: ${err.message}`);
+    });
+
+    sock.on("close", () => {
+      const wasConnected = this.connected;
+      this.connected = false;
+      this.clearTimers();
+      this.socket = null;
+      if (wasConnected) {
+        log.info("TGCC socket closed, scheduling reconnect");
+        this.emit("disconnected");
+      } else {
+        // Socket closed before we ever connected (ENOENT, ECONNREFUSED, etc.)
+        this.emit("connectFailed");
+      }
+      this.scheduleReconnect();
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.destroyed) {return;}
+    if (this.reconnectTimer) {return;}
+
+    const delay = this.reconnectDelay;
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.config.reconnectMaxMs);
+
+    log.info(`reconnecting in ${delay}ms`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private register(): void {
+    // Registration uses the ctl request format (type: "register_supervisor"),
+    // NOT the supervisor command format (type: "command", action: ...).
+    // Once registered, the connection switches to supervisor mode where
+    // commands use {type: "command", action: "..."}.
+    this.sendRaw({
+      type: "register_supervisor",
+      agentId: "openclaw",
+      capabilities: ["exec", "notify"],
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- ctl request format, not supervisor command
+  }
+
+  // ── Heartbeat ────────────────────────────────────────────────────────
+
+  private startHeartbeat(): void {
+    this.clearHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.sendPing();
+    }, this.config.heartbeatMs);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private sendPing(): void {
+    if (!this.connected) {return;}
+
+    const requestId = crypto.randomUUID();
+    this.sendRaw({
+      type: "command",
+      requestId,
+      action: "ping",
+    });
+
+    // Expect pong within timeout
+    this.pongTimer = setTimeout(() => {
+      log.warn("TGCC pong timeout, forcing reconnect");
+      this.forceReconnect();
+    }, HEARTBEAT_PONG_TIMEOUT_MS);
+    this.pongTimer.unref?.();
+
+    // Register a pending request for pong correlation
+    this.pendingRequests.set(requestId, {
+      resolve: () => {
+        if (this.pongTimer) {
+          clearTimeout(this.pongTimer);
+          this.pongTimer = null;
+        }
+      },
+      reject: () => {},
+      timer: setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+      }, HEARTBEAT_PONG_TIMEOUT_MS + 1_000),
+    });
+    this.pendingRequests.get(requestId)!.timer.unref?.();
+  }
+
+  private forceReconnect(): void {
+    this.rejectAllPending("Connection lost");
+    if (this.socket) {
+      this.socket.removeAllListeners();
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.connected = false;
+    this.clearTimers();
+    this.scheduleReconnect();
+  }
+
+  // ── Data parsing ─────────────────────────────────────────────────────
+
+  private handleData(data: Buffer): void {
+    this.lineBuffer += data.toString("utf-8");
+    const lines = this.lineBuffer.split("\n");
+    // Keep the incomplete last line in the buffer
+    this.lineBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {continue;}
+      try {
+        const msg = JSON.parse(trimmed) as WireMessage;
+        this.handleMessage(msg);
+      } catch {
+        log.warn(`failed to parse TGCC message: ${trimmed.slice(0, 200)}`);
+      }
+    }
+  }
+
+  private handleMessage(msg: WireMessage): void {
+    if (msg.type === "response") {
+      this.handleResponse(msg);
+    } else if (msg.type === "event") {
+      this.handleEvent(msg);
+    } else if (msg.type === "command") {
+      // Phase 3: reverse commands from TGCC → OpenClaw
+      log.info(`received reverse command: ${msg.action} (not yet implemented)`);
+    }
+  }
+
+  private handleResponse(msg: SupervisorResponse): void {
+    const pending = this.pendingRequests.get(msg.requestId);
+    if (!pending) {return;}
+
+    this.pendingRequests.delete(msg.requestId);
+    clearTimeout(pending.timer);
+
+    if (msg.error) {
+      pending.reject(new Error(msg.error));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleEvent(msg: SupervisorEvent): void {
+    const eventName = msg.event;
+    log.info(`received event: ${String(eventName)} agentId=${String(msg.agentId ?? "?")}`);
+
+    switch (eventName) {
+      case "result":
+        this.emit("tgcc:result", {
+          agentId: msg.agentId,
+          sessionId: msg.sessionId,
+          text: msg.text,
+          cost_usd: msg.cost_usd,
+          duration_ms: msg.duration_ms,
+          is_error: msg.is_error,
+        } as TgccResultEvent);
+        break;
+
+      case "process_exit":
+        this.emit("tgcc:process_exit", {
+          agentId: msg.agentId,
+          sessionId: msg.sessionId,
+          exitCode: msg.exitCode ?? null,
+        } as TgccProcessExitEvent);
+        break;
+
+      case "session_takeover":
+        this.emit("tgcc:session_takeover", {
+          agentId: msg.agentId,
+          sessionId: msg.sessionId,
+          exitCode: msg.exitCode ?? null,
+        } as TgccSessionTakeoverEvent);
+        break;
+
+      case "api_error":
+        this.emit("tgcc:api_error", {
+          agentId: msg.agentId,
+          sessionId: msg.sessionId,
+          message: msg.message,
+        } as TgccApiErrorEvent);
+        break;
+
+      case "registered":
+        log.info("supervisor registered with TGCC");
+        this.emit("registered");
+        // Re-sync state after registration
+        void this.syncStateAfterConnect();
+        break;
+
+      default:
+        this.emit(`tgcc:${eventName}`, msg);
+        break;
+    }
+  }
+
+  private async syncStateAfterConnect(): Promise<void> {
+    try {
+      const status = await this.getStatus();
+      this.emit("tgcc:status_sync", status);
+    } catch (err) {
+      log.warn(`failed to sync state after connect: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // ── Command sending ──────────────────────────────────────────────────
+
+  private sendCommand(action: string, params?: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.connected || !this.socket) {
+        reject(new Error("Not connected to TGCC"));
+        return;
+      }
+
+      const requestId = crypto.randomUUID();
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(requestId);
+        reject(new Error(`TGCC command timeout: ${action}`));
+      }, COMMAND_TIMEOUT_MS);
+      timer.unref?.();
+
+      this.pendingRequests.set(requestId, { resolve, reject, timer });
+
+      this.sendRaw({
+        type: "command",
+        requestId,
+        action,
+        params,
+      });
+    });
+  }
+
+  private sendRaw(msg: Record<string, unknown>): void {
+    if (!this.socket || this.socket.destroyed) {return;}
+    try {
+      this.socket.write(JSON.stringify(msg) + "\n");
+    } catch (err) {
+      log.warn(`failed to send to TGCC: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // ── Timer management ─────────────────────────────────────────────────
+
+  private clearTimers(): void {
+    this.clearHeartbeat();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+  }
+
+  private rejectAllPending(reason: string): void {
+    for (const [_id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error(reason));
+    }
+    this.pendingRequests.clear();
+  }
+}

--- a/src/agents/tgcc-supervisor/client.ts
+++ b/src/agents/tgcc-supervisor/client.ts
@@ -95,6 +95,13 @@ export interface TgccApiErrorEvent {
   message: string;
 }
 
+export interface TgccPermissionRequestEvent {
+  agentId: string;
+  toolName: string;
+  requestId: string;
+  description: string;
+}
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -224,6 +231,15 @@ export class TgccSupervisorClient extends EventEmitter {
   /** Unsubscribe from an agent's CC process events. */
   async unsubscribe(agentId: string): Promise<unknown> {
     return this.sendCommand("unsubscribe", { agentId });
+  }
+
+  /** Respond to a permission request from a CC process. */
+  async respondToPermission(
+    agentId: string,
+    permissionRequestId: string,
+    decision: "allow" | "deny",
+  ): Promise<unknown> {
+    return this.sendCommand("permission_response", { agentId, permissionRequestId, decision });
   }
 
   // ── Phase 2: Ephemeral agent management ──────────────────────────────
@@ -485,6 +501,15 @@ export class TgccSupervisorClient extends EventEmitter {
           sessionId: msg.sessionId,
           message: msg.message,
         } as TgccApiErrorEvent);
+        break;
+
+      case "permission_request":
+        this.emit("tgcc:permission_request", {
+          agentId: msg.agentId,
+          toolName: msg.toolName,
+          requestId: msg.requestId,
+          description: msg.description,
+        } as TgccPermissionRequestEvent);
         break;
 
       case "registered":

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -4,6 +4,7 @@
  * Started on gateway startup, stopped on shutdown.
  */
 
+import crypto from "node:crypto";
 import { execSync } from "node:child_process";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
@@ -488,12 +489,29 @@ function handleObservabilityEvent(event: Record<string, unknown>): void {
   log.info(`observability: ${message}`);
 
   const run = findTgccRun(agentId);
-  if (!run) {
-    log.info(`no subagent run for tgcc:${agentId}, skipping injection`);
+  if (run) {
+    void injectObservabilityMessage(run, message);
     return;
   }
 
-  void injectObservabilityMessage(run, message);
+  // No tracked subagent run — persistent agent not spawned by OpenClaw.
+  // Deliver to main session. Only wake agent for cc_message (explicit notify_parent).
+  const eventName = String(event.event ?? "");
+  const shouldWake = eventName === "cc_message";
+  const cfg = loadConfig();
+  const mainKey = cfg.session?.mainKey ?? "agent:main:main";
+  void callGateway({
+    method: "agent",
+    params: {
+      sessionKey: mainKey,
+      idempotencyKey: crypto.randomUUID(),
+      message: `[System Event] ${message}`,
+      deliver: shouldWake,
+    },
+    timeoutMs: 10_000,
+  }).catch((err: unknown) => {
+    log.warn(`observability fallback to main failed: ${err instanceof Error ? err.message : String(err)}`);
+  });
 }
 
 /**
@@ -511,7 +529,7 @@ async function injectObservabilityMessage(
         sessionKey: run.requesterSessionKey,
         message: `[System Event] ${message}`,
         deliver: false,
-        channel: "internal",
+        
       },
       timeoutMs: 10_000,
     });
@@ -541,9 +559,10 @@ function handleReverseNotify(event: { target: string; message: string }): void {
     method: "agent",
     params: {
       sessionKey,
+      idempotencyKey: crypto.randomUUID(),
       message: `[TGCC Notification] ${message}`,
-      deliver: false,
-      channel: "internal",
+      deliver: true,
+      
     },
     timeoutMs: 10_000,
   }).catch((err: unknown) => {

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -1,0 +1,339 @@
+/**
+ * TGCC Supervisor integration — singleton client and event handlers.
+ *
+ * Started on gateway startup, stopped on shutdown.
+ */
+
+import { execSync } from "node:child_process";
+import { loadConfig } from "../../config/config.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  findSubagentRunByChildSessionKey,
+
+  markExternalSubagentRunComplete,
+} from "../subagent-registry.js";
+import { runSubagentAnnounceFlow } from "../subagent-announce.js";
+import type { SubagentRunRecord } from "../subagent-registry.types.js";
+import {
+  TgccSupervisorClient,
+  type TgccResultEvent,
+  type TgccProcessExitEvent,
+  type TgccSessionTakeoverEvent,
+  type TgccApiErrorEvent,
+  type TgccSupervisorClientConfig,
+  type TgccAgentStatus,
+  type TgccStatusResult,
+} from "./client.js";
+
+export type { TgccAgentStatus, TgccStatusResult } from "./client.js";
+
+const log = createSubsystemLogger("tgcc-supervisor");
+
+let client: TgccSupervisorClient | null = null;
+
+// ---------------------------------------------------------------------------
+// Public accessors
+// ---------------------------------------------------------------------------
+
+/** Get the active supervisor client (null if not configured or stopped). */
+export function getTgccSupervisorClient(): TgccSupervisorClient | null {
+  return client;
+}
+
+/** Check if the supervisor client is connected. */
+export function isTgccSupervisorConnected(): boolean {
+  return client?.isConnected() === true;
+}
+
+// ---------------------------------------------------------------------------
+// Health status
+// ---------------------------------------------------------------------------
+
+export interface TgccHealthStatus {
+  configured: boolean;
+  connected: boolean;
+  agentCount?: number;
+  socketPath?: string;
+  reconnecting?: boolean;
+}
+
+/** Build a health-status snapshot for status tools and heartbeat checks. */
+export function getTgccHealthStatus(): TgccHealthStatus {
+  const cfg = loadConfig();
+  const tgccCfg = cfg.agents?.defaults?.subagents?.claudeCode?.tgccSupervisor;
+  if (!tgccCfg?.socket) {
+    return { configured: false, connected: false };
+  }
+
+  const connected = isTgccSupervisorConnected();
+  const agentNames = Object.keys(agentCache);
+  return {
+    configured: true,
+    connected,
+    socketPath: tgccCfg.socket,
+    agentCount: agentNames.length || undefined,
+    reconnecting: !connected && client != null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Live agent cache (source of truth: TGCC status command)
+// ---------------------------------------------------------------------------
+
+export interface TgccAgentMapping {
+  description?: string;
+  repo: string;
+  type?: "persistent" | "ephemeral";
+  state?: "idle" | "active";
+}
+
+/** Cached agent list from TGCC. Refreshed on connect and periodically. */
+let agentCache: Record<string, TgccAgentMapping> = {};
+let agentCacheUpdatedAt = 0;
+const AGENT_CACHE_TTL_MS = 60_000; // refresh every 60s max
+
+/** Refresh the agent cache from TGCC status. */
+async function refreshAgentCache(): Promise<void> {
+  if (!client?.isConnected()) {return;}
+  try {
+    const result = await client.getStatus();
+    const fresh: Record<string, TgccAgentMapping> = {};
+    for (const agent of result.agents) {
+      fresh[agent.id] = {
+        repo: agent.repo,
+        type: agent.type,
+        state: agent.state,
+      };
+    }
+    agentCache = fresh;
+    agentCacheUpdatedAt = Date.now();
+    log.info(`agent cache refreshed: ${result.agents.map((a) => a.id).join(", ")}`);
+  } catch (err) {
+    log.warn(`failed to refresh agent cache: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Get live TGCC agent mappings. Returns cached data, refreshes in background if stale. */
+export function getTgccAgentMappings(): Record<string, TgccAgentMapping> {
+  // Trigger background refresh if stale
+  if (Date.now() - agentCacheUpdatedAt > AGENT_CACHE_TTL_MS) {
+    void refreshAgentCache();
+  }
+  return agentCache;
+}
+
+/** Check if a target name matches a known TGCC agent. */
+export function isTgccAgent(target: string): boolean {
+  return target in agentCache;
+}
+
+/** Build a tgcc: child session key. Keyed by agentId only — TGCC owns session state. */
+export function buildTgccChildSessionKey(agentId: string): string {
+  return `tgcc:${agentId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-start via systemd
+// ---------------------------------------------------------------------------
+
+let autoStartAttempted = false;
+
+/**
+ * Attempt to start the TGCC service via systemd if autoStart is configured.
+ * Only runs once — subsequent reconnect failures skip this.
+ */
+function attemptAutoStart(tgccCfg: {
+  autoStart?: boolean;
+  serviceName?: string;
+  [key: string]: unknown;
+}): void {
+  if (autoStartAttempted) {return;}
+  if (!tgccCfg.autoStart) {return;}
+  autoStartAttempted = true;
+
+  const service = tgccCfg.serviceName ?? "tgcc";
+
+  try {
+    const result = execSync(`systemctl --user is-active ${service}.service 2>/dev/null`, {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+
+    if (result === "active") {
+      log.info(`TGCC service ${service}.service is already active, socket may not be ready yet`);
+      return;
+    }
+  } catch {
+    // is-active returns non-zero for inactive/failed — expected
+  }
+
+  log.info(`TGCC auto-start: starting ${service}.service via systemd`);
+
+  try {
+    execSync(`systemctl --user start ${service}.service`, {
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    log.info(`TGCC auto-start: ${service}.service started successfully`);
+  } catch (err) {
+    log.warn(
+      `TGCC auto-start: failed to start ${service}.service: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Check if the service is enabled (boot persistence)
+  try {
+    const enabled = execSync(`systemctl --user is-enabled ${service}.service 2>/dev/null`, {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+
+    if (enabled !== "enabled") {
+      log.info(
+        `TGCC service ${service}.service is not enabled for boot. ` +
+          `Run: systemctl --user enable ${service}`,
+      );
+    }
+  } catch {
+    log.info(
+      `TGCC service ${service}.service may not be enabled for boot. ` +
+        `Run: systemctl --user enable ${service}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/** Start the supervisor client if configured. Called on gateway startup. */
+export function startTgccSupervisor(): void {
+  if (client) {
+    log.info("TGCC supervisor client already running");
+    return;
+  }
+
+  const cfg = loadConfig();
+  const tgccCfg = cfg.agents?.defaults?.subagents?.claudeCode?.tgccSupervisor;
+  if (!tgccCfg?.socket) {
+    log.info("TGCC supervisor not configured (no socket path)");
+    return;
+  }
+
+  const clientConfig: TgccSupervisorClientConfig = {
+    socket: tgccCfg.socket,
+    reconnectInitialMs: tgccCfg.reconnectInitialMs,
+    reconnectMaxMs: tgccCfg.reconnectMaxMs,
+    heartbeatMs: tgccCfg.heartbeatMs,
+  };
+
+  client = new TgccSupervisorClient(clientConfig);
+  attachEventHandlers(client);
+
+  // On first connection failure, attempt systemd auto-start
+  client.on("connectFailed", () => {
+    attemptAutoStart(tgccCfg);
+  });
+
+  client.start();
+  log.info(`TGCC supervisor client started (socket: ${tgccCfg.socket})`);
+}
+
+/** Stop the supervisor client. Called on gateway shutdown. */
+export function stopTgccSupervisor(): void {
+  if (!client) {return;}
+  client.stop();
+  client = null;
+  agentCache = {};
+  agentCacheUpdatedAt = 0;
+  log.info("TGCC supervisor client stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+function attachEventHandlers(c: TgccSupervisorClient): void {
+  c.on("connected", () => void refreshAgentCache());
+  c.on("tgcc:result", handleResult);
+  c.on("tgcc:process_exit", handleProcessExit);
+  c.on("tgcc:session_takeover", handleSessionTakeover);
+  c.on("tgcc:api_error", handleApiError);
+}
+
+/** Find the active subagent run for a TGCC agent. Keyed by agentId only. */
+function findTgccRun(agentId: string): SubagentRunRecord | null {
+  const childKey = buildTgccChildSessionKey(agentId);
+  return findSubagentRunByChildSessionKey(childKey);
+}
+
+function handleResult(event: TgccResultEvent): void {
+  log.info(
+    `result from ${event.agentId} (${event.is_error ? "error" : "ok"}, cost=$${event.cost_usd?.toFixed(4) ?? "?"})`,
+  );
+
+  const run = findTgccRun(event.agentId);
+  if (!run) {
+    log.info(`no subagent run found for tgcc:${event.agentId}, ignoring result`);
+    return;
+  }
+
+  const now = Date.now();
+  markExternalSubagentRunComplete({
+    runId: run.runId,
+    outcome: event.is_error ? { status: "error", error: event.text } : { status: "ok" },
+    endedAt: now,
+  });
+
+  // Announce result back to the requester session
+  const cfg = loadConfig();
+  const timeoutMs = cfg.agents?.defaults?.subagents?.announceTimeoutMs ?? 30_000;
+  void runSubagentAnnounceFlow({
+    childSessionKey: run.childSessionKey,
+    childRunId: run.runId,
+    requesterSessionKey: run.requesterSessionKey,
+    requesterDisplayKey: run.requesterSessionKey,
+    task: run.task,
+    timeoutMs,
+    cleanup: "keep",
+    roundOneReply: event.text,
+    waitForCompletion: false,
+    startedAt: run.startedAt ?? run.createdAt,
+    endedAt: now,
+    outcome: event.is_error ? { status: "error", error: event.text } : { status: "ok" },
+    label: run.label,
+  }).then((announced) => {
+    log.info(`announce flow for ${event.agentId}: ${announced ? "delivered" : "not delivered"}`);
+  }).catch((err) => {
+    log.warn(`announce flow error for ${event.agentId}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
+function handleProcessExit(event: TgccProcessExitEvent): void {
+  log.info(`process_exit from ${event.agentId} (exit=${event.exitCode})`);
+
+  const run = findTgccRun(event.agentId);
+  if (!run) {return;}
+  if (run.endedAt) {return;}
+
+  markExternalSubagentRunComplete({
+    runId: run.runId,
+    outcome:
+      event.exitCode === 0 ? { status: "ok" } : { status: "error", error: `exit code ${event.exitCode}` },
+    endedAt: Date.now(),
+  });
+}
+
+function handleSessionTakeover(event: TgccSessionTakeoverEvent): void {
+  log.info(`session_takeover for ${event.agentId}`);
+
+  const run = findTgccRun(event.agentId);
+  if (!run) {return;}
+
+  log.info(`session taken over by another client, run ${run.runId} stays active`);
+}
+
+function handleApiError(event: TgccApiErrorEvent): void {
+  log.warn(`api_error from ${event.agentId}:${event.sessionId}: ${event.message}`);
+  // Phase 1: just log. Could inject as system message into requester session later.
+}

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -6,6 +6,7 @@
 
 import { execSync } from "node:child_process";
 import { loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   findSubagentRunByChildSessionKey,
@@ -259,6 +260,27 @@ function attachEventHandlers(c: TgccSupervisorClient): void {
   c.on("tgcc:process_exit", handleProcessExit);
   c.on("tgcc:session_takeover", handleSessionTakeover);
   c.on("tgcc:api_error", handleApiError);
+
+  // Phase 2: lifecycle events
+  c.on("tgcc:bridge_started", () => void refreshAgentCache());
+  c.on("tgcc:cc_spawned", handleCcSpawned);
+  c.on("tgcc:agent_created", handleAgentCreated);
+  c.on("tgcc:agent_destroyed", handleAgentDestroyed);
+  c.on("tgcc:state_changed", handleStateChanged);
+
+  // Phase 2: high-signal observability events → inject into requester session
+  c.on("tgcc:build_result", handleObservabilityEvent);
+  c.on("tgcc:git_commit", handleObservabilityEvent);
+  c.on("tgcc:context_pressure", handleObservabilityEvent);
+  c.on("tgcc:failure_loop", handleObservabilityEvent);
+  c.on("tgcc:stuck", handleObservabilityEvent);
+  c.on("tgcc:task_milestone", handleObservabilityEvent);
+  c.on("tgcc:cc_message", handleObservabilityEvent);
+  c.on("tgcc:subagent_spawn", handleObservabilityEvent);
+  c.on("tgcc:budget_alert", handleObservabilityEvent);
+
+  // Phase 3: reverse notify
+  c.on("tgcc:reverse_notify", handleReverseNotify);
 }
 
 /** Find the active subagent run for a TGCC agent. Keyed by agentId only. */
@@ -335,5 +357,196 @@ function handleSessionTakeover(event: TgccSessionTakeoverEvent): void {
 
 function handleApiError(event: TgccApiErrorEvent): void {
   log.warn(`api_error from ${event.agentId}:${event.sessionId}: ${event.message}`);
-  // Phase 1: just log. Could inject as system message into requester session later.
+  // Inject as observability notification
+  const run = findTgccRun(event.agentId);
+  if (run) {
+    void injectObservabilityMessage(
+      run,
+      `[subagent:${event.agentId}] ❌ API error: ${event.message}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Lifecycle event handlers
+// ---------------------------------------------------------------------------
+
+function handleCcSpawned(event: Record<string, unknown>): void {
+  const agentId = String(event.agentId ?? "");
+  const source = String(event.source ?? "unknown");
+  log.info(`cc_spawned: ${agentId} (source=${source})`);
+  // Update cache state
+  if (agentId && agentCache[agentId]) {
+    agentCache[agentId].state = "active";
+  }
+}
+
+function handleAgentCreated(event: Record<string, unknown>): void {
+  const agentId = String(event.agentId ?? "");
+  const repo = String(event.repo ?? "");
+  const agentType = String(event.type ?? "ephemeral") as "persistent" | "ephemeral";
+  log.info(`agent_created: ${agentId} (type=${agentType}, repo=${repo})`);
+  if (agentId) {
+    agentCache[agentId] = { repo, type: agentType, state: "idle" };
+    agentCacheUpdatedAt = Date.now();
+  }
+}
+
+function handleAgentDestroyed(event: Record<string, unknown>): void {
+  const agentId = String(event.agentId ?? "");
+  log.info(`agent_destroyed: ${agentId}`);
+  if (agentId) {
+    delete agentCache[agentId];
+    agentCacheUpdatedAt = Date.now();
+  }
+  // Clean up subagent run if exists
+  const run = findTgccRun(agentId);
+  if (run && !run.endedAt) {
+    markExternalSubagentRunComplete({
+      runId: run.runId,
+      outcome: { status: "error", error: "agent destroyed" },
+      endedAt: Date.now(),
+    });
+  }
+}
+
+function handleStateChanged(event: Record<string, unknown>): void {
+  const agentId = String(event.agentId ?? "");
+  const field = String(event.field ?? "");
+  const newValue = event.newValue;
+  log.info(`state_changed: ${agentId}.${field} = ${String(newValue)}`);
+  if (agentId && agentCache[agentId]) {
+    if (field === "state" && (newValue === "idle" || newValue === "active")) {
+      agentCache[agentId].state = newValue;
+    } else if (field === "repo" && typeof newValue === "string") {
+      agentCache[agentId].repo = newValue;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Observability event handler — inject system messages
+// ---------------------------------------------------------------------------
+
+function formatObservabilityMessage(event: Record<string, unknown>): string | null {
+  const agentId = String(event.agentId ?? "unknown");
+  const prefix = `[subagent:${agentId}]`;
+  const eventName = String(event.event ?? "");
+
+  switch (eventName) {
+    case "build_result": {
+      const passed = event.passed === true;
+      if (passed) return `${prefix} 🔨 Build passed ✅`;
+      const errors = typeof event.errors === "number" ? event.errors : "?";
+      const summary = typeof event.summary === "string" ? `: ${event.summary}` : "";
+      return `${prefix} 🔨 Build failed: ${errors} errors${summary}`;
+    }
+    case "git_commit": {
+      const msg = typeof event.message === "string" ? event.message : "?";
+      return `${prefix} 📝 Committed: "${msg}"`;
+    }
+    case "context_pressure": {
+      const pct = typeof event.percent === "number" ? event.percent : "?";
+      return `${prefix} 🧠 Context at ${pct}%`;
+    }
+    case "failure_loop": {
+      const n = typeof event.consecutiveFailures === "number" ? event.consecutiveFailures : "?";
+      return `${prefix} 🔁 ${n} consecutive failures`;
+    }
+    case "stuck": {
+      const mins = typeof event.silentMs === "number" ? Math.round(event.silentMs / 60_000) : "?";
+      return `${prefix} ⚠️ No progress for ${mins}m`;
+    }
+    case "task_milestone": {
+      const task = typeof event.task === "string" ? event.task : "?";
+      const progress = typeof event.progress === "string" ? `[${event.progress}] ` : "";
+      return `${prefix} 📋 ${progress}${task} ✅`;
+    }
+    case "cc_message": {
+      const text = typeof event.text === "string" ? event.text : "?";
+      return `${prefix} 💬 "${text}"`;
+    }
+    case "subagent_spawn": {
+      const count = typeof event.count === "number" ? event.count : "?";
+      return `${prefix} 🔄 Spawned ${count} sub-agents`;
+    }
+    case "budget_alert": {
+      const cost = typeof event.costUsd === "number" ? `$${event.costUsd.toFixed(2)}` : "$?";
+      const budget = typeof event.budgetUsd === "number" ? `$${event.budgetUsd.toFixed(2)}` : "$?";
+      return `${prefix} 💰 ${cost} spent (budget: ${budget})`;
+    }
+    default:
+      return null;
+  }
+}
+
+function handleObservabilityEvent(event: Record<string, unknown>): void {
+  const agentId = String(event.agentId ?? "");
+  const message = formatObservabilityMessage(event);
+  if (!message) return;
+
+  log.info(`observability: ${message}`);
+
+  const run = findTgccRun(agentId);
+  if (!run) {
+    log.info(`no subagent run for tgcc:${agentId}, skipping injection`);
+    return;
+  }
+
+  void injectObservabilityMessage(run, message);
+}
+
+/**
+ * Inject a system-level message into the requester's session context.
+ * Uses callGateway to send a user-role message that the agent will process.
+ */
+async function injectObservabilityMessage(
+  run: SubagentRunRecord,
+  message: string,
+): Promise<void> {
+  try {
+    await callGateway({
+      method: "agent",
+      params: {
+        sessionKey: run.requesterSessionKey,
+        message: `[System Event] ${message}`,
+        deliver: false,
+        channel: "internal",
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    log.warn(
+      `failed to inject observability message: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Reverse notify handler
+// ---------------------------------------------------------------------------
+
+function handleReverseNotify(event: { target: string; message: string }): void {
+  const { target, message } = event;
+  log.info(`reverse notify to ${target}: ${message.slice(0, 200)}`);
+
+  if (!target || !message) return;
+
+  // Resolve target to a session key — "main" maps to the main agent session
+  const cfg = loadConfig();
+  const mainKey = cfg.session?.mainKey ?? "agent:main:main";
+  const sessionKey = target === "main" ? mainKey : `agent:${target}:main`;
+
+  void callGateway({
+    method: "agent",
+    params: {
+      sessionKey,
+      message: `[TGCC Notification] ${message}`,
+      deliver: false,
+      channel: "internal",
+    },
+    timeoutMs: 10_000,
+  }).catch((err: unknown) => {
+    log.warn(`reverse notify failed: ${err instanceof Error ? err.message : String(err)}`);
+  });
 }

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -503,7 +503,6 @@ function handleObservabilityEvent(event: Record<string, unknown>): void {
   // No tracked subagent run — persistent agent not spawned by OpenClaw.
   // Deliver to main session. Only wake agent for cc_message (explicit notify_parent).
   const eventName = String(event.event ?? "");
-  const shouldWake = eventName === "cc_message";
   const cfg = loadConfig();
   const mainKey = cfg.session?.mainKey ?? "agent:main:main";
   void callGateway({
@@ -512,7 +511,7 @@ function handleObservabilityEvent(event: Record<string, unknown>): void {
       sessionKey: mainKey,
       idempotencyKey: crypto.randomUUID(),
       message: `[System Event] ${message}`,
-      deliver: shouldWake,
+      deliver: true,
     },
     timeoutMs: 10_000,
   }).catch((err: unknown) => {
@@ -535,7 +534,7 @@ async function injectObservabilityMessage(
         sessionKey: run.requesterSessionKey,
         idempotencyKey: crypto.randomUUID(),
         message: `[System Event] ${message}`,
-        deliver: false,
+        deliver: true,
       },
       timeoutMs: 10_000,
     });

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -16,12 +16,15 @@ import {
 } from "../subagent-registry.js";
 import { runSubagentAnnounceFlow } from "../subagent-announce.js";
 import type { SubagentRunRecord } from "../subagent-registry.types.js";
+import { resolveTelegramAccount } from "../../telegram/accounts.js";
+import { sendMessageTelegram } from "../../telegram/send.js";
 import {
   TgccSupervisorClient,
   type TgccResultEvent,
   type TgccProcessExitEvent,
   type TgccSessionTakeoverEvent,
   type TgccApiErrorEvent,
+  type TgccPermissionRequestEvent,
   type TgccSupervisorClientConfig,
   type TgccAgentStatus,
   type TgccStatusResult,
@@ -282,6 +285,9 @@ function attachEventHandlers(c: TgccSupervisorClient): void {
 
   // Phase 3: reverse notify
   c.on("tgcc:reverse_notify", handleReverseNotify);
+
+  // Permission requests from CC processes
+  c.on("tgcc:permission_request", handlePermissionRequest);
 }
 
 /** Find the active subagent run for a TGCC agent. Keyed by agentId only. */
@@ -543,6 +549,95 @@ async function injectObservabilityMessage(
 // ---------------------------------------------------------------------------
 // Phase 3: Reverse notify handler
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Permission request handler — deliver to agent session AND send TG buttons
+// ---------------------------------------------------------------------------
+
+// Max bytes for Telegram callback_data is 64. With prefix `tgcc_perm:a:` (12 chars),
+// separator `:` (1 char), and UUID (36 chars), the agentId budget is 15 chars.
+const TGCC_PERM_AGENT_ID_MAX = 15;
+
+function buildPermCallbackData(decision: "a" | "d", agentId: string, requestId: string): string {
+  const safeId = agentId.length > TGCC_PERM_AGENT_ID_MAX
+    ? agentId.slice(0, TGCC_PERM_AGENT_ID_MAX)
+    : agentId;
+  return `tgcc_perm:${decision}:${safeId}:${requestId}`;
+}
+
+function handlePermissionRequest(event: TgccPermissionRequestEvent): void {
+  const { agentId, toolName, requestId, description } = event;
+  log.info(`permission_request: agent=${agentId} tool=${toolName} requestId=${requestId}`);
+
+  // a) Wake the requester agent so it can auto-approve based on its own rules.
+  //    Include requestId and agentId so the agent can call respondToPermission.
+  const systemMsg =
+    `[subagent:${agentId}] 🔒 Permission request: ${toolName} — ${description}` +
+    ` [permissionRequestId=${requestId}]`;
+
+  const run = findTgccRun(agentId);
+  if (run) {
+    void callGateway({
+      method: "agent",
+      params: {
+        sessionKey: run.requesterSessionKey,
+        idempotencyKey: crypto.randomUUID(),
+        message: `[System Event] ${systemMsg}`,
+        deliver: true,
+      },
+      timeoutMs: 10_000,
+    }).catch((err: unknown) => {
+      log.warn(`permission_request session inject failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  } else {
+    // No tracked run — deliver to main session
+    const cfg = loadConfig();
+    const mainKey = cfg.session?.mainKey ?? "agent:main:main";
+    void callGateway({
+      method: "agent",
+      params: {
+        sessionKey: mainKey,
+        idempotencyKey: crypto.randomUUID(),
+        message: `[System Event] ${systemMsg}`,
+        deliver: true,
+      },
+      timeoutMs: 10_000,
+    }).catch((err: unknown) => {
+      log.warn(`permission_request main session inject failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+
+  // b) Send Telegram message with Allow / Deny inline buttons as a user-facing fallback.
+  const cfg = loadConfig();
+  let tgDefaultTo: string | undefined;
+  try {
+    const tgVal = resolveTelegramAccount({ cfg }).config.defaultTo;
+    tgDefaultTo = tgVal != null ? String(tgVal) : undefined;
+  } catch {
+    // Telegram may not be configured — skip button message
+  }
+
+  if (!tgDefaultTo) {
+    log.info(`permission_request: no telegram defaultTo configured, skipping button message`);
+    return;
+  }
+
+  const tgText =
+    `🔒 <b>${agentId}</b> needs permission: <b>${toolName}</b>\n${description}`;
+  const buttons = [
+    [
+      { text: "✅ Allow", callback_data: buildPermCallbackData("a", agentId, requestId) },
+      { text: "❌ Deny",  callback_data: buildPermCallbackData("d", agentId, requestId) },
+    ],
+  ];
+
+  void sendMessageTelegram(tgDefaultTo, tgText, {
+    textMode: "html",
+    buttons,
+  }).catch((err: unknown) => {
+    log.warn(`permission_request telegram message failed: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
 
 function handleReverseNotify(event: { target: string; message: string }): void {
   const { target, message } = event;

--- a/src/agents/tgcc-supervisor/index.ts
+++ b/src/agents/tgcc-supervisor/index.ts
@@ -527,9 +527,9 @@ async function injectObservabilityMessage(
       method: "agent",
       params: {
         sessionKey: run.requesterSessionKey,
+        idempotencyKey: crypto.randomUUID(),
         message: `[System Event] ${message}`,
         deliver: false,
-        
       },
       timeoutMs: 10_000,
     });

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -9,6 +9,7 @@ import { resolveAgentConfig } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
+import { getTgccAgentMappings } from "../tgcc-supervisor/index.js";
 
 const AgentsListToolSchema = Type.Object({});
 
@@ -88,10 +89,23 @@ export function createAgentsListTool(opts?: {
         configured: configuredIds.includes(id),
       }));
 
+      // Append TGCC agents (reachable via sessions_send, not sessions_spawn)
+      const tgccMappings = getTgccAgentMappings();
+      const tgccAgents: Array<{ id: string; type: string; state: string; repo: string }> = [];
+      for (const [id, mapping] of Object.entries(tgccMappings)) {
+        tgccAgents.push({
+          id,
+          type: mapping.type ?? "persistent",
+          state: mapping.state ?? "idle",
+          repo: mapping.repo,
+        });
+      }
+
       return jsonResult({
         requester: requesterAgentId,
         allowAny,
         agents,
+        tgccAgents: tgccAgents.length > 0 ? tgccAgents : undefined,
       });
     },
   };

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -24,6 +24,7 @@ import {
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveAgentDir } from "../agent-scope.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import { getTgccHealthStatus } from "../tgcc-supervisor/index.js";
 import { resolveModelAuthLabel } from "../model-auth-label.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
@@ -384,13 +385,24 @@ export function createSessionStatusTool(opts?: {
         includeTranscriptUsage: true,
       });
 
+      // Append TGCC supervisor status
+      const tgccHealth = getTgccHealthStatus();
+      let fullStatusText = statusText;
+      if (tgccHealth.configured) {
+        const tgccLine = tgccHealth.connected
+          ? `🔌 TGCC: connected (${tgccHealth.agentCount ?? 0} agents)`
+          : `🔌 TGCC: ${tgccHealth.reconnecting ? "reconnecting" : "disconnected"}`;
+        fullStatusText = `${statusText}\n${tgccLine}`;
+      }
+
       return {
-        content: [{ type: "text", text: statusText }],
+        content: [{ type: "text", text: fullStatusText }],
         details: {
           ok: true,
           sessionKey: resolved.key,
           changedModel,
-          statusText,
+          statusText: fullStatusText,
+          tgccHealth: tgccHealth.configured ? tgccHealth : undefined,
         },
       };
     },

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -23,6 +23,12 @@ import {
 } from "./sessions-helpers.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+import {
+  getTgccSupervisorClient,
+  isTgccAgent,
+  buildTgccChildSessionKey,
+} from "../tgcc-supervisor/index.js";
+import { registerSubagentRun, listSubagentRunsForRequester } from "../subagent-registry.js";
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
@@ -69,6 +75,61 @@ export function createSessionsSendTool(opts?: {
           status: "error",
           error: "Provide either sessionKey or label (not both).",
         });
+      }
+
+      // ── TGCC agent interception ─────────────────────────────────────
+      // If the target matches a known TGCC agent, route through the supervisor
+      // protocol instead of the normal session resolution flow.
+      const tgccTarget = labelParam ?? sessionKeyParam;
+      if (tgccTarget && isTgccAgent(tgccTarget)) {
+        const tgccClient = getTgccSupervisorClient();
+        if (!tgccClient?.isConnected()) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: `TGCC supervisor not connected. Cannot reach agent "${tgccTarget}".`,
+          });
+        }
+        try {
+          const result = await tgccClient.sendMessage(tgccTarget, message, { subscribe: true });
+          const childKey = buildTgccChildSessionKey(tgccTarget);
+          const runId = crypto.randomUUID();
+          registerSubagentRun({
+            runId,
+            childSessionKey: childKey,
+            requesterSessionKey: effectiveRequesterKey,
+            requesterDisplayKey: effectiveRequesterKey,
+            task: message.slice(0, 200),
+            cleanup: "keep",
+            label: tgccTarget,
+            spawnMode: "run",
+            expectsCompletionMessage: false,
+          });
+          // Patch the run with TGCC transport info
+          const runs = listSubagentRunsForRequester(effectiveRequesterKey);
+          const tgccRun = runs.find((r) => r.runId === runId);
+          if (tgccRun) {
+            tgccRun.transport = "tgcc-supervisor";
+            tgccRun.tgccAgentId = tgccTarget;
+          }
+          return jsonResult({
+            runId,
+            status: "accepted",
+            sessionKey: childKey,
+            tgccAgent: tgccTarget,
+            sessionId: result.sessionId,
+            state: result.state,
+            delivery: { status: "pending", mode: "tgcc-supervisor" },
+            text: `Message sent to TGCC agent "${tgccTarget}". Results will be announced when CC completes.`,
+          });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: `TGCC send_message failed: ${errMsg}`,
+          });
+        }
       }
 
       let sessionKey = sessionKeyParam;

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -94,6 +94,7 @@ export function createSessionsSpawnTool(opts?: {
                 agentId: requestedAgentId,
                 model: modelOverride,
                 thinking: thinkingOverrideRaw,
+                cwd,
                 runTimeoutSeconds,
                 thread,
                 mode,

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -40,6 +40,11 @@ import {
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
+import {
+  getTgccSupervisorClient,
+  getTgccAgentMappings,
+
+} from "../tgcc-supervisor/index.js";
 
 const SUBAGENT_ACTIONS = ["list", "kill", "steer"] as const;
 type SubagentAction = (typeof SUBAGENT_ACTIONS)[number];
@@ -404,7 +409,31 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
             buildListEntry(entry, (entry.endedAt ?? now) - (entry.startedAt ?? entry.createdAt)),
           );
 
+        // Append TGCC agent info to list entries
+        const tgccMappings = getTgccAgentMappings();
+        for (const entry of [...active, ...recent]) {
+          const run = runs.find((r) => r.runId === entry.view.runId);
+          if (run?.transport === "tgcc-supervisor") {
+            entry.line = entry.line.replace(/^(\d+\.)/, "$1 [tgcc]");
+            (entry.view as Record<string, unknown>).transport = "tgcc-supervisor";
+          }
+        }
+
+        // Show TGCC agents that have active CC processes but no tracked subagent run
+        const trackedTgccAgents = new Set(
+          runs.filter((r) => r.tgccAgentId).map((r) => r.tgccAgentId!),
+        );
+        const tgccLines: string[] = [];
+        for (const [agentId, mapping] of Object.entries(tgccMappings)) {
+          if (trackedTgccAgents.has(agentId)) {continue;}
+          if (mapping.state !== "active") {continue;}
+          tgccLines.push(`  [tgcc] ${agentId} (${mapping.type ?? "persistent"}, active)`);
+        }
+
         const text = buildListText({ active, recent, recentMinutes });
+        const fullText = tgccLines.length > 0
+          ? `${text}\n\ntgcc agents (untracked):\n${tgccLines.join("\n")}`
+          : text;
         return jsonResult({
           status: "ok",
           action: "list",
@@ -414,7 +443,8 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           total: runs.length,
           active: active.map((entry) => entry.view),
           recent: recent.map((entry) => entry.view),
-          text,
+          tgccAgents: Object.keys(tgccMappings),
+          text: fullText,
         });
       }
 
@@ -471,6 +501,43 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
             error: resolved.error ?? "Unknown subagent target.",
           });
         }
+        // Route TGCC-backed kills through the supervisor protocol
+        if (resolved.entry.transport === "tgcc-supervisor" && resolved.entry.tgccAgentId) {
+          const tgccClient = getTgccSupervisorClient();
+          if (!tgccClient?.isConnected()) {
+            return jsonResult({
+              status: "error",
+              action: "kill",
+              target,
+              error: "TGCC supervisor not connected.",
+            });
+          }
+          try {
+            await tgccClient.killCC(resolved.entry.tgccAgentId);
+            markSubagentRunTerminated({
+              runId: resolved.entry.runId,
+              reason: "killed via tgcc supervisor",
+            });
+            return jsonResult({
+              status: "ok",
+              action: "kill",
+              target,
+              runId: resolved.entry.runId,
+              sessionKey: resolved.entry.childSessionKey,
+              label: resolveSubagentLabel(resolved.entry),
+              text: `killed [tgcc] ${resolveSubagentLabel(resolved.entry)}.`,
+            });
+          } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            return jsonResult({
+              status: "error",
+              action: "kill",
+              target,
+              error: `TGCC kill_cc failed: ${errMsg}`,
+            });
+          }
+        }
+
         const killCache = new Map<string, Record<string, SessionEntry>>();
         const stopResult = await killSubagentRun({
           cfg,
@@ -575,6 +642,39 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           });
         }
         steerRateLimit.set(rateKey, now);
+
+        // Route TGCC-backed steers through the supervisor protocol
+        if (resolved.entry.transport === "tgcc-supervisor" && resolved.entry.tgccAgentId) {
+          const tgccClient = getTgccSupervisorClient();
+          if (!tgccClient?.isConnected()) {
+            return jsonResult({
+              status: "error",
+              action: "steer",
+              target,
+              error: "TGCC supervisor not connected.",
+            });
+          }
+          try {
+            await tgccClient.sendToCC(resolved.entry.tgccAgentId, message);
+            return jsonResult({
+              status: "accepted",
+              action: "steer",
+              target,
+              runId: resolved.entry.runId,
+              sessionKey: resolved.entry.childSessionKey,
+              label: resolveSubagentLabel(resolved.entry),
+              text: `steered [tgcc] ${resolveSubagentLabel(resolved.entry)}.`,
+            });
+          } catch (err) {
+            const errMsg = err instanceof Error ? err.message : String(err);
+            return jsonResult({
+              status: "error",
+              action: "steer",
+              target,
+              error: `TGCC send_to_cc failed: ${errMsg}`,
+            });
+          }
+        }
 
         // Suppress announce for the interrupted run before aborting so we don't
         // emit stale pre-steer findings if the run exits immediately.

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -46,7 +46,7 @@ import {
 
 } from "../tgcc-supervisor/index.js";
 
-const SUBAGENT_ACTIONS = ["list", "kill", "steer"] as const;
+const SUBAGENT_ACTIONS = ["list", "kill", "steer", "log"] as const;
 type SubagentAction = (typeof SUBAGENT_ACTIONS)[number];
 
 const DEFAULT_RECENT_MINUTES = 30;
@@ -62,6 +62,11 @@ const SubagentsToolSchema = Type.Object({
   target: Type.Optional(Type.String()),
   message: Type.Optional(Type.String()),
   recentMinutes: Type.Optional(Type.Number({ minimum: 1 })),
+  offset: Type.Optional(Type.Number({ minimum: 0 })),
+  limit: Type.Optional(Type.Number({ minimum: 1 })),
+  grep: Type.Optional(Type.String()),
+  since: Type.Optional(Type.Number()),
+  type: Type.Optional(Type.String()),
 });
 
 type SessionEntryResolution = {
@@ -349,7 +354,7 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
     label: "Subagents",
     name: "subagents",
     description:
-      "List, kill, or steer spawned sub-agents for this requester session. Use this for sub-agent orchestration.",
+      "List, kill, steer, or view logs of spawned sub-agents for this requester session. Use this for sub-agent orchestration.",
     parameters: SubagentsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -428,6 +433,31 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           if (trackedTgccAgents.has(agentId)) {continue;}
           if (mapping.state !== "active") {continue;}
           tgccLines.push(`  [tgcc] ${agentId} (${mapping.type ?? "persistent"}, active)`);
+        }
+
+        // Enrich TGCC-backed active runs with live status (runtime, cost)
+        const tgccClient = getTgccSupervisorClient();
+        if (tgccClient?.isConnected()) {
+          for (const entry of active) {
+            const run = runs.find((r) => r.runId === entry.view.runId);
+            if (run?.transport === "tgcc-supervisor" && run.tgccAgentId) {
+              try {
+                const status = await tgccClient.getStatus(run.tgccAgentId);
+                const agent = status.agents?.[0];
+                if (agent) {
+                  (entry.view as Record<string, unknown>).tgccState = agent.state;
+                }
+                // Include session cost if available
+                const session = status.sessions?.[0];
+                if (session?.totalCostUsd != null) {
+                  (entry.view as Record<string, unknown>).costUsd = session.totalCostUsd;
+                  entry.line += ` ($${session.totalCostUsd.toFixed(4)})`;
+                }
+              } catch {
+                // Non-critical — don't fail the list
+              }
+            }
+          }
         }
 
         const text = buildListText({ active, recent, recentMinutes });
@@ -771,6 +801,78 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           text: `steered ${resolveSubagentLabel(resolved.entry)}.`,
         });
       }
+      if (action === "log") {
+        const target = readStringParam(params, "target", { required: true });
+        const resolved = resolveSubagentTarget(runs, target, { recentMinutes });
+        if (!resolved.entry) {
+          return jsonResult({
+            status: "error",
+            action: "log",
+            target,
+            error: resolved.error ?? "Unknown subagent target.",
+          });
+        }
+
+        // Only TGCC-backed runs support log retrieval
+        if (resolved.entry.transport !== "tgcc-supervisor" || !resolved.entry.tgccAgentId) {
+          return jsonResult({
+            status: "error",
+            action: "log",
+            target,
+            error: "Log retrieval is only available for TGCC-backed subagents.",
+          });
+        }
+
+        const tgccClient = getTgccSupervisorClient();
+        if (!tgccClient?.isConnected()) {
+          return jsonResult({
+            status: "error",
+            action: "log",
+            target,
+            error: "TGCC supervisor not connected.",
+          });
+        }
+
+        try {
+          const logOpts: { offset?: number; limit?: number; grep?: string; since?: number; type?: string } = {};
+          const offsetParam = readNumberParam(params, "offset");
+          if (offsetParam != null) logOpts.offset = offsetParam;
+          const limitParam = readNumberParam(params, "limit");
+          if (limitParam != null) logOpts.limit = limitParam;
+          const grepParam = readStringParam(params, "grep");
+          if (grepParam) logOpts.grep = grepParam;
+          const sinceParam = readNumberParam(params, "since");
+          if (sinceParam != null) logOpts.since = sinceParam;
+          const typeParam = readStringParam(params, "type");
+          if (typeParam) logOpts.type = typeParam;
+
+          const logResult = await tgccClient.getLog(resolved.entry.tgccAgentId, logOpts);
+          const lines = logResult.lines.map((line) => {
+            const ts = new Date(line.ts).toISOString().slice(11, 19);
+            return `[${ts}] [${line.type}] ${line.text}`;
+          });
+
+          return jsonResult({
+            status: "ok",
+            action: "log",
+            target,
+            label: resolveSubagentLabel(resolved.entry),
+            totalLines: logResult.totalLines,
+            returnedLines: logResult.returnedLines,
+            offset: logResult.offset,
+            text: lines.length > 0 ? lines.join("\n") : "(no log lines)",
+          });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          return jsonResult({
+            status: "error",
+            action: "log",
+            target,
+            error: `TGCC get_log failed: ${errMsg}`,
+          });
+        }
+      }
+
       return jsonResult({
         status: "error",
         error: "Unsupported action.",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -263,6 +263,34 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /** Claude Code process management via TGCC bridge. */
+    claudeCode?: {
+      /** Whether Claude Code spawning is enabled. */
+      enabled?: boolean;
+      /** Map of repo name → absolute path for CC-managed repos. */
+      repos?: Record<string, string>;
+      /** Maximum budget in USD per CC session. */
+      maxBudgetUsd?: number;
+      /** Timeout in seconds for CC sessions. */
+      timeoutSeconds?: number;
+      /** Permission mode for CC sessions (e.g. "bypassPermissions"). */
+      permissionMode?: string;
+      /** TGCC supervisor protocol configuration. */
+      tgccSupervisor?: {
+        /** Path to the TGCC Unix socket. */
+        socket: string;
+        /** Attempt to start TGCC via systemd on first connection failure. */
+        autoStart?: boolean;
+        /** systemd service name (default: "tgcc"). */
+        serviceName?: string;
+        /** Initial reconnect delay in ms (default: 1000). */
+        reconnectInitialMs?: number;
+        /** Maximum reconnect delay in ms (default: 30000). */
+        reconnectMaxMs?: number;
+        /** Heartbeat interval in ms (default: 30000). */
+        heartbeatMs?: number;
+      };
+    };
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -26,6 +26,11 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /** Claude Code settings for this agent. */
+    claudeCode?: {
+      defaultRepo?: string;
+      repos?: Record<string, string>;
+    };
   };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -160,6 +160,27 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        claudeCode: z
+          .object({
+            enabled: z.boolean().optional(),
+            repos: z.record(z.string(), z.string()).optional(),
+            maxBudgetUsd: z.number().positive().optional(),
+            timeoutSeconds: z.number().int().positive().optional(),
+            permissionMode: z.string().optional(),
+            tgccSupervisor: z
+              .object({
+                socket: z.string().default("/tmp/tgcc/ctl/tgcc.sock"),
+                autoStart: z.boolean().optional(),
+                serviceName: z.string().optional(),
+                reconnectInitialMs: z.number().int().positive().optional(),
+                reconnectMaxMs: z.number().int().positive().optional(),
+                heartbeatMs: z.number().int().positive().optional(),
+              })
+              .strict()
+              .optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -699,6 +699,13 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        claudeCode: z
+          .object({
+            defaultRepo: z.string().optional(),
+            repos: z.record(z.string(), z.string()).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -3,6 +3,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
+import { startTgccSupervisor, stopTgccSupervisor } from "../agents/tgcc-supervisor/index.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -378,6 +379,7 @@ export async function startGatewayServer(
     () => getTotalQueueSize() + getTotalPendingReplies() + getActiveEmbeddedRunCount(),
   );
   initSubagentRegistry();
+  startTgccSupervisor();
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
@@ -928,6 +930,7 @@ export async function startGatewayServer(
       authRateLimiter?.dispose();
       browserAuthRateLimiter.dispose();
       channelHealthMonitor?.stop();
+      stopTgccSupervisor();
       clearSecretsRuntimeSnapshot();
       await close(opts);
     },

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,6 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { getTgccSupervisorClient } from "../agents/tgcc-supervisor/index.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
@@ -1231,6 +1232,27 @@ export const registerTelegramHandlers = ({
           return;
         }
 
+        return;
+      }
+
+      // TGCC permission request callback (tgcc_perm:{a|d}:{agentId}:{requestId})
+      const permMatch = data.match(/^tgcc_perm:([ad]):([^:]+):(.+)$/);
+      if (permMatch) {
+        const [, decisionCode, permAgentId, permRequestId] = permMatch;
+        const decision = decisionCode === "a" ? "allow" : "deny";
+        const tgccClient = getTgccSupervisorClient();
+        if (tgccClient && permAgentId && permRequestId) {
+          try {
+            await tgccClient.respondToPermission(permAgentId, permRequestId, decision);
+            const label = decision === "allow" ? "✅ Allowed" : "❌ Denied";
+            await editCallbackMessage(
+              `${label} — <b>${permAgentId}</b> permission for tool request`,
+              { parse_mode: "HTML", reply_markup: { inline_keyboard: [] } },
+            );
+          } catch (permErr) {
+            runtime.error?.(danger(`tgcc_perm callback failed: ${String(permErr)}`));
+          }
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Connect OpenClaw to TGCC (Telegram ↔ Claude Code bridge) via Unix socket supervisor protocol. TGCC becomes the single CC process manager; OpenClaw routes messages and tracks results through it.

## What it does

- **TgccSupervisorClient** — connects to TGCC's control socket, registers as supervisor, reconnects with backoff, heartbeat
- **Tool routing** — `sessions_send` to TGCC agents routes through supervisor instead of spawning CC directly
- **Subagent tracking** — TGCC-backed runs appear in `subagents list` with `[tgcc]` tag, `steer`/`kill` work through supervisor
- **Agent discovery** — agents auto-discovered from TGCC `status` (60s TTL cache), no static config needed
- **Event handling** — `result` → announce flow, `process_exit` → mark complete, `session_takeover` → log warning
- **Status** — `session_status` shows TGCC connection state and agent count

## Config

```yaml
agents:
  defaults:
    subagents:
      claudeCode:
        tgccSupervisor:
          socket: /tmp/tgcc/ctl/tgcc.sock
```

## Files changed

**New:**
- `src/agents/tgcc-supervisor/client.ts` — socket client
- `src/agents/tgcc-supervisor/index.ts` — event handlers + gateway wiring
- `docs/SPEC-SUBAGENT-OBSERVABILITY.md` — future observability spec

**Modified:**
- `sessions-send-tool.ts` — TGCC agent routing
- `subagents-tool.ts` — list/steer/kill for TGCC runs
- `agents-list-tool.ts` — include TGCC agents
- `session-status-tool.ts` — TGCC connection status
- `subagent-registry.ts/.types.ts` — transport + tgccAgentId fields
- `zod-schema.agent-defaults.ts` — tgccSupervisor config
- `gateway/server.impl.ts` — startup/shutdown wiring

## Related

- TGCC repo: https://github.com/botverse/tgcc
- Protocol spec: `SPEC-SUPERVISOR-PROTOCOL.md` in TGCC repo