### PR TITLE
docs(secrets): add Bitwarden Secrets exec resolver example

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -219,6 +219,7 @@ This example uses a small wrapper script that implements the exec provider proto
 
 - Script: `scripts/secrets/openclaw-bws-resolver`
 - `bws` must be installed and authenticated via `BWS_ACCESS_TOKEN`
+- `bws` is resolved from `PATH` by default (set `BWS_BIN` for an absolute override)
 
 ```json5
 {
@@ -229,7 +230,7 @@ This example uses a small wrapper script that implements the exec provider proto
         // Point this at wherever you install the resolver.
         command: "/usr/local/bin/openclaw-bws-resolver",
         args: [],
-        passEnv: ["BWS_ACCESS_TOKEN", "PATH"],
+        passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN"],
         jsonOnly: true,
       },
     },

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -213,6 +213,39 @@ Optional per-id errors:
 }
 ```
 
+### Bitwarden Secrets (BWS)
+
+This example uses a small wrapper script that implements the exec provider protocol and calls the Bitwarden Secrets CLI (`bws`) once per batch.
+
+- Script: `scripts/secrets/openclaw-bws-resolver`
+- `bws` must be installed and authenticated via `BWS_ACCESS_TOKEN`
+
+```json5
+{
+  secrets: {
+    providers: {
+      bws: {
+        source: "exec",
+        // Point this at wherever you install the resolver.
+        command: "/usr/local/bin/openclaw-bws-resolver",
+        args: [],
+        passEnv: ["BWS_ACCESS_TOKEN", "PATH"],
+        jsonOnly: true,
+      },
+    },
+  },
+  models: {
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        models: [{ id: "gpt-5", name: "gpt-5" }],
+        apiKey: { source: "exec", provider: "bws", id: "OPENAI_API_KEY" },
+      },
+    },
+  },
+}
+```
+
 ### `sops`
 
 ```json5

--- a/scripts/secrets/openclaw-bws-resolver
+++ b/scripts/secrets/openclaw-bws-resolver
@@ -4,9 +4,9 @@
 // Protocol v1: reads JSON from stdin, returns JSON on stdout.
 //
 
-const { execFileSync } = require("child_process");
+import { execFileSync } from "node:child_process";
 
-const BWS = "/usr/local/bin/bws";
+const BWS = process.env.BWS_BIN?.trim() || "bws";
 
 async function main() {
   let input = "";
@@ -24,14 +24,20 @@ async function main() {
     return;
   }
 
+  if (!process.env.BWS_ACCESS_TOKEN) {
+    process.stderr.write("BWS_ACCESS_TOKEN is required\n");
+    process.exit(1);
+  }
+
   let secrets;
   try {
     const raw = execFileSync(BWS, ["secret", "list"], {
       env: { BWS_ACCESS_TOKEN: process.env.BWS_ACCESS_TOKEN, PATH: process.env.PATH || "" },
       timeout: 15000,
       maxBuffer: 1024 * 1024,
+      encoding: "utf8",
     });
-    secrets = JSON.parse(raw.toString());
+    secrets = JSON.parse(raw);
   } catch (err) {
     process.stderr.write(`bws secret list failed: ${err.message}\n`);
     process.exit(1);

--- a/scripts/secrets/openclaw-bws-resolver
+++ b/scripts/secrets/openclaw-bws-resolver
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+//
+// OpenClaw SecretRef exec resolver for Bitwarden Secrets (bws).
+// Protocol v1: reads JSON from stdin, returns JSON on stdout.
+//
+
+const { execFileSync } = require("child_process");
+
+const BWS = "/usr/local/bin/bws";
+
+async function main() {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+
+  const req = JSON.parse(input);
+  if (req.protocolVersion !== 1) {
+    process.stderr.write(`unsupported protocol version: ${req.protocolVersion}\n`);
+    process.exit(1);
+  }
+
+  const ids = req.ids || [];
+  if (ids.length === 0) {
+    process.stdout.write(JSON.stringify({ protocolVersion: 1, values: {} }));
+    return;
+  }
+
+  let secrets;
+  try {
+    const raw = execFileSync(BWS, ["secret", "list"], {
+      env: { BWS_ACCESS_TOKEN: process.env.BWS_ACCESS_TOKEN, PATH: process.env.PATH || "" },
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    });
+    secrets = JSON.parse(raw.toString());
+  } catch (err) {
+    process.stderr.write(`bws secret list failed: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const keyMap = {};
+  for (const s of secrets) keyMap[s.key] = s.value;
+
+  const values = {};
+  const errors = {};
+  for (const id of ids) {
+    if (id in keyMap) values[id] = keyMap[id];
+    else errors[id] = { message: `secret key "${id}" not found in BWS` };
+  }
+
+  process.stdout.write(JSON.stringify({ protocolVersion: 1, values, errors }));
+}
+
+main().catch((err) => {
+  process.stderr.write(`resolver error: ${err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a small exec-provider-compatible resolver script for Bitwarden Secrets (bws) and documents it as an exec integration example in docs/gateway/secrets.md.

- No core changes required: uses the existing exec SecretRef protocol v1 (batch).
- Resolver calls `bws secret list` once per request batch and maps by secret `key`.

Operational notes:
- The resolver expects `BWS_ACCESS_TOKEN` in the gateway environment.
- `bws` is resolved from `PATH` by default; set `BWS_BIN` for an absolute override.

AI-assisted: yes (Codex)
Testing level: lightly tested
- `printf '{"protocolVersion":1,"provider":"bws","ids":[]}' | ./scripts/secrets/openclaw-bws-resolver`
- `printf '{"protocolVersion":2,"provider":"bws","ids":[]}' | ./scripts/secrets/openclaw-bws-resolver`
- `printf '{"protocolVersion":1,"provider":"bws","ids":["OPENAI_API_KEY"]}' | env -u BWS_ACCESS_TOKEN ./scripts/secrets/openclaw-bws-resolver`
