### PR TITLE
fix(telegram): prevent cross-bot mention collision with substring match

### DIFF
--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -249,7 +249,11 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
 
 export function hasBotMention(msg: Message, botUsername: string) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
+  const mention = `@${botUsername}`;
+  const idx = text.indexOf(mention);
+  // Check for word boundary after mention to prevent substring collisions
+  // e.g., "@gaian" should not match "@gaianchat_bot"
+  if (idx !== -1 && (idx + mention.length >= text.length || !/\w/.test(text[idx + mention.length]))) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];


### PR DESCRIPTION
## Summary

Fixes #29173

The `hasBotMention()` function used `.includes()` for text-based mention detection, which caused `@gaian` to incorrectly match inside `@gaianchat_bot`.

## Root Cause

```js
// Before: substring match
if (text.includes(\`@\${botUsername}\`)) return true;
// "@gaianchat_bot".includes("@gaian") → true ❌
```

## Fix

Replace substring check with word-boundary check:

```js
const mention = \`@\${botUsername}\`;
const idx = text.indexOf(mention);
if (idx !== -1 && (idx + mention.length >= text.length || !/\\w/.test(text[idx + mention.length]))) {
  return true;
}
```

The mention must be followed by a non-word character or end of string.

## Testing

| Input | Bot Username | Before | After |
|-------|--------------|--------|-------|
| `@GaianChat_Bot what is the group id?` | `gaian` | ✅ (wrong) | ❌ (correct) |
| `@GaianChat_Bot what is the group id?` | `gaianchat_bot` | ✅ | ✅ |
| `@gaian hello` | `gaian` | ✅ | ✅ |
| `hey @gaian!` | `gaian` | ✅ | ✅ |

## Notes

- The entity-based check (line 261) already uses exact comparison (`===`) and was not affected
- This is a minimal, targeted fix that preserves existing behavior for valid mentions