### PR TITLE
docs(cron): add agent tool call format and common mistakes

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -273,7 +273,111 @@ Use these shapes when calling Gateway `cron.*` tools directly (agent tool calls 
 CLI flags accept human durations like `20m`, but tool calls should use an ISO 8601 string
 for `schedule.at` and milliseconds for `schedule.everyMs`.
 
-### cron.add params
+> **Important for agents**: When using the `cron` tool programmatically (not CLI), wrap the
+> job object in a `job` parameter. See [Agent tool call format](#agent-tool-call-format) below.
+
+### Required fields
+
+Every `cron.add` call requires these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Human-readable job name |
+| `schedule` | object | When to run (see schedule kinds below) |
+| `schedule.kind` | string | `"at"`, `"every"`, or `"cron"` |
+| `sessionTarget` | string | `"main"` or `"isolated"` |
+| `payload` | object | What to run |
+| `payload.kind` | string | `"systemEvent"` (main) or `"agentTurn"` (isolated) |
+
+**Payload text field** (depends on `payload.kind`):
+- `systemEvent` → `payload.text` (required)
+- `agentTurn` → `payload.message` (required)
+
+### Schedule kinds
+
+| Kind | Required fields | Example |
+|------|-----------------|---------|
+| `at` | `schedule.at` (ISO 8601) | `{ "kind": "at", "at": "2026-02-01T16:00:00Z" }` |
+| `every` | `schedule.everyMs` (milliseconds) | `{ "kind": "every", "everyMs": 3600000 }` |
+| `cron` | `schedule.expr` (cron expression) | `{ "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" }` |
+
+### Agent tool call format
+
+When calling the `cron` tool from an agent (not CLI), pass the job inside a `job` parameter:
+
+```
+cron action=add job={"name": "...", "schedule": {...}, ...}
+```
+
+**Example: One-shot reminder (main session)**
+
+```json
+{
+  "action": "add",
+  "job": {
+    "name": "Reminder",
+    "schedule": { "kind": "at", "at": "2026-02-01T16:00:00Z" },
+    "sessionTarget": "main",
+    "wakeMode": "now",
+    "payload": { "kind": "systemEvent", "text": "Reminder text" },
+    "deleteAfterRun": true
+  }
+}
+```
+
+**Example: Recurring isolated job with delivery**
+
+```json
+{
+  "action": "add",
+  "job": {
+    "name": "Morning brief",
+    "schedule": { "kind": "cron", "expr": "0 7 * * *", "tz": "America/Los_Angeles" },
+    "sessionTarget": "isolated",
+    "wakeMode": "next-heartbeat",
+    "payload": {
+      "kind": "agentTurn",
+      "message": "Summarize overnight updates."
+    },
+    "delivery": {
+      "mode": "announce",
+      "channel": "slack",
+      "to": "channel:C1234567890",
+      "bestEffort": true
+    }
+  }
+}
+```
+
+### Common mistakes
+
+These patterns will cause validation errors:
+
+```json
+// ❌ Missing job wrapper (agent tool calls)
+{ "name": "Test", "schedule": {...} }
+// ✅ Correct: wrap in job parameter
+{ "action": "add", "job": { "name": "Test", "schedule": {...} } }
+
+// ❌ Schedule as string instead of object
+{ "schedule": "0 7 * * *" }
+// ✅ Correct: schedule is an object with kind
+{ "schedule": { "kind": "cron", "expr": "0 7 * * *" } }
+
+// ❌ Wrong payload text field for agentTurn
+{ "payload": { "kind": "agentTurn", "text": "..." } }
+// ✅ Correct: agentTurn uses "message"
+{ "payload": { "kind": "agentTurn", "message": "..." } }
+
+// ❌ Missing sessionTarget
+{ "name": "Test", "schedule": {...}, "payload": {...} }
+// ✅ Correct: sessionTarget is required
+{ "name": "Test", "schedule": {...}, "sessionTarget": "isolated", "payload": {...} }
+```
+
+### cron.add params (raw job object)
+
+For reference, here are the raw job object shapes (without the `job` wrapper):
 
 One-shot, main session job (system event):
 

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -29,6 +29,35 @@ openclaw cron list
 openclaw system heartbeat last
 ```
 
+## Cron validation errors (cron.add fails)
+
+When `cron.add` fails with validation errors, check these common issues:
+
+```bash
+# Check recent logs for validation errors
+openclaw logs --tail 50 | grep -i "validation\|required\|invalid"
+```
+
+Common validation error signatures:
+
+- `must have required property 'name'` → Job object missing `name` field.
+- `must have required property 'sessionTarget'` → Missing `sessionTarget: "main"` or `"isolated"`.
+- `must have required property 'payload'` → Missing `payload` object.
+- `at /schedule: must have required property 'kind'` → Schedule must be an object with `kind` field.
+- `at /payload: must have required property 'text'` → systemEvent payload needs `text` field.
+- `at /payload: must have required property 'message'` → agentTurn payload needs `message` field.
+
+**Quick fix checklist:**
+
+1. Is `schedule` an object (not a string)? → `{ "kind": "cron", "expr": "..." }`
+2. Does `schedule` have a `kind` field? → `"at"`, `"every"`, or `"cron"`
+3. Is `sessionTarget` present? → `"main"` or `"isolated"`
+4. Does payload text field match payload kind?
+   - `systemEvent` → `payload.text`
+   - `agentTurn` → `payload.message`
+
+See [cron-jobs.md#common-mistakes](/automation/cron-jobs#common-mistakes) for examples.
+
 ## Cron not firing
 
 ```bash


### PR DESCRIPTION
## Summary

This PR improves the cron documentation to help agents avoid common schema validation errors when using the cron tool programmatically.

## Changes

- **Required fields table**: Quick reference for what fields are mandatory
- **Schedule kinds table**: Reference for at/every/cron schedule types
- **Agent tool call format section**: Shows the `job` wrapper needed for tool calls (vs raw CLI)
- **Common mistakes section**: Examples of validation errors with corrections:
  - Missing job wrapper
  - Schedule as string instead of object
  - Using `text` instead of `message` for agentTurn
  - Missing sessionTarget

## Motivation

I repeatedly hit cron.add validation errors due to:
1. Not wrapping the job object in a `job` parameter
2. Using wrong payload text field (`text` vs `message`)
3. Missing required fields like `sessionTarget`

The existing docs show correct JSON shapes but don't clearly indicate:
- Which fields are required vs optional
- The tool call wrapper format
- Common pitfalls that cause validation failures

## Testing

Verified the documentation renders correctly locally.