### PR TITLE
fix: increase VERIFY_TIMEOUT_MS from 10s to 120s for local LLMs

### DIFF
--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,7 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 10000;
+const VERIFY_TIMEOUT_MS = 120_000;
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.


### PR DESCRIPTION
## Summary

Increases the verification timeout during custom model onboarding from 10 seconds to 120 seconds.

## Problem

Users running local LLMs (e.g., Qwen3 14B on a laptop GPU via llama.cpp) frequently exceed the 10-second verification timeout, causing onboarding to fail unnecessarily. The model works fine — it just needs more time to generate its first response.

## Fix

Bump `VERIFY_TIMEOUT_MS` from `10_000` (10s) to `120_000` (120s). This is generous enough for slow local models while still providing a reasonable upper bound.

Closes #28972