### PR TITLE
test(infra): cover npm fallback double-failure and multi-archive mtime selection

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -314,4 +314,41 @@ describe("packNpmSpecToArchive", () => {
       error: "npm pack failed: network timeout",
     });
   });
+
+  it("selects newest archive by mtime when multiple tgz files exist in cwd", async () => {
+    const cwd = await createTempDir("openclaw-install-source-utils-");
+
+    // Create an older archive first
+    const olderArchive = path.join(cwd, "openclaw-plugin-old-1.0.0.tgz");
+    await fs.writeFile(olderArchive, "old", "utf-8");
+
+    // Set the older file's mtime to 10 seconds in the past
+    const pastTime = new Date(Date.now() - 10_000);
+    await fs.utimes(olderArchive, pastTime, pastTime);
+
+    // Create a newer archive
+    const newerArchive = path.join(cwd, "openclaw-plugin-new-2.0.0.tgz");
+    await fs.writeFile(newerArchive, "new", "utf-8");
+
+    // npm pack returns empty stdout so the fallback dir scan triggers
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: " \n\n",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await packNpmSpecToArchive({
+      spec: "openclaw-plugin@2.0.0",
+      timeoutMs: 5000,
+      cwd,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Should pick the newer archive (most recent mtime)
+      expect(result.archivePath).toBe(newerArchive);
+    }
+  });
 });

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -462,6 +462,46 @@ describe("runGatewayUpdate", () => {
     ]);
   });
 
+  it("returns error when both primary and --omit=optional fallback fail", async () => {
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    await seedGlobalPackageRoot(pkgRoot);
+
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      if (key === `git -C ${pkgRoot} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === "npm root -g") {
+        return { stdout: nodeModules, stderr: "", code: 0 };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (key === "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error") {
+        return { stdout: "", stderr: "node-gyp failed", code: 1 };
+      }
+      if (
+        key === "npm i -g openclaw@latest --omit=optional --no-fund --no-audit --loglevel=error"
+      ) {
+        return { stdout: "", stderr: "permission denied", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const result = await runWithCommand(runCommand, { cwd: pkgRoot });
+
+    expect(result.status).toBe("error");
+    expect(result.mode).toBe("npm");
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps.map((s) => s.name)).toEqual([
+      "global update",
+      "global update (omit optional)",
+    ]);
+    expect(result.steps[0]?.exitCode).toBe(1);
+    expect(result.steps[1]?.exitCode).toBe(1);
+  });
+
   it("updates global bun installs when detected", async () => {
     const bunInstall = path.join(tempDir, "bun-install");
     await withEnvAsync({ BUN_INSTALL: bunInstall }, async () => {


### PR DESCRIPTION
## Summary

- Add test for `update-runner` verifying `status: "error"` when both the primary `npm i -g` and the `--omit=optional` fallback both fail, with both steps recorded
- Add test for `install-source-utils` verifying `findPackedArchiveInDir` selects the newest `.tgz` by mtime when multiple archives exist in the working directory

## Test plan

- [x] `pnpm test -- src/infra/update-runner.test.ts` passes (31 tests)
- [x] `pnpm test -- src/infra/install-source-utils.test.ts` passes (14 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)