### PR TITLE
fix(telegram): keep default account in polling list

### DIFF
--- a/src/telegram/accounts.test.ts
+++ b/src/telegram/accounts.test.ts
@@ -98,6 +98,35 @@ describe("resolveTelegramAccount", () => {
     expect(lines).toContain("listTelegramAccountIds [ 'work' ]");
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
   });
+
+  it("keeps the default account in the polling list when a top-level bot token is configured", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "tok-default",
+            accounts: { alerts: { botToken: "tok-alerts" } },
+          },
+        },
+      };
+
+      expect(listTelegramAccountIds(cfg)).toEqual(["alerts", "default"]);
+    });
+  });
+
+  it("keeps the default account in the polling list when TELEGRAM_BOT_TOKEN is set", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "tok-env" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            accounts: { alerts: { botToken: "tok-alerts" } },
+          },
+        },
+      };
+
+      expect(listTelegramAccountIds(cfg)).toEqual(["alerts", "default"]);
+    });
+  });
 });
 
 describe("resolveTelegramAccount allowFrom precedence", () => {

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -39,15 +39,17 @@ export type ResolvedTelegramAccount = {
 
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
   const accounts = cfg.channels?.telegram?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
   const ids = new Set<string>();
-  for (const key of Object.keys(accounts)) {
-    if (!key) {
-      continue;
+  if (accounts && typeof accounts === "object") {
+    for (const key of Object.keys(accounts)) {
+      if (!key) {
+        continue;
+      }
+      ids.add(normalizeAccountId(key));
     }
-    ids.add(normalizeAccountId(key));
+  }
+  if (resolveTelegramToken(cfg, { accountId: DEFAULT_ACCOUNT_ID }).source !== "none") {
+    ids.add(DEFAULT_ACCOUNT_ID);
   }
   return [...ids];
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when `channels.telegram.botToken` or `TELEGRAM_BOT_TOKEN` configured the default Telegram account, `listTelegramAccountIds()` dropped `default` as soon as any named `channels.telegram.accounts.*` entry existed.
- Why it matters: the default Telegram bot resolved correctly for sends, but polling startup only iterated the named accounts list, so the default bot silently stopped polling for inbound updates.
- What changed: include `default` in the configured account id list whenever default Telegram credentials resolve from config or env, and add regression tests for top-level token and env-token setups.
- What did NOT change (scope boundary): no Telegram account resolution, webhook behavior, or named-account routing logic changed outside the polling account-id list.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26681
- Related #

## User-visible / Behavior Changes

Telegram polling now keeps the default bot active when top-level default Telegram credentials are configured alongside named Telegram accounts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.1
- Runtime/container: Node v22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Telegram polling
- Relevant config (redacted):

```json
{
  "channels": {
    "telegram": {
      "botToken": "<default-token>",
      "accounts": {
        "alerts": {
          "botToken": "<alerts-token>"
        }
      }
    }
  }
}
```

### Steps

1. Reproduce the account-id list with a default bot token plus one named Telegram account:
   ```bash
   pnpm exec tsx -e 'import { resolveTelegramAccount, listTelegramAccountIds } from "./src/telegram/accounts.ts"; const cfg={channels:{telegram:{botToken:"tok-default",accounts:{alerts:{botToken:"tok-alerts"}}}}}; console.log(JSON.stringify({ids:listTelegramAccountIds(cfg as any), resolved:resolveTelegramAccount({cfg:cfg as any, accountId:"default"})}, null, 2));'
   ```
2. Observe the pre-fix output only contains `"alerts"` in `ids`, even though `resolved.token` comes from the default bot token.
3. Run `pnpm exec vitest run src/telegram/accounts.test.ts` after the fix.
4. Run `pnpm check`.

### Expected

- The polling account list includes both `alerts` and `default` whenever default Telegram credentials are configured.
- The regression tests and repo checks pass.

### Actual

- Before the fix, `listTelegramAccountIds()` returned only named accounts, so the default bot never entered the polling startup loop.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bug with the `tsx` command above, confirmed the default account resolved while the polling list omitted it before the fix, then reran the same repro after the fix and saw `ids` become `["alerts","default"]`.
- Edge cases checked: top-level `channels.telegram.botToken`; `TELEGRAM_BOT_TOKEN` with named accounts present.
- What you did **not** verify: live Telegram network polling against the real API.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous `listConfiguredAccountIds()` behavior in `src/telegram/accounts.ts`.
- Files/config to restore: `src/telegram/accounts.ts`, `src/telegram/accounts.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: duplicate Telegram polling startups for the default account. I did not observe that in the local repro because the list still dedupes via `Set`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: default could be added twice when callers already pass an explicit `default` named entry.
  - Mitigation: the account-id list is built through a `Set`, so the final list stays deduped.
