### PR TITLE
fix: add Bearer auth header for anthropic-messages providers

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -627,6 +627,7 @@ function buildSyntheticProvider(): ProviderConfig {
   return {
     baseUrl: SYNTHETIC_BASE_URL,
     api: "anthropic-messages",
+    authHeader: true,
     models: SYNTHETIC_MODEL_CATALOG.map(buildSyntheticModelDefinition),
   };
 }
@@ -667,6 +668,7 @@ export function buildXiaomiProvider(): ProviderConfig {
   return {
     baseUrl: XIAOMI_BASE_URL,
     api: "anthropic-messages",
+    authHeader: true,
     models: [
       {
         id: XIAOMI_DEFAULT_MODEL_ID,
@@ -953,6 +955,7 @@ export async function resolveImplicitProviders(params: {
     providers["cloudflare-ai-gateway"] = {
       baseUrl,
       api: "anthropic-messages",
+      authHeader: true,
       apiKey,
       models: [buildCloudflareAiGatewayModelDefinition()],
     };


### PR DESCRIPTION
## Summary

- MiniMax's `/anthropic` endpoint requires `Authorization: Bearer <key>` but the Anthropic SDK only sends `X-Api-Key`, causing HTTP 401 errors
- Set `authHeader: true` on all `anthropic-messages` providers using non-Anthropic endpoints (MiniMax, MiniMax Portal, Xiaomi, Synthetic, Cloudflare AI Gateway)
- The existing `authHeader` mechanism in the model registry injects `Authorization: Bearer <key>` alongside the SDK's default `X-Api-Key` header

## Root Cause

When using `api: "anthropic-messages"`, the Anthropic SDK constructs requests with `X-Api-Key: <raw-key>`. MiniMax (and potentially other third-party providers) now require the standard `Authorization: Bearer <key>` format instead.

The `authHeader: true` provider config flag already exists in the model registry and correctly adds the `Authorization: Bearer` header — it just wasn't set on these providers.

## Test plan

- [x] Existing MiniMax provider test updated to assert `authHeader: true`
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] All provider tests pass (`pnpm test`)

Fixes #29095