### PR TITLE
fix(browser): accept 'url' as alias for 'targetUrl' in open/navigate actions

### DIFF
--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -405,9 +405,10 @@ export function createBrowserTool(opts?: {
             return formatTabsToolResult(tabs);
           }
         case "open": {
-          const targetUrl = readStringParam(params, "targetUrl", {
-            required: true,
-          });
+          // Accept both "targetUrl" and "url" for compatibility (url is a common alias)
+          const targetUrl =
+            readStringParam(params, "targetUrl") ??
+            readStringParam(params, "url", { required: true, label: "targetUrl" });
           if (proxyRequest) {
             const result = await proxyRequest({
               method: "POST",
@@ -635,9 +636,10 @@ export function createBrowserTool(opts?: {
           });
         }
         case "navigate": {
-          const targetUrl = readStringParam(params, "targetUrl", {
-            required: true,
-          });
+          // Accept both "targetUrl" and "url" for compatibility (url is a common alias)
+          const targetUrl =
+            readStringParam(params, "targetUrl") ??
+            readStringParam(params, "url", { required: true, label: "targetUrl" });
           const targetId = readStringParam(params, "targetId");
           if (proxyRequest) {
             const result = await proxyRequest({


### PR DESCRIPTION
## Summary

Fixes #29136

Users naturally pass `url` parameter when using browser open/navigate actions, but the tool only accepted `targetUrl`, causing confusing "targetUrl required" errors.

## Changes

Both `open` and `navigate` actions now accept either parameter:

```
browser action=open url=https://example.com     ✅ (new)
browser action=navigate url=https://example.com ✅ (new)  
browser action=open targetUrl=https://example.com ✅ (still works)
```

## Implementation

Uses `readStringParam` with fallback:
```typescript
const targetUrl =
  readStringParam(params, "targetUrl") ??
  readStringParam(params, "url", { required: true, label: "targetUrl" });
```

If `targetUrl` is provided, use it. Otherwise fall back to `url`. The error message still says "targetUrl required" for consistency with the canonical parameter name.

## Backward Compatibility

Fully backward compatible - `targetUrl` still works exactly as before.