### PR TITLE
fix(telegram): honor env proxy settings

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -13,7 +13,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -134,8 +134,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     }
 
-    const proxyFetch =
-      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+    const proxyFetch = opts.proxyFetch ?? resolveTelegramProxyFetch(account.config.proxy);
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() => {
+const {
+  EnvHttpProxyAgent,
+  ProxyAgent,
+  undiciFetch,
+  proxyAgentSpy,
+  envProxyAgentSpy,
+  getLastAgent,
+} = vi.hoisted(() => {
   const undiciFetch = vi.fn();
   const proxyAgentSpy = vi.fn();
+  const envProxyAgentSpy = vi.fn();
   class ProxyAgent {
     static lastCreated: ProxyAgent | undefined;
     proxyUrl: string;
@@ -13,20 +21,42 @@ const { ProxyAgent, undiciFetch, proxyAgentSpy, getLastAgent } = vi.hoisted(() =
     }
   }
 
+  class EnvHttpProxyAgent {
+    static lastCreated: EnvHttpProxyAgent | undefined;
+    constructor() {
+      EnvHttpProxyAgent.lastCreated = this;
+      envProxyAgentSpy();
+    }
+  }
+
   return {
+    EnvHttpProxyAgent,
     ProxyAgent,
     undiciFetch,
     proxyAgentSpy,
+    envProxyAgentSpy,
     getLastAgent: () => ProxyAgent.lastCreated,
   };
 });
 
 vi.mock("undici", () => ({
+  EnvHttpProxyAgent,
   ProxyAgent,
   fetch: undiciFetch,
 }));
 
-import { makeProxyFetch } from "./proxy.js";
+import { makeEnvProxyFetch, makeProxyFetch, resolveTelegramProxyFetch } from "./proxy.js";
+
+beforeEach(() => {
+  undiciFetch.mockReset();
+  proxyAgentSpy.mockClear();
+  envProxyAgentSpy.mockClear();
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("makeProxyFetch", () => {
   it("uses undici fetch with ProxyAgent dispatcher", async () => {
@@ -41,5 +71,42 @@ describe("makeProxyFetch", () => {
       "https://api.telegram.org/bot123/getMe",
       expect.objectContaining({ dispatcher: getLastAgent() }),
     );
+  });
+});
+
+describe("makeEnvProxyFetch", () => {
+  it("uses EnvHttpProxyAgent when proxy env is configured", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const proxyFetch = makeEnvProxyFetch();
+    expect(proxyFetch).toBeTypeOf("function");
+
+    await proxyFetch?.("https://api.telegram.org/bot123/getMe");
+
+    expect(envProxyAgentSpy).toHaveBeenCalledOnce();
+    expect(undiciFetch).toHaveBeenCalledWith(
+      "https://api.telegram.org/bot123/getMe",
+      expect.objectContaining({ dispatcher: EnvHttpProxyAgent.lastCreated }),
+    );
+  });
+
+  it("returns undefined when no proxy env is configured", () => {
+    vi.unstubAllEnvs();
+
+    expect(makeEnvProxyFetch()).toBeUndefined();
+  });
+});
+
+describe("resolveTelegramProxyFetch", () => {
+  it("prefers explicit proxy config over env proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://env-proxy.test:8080");
+    undiciFetch.mockResolvedValue({ ok: true });
+
+    const proxyFetch = resolveTelegramProxyFetch("http://config-proxy.test:8080");
+    await proxyFetch?.("https://api.telegram.org/bot123/getMe");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://config-proxy.test:8080");
+    expect(envProxyAgentSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,15 +1,48 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 
-export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const agent = new ProxyAgent(proxyUrl);
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
+const ENV_PROXY_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+] as const;
+
+function makeDispatcherFetch(dispatcher: ProxyAgent | EnvHttpProxyAgent): typeof fetch {
   const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
       ...(init as Record<string, unknown>),
-      dispatcher: agent,
+      dispatcher,
     }) as unknown as Promise<Response>) as typeof fetch;
+  return fetcher;
+}
+
+export function makeProxyFetch(proxyUrl: string): typeof fetch {
+  const agent = new ProxyAgent(proxyUrl);
   // Return raw proxy fetch; call sites that need AbortSignal normalization
   // should opt into resolveFetch/wrapFetchWithAbortSignal once at the edge.
-  return fetcher;
+  return makeDispatcherFetch(agent);
+}
+
+function hasEnvProxyConfigured(): boolean {
+  return ENV_PROXY_KEYS.some((key) => {
+    const value = process.env[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+export function makeEnvProxyFetch(): typeof fetch | undefined {
+  if (!hasEnvProxyConfigured()) {
+    return undefined;
+  }
+  return makeDispatcherFetch(new EnvHttpProxyAgent());
+}
+
+export function resolveTelegramProxyFetch(proxyUrl?: string): typeof fetch | undefined {
+  const trimmedProxyUrl = proxyUrl?.trim();
+  if (trimmedProxyUrl) {
+    return makeProxyFetch(trimmedProxyUrl);
+  }
+  return makeEnvProxyFetch();
 }

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,7 +27,7 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { resolveTelegramProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
 import {
@@ -121,8 +121,7 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
+  const proxyFetch = resolveTelegramProxyFetch(account.config.proxy);
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
     network: account.config.network,
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram only built a proxy fetch from explicit Telegram config (`channels.telegram.proxy` / account proxy) and ignored `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` from the process environment.
- Why it matters: in restricted-network environments, polling startup and outbound Telegram API calls failed even when the gateway process had working proxy env vars configured.
- What changed: add a shared Telegram proxy resolver that prefers explicit Telegram proxy config but falls back to Undici's env-aware proxy agent, then use it in both polling (`monitor.ts`) and outbound sends (`send.ts`).
- What did NOT change (scope boundary): no Telegram routing, auth, webhook semantics, or explicit configured proxy behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29133
- Related #

## User-visible / Behavior Changes

Telegram now honors process proxy env vars for polling and outbound API calls when no explicit Telegram proxy is configured.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.1
- Runtime/container: Node v22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted):

```json
{
  "channels": {
    "telegram": {}
  }
}
```

### Steps

1. Create a local repro test on `upstream/main`:
   ```bash
   cat > test/repro-29133.test.ts <<'EOF_TEST'
   import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

   const { loadConfig, createTelegramBotSpy, runSpy } = vi.hoisted(() => ({
     loadConfig: vi.fn(() => ({ agents: { defaults: { maxConcurrent: 2 } }, channels: { telegram: {} } })),
     createTelegramBotSpy: vi.fn(),
     runSpy: vi.fn(() => ({ task: () => Promise.resolve(), stop: vi.fn(), isRunning: () => false })),
   }));

   vi.mock("../src/config/config.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../src/config/config.js")>();
     return { ...actual, loadConfig };
   });
   vi.mock("../src/telegram/bot.js", () => ({
     createTelegramBot: (opts: unknown) => {
       createTelegramBotSpy(opts);
       return {
         on: vi.fn(),
         api: { deleteWebhook: vi.fn(async () => undefined) },
         me: { username: "mybot" },
         init: vi.fn(async () => undefined),
         stop: vi.fn(),
         start: vi.fn(),
       };
     },
     createTelegramWebhookCallback: vi.fn(),
   }));
   vi.mock("@grammyjs/runner", () => ({ run: runSpy }));
   vi.mock("../src/infra/backoff.js", () => ({ computeBackoff: vi.fn(() => 0), sleepWithAbort: vi.fn(async () => undefined) }));
   vi.mock("../src/infra/unhandled-rejections.js", () => ({ registerUnhandledRejectionHandler: vi.fn(() => () => {}) }));
   vi.mock("../src/telegram/webhook.js", () => ({ startTelegramWebhook: vi.fn(async () => ({ server: { close: vi.fn() }, stop: vi.fn() })) }));

   describe("repro #29133", () => {
     beforeEach(() => {
       createTelegramBotSpy.mockClear();
       runSpy.mockReset().mockImplementation(() => ({ task: () => Promise.resolve(), stop: vi.fn(), isRunning: () => false }));
     });
     afterEach(() => {
       vi.unstubAllEnvs();
     });
     it("fails to pass a proxy fetch when HTTPS_PROXY is set", async () => {
       vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
       const abort = new AbortController();
       runSpy.mockImplementationOnce(() => ({
         task: async () => { abort.abort(); },
         stop: vi.fn(),
         isRunning: () => false,
       }));
       const { monitorTelegramProvider } = await import("../src/telegram/monitor.js");
       await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
       expect(createTelegramBotSpy).toHaveBeenCalledWith(
         expect.objectContaining({ proxyFetch: expect.any(Function) }),
       );
     });
   });
   EOF_TEST
   pnpm exec vitest run test/repro-29133.test.ts
   ```
2. Observe the failure: `proxyFetch: undefined` even though `HTTPS_PROXY` is set.
3. Apply this PR and run:
   ```bash
   pnpm exec vitest run src/telegram/proxy.test.ts src/telegram/send.proxy.test.ts src/telegram/monitor.test.ts
   pnpm check
   ```
4. Remove the temporary repro file if you created it.

### Expected

- Telegram polling and outbound sends should use an env-backed proxy fetch when explicit Telegram proxy config is absent and proxy env vars are set.
- Explicit Telegram proxy config should still take precedence over env proxy settings.

### Actual

- Before the fix, both polling and send-side Telegram clients skipped env proxy settings entirely unless `channels.telegram.proxy` was explicitly configured.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: captured the failing polling repro above on `upstream/main`; after the fix, confirmed the shared proxy resolver uses env proxy settings, confirmed polling passes the resolved proxy fetch into `createTelegramBot`, and confirmed outbound send/reaction/delete paths do the same.
- Edge cases checked: explicit Telegram proxy config still overrides env proxy config; no proxy env returns `undefined` and preserves existing non-proxy behavior.
- What you did **not** verify: live Telegram API traffic through a real proxy server.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore direct `makeProxyFetch(account.config.proxy)` call sites in `src/telegram/monitor.ts` and `src/telegram/send.ts`.
- Files/config to restore: `src/telegram/proxy.ts`, `src/telegram/monitor.ts`, `src/telegram/send.ts`, related tests, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: Telegram traffic unexpectedly using env proxy when an explicit per-account proxy should win.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: env proxy handling could override explicit Telegram proxy config.
  - Mitigation: `resolveTelegramProxyFetch()` always prefers the explicit Telegram proxy string and only falls back to env proxies when config proxy is absent/empty.
