### PR TITLE
fix(exec): inherit ask from exec-approvals.json when tools.exec.ask unset

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import { type ExecHost, maxAsk, minSecurity } from "../infra/exec-approvals.js";
+import {
+  type ExecHost,
+  loadExecApprovals,
+  maxAsk,
+  minSecurity,
+} from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   getShellPathFromLoginShell,
@@ -324,7 +329,12 @@ export function createExecTool(
       if (elevatedRequested && elevatedMode === "full") {
         security = "full";
       }
-      const configuredAsk = defaults?.ask ?? "on-miss";
+      // Fix #29172: Inherit ask from exec-approvals.json when tools.exec.ask is not set.
+      // Previously this would hardcode "on-miss" when defaults?.ask was undefined,
+      // ignoring exec-approvals.json which may have ask: "off".
+      const execApprovalsFile = loadExecApprovals();
+      const execApprovalsAsk = execApprovalsFile.defaults?.ask;
+      const configuredAsk = defaults?.ask ?? execApprovalsAsk ?? "on-miss";
       const requestedAsk = normalizeExecAsk(params.ask);
       let ask = maxAsk(configuredAsk, requestedAsk ?? configuredAsk);
       const bypassApprovals = elevatedRequested && elevatedMode === "full";

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -7,6 +7,7 @@ import {
   type ExecApprovalsFile,
   type ExecAsk,
   type ExecSecurity,
+  loadExecApprovals,
   maxAsk,
   minSecurity,
   resolveExecApprovalsFromFile,
@@ -110,7 +111,10 @@ function resolveNodesRunPolicy(opts: NodesRunOpts, execDefaults: ExecDefaults | 
   if (opts.security && !requestedSecurity) {
     throw new Error("invalid --security (use deny|allowlist|full)");
   }
-  const configuredAsk = normalizeExecAsk(execDefaults?.ask) ?? "on-miss";
+  // Fix #29172: Inherit ask from exec-approvals.json when tools.exec.ask is not set.
+  const execApprovalsFile = loadExecApprovals();
+  const execApprovalsAsk = execApprovalsFile.defaults?.ask;
+  const configuredAsk = normalizeExecAsk(execDefaults?.ask) ?? execApprovalsAsk ?? "on-miss";
   const requestedAsk = normalizeExecAsk(opts.ask);
   if (opts.ask && !requestedAsk) {
     throw new Error("invalid --ask (use off|on-miss|always)");


### PR DESCRIPTION
## Summary

When `tools.exec.ask` is not configured in `openclaw.json`, the dispatch code hardcodes `'on-miss'` as the default, ignoring `exec-approvals.json` which may have `ask: 'off'` at the defaults level.

## Fix

Read `exec-approvals.json` defaults.ask as a fallback in the chain:

```js
const configuredAsk = defaults?.ask ?? execApprovals.defaults?.ask ?? 'on-miss';
```

## Files Changed

- `src/agents/bash-tools.exec.ts` - Main exec tool dispatch
- `src/cli/nodes-cli/register.invoke.ts` - Nodes run CLI command

## Testing

Users with `exec-approvals.json` set to:
```json
{ "defaults": { "ask": "off" } }
```

...and NO `tools.exec.ask` in `openclaw.json` will now correctly inherit `ask: 'off'` instead of defaulting to `'on-miss'`.

Fixes #29172