### PR TITLE
Gateway: harden singleton lock startup with stale recovery telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+
+# Local agent guardrails
+AGENTS.local.md

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
-const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
-  release: vi.fn(async () => {}),
-}));
+const acquireGatewayLock = vi.fn(
+  async (_opts?: { port?: number; onTelemetry?: (event: unknown) => void }) => ({
+    release: vi.fn(async () => {}),
+  }),
+);
 const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
@@ -23,7 +25,8 @@ const gatewayLog = {
 };
 
 vi.mock("../../infra/gateway-lock.js", () => ({
-  acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
+  acquireGatewayLock: (opts?: { port?: number; onTelemetry?: (event: unknown) => void }) =>
+    acquireGatewayLock(opts),
 }));
 
 vi.mock("../../infra/restart.js", () => ({
@@ -295,9 +298,80 @@ describe("runGatewayLoop", () => {
       process.emit("SIGUSR1");
 
       await expect(loopPromise).rejects.toThrow("stop-loop");
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
+      expect(acquireGatewayLock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ port: 18789 }),
+      );
+      expect(acquireGatewayLock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ port: 18789 }),
+      );
+      expect(acquireGatewayLock).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ port: 18789 }),
+      );
+    });
+  });
+
+  it("logs explicit singleton-lock startup telemetry", async () => {
+    vi.clearAllMocks();
+
+    acquireGatewayLock.mockImplementationOnce(async (opts) => {
+      opts?.onTelemetry?.({
+        event: "acquire-start",
+        lockPath: "/tmp/openclaw/gateway.test.lock",
+        configPath: "/tmp/openclaw/openclaw.json",
+        timeoutMs: 5000,
+        pollIntervalMs: 100,
+        staleMs: 30_000,
+        platform: "darwin",
+        port: 18789,
+      });
+      opts?.onTelemetry?.({
+        event: "acquire-contention",
+        lockPath: "/tmp/openclaw/gateway.test.lock",
+        ownerPid: 99,
+        ownerStatus: "unknown",
+        waitedMs: 150,
+        attempt: 2,
+      });
+      opts?.onTelemetry?.({
+        event: "stale-lock-recovered",
+        lockPath: "/tmp/openclaw/gateway.test.lock",
+        ownerPid: 99,
+        ownerStatus: "unknown",
+        reason: "stale-unknown-owner",
+        waitedMs: 155,
+        attempt: 2,
+      });
+      opts?.onTelemetry?.({
+        event: "acquire-success",
+        lockPath: "/tmp/openclaw/gateway.test.lock",
+        configPath: "/tmp/openclaw/openclaw.json",
+        waitedMs: 160,
+        attempts: 3,
+        staleRecoveries: 1,
+      });
+      return { release: vi.fn(async () => {}) };
+    });
+
+    await withIsolatedSignals(async () => {
+      const { exited } = await createSignaledLoopHarness();
+      process.emit("SIGTERM");
+
+      await expect(exited).resolves.toBe(0);
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        expect.stringContaining("singleton lock: acquiring"),
+      );
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("singleton lock: waiting"),
+      );
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("singleton lock: removed stale lock"),
+      );
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        expect.stringContaining("singleton lock: acquired"),
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,5 @@
 import type { startGatewayServer } from "../../gateway/server.js";
-import { acquireGatewayLock } from "../../infra/gateway-lock.js";
+import { acquireGatewayLock, type GatewayLockTelemetryEvent } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
 import {
   consumeGatewaySigusr1RestartAuthorization,
@@ -25,7 +25,54 @@ export async function runGatewayLoop(params: {
   runtime: typeof defaultRuntime;
   lockPort?: number;
 }) {
-  let lock = await acquireGatewayLock({ port: params.lockPort });
+  const formatOwner = (pid?: number) => (pid ? `pid=${pid}` : "pid=unknown");
+  const onLockTelemetry = (event: GatewayLockTelemetryEvent) => {
+    switch (event.event) {
+      case "acquire-skipped": {
+        const reason =
+          event.reason === "multi-gateway-override"
+            ? "OPENCLAW_ALLOW_MULTI_GATEWAY=1"
+            : "test environment";
+        gatewayLog.info(`singleton lock: skipped (${reason})`);
+        return;
+      }
+      case "acquire-start": {
+        const port = event.port != null ? `, port=${event.port}` : "";
+        gatewayLog.info(
+          `singleton lock: acquiring (${event.lockPath}, timeout=${event.timeoutMs}ms, stale=${event.staleMs}ms${port})`,
+        );
+        return;
+      }
+      case "acquire-contention":
+        gatewayLog.warn(
+          `singleton lock: waiting (status=${event.ownerStatus}, ${formatOwner(
+            event.ownerPid,
+          )}, waited=${event.waitedMs}ms)`,
+        );
+        return;
+      case "stale-lock-recovered":
+        gatewayLog.warn(
+          `singleton lock: removed stale lock (${event.reason}, status=${event.ownerStatus}, ${formatOwner(
+            event.ownerPid,
+          )}, waited=${event.waitedMs}ms)`,
+        );
+        return;
+      case "acquire-success":
+        gatewayLog.info(
+          `singleton lock: acquired (${event.lockPath}, waited=${event.waitedMs}ms, attempts=${event.attempts}, staleRecoveries=${event.staleRecoveries})`,
+        );
+        return;
+      case "acquire-timeout":
+        gatewayLog.error(
+          `singleton lock: timeout after ${event.timeoutMs}ms (${formatOwner(
+            event.ownerPid,
+          )}, attempts=${event.attempts})`,
+        );
+        return;
+    }
+  };
+
+  let lock = await acquireGatewayLock({ port: params.lockPort, onTelemetry: onLockTelemetry });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;
@@ -49,7 +96,7 @@ export async function runGatewayLoop(params: {
   };
   const reacquireLockForInProcessRestart = async (): Promise<boolean> => {
     try {
-      lock = await acquireGatewayLock({ port: params.lockPort });
+      lock = await acquireGatewayLock({ port: params.lockPort, onTelemetry: onLockTelemetry });
       return true;
     } catch (err) {
       gatewayLog.error(`failed to reacquire gateway lock for in-process restart: ${String(err)}`);

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -359,11 +359,10 @@ describe("gateway lock", () => {
     const results = await Promise.allSettled(
       Array.from({ length: contenders }, async (_value, idx) => {
         const lock = await acquireForTest(env, {
-          timeoutMs: 3_000,
+          timeoutMs: 6_000,
           pollIntervalMs: 1,
           staleMs: 10_000,
           platform: idx % 2 === 0 ? "darwin" : "linux",
-          port: idx % 2 === 0 ? 18789 : undefined,
         });
         expect(lock).not.toBeNull();
         await sleep(2);
@@ -375,6 +374,54 @@ describe("gateway lock", () => {
     expect(rejected).toHaveLength(0);
     const { lockPath } = resolveLockPath(env);
     await expect(fs.access(lockPath)).rejects.toThrow();
+  });
+
+  it("propagates stale lock removal errors during owner-dead recovery", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeLockFile(env, { startTime: 111 });
+    const procSpy = mockProcStatRead({
+      onProcRead: () => makeProcStat(process.pid, 222),
+    });
+    const rmSpy = vi
+      .spyOn(fs, "rm")
+      .mockRejectedValueOnce(Object.assign(new Error("EPERM"), { code: "EPERM" }));
+
+    await expect(
+      acquireForTest(env, {
+        timeoutMs: 80,
+        pollIntervalMs: 5,
+        platform: "linux",
+      }),
+    ).rejects.toMatchObject({
+      name: "GatewayLockError",
+      message: expect.stringContaining("stale-owner recovery"),
+    });
+
+    rmSpy.mockRestore();
+    procSpy.mockRestore();
+  });
+
+  it("surfaces lock-file removal failures during release", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const lock = await acquireForTest(env, { timeoutMs: 80 });
+    expect(lock).not.toBeNull();
+    if (!lock) {
+      throw new Error("expected lock handle");
+    }
+
+    const rmSpy = vi
+      .spyOn(fs, "rm")
+      .mockRejectedValueOnce(Object.assign(new Error("EROFS"), { code: "EROFS" }));
+    await expect(lock.release()).rejects.toMatchObject({
+      name: "GatewayLockError",
+      message: expect.stringContaining("release"),
+    });
+    rmSpy.mockRestore();
+
+    const { lockPath } = resolveLockPath(env);
+    await fs.rm(lockPath, { force: true });
   });
 
   it("returns null when multi-gateway override is enabled", async () => {

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -7,7 +7,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
-import { acquireGatewayLock, GatewayLockError, type GatewayLockOptions } from "./gateway-lock.js";
+import {
+  acquireGatewayLock,
+  GatewayLockError,
+  type GatewayLockOptions,
+  type GatewayLockTelemetryEvent,
+} from "./gateway-lock.js";
 
 let fixtureRoot = "";
 let fixtureCount = 0;
@@ -135,6 +140,10 @@ async function writeRecentLockFile(env: NodeJS.ProcessEnv, startTime = 111) {
     startTime,
     createdAt: new Date().toISOString(),
   });
+}
+
+async function sleep(ms: number) {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
 describe("gateway lock", () => {
@@ -268,6 +277,104 @@ describe("gateway lock", () => {
     } finally {
       connectSpy.mockRestore();
     }
+  });
+
+  it("emits stale recovery telemetry for macOS-style lock checks", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeRecentLockFile(env);
+    const connectSpy = createPortProbeConnectionSpy("refused");
+    const events: GatewayLockTelemetryEvent[] = [];
+    try {
+      const lock = await acquireForTest(env, {
+        timeoutMs: 80,
+        pollIntervalMs: 5,
+        staleMs: 10_000,
+        platform: "darwin",
+        port: 18789,
+        onTelemetry: (event) => events.push(event),
+      });
+      expect(lock).not.toBeNull();
+      await lock?.release();
+    } finally {
+      connectSpy.mockRestore();
+    }
+
+    expect(events.some((event) => event.event === "acquire-start")).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.event === "stale-lock-recovered" &&
+          event.reason === "owner-dead" &&
+          event.ownerStatus === "dead",
+      ),
+    ).toBe(true);
+    const success = events.find((event) => event.event === "acquire-success");
+    expect(success).toBeDefined();
+    if (success && success.event === "acquire-success") {
+      expect(success.staleRecoveries).toBeGreaterThan(0);
+    }
+  });
+
+  it("emits stale recovery telemetry for linux pid reuse checks", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const { lockPath, configPath } = resolveLockPath(env);
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify(createLockPayload({ configPath, startTime: 111 })),
+      "utf8",
+    );
+    const spy = mockProcStatRead({
+      onProcRead: () => makeProcStat(process.pid, 222),
+    });
+    const events: GatewayLockTelemetryEvent[] = [];
+    try {
+      const lock = await acquireForTest(env, {
+        timeoutMs: 80,
+        pollIntervalMs: 5,
+        platform: "linux",
+        onTelemetry: (event) => events.push(event),
+      });
+      expect(lock).not.toBeNull();
+      await lock?.release();
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(
+      events.some(
+        (event) =>
+          event.event === "stale-lock-recovered" &&
+          event.reason === "owner-dead" &&
+          event.ownerStatus === "dead",
+      ),
+    ).toBe(true);
+  });
+
+  it("serializes parallel startup storms without leaking lock files", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const contenders = 20;
+    const results = await Promise.allSettled(
+      Array.from({ length: contenders }, async (_value, idx) => {
+        const lock = await acquireForTest(env, {
+          timeoutMs: 3_000,
+          pollIntervalMs: 1,
+          staleMs: 10_000,
+          platform: idx % 2 === 0 ? "darwin" : "linux",
+          port: idx % 2 === 0 ? 18789 : undefined,
+        });
+        expect(lock).not.toBeNull();
+        await sleep(2);
+        await lock?.release();
+      }),
+    );
+
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(rejected).toHaveLength(0);
+    const { lockPath } = resolveLockPath(env);
+    await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
   it("returns null when multi-gateway override is enabled", async () => {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -278,12 +278,14 @@ async function isLockMtimeStale(
   }
 }
 
-async function tryRemoveLockFile(lockPath: string): Promise<boolean> {
+async function removeLockFile(lockPath: string, reason: string): Promise<void> {
   try {
     await fs.rm(lockPath, { force: true });
-    return true;
-  } catch {
-    return false;
+  } catch (err) {
+    throw new GatewayLockError(
+      `failed to remove gateway lock file (${reason}) at ${lockPath}`,
+      err,
+    );
   }
 }
 
@@ -349,7 +351,7 @@ export async function acquireGatewayLock(
         await handle.writeFile(JSON.stringify(payload), "utf8");
       } catch (writeErr) {
         await handle.close().catch(() => undefined);
-        await tryRemoveLockFile(lockPath);
+        await removeLockFile(lockPath, "cleanup after write failure").catch(() => undefined);
         throw new GatewayLockError(`failed to write gateway lock payload at ${lockPath}`, writeErr);
       }
       emitTelemetry({
@@ -365,7 +367,7 @@ export async function acquireGatewayLock(
         configPath,
         release: async () => {
           await handle.close().catch(() => undefined);
-          await tryRemoveLockFile(lockPath);
+          await removeLockFile(lockPath, "release");
         },
       };
     } catch (err) {
@@ -395,20 +397,19 @@ export async function acquireGatewayLock(
         contentionReported = true;
       }
       if (ownerStatus === "dead" && ownerPid) {
-        if (await tryRemoveLockFile(lockPath)) {
-          staleRecoveries += 1;
-          emitTelemetry({
-            event: "stale-lock-recovered",
-            lockPath,
-            ownerPid,
-            ownerStatus,
-            reason: "owner-dead",
-            waitedMs,
-            attempt: attempts,
-          });
-          contentionReported = false;
-          continue;
-        }
+        await removeLockFile(lockPath, "stale-owner recovery");
+        staleRecoveries += 1;
+        emitTelemetry({
+          event: "stale-lock-recovered",
+          lockPath,
+          ownerPid,
+          ownerStatus,
+          reason: "owner-dead",
+          waitedMs,
+          attempt: attempts,
+        });
+        contentionReported = false;
+        continue;
       }
       if (ownerStatus !== "alive") {
         const nowMs = Date.now();
@@ -416,7 +417,8 @@ export async function acquireGatewayLock(
         if (!stale) {
           stale = await isLockMtimeStale(lockPath, staleMs, nowMs);
         }
-        if (stale && (await tryRemoveLockFile(lockPath))) {
+        if (stale) {
+          await removeLockFile(lockPath, "stale-timestamp recovery");
           staleRecoveries += 1;
           emitTelemetry({
             event: "stale-lock-recovered",

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -32,6 +32,7 @@ export type GatewayLockOptions = {
   allowInTests?: boolean;
   platform?: NodeJS.Platform;
   port?: number;
+  onTelemetry?: (event: GatewayLockTelemetryEvent) => void;
 };
 
 export class GatewayLockError extends Error {
@@ -45,6 +46,55 @@ export class GatewayLockError extends Error {
 }
 
 type LockOwnerStatus = "alive" | "dead" | "unknown";
+
+export type GatewayLockTelemetryEvent =
+  | {
+      event: "acquire-skipped";
+      reason: "multi-gateway-override" | "test-env";
+    }
+  | {
+      event: "acquire-start";
+      lockPath: string;
+      configPath: string;
+      timeoutMs: number;
+      pollIntervalMs: number;
+      staleMs: number;
+      platform: NodeJS.Platform;
+      port?: number;
+    }
+  | {
+      event: "acquire-contention";
+      lockPath: string;
+      ownerPid?: number;
+      ownerStatus: LockOwnerStatus;
+      waitedMs: number;
+      attempt: number;
+    }
+  | {
+      event: "stale-lock-recovered";
+      lockPath: string;
+      ownerPid?: number;
+      ownerStatus: LockOwnerStatus;
+      reason: "owner-dead" | "stale-unknown-owner";
+      waitedMs: number;
+      attempt: number;
+    }
+  | {
+      event: "acquire-success";
+      lockPath: string;
+      configPath: string;
+      waitedMs: number;
+      attempts: number;
+      staleRecoveries: number;
+    }
+  | {
+      event: "acquire-timeout";
+      lockPath: string;
+      ownerPid?: number;
+      waitedMs: number;
+      timeoutMs: number;
+      attempts: number;
+    };
 
 function normalizeProcArg(arg: string): string {
   return arg.replaceAll("\\", "/").toLowerCase();
@@ -201,15 +251,60 @@ function resolveGatewayLockPath(env: NodeJS.ProcessEnv) {
   return { lockPath, configPath };
 }
 
+function isLockPayloadStale(payload: LockPayload | null, staleMs: number, nowMs: number): boolean {
+  const createdAt = payload?.createdAt;
+  if (!createdAt) {
+    return false;
+  }
+  const createdAtMs = Date.parse(createdAt);
+  if (!Number.isFinite(createdAtMs)) {
+    return false;
+  }
+  return nowMs - createdAtMs > staleMs;
+}
+
+async function isLockMtimeStale(
+  lockPath: string,
+  staleMs: number,
+  nowMs: number,
+): Promise<boolean> {
+  try {
+    const st = await fs.stat(lockPath);
+    return nowMs - st.mtimeMs > staleMs;
+  } catch {
+    // On Windows or locked filesystems we may be unable to stat the lock file
+    // even when another gateway owns it. Prefer waiting over force-removal.
+    return false;
+  }
+}
+
+async function tryRemoveLockFile(lockPath: string): Promise<boolean> {
+  try {
+    await fs.rm(lockPath, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function acquireGatewayLock(
   opts: GatewayLockOptions = {},
 ): Promise<GatewayLockHandle | null> {
+  const emitTelemetry = (event: GatewayLockTelemetryEvent) => {
+    try {
+      opts.onTelemetry?.(event);
+    } catch {
+      // Best-effort telemetry only; lock behavior must remain unaffected.
+    }
+  };
   const env = opts.env ?? process.env;
   const allowInTests = opts.allowInTests === true;
-  if (
-    env.OPENCLAW_ALLOW_MULTI_GATEWAY === "1" ||
-    (!allowInTests && (env.VITEST || env.NODE_ENV === "test"))
-  ) {
+  if (env.OPENCLAW_ALLOW_MULTI_GATEWAY === "1") {
+    emitTelemetry({ event: "acquire-skipped", reason: "multi-gateway-override" });
+    return null;
+  }
+  if (!allowInTests && (env.VITEST || env.NODE_ENV === "test")) {
+    emitTelemetry({ event: "acquire-skipped", reason: "test-env" });
     return null;
   }
 
@@ -220,11 +315,25 @@ export async function acquireGatewayLock(
   const port = opts.port;
   const { lockPath, configPath } = resolveGatewayLockPath(env);
   await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  emitTelemetry({
+    event: "acquire-start",
+    lockPath,
+    configPath,
+    timeoutMs,
+    pollIntervalMs,
+    staleMs,
+    platform,
+    port,
+  });
 
   const startedAt = Date.now();
   let lastPayload: LockPayload | null = null;
+  let attempts = 0;
+  let staleRecoveries = 0;
+  let contentionReported = false;
 
   while (Date.now() - startedAt < timeoutMs) {
+    attempts += 1;
     try {
       const handle = await fs.open(lockPath, "wx");
       const startTime = platform === "linux" ? readLinuxStartTime(process.pid) : null;
@@ -236,50 +345,89 @@ export async function acquireGatewayLock(
       if (typeof startTime === "number" && Number.isFinite(startTime)) {
         payload.startTime = startTime;
       }
-      await handle.writeFile(JSON.stringify(payload), "utf8");
+      try {
+        await handle.writeFile(JSON.stringify(payload), "utf8");
+      } catch (writeErr) {
+        await handle.close().catch(() => undefined);
+        await tryRemoveLockFile(lockPath);
+        throw new GatewayLockError(`failed to write gateway lock payload at ${lockPath}`, writeErr);
+      }
+      emitTelemetry({
+        event: "acquire-success",
+        lockPath,
+        configPath,
+        waitedMs: Date.now() - startedAt,
+        attempts,
+        staleRecoveries,
+      });
       return {
         lockPath,
         configPath,
         release: async () => {
           await handle.close().catch(() => undefined);
-          await fs.rm(lockPath, { force: true });
+          await tryRemoveLockFile(lockPath);
         },
       };
     } catch (err) {
+      if (err instanceof GatewayLockError) {
+        throw err;
+      }
       const code = (err as { code?: unknown }).code;
       if (code !== "EEXIST") {
         throw new GatewayLockError(`failed to acquire gateway lock at ${lockPath}`, err);
       }
 
       lastPayload = await readLockPayload(lockPath);
-      const ownerPid = lastPayload?.pid;
+      const ownerPid = typeof lastPayload?.pid === "number" ? lastPayload.pid : undefined;
       const ownerStatus = ownerPid
         ? await resolveGatewayOwnerStatus(ownerPid, lastPayload, platform, port)
         : "unknown";
+      const waitedMs = Date.now() - startedAt;
+      if (!contentionReported) {
+        emitTelemetry({
+          event: "acquire-contention",
+          lockPath,
+          ownerPid,
+          ownerStatus,
+          waitedMs,
+          attempt: attempts,
+        });
+        contentionReported = true;
+      }
       if (ownerStatus === "dead" && ownerPid) {
-        await fs.rm(lockPath, { force: true });
-        continue;
+        if (await tryRemoveLockFile(lockPath)) {
+          staleRecoveries += 1;
+          emitTelemetry({
+            event: "stale-lock-recovered",
+            lockPath,
+            ownerPid,
+            ownerStatus,
+            reason: "owner-dead",
+            waitedMs,
+            attempt: attempts,
+          });
+          contentionReported = false;
+          continue;
+        }
       }
       if (ownerStatus !== "alive") {
-        let stale = false;
-        if (lastPayload?.createdAt) {
-          const createdAt = Date.parse(lastPayload.createdAt);
-          stale = Number.isFinite(createdAt) ? Date.now() - createdAt > staleMs : false;
-        }
+        const nowMs = Date.now();
+        let stale = isLockPayloadStale(lastPayload, staleMs, nowMs);
         if (!stale) {
-          try {
-            const st = await fs.stat(lockPath);
-            stale = Date.now() - st.mtimeMs > staleMs;
-          } catch {
-            // On Windows or locked filesystems we may be unable to stat the
-            // lock file even though the existing gateway is still healthy.
-            // Treat the lock as non-stale so we keep waiting instead of
-            // forcefully removing another gateway's lock.
-            stale = false;
-          }
+          stale = await isLockMtimeStale(lockPath, staleMs, nowMs);
         }
-        if (stale) {
-          await fs.rm(lockPath, { force: true });
+        if (stale && (await tryRemoveLockFile(lockPath))) {
+          staleRecoveries += 1;
+          emitTelemetry({
+            event: "stale-lock-recovered",
+            lockPath,
+            ownerPid,
+            ownerStatus,
+            reason: "stale-unknown-owner",
+            waitedMs,
+            attempt: attempts,
+          });
+          contentionReported = false;
           continue;
         }
       }
@@ -288,6 +436,14 @@ export async function acquireGatewayLock(
     }
   }
 
-  const owner = lastPayload?.pid ? ` (pid ${lastPayload.pid})` : "";
+  emitTelemetry({
+    event: "acquire-timeout",
+    lockPath,
+    ownerPid: typeof lastPayload?.pid === "number" ? lastPayload.pid : undefined,
+    waitedMs: Date.now() - startedAt,
+    timeoutMs,
+    attempts,
+  });
+  const owner = typeof lastPayload?.pid === "number" ? ` (pid ${lastPayload.pid})` : "";
   throw new GatewayLockError(`gateway already running${owner}; lock timeout after ${timeoutMs}ms`);
 }


### PR DESCRIPTION
## Summary

- Problem: gateway singleton lock behavior under contention had limited startup observability and weaker stale-lock recovery signaling, making startup storms and stale-lock incidents harder to triage.
- Why it matters: parallel starts/restarts can happen in real use (daemon restarts, local relaunches, CI/e2e), and lock ambiguity increases false "already running" failures and operator confusion.
- What changed:
  - Added structured gateway lock telemetry events for acquire start/contention/stale recovery/success/timeout.
  - Hardened stale-lock recovery and lock lifecycle cleanup paths in `acquireGatewayLock`.
  - Wired explicit startup telemetry logs into gateway run-loop lock acquisition/reacquisition paths.
  - Added regression tests for macOS/Linux stale recovery paths and parallel startup storms.
  - Added `AGENTS.local.md` to `.gitignore` so local guardrails are never staged.
- What did NOT change (scope boundary):
  - No auth model or gateway network bind behavior changes.
  - No config schema/user-facing flags added.
  - No channel/business-logic routing changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

- Gateway startup now logs explicit singleton-lock lifecycle telemetry (acquire/wait/recovered/acquired/timeout).
- Under stale-lock conditions, lock recovery behavior is more deterministic and diagnosable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`) (existing localhost port probe behavior only)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (authoring), Linux lock paths covered in tests.
- Runtime/container: Node 22 + pnpm.
- Model/provider: N/A.
- Integration/channel (if any): Gateway core lock path.
- Relevant config (redacted): default local config path hashing + lock dir behavior.

### Steps

1. `pnpm format:check -- .gitignore src/infra/gateway-lock.ts src/infra/gateway-lock.test.ts src/cli/gateway-cli/run-loop.ts src/cli/gateway-cli/run-loop.test.ts`
2. `pnpm test -- src/infra/gateway-lock.test.ts src/cli/gateway-cli/run-loop.test.ts`
3. `pnpm build`

### Expected

- New telemetry tests pass.
- Parallel startup storm regression passes.
- Gateway lock + run-loop changes build and tests are green.

### Actual

- Format check passed for touched files.
- Targeted tests passed (`21/21`).
- Build passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence included via new/updated tests:
- `src/infra/gateway-lock.test.ts`
- `src/cli/gateway-cli/run-loop.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - lock telemetry flow (start -> contention -> stale recovery -> success)
  - lock reacquire path during restart in run-loop
  - stale lock handling on darwin-style and linux-style paths
  - parallel startup storm serialization and lock cleanup
- Edge cases checked:
  - malformed/unknown owner + stale timeout reclaim
  - owner dead reclaim path
  - startup timeout telemetry emission path
- What you did **not** verify:
  - full end-to-end multi-process gateway startup under external daemon orchestration beyond unit-level coverage.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commits `3c4533239` and `4525a5a23`
- Files/config to restore:
  - `.gitignore`
  - `src/infra/gateway-lock.ts`
  - `src/infra/gateway-lock.test.ts`
  - `src/cli/gateway-cli/run-loop.ts`
  - `src/cli/gateway-cli/run-loop.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected lock timeout spam during normal single-instance startup
  - lock telemetry logs appearing without corresponding contention

## Risks and Mitigations

- Risk:
  - False stale-lock reclaim in edge environments with unusual FS/stat behavior.
  - Mitigation:
    - Conservative stat fallback; reclaim only on explicit stale/dead signals; added regression coverage.
- Risk:
  - Increased startup log volume from telemetry.
  - Mitigation:
    - Concise single-line events emitted only on lock lifecycle transitions.

---
AI-assisted: Yes (Codex). Author reviewed resulting code and behavior.
Testing level: Fully tested for touched units + build.
