### PR TITLE
Feishu: pass agent-scoped media local roots on outbound uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -770,8 +770,6 @@ Docs: https://docs.openclaw.ai
 
 - Security: strip hidden text from `web_fetch` extracted content to prevent indirect prompt injection, covering CSS-hidden elements, class-based hiding (sr-only, d-none, etc.), invisible Unicode, color:transparent, offscreen transforms, and non-content tags. (#8027, #21074) Thanks @hydro13 for the fix and @LucasAIBuilder for reporting.
 - Channels/Feishu: pass agent-scoped media local roots through outbound uploads so files from per-agent workspaces upload instead of falling back to plain path links.
-- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
-- Android/Security: exclude `openclaw/identity` from Android cloud backup/device-transfer rules so device private identity material is not exported.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -769,6 +769,9 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security: strip hidden text from `web_fetch` extracted content to prevent indirect prompt injection, covering CSS-hidden elements, class-based hiding (sr-only, d-none, etc.), invisible Unicode, color:transparent, offscreen transforms, and non-content tags. (#8027, #21074) Thanks @hydro13 for the fix and @LucasAIBuilder for reporting.
+- Channels/Feishu: pass agent-scoped media local roots through outbound uploads so files from per-agent workspaces upload instead of falling back to plain path links.
+- Android/Security: require TLS for non-loopback gateway connections, block manual non-loopback plaintext attempts with a clear status error, and keep plaintext WS limited to loopback-only development flows.
+- Android/Security: exclude `openclaw/identity` from Android cloud backup/device-transfer rules so device private identity material is not exported.
 - Agents/Streaming: keep assistant partial streaming active during reasoning streams, handle native `thinking_*` stream events consistently, dedupe mixed reasoning-end signals, and clear stale mutating tool errors after same-target retry success. (#20635) Thanks @obviyus.
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -209,6 +209,26 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).not.toHaveBeenCalled();
   });
 
+  it("forwards explicit localRoots when loading local media URLs", async () => {
+    const localRoots = ["/tmp/workspace-clawdy"];
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaUrl: "/tmp/workspace-clawdy/tmp/render.opus",
+      localRoots,
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "/tmp/workspace-clawdy/tmp/render.opus",
+      expect.objectContaining({
+        maxBytes: 30 * 1024 * 1024,
+        optimizeImages: false,
+        localRoots,
+      }),
+    );
+  });
+
   it("uses isolated temp paths for image downloads", async () => {
     const imageKey = "img_v3_01abc123";
     let capturedPath: string | undefined;

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -383,11 +383,13 @@ export async function sendMediaFeishu(params: {
   to: string;
   mediaUrl?: string;
   mediaBuffer?: Buffer;
+  localRoots?: readonly string[];
   fileName?: string;
   replyToMessageId?: string;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, mediaUrl, mediaBuffer, fileName, replyToMessageId, accountId } = params;
+  const { cfg, to, mediaUrl, mediaBuffer, localRoots, fileName, replyToMessageId, accountId } =
+    params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -404,6 +406,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
+      localRoots,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
+const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./media.js", () => ({
+  sendMediaFeishu: sendMediaFeishuMock,
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageFeishu: sendMessageFeishuMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      text: {
+        chunkMarkdownText: vi.fn((text: string) => [text]),
+      },
+    },
+  }),
+}));
+
+import { feishuOutbound } from "./outbound.js";
+
+describe("feishuOutbound", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "msg_1", chatId: "chat_1" });
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "msg_text", chatId: "chat_1" });
+  });
+
+  it("forwards mediaLocalRoots to sendMediaFeishu", async () => {
+    const mediaLocalRoots = ["/tmp/workspace-clawdy"];
+
+    await feishuOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "",
+      mediaUrl: "/tmp/workspace-clawdy/tmp/render.bin",
+      mediaLocalRoots,
+    });
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace-clawdy/tmp/render.bin",
+        localRoots: mediaLocalRoots,
+      }),
+    );
+  });
+
+  it("falls back to a link when media upload fails", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("blocked"));
+
+    await feishuOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "",
+      mediaUrl: "/tmp/workspace-clawdy/tmp/render.bin",
+      mediaLocalRoots: ["/tmp/workspace-clawdy"],
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "📎 /tmp/workspace-clawdy/tmp/render.bin",
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -12,7 +12,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
+  sendMedia: async ({ cfg, to, text, mediaUrl, mediaLocalRoots, accountId }) => {
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -25,6 +25,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           cfg,
           to,
           mediaUrl,
+          localRoots: mediaLocalRoots,
           accountId: accountId ?? undefined,
         });
         return { channel: "feishu", ...result };


### PR DESCRIPTION
## Summary

- Problem: Feishu outbound media sends dropped core-provided `mediaLocalRoots`, so files under per-agent `workspace-*` roots were rejected by the local media allowlist.
- Why it matters: Feishu fell back to posting a plain `📎 /path/to/file` message instead of uploading the media.
- What changed: forwarded `mediaLocalRoots` through the Feishu outbound adapter into `sendMediaFeishu`, and passed them into `loadWebMedia`; added regression tests at the helper and adapter boundaries.
- What did NOT change (scope boundary): SSRF/local-path policy, Feishu upload behavior for remote URLs, and the fallback-to-link path for genuinely blocked uploads.
- Disclosure: AI-assisted (per `CONTRIBUTING.md`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28802
- Related #28802

## User-visible / Behavior Changes

- Feishu outbound media uploads now honor agent-scoped workspace local roots, so files generated inside per-agent `workspace-*` directories upload instead of degrading to a plain path link.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation:
  This only restores the existing core-scoped media roots that were already computed for the active agent. The Feishu adapter now passes those roots through instead of dropping them, and the scope remains bounded by `getAgentScopedMediaLocalRoots` plus the existing local media allowlist.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): Feishu
- Relevant config (redacted): local file under `$OPENCLAW_STATE_DIR/workspace-clawdy/tmp/render.bin`

### Steps

1. Create a real file under a per-agent workspace path such as `$OPENCLAW_STATE_DIR/workspace-clawdy/tmp/render.bin`.
2. Deliver that file through the Feishu outbound path with agent-scoped `mediaLocalRoots` present in core delivery.
3. Observe whether Feishu uploads the file or falls back to a `📎 /path` text message.

### Expected

- Feishu uploads the file because the active agent workspace is already an allowed local media root.

### Actual

- Before this patch, Feishu dropped `mediaLocalRoots`, `loadWebMedia` raised `LocalMediaAccessError(code="path-not-allowed")`, and the adapter fell back to a plain link.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the failure with a real temp file under `workspace-clawdy`, confirmed `loadWebMedia(..., { localRoots })` succeeds while the pre-fix Feishu path failed, and verified the patched adapter/helper behavior with targeted Vitest coverage.
- Edge cases checked: remote-url failure fallback still works; direct helper calls without `localRoots` still fail closed for disallowed local paths.
- What you did **not** verify: live Feishu API delivery against a real tenant.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `extensions/feishu/src/outbound.ts` and `extensions/feishu/src/media.ts`.
- Known bad symptoms reviewers should watch for: unexpected local file access outside the computed agent-scoped roots.

## Risks and Mitigations

- Risk: Feishu could gain access to broader local paths if the wrong roots were threaded through.
  Mitigation: the adapter now forwards only the existing core-provided `mediaLocalRoots`, and regression tests cover both helper-level and adapter-level plumbing.
