### PR TITLE
fix(voice-call): play inbound greeting for Twilio answered calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice-call/Twilio inbound greeting: run answered-call initial notify greeting for Twilio instead of skipping the manager speak path, with regression coverage for both Twilio and Plivo notify flows. (#29121) Thanks @xinhuagu.
 - Feishu/topic session routing: use `thread_id` as topic session scope fallback when `root_id` is absent, keep first-turn topic keys stable across thread creation, and force thread replies when inbound events already carry topic/thread context. (#29788) Thanks @songyaolun.
 - Feishu/topic root replies: prefer `root_id` as outbound `replyTargetMessageId` when present, and parse millisecond `message_create_time` values correctly so topic replies anchor to the root message in grouped thread flows. (#29968) Thanks @bmendonca3.
 - Feishu/DM pairing reply target: send pairing challenge replies to `chat:<chat_id>` instead of `user:<sender_open_id>` so Lark/Feishu private chats with user-id-only sender payloads receive pairing messages reliably. (#31403) Thanks @stakeswky.

--- a/extensions/voice-call/src/manager.test.ts
+++ b/extensions/voice-call/src/manager.test.ts
@@ -111,28 +111,31 @@ describe("CallManager", () => {
     expect(manager.getCallByProviderCallId("request-uuid")).toBeUndefined();
   });
 
-  it("speaks initial message on answered for notify mode (non-Twilio)", async () => {
-    const { manager, provider } = createManagerHarness();
+  it.each(["plivo", "twilio"] as const)(
+    "speaks initial message on answered for notify mode (%s)",
+    async (providerName) => {
+      const { manager, provider } = createManagerHarness({}, new FakeProvider(providerName));
 
-    const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
-      message: "Hello there",
-      mode: "notify",
-    });
-    expect(success).toBe(true);
+      const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
+        message: "Hello there",
+        mode: "notify",
+      });
+      expect(success).toBe(true);
 
-    manager.processEvent({
-      id: "evt-2",
-      type: "call.answered",
-      callId,
-      providerCallId: "call-uuid",
-      timestamp: Date.now(),
-    });
+      manager.processEvent({
+        id: `evt-2-${providerName}`,
+        type: "call.answered",
+        callId,
+        providerCallId: "call-uuid",
+        timestamp: Date.now(),
+      });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(provider.playTtsCalls).toHaveLength(1);
-    expect(provider.playTtsCalls[0]?.text).toBe("Hello there");
-  });
+      expect(provider.playTtsCalls).toHaveLength(1);
+      expect(provider.playTtsCalls[0]?.text).toBe("Hello there");
+    },
+  );
 
   it("rejects inbound calls with missing caller ID when allowlist enabled", () => {
     const { manager, provider } = createManagerHarness({

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -166,12 +166,6 @@ export class CallManager {
       return;
     }
 
-    // Twilio has provider-specific state for speaking (<Say> fallback) and can
-    // fail for inbound calls; keep existing Twilio behavior unchanged.
-    if (this.provider.name === "twilio") {
-      return;
-    }
-
     void this.speakInitialMessage(call.providerCallId);
   }
 


### PR DESCRIPTION
## Summary
- remove the Twilio early-return in `CallManager.maybeSpeakInitialMessageOnAnswered`
- let Twilio follow the same initial-message path as other providers when calls are answered
- expand manager tests to assert notify-mode initial greeting is spoken for both Plivo and Twilio

## Why
Inbound Twilio calls were creating `metadata.initialMessage` but never speaking it, because answered-call handling explicitly skipped Twilio.

Fixes #29101

## Testing
- `pnpm -C openclaw-repo test extensions/voice-call/src/manager.test.ts`