### PR TITLE
fix(cron): notify user when cron job is auto-disabled after repeated errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
+- Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -208,6 +208,19 @@ function recordScheduleComputeError(params: {
       { jobId: job.id, name: job.name, errorCount, err: errText },
       "cron: auto-disabled job after repeated schedule errors",
     );
+
+    // Notify the user so the auto-disable is not silent (#28861).
+    const notifyText = `⚠️ Cron job "${job.name}" has been auto-disabled after ${errorCount} consecutive schedule errors. Last error: ${errText}`;
+    state.deps.enqueueSystemEvent(notifyText, {
+      agentId: job.agentId,
+      sessionKey: job.sessionKey,
+      contextKey: `cron:${job.id}:auto-disabled`,
+    });
+    state.deps.requestHeartbeatNow({
+      reason: `cron:${job.id}:auto-disabled`,
+      agentId: job.agentId,
+      sessionKey: job.sessionKey,
+    });
   } else {
     state.deps.log.warn(
       { jobId: job.id, name: job.name, errorCount, err: errText },


### PR DESCRIPTION
## Summary

When a cron job encounters 3 consecutive schedule computation errors, it is silently auto-disabled with only a log message. Users discover their jobs stopped running days later with no indication of what happened.

Closes #28861.

### Problem

In `src/cron/service/jobs.ts`, `recordScheduleComputeError()` disables the job after `MAX_SCHEDULE_ERRORS` (3) but only calls `logCron.warn()`. No user-facing notification is sent.

### Fix

Added a user notification via the existing `enqueueSystemEvent` + `requestHeartbeatNow` mechanism (same pattern used by isolated agent job results). When auto-disabled, the user receives:

> ⚠️ Cron job "my-job" has been auto-disabled after 3 consecutive schedule errors. Last error: ...

Routing uses the job’s `agentId` and `sessionKey` so the notification reaches the right channel.

### Changes

**`src/cron/service/jobs.ts`** — 1 file, +13 lines

### Testing

- [x] `pnpm build` passes
- [x] Existing tests unaffected
- [x] AI-assisted (Claude Code) — fully reviewed and understood
