### PR TITLE
[AI] gateway: fix /approve slug resolution and broadcast truncation for large payloads

### DIFF
--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -170,4 +170,31 @@ export class ExecApprovalManager {
     const entry = this.pending.get(recordId);
     return entry?.promise ?? null;
   }
+
+  /**
+   * Resolve a full ID or a short slug/prefix to the canonical pending ID.
+   * Exact match is tried first (O(1)). Falls back to a prefix scan so that
+   * 8-char slugs shown in "/approve <slug>" notifications work correctly.
+   * Returns the full ID when exactly one match is found, null otherwise
+   * (not found, or ambiguous when multiple pending entries share the prefix).
+   */
+  resolveIdByPrefix(idOrPrefix: string): string | null {
+    const trimmed = idOrPrefix.trim();
+    if (!trimmed) {
+      return null;
+    }
+    // Fast path: exact match (full UUID or explicitly-provided ID)
+    if (this.pending.has(trimmed)) {
+      return trimmed;
+    }
+    // Prefix scan: supports short slugs (e.g. first 8 chars of UUID)
+    const matches: string[] = [];
+    for (const key of this.pending.keys()) {
+      if (key.startsWith(trimmed)) {
+        matches.push(key);
+      }
+    }
+    // Only resolve when unambiguous
+    return matches.length === 1 ? matches[0] : null;
+  }
 }

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -160,11 +160,24 @@ export function createExecApprovalHandlers(
         );
         return;
       }
+      // Truncate command in the broadcast payload to prevent large WebSocket frames
+      // from being silently dropped by the `dropIfSlow` backpressure mechanism.
+      // The full command remains in the manager for audit/forwarder use.
+      const MAX_BROADCAST_COMMAND_CHARS = 4096;
+      const broadcastCommand = record.request.command ?? "";
+      const broadcastRequest =
+        broadcastCommand.length > MAX_BROADCAST_COMMAND_CHARS
+          ? {
+              ...record.request,
+              command: broadcastCommand.slice(0, MAX_BROADCAST_COMMAND_CHARS),
+              commandTruncated: true,
+            }
+          : record.request;
       context.broadcast(
         "exec.approval.requested",
         {
           id: record.id,
-          request: record.request,
+          request: broadcastRequest,
           createdAtMs: record.createdAtMs,
           expiresAtMs: record.expiresAtMs,
         },
@@ -267,21 +280,28 @@ export function createExecApprovalHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid decision"));
         return;
       }
-      const snapshot = manager.getSnapshot(p.id);
+      // Support 8-char slugs shown in notifications (e.g. "/approve 7083ec31 allow-once").
+      // resolveIdByPrefix does an exact match first, then a prefix scan for unambiguous slugs.
+      const resolvedId = manager.resolveIdByPrefix(p.id);
+      if (!resolvedId) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
+        return;
+      }
+      const snapshot = manager.getSnapshot(resolvedId);
       const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
-      const ok = manager.resolve(p.id, decision, resolvedBy ?? null);
+      const ok = manager.resolve(resolvedId, decision, resolvedBy ?? null);
       if (!ok) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
         return;
       }
       context.broadcast(
         "exec.approval.resolved",
-        { id: p.id, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
+        { id: resolvedId, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
         { dropIfSlow: true },
       );
       void opts?.forwarder
         ?.handleResolved({
-          id: p.id,
+          id: resolvedId,
           decision,
           resolvedBy,
           ts: Date.now(),

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -668,6 +668,130 @@ describe("exec approval handlers", () => {
       vi.useRealTimers();
     }
   });
+
+  it("resolves approval via 8-char slug (prefix match)", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { twoPhase: true },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const fullId = (requested?.payload as { id?: string })?.id ?? "";
+    expect(fullId.length).toBeGreaterThan(8);
+
+    // Use the 8-char slug (as shown in "/approve <slug>" notifications)
+    const slug = fullId.slice(0, 8);
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id: slug,
+      respond: resolveRespond,
+      context,
+    });
+
+    await requestPromise;
+
+    expect(resolveRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+    // Final decision response should reference the full UUID, not the slug
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: fullId, decision: "allow-once" }),
+      undefined,
+    );
+    // Resolved broadcast should carry the full UUID so UI can match the entry
+    const resolved = broadcasts.find((entry) => entry.event === "exec.approval.resolved");
+    expect((resolved?.payload as { id?: string })?.id).toBe(fullId);
+  });
+
+  it("rejects resolve when slug is ambiguous (matches multiple pending entries)", async () => {
+    // Create two approvals whose IDs share the same first 8 chars by using explicit IDs
+    const manager = new ExecApprovalManager();
+    const handlers = createExecApprovalHandlers(manager);
+    const broadcasts: Array<{ event: string; payload: unknown }> = [];
+    const context = {
+      broadcast: (event: string, payload: unknown) => {
+        broadcasts.push({ event, payload });
+      },
+      hasExecApprovalClients: () => true,
+    };
+
+    const sharedPrefix = "aabbccdd";
+    // Register two entries manually so they share the same 8-char prefix
+    void requestExecApproval({
+      handlers,
+      respond: vi.fn(),
+      context,
+      params: { id: `${sharedPrefix}-0000-0000-0000-000000000001`, host: "gateway" },
+    });
+    void requestExecApproval({
+      handlers,
+      respond: vi.fn(),
+      context,
+      params: { id: `${sharedPrefix}-0000-0000-0000-000000000002`, host: "gateway" },
+    });
+    // Flush microtasks so both registrations complete
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id: sharedPrefix,
+      respond: resolveRespond,
+      context,
+    });
+
+    expect(resolveRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("unknown approval id") }),
+    );
+  });
+
+  it("truncates long command in broadcast payload to prevent dropIfSlow drops", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    const longCommand = "x".repeat(8000);
+
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { command: longCommand, host: "gateway" },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const broadcastedCommand = (requested?.payload as { request?: { command?: string } })?.request
+      ?.command;
+    expect(broadcastedCommand?.length).toBeLessThanOrEqual(4096);
+    const truncatedFlag = (requested?.payload as { request?: { commandTruncated?: boolean } })
+      ?.request?.commandTruncated;
+    expect(truncatedFlag).toBe(true);
+  });
+
+  it("does not truncate short commands in broadcast payload", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    const shortCommand = "echo hello";
+
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { command: shortCommand, host: "gateway" },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const broadcastedCommand = (requested?.payload as { request?: { command?: string } })?.request
+      ?.command;
+    expect(broadcastedCommand).toBe(shortCommand);
+    const truncatedFlag = (requested?.payload as { request?: { commandTruncated?: unknown } })
+      ?.request?.commandTruncated;
+    expect(truncatedFlag).toBeUndefined();
+  });
 });
 
 describe("gateway healthHandlers.status scope handling", () => {


### PR DESCRIPTION
## Summary

- **Problem:** `/approve <slug>` always failed with "unknown approval id" — the pending map keys are full UUIDs but notifications show an 8-char slug, so exact lookup always misses. This causes `waitForExecApprovalDecision` to time out and retry with a new UUID, creating an approval loop. Separately, large command payloads (multi-line here-docs, long scripts) were silently dropped by the `dropIfSlow` backpressure path in the RPC broadcast layer, so the GUI never received the `exec.approval.requested` event and buttons never appeared.
- **Why it matters:** Both bugs block any automation that needs exec approval — users could not approve via `/approve` CLI or GUI buttons when commands exceeded ~4 KB.
- **What changed:** (1) Added `resolveIdByPrefix()` to `ExecApprovalManager`: exact match first (O(1)), then unambiguous prefix scan so 8-char slugs resolve to the correct full UUID; returns `null` on no match or ambiguous prefix. (2) Truncate `command` to 4096 chars in the `exec.approval.requested` broadcast payload only — full command stays in the manager for actual execution; adds `commandTruncated: true` flag when truncated.
- **What did NOT change:** Full UUID resolution paths, the UI button flow, agent internals, forwarder/audit paths — all untouched and backward compatible.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Closes #27829

## User-visible / Behavior Changes

- `/approve <8-char-slug> allow-once|allow-always|deny` now resolves correctly instead of always returning "unknown approval id".
- GUI approval buttons now appear reliably for commands > 4 KB.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — prefix resolution is read-only on the pending map; the actual exec decision and forwarder paths are unchanged.
- Data access scope changed? No

## Repro + Verification

### Steps

1. Trigger an exec approval with a script > 4096 chars — GUI buttons should now appear.
2. Copy the 8-char slug from the approval notification (e.g. `7083ec31`).
3. Run `/approve 7083ec31 allow-once` — should succeed instead of "unknown approval id".

### Expected

- GUI shows approval buttons for large commands.
- `/approve <slug>` resolves and acts on the correct pending entry.

### Actual (before fix)

- GUI buttons never appeared for large commands (broadcast payload dropped by `dropIfSlow`).
- `/approve <slug>` always returned "unknown approval id" — 120s timeout — retry loop with new UUID.

## Evidence

- [x] Failing test/log before + passing after

4 new regression tests, all passing (43/43 in `server-methods.test.ts`):
- `resolves approval via 8-char slug (prefix match)`
- `rejects resolve when slug is ambiguous (matches multiple pending entries)`
- `truncates long command in broadcast payload to prevent dropIfSlow drops`
- `does not truncate short commands in broadcast payload`

`pnpm build` + `pnpm format:check` + `pnpm test` 43/43 + lint 0 errors all pass.

## AI Disclosure

- **Tool:** Augment Agent (Claude Sonnet 4.6)
- **Degree of testing:** Fully tested — lint clean (0 errors), TypeScript clean (build passes), 43/43 unit tests pass including 4 new regression tests covering both bugs and their edge cases.
- **Code understanding:** The fix is understood end-to-end: the slug mismatch is a key type issue (8-char prefix vs full UUID in the pending map), prefix scan is safe because concurrent approvals sharing an 8-char prefix are astronomically rare and the ambiguity guard returns null, and the broadcast truncation is a presentation-layer change that does not touch the stored command used for actual execution.

## Human Verification (required)

- Verified scenarios: TypeScript build clean, lint clean (0 warnings/errors), 43/43 tests pass.
- Edge cases checked: ambiguous prefix returns null ("unknown approval id"); short commands not truncated; full UUIDs still resolve via fast exact-match path.
- What you did **not** verify: live end-to-end with a real gateway and channel integration.

## Compatibility / Migration

- Backward compatible? Yes — full UUID callers hit the exact-match fast path unchanged.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: `git revert 1cfa60597`
- Files to restore: `src/gateway/exec-approval-manager.ts`, `src/gateway/server-methods/exec-approval.ts`
- Bad symptoms to watch for: slug resolving to wrong pending entry (prevented by the ambiguity check — returns null if 2+ entries share the prefix).

## Risks and Mitigations

- Risk: prefix scan resolves an ambiguous slug to a wrong entry.
  - Mitigation: `resolveIdByPrefix` returns `null` (unknown approval id) if 2+ pending entries match the prefix. The user must use the full UUID in that case.

lobster-biscuit

