### PR TITLE
Fix gateway auth: accept MOLTBOT_* legacy env vars

### DIFF
--- a/src/gateway/auth.env-alias.test.ts
+++ b/src/gateway/auth.env-alias.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { resolveGatewayAuth } from "./auth.js";
+
+function withEnv<T>(patch: Record<string, string | undefined>, fn: () => T): T {
+  const prev: Record<string, string | undefined> = {};
+  for (const key of Object.keys(patch)) prev[key] = process.env[key];
+  try {
+    for (const [key, value] of Object.entries(patch)) {
+      if (typeof value === "string") process.env[key] = value;
+      else delete process.env[key];
+    }
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(prev)) {
+      if (typeof value === "string") process.env[key] = value;
+      else delete process.env[key];
+    }
+  }
+}
+
+describe("resolveGatewayAuth env aliases", () => {
+  it("accepts MOLTBOT_GATEWAY_TOKEN as legacy alias", () => {
+    const auth = withEnv(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        CLAWDBOT_GATEWAY_TOKEN: undefined,
+        MOLTBOT_GATEWAY_TOKEN: "moltworker-secret",
+      },
+      () => resolveGatewayAuth({ authConfig: { mode: "token" } }),
+    );
+
+    expect(auth.mode).toBe("token");
+    expect(auth.token).toBe("moltworker-secret");
+  });
+
+  it("prefers OPENCLAW_GATEWAY_TOKEN over legacy aliases", () => {
+    const auth = withEnv(
+      {
+        OPENCLAW_GATEWAY_TOKEN: "openclaw-secret",
+        MOLTBOT_GATEWAY_TOKEN: "moltworker-secret",
+        CLAWDBOT_GATEWAY_TOKEN: "clawdbot-secret",
+      },
+      () => resolveGatewayAuth({ authConfig: { mode: "token" } }),
+    );
+
+    expect(auth.token).toBe("openclaw-secret");
+  });
+});

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -247,7 +247,8 @@ export function resolveGatewayAuth(params: {
     configToken: authConfig.token,
     configPassword: authConfig.password,
     env,
-    includeLegacyEnv: false,
+    // Support legacy env vars used by older deploy scripts (moltbot/clawdbot)
+    includeLegacyEnv: true,
     tokenPrecedence: "config-first",
     passwordPrecedence: "config-first",
   });
@@ -273,7 +274,6 @@ export function resolveGatewayAuth(params: {
     mode = "token";
     modeSource = "default";
   }
-
   const allowTailscale =
     authConfig.allowTailscale ??
     (params.tailscaleMode === "serve" && mode !== "password" && mode !== "trusted-proxy");

--- a/src/gateway/credentials.ts
+++ b/src/gateway/credentials.ts
@@ -43,7 +43,10 @@ function readGatewayTokenEnv(
   if (!includeLegacyEnv) {
     return undefined;
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
+  return firstDefined([
+    trimToUndefined(env.MOLTBOT_GATEWAY_TOKEN),
+    trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN),
+  ]);
 }
 
 function readGatewayPasswordEnv(
@@ -57,7 +60,10 @@ function readGatewayPasswordEnv(
   if (!includeLegacyEnv) {
     return undefined;
   }
-  return trimToUndefined(env.CLAWDBOT_GATEWAY_PASSWORD);
+  return firstDefined([
+    trimToUndefined(env.MOLTBOT_GATEWAY_PASSWORD),
+    trimToUndefined(env.CLAWDBOT_GATEWAY_PASSWORD),
+  ]);
 }
 
 export function resolveGatewayCredentialsFromValues(params: {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -281,8 +281,16 @@ export async function runOnboardingWizard(
   const localUrl = `ws://127.0.0.1:${localPort}`;
   const localProbe = await onboardHelpers.probeGatewayReachable({
     url: localUrl,
-    token: baseConfig.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN,
-    password: baseConfig.gateway?.auth?.password ?? process.env.OPENCLAW_GATEWAY_PASSWORD,
+    token:
+      baseConfig.gateway?.auth?.token ??
+      process.env.OPENCLAW_GATEWAY_TOKEN ??
+      process.env.MOLTBOT_GATEWAY_TOKEN ??
+      process.env.CLAWDBOT_GATEWAY_TOKEN,
+    password:
+      baseConfig.gateway?.auth?.password ??
+      process.env.OPENCLAW_GATEWAY_PASSWORD ??
+      process.env.MOLTBOT_GATEWAY_PASSWORD ??
+      process.env.CLAWDBOT_GATEWAY_PASSWORD,
   });
   const remoteUrl = baseConfig.gateway?.remote?.url?.trim() ?? "";
   const remoteProbe = remoteUrl


### PR DESCRIPTION
Fixes Cloudflare moltworker/moltbot deployments where the runtime provides MOLTBOT_GATEWAY_TOKEN (and/or MOLTBOT_GATEWAY_PASSWORD) instead of OPENCLAW_GATEWAY_TOKEN.\n\nChanges:\n- gateway server auth resolver accepts MOLTBOT_* as legacy aliases\n- callGateway client token/password resolution accepts MOLTBOT_*\n- onboarding wizard probe accepts MOLTBOT_* so it doesn’t auto-generate a mismatched token\n- added unit test for alias behavior\n\nTask: task-1772213896912-y42guwxa7