### PR TITLE
fix(gateway): do not treat unknown lock owner status as stale

### DIFF
--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -286,6 +286,47 @@ describe("gateway lock", () => {
     expect(lock).toBeNull();
   });
 
+  it("does not remove lock when owner status is unknown even past staleMs", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    await writeLockFile(env, {
+      startTime: 111,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const spy = createEaccesProcStatSpy();
+
+    const pending = acquireForTest(env, {
+      timeoutMs: 30,
+      staleMs: 5,
+      platform: "linux",
+    });
+    await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
+
+    spy.mockRestore();
+  });
+
+  it("removes corrupt lock file with no pid when stale", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const { lockPath } = resolveLockPath(env);
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        configPath: "bogus",
+      }),
+      "utf8",
+    );
+
+    const lock = await acquireForTest(env, {
+      timeoutMs: 80,
+      pollIntervalMs: 5,
+      staleMs: 5,
+    });
+    expect(lock).not.toBeNull();
+    await lock?.release();
+  });
+
   it("wraps unexpected fs errors as GatewayLockError", async () => {
     const env = await makeEnv();
     const openSpy = vi.spyOn(fs, "open").mockRejectedValueOnce(

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -4,7 +4,10 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { resolveConfigPath, resolveGatewayLockDir, resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPidAlive } from "../shared/pid-alive.js";
+
+const log = createSubsystemLogger("gateway/lock");
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_POLL_INTERVAL_MS = 100;
@@ -260,7 +263,10 @@ export async function acquireGatewayLock(
         await fs.rm(lockPath, { force: true });
         continue;
       }
-      if (ownerStatus !== "alive") {
+      if (ownerPid && ownerStatus === "unknown") {
+        log.warn(`lock owner status unknown for pid ${ownerPid}; waiting for next probe`);
+      }
+      if (!ownerPid) {
         let stale = false;
         if (lastPayload?.createdAt) {
           const createdAt = Date.parse(lastPayload.createdAt);


### PR DESCRIPTION
## Summary

Fixes #28705

- When `/proc` reads fail on Linux (EACCES, race condition), `resolveGatewayOwnerStatus()` returns `"unknown"`. Previously the stale check treated `"unknown"` the same as `"dead"`, removing a valid lock after 30s and allowing a duplicate gateway to start.
- Changed the stale-time condition from `ownerStatus !== "alive"` to `!ownerPid` so it only fires for corrupt/unreadable lock files (no valid PID). When a PID is known but status is uncertain, the poll loop keeps waiting and re-probes on the next iteration.
- Added a subsystem logger warning when status is `"unknown"` for observability.

## Test plan

- [x] New test: unknown status does NOT remove lock even when `staleMs` is exceeded
- [x] New test: corrupt lock file (no PID) is still cleaned up via stale check
- [x] All existing gateway-lock tests pass
- [x] `pnpm tsgo` — no type errors
- [x] `pnpm check` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)