### PR TITLE
fix(android): TalkModeManager TTS pipeline reliability

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -57,7 +57,12 @@ class TalkModeManager(
     private const val tag = "TalkMode"
     private const val defaultModelIdFallback = "eleven_v3"
     private const val defaultOutputFormatFallback = "pcm_24000"
-    private const val defaultTalkProvider = "elevenlabs"
+private const val defaultTalkProvider = "elevenlabs"
+    private const val silenceWindowMs = 500L
+    private const val listenWatchdogMs = 12_000L
+    private const val chatFinalWaitWithSubscribeMs = 45_000L
+    private const val chatFinalWaitWithoutSubscribeMs = 6_000L
+    private const val maxCachedRunCompletions = 128
 
     internal data class TalkProviderConfigSelection(
       val provider: String,
@@ -348,6 +353,10 @@ class TalkModeManager(
         putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
         putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
         putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
+        // Use cloud recognition — it handles natural speech and pauses better
+        // than on-device which cuts off aggressively after short silences.
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2500L)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 1800L)
       }
 
     if (markListening) {
@@ -396,6 +405,9 @@ class TalkModeManager(
 
     if (isFinal) {
       lastTranscript = trimmed
+      // Don't finalize immediately — let the silence monitor trigger after
+      // silenceWindowMs. This allows the recognizer to fire onResults and
+      // still give the user a natural pause before we send.
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.AudioAttributes
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
@@ -155,6 +156,25 @@ class TalkModeManager(
   private var systemTtsPending: CompletableDeferred<Unit>? = null
   private var systemTtsPendingId: String? = null
 
+  private var audioFocusRequest: AudioFocusRequest? = null
+  private val audioFocusListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+    when (focusChange) {
+      AudioManager.AUDIOFOCUS_LOSS,
+      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+        if (_isSpeaking.value) {
+          Log.d(tag, "audio focus lost; stopping TTS")
+          stopSpeaking(resetInterrupt = true, markIntentionalStop = false)
+        }
+      }
+      else -> { /* regained or duck — ignore */ }
+    }
+  }
+
+  fun setElevenLabsConfig(apiKey: String?, voiceId: String?) {
+    this.apiKey = apiKey?.trim()?.takeIf { it.isNotEmpty() }
+    this.defaultVoiceId = voiceId?.trim()?.takeIf { it.isNotEmpty() }
+  }
+
   fun setMainSessionKey(sessionKey: String?) {
     val trimmed = sessionKey?.trim().orEmpty()
     if (trimmed.isEmpty()) return
@@ -187,11 +207,19 @@ class TalkModeManager(
     val runId = obj["runId"].asStringOrNull() ?: return
     if (runId != pending) return
     val state = obj["state"].asStringOrNull() ?: return
-    if (state == "final") {
-      pendingFinal?.complete(true)
-      pendingFinal = null
-      pendingRunId = null
-    }
+    Log.d(tag, "chat event arrived runId=$runId state=$state pendingRunId=$pendingRunId")
+    val terminal =
+      when (state) {
+        "final" -> true
+        "aborted", "error" -> false
+        else -> null
+      } ?: return
+    cacheRunCompletion(runId, terminal)
+
+    if (runId != pendingRunId) return
+    pendingFinal?.complete(terminal)
+    pendingFinal = null
+    pendingRunId = null
   }
 
   private fun start() {
@@ -531,6 +559,7 @@ class TalkModeManager(
     _isSpeaking.value = true
     lastSpokenText = cleaned
     ensureInterruptListener()
+    requestAudioFocusForTts()
 
     try {
       val canUseElevenLabs = !voiceId.isNullOrBlank() && !apiKey.isNullOrEmpty()
@@ -577,6 +606,10 @@ class TalkModeManager(
         _statusText.value = "Speak failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}"
         Log.w(tag, "system voice failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}")
       }
+    } finally {
+      abandonAudioFocus()
+      stopSpeakingRequested = false
+      _isSpeaking.value = false
     }
 
     _isSpeaking.value = false
@@ -818,6 +851,52 @@ class TalkModeManager(
     systemTtsPending = null
     systemTtsPendingId = null
     _isSpeaking.value = false
+  }
+
+  private fun isIntentionalSpeechStop(err: Throwable): Boolean {
+    if (stopSpeakingRequested || pcmStopRequested) return true
+    return err is CancellationException
+  }
+
+  private fun requestAudioFocusForTts(): Boolean {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return true
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+        .setAudioAttributes(
+          AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ASSISTANT)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+        )
+        .setOnAudioFocusChangeListener(audioFocusListener)
+        .build()
+      audioFocusRequest = req
+      val result = am.requestAudioFocus(req)
+      Log.d(tag, "audio focus request result=$result")
+      result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED || result == AudioManager.AUDIOFOCUS_REQUEST_DELAYED
+    } else {
+      @Suppress("DEPRECATION")
+      val result = am.requestAudioFocus(
+        audioFocusListener,
+        AudioManager.STREAM_MUSIC,
+        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+      )
+      result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+  }
+
+  private fun abandonAudioFocus() {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      audioFocusRequest?.let {
+        am.abandonAudioFocusRequest(it)
+        Log.d(tag, "audio focus abandoned")
+      }
+      audioFocusRequest = null
+    } else {
+      @Suppress("DEPRECATION")
+      am.abandonAudioFocus(audioFocusListener)
+    }
   }
 
   private fun cleanupPlayer() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -24,10 +24,12 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.android.gateway.GatewaySession
 import ai.openclaw.android.isCanonicalMainSessionKey
 import ai.openclaw.android.normalizeMainKey
+import android.os.Build
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -165,6 +167,9 @@ private const val defaultTalkProvider = "elevenlabs"
   private var streamingSource: StreamingMediaDataSource? = null
   private var pcmTrack: AudioTrack? = null
   @Volatile private var pcmStopRequested = false
+  @Volatile private var finalizeInFlight = false
+  @Volatile private var stopSpeakingRequested = false
+  private var listenWatchdogJob: Job? = null
   private var systemTts: TextToSpeech? = null
   private var systemTtsPending: CompletableDeferred<Unit>? = null
   private var systemTtsPendingId: String? = null
@@ -176,7 +181,7 @@ private const val defaultTalkProvider = "elevenlabs"
       AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
         if (_isSpeaking.value) {
           Log.d(tag, "audio focus lost; stopping TTS")
-          stopSpeaking(resetInterrupt = true, markIntentionalStop = false)
+          stopSpeaking(resetInterrupt = true)
         }
       }
       else -> { /* regained or duck — ignore */ }
@@ -221,7 +226,7 @@ private const val defaultTalkProvider = "elevenlabs"
         val startedAt = System.currentTimeMillis().toDouble() / 1000.0
         val prompt = buildPrompt(command)
         val runId = sendChat(prompt, session)
-        val ok = waitForChatFinal(runId, timeoutMs = waitForFinalTimeoutMs())
+        val ok = waitForChatFinal(runId)
         val assistant = consumeRunText(runId)
           ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
         if (!assistant.isNullOrBlank()) {
@@ -1040,6 +1045,15 @@ private const val defaultTalkProvider = "elevenlabs"
     systemTtsPending = null
     systemTtsPendingId = null
     _isSpeaking.value = false
+  }
+
+  private fun shouldAllowSpeechInterrupt(): Boolean {
+    return !finalizeInFlight && !stopSpeakingRequested
+  }
+
+  private fun clearListenWatchdog() {
+    listenWatchdogJob?.cancel()
+    listenWatchdogJob = null
   }
 
   private fun isIntentionalSpeechStop(err: Throwable): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -139,7 +139,10 @@ class TalkModeManager(
   private var defaultOutputFormat: String? = null
   private var apiKey: String? = null
   private var voiceAliases: Map<String, String> = emptyMap()
-  private var interruptOnSpeech: Boolean = true
+  // Interrupt-on-speech is disabled by default: starting a SpeechRecognizer during
+  // TTS creates an audio session conflict on OxygenOS/OnePlus that causes AudioTrack
+  // write to return 0 and MediaPlayer to error. Can be enabled via gateway talk config.
+  private var interruptOnSpeech: Boolean = false
   private var voiceOverrideActive = false
   private var modelOverrideActive = false
   private var mainSessionKey: String = "main"
@@ -1331,9 +1334,13 @@ class TalkModeManager(
   }
 
   private fun ensureInterruptListener() {
-    if (!interruptOnSpeech || !_isEnabled.value) return
+    if (!interruptOnSpeech || !_isEnabled.value || !shouldAllowSpeechInterrupt()) return
+    // Don't create a new recognizer when we just destroyed one for TTS (finalizeInFlight=true).
+    // Starting a new recognizer mid-TTS causes audio session conflict that kills AudioTrack
+    // writes (returns 0) and MediaPlayer on OxygenOS/OnePlus devices.
+    if (finalizeInFlight) return
     mainHandler.post {
-      if (stopRequested) return@post
+      if (stopRequested || finalizeInFlight) return@post
       if (!SpeechRecognizer.isRecognitionAvailable(context)) return@post
       try {
         if (recognizer == null) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -424,8 +424,11 @@ class TalkModeManager(
     lastTranscript = ""
     lastHeardAtMs = null
     // Release SpeechRecognizer before making the API call and playing TTS.
-    // Leaving it live causes MediaPlayer to fail — both compete for the audio session.
-    mainHandler.post {
+    // Must use withContext(Main) — not post() — so we WAIT for destruction before
+    // proceeding. A fire-and-forget post() races with TTS startup: the recognizer
+    // stays alive, picks up TTS audio as speech (onBeginningOfSpeech), and the
+    // OS kills the AudioTrack write (returns 0) on OxygenOS/OnePlus devices.
+    withContext(Dispatchers.Main) {
       recognizer?.cancel()
       recognizer?.destroy()
       recognizer = null
@@ -723,7 +726,16 @@ class TalkModeManager(
       }
     }
 
-    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = request)
+    // When falling back from PCM, rewrite the format to MP3 so ElevenLabs returns
+    // data that MediaPlayer can actually decode. Without this the fallback request
+    // still carries outputFormat=pcm_24000, ElevenLabs streams raw PCM, and
+    // MediaPlayer fails immediately with a codec error.
+    val mp3Request = if (request.outputFormat?.startsWith("pcm_") == true) {
+      request.copy(outputFormat = "mp3_44100_128")
+    } else {
+      request
+    }
+    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = mp3Request)
   }
 
   private suspend fun streamAndPlayMp3(voiceId: String, apiKey: String, request: ElevenLabsRequest) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -813,7 +814,20 @@ class TalkModeManager(
           throw IllegalStateException("ElevenLabs failed: $code $body")
         }
         Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
-        conn.inputStream.use { input -> file.outputStream().use { out -> input.copyTo(out) } }
+        // Manual loop so cancellation is honoured on every chunk.
+        // input.copyTo() is a single blocking call with no yield points; if the
+        // coroutine is cancelled mid-download the entire response would finish
+        // before cancellation was observed.
+        conn.inputStream.use { input ->
+          file.outputStream().use { out ->
+            val buf = ByteArray(8192)
+            var n: Int
+            while (input.read(buf).also { n = it } != -1) {
+              ensureActive()
+              out.write(buf, 0, n)
+            }
+          }
+        }
       } catch (err: Throwable) {
         file.delete()
         throw err

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -369,6 +369,13 @@ class TalkModeManager(
     _statusText.value = "Thinking…"
     lastTranscript = ""
     lastHeardAtMs = null
+    // Release SpeechRecognizer before making the API call and playing TTS.
+    // Leaving it live causes MediaPlayer to fail — both compete for the audio session.
+    mainHandler.post {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
 
     reloadConfig()
     val prompt = buildPrompt(transcript)

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -149,7 +149,7 @@ class TalkModeManager(
   private var modelOverrideActive = false
   private var mainSessionKey: String = "main"
 
-  private var pendingRunId: String? = null
+  @Volatile private var pendingRunId: String? = null
   private var pendingFinal: CompletableDeferred<Boolean>? = null
   private val completedRunsLock = Any()
   private val completedRunStates = LinkedHashMap<String, Boolean>()
@@ -180,6 +180,7 @@ class TalkModeManager(
 
   fun setElevenLabsConfig(apiKey: String?, voiceId: String?) {
     this.apiKey = apiKey?.trim()?.takeIf { it.isNotEmpty() }
+    Log.d(tag, "setElevenLabsConfig voiceId=$voiceId")
     this.defaultVoiceId = voiceId?.trim()?.takeIf { it.isNotEmpty() }
   }
 
@@ -858,7 +859,7 @@ class TalkModeManager(
       finished.await()
       Log.d(tag, "file play done")
     } finally {
-      cleanupPlayer()
+      try { cleanupPlayer() } catch (_: Throwable) {}
       tempFile.delete()
     }
   }
@@ -1145,12 +1146,8 @@ class TalkModeManager(
       defaultModelId = model ?: defaultModelIdFallback
       if (!modelOverrideActive) currentModelId = defaultModelId
       defaultOutputFormat = outputFormat ?: defaultOutputFormatFallback
-      apiKey =
-        if (activeProvider == defaultTalkProvider) {
-          key ?: envKey?.takeIf { it.isNotEmpty() }
-        } else {
-          null
-        }
+      apiKey = key ?: envKey?.takeIf { it.isNotEmpty() }
+      Log.d(tag, "reloadConfig apiKey=${if (apiKey != null) "set" else "null"} voiceId=$defaultVoiceId")
       if (interrupt != null) interruptOnSpeech = interrupt
       if (activeProvider != defaultTalkProvider) {
         Log.w(tag, "talk provider $activeProvider unsupported; using system voice fallback")
@@ -1188,6 +1185,7 @@ class TalkModeManager(
         Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat} keyLen=${apiKey.length} keyPrefix=${apiKey.take(8)}")
         if (code >= 400) {
           val message = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          Log.w(tag, "elevenlabs error code=$code voiceId=$voiceId body=$message")
           sink.fail()
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
@@ -1260,6 +1258,20 @@ class TalkModeManager(
         }
       } finally {
         conn.disconnect()
+      }
+    }
+  }
+
+  private suspend fun waitForPcmDrain(track: AudioTrack, totalFrames: Long, sampleRate: Int) {
+    if (totalFrames <= 0) return
+    withContext(Dispatchers.IO) {
+      val drainDeadline = SystemClock.elapsedRealtime() + 15_000
+      while (!pcmStopRequested && SystemClock.elapsedRealtime() < drainDeadline) {
+        val played = track.playbackHeadPosition.toLong().and(0xFFFFFFFFL)
+        if (played >= totalFrames) break
+        val remainingFrames = totalFrames - played
+        val sleepMs = ((remainingFrames * 1000L) / sampleRate.toLong()).coerceIn(12L, 120L)
+        delay(sleepMs)
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -146,6 +146,9 @@ class TalkModeManager(
 
   private var pendingRunId: String? = null
   private var pendingFinal: CompletableDeferred<Boolean>? = null
+  private val completedRunsLock = Any()
+  private val completedRunStates = LinkedHashMap<String, Boolean>()
+  private val completedRunTexts = LinkedHashMap<String, String>()
   private var chatSubscribedSessionKey: String? = null
 
   private var player: MediaPlayer? = null
@@ -194,6 +197,35 @@ class TalkModeManager(
     }
   }
 
+  /**
+   * Speak a wake-word command through TalkMode's full pipeline:
+   * chat.send → wait for final → read assistant text → TTS.
+   * Calls [onComplete] when done so the caller can disable TalkMode and re-arm VoiceWake.
+   */
+  fun speakWakeCommand(command: String, onComplete: () -> Unit) {
+    scope.launch {
+      try {
+        reloadConfig()
+        subscribeChatIfNeeded(session = session, sessionKey = mainSessionKey.ifBlank { "main" })
+        val startedAt = System.currentTimeMillis().toDouble() / 1000.0
+        val prompt = buildPrompt(command)
+        val runId = sendChat(prompt, session)
+        val ok = waitForChatFinal(runId, timeoutMs = waitForFinalTimeoutMs())
+        val assistant = consumeRunText(runId)
+          ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+        if (!assistant.isNullOrBlank()) {
+          _statusText.value = "Speaking…"
+          playAssistant(assistant)
+        } else {
+          _statusText.value = "No reply"
+        }
+      } catch (err: Throwable) {
+        Log.w(tag, "speakWakeCommand failed: ${err.message}")
+      }
+      onComplete()
+    }
+  }
+
   fun handleGatewayEvent(event: String, payloadJson: String?) {
     if (event != "chat") return
     if (payloadJson.isNullOrBlank()) return
@@ -214,6 +246,18 @@ class TalkModeManager(
         "aborted", "error" -> false
         else -> null
       } ?: return
+    // Cache text from final event so we never need to poll chat.history
+    if (terminal) {
+      val text = extractTextFromChatEventMessage(obj["message"])
+      if (!text.isNullOrBlank()) {
+        synchronized(completedRunsLock) {
+          completedRunTexts[runId] = text
+          while (completedRunTexts.size > maxCachedRunCompletions) {
+            completedRunTexts.entries.firstOrNull()?.let { completedRunTexts.remove(it.key) }
+          }
+        }
+      }
+    }
     cacheRunCompletion(runId, terminal)
 
     if (runId != pendingRunId) return
@@ -271,6 +315,13 @@ class TalkModeManager(
     stopSpeaking()
     _usingFallbackTts.value = false
     chatSubscribedSessionKey = null
+    pendingRunId = null
+    pendingFinal?.cancel()
+    pendingFinal = null
+    synchronized(completedRunsLock) {
+      completedRunStates.clear()
+      completedRunTexts.clear()
+    }
 
     mainHandler.post {
       recognizer?.cancel()
@@ -396,7 +447,9 @@ class TalkModeManager(
       if (!ok) {
         Log.w(tag, "chat final timeout runId=$runId; attempting history fallback")
       }
-      val assistant = waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
+      // Use text cached from the final event first — avoids chat.history polling
+      val assistant = consumeRunText(runId)
+        ?: waitForAssistantText(session, startedAt, if (ok) 12_000 else 25_000)
       if (assistant.isNullOrBlank()) {
         _statusText.value = "No reply"
         Log.w(tag, "assistant text timeout runId=$runId")
@@ -481,6 +534,36 @@ class TalkModeManager(
       pendingRunId = null
     }
     return result
+  }
+
+  private fun cacheRunCompletion(runId: String, isFinal: Boolean) {
+    synchronized(completedRunsLock) {
+      completedRunStates[runId] = isFinal
+      while (completedRunStates.size > maxCachedRunCompletions) {
+        val first = completedRunStates.entries.firstOrNull() ?: break
+        completedRunStates.remove(first.key)
+      }
+    }
+  }
+
+  private fun consumeRunCompletion(runId: String): Boolean? {
+    synchronized(completedRunsLock) {
+      return completedRunStates.remove(runId)
+    }
+  }
+
+  private fun consumeRunText(runId: String): String? {
+    synchronized(completedRunsLock) {
+      return completedRunTexts.remove(runId)
+    }
+  }
+
+  private fun extractTextFromChatEventMessage(messageEl: JsonElement?): String? {
+    val msg = messageEl?.asObjectOrNull() ?: return null
+    val content = msg["content"] as? JsonArray ?: return null
+    return content.mapNotNull { entry ->
+      entry.asObjectOrNull()?.get("text")?.asStringOrNull()?.trim()
+    }.filter { it.isNotEmpty() }.joinToString("\n").takeIf { it.isNotBlank() }
   }
 
   private suspend fun waitForAssistantText(
@@ -653,7 +736,7 @@ class TalkModeManager(
     player.setAudioAttributes(
       AudioAttributes.Builder()
         .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-        .setUsage(AudioAttributes.USAGE_ASSISTANT)
+        .setUsage(AudioAttributes.USAGE_MEDIA)
         .build(),
     )
     player.setOnPreparedListener {
@@ -718,7 +801,7 @@ class TalkModeManager(
       AudioTrack(
         AudioAttributes.Builder()
           .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-          .setUsage(AudioAttributes.USAGE_ASSISTANT)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
           .build(),
         AudioFormat.Builder()
           .setSampleRate(sampleRate)
@@ -871,7 +954,7 @@ class TalkModeManager(
       val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
         .setAudioAttributes(
           AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_ASSISTANT)
+            .setUsage(AudioAttributes.USAGE_MEDIA)
             .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
             .build()
         )
@@ -1016,6 +1099,7 @@ class TalkModeManager(
         conn.outputStream.use { it.write(payload.toByteArray()) }
 
         val code = conn.responseCode
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat} keyLen=${apiKey.length} keyPrefix=${apiKey.take(8)}")
         if (code >= 400) {
           val message = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
           sink.fail()
@@ -1264,8 +1348,9 @@ class TalkModeManager(
     val trimmed = preferred?.trim().orEmpty()
     if (trimmed.isNotEmpty()) {
       val resolved = resolveVoiceAlias(trimmed)
-      if (resolved != null) return resolved
-      Log.w(tag, "unknown voice alias $trimmed")
+      // If it resolves as an alias, use the alias target.
+      // Otherwise treat it as a direct voice ID (e.g. "21m00Tcm4TlvDq8ikWAM").
+      return resolved ?: trimmed
     }
     fallbackVoiceId?.let { return it }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -817,7 +817,10 @@ class TalkModeManager(
       throw IllegalStateException("AudioTrack init failed")
     }
     pcmTrack = track
-    track.play()
+    // Don't call track.play() yet — start the track only when the first audio
+    // chunk arrives from ElevenLabs (see streamPcm). OxygenOS/OnePlus kills an
+    // AudioTrack that underruns (no data written) for ~1+ seconds, causing
+    // write() to return 0. Deferring play() until first data avoids the underrun.
 
     Log.d(tag, "pcm play start sampleRate=$sampleRate bufferSize=$bufferSize")
     try {
@@ -1139,12 +1142,21 @@ class TalkModeManager(
           throw IllegalStateException("ElevenLabs failed: $code $message")
         }
 
+        var totalBytesWritten = 0L
+        var trackStarted = false
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
             if (pcmStopRequested) return@withContext
             val read = input.read(buffer)
             if (read <= 0) break
+            // Start the AudioTrack only when the first chunk is ready — avoids
+            // the ~1.4s underrun window while ElevenLabs prepares audio.
+            // OxygenOS kills a track that underruns for >1s (write() returns 0).
+            if (!trackStarted) {
+              track.play()
+              trackStarted = true
+            }
             var offset = 0
             while (offset < read) {
               if (pcmStopRequested) return@withContext

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -1024,6 +1024,7 @@ private const val defaultTalkProvider = "elevenlabs"
   }
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
+    stopSpeakingRequested = true
     pcmStopRequested = true
     if (!_isSpeaking.value) {
       cleanupPlayer()
@@ -1208,7 +1209,7 @@ private const val defaultTalkProvider = "elevenlabs"
         conn.outputStream.use { it.write(payload.toByteArray()) }
 
         val code = conn.responseCode
-        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat} keyLen=${apiKey.length} keyPrefix=${apiKey.take(8)}")
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat} keyLen=${apiKey.length}")
         if (code >= 400) {
           val message = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
           Log.w(tag, "elevenlabs error code=$code voiceId=$voiceId body=$message")

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -24,6 +24,7 @@ import androidx.core.content.ContextCompat
 import ai.openclaw.android.gateway.GatewaySession
 import ai.openclaw.android.isCanonicalMainSessionKey
 import ai.openclaw.android.normalizeMainKey
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
@@ -726,16 +727,14 @@ class TalkModeManager(
       }
     }
 
-    // When falling back from PCM, rewrite the format to MP3 so ElevenLabs returns
-    // data that MediaPlayer can actually decode. Without this the fallback request
-    // still carries outputFormat=pcm_24000, ElevenLabs streams raw PCM, and
-    // MediaPlayer fails immediately with a codec error.
+    // When falling back from PCM, rewrite format to MP3 and download to file.
+    // File-based playback avoids custom DataSource races and is reliable across OEMs.
     val mp3Request = if (request.outputFormat?.startsWith("pcm_") == true) {
       request.copy(outputFormat = "mp3_44100_128")
     } else {
       request
     }
-    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = mp3Request)
+    streamAndPlayViaFile(voiceId = voiceId, apiKey = apiKey, request = mp3Request)
   }
 
   private suspend fun streamAndPlayMp3(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
@@ -793,6 +792,61 @@ class TalkModeManager(
       cleanupPlayer()
     }
     Log.d(tag, "play done")
+  }
+
+  /**
+   * Download ElevenLabs audio to a temp file, then play from disk via MediaPlayer.
+   * Simpler and more reliable than streaming: avoids custom DataSource races and
+   * AudioTrack underrun issues on OxygenOS/OnePlus.
+   */
+  private suspend fun streamAndPlayViaFile(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+    val tempFile = withContext(Dispatchers.IO) {
+      val file = File.createTempFile("tts_", ".mp3", context.cacheDir)
+      val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
+      try {
+        val payload = buildRequestPayload(request)
+        conn.outputStream.use { it.write(payload.toByteArray()) }
+        val code = conn.responseCode
+        if (code >= 400) {
+          val body = conn.errorStream?.readBytes()?.toString(Charsets.UTF_8) ?: ""
+          file.delete()
+          throw IllegalStateException("ElevenLabs failed: $code $body")
+        }
+        Log.d(tag, "elevenlabs http code=$code voiceId=$voiceId format=${request.outputFormat}")
+        conn.inputStream.use { input -> file.outputStream().use { out -> input.copyTo(out) } }
+      } catch (err: Throwable) {
+        file.delete()
+        throw err
+      } finally {
+        conn.disconnect()
+      }
+      file
+    }
+    try {
+      val player = MediaPlayer()
+      this.player = player
+      val finished = CompletableDeferred<Unit>()
+      player.setAudioAttributes(
+        AudioAttributes.Builder()
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .build(),
+      )
+      player.setOnCompletionListener { finished.complete(Unit) }
+      player.setOnErrorListener { _, what, extra ->
+        finished.completeExceptionally(IllegalStateException("MediaPlayer error what=$what extra=$extra"))
+        true
+      }
+      player.setDataSource(tempFile.absolutePath)
+      withContext(Dispatchers.IO) { player.prepare() }
+      Log.d(tag, "file play start bytes=${tempFile.length()}")
+      player.start()
+      finished.await()
+      Log.d(tag, "file play done")
+    } finally {
+      cleanupPlayer()
+      tempFile.delete()
+    }
   }
 
   private suspend fun streamAndPlayPcm(

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -361,8 +361,8 @@ class TalkModeManager(
           if (stopRequested) return@post
           try {
             recognizer?.cancel()
-            val shouldListen = listeningMode
-            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech
+            val shouldListen = listeningMode && !finalizeInFlight
+            val shouldInterrupt = _isSpeaking.value && interruptOnSpeech && shouldAllowSpeechInterrupt()
             if (!shouldListen && !shouldInterrupt) return@post
             startListeningInternal(markListening = shouldListen)
           } catch (_: Throwable) {
@@ -1426,7 +1426,12 @@ class TalkModeManager(
       override fun onBufferReceived(buffer: ByteArray?) {}
 
       override fun onEndOfSpeech() {
-        scheduleRestart()
+        clearListenWatchdog()
+        // Don't restart while a transcript is being processed — the recognizer
+        // competing for audio resources kills AudioTrack PCM playback.
+        if (!finalizeInFlight) {
+          scheduleRestart()
+        }
       }
 
       override fun onError(error: Int) {


### PR DESCRIPTION
Cherry-picked fixes from local Talk Mode work. All changes are to `TalkModeManager.kt` only — no wiring changes, no new files.

## Changes

- Audio focus management for TTS playback (request/abandon around ElevenLabs)
- Stop SpeechRecognizer before TTS to prevent audio session conflict on OxygenOS/OnePlus
- Treat unresolved voice alias string as direct ElevenLabs voice ID
- Prevent SpeechRecognizer restart during TTS
- Defer `AudioTrack.play()` until first data chunk (avoids ~1.4s underrun on OxygenOS)
- Disable `interruptOnSpeech` by default — starting SpeechRecognizer during TTS causes AudioTrack write to return 0
- Destroy SpeechRecognizer synchronously before TTS; fix PCM→MP3 fallback format
- File-based TTS fallback for MediaPlayer streaming issues
- Honour cancellation during ElevenLabs download
- Remove API key from logs; fix temp file cleanup; `@Volatile` on `pendingRunId`
- Revert premature `finalizeTranscript` on `onResults` (caused recording cut-off)
- Add missing guard flag declarations (`finalizeInFlight`, `stopSpeakingRequested`, `clearListenWatchdog`, `shouldAllowSpeechInterrupt`)

## Testing
Tested on OnePlus 12 (Android 15, OxygenOS). All fixes address real crashes or audio glitches observed during testing.

cc @obviyus