### PR TITLE
docs(chrome-extension): troubleshoot `!` badge — host_permissions scope & extension conflicts

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -131,7 +131,7 @@ Chrome "site access" setting for the extension.
 ```
 
 2. `chrome://extensions` → **Reload** the extension.
-3. Right-click the extension icon → *This can read and change site data* → select **On all sites**.
+3. Right-click the extension icon → _This can read and change site data_ → select **On all sites**.
 
 ### `chrome.debugger` conflicts with other extensions
 
@@ -139,7 +139,7 @@ Some Chrome extensions conflict with OpenClaw's use of the `chrome.debugger` API
 
 **Symptom:** all configuration is correct (Options page shows "Relay reachable and authenticated"),
 but clicking the toolbar button still shows `!`. The service worker console
-(`chrome://extensions` → inspect *Service Worker* → Console) logs:
+(`chrome://extensions` → inspect _Service Worker_ → Console) logs:
 
 ```
 attach failed Cannot access a chrome-extension:// URL of different extension

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -113,6 +113,43 @@ If you see `!`:
 - Make sure the Gateway is running locally (default setup), or run a node host on this machine if the Gateway runs elsewhere.
 - Open the extension Options page; it validates relay reachability + gateway-token auth.
 
+### `!` on non-localhost tabs (`host_permissions` scope)
+
+The extension's `manifest.json` declares `host_permissions` for `http://127.0.0.1/*` and `http://localhost/*` only.
+On Chrome MV3, this can cause the service worker's `fetch()` and `WebSocket` connections to the relay
+to be blocked when the **active tab** is a non-localhost page (e.g. `google.com`), depending on your
+Chrome "site access" setting for the extension.
+
+**Symptom:** extension shows `ON` on `127.0.0.1` tabs but `!` on any other site.
+
+**Workaround** (until upstream ships a broader `host_permissions`):
+
+1. Edit `manifest.json` (find its path with `openclaw browser extension path`):
+
+```json
+"host_permissions": ["http://127.0.0.1/*", "http://localhost/*", "<all_urls>"]
+```
+
+2. `chrome://extensions` → **Reload** the extension.
+3. Right-click the extension icon → *This can read and change site data* → select **On all sites**.
+
+### `chrome.debugger` conflicts with other extensions
+
+Some Chrome extensions conflict with OpenClaw's use of the `chrome.debugger` API.
+
+**Symptom:** all configuration is correct (Options page shows "Relay reachable and authenticated"),
+but clicking the toolbar button still shows `!`. The service worker console
+(`chrome://extensions` → inspect *Service Worker* → Console) logs:
+
+```
+attach failed Cannot access a chrome-extension:// URL of different extension
+```
+
+**Fix:** disable other extensions one by one to find the conflicting one.
+Once found, either keep it disabled while using OpenClaw, or — recommended — use a
+**dedicated Chrome profile** for OpenClaw browser relay
+(this also improves security by isolating your browsing sessions from agent control).
+
 ## Remote Gateway (use a node host)
 
 ### Local Gateway (same machine as Chrome) — usually **no extra steps**


### PR DESCRIPTION
## Summary

Two common issues that cause the `!` badge on the Chrome extension but are not covered in the current docs:

- **`host_permissions` scope on non-localhost tabs**: The extension's `manifest.json` only declares `http://127.0.0.1/*` and `http://localhost/*`. On Chrome MV3, depending on the user's "site access" setting, this can block the service worker's `fetch()` / `WebSocket` to the relay when the active tab is a non-localhost page. Documented the symptom (`ON` on localhost, `!` elsewhere) and workaround (add `<all_urls>` + set "On all sites").

- **`chrome.debugger` conflicts with other extensions**: Some Chrome extensions conflict with OpenClaw's debugger API usage, producing `Cannot access a chrome-extension:// URL of different extension`. Documented the symptom, how to diagnose via the service worker console, and the fix (disable conflicting extensions or use a dedicated Chrome profile).

## Test plan

- [x] Verify the new sections render correctly on the docs site
- [x] Confirm the workaround steps are accurate on a fresh Chrome + OpenClaw install


Made with [Cursor](https://cursor.com)