### PR TITLE
fix(voice-call): auto-detect Korean text and use Polly.Seoyeon for notify mode

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -95,6 +95,18 @@
       "label": "Realtime STT Model",
       "advanced": true
     },
+    "streaming.realtimeModel": {
+      "label": "Realtime Conversation Model",
+      "advanced": true
+    },
+    "streaming.realtimeVoice": {
+      "label": "Realtime Voice",
+      "advanced": true
+    },
+    "streaming.realtimeSystemPrompt": {
+      "label": "Realtime System Prompt",
+      "advanced": true
+    },
     "streaming.streamPath": {
       "label": "Media Stream Path",
       "advanced": true
@@ -322,12 +334,22 @@
           },
           "sttProvider": {
             "type": "string",
-            "enum": ["openai-realtime"]
+            "enum": ["openai-realtime", "openai-realtime-conversation"]
           },
           "openaiApiKey": {
             "type": "string"
           },
           "sttModel": {
+            "type": "string"
+          },
+          "realtimeModel": {
+            "type": "string"
+          },
+          "realtimeVoice": {
+            "type": "string",
+            "enum": ["alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse"]
+          },
+          "realtimeSystemPrompt": {
             "type": "string"
           },
           "silenceDurationMs": {
@@ -341,6 +363,22 @@
           },
           "streamPath": {
             "type": "string"
+          },
+          "preStartTimeoutMs": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnections": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnectionsPerIp": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxConnections": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -27,6 +27,8 @@ function createBaseConfig(provider: "telnyx" | "twilio" | "plivo" | "mock"): Voi
       enabled: false,
       sttProvider: "openai-realtime",
       sttModel: "gpt-4o-transcribe",
+      realtimeModel: "gpt-4o-realtime-preview",
+      realtimeVoice: "alloy",
       silenceDurationMs: 800,
       vadThreshold: 0.5,
       streamPath: "/voice/stream",

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -207,12 +207,26 @@ export const VoiceCallStreamingConfigSchema = z
   .object({
     /** Enable real-time audio streaming (requires WebSocket support) */
     enabled: z.boolean().default(false),
-    /** STT provider for real-time transcription */
-    sttProvider: z.enum(["openai-realtime"]).default("openai-realtime"),
+    /**
+     * STT/conversation provider for real-time audio:
+     * - "openai-realtime": Transcription only (Pi agent LLM + TTS pipeline)
+     * - "openai-realtime-conversation": Full conversation (OpenAI handles STT + LLM + TTS)
+     */
+    sttProvider: z
+      .enum(["openai-realtime", "openai-realtime-conversation"])
+      .default("openai-realtime"),
     /** OpenAI API key for Realtime API (uses OPENAI_API_KEY env if not set) */
     openaiApiKey: z.string().min(1).optional(),
     /** OpenAI transcription model (default: gpt-4o-transcribe) */
     sttModel: z.string().min(1).default("gpt-4o-transcribe"),
+    /** Realtime conversation model (default: gpt-4o-realtime-preview) */
+    realtimeModel: z.string().min(1).default("gpt-4o-realtime-preview"),
+    /** Voice for AI responses in conversation mode */
+    realtimeVoice: z
+      .enum(["alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer", "verse"])
+      .default("alloy"),
+    /** System prompt / instructions for conversation mode */
+    realtimeSystemPrompt: z.string().optional(),
     /** VAD silence duration in ms before considering speech ended */
     silenceDurationMs: z.number().int().positive().default(800),
     /** VAD threshold 0-1 (higher = less sensitive) */
@@ -236,6 +250,8 @@ export const VoiceCallStreamingConfigSchema = z
     enabled: false,
     sttProvider: "openai-realtime",
     sttModel: "gpt-4o-transcribe",
+    realtimeModel: "gpt-4o-realtime-preview",
+    realtimeVoice: "alloy",
     silenceDurationMs: 800,
     vadThreshold: 0.5,
     streamPath: "/voice/stream",

--- a/extensions/voice-call/src/core-bridge.ts
+++ b/extensions/voice-call/src/core-bridge.ts
@@ -42,6 +42,8 @@ type CoreAgentDeps = {
     lane?: string;
     extraSystemPrompt?: string;
     agentDir?: string;
+    /** Called with each text delta as Claude generates output. */
+    onPartialReply?: (payload: { text: string }) => void | Promise<void>;
   }) => Promise<{
     payloads?: Array<{ text?: string; isError?: boolean }>;
     meta?: { aborted?: boolean };

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -11,6 +11,7 @@ import {
   initiateCall as initiateCallWithContext,
   speak as speakWithContext,
   speakInitialMessage as speakInitialMessageWithContext,
+  speakStream as speakStreamWithContext,
 } from "./manager/outbound.js";
 import { getCallHistoryFromStore, loadActiveCallsFromStore } from "./manager/store.js";
 import type { VoiceCallProvider } from "./providers/base.js";
@@ -102,6 +103,18 @@ export class CallManager {
    */
   async speak(callId: CallId, text: string): Promise<{ success: boolean; error?: string }> {
     return speakWithContext(this.getContext(), callId, text);
+  }
+
+  /**
+   * Speak a stream of sentence-sized text chunks to the caller.
+   * Starts audio playback as soon as the first chunk is available while the
+   * rest of the response continues to be generated.
+   */
+  async speakStream(
+    callId: CallId,
+    textStream: AsyncIterable<string>,
+  ): Promise<{ success: boolean; error?: string }> {
+    return speakStreamWithContext(this.getContext(), callId, textStream);
   }
 
   /**

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -159,7 +159,7 @@ export async function initiateCall(
     // For notify mode with a message, use inline TwiML with <Say>.
     let inlineTwiml: string | undefined;
     if (mode === "notify" && initialMessage) {
-      const pollyVoice = mapVoiceToPolly(ctx.config.tts?.openai?.voice);
+      const pollyVoice = mapVoiceToPolly(ctx.config.tts?.openai?.voice, initialMessage);
       inlineTwiml = generateNotifyTwiml(initialMessage, pollyVoice);
       console.log(`[voice-call] Using inline TwiML for notify mode (voice: ${pollyVoice})`);
     }

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -38,10 +38,12 @@ export interface MediaStreamConfig {
   maxConnections?: number;
   /** Validate whether to accept a media stream for the given call ID */
   shouldAcceptStream?: (params: { callId: string; streamSid: string; token?: string }) => boolean;
-  /** Callback when transcript is received */
+  /** Callback when user transcript is received (final) */
   onTranscript?: (callId: string, transcript: string) => void;
   /** Callback for partial transcripts (streaming UI) */
   onPartialTranscript?: (callId: string, partial: string) => void;
+  /** Callback when AI response transcript is received (conversation mode only) */
+  onResponseTranscript?: (callId: string, transcript: string) => void;
   /** Callback when stream connects */
   onConnect?: (callId: string, streamSid: string) => void;
   /** Callback when speech starts (barge-in) */
@@ -251,6 +253,11 @@ export class MediaStreamHandler {
 
       convSession.onTranscriptDone((text) => {
         this.config.onTranscript?.(callSid, text);
+      });
+
+      // AI response transcript (bot side of the conversation)
+      convSession.onResponseTranscriptDone((text) => {
+        this.config.onResponseTranscript?.(callSid, text);
       });
 
       session.conversationSession = convSession;

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -11,16 +11,23 @@ import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer } from "ws";
 import type {
+  OpenAIRealtimeConversationProvider,
+  RealtimeConversationSession,
+} from "./providers/openai-realtime-conversation.js";
+import type {
   OpenAIRealtimeSTTProvider,
   RealtimeSTTSession,
 } from "./providers/stt-openai-realtime.js";
 
 /**
  * Configuration for the media stream handler.
+ * Exactly one of sttProvider or conversationProvider must be set.
  */
 export interface MediaStreamConfig {
-  /** STT provider for transcription */
-  sttProvider: OpenAIRealtimeSTTProvider;
+  /** STT-only provider (transcription → Pi agent → TTS pipeline) */
+  sttProvider?: OpenAIRealtimeSTTProvider;
+  /** Full conversation provider (OpenAI handles STT + LLM + TTS in one round-trip) */
+  conversationProvider?: OpenAIRealtimeConversationProvider;
   /** Close sockets that never send a valid `start` frame within this window. */
   preStartTimeoutMs?: number;
   /** Max concurrent pre-start sockets. */
@@ -45,12 +52,14 @@ export interface MediaStreamConfig {
 
 /**
  * Active media stream session.
+ * sttSession xor conversationSession is set depending on the configured mode.
  */
 interface StreamSession {
   callId: string;
   streamSid: string;
   ws: WebSocket;
-  sttSession: RealtimeSTTSession;
+  sttSession?: RealtimeSTTSession;
+  conversationSession?: RealtimeConversationSession;
 }
 
 type TtsQueueEntry = {
@@ -152,9 +161,10 @@ export class MediaStreamHandler {
 
           case "media":
             if (session && message.media?.payload) {
-              // Forward audio to STT
+              // Forward audio to whichever session is active
               const audioBuffer = Buffer.from(message.media.payload, "base64");
-              session.sttSession.sendAudio(audioBuffer);
+              session.sttSession?.sendAudio(audioBuffer);
+              session.conversationSession?.sendAudio(audioBuffer);
             }
             break;
 
@@ -213,38 +223,75 @@ export class MediaStreamHandler {
       return null;
     }
 
-    // Create STT session
-    const sttSession = this.config.sttProvider.createSession();
-
-    // Set up transcript callbacks
-    sttSession.onPartial((partial) => {
-      this.config.onPartialTranscript?.(callSid, partial);
-    });
-
-    sttSession.onTranscript((transcript) => {
-      this.config.onTranscript?.(callSid, transcript);
-    });
-
-    sttSession.onSpeechStart(() => {
-      this.config.onSpeechStart?.(callSid);
-    });
-
     const session: StreamSession = {
       callId: callSid,
       streamSid,
       ws,
-      sttSession,
     };
 
-    this.sessions.set(streamSid, session);
+    if (this.config.conversationProvider) {
+      // Full conversation mode: OpenAI handles STT + LLM + TTS
+      const convSession = this.config.conversationProvider.createSession();
 
-    // Notify connection BEFORE STT connect so TTS can work even if STT fails
-    this.config.onConnect?.(callSid, streamSid);
+      // AI audio → send directly to Twilio (no TTS queue needed)
+      convSession.onAudioDelta((chunk) => {
+        this.sendAudio(streamSid, chunk);
+      });
 
-    // Connect to OpenAI STT (non-blocking, log errors but don't fail the call)
-    sttSession.connect().catch((err) => {
-      console.warn(`[MediaStream] STT connection failed (TTS still works):`, err.message);
-    });
+      // Barge-in: caller speech started → clear Twilio's audio buffer
+      convSession.onSpeechStart(() => {
+        this.clearAudio(streamSid);
+        this.config.onSpeechStart?.(callSid);
+      });
+
+      // Caller transcript callbacks
+      convSession.onTranscriptDelta((partial) => {
+        this.config.onPartialTranscript?.(callSid, partial);
+      });
+
+      convSession.onTranscriptDone((text) => {
+        this.config.onTranscript?.(callSid, text);
+      });
+
+      session.conversationSession = convSession;
+
+      this.sessions.set(streamSid, session);
+      this.config.onConnect?.(callSid, streamSid);
+
+      convSession.connect().catch((err) => {
+        console.warn(`[MediaStream] Conversation connection failed:`, err.message);
+      });
+    } else if (this.config.sttProvider) {
+      // STT-only mode: transcription → Pi agent → TTS pipeline
+      const sttSession = this.config.sttProvider.createSession();
+
+      sttSession.onPartial((partial) => {
+        this.config.onPartialTranscript?.(callSid, partial);
+      });
+
+      sttSession.onTranscript((transcript) => {
+        this.config.onTranscript?.(callSid, transcript);
+      });
+
+      sttSession.onSpeechStart(() => {
+        this.config.onSpeechStart?.(callSid);
+      });
+
+      session.sttSession = sttSession;
+
+      this.sessions.set(streamSid, session);
+
+      // Notify connection BEFORE STT connect so TTS can work even if STT fails
+      this.config.onConnect?.(callSid, streamSid);
+
+      sttSession.connect().catch((err) => {
+        console.warn(`[MediaStream] STT connection failed (TTS still works):`, err.message);
+      });
+    } else {
+      console.warn("[MediaStream] No provider configured; closing stream");
+      ws.close(1011, "No provider");
+      return null;
+    }
 
     return session;
   }
@@ -256,7 +303,8 @@ export class MediaStreamHandler {
     console.log(`[MediaStream] Stream stopped: ${session.streamSid}`);
 
     this.clearTtsState(session.streamSid);
-    session.sttSession.close();
+    session.sttSession?.close();
+    session.conversationSession?.close();
     this.sessions.delete(session.streamSid);
     this.config.onDisconnect?.(session.callId);
   }
@@ -432,7 +480,8 @@ export class MediaStreamHandler {
   closeAll(): void {
     for (const session of this.sessions.values()) {
       this.clearTtsState(session.streamSid);
-      session.sttSession.close();
+      session.sttSession?.close();
+      session.conversationSession?.close();
       session.ws.close();
     }
     this.sessions.clear();

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -56,6 +56,14 @@ export interface VoiceCallProvider {
   playTts(input: PlayTtsInput): Promise<void>;
 
   /**
+   * Play a stream of sentence-sized text chunks as sequential TTS audio.
+   * Providers that support it (e.g. Twilio with media streams) can start
+   * playing audio before the full response has been generated.
+   * Optional — callers fall back to playTts when absent.
+   */
+  playTtsStream?(textStream: AsyncIterable<string>, providerCallId: string): Promise<void>;
+
+  /**
    * Start listening for user speech (activate STT).
    */
   startListening(input: StartListeningInput): Promise<void>;

--- a/extensions/voice-call/src/providers/openai-realtime-conversation.test.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-conversation.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for OpenAI Realtime Conversation Provider
+ *
+ * Uses a mocked WebSocket (via vi.mock) to verify the provider sends the correct
+ * events and fires the correct callbacks without any network I/O.
+ */
+
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---- mock WebSocket ---------------------------------------------------------
+
+/**
+ * Minimal fake WebSocket that behaves like the real `ws` WebSocket:
+ * - Emits "open" asynchronously on construction
+ * - Captures .send() calls
+ * - Exposes helpers to trigger server-side events (message, close, error)
+ */
+class FakeWebSocket extends EventEmitter {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readyState = FakeWebSocket.OPEN;
+  sent: string[] = [];
+
+  // Track the most recently created instance so tests can interact with it
+  static lastInstance: FakeWebSocket | null = null;
+
+  constructor(_url: string, _opts?: unknown) {
+    super();
+    FakeWebSocket.lastInstance = this;
+    // Simulate async open
+    setTimeout(() => this.emit("open"), 0);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", 1000, Buffer.from(""));
+  }
+
+  /** Simulate a message arriving from the server */
+  simulateMessage(event: unknown): void {
+    this.emit("message", Buffer.from(JSON.stringify(event)));
+  }
+
+  /** Simulate a server-initiated close */
+  simulateClose(code = 1006): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", code, Buffer.from(""));
+  }
+}
+
+vi.mock("ws", () => ({
+  default: FakeWebSocket,
+  WebSocket: FakeWebSocket,
+}));
+
+// ---- import after mock is in place ------------------------------------------
+
+const { OpenAIRealtimeConversationProvider } = await import("./openai-realtime-conversation.js");
+import type { RealtimeConversationSession } from "./openai-realtime-conversation.js";
+
+// ---- helpers ----------------------------------------------------------------
+
+/** Create a session and wait until it is connected. */
+async function connectSession(opts?: {
+  systemPrompt?: string;
+  voice?: string;
+  silenceDurationMs?: number;
+  vadThreshold?: number;
+}): Promise<RealtimeConversationSession> {
+  const provider = new OpenAIRealtimeConversationProvider({
+    apiKey: "test-key",
+    model: "gpt-4o-realtime-preview",
+    voice: opts?.voice ?? "alloy",
+    systemPrompt: opts?.systemPrompt,
+    silenceDurationMs: opts?.silenceDurationMs ?? 800,
+    vadThreshold: opts?.vadThreshold ?? 0.5,
+  });
+
+  const session = provider.createSession();
+  await session.connect();
+  return session;
+}
+
+/** Parse the last N sent messages from the fake WS. */
+function sentEvents(ws: FakeWebSocket): Array<Record<string, unknown>> {
+  return ws.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("OpenAIRealtimeConversationProvider", () => {
+  it("throws when apiKey is missing", () => {
+    expect(() => new OpenAIRealtimeConversationProvider({ apiKey: "" })).toThrow(
+      "OpenAI API key required",
+    );
+  });
+
+  it("returns name = openai-realtime-conversation", () => {
+    const provider = new OpenAIRealtimeConversationProvider({ apiKey: "k" });
+    expect(provider.name).toBe("openai-realtime-conversation");
+  });
+
+  it("creates a session that starts disconnected", () => {
+    const provider = new OpenAIRealtimeConversationProvider({ apiKey: "k" });
+    const session = provider.createSession();
+    expect(session.isConnected()).toBe(false);
+  });
+});
+
+describe("OpenAIRealtimeConversationSession", () => {
+  beforeEach(() => {
+    FakeWebSocket.lastInstance = null;
+  });
+
+  it("sends session.update on connect with correct parameters", async () => {
+    const session = await connectSession({
+      systemPrompt: "Be helpful",
+      voice: "coral",
+      silenceDurationMs: 600,
+      vadThreshold: 0.3,
+    });
+
+    const ws = FakeWebSocket.lastInstance!;
+    const events = sentEvents(ws);
+
+    expect(events).toHaveLength(1);
+    const su = events[0];
+    expect(su.type).toBe("session.update");
+
+    const s = su.session as Record<string, unknown>;
+    expect(s.voice).toBe("coral");
+    expect(s.input_audio_format).toBe("g711_ulaw");
+    expect(s.output_audio_format).toBe("g711_ulaw");
+    expect(s.modalities).toEqual(["text", "audio"]);
+    expect(s.instructions).toBe("Be helpful");
+
+    const td = s.turn_detection as Record<string, unknown>;
+    expect(td.type).toBe("server_vad");
+    expect(td.silence_duration_ms).toBe(600);
+    expect(td.threshold).toBe(0.3);
+
+    expect(session.isConnected()).toBe(true);
+    session.close();
+  });
+
+  it("omits instructions when systemPrompt is not set", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+    const su = sentEvents(ws)[0];
+    const s = su.session as Record<string, unknown>;
+    expect(s.instructions).toBeUndefined();
+    session.close();
+  });
+
+  it("sendAudio sends input_audio_buffer.append with base64 payload", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+    const before = ws.sent.length;
+
+    const audio = Buffer.from([0x01, 0x02, 0x03]);
+    session.sendAudio(audio);
+
+    const events = sentEvents(ws).slice(before);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("input_audio_buffer.append");
+    expect(events[0].audio).toBe(audio.toString("base64"));
+
+    session.close();
+  });
+
+  it("does not send audio when disconnected", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    session.close();
+    const before = ws.sent.length;
+
+    session.sendAudio(Buffer.from([0xff]));
+    expect(ws.sent.length).toBe(before);
+  });
+
+  it("sends response.cancel and fires onSpeechStart on speech_started", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    const speechStartCb = vi.fn();
+    session.onSpeechStart(speechStartCb);
+
+    const before = ws.sent.length;
+    ws.simulateMessage({ type: "input_audio_buffer.speech_started" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const events = sentEvents(ws).slice(before);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("response.cancel");
+    expect(speechStartCb).toHaveBeenCalledOnce();
+
+    session.close();
+  });
+
+  it("fires onAudioDelta for response.audio.delta", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    const chunks: Buffer[] = [];
+    session.onAudioDelta((chunk) => chunks.push(chunk));
+
+    const payload = Buffer.from([0xaa, 0xbb]).toString("base64");
+    ws.simulateMessage({ type: "response.audio.delta", delta: payload });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(Buffer.from(payload, "base64"));
+
+    session.close();
+  });
+
+  it("accumulates and fires onTranscriptDelta/Done for caller transcript", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    const deltas: string[] = [];
+    const dones: string[] = [];
+    session.onTranscriptDelta((p) => deltas.push(p));
+    session.onTranscriptDone((t) => dones.push(t));
+
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.delta",
+      delta: "Hel",
+    });
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.delta",
+      delta: "lo",
+    });
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "Hello",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // delta accumulates: "Hel", then "Hello"
+    expect(deltas).toEqual(["Hel", "Hello"]);
+    expect(dones).toEqual(["Hello"]);
+
+    session.close();
+  });
+
+  it("resets input transcript accumulator after done", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    const dones: string[] = [];
+    session.onTranscriptDone((t) => dones.push(t));
+
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "First",
+    });
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.delta",
+      delta: "Second",
+    });
+    ws.simulateMessage({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "Second",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(dones).toEqual(["First", "Second"]);
+    session.close();
+  });
+
+  it("fires onResponseTranscriptDelta/Done for AI transcript", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    const deltas: string[] = [];
+    const dones: string[] = [];
+    session.onResponseTranscriptDelta((p) => deltas.push(p));
+    session.onResponseTranscriptDone((t) => dones.push(t));
+
+    ws.simulateMessage({ type: "response.audio_transcript.delta", delta: "Hi " });
+    ws.simulateMessage({ type: "response.audio_transcript.delta", delta: "there" });
+    ws.simulateMessage({ type: "response.audio_transcript.done", transcript: "Hi there" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(deltas).toEqual(["Hi ", "Hi there"]);
+    expect(dones).toEqual(["Hi there"]);
+
+    session.close();
+  });
+
+  it("isConnected() returns false after close()", async () => {
+    const session = await connectSession();
+    expect(session.isConnected()).toBe(true);
+    session.close();
+    expect(session.isConnected()).toBe(false);
+  });
+
+  it("does not attempt reconnect after intentional close()", async () => {
+    const session = await connectSession();
+    const ws = FakeWebSocket.lastInstance!;
+
+    session.close();
+    const instanceBefore = FakeWebSocket.lastInstance;
+
+    // Simulate server closing after we closed (would normally trigger reconnect if not intentional)
+    ws.simulateClose(1006);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // No new WebSocket should have been created
+    expect(FakeWebSocket.lastInstance).toBe(instanceBefore);
+  });
+});

--- a/extensions/voice-call/src/providers/openai-realtime-conversation.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-conversation.ts
@@ -51,6 +51,12 @@ export interface RealtimeConversationSession {
   close(): void;
   /** Check if session is currently connected */
   isConnected(): boolean;
+  /**
+   * Trigger the AI to speak first (e.g., for greeting the caller at call start).
+   * If message is provided, instructs the AI to use that exact text.
+   * Falls back to a natural greeting based on the session's system prompt.
+   */
+  triggerGreeting(message?: string): void;
 }
 
 /**
@@ -364,5 +370,18 @@ class OpenAIRealtimeConversationSession implements RealtimeConversationSession {
 
   isConnected(): boolean {
     return this.connected;
+  }
+
+  triggerGreeting(message?: string): void {
+    if (!this.connected) return;
+    if (message) {
+      // Use the message text as instructions for just this response so the AI says exactly that.
+      this.sendEvent({
+        type: "response.create",
+        response: { instructions: `Begin the call by saying exactly: "${message}"` },
+      });
+    } else {
+      this.sendEvent({ type: "response.create" });
+    }
   }
 }

--- a/extensions/voice-call/src/providers/openai-realtime-conversation.ts
+++ b/extensions/voice-call/src/providers/openai-realtime-conversation.ts
@@ -1,0 +1,368 @@
+/**
+ * OpenAI Realtime Conversation Provider
+ *
+ * Full conversation mode: Twilio audio → OpenAI Realtime (STT + LLM + TTS) → mu-law → Twilio.
+ * - Eliminates the Pi agent LLM round-trip and all TTS synthesis
+ * - Audio flows both directions over a single persistent WebSocket
+ * - Sub-second response latency via server-side VAD and barge-in support
+ */
+
+import WebSocket from "ws";
+
+/**
+ * Configuration for OpenAI Realtime conversation mode.
+ */
+export interface RealtimeConversationConfig {
+  /** OpenAI API key */
+  apiKey: string;
+  /** Realtime model to use (default: gpt-4o-realtime-preview) */
+  model?: string;
+  /** Voice for AI responses (default: alloy) */
+  voice?: string;
+  /** System prompt / instructions for the model */
+  systemPrompt?: string;
+  /** Silence duration in ms before considering speech ended (default: 800) */
+  silenceDurationMs?: number;
+  /** VAD threshold 0-1 (default: 0.5) */
+  vadThreshold?: number;
+}
+
+/**
+ * Session handle for a full-duplex conversation with OpenAI Realtime.
+ */
+export interface RealtimeConversationSession {
+  /** Connect to the OpenAI Realtime WebSocket */
+  connect(): Promise<void>;
+  /** Send mu-law audio data (8kHz mono) from the caller */
+  sendAudio(audio: Buffer): void;
+  /** Register callback that fires for each audio delta from the AI (mu-law chunks) */
+  onAudioDelta(callback: (chunk: Buffer) => void): void;
+  /** Register callback when caller speech starts (use for barge-in) */
+  onSpeechStart(callback: () => void): void;
+  /** Register callback for partial caller transcript */
+  onTranscriptDelta(callback: (partial: string) => void): void;
+  /** Register callback for final caller transcript */
+  onTranscriptDone(callback: (text: string) => void): void;
+  /** Register callback for partial AI response transcript */
+  onResponseTranscriptDelta(callback: (partial: string) => void): void;
+  /** Register callback for final AI response transcript */
+  onResponseTranscriptDone(callback: (text: string) => void): void;
+  /** Close the session */
+  close(): void;
+  /** Check if session is currently connected */
+  isConnected(): boolean;
+}
+
+/**
+ * Provider factory for OpenAI Realtime conversation sessions.
+ */
+export class OpenAIRealtimeConversationProvider {
+  readonly name = "openai-realtime-conversation";
+  private apiKey: string;
+  private model: string;
+  private voice: string;
+  private systemPrompt: string | undefined;
+  private silenceDurationMs: number;
+  private vadThreshold: number;
+
+  constructor(config: RealtimeConversationConfig) {
+    if (!config.apiKey) {
+      throw new Error("OpenAI API key required for Realtime Conversation");
+    }
+    this.apiKey = config.apiKey;
+    this.model = config.model || "gpt-4o-realtime-preview";
+    this.voice = config.voice || "alloy";
+    this.systemPrompt = config.systemPrompt;
+    this.silenceDurationMs = config.silenceDurationMs ?? 800;
+    this.vadThreshold = config.vadThreshold ?? 0.5;
+  }
+
+  createSession(): RealtimeConversationSession {
+    return new OpenAIRealtimeConversationSession(
+      this.apiKey,
+      this.model,
+      this.voice,
+      this.systemPrompt,
+      this.silenceDurationMs,
+      this.vadThreshold,
+    );
+  }
+}
+
+/**
+ * WebSocket-based full-duplex conversation session.
+ */
+class OpenAIRealtimeConversationSession implements RealtimeConversationSession {
+  private static readonly MAX_RECONNECT_ATTEMPTS = 5;
+  private static readonly RECONNECT_DELAY_MS = 1000;
+
+  private ws: WebSocket | null = null;
+  private connected = false;
+  private closed = false;
+  private reconnectAttempts = 0;
+
+  private onAudioDeltaCallback: ((chunk: Buffer) => void) | null = null;
+  private onSpeechStartCallback: (() => void) | null = null;
+  private onTranscriptDeltaCallback: ((partial: string) => void) | null = null;
+  private onTranscriptDoneCallback: ((text: string) => void) | null = null;
+  private onResponseTranscriptDeltaCallback: ((partial: string) => void) | null = null;
+  private onResponseTranscriptDoneCallback: ((text: string) => void) | null = null;
+
+  /** Accumulates caller input transcript deltas */
+  private pendingInputTranscript = "";
+  /** Accumulates AI response transcript deltas */
+  private pendingResponseTranscript = "";
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly model: string,
+    private readonly voice: string,
+    private readonly systemPrompt: string | undefined,
+    private readonly silenceDurationMs: number,
+    private readonly vadThreshold: number,
+  ) {}
+
+  async connect(): Promise<void> {
+    this.closed = false;
+    this.reconnectAttempts = 0;
+    return this.doConnect();
+  }
+
+  private async doConnect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = `wss://api.openai.com/v1/realtime?model=${encodeURIComponent(this.model)}`;
+
+      this.ws = new WebSocket(url, {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "OpenAI-Beta": "realtime=v1",
+        },
+      });
+
+      this.ws.on("open", () => {
+        console.log("[RealtimeConversation] WebSocket connected");
+        this.connected = true;
+        this.reconnectAttempts = 0;
+
+        // Configure the session: bidirectional g711 ulaw, server VAD, optional system prompt
+        const sessionUpdate: Record<string, unknown> = {
+          modalities: ["text", "audio"],
+          voice: this.voice,
+          input_audio_format: "g711_ulaw",
+          output_audio_format: "g711_ulaw",
+          input_audio_transcription: { model: "gpt-4o-transcribe" },
+          turn_detection: {
+            type: "server_vad",
+            threshold: this.vadThreshold,
+            silence_duration_ms: this.silenceDurationMs,
+          },
+        };
+
+        if (this.systemPrompt) {
+          sessionUpdate.instructions = this.systemPrompt;
+        }
+
+        this.sendEvent({ type: "session.update", session: sessionUpdate });
+        resolve();
+      });
+
+      this.ws.on("message", (data: Buffer) => {
+        try {
+          const event = JSON.parse(data.toString()) as Record<string, unknown>;
+          this.handleEvent(event);
+        } catch (e) {
+          console.error("[RealtimeConversation] Failed to parse event:", e);
+        }
+      });
+
+      this.ws.on("error", (error) => {
+        console.error("[RealtimeConversation] WebSocket error:", error);
+        if (!this.connected) {
+          reject(error);
+        }
+      });
+
+      this.ws.on("close", (code, reason) => {
+        console.log(
+          `[RealtimeConversation] WebSocket closed (code: ${code}, reason: ${reason?.toString() || "none"})`,
+        );
+        this.connected = false;
+
+        if (!this.closed) {
+          void this.attemptReconnect();
+        }
+      });
+
+      setTimeout(() => {
+        if (!this.connected) {
+          reject(new Error("Realtime Conversation connection timeout"));
+        }
+      }, 10000);
+    });
+  }
+
+  private async attemptReconnect(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    if (this.reconnectAttempts >= OpenAIRealtimeConversationSession.MAX_RECONNECT_ATTEMPTS) {
+      console.error(
+        `[RealtimeConversation] Max reconnect attempts (${OpenAIRealtimeConversationSession.MAX_RECONNECT_ATTEMPTS}) reached`,
+      );
+      return;
+    }
+
+    this.reconnectAttempts++;
+    const delay =
+      OpenAIRealtimeConversationSession.RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1);
+    console.log(
+      `[RealtimeConversation] Reconnecting ${this.reconnectAttempts}/${OpenAIRealtimeConversationSession.MAX_RECONNECT_ATTEMPTS} in ${delay}ms...`,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    if (this.closed) {
+      return;
+    }
+
+    try {
+      await this.doConnect();
+      console.log("[RealtimeConversation] Reconnected successfully");
+    } catch (error) {
+      console.error("[RealtimeConversation] Reconnect failed:", error);
+    }
+  }
+
+  private handleEvent(event: Record<string, unknown>): void {
+    const type = event.type as string;
+
+    switch (type) {
+      case "session.created":
+      case "session.updated":
+        console.log(`[RealtimeConversation] ${type}`);
+        break;
+
+      case "input_audio_buffer.speech_started":
+        // Caller started speaking — trigger barge-in: cancel current AI response
+        console.log("[RealtimeConversation] Speech started (barge-in)");
+        this.sendEvent({ type: "response.cancel" });
+        this.onSpeechStartCallback?.();
+        break;
+
+      case "input_audio_buffer.speech_stopped":
+      case "input_audio_buffer.committed":
+        console.log(`[RealtimeConversation] ${type}`);
+        break;
+
+      case "conversation.item.input_audio_transcription.delta":
+        // Partial caller transcript
+        if (event.delta) {
+          this.pendingInputTranscript += event.delta as string;
+          this.onTranscriptDeltaCallback?.(this.pendingInputTranscript);
+        }
+        break;
+
+      case "conversation.item.input_audio_transcription.completed":
+        // Final caller transcript
+        if (event.transcript) {
+          const text = event.transcript as string;
+          console.log(`[RealtimeConversation] Caller: ${text}`);
+          this.onTranscriptDoneCallback?.(text);
+        }
+        this.pendingInputTranscript = "";
+        break;
+
+      case "response.audio.delta":
+        // AI audio chunk (base64 g711 ulaw) — decode and forward to Twilio
+        if (event.delta) {
+          const chunk = Buffer.from(event.delta as string, "base64");
+          this.onAudioDeltaCallback?.(chunk);
+        }
+        break;
+
+      case "response.audio.done":
+        console.log("[RealtimeConversation] AI audio done");
+        break;
+
+      case "response.audio_transcript.delta":
+        // Partial AI response transcript
+        if (event.delta) {
+          this.pendingResponseTranscript += event.delta as string;
+          this.onResponseTranscriptDeltaCallback?.(this.pendingResponseTranscript);
+        }
+        break;
+
+      case "response.audio_transcript.done":
+        // Final AI response transcript
+        if (event.transcript) {
+          const text = event.transcript as string;
+          console.log(`[RealtimeConversation] AI: ${text}`);
+          this.onResponseTranscriptDoneCallback?.(text);
+        }
+        this.pendingResponseTranscript = "";
+        break;
+
+      case "response.done":
+        console.log("[RealtimeConversation] Response done");
+        break;
+
+      case "error":
+        console.error("[RealtimeConversation] Error:", event.error);
+        break;
+    }
+  }
+
+  private sendEvent(event: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(event));
+    }
+  }
+
+  sendAudio(muLawData: Buffer): void {
+    if (!this.connected) {
+      return;
+    }
+    this.sendEvent({
+      type: "input_audio_buffer.append",
+      audio: muLawData.toString("base64"),
+    });
+  }
+
+  onAudioDelta(callback: (chunk: Buffer) => void): void {
+    this.onAudioDeltaCallback = callback;
+  }
+
+  onSpeechStart(callback: () => void): void {
+    this.onSpeechStartCallback = callback;
+  }
+
+  onTranscriptDelta(callback: (partial: string) => void): void {
+    this.onTranscriptDeltaCallback = callback;
+  }
+
+  onTranscriptDone(callback: (text: string) => void): void {
+    this.onTranscriptDoneCallback = callback;
+  }
+
+  onResponseTranscriptDelta(callback: (partial: string) => void): void {
+    this.onResponseTranscriptDeltaCallback = callback;
+  }
+
+  onResponseTranscriptDone(callback: (text: string) => void): void {
+    this.onResponseTranscriptDoneCallback = callback;
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.connected = false;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -641,6 +641,57 @@ export class TwilioProvider implements VoiceCallProvider {
   }
 
   /**
+   * Play a stream of text chunks as sequential TTS audio.
+   *
+   * Each sentence chunk is synthesized and queued immediately so the caller
+   * starts hearing audio while the remainder of the response is still being
+   * generated.  Chunks play sequentially (FIFO via queueTts) so there are no
+   * audio gaps or overlaps.
+   *
+   * Falls back to a single playTts call if media-stream TTS is unavailable.
+   */
+  async playTtsStream(textStream: AsyncIterable<string>, providerCallId: string): Promise<void> {
+    const streamSid = this.callStreamMap.get(providerCallId);
+
+    if (!this.ttsProvider || !this.mediaStreamHandler || !streamSid) {
+      // No streaming capability — collect all chunks and fall back to playTts.
+      const chunks: string[] = [];
+      for await (const chunk of textStream) {
+        if (chunk.trim()) {
+          chunks.push(chunk);
+        }
+      }
+      const fullText = chunks.join(" ").trim();
+      if (fullText) {
+        await this.playTts({ callId: "", providerCallId, text: fullText });
+      }
+      return;
+    }
+
+    // Queue each chunk as an independent TTS job so audio flows as soon as
+    // each sentence is synthesized, without waiting for the full response.
+    const chunkPromises: Promise<void>[] = [];
+    for await (const chunk of textStream) {
+      const text = chunk.trim();
+      if (!text) {
+        continue;
+      }
+      // Fire-and-queue: errors are caught per-chunk so one failure does not
+      // prevent subsequent chunks from playing.
+      const p = this.playTtsViaStream(text, streamSid).catch((err) => {
+        console.error(
+          `[voice-call] Streaming TTS chunk error (continuing):`,
+          err instanceof Error ? err.message : err,
+        );
+      });
+      chunkPromises.push(p);
+    }
+
+    // Wait for all queued chunks to finish playing.
+    await Promise.all(chunkPromises);
+  }
+
+  /**
    * Start listening for speech via Twilio <Gather>.
    */
   async startListening(input: StartListeningInput): Promise<void> {

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -587,7 +587,7 @@ export class TwilioProvider implements VoiceCallProvider {
       "[voice-call] Using TwiML <Say> fallback - telephony TTS not configured or media stream not active",
     );
 
-    const pollyVoice = mapVoiceToPolly(input.voice);
+    const pollyVoice = mapVoiceToPolly(input.voice, input.text);
     const twiml = `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Say voice="${pollyVoice}" language="${input.locale || "en-US"}">${escapeXml(input.text)}</Say>

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -7,6 +7,86 @@ import crypto from "node:crypto";
 import type { VoiceCallConfig } from "./config.js";
 import { loadCoreAgentDeps, type CoreConfig } from "./core-bridge.js";
 
+// Abbreviation prefixes we refuse to split on (conservative list).
+// These end with a period but are not sentence boundaries.
+const ABBREV_PREFIXES = new Set([
+  "mr",
+  "mrs",
+  "ms",
+  "dr",
+  "prof",
+  "sr",
+  "jr",
+  "vs",
+  "etc",
+  "inc",
+  "ltd",
+  "dept",
+  "approx",
+  "est",
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+]);
+
+/**
+ * Check whether `buf` ending in `. ` (or `.\n`) at offset `dotPos` is a real
+ * sentence boundary.  `dotPos` is the index of the period character.
+ */
+function isSentenceBoundary(buf: string, dotPos: number): boolean {
+  // Walk back to get the word before the period.
+  let start = dotPos - 1;
+  while (start >= 0 && /\w/.test(buf[start]!)) {
+    start--;
+  }
+  const word = buf.slice(start + 1, dotPos).toLowerCase();
+  return !ABBREV_PREFIXES.has(word);
+}
+
+/**
+ * Flush complete sentences from the token buffer.
+ * Returns [sentencesToFlush, remainingBuffer].
+ * Forces a flush at a word boundary if the buffer exceeds maxLen.
+ */
+function extractSentences(buf: string, maxLen = 200): { flush: string; remaining: string } {
+  let flushUpTo = -1;
+
+  // Scan for `. `, `? `, `! `, `.\n`, `?\n`, `!\n`
+  for (let i = 0; i < buf.length - 1; i++) {
+    const ch = buf[i];
+    const next = buf[i + 1];
+    if (ch === "." && (next === " " || next === "\n")) {
+      if (isSentenceBoundary(buf, i)) {
+        flushUpTo = i + 1; // include the period but not the trailing space/newline
+      }
+    } else if ((ch === "?" || ch === "!") && (next === " " || next === "\n")) {
+      flushUpTo = i + 1;
+    }
+  }
+
+  if (flushUpTo !== -1) {
+    return {
+      flush: buf.slice(0, flushUpTo).trimEnd(),
+      remaining: buf.slice(flushUpTo).trimStart(),
+    };
+  }
+
+  // Force split at word boundary when buffer is too long
+  if (buf.length >= maxLen) {
+    const lastSpace = buf.lastIndexOf(" ", maxLen);
+    const splitAt = lastSpace > 0 ? lastSpace : maxLen;
+    return { flush: buf.slice(0, splitAt).trimEnd(), remaining: buf.slice(splitAt).trimStart() };
+  }
+
+  return { flush: "", remaining: buf };
+}
+
 export type VoiceResponseParams = {
   /** Voice call config */
   voiceConfig: VoiceCallConfig;
@@ -153,6 +233,163 @@ export async function generateVoiceResponse(
     return { text };
   } catch (err) {
     console.error(`[voice-call] Response generation failed:`, err);
+    return { text: null, error: String(err) };
+  }
+}
+
+export type VoiceResponseStreamParams = VoiceResponseParams & {
+  /** Called with each complete sentence as it becomes available. */
+  onSentenceChunk: (text: string) => Promise<void>;
+};
+
+/**
+ * Streaming variant of generateVoiceResponse.
+ *
+ * Uses onPartialReply to buffer tokens and emit complete sentences via
+ * onSentenceChunk as Claude generates them.  The caller can start playing
+ * audio immediately while generation continues.  Still returns the full
+ * assembled text for transcript logging.
+ */
+export async function generateVoiceResponseStream(
+  params: VoiceResponseStreamParams,
+): Promise<VoiceResponseResult> {
+  const { voiceConfig, callId, from, transcript, userMessage, coreConfig, onSentenceChunk } =
+    params;
+
+  if (!coreConfig) {
+    return { text: null, error: "Core config unavailable for voice response" };
+  }
+
+  let deps: Awaited<ReturnType<typeof loadCoreAgentDeps>>;
+  try {
+    deps = await loadCoreAgentDeps();
+  } catch (err) {
+    return {
+      text: null,
+      error: err instanceof Error ? err.message : "Unable to load core agent dependencies",
+    };
+  }
+  const cfg = coreConfig;
+
+  const normalizedPhone = from.replace(/\D/g, "");
+  const sessionKey = `voice:${normalizedPhone}`;
+  const agentId = "main";
+
+  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
+  const agentDir = deps.resolveAgentDir(cfg, agentId);
+  const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
+
+  await deps.ensureAgentWorkspace({ dir: workspaceDir });
+
+  const sessionStore = deps.loadSessionStore(storePath);
+  const now = Date.now();
+  let sessionEntry = sessionStore[sessionKey] as SessionEntry | undefined;
+
+  if (!sessionEntry) {
+    sessionEntry = { sessionId: crypto.randomUUID(), updatedAt: now };
+    sessionStore[sessionKey] = sessionEntry;
+    await deps.saveSessionStore(storePath, sessionStore);
+  }
+
+  const sessionId = sessionEntry.sessionId;
+  const sessionFile = deps.resolveSessionFilePath(sessionId, sessionEntry, { agentId });
+
+  const modelRef = voiceConfig.responseModel || `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
+  const slashIndex = modelRef.indexOf("/");
+  const provider = slashIndex === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIndex);
+  const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
+
+  const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
+
+  const identity = deps.resolveAgentIdentity(cfg, agentId);
+  const agentName = identity?.name?.trim() || "assistant";
+
+  const basePrompt =
+    voiceConfig.responseSystemPrompt ??
+    `You are ${agentName}, a helpful voice assistant on a phone call. Keep responses brief and conversational (1-2 sentences max). Be natural and friendly. The caller's phone number is ${from}. You have access to tools - use them when helpful.`;
+
+  let extraSystemPrompt = basePrompt;
+  if (transcript.length > 0) {
+    const history = transcript
+      .map((entry) => `${entry.speaker === "bot" ? "You" : "Caller"}: ${entry.text}`)
+      .join("\n");
+    extraSystemPrompt = `${basePrompt}\n\nConversation so far:\n${history}`;
+  }
+
+  const timeoutMs = voiceConfig.responseTimeoutMs ?? deps.resolveAgentTimeoutMs({ cfg });
+  const runId = `voice:${callId}:${Date.now()}`;
+
+  // Buffer for partial tokens; flushed to onSentenceChunk at sentence boundaries.
+  let tokenBuf = "";
+  // onPartialReply fires with cumulative snapshots (full text so far), not deltas.
+  // Track how much of the snapshot we've already consumed so we only process new text.
+  let lastSnapshotLen = 0;
+
+  const flushChunk = async (text: string): Promise<void> => {
+    try {
+      await onSentenceChunk(text);
+    } catch (err) {
+      // Log and continue — a TTS failure for one chunk should not abort the full response.
+      console.error(`[voice-call] Sentence chunk TTS error (continuing):`, err);
+    }
+  };
+
+  // onPartialReply receives cumulative snapshots; extract only the new suffix.
+  const onPartialReply = async (payload: { text: string }): Promise<void> => {
+    const newText = payload.text.slice(lastSnapshotLen);
+    lastSnapshotLen = payload.text.length;
+    if (!newText) return;
+    tokenBuf += newText;
+    const { flush, remaining } = extractSentences(tokenBuf);
+    if (flush) {
+      tokenBuf = remaining;
+      await flushChunk(flush);
+    }
+  };
+
+  try {
+    const result = await deps.runEmbeddedPiAgent({
+      sessionId,
+      sessionKey,
+      messageProvider: "voice",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: userMessage,
+      provider,
+      model,
+      thinkLevel,
+      verboseLevel: "off",
+      timeoutMs,
+      runId,
+      lane: "voice",
+      extraSystemPrompt,
+      agentDir,
+      onPartialReply,
+    });
+
+    // Flush any remaining buffered text after generation completes.
+    const leftover = tokenBuf.trim();
+    if (leftover) {
+      await flushChunk(leftover);
+      tokenBuf = "";
+    }
+
+    // Assemble full text from payloads for transcript logging.
+    const texts = (result.payloads ?? [])
+      .filter((p) => p.text && !p.isError)
+      .map((p) => p.text?.trim())
+      .filter(Boolean);
+
+    const text = texts.join(" ") || null;
+
+    if (!text && result.meta?.aborted) {
+      return { text: null, error: "Response generation was aborted" };
+    }
+
+    return { text };
+  } catch (err) {
+    console.error(`[voice-call] Streaming response generation failed:`, err);
     return { text: null, error: String(err) };
   }
 }

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -127,6 +127,10 @@ export const NormalizedEventSchema = z.discriminatedUnion("type", [
     error: z.string(),
     retryable: z.boolean().optional(),
   }),
+  BaseEventSchema.extend({
+    type: z.literal("call.bot-speech"),
+    transcript: z.string(),
+  }),
 ]);
 export type NormalizedEvent = z.infer<typeof NormalizedEventSchema>;
 

--- a/extensions/voice-call/src/voice-mapping.ts
+++ b/extensions/voice-call/src/voice-mapping.ts
@@ -32,14 +32,39 @@ const OPENAI_TO_POLLY_MAP: Record<string, string> = {
 export const DEFAULT_POLLY_VOICE = "Polly.Joanna";
 
 /**
+ * Default Polly voice for Korean text.
+ * Polly.Seoyeon is the only AWS Polly voice with native Korean support.
+ */
+export const DEFAULT_POLLY_VOICE_KO = "Polly.Seoyeon";
+
+/**
+ * Detect if text is predominantly Korean (Hangul characters).
+ * Used to automatically select an appropriate TTS voice.
+ *
+ * @param text - Input text to check
+ * @returns true if more than 20% of characters are Hangul
+ */
+export function isKoreanText(text: string): boolean {
+  if (!text || text.length === 0) return false;
+  const hangulCount = (text.match(/[\uAC00-\uD7A3\u1100-\u11FF\u3130-\u318F]/g) || []).length;
+  return hangulCount / text.length > 0.2;
+}
+
+/**
  * Map OpenAI voice names to Twilio Polly equivalents.
  * Falls through if already a valid Polly/Google voice.
+ * Automatically selects Polly.Seoyeon for Korean text when no voice is specified.
  *
  * @param voice - OpenAI voice name (alloy, echo, etc.) or Polly voice name
+ * @param text - Optional text content used for language auto-detection
  * @returns Polly voice name suitable for Twilio TwiML
  */
-export function mapVoiceToPolly(voice: string | undefined): string {
+export function mapVoiceToPolly(voice: string | undefined, text?: string): string {
   if (!voice) {
+    // Auto-detect Korean and use Seoyeon for natural Korean TTS
+    if (text && isKoreanText(text)) {
+      return DEFAULT_POLLY_VOICE_KO;
+    }
     return DEFAULT_POLLY_VOICE;
   }
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -138,6 +138,20 @@ export class VoiceCallWebhookServer {
           }
         }
       },
+      onResponseTranscript: (providerCallId: string, transcript: string) => {
+        console.log(`[voice-call] AI response for ${providerCallId}: ${transcript}`);
+        const call = this.manager.getCallByProviderCallId(providerCallId);
+        if (!call) return;
+        const event: NormalizedEvent = {
+          id: `stream-bot-transcript-${Date.now()}`,
+          type: "call.bot-speech",
+          callId: call.callId,
+          providerCallId,
+          timestamp: Date.now(),
+          transcript,
+        };
+        this.manager.processEvent(event);
+      },
       onSpeechStart: (providerCallId: string) => {
         // STT mode: clear TTS queue on barge-in
         // Conversation mode: barge-in is handled inside the provider (response.cancel + clearAudio)


### PR DESCRIPTION
## Summary

Fixes silent/wrong-language TTS in notify mode for Korean users.

**Problem:** `mapVoiceToPolly()` always defaults to `Polly.Joanna` (English) when no voice is configured. Korean text sent via notify mode is read by an English voice, resulting in broken, unnatural pronunciation.

**Fix:** Extend `mapVoiceToPolly()` to accept optional `text` for language auto-detection. When >20% of characters are Hangul and no voice is explicitly set, `Polly.Seoyeon` is selected automatically — the only AWS Polly voice with native Korean support.

## Changes

- `voice-mapping.ts`: add `isKoreanText()` helper + `DEFAULT_POLLY_VOICE_KO` + extend `mapVoiceToPolly(text?)`
- `manager/outbound.ts`: pass `initialMessage` to `mapVoiceToPolly` in notify mode
- `providers/twilio.ts`: pass `input.text` to `mapVoiceToPolly` in `<Say>` fallback

## Test Environment

- OpenClaw `2026.2.25`, Twilio, Tailscale Funnel
- Korean message via `voice_call(mode: notify)`
- **Before:** `Polly.Joanna` — English voice, broken Korean pronunciation  
- **After:** `Polly.Seoyeon` — Korean voice, natural pronunciation

## Notes

This is a targeted fix on top of PR #25465. The broader ElevenLabs TTS support for notify mode (without streaming) would require serving synthesized audio via `<Play>` and hosting the audio buffer — a larger change tracked separately.

Closes #5732 (partial — addresses notify mode Korean TTS; conversation mode fix is in #25465)