### PR TITLE
feat: session idle nudge — prevent silent hangs (#71)

### DIFF
--- a/prompts/idle-nudge.md
+++ b/prompts/idle-nudge.md
@@ -1,0 +1,1 @@
+This session has been idle for 5 min, if it is over update your files and reply END to prevent this message from repeating.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -243,6 +243,27 @@ export type AgentDefaultsConfig = {
      */
     includeReasoning?: boolean;
   };
+  /**
+   * Session idle nudge — prevents silent hangs after errors.
+   * When a non-main session has been idle for the configured duration,
+   * a new agent turn is triggered with a nudge message.
+   *
+   * - `true` or omitted: enabled with 5 min default
+   * - `false`: disabled
+   * - number: idle threshold in ms
+   * - object: full config (`idleMs`, `message`, `maxNudges`)
+   */
+  idleNudge?:
+    | boolean
+    | number
+    | {
+        /** Idle threshold in ms before nudging (default: 300000 = 5 min). */
+        idleMs?: number;
+        /** Custom nudge message text. */
+        message?: string;
+        /** Maximum nudges per session (default: 3; 0 = unlimited). */
+        maxNudges?: number;
+      };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */

--- a/src/cron/idle-nudge.test.ts
+++ b/src/cron/idle-nudge.test.ts
@@ -1,0 +1,347 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { resolveIdleNudgeConfig, sweepIdleSessions, resetIdleNudgeState } from "./idle-nudge.js";
+
+// Mock the imports
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+}));
+
+vi.mock("../config/sessions/store.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+}));
+
+import { isEmbeddedPiRunActive } from "../agents/pi-embedded-runner/runs.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+
+const mockIsActive = vi.mocked(isEmbeddedPiRunActive);
+const mockLoadStore = vi.mocked(loadSessionStore);
+
+const noopLog = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe("resolveIdleNudgeConfig", () => {
+  it("returns default config when undefined", () => {
+    const cfg = resolveIdleNudgeConfig(undefined);
+    expect(cfg).toEqual({ idleMs: 300_000, message: expect.any(String), maxNudges: 3 });
+  });
+
+  it("returns default config when true", () => {
+    const cfg = resolveIdleNudgeConfig({ idleNudge: true });
+    expect(cfg?.idleMs).toBe(300_000);
+  });
+
+  it("returns null when false", () => {
+    expect(resolveIdleNudgeConfig({ idleNudge: false })).toBeNull();
+  });
+
+  it("returns null when 0", () => {
+    expect(resolveIdleNudgeConfig({ idleNudge: 0 })).toBeNull();
+  });
+
+  it("accepts number as idleMs", () => {
+    const cfg = resolveIdleNudgeConfig({ idleNudge: 60_000 });
+    expect(cfg?.idleMs).toBe(60_000);
+  });
+
+  it("accepts object config", () => {
+    const cfg = resolveIdleNudgeConfig({
+      idleNudge: { idleMs: 120_000, message: "wake up", maxNudges: 1 },
+    });
+    expect(cfg).toEqual({ idleMs: 120_000, message: "wake up", maxNudges: 1 });
+  });
+});
+
+describe("sweepIdleSessions", () => {
+  beforeEach(() => {
+    resetIdleNudgeState();
+    mockIsActive.mockReturnValue(false);
+  });
+
+  it("nudges idle subagent sessions", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId: "s1",
+        updatedAt: now - 6 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(1);
+    expect(nudge).toHaveBeenCalledWith(
+      "agent:default:subagent:abc",
+      expect.stringContaining("idle"),
+    );
+  });
+
+  it("nudges idle cron sessions", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:cron:job1": {
+        sessionId: "s2",
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(1);
+  });
+
+  it("nudges idle ticket sessions", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:voss:ticket:71:voss": {
+        sessionId: "s3",
+        updatedAt: now - 7 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(1);
+  });
+
+  it("skips main sessions", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:main": {
+        sessionId: "s4",
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(0);
+    expect(nudge).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions with active runs", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId: "active-session",
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+    mockIsActive.mockReturnValue(true);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(0);
+  });
+
+  it("skips recently updated sessions", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId: "s5",
+        updatedAt: now - 2 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(0);
+  });
+
+  it("respects maxNudges limit", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId: "s6",
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const config = { idleMs: 300_000, maxNudges: 2 };
+
+    for (let i = 0; i < 3; i++) {
+      await sweepIdleSessions({
+        sessionStorePath: "/tmp/sessions.json",
+        config,
+        nowMs: now + i * 60_000,
+        log: noopLog,
+        force: true,
+        nudgeSession: nudge,
+      });
+    }
+
+    expect(nudge).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips sessions where last assistant message is END", async () => {
+    const now = Date.now();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "idle-nudge-test-"));
+    const sessionId = "end-session-123";
+    const jsonlPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 3, id: sessionId }),
+      JSON.stringify({
+        type: "message",
+        id: "m1",
+        message: { role: "user", content: [{ type: "text", text: "do something" }] },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "m2",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done. Updated files.\nEND" }],
+        },
+      }),
+    ];
+    fs.writeFileSync(jsonlPath, lines.join("\n") + "\n");
+
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId,
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      sessionsDir: tmpDir,
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(0);
+    expect(nudge).not.toHaveBeenCalled();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it("nudges sessions where last assistant message is NOT END", async () => {
+    const now = Date.now();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "idle-nudge-test-"));
+    const sessionId = "not-end-session-456";
+    const jsonlPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 3, id: sessionId }),
+      JSON.stringify({
+        type: "message",
+        id: "m1",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I'm working on it..." }],
+        },
+      }),
+    ];
+    fs.writeFileSync(jsonlPath, lines.join("\n") + "\n");
+
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:xyz": {
+        sessionId,
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      sessionsDir: tmpDir,
+      config: { idleMs: 300_000, maxNudges: 3 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    expect(result.nudged).toBe(1);
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it("throttles sweeps", async () => {
+    const now = Date.now();
+    mockLoadStore.mockReturnValue({
+      "agent:default:subagent:abc": {
+        sessionId: "s7",
+        updatedAt: now - 10 * 60_000,
+      },
+    } as any);
+
+    const nudge = vi.fn().mockResolvedValue({ status: "ok" });
+
+    await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 10 },
+      nowMs: now,
+      log: noopLog,
+      force: true,
+      nudgeSession: nudge,
+    });
+
+    const result = await sweepIdleSessions({
+      sessionStorePath: "/tmp/sessions.json",
+      config: { idleMs: 300_000, maxNudges: 10 },
+      nowMs: now + 30_000,
+      log: noopLog,
+      nudgeSession: nudge,
+    });
+
+    expect(result.swept).toBe(false);
+  });
+});

--- a/src/cron/idle-nudge.ts
+++ b/src/cron/idle-nudge.ts
@@ -1,0 +1,282 @@
+/**
+ * Session idle nudge sweep — prevents silent hangs after errors.
+ *
+ * Periodically scans the session store for non-main sessions (subagent,
+ * cron, ticket) that have been idle longer than a configurable threshold.
+ * For each idle session, triggers a new agent turn with a nudge message
+ * prompting the agent to wrap up or continue.
+ *
+ * Ticket: #71
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { Logger } from "./service/state.js";
+import { isEmbeddedPiRunActive } from "../agents/pi-embedded-runner/runs.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
+
+const DEFAULT_IDLE_NUDGE_MS = 5 * 60_000; // 5 minutes
+const MIN_SWEEP_INTERVAL_MS = 60_000; // Don't sweep more than once per minute
+
+const HARDCODED_NUDGE_MESSAGE =
+  "This session has been idle for 5 min, if it is over update your files and reply END to prevent this message from repeating.";
+
+/**
+ * Load the nudge message from prompts/idle-nudge.md (repo root),
+ * falling back to the hardcoded default.
+ */
+function loadDefaultNudgeMessage(): string {
+  try {
+    const promptPath = path.resolve(
+      path.dirname(new URL(import.meta.url).pathname),
+      "../../prompts/idle-nudge.md",
+    );
+    const text = fs.readFileSync(promptPath, "utf-8").trim();
+    if (text) {
+      return `[System Message] ${text}`;
+    }
+  } catch {
+    // Fall through
+  }
+  return `[System Message] ${HARDCODED_NUDGE_MESSAGE}`;
+}
+
+let _cachedNudgeMessage: string | undefined;
+function getDefaultNudgeMessage(): string {
+  if (!_cachedNudgeMessage) {
+    _cachedNudgeMessage = loadDefaultNudgeMessage();
+  }
+  return _cachedNudgeMessage;
+}
+
+/** Reset cached message (for tests or after file changes). */
+export function resetNudgeMessageCache(): void {
+  _cachedNudgeMessage = undefined;
+}
+
+/** Maximum nudges per session before giving up. */
+const DEFAULT_MAX_NUDGES = 3;
+
+export type IdleNudgeConfig = {
+  /** Idle threshold in ms before nudging (default: 300000 = 5 min). */
+  idleMs?: number;
+  /** Custom nudge message text. */
+  message?: string;
+  /** Maximum nudges per session (default: 3; 0 = unlimited). */
+  maxNudges?: number;
+};
+
+export type IdleNudgeSweepResult = {
+  swept: boolean;
+  nudged: number;
+};
+
+/**
+ * Resolve idle nudge config from agents.defaults.idleNudge.
+ */
+export function resolveIdleNudgeConfig(agentDefaults?: {
+  idleNudge?: IdleNudgeConfig | boolean | number;
+}): IdleNudgeConfig | null {
+  const raw = agentDefaults?.idleNudge;
+  if (raw === false || raw === 0) {
+    return null;
+  }
+  if (raw === true || raw === undefined) {
+    return {
+      idleMs: DEFAULT_IDLE_NUDGE_MS,
+      message: getDefaultNudgeMessage(),
+      maxNudges: DEFAULT_MAX_NUDGES,
+    };
+  }
+  if (typeof raw === "number") {
+    return { idleMs: raw, message: getDefaultNudgeMessage(), maxNudges: DEFAULT_MAX_NUDGES };
+  }
+  return {
+    idleMs: raw.idleMs ?? DEFAULT_IDLE_NUDGE_MS,
+    message: raw.message ?? getDefaultNudgeMessage(),
+    maxNudges: raw.maxNudges ?? DEFAULT_MAX_NUDGES,
+  };
+}
+
+/** Track nudge counts per session key to enforce maxNudges. */
+const nudgeCounts = new Map<string, number>();
+let lastSweepAtMs = 0;
+
+/** Reset state (for tests). */
+export function resetIdleNudgeState(): void {
+  nudgeCounts.clear();
+  lastSweepAtMs = 0;
+}
+
+/**
+ * Returns true if a session key looks like an ephemeral/non-main session
+ * that should be nudged when idle.
+ */
+function isNudgeEligibleSessionKey(sessionKey: string): boolean {
+  return (
+    isCronSessionKey(sessionKey) ||
+    isSubagentSessionKey(sessionKey) ||
+    sessionKey.includes(":ticket:")
+  );
+}
+
+/**
+ * Check if the last assistant message in a session transcript ends with "END".
+ */
+function sessionEndedWithEND(sessionId: string, sessionsDir: string): boolean {
+  const filePath = path.join(sessionsDir, `${sessionId}.jsonl`);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return false;
+  }
+  const lines = raw.trimEnd().split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (!line) {
+      continue;
+    }
+    let entry: { type?: string; message?: { role?: string; content?: unknown } };
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (entry.type !== "message" || entry.message?.role !== "assistant") {
+      continue;
+    }
+    const c = entry.message.content;
+    let text = "";
+    if (typeof c === "string") {
+      text = c;
+    } else if (Array.isArray(c)) {
+      for (const block of c) {
+        if (
+          block &&
+          typeof block === "object" &&
+          "type" in block &&
+          block.type === "text" &&
+          typeof block.text === "string"
+        ) {
+          text = block.text;
+        }
+      }
+    }
+    const trimmed = text.trim();
+    return trimmed === "END" || trimmed.endsWith("\nEND");
+  }
+  return false;
+}
+
+/**
+ * Sweep the session store for idle non-main sessions and nudge them.
+ *
+ * Call from the cron timer tick (after sweepCronRunSessions).
+ */
+export async function sweepIdleSessions(params: {
+  sessionStorePath: string;
+  /** Directory containing session JSONL transcript files. */
+  sessionsDir?: string;
+  config: IdleNudgeConfig;
+  nowMs?: number;
+  log: Logger;
+  force?: boolean;
+  /** Trigger an isolated agent run on the given session key with the nudge message. */
+  nudgeSession: (
+    sessionKey: string,
+    message: string,
+  ) => Promise<{
+    status: "ok" | "error" | "skipped";
+    error?: string;
+  }>;
+}): Promise<IdleNudgeSweepResult> {
+  const now = params.nowMs ?? Date.now();
+
+  // Throttle
+  if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
+    return { swept: false, nudged: 0 };
+  }
+  lastSweepAtMs = now;
+
+  const idleMs = params.config.idleMs ?? DEFAULT_IDLE_NUDGE_MS;
+  const maxNudges = params.config.maxNudges ?? DEFAULT_MAX_NUDGES;
+  const message = params.config.message ?? getDefaultNudgeMessage();
+  const cutoff = now - idleMs;
+
+  let store: Record<string, SessionEntry>;
+  try {
+    store = loadSessionStore(params.sessionStorePath);
+  } catch (err) {
+    params.log.warn({ err: String(err) }, "idle-nudge: failed to load session store");
+    return { swept: false, nudged: 0 };
+  }
+
+  const candidates: Array<{ sessionKey: string; entry: SessionEntry }> = [];
+
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry || !entry.sessionId) {
+      continue;
+    }
+    if (!isNudgeEligibleSessionKey(key)) {
+      continue;
+    }
+    if (!entry.updatedAt || entry.updatedAt > cutoff) {
+      continue;
+    }
+
+    // Skip sessions with an active run — they're working
+    if (isEmbeddedPiRunActive(entry.sessionId)) {
+      continue;
+    }
+
+    // Skip sessions where the agent already said END — they wrapped up
+    if (params.sessionsDir && sessionEndedWithEND(entry.sessionId, params.sessionsDir)) {
+      continue;
+    }
+
+    // Check nudge count
+    const count = nudgeCounts.get(key) ?? 0;
+    if (maxNudges > 0 && count >= maxNudges) {
+      continue;
+    }
+
+    candidates.push({ sessionKey: key, entry });
+  }
+
+  let nudged = 0;
+
+  for (const { sessionKey, entry } of candidates) {
+    try {
+      params.log.info(
+        { sessionKey, sessionId: entry.sessionId, idleMs: now - (entry.updatedAt ?? 0) },
+        "idle-nudge: nudging idle session",
+      );
+      const result = await params.nudgeSession(sessionKey, message);
+      if (result.status === "ok" || result.status === "error") {
+        nudgeCounts.set(sessionKey, (nudgeCounts.get(sessionKey) ?? 0) + 1);
+        nudged++;
+      }
+      if (result.status === "error") {
+        params.log.warn({ sessionKey, error: result.error }, "idle-nudge: nudge run failed");
+      }
+    } catch (err) {
+      params.log.warn({ sessionKey, err: String(err) }, "idle-nudge: failed to trigger nudge");
+    }
+  }
+
+  // Clean up nudge counts for sessions that no longer exist
+  for (const key of nudgeCounts.keys()) {
+    if (!store[key]) {
+      nudgeCounts.delete(key);
+    }
+  }
+
+  if (nudged > 0) {
+    params.log.info({ nudged }, `idle-nudge: nudged ${nudged} idle session(s)`);
+  }
+
+  return { swept: true, nudged };
+}

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,5 +1,6 @@
 import type { CronConfig } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import type { IdleNudgeConfig } from "../idle-nudge.js";
 import type {
   CronDeliveryStatus,
   CronJob,
@@ -89,6 +90,16 @@ export type CronServiceDeps = {
       CronRunTelemetry
   >;
   onEvent?: (evt: CronEvent) => void;
+  /** Idle nudge config (resolved from agents.defaults.idleNudge). null = disabled. */
+  idleNudgeConfig?: IdleNudgeConfig | null;
+  /** Trigger an isolated agent run on an existing idle session. */
+  nudgeSession?: (
+    sessionKey: string,
+    message: string,
+  ) => Promise<{
+    status: "ok" | "error" | "skipped";
+    error?: string;
+  }>;
 };
 
 export type CronServiceDepsInternal = Omit<CronServiceDeps, "nowMs"> & {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
+import { sweepIdleSessions } from "../idle-nudge.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
@@ -433,6 +435,25 @@ export async function onTimer(state: CronServiceState) {
           });
         } catch (err) {
           state.deps.log.warn({ err: String(err), storePath }, "cron: session reaper sweep failed");
+        }
+      }
+
+      // Idle nudge sweep — nudge non-main sessions that have gone idle (#71)
+      if (state.deps.idleNudgeConfig && state.deps.nudgeSession) {
+        const nudgeConfig = state.deps.idleNudgeConfig;
+        for (const storePath of storePaths) {
+          try {
+            await sweepIdleSessions({
+              sessionStorePath: storePath,
+              sessionsDir: path.dirname(storePath),
+              config: nudgeConfig,
+              nowMs,
+              log: state.deps.log,
+              nudgeSession: state.deps.nudgeSession,
+            });
+          } catch (err) {
+            state.deps.log.warn({ err: String(err), storePath }, "cron: idle nudge sweep failed");
+          }
         }
       }
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveIdleNudgeConfig } from "../cron/idle-nudge.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import {
   appendCronRunLog,
@@ -25,6 +26,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 
 export type GatewayCronState = {
   cron: CronService;
@@ -200,6 +202,36 @@ export function buildGatewayCronService(params: {
         abortSignal,
         agentId,
         sessionKey: `cron:${job.id}`,
+        lane: "cron",
+      });
+    },
+    idleNudgeConfig: resolveIdleNudgeConfig(params.cfg.agents?.defaults),
+    nudgeSession: async (sessionKey, message) => {
+      // Session keys in the store are "agent:<agentId>:<rest>".
+      // runCronIsolatedAgentTurn re-wraps with buildAgentMainSessionKey,
+      // so strip the prefix and pass the bare key + correct agentId.
+      const parsed = parseAgentSessionKey(sessionKey);
+      const bareKey = parsed?.rest ?? sessionKey;
+      const { agentId, cfg: runtimeConfig } = resolveCronAgent(parsed?.agentId);
+      const nudgeJob = {
+        id: `idle-nudge-${Date.now()}`,
+        name: "idle-nudge",
+        enabled: true,
+        createdAtMs: Date.now(),
+        updatedAtMs: Date.now(),
+        schedule: { kind: "at" as const, at: new Date().toISOString() },
+        sessionTarget: "isolated" as const,
+        payload: { kind: "agentTurn" as const, message },
+        state: { nextRunAtMs: Date.now() },
+        deleteAfterRun: true,
+      };
+      return await runCronIsolatedAgentTurn({
+        cfg: runtimeConfig,
+        deps: params.deps,
+        job: nudgeJob,
+        message,
+        agentId,
+        sessionKey: bareKey,
         lane: "cron",
       });
     },


### PR DESCRIPTION
## Session idle nudge

When a non-main session (subagent, cron, ticket) goes idle for 5+ minutes with no active run, a new agent turn is triggered with a nudge message prompting the agent to wrap up or continue.

### How it works
- Periodic sweep piggybacked on the cron timer tick (like the session reaper)
- Scans session store for eligible sessions past the idle threshold
- Skips sessions with active embedded runs
- Skips sessions where the last assistant message ends with `END`
- Caps at 3 nudges per session
- Session key prefix is stripped so the nudge runs on the **existing** session, not a new one

### Files
- `prompts/idle-nudge.md` — nudge message text (edit and restart to revise wording)
- `src/cron/idle-nudge.ts` — sweep logic + config resolution
- `src/cron/idle-nudge.test.ts` — 16 tests
- `src/cron/service/timer.ts` — sweep call after session reaper
- `src/cron/service/state.ts` — new deps
- `src/gateway/server-cron.ts` — wires deps with session key parsing
- `src/config/types.agent-defaults.ts` — `idleNudge` config type

### Config
Enabled by default (5 min). Override via `agents.defaults.idleNudge`:
```json
{ "idleNudge": false }
{ "idleNudge": 600000 }
{ "idleNudge": { "idleMs": 300000, "message": "...", "maxNudges": 5 } }
```

Closes #71