### PR TITLE
fix(bluebubbles): suppress typing indicator on NO_REPLY and tapback responses

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1155,10 +1155,12 @@ export async function processMessage(
     }
   };
   const startTyping = async () => {
-    if (!typingChatGuid || streamingActive) {
+    if (!typingChatGuid) {
       return;
     }
-    streamingActive = true;
+    if (!streamingActive) {
+      streamingActive = true;
+    }
     clearTypingRestartTimer();
     try {
       await sendBlueBubblesTyping(typingChatGuid, true, {
@@ -1323,7 +1325,10 @@ export async function processMessage(
           }
         },
         onReplyStart: async () => {
-          if (!typingChatGuid || typingStartsOnMessage) {
+          if (!typingChatGuid) {
+            return;
+          }
+          if (typingStartsOnMessage && !streamingActive) {
             return;
           }
           await startTyping();

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1141,6 +1141,11 @@ export async function processMessage(
 
   let sentMessage = false;
   let streamingActive = false;
+  const configuredTypingMode = config.session?.typingMode ?? config.agents?.defaults?.typingMode;
+  const typingSuppressed = isTapbackMessage || configuredTypingMode === "never";
+  const typingStartsOnMessage = configuredTypingMode === "message";
+  const typingChatGuid =
+    !typingSuppressed && chatGuidForActions && baseUrl && password ? chatGuidForActions : undefined;
   let typingRestartTimer: NodeJS.Timeout | undefined;
   const typingRestartDelayMs = 150;
   const clearTypingRestartTimer = () => {
@@ -1149,8 +1154,23 @@ export async function processMessage(
       typingRestartTimer = undefined;
     }
   };
+  const startTyping = async () => {
+    if (!typingChatGuid || streamingActive) {
+      return;
+    }
+    streamingActive = true;
+    clearTypingRestartTimer();
+    try {
+      await sendBlueBubblesTyping(typingChatGuid, true, {
+        cfg: config,
+        accountId: account.accountId,
+      });
+    } catch (err) {
+      runtime.error?.(`[bluebubbles] typing start failed: ${String(err)}`);
+    }
+  };
   const restartTypingSoon = () => {
-    if (!streamingActive || !chatGuidForActions || !baseUrl || !password) {
+    if (!streamingActive || !typingChatGuid) {
       return;
     }
     clearTypingRestartTimer();
@@ -1159,7 +1179,7 @@ export async function processMessage(
       if (!streamingActive) {
         return;
       }
-      sendBlueBubblesTyping(chatGuidForActions, true, {
+      sendBlueBubblesTyping(typingChatGuid, true, {
         cfg: config,
         accountId: account.accountId,
       }).catch((err) => {
@@ -1202,6 +1222,9 @@ export async function processMessage(
             const text = sanitizeReplyDirectiveText(
               core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode),
             );
+            if (typingStartsOnMessage && text.trim()) {
+              await startTyping();
+            }
             let first = true;
             for (const mediaUrl of mediaList) {
               const caption = first ? text : undefined;
@@ -1265,6 +1288,9 @@ export async function processMessage(
           if (!chunks.length) {
             return;
           }
+          if (typingStartsOnMessage) {
+            await startTyping();
+          }
           for (const chunk of chunks) {
             const pendingId = rememberPendingOutboundMessageId({
               accountId: account.accountId,
@@ -1297,28 +1323,13 @@ export async function processMessage(
           }
         },
         onReplyStart: async () => {
-          if (!chatGuidForActions) {
+          if (!typingChatGuid || typingStartsOnMessage) {
             return;
           }
-          if (!baseUrl || !password) {
-            return;
-          }
-          streamingActive = true;
-          clearTypingRestartTimer();
-          try {
-            await sendBlueBubblesTyping(chatGuidForActions, true, {
-              cfg: config,
-              accountId: account.accountId,
-            });
-          } catch (err) {
-            runtime.error?.(`[bluebubbles] typing start failed: ${String(err)}`);
-          }
+          await startTyping();
         },
         onIdle: async () => {
-          if (!chatGuidForActions) {
-            return;
-          }
-          if (!baseUrl || !password) {
+          if (!typingChatGuid) {
             return;
           }
           // Intentionally no-op for block streaming. We stop typing in finally
@@ -1337,8 +1348,7 @@ export async function processMessage(
       },
     });
   } finally {
-    const shouldStopTyping =
-      Boolean(chatGuidForActions && baseUrl && password) && (streamingActive || !sentMessage);
+    const shouldStopTyping = Boolean(typingChatGuid) && (streamingActive || !sentMessage);
     streamingActive = false;
     clearTypingRestartTimer();
     if (sentMessage && chatGuidForActions && ackMessageId) {
@@ -1364,9 +1374,9 @@ export async function processMessage(
         },
       });
     }
-    if (shouldStopTyping && chatGuidForActions) {
+    if (shouldStopTyping && typingChatGuid) {
       // Stop typing after streaming completes to avoid a stuck indicator.
-      sendBlueBubblesTyping(chatGuidForActions, false, {
+      sendBlueBubblesTyping(typingChatGuid, false, {
         cfg: config,
         accountId: account.accountId,
       }).catch((err) => {
@@ -1374,7 +1384,7 @@ export async function processMessage(
           log: (msg) => logVerbose(core, runtime, msg),
           channel: "bluebubbles",
           action: "stop",
-          target: chatGuidForActions,
+          target: typingChatGuid,
           error: err,
         });
       });

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2483,6 +2483,58 @@ describe("BlueBubbles webhook monitor", () => {
       );
     });
 
+    it("refreshes typing keepalive when onReplyStart is called repeatedly", async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+        await params.dispatcherOptions.onReplyStart?.();
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      const typingStartCalls = vi
+        .mocked(sendBlueBubblesTyping)
+        .mock.calls.filter((call) => call[1] === true);
+      expect(typingStartCalls.length).toBeGreaterThanOrEqual(2);
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        expect.any(String),
+        false,
+        expect.any(Object),
+      );
+    });
+
     it("does not send typing indicator for tapback messages", async () => {
       const { sendBlueBubblesTyping } = await import("./chat.js");
       vi.mocked(sendBlueBubblesTyping).mockClear();

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2483,6 +2483,49 @@ describe("BlueBubbles webhook monitor", () => {
       );
     });
 
+    it("does not send typing indicator for tapback messages", async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Reacted 😅 to "nice one"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-tapback",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(sendBlueBubblesTyping).not.toHaveBeenCalled();
+    });
+
     it("stops typing on idle", async () => {
       const { sendBlueBubblesTyping } = await import("./chat.js");
       vi.mocked(sendBlueBubblesTyping).mockClear();
@@ -2562,7 +2605,9 @@ describe("BlueBubbles webhook monitor", () => {
         },
       };
 
-      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async () => undefined);
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+      });
 
       const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
       const res = createMockResponse();
@@ -2572,9 +2617,123 @@ describe("BlueBubbles webhook monitor", () => {
 
       expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
         expect.any(String),
+        true,
+        expect.any(Object),
+      );
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        expect.any(String),
         false,
         expect.any(Object),
       );
+    });
+
+    it('defers typing start until text output when typingMode="message"', async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {
+        session: {
+          typingMode: "message",
+        },
+      };
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+        const startedBeforeDeliver = vi
+          .mocked(sendBlueBubblesTyping)
+          .mock.calls.some((call) => call[1] === true);
+        expect(startedBeforeDeliver).toBe(false);
+        await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        expect.any(String),
+        true,
+        expect.any(Object),
+      );
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        expect.any(String),
+        false,
+        expect.any(Object),
+      );
+    });
+
+    it('never sends typing indicators when typingMode="never"', async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {
+        session: {
+          typingMode: "never",
+        },
+      };
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: "hello",
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+        await params.dispatcherOptions.deliver({ text: "replying now" }, { kind: "final" });
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(sendBlueBubblesTyping).not.toHaveBeenCalled();
     });
   });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -470,7 +470,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("suppresses tool-start typing in message mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -480,9 +480,25 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
+    // In message mode, tool execution should NOT start typing.
+    // Typing should only start when actual text output begins.
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+  });
+
+  it("starts typing on tool-start in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
     expect(typing.startTypingLoop).toHaveBeenCalled();
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
     (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
     (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -125,7 +125,8 @@ export function createTypingSignaler(params: {
   };
 
   const signalToolStart = async () => {
-    if (disabled) {
+    if (disabled || shouldStartOnMessageStart) {
+      // In "message" mode, don't start typing on tool calls — wait for actual text output.
       return;
     }
     // Start typing as soon as tools begin executing, even before the first text delta.


### PR DESCRIPTION
## Problem

The typing indicator fires and lingers on iMessage (BlueBubbles) when the agent returns `NO_REPLY` or processes a tapback/reaction. Users see the "..." typing bubble with no message following, which is confusing and makes the bot look stuck.

This has three root causes:

### 1. BlueBubbles extension: `onReplyStart` fires unconditionally
The `onReplyStart` callback in `monitor-processing.ts` starts the typing indicator without checking if the message is a tapback or if `typingMode` is set to suppress typing.

**Fix:** Check `isTapbackMessage` flag and `typingMode` config before starting typing. Extract a `startTyping()` helper. For `typingMode="message"`, defer typing start until actual text content is being delivered.

### 2. Core: `signalToolStart` ignores `typingMode="message"`
In `typing-mode.ts`, the `signalToolStart` function starts the typing loop whenever any tool executes (e.g., `memory_search`), even when `typingMode="message"`. This causes ghost typing bubbles because tools fire before the model decides whether to respond.

**Fix:** Add `shouldStartOnMessageStart` guard to `signalToolStart` so it respects "message" mode.

### 3. Core: `createTypingCallbacks` wrapper (NOT YET FIXED)
The core `createTypingCallbacks` in `pi-embedded` wraps channel extension callbacks with its own typing lifecycle. It calls `onReplyStart` at the wrapper level before the channel extension's patched code can suppress it. This requires a deeper refactor of how the core typing system interacts with channel extensions.

## Changes

- **`extensions/bluebubbles/src/monitor-processing.ts`**: Skip typing for tapbacks, respect `typingMode` config, extract `startTyping()` helper, simplify guard checks
- **`extensions/bluebubbles/src/monitor.test.ts`**: 4 new test cases (tapback, NO_REPLY cleanup, `typingMode="message"`, `typingMode="never"`)
- **`src/auto-reply/reply/typing-mode.ts`**: `signalToolStart` respects "message" mode

## Test Results

All 71 BlueBubbles tests pass (67 existing + 4 new).

## Status

This PR fixes layers 1 and 2. Layer 3 (core typing callbacks wrapper) still allows the typing indicator to leak through on some code paths. A follow-up PR is needed for a complete fix.

Fixes #25515
Relates to #6523, #26881