### PR TITLE
test: fix pi extra params responses model typing in regression test

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -870,7 +870,13 @@ describe("applyExtraParamsToAgent", () => {
         api: "openai-responses",
         provider: "azure-openai-responses",
         id: "gpt-4o",
+        name: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 16_384,
         compat: { supportsStore: false },
       } as Model<"openai-responses">,
     });


### PR DESCRIPTION
## Summary
- fix TS2352 in `src/agents/pi-embedded-runner-extraparams.test.ts` for the `supportsStore=false` regression test
- keep this change test-only and scoped to typing compatibility with `Model<"openai-responses">`

## Why
The CI `check` job currently fails in `pnpm tsgo` because that test case casts an object literal that no longer overlaps enough with the newer `Model<"openai-responses">` type shape.

## Validation
- pnpm format:check
- pnpm tsgo
- pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts
