### PR TITLE
fix: warn and hint when fallback model normalizes to same key as primary

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -145,7 +145,7 @@ function throwFallbackFailureSummary(params: {
     // did not occur.
     if ((params.deduplicatedCount ?? 0) > 0 && params.lastError instanceof Error) {
       const hint =
-        ` (${params.deduplicatedCount} configured fallback(s) normalized to the same model and were skipped` +
+        ` (${params.deduplicatedCount} configured fallback${params.deduplicatedCount === 1 ? "" : "s"} normalized to the same model and ${params.deduplicatedCount === 1 ? "was" : "were"} skipped` +
         ` — configure a fallback with a different model to enable failover)`;
       const wrapped = new Error(params.lastError.message + hint, {
         cause: params.lastError,


### PR DESCRIPTION
## Problem

When configuring `openai-codex/gpt-5.3-codex` as primary and `openai/gpt-5.3-codex` as fallback, failover silently fails. The user gets a `FailoverError` with no indication that their fallback was never attempted.

**Affected:** Any user configuring cross-provider fallback where primary and fallback share the same model slug but different providers that normalize to the same provider (e.g. `openai` → `openai-codex` for codex models).

Fixes #29007

## Root Cause

`normalizeModelRef()` in `model-selection.ts` correctly coerces `openai/gpt-5.3-codex` → `openai-codex/gpt-5.3-codex` (codex models require the OAuth endpoint). However, in `resolveFallbackCandidates()`, the deduplication logic in `createModelCandidateCollector` uses the **normalized** model key for dedup. Both primary and fallback normalize to `openai-codex/gpt-5.3-codex`, so the fallback is silently dropped.

The user ends up with a single candidate. When it fails (rate limit), the error is thrown directly with no fallback attempted and no explanation of why.

**File:** `src/agents/model-fallback.ts`, lines 66-106 (collector) and 249-300 (candidate resolution)

## Fix

Two-layer improvement:

1. **Detection:** `createModelCandidateCollector` now tracks when a fallback candidate is deduplicated because provider normalization collapsed it into an existing candidate (comparing pre-normalization provider vs post-normalization provider).

2. **User feedback:**
   - **Log warning** via subsystem logger when deduplication happens, explaining what was normalized and suggesting to use a different model.
   - **Error hint** appended to the `FailoverError` message when the single remaining candidate fails: `"(1 configured fallback(s) normalized to the same model and were skipped — configure a fallback with a different model to enable failover)"`.

This approach is minimal and non-breaking: no behavior changes for valid configurations, only better diagnostics for misconfigured ones.

## Testing

2 new tests added to `src/agents/model-fallback.test.ts`:

- `includes deduplication hint when fallback normalizes to same key as primary (#29007)` — verifies the error message includes the diagnostic hint when `openai/gpt-5.3-codex` fallback is deduplicated against `openai-codex/gpt-5.3-codex` primary
- `does not show deduplication hint when fallback resolves to a different model` — verifies normal fallback (e.g. `openai/gpt-5.2`) works correctly without false warnings

All 45 tests in `model-fallback.test.ts` pass. All 31 tests in `model-selection.test.ts` pass. All 13 tests in `failover-error.test.ts` pass.

@greptile-apps