### PR TITLE
fix(cli): respect OPENCLAW_HIDE_BANNER in route-first path

### DIFF
--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -12,7 +12,9 @@ async function prepareRoutedCommand(params: {
   commandPath: string[];
   loadPlugins?: boolean;
 }) {
-  emitCliBanner(VERSION, { argv: params.argv });
+  if (!isTruthyEnvValue(process.env.OPENCLAW_HIDE_BANNER)) {
+    emitCliBanner(VERSION, { argv: params.argv });
+  }
   await ensureConfigReady({ runtime: defaultRuntime, commandPath: params.commandPath });
   if (params.loadPlugins) {
     ensurePluginRegistryLoaded();


### PR DESCRIPTION
## Summary                                                                                                                                      
                                                            
  - **Problem:** `OPENCLAW_HIDE_BANNER=1` does not suppress the CLI banner for commands routed via the route-first fast path (`src/cli/route.ts`).
   Only commands falling through to the Commander preAction hook (`src/cli/program/preaction.ts`) respect the env var.                            
  - **Why it matters:** Users who set `OPENCLAW_HIDE_BANNER=1` expect the banner to be hidden for all commands. The current workaround requires also setting `OPENCLAW_DISABLE_ROUTE_FIRST=1`, which disables an unrelated optimization.
  - **What changed:** Added the same `isTruthyEnvValue(process.env.OPENCLAW_HIDE_BANNER)` guard in `prepareRoutedCommand()` before calling `emitCliBanner()`.
  - **What did NOT change:** No changes to the preAction hook, banner formatting, tagline selection, or any other CLI behavior.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes # N/A
  - Related # N/A

  ## User-visible / Behavior Changes

  - `OPENCLAW_HIDE_BANNER=1` now suppresses the banner for all commands, including those handled by the route-first path. Previously only commands routed through the Commander preAction hook were affected.

  ## Security Impact (required)

  - New permissions/capabilities? `No`
  - Secrets/tokens handling changed? `No`
  - New/changed network calls? `No`
  - Command/tool execution surface changed? `No`
  - Data access scope changed? `No`

  ## Repro + Verification

  ### Environment

  - OS: Linux 6.18.9-arch1-2 (x64)
  - Runtime/container: Node 25.6.1
  - Model/provider: N/A
  - Integration/channel: N/A
  - Relevant config: `OPENCLAW_HIDE_BANNER=1`

  ### Steps

  1. `export OPENCLAW_HIDE_BANNER=1`
  2. `openclaw status`

  ### Expected

  - No banner/tagline in output.

  ### Actual (before fix)

  - Banner and random tagline still displayed.

  ## Evidence

  - [ ] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - **Verified scenarios:** Ran `openclaw status` with `OPENCLAW_HIDE_BANNER=1` before and after the fix. Banner appeared before, suppressed after.
  - **Edge cases checked:** Confirmed banner still shows when env var is unset. Confirmed `--help` path is unaffected (separate issue).
  - **What you did not verify:** Did not run the full test suite. Did not verify against a built/packaged release.

  ## Compatibility / Migration

  - Backward compatible? `Yes`
  - Config/env changes? `No`
  - Migration needed? `No`

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert the single commit or unset `OPENCLAW_HIDE_BANNER`.
  - Files/config to restore: `src/cli/route.ts`
  - Known bad symptoms reviewers should watch for: Banner not appearing when it should (i.e., when `OPENCLAW_HIDE_BANNER` is not set).

  ## Risks and Mitigations

  None.