### PR TITLE
docs(ollama): clarify /v1 tool-calling guidance

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -10,6 +10,10 @@ title: "Ollama"
 
 Ollama is a local LLM runtime that makes it easy to run open-source models on your machine. OpenClaw integrates with Ollama's native API (`/api/chat`), supporting streaming and tool calling, and can **auto-discover tool-capable models** when you opt in with `OLLAMA_API_KEY` (or an auth profile) and do not define an explicit `models.providers.ollama` entry.
 
+<Warning>
+**Remote Ollama users**: Do not use the `/v1` OpenAI-compatible URL (`http://host:11434/v1`) with OpenClaw. This breaks tool calling and models may output raw tool JSON as plain text. Use the native Ollama API URL instead: `baseUrl: "http://host:11434"` (no `/v1`).
+</Warning>
+
 ## Quick start
 
 1. Install Ollama: [https://ollama.ai](https://ollama.ai)
@@ -133,12 +137,17 @@ If Ollama is running on a different host or port (explicit config disables auto-
     providers: {
       ollama: {
         apiKey: "ollama-local",
-        baseUrl: "http://ollama-host:11434",
+        baseUrl: "http://ollama-host:11434", // No /v1 - use native Ollama API URL
+        api: "ollama", // Set explicitly to guarantee native tool-calling behavior
       },
     },
   },
 }
 ```
+
+<Warning>
+Do not add `/v1` to the URL. The `/v1` path uses OpenAI-compatible mode, where tool calling is not reliable. Use the base Ollama URL without a path suffix.
+</Warning>
 
 ### Model selection
 
@@ -177,6 +186,10 @@ OpenClaw's Ollama integration uses the **native Ollama API** (`/api/chat`) by de
 
 #### Legacy OpenAI-Compatible Mode
 
+<Warning>
+**Tool calling is not reliable in OpenAI-compatible mode.** Use this mode only if you need OpenAI format for a proxy and do not depend on native tool calling behavior.
+</Warning>
+
 If you need to use the OpenAI-compatible endpoint instead (e.g., behind a proxy that only supports OpenAI format), set `api: "openai-completions"` explicitly:
 
 ```json5
@@ -194,7 +207,7 @@ If you need to use the OpenAI-compatible endpoint instead (e.g., behind a proxy 
 }
 ```
 
-Note: The OpenAI-compatible endpoint may not support streaming + tool calling simultaneously. You may need to disable streaming with `params: { streaming: false }` in model config.
+This mode may not support streaming + tool calling simultaneously. You may need to disable streaming with `params: { streaming: false }` in model config.
 
 ### Context windows
 


### PR DESCRIPTION
## Summary

- Problem: Ollama `/v1` usage was easy to miss and led to broken tool-calling behavior.
- Why it matters: Users configuring remote Ollama could silently end up in OpenAI-compatible mode and get raw tool JSON output.
- What changed: Added prominent warnings and clarified explicit config examples for native Ollama usage.
- What did NOT change: No code/runtime behavior changes; docs-only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21243
- Related #21437

## User-visible / Behavior Changes

None (docs-only). Ollama setup warnings are now more visible and wording around `api: "ollama"` is precise.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: N/A (docs)
- Runtime/container: N/A
- Model/provider: Ollama
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Read `docs/providers/ollama.md`.
2. Confirm top-level `/v1` warning appears before setup.
3. Confirm custom URL and legacy mode sections both warn about tool-calling limitations.

### Expected

- Users see `/v1` pitfall warnings before copying config.

### Actual

- Warnings are present in all relevant sections.

## Evidence

- [x] Diff shows targeted warning and wording updates in `docs/providers/ollama.md`

## Human Verification (required)

- Verified scenarios: Manual read-through of Ollama docs flow.
- Edge cases checked: Wording avoids overstating `api: "ollama"` as universally required.
- What I did NOT verify: Mintlify local render.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `docs/providers/ollama.md`
- Known bad symptoms reviewers should watch for: N/A (docs-only)

## Risks and Mitigations

None.
