### PR TITLE
fix(cron): enable completion direct send for text-only announce delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -70,12 +70,17 @@ function buildCompletionDeliveryMessage(params: {
   subagentName: string;
   spawnMode?: SpawnSubagentMode;
   outcome?: SubagentRunOutcome;
+  announceType?: SubagentAnnounceType;
 }): string {
   const findingsText = params.findings.trim();
   if (isAnnounceSkip(findingsText)) {
     return "";
   }
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
+  // Cron completions are standalone messages — skip the subagent status header.
+  if (params.announceType === "cron job") {
+    return hasFindings ? findingsText : "";
+  }
   const header = (() => {
     if (params.outcome?.status === "error") {
       return params.spawnMode === "session"
@@ -1278,6 +1283,7 @@ export async function runSubagentAnnounceFlow(params: {
       subagentName,
       spawnMode: params.spawnMode,
       outcome,
+      announceType,
     });
     const internalSummaryMessage = [
       `[System Message] [sessionId: ${announceSessionId}] A ${announceType} "${taskLabel}" just ${statusLabel}.`,

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -1,5 +1,5 @@
 import "./isolated-agent.mocks.js";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
 import {
   createCliDeps,
@@ -56,6 +56,10 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
 
       expect(res.status).toBe("ok");
       expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      const announceArgs = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as
+        | { expectsCompletionMessage?: boolean }
+        | undefined;
+      expect(announceArgs?.expectsCompletionMessage).toBe(true);
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
   });

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -89,6 +89,9 @@ async function expectExplicitTelegramTargetAnnounce(params: {
     expect(announceArgs?.requesterOrigin?.to).toBe("123");
     expect(announceArgs?.roundOneReply).toBe(params.expectedText);
     expect(announceArgs?.bestEffortDeliver).toBe(false);
+    expect((announceArgs as { expectsCompletionMessage?: boolean })?.expectsCompletionMessage).toBe(
+      true,
+    );
     expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
   });
 }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -309,6 +309,10 @@ export async function dispatchCronDelivery(
         timeoutMs: params.timeoutMs,
         cleanup: params.job.deleteAfterRun ? "delete" : "keep",
         roundOneReply: synthesizedText,
+        // Cron output is a finished completion message: send it directly to the
+        // target channel via the completion-direct-send path rather than injecting
+        // a trigger message into the (likely idle) main agent session.
+        expectsCompletionMessage: true,
         // Keep delivery outcome truthful for cron state: if outbound send fails,
         // announce flow must report false so caller can apply best-effort policy.
         bestEffortDeliver: false,


### PR DESCRIPTION
## Summary

Fix text-only cron announce delivery silently dropping messages.

When a cron job fires and the agent responds with plain text, the output is routed through the announce flow but never reaches the user. The root cause: cron's call to `runSubagentAnnounceFlow` doesn't set `expectsCompletionMessage`, so it defaults to `false`. This gates out the completion direct send path in `sendSubagentAnnounceDirectly`, causing the flow to fall through to the trigger/agent injection path — which injects an internal system message into an idle main agent session where it's silently consumed.

The fix is to set `expectsCompletionMessage: true` on the cron announce call, matching what spawned subagents already do (via `subagent-spawn.ts` line 192). This enables:
- Direct-first dispatch strategy (instead of queue-first, which fails when the main agent is idle)
- The completion direct send path, which delivers the user-facing message via `callGateway({ method: "send" })` to the target channel

Also strips the "✅ Subagent main finished" status header from cron completion messages — cron output is a standalone message, not a subagent result report.

## Changes

- `src/cron/isolated-agent/delivery-dispatch.ts`: set `expectsCompletionMessage: true` on the `runSubagentAnnounceFlow` call
- `src/agents/subagent-announce.ts`: skip subagent status header in `buildCompletionDeliveryMessage` when `announceType === "cron job"`
- Two test files: assert `expectsCompletionMessage` is `true` in announce call args

## Test plan

- [x] `pnpm test src/agents/subagent-announce` — 66 tests pass
- [x] `pnpm test src/cron/isolated-agent` — 79 tests pass
- [x] Live-tested: cron job with text-only announce delivery to Slack channel — message arrives clean, no subagent header

🤖 Generated with [Claude Code](https://claude.com/claude-code)