### PR TITLE
feat(cli): add agent-ui command for external agent UIs

### DIFF
--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -7,6 +7,7 @@ import type { ProgramContext } from "./context.js";
 vi.mock("./register.agent.js", () => ({
   registerAgentCommands: (program: Command) => {
     program.command("agent");
+    program.command("agent-ui");
     program.command("agents");
   },
 }));
@@ -59,6 +60,7 @@ describe("command-registry", () => {
   it("includes both agent and agents in core CLI command names", () => {
     const names = getCoreCliCommandNames();
     expect(names).toContain("agent");
+    expect(names).toContain("agent-ui");
     expect(names).toContain("agents");
   });
 
@@ -70,6 +72,7 @@ describe("command-registry", () => {
     expect(names).toContain("browser");
     expect(names).toContain("sessions");
     expect(names).not.toContain("agent");
+    expect(names).not.toContain("agent-ui");
     expect(names).not.toContain("status");
     expect(names).not.toContain("doctor");
   });
@@ -83,6 +86,8 @@ describe("command-registry", () => {
     // The registrar also installs the singular "agent" command from the same entry.
     const agentCmd = program.commands.find((c) => c.name() === "agent");
     expect(agentCmd).toBeDefined();
+    const agentUiCmd = program.commands.find((c) => c.name() === "agent-ui");
+    expect(agentUiCmd).toBeDefined();
   });
 
   it("registerCoreCliByName returns false for unknown commands", async () => {

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -154,6 +154,11 @@ const coreEntries: CoreCliEntry[] = [
         hasSubcommands: false,
       },
       {
+        name: "agent-ui",
+        description: "Launch an external CLI agent UI with OpenClaw memory bridge",
+        hasSubcommands: false,
+      },
+      {
         name: "agents",
         description: "Manage isolated agents (workspaces, auth, routing)",
         hasSubcommands: true,

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const agentCliCommandMock = vi.fn();
+const agentUiCommandMock = vi.fn();
 const agentsAddCommandMock = vi.fn();
 const agentsBindingsCommandMock = vi.fn();
 const agentsBindCommandMock = vi.fn();
@@ -20,6 +21,10 @@ const runtime = {
 
 vi.mock("../../commands/agent-via-gateway.js", () => ({
   agentCliCommand: agentCliCommandMock,
+}));
+
+vi.mock("../../commands/agent-ui.js", () => ({
+  agentUiCommand: agentUiCommandMock,
 }));
 
 vi.mock("../../commands/agents.js", () => ({
@@ -60,6 +65,7 @@ describe("registerAgentCommands", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     agentCliCommandMock.mockResolvedValue(undefined);
+    agentUiCommandMock.mockResolvedValue(undefined);
     agentsAddCommandMock.mockResolvedValue(undefined);
     agentsBindingsCommandMock.mockResolvedValue(undefined);
     agentsBindCommandMock.mockResolvedValue(undefined);
@@ -97,6 +103,40 @@ describe("registerAgentCommands", () => {
       }),
       runtime,
       { deps: true },
+    );
+  });
+
+  it("runs agent-ui command and forwards options", async () => {
+    await runCli([
+      "agent-ui",
+      "--command",
+      "codex",
+      "--arg",
+      "--profile",
+      "--arg",
+      "work",
+      "--cwd",
+      "/tmp/work",
+      "--agent",
+      "ops",
+      "--no-bridge-memory",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(agentUiCommandMock).toHaveBeenCalledWith(
+      {
+        command: "codex",
+        arg: ["--profile", "work"],
+        provider: undefined,
+        model: undefined,
+        cwd: "/tmp/work",
+        agent: "ops",
+        noBridgeMemory: true,
+        dryRun: true,
+        json: true,
+      },
+      runtime,
     );
   });
 

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { agentUiCommand } from "../../commands/agent-ui.js";
 import { agentCliCommand } from "../../commands/agent-via-gateway.js";
 import {
   agentsAddCommand,
@@ -79,6 +80,58 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       const deps = createDefaultDeps();
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentCliCommand(opts, defaultRuntime, deps);
+      });
+    });
+
+  program
+    .command("agent-ui")
+    .description("Launch an external CLI agent UI (Codex/Claude/OpenCode/etc.)")
+    .option("--command <bin>", "Executable to launch (e.g. codex, claude, opencode)")
+    .option("--arg <value>", "Argument passed to the external CLI (repeatable)", collectOption, [])
+    .option(
+      "--provider <id>",
+      "CLI backend provider id from agents.defaults.cliBackends (used when --command is omitted)",
+    )
+    .option("--model <provider/model>", "Infer provider from model ref when --provider is omitted")
+    .option("--cwd <dir>", "Working directory for the external UI (default: current directory)")
+    .option("--agent <id>", "Agent id used to resolve OpenClaw workspace and memory files")
+    .option("--no-bridge-memory", "Do not write/update AGENTS.md memory bridge in target cwd")
+    .option("--dry-run", "Show resolved launch plan without executing")
+    .option("--json", "Output launch plan as JSON")
+    .addHelpText(
+      "after",
+      () =>
+        `
+${theme.heading("Examples:")}
+${formatHelpExamples([
+  ["openclaw agent-ui --command codex", "Launch Codex UI in the current directory."],
+  [
+    "openclaw agent-ui --provider claude-cli --cwd ~/code/my-repo",
+    "Launch configured Claude backend in a project directory.",
+  ],
+  [
+    "openclaw agent-ui --command opencode --agent ops --dry-run --json",
+    "Preview launch plan + memory bridge for a specific OpenClaw agent.",
+  ],
+])}
+`,
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await agentUiCommand(
+          {
+            command: opts.command as string | undefined,
+            arg: Array.isArray(opts.arg) ? (opts.arg as string[]) : undefined,
+            provider: opts.provider as string | undefined,
+            model: opts.model as string | undefined,
+            cwd: opts.cwd as string | undefined,
+            agent: opts.agent as string | undefined,
+            noBridgeMemory: opts.bridgeMemory === false,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
       });
     });
 

--- a/src/commands/agent-ui.test.ts
+++ b/src/commands/agent-ui.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { ensureAgentUiMemoryBridge, resolveAgentUiLaunchSpec } from "./agent-ui.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(async (dir) => {
+      await fs.rm(dir, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("resolveAgentUiLaunchSpec", () => {
+  it("prefers explicit command", () => {
+    const result = resolveAgentUiLaunchSpec({
+      command: "codex",
+      args: ["--profile", "work"],
+      provider: "codex-cli",
+      config: {} as OpenClawConfig,
+    });
+
+    expect(result).toEqual({
+      command: "codex",
+      args: ["--profile", "work"],
+      provider: "codex-cli",
+    });
+  });
+
+  it("resolves command from configured provider", () => {
+    const result = resolveAgentUiLaunchSpec({
+      provider: "my-cli",
+      args: ["--foo"],
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "my-cli": {
+                command: "myagent",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result).toEqual({
+      command: "myagent",
+      args: ["--foo"],
+      provider: "my-cli",
+    });
+  });
+
+  it("fails without command/provider", () => {
+    expect(() =>
+      resolveAgentUiLaunchSpec({
+        config: {} as OpenClawConfig,
+      }),
+    ).toThrow("Provide --command <binary> or --provider <id>");
+  });
+});
+
+describe("ensureAgentUiMemoryBridge", () => {
+  it("creates AGENTS bridge and MEMORY.md if missing", async () => {
+    const targetDir = await makeTempDir("openclaw-agent-ui-target-");
+    const workspaceDir = await makeTempDir("openclaw-agent-ui-workspace-");
+
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "# Workspace AGENTS\n", "utf-8");
+
+    const result = await ensureAgentUiMemoryBridge({
+      targetDir,
+      workspaceDir,
+    });
+
+    const targetAgents = await fs.readFile(path.join(targetDir, "AGENTS.md"), "utf-8");
+    const memoryFile = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+
+    expect(targetAgents).toContain("OPENCLAW_MEMORY_BRIDGE:START");
+    expect(targetAgents).toContain(result.workspaceAgentsPath);
+    expect(targetAgents).toContain(result.memoryDir);
+    expect(targetAgents).toContain(result.memoryFile);
+    expect(memoryFile).toContain("# MEMORY.md");
+  });
+
+  it("replaces existing bridge block instead of duplicating", async () => {
+    const targetDir = await makeTempDir("openclaw-agent-ui-target-");
+    const workspaceDirA = await makeTempDir("openclaw-agent-ui-workspace-a-");
+    const workspaceDirB = await makeTempDir("openclaw-agent-ui-workspace-b-");
+
+    await fs.writeFile(path.join(workspaceDirA, "AGENTS.md"), "# A\n", "utf-8");
+    await fs.writeFile(path.join(workspaceDirB, "AGENTS.md"), "# B\n", "utf-8");
+
+    await ensureAgentUiMemoryBridge({ targetDir, workspaceDir: workspaceDirA });
+    await ensureAgentUiMemoryBridge({ targetDir, workspaceDir: workspaceDirB });
+
+    const content = await fs.readFile(path.join(targetDir, "AGENTS.md"), "utf-8");
+    const occurrences = content.match(/OPENCLAW_MEMORY_BRIDGE:START/g) ?? [];
+
+    expect(occurrences).toHaveLength(1);
+    expect(content).toContain(path.join(workspaceDirB, "MEMORY.md"));
+    expect(content).not.toContain(path.join(workspaceDirA, "MEMORY.md"));
+  });
+});

--- a/src/commands/agent-ui.test.ts
+++ b/src/commands/agent-ui.test.ts
@@ -1,9 +1,16 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearConfigCache } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { ensureAgentUiMemoryBridge, resolveAgentUiLaunchSpec } from "./agent-ui.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  agentUiCommand,
+  ensureAgentUiMemoryBridge,
+  resolveAgentUiLaunchSpec,
+  resolveAgentUiMemoryBridgePaths,
+} from "./agent-ui.js";
 
 const tempDirs: string[] = [];
 
@@ -11,6 +18,15 @@ async function makeTempDir(prefix: string) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+async function pathExists(pathname: string): Promise<boolean> {
+  try {
+    await fs.access(pathname);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 afterEach(async () => {
@@ -71,6 +87,18 @@ describe("resolveAgentUiLaunchSpec", () => {
 });
 
 describe("ensureAgentUiMemoryBridge", () => {
+  it("resolves bridge paths without creating files", async () => {
+    const targetDir = await makeTempDir("openclaw-agent-ui-target-");
+    const workspaceDir = await makeTempDir("openclaw-agent-ui-workspace-");
+
+    const paths = resolveAgentUiMemoryBridgePaths({ targetDir, workspaceDir });
+
+    expect(paths.targetAgentsPath).toBe(path.join(targetDir, "AGENTS.md"));
+    expect(paths.workspaceAgentsPath).toBe(path.join(workspaceDir, "AGENTS.md"));
+    expect(paths.memoryDir).toBe(path.join(workspaceDir, "memory"));
+    expect(paths.memoryFile).toBe(path.join(workspaceDir, "MEMORY.md"));
+  });
+
   it("creates AGENTS bridge and MEMORY.md if missing", async () => {
     const targetDir = await makeTempDir("openclaw-agent-ui-target-");
     const workspaceDir = await makeTempDir("openclaw-agent-ui-workspace-");
@@ -109,5 +137,58 @@ describe("ensureAgentUiMemoryBridge", () => {
     expect(occurrences).toHaveLength(1);
     expect(content).toContain(path.join(workspaceDirB, "MEMORY.md"));
     expect(content).not.toContain(path.join(workspaceDirA, "MEMORY.md"));
+  });
+});
+
+describe("agentUiCommand", () => {
+  it("does not write workspace or bridge files in dry-run mode", async () => {
+    const rootDir = await makeTempDir("openclaw-agent-ui-dry-run-");
+    const stateDir = path.join(rootDir, "state");
+    const targetDir = path.join(rootDir, "target");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const configPath = path.join(stateDir, "openclaw.json");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withEnvAsync(
+      {
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      },
+      async () => {
+        clearConfigCache();
+        const runtime = { log: vi.fn(), error: vi.fn() };
+        const result = await agentUiCommand(
+          {
+            command: "codex",
+            cwd: targetDir,
+            dryRun: true,
+            json: true,
+          },
+          runtime as never,
+        );
+
+        expect(result.bridge?.targetAgentsPath).toBe(path.join(targetDir, "AGENTS.md"));
+        expect(result.bridge?.memoryFile).toBe(path.join(workspaceDir, "MEMORY.md"));
+        expect(await pathExists(targetDir)).toBe(false);
+        expect(await pathExists(path.join(targetDir, "AGENTS.md"))).toBe(false);
+        expect(await pathExists(workspaceDir)).toBe(false);
+        expect(await pathExists(path.join(workspaceDir, "memory"))).toBe(false);
+        expect(await pathExists(path.join(workspaceDir, "MEMORY.md"))).toBe(false);
+      },
+    );
+
+    clearConfigCache();
   });
 });

--- a/src/commands/agent-ui.ts
+++ b/src/commands/agent-ui.ts
@@ -106,7 +106,6 @@ async function writeFileIfMissing(filePath: string, content: string) {
 }
 
 function buildBridgeBlock(params: {
-  workspaceDir: string;
   workspaceAgentsPath: string;
   memoryDir: string;
   memoryFile: string;
@@ -126,30 +125,43 @@ function buildBridgeBlock(params: {
   ].join("\n");
 }
 
-export async function ensureAgentUiMemoryBridge(params: {
+export function resolveAgentUiMemoryBridgePaths(params: {
   targetDir: string;
   workspaceDir: string;
 }) {
   const targetDir = resolveUserPath(params.targetDir);
   const workspaceDir = resolveUserPath(params.workspaceDir);
 
-  await fs.mkdir(targetDir, { recursive: true });
-
   const workspaceAgentsPath = path.join(workspaceDir, "AGENTS.md");
   const memoryDir = path.join(workspaceDir, "memory");
   const memoryFile = path.join(workspaceDir, "MEMORY.md");
+  const targetAgentsPath = path.join(targetDir, "AGENTS.md");
+
+  return {
+    targetAgentsPath,
+    workspaceAgentsPath,
+    memoryDir,
+    memoryFile,
+  };
+}
+
+export async function ensureAgentUiMemoryBridge(params: {
+  targetDir: string;
+  workspaceDir: string;
+}) {
+  const { targetAgentsPath, workspaceAgentsPath, memoryDir, memoryFile } =
+    resolveAgentUiMemoryBridgePaths(params);
+
+  await fs.mkdir(path.dirname(targetAgentsPath), { recursive: true });
 
   await fs.mkdir(memoryDir, { recursive: true });
   await writeFileIfMissing(memoryFile, DEFAULT_MEMORY_TEMPLATE);
 
   const bridgeBlock = buildBridgeBlock({
-    workspaceDir,
     workspaceAgentsPath,
     memoryDir,
     memoryFile,
   });
-
-  const targetAgentsPath = path.join(targetDir, "AGENTS.md");
 
   let current = "";
   try {
@@ -212,7 +224,9 @@ export async function agentUiCommand(opts: AgentUiCommandOpts, runtime: RuntimeE
 
   const agentId = trimOrUndefined(opts.agent) ?? resolveDefaultAgentId(cfg);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
+  if (!opts.dryRun) {
+    await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
+  }
 
   const launchCwd = resolveUserPath(trimOrUndefined(opts.cwd) ?? process.cwd());
 
@@ -230,7 +244,9 @@ export async function agentUiCommand(opts: AgentUiCommandOpts, runtime: RuntimeE
 
   const bridgeEnabled = opts.noBridgeMemory !== true;
   const bridge = bridgeEnabled
-    ? await ensureAgentUiMemoryBridge({ targetDir: launchCwd, workspaceDir })
+    ? opts.dryRun
+      ? resolveAgentUiMemoryBridgePaths({ targetDir: launchCwd, workspaceDir })
+      : await ensureAgentUiMemoryBridge({ targetDir: launchCwd, workspaceDir })
     : null;
 
   const payload = {

--- a/src/commands/agent-ui.ts
+++ b/src/commands/agent-ui.ts
@@ -1,0 +1,287 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveDefaultAgentId, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveCliBackendConfig } from "../agents/cli-backends.js";
+import { parseModelRef } from "../agents/model-selection.js";
+import { ensureAgentWorkspace } from "../agents/workspace.js";
+import { loadConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+
+export type AgentUiCommandOpts = {
+  command?: string;
+  arg?: string[];
+  provider?: string;
+  model?: string;
+  cwd?: string;
+  agent?: string;
+  noBridgeMemory?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+type LaunchSpec = {
+  command: string;
+  args: string[];
+  provider?: string;
+};
+
+type SpawnResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+const BRIDGE_START = "<!-- OPENCLAW_MEMORY_BRIDGE:START -->";
+const BRIDGE_END = "<!-- OPENCLAW_MEMORY_BRIDGE:END -->";
+
+const DEFAULT_MEMORY_TEMPLATE = `# MEMORY.md\n\nLong-term memory for this OpenClaw agent workspace.\n`;
+
+function trimOrUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function resolveProviderFromOpts(params: {
+  provider?: string;
+  model?: string;
+}): string | undefined {
+  const explicit = trimOrUndefined(params.provider);
+  if (explicit) {
+    return explicit;
+  }
+  const model = trimOrUndefined(params.model);
+  if (!model) {
+    return undefined;
+  }
+  const parsed = parseModelRef(model, "");
+  const parsedProvider = parsed?.provider?.trim();
+  return parsedProvider || undefined;
+}
+
+export function resolveAgentUiLaunchSpec(params: {
+  command?: string;
+  args?: string[];
+  provider?: string;
+  config: ReturnType<typeof loadConfig>;
+}): LaunchSpec {
+  const commandOverride = trimOrUndefined(params.command);
+  const args = Array.isArray(params.args) ? params.args.map(String) : [];
+  if (commandOverride) {
+    return {
+      command: commandOverride,
+      args,
+      provider: trimOrUndefined(params.provider),
+    };
+  }
+
+  const provider = trimOrUndefined(params.provider);
+  if (!provider) {
+    throw new Error("Provide --command <binary> or --provider <id> (or --model provider/model).");
+  }
+
+  const backend = resolveCliBackendConfig(provider, params.config);
+  if (!backend?.config.command?.trim()) {
+    throw new Error(
+      `No CLI backend configured for provider "${provider}". Set agents.defaults.cliBackends.${provider}.command or pass --command.`,
+    );
+  }
+
+  return {
+    command: backend.config.command.trim(),
+    args,
+    provider: backend.id,
+  };
+}
+
+async function writeFileIfMissing(filePath: string, content: string) {
+  try {
+    await fs.writeFile(filePath, content, { encoding: "utf-8", flag: "wx" });
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    if (code !== "EEXIST") {
+      throw error;
+    }
+  }
+}
+
+function buildBridgeBlock(params: {
+  workspaceDir: string;
+  workspaceAgentsPath: string;
+  memoryDir: string;
+  memoryFile: string;
+}): string {
+  return [
+    BRIDGE_START,
+    "## OpenClaw Memory Bridge",
+    "",
+    "Use the OpenClaw workspace memory files as canonical memory for this project:",
+    `- OpenClaw AGENTS.md: ${params.workspaceAgentsPath}`,
+    `- Daily memory dir: ${params.memoryDir}`,
+    `- Long-term memory file: ${params.memoryFile}`,
+    "",
+    "If this project has extra rules, follow both sets of instructions.",
+    BRIDGE_END,
+    "",
+  ].join("\n");
+}
+
+export async function ensureAgentUiMemoryBridge(params: {
+  targetDir: string;
+  workspaceDir: string;
+}) {
+  const targetDir = resolveUserPath(params.targetDir);
+  const workspaceDir = resolveUserPath(params.workspaceDir);
+
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const workspaceAgentsPath = path.join(workspaceDir, "AGENTS.md");
+  const memoryDir = path.join(workspaceDir, "memory");
+  const memoryFile = path.join(workspaceDir, "MEMORY.md");
+
+  await fs.mkdir(memoryDir, { recursive: true });
+  await writeFileIfMissing(memoryFile, DEFAULT_MEMORY_TEMPLATE);
+
+  const bridgeBlock = buildBridgeBlock({
+    workspaceDir,
+    workspaceAgentsPath,
+    memoryDir,
+    memoryFile,
+  });
+
+  const targetAgentsPath = path.join(targetDir, "AGENTS.md");
+
+  let current = "";
+  try {
+    current = await fs.readFile(targetAgentsPath, "utf-8");
+  } catch (error) {
+    const code = (error as { code?: string }).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  let next: string;
+  if (!current.trim()) {
+    next = bridgeBlock;
+  } else if (current.includes(BRIDGE_START) && current.includes(BRIDGE_END)) {
+    const pattern = new RegExp(`${BRIDGE_START}[\\s\\S]*?${BRIDGE_END}\\n?`, "m");
+    next = current.replace(pattern, bridgeBlock);
+  } else {
+    const normalized = current.endsWith("\n") ? current : `${current}\n`;
+    next = `${normalized}\n${bridgeBlock}`;
+  }
+
+  if (next !== current) {
+    await fs.writeFile(targetAgentsPath, next, { encoding: "utf-8" });
+  }
+
+  return {
+    targetAgentsPath,
+    workspaceAgentsPath,
+    memoryDir,
+    memoryFile,
+  };
+}
+
+async function spawnInteractiveProcess(params: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<SpawnResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(params.command, params.args, {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", (error) => {
+      reject(error);
+    });
+
+    child.once("close", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+}
+
+export async function agentUiCommand(opts: AgentUiCommandOpts, runtime: RuntimeEnv) {
+  const cfg = loadConfig();
+
+  const agentId = trimOrUndefined(opts.agent) ?? resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
+
+  const launchCwd = resolveUserPath(trimOrUndefined(opts.cwd) ?? process.cwd());
+
+  const provider = resolveProviderFromOpts({
+    provider: opts.provider,
+    model: opts.model,
+  });
+
+  const launchSpec = resolveAgentUiLaunchSpec({
+    command: opts.command,
+    args: opts.arg,
+    provider,
+    config: cfg,
+  });
+
+  const bridgeEnabled = opts.noBridgeMemory !== true;
+  const bridge = bridgeEnabled
+    ? await ensureAgentUiMemoryBridge({ targetDir: launchCwd, workspaceDir })
+    : null;
+
+  const payload = {
+    mode: "external-ui",
+    agentId,
+    cwd: launchCwd,
+    workspaceDir,
+    provider: launchSpec.provider,
+    command: launchSpec.command,
+    args: launchSpec.args,
+    bridge,
+  };
+
+  if (opts.json) {
+    runtime.log(JSON.stringify(payload, null, 2));
+  } else {
+    runtime.log(
+      `Launching external agent UI: ${launchSpec.command} ${launchSpec.args.join(" ")}`.trim(),
+    );
+    runtime.log(`cwd: ${launchCwd}`);
+    if (bridge) {
+      runtime.log(`AGENTS bridge: ${bridge.targetAgentsPath}`);
+    }
+  }
+
+  if (opts.dryRun) {
+    return payload;
+  }
+
+  const env = {
+    ...process.env,
+    OPENCLAW_EXTERNAL_UI: "1",
+    OPENCLAW_AGENT_ID: agentId,
+    OPENCLAW_AGENT_WORKSPACE: workspaceDir,
+    OPENCLAW_AGENT_MEMORY_DIR: path.join(workspaceDir, "memory"),
+    OPENCLAW_AGENT_MEMORY_FILE: path.join(workspaceDir, "MEMORY.md"),
+  };
+
+  const result = await spawnInteractiveProcess({
+    command: launchSpec.command,
+    args: launchSpec.args,
+    cwd: launchCwd,
+    env,
+  });
+
+  if (result.signal) {
+    throw new Error(`External agent UI terminated by signal ${result.signal}.`);
+  }
+  if ((result.code ?? 1) !== 0) {
+    throw new Error(`External agent UI exited with code ${String(result.code)}.`);
+  }
+
+  return payload;
+}


### PR DESCRIPTION
## Summary
- add a new top-level `openclaw agent-ui` command to launch external CLI agent UIs (Codex, Claude Code, OpenCode, etc.)
- allow launch resolution from either `--command` directly or existing `agents.defaults.cliBackends` via `--provider` / `--model`
- add an OpenClaw memory bridge writer that injects a managed block into target `AGENTS.md` pointing to the canonical OpenClaw workspace memory files

## Details
- new command implementation: `src/commands/agent-ui.ts`
  - resolves OpenClaw agent workspace and ensures bootstrap files exist
  - writes/updates a tagged memory bridge block in the target project (`--no-bridge-memory` to disable)
  - supports `--dry-run` + `--json` to preview launch spec and bridge paths
  - launches external CLI with inherited stdio and passes OpenClaw context via env vars
- command registration and discoverability updates:
  - `src/cli/program/register.agent.ts`
  - `src/cli/program/command-registry.ts`
- tests:
  - `src/commands/agent-ui.test.ts`
  - `src/cli/program/register.agent.test.ts`
  - `src/cli/program/command-registry.test.ts`

## Validation
- `pnpm lint -- src/commands/agent-ui.ts src/commands/agent-ui.test.ts src/cli/program/register.agent.ts src/cli/program/register.agent.test.ts src/cli/program/command-registry.ts src/cli/program/command-registry.test.ts`
- `pnpm vitest run src/commands/agent-ui.test.ts src/cli/program/register.agent.test.ts src/cli/program/command-registry.test.ts`
