### PR TITLE
fix(telegram): prevent cross-bot mention collision in multi-account groups

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -1,9 +1,11 @@
+import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramThreadParams,
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramForumThreadId,
 } from "./helpers.js";
@@ -328,6 +330,42 @@ describe("describeReplyTarget", () => {
     expect(result?.forwardedFrom?.fromType).toBe("user");
     expect(result?.forwardedFrom?.fromId).toBe("123");
     expect(result?.forwardedFrom?.date).toBe(700);
+  });
+});
+
+function makeMsg(text: string, entities?: Message["entities"]): Message {
+  return { message_id: 1, date: 0, chat: { id: 1, type: "group" }, text, entities } as Message;
+}
+
+describe("hasBotMention", () => {
+  it("matches exact mention at end of text", () => {
+    expect(hasBotMention(makeMsg("hello @gaian"), "gaian")).toBe(true);
+  });
+
+  it("matches mention followed by punctuation", () => {
+    expect(hasBotMention(makeMsg("@gaian, what's up?"), "gaian")).toBe(true);
+  });
+
+  it("matches mention followed by space", () => {
+    expect(hasBotMention(makeMsg("@gaian how are you"), "gaian")).toBe(true);
+  });
+
+  it("does not match substring of a longer username", () => {
+    expect(hasBotMention(makeMsg("@gaianchat_bot hello"), "gaian")).toBe(false);
+  });
+
+  it("does not match when mention is a prefix of another word", () => {
+    expect(hasBotMention(makeMsg("@gaianbot do something"), "gaian")).toBe(false);
+  });
+
+  it("matches via exact entity even when text check would fail", () => {
+    const msg = makeMsg("hello @gaian world", [{ type: "mention", offset: 6, length: 6 }]);
+    expect(hasBotMention(msg, "gaian")).toBe(true);
+  });
+
+  it("does not match entity with different username", () => {
+    const msg = makeMsg("@gaianchat_bot", [{ type: "mention", offset: 0, length: 14 }]);
+    expect(hasBotMention(msg, "gaian")).toBe(false);
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -249,7 +249,12 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
 
 export function hasBotMention(msg: Message, botUsername: string) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
+  const mention = `@${botUsername}`;
+  const idx = text.indexOf(mention);
+  if (
+    idx !== -1 &&
+    (idx + mention.length >= text.length || !/\w/.test(text[idx + mention.length]))
+  ) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];


### PR DESCRIPTION
## Summary

Fixes #29173 — `hasBotMention()` uses `String.includes()` for text-based mention detection, which matches substrings of longer usernames. In multi-account Telegram groups, `@gaian` incorrectly triggers when `@GaianChat_Bot` is mentioned because `"@gaianchat_bot".includes("@gaian")` evaluates to `true`.

## Root Cause

In `src/telegram/bot/helpers.ts`, `hasBotMention()` has two detection paths:

1. **Text-based fallback** (line 252): Uses `.includes()` — matches substrings, causing false positives
2. **Entity-based check** (line 261): Uses `===` — correct, exact match only

The text-based path fires first, so the entity check never gets a chance to reject the false match.

## Fix

Replace the `.includes()` substring check with a word-boundary-aware check using `.indexOf()` + next-character inspection:

```typescript
const mention = `@${botUsername}`;
const idx = text.indexOf(mention);
if (idx !== -1 && (idx + mention.length >= text.length || !/\w/.test(text[idx + mention.length]))) {
  return true;
}
```

This ensures `@gaian` matches only when followed by a non-word character (space, comma, period, etc.) or end-of-string — not when it's a prefix of `@gaianchat_bot`.

## Test plan

Added 7 test cases to `src/telegram/bot/helpers.test.ts` covering:
- Exact mention at end of text
- Mention followed by punctuation
- Mention followed by space
- Substring of longer username (must NOT match)
- Prefix of another word (must NOT match)
- Exact entity match
- Entity with different username (must NOT match)