### PR TITLE
fix: drop leading orphan tool_result messages after history limiting

### DIFF
--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -5,6 +5,7 @@ import {
   estimateMessagesTokens,
   pruneHistoryForContextShare,
   splitMessagesByTokenShare,
+  dropLeadingOrphanToolMessages,
 } from "./compaction.js";
 
 function makeMessage(id: number, size: number): AgentMessage {
@@ -145,5 +146,62 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.droppedChunks).toBe(0);
     expect(pruned.droppedMessagesList).toEqual([]);
     expect(pruned.messages.length).toBe(1);
+  });
+
+  it("strips leading orphan tool_result messages after dropping chunks", () => {
+    const toolResult = (id: number): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId: `call_${id}`,
+        toolName: "test",
+        content: [{ type: "text", text: "ok" }],
+        timestamp: id,
+      }) as AgentMessage;
+    const assistant = (id: number, size: number): AgentMessage =>
+      ({
+        role: "assistant",
+        content: "a".repeat(size),
+        timestamp: id,
+      }) as AgentMessage;
+    // Chunk boundary will drop first chunk; second chunk starts with tool_result(s).
+    const messages: AgentMessage[] = [
+      makeMessage(1, 2000),
+      assistant(2, 2000),
+      toolResult(3),
+      makeMessage(4, 2000),
+      assistant(5, 2000),
+      toolResult(6),
+      makeMessage(7, 2000),
+    ];
+    const maxContextTokens = 2000;
+    const pruned = pruneHistoryForContextShare({
+      messages,
+      maxContextTokens,
+      maxHistoryShare: 0.5,
+      parts: 2,
+    });
+    expect(pruned.droppedChunks).toBeGreaterThan(0);
+    const roles = pruned.messages.map((m) => (m as { role?: string }).role);
+    expect(roles[0]).not.toBe("toolResult");
+  });
+
+  it("dropLeadingOrphanToolMessages leaves non-tool start unchanged", () => {
+    const messages: AgentMessage[] = [makeMessage(1, 100), makeMessage(2, 100)];
+    expect(dropLeadingOrphanToolMessages(messages)).toBe(messages);
+  });
+
+  it("dropLeadingOrphanToolMessages strips leading toolResult only", () => {
+    const toolResult = (id: number): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId: `call_${id}`,
+        toolName: "test",
+        content: [],
+        timestamp: id,
+      }) as AgentMessage;
+    const messages: AgentMessage[] = [toolResult(1), toolResult(2), makeMessage(3, 100)];
+    const out = dropLeadingOrphanToolMessages(messages);
+    expect(out.length).toBe(1);
+    expect((out[0] as { role?: string }).role).toBe("user");
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -304,6 +304,21 @@ export async function summarizeInStages(params: {
   });
 }
 
+/**
+ * Remove leading tool_result messages. When history is trimmed by dropping an
+ * initial chunk, the kept list can start with tool results whose tool_use was
+ * in the dropped chunk; the API requires each tool_result to have a matching
+ * tool_use in the immediately previous message, so leading tool messages must
+ * be dropped to avoid invalid_request_error.
+ */
+export function dropLeadingOrphanToolMessages(messages: AgentMessage[]): AgentMessage[] {
+  let i = 0;
+  while (i < messages.length && (messages[i] as { role?: string }).role === "toolResult") {
+    i += 1;
+  }
+  return i === 0 ? messages : messages.slice(i);
+}
+
 export function pruneHistoryForContextShare(params: {
   messages: AgentMessage[];
   maxContextTokens: number;
@@ -339,6 +354,10 @@ export function pruneHistoryForContextShare(params: {
     droppedTokens += estimateMessagesTokens(dropped);
     allDroppedMessages.push(...dropped);
     keptMessages = rest.flat();
+    // After dropping a chunk, the kept list might start with tool_result messages whose
+    // corresponding tool_use was in the dropped chunk. Leading tool messages have no
+    // preceding assistant message, so they cause "unexpected tool_use_id" from the API.
+    keptMessages = dropLeadingOrphanToolMessages(keptMessages);
   }
 
   return {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -31,6 +31,7 @@ import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
+import { dropLeadingOrphanToolMessages } from "../compaction.js";
 import {
   ensureSessionHeader,
   validateAnthropicTurns,
@@ -431,8 +432,9 @@ export async function compactEmbeddedPiSessionDirect(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
-        if (limited.length > 0) {
-          session.agent.replaceMessages(limited);
+        const noOrphanTools = dropLeadingOrphanToolMessages(limited);
+        if (noOrphanTools.length > 0) {
+          session.agent.replaceMessages(noOrphanTools);
         }
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -26,6 +26,7 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { resolveUserPath } from "../../../utils.js";
 import { createCacheTrace } from "../../cache-trace.js";
+import { dropLeadingOrphanToolMessages } from "../../compaction.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
@@ -554,9 +555,12 @@ export async function runEmbeddedAttempt(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
-        cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0) {
-          activeSession.agent.replaceMessages(limited);
+        const noOrphanTools = dropLeadingOrphanToolMessages(limited);
+        cacheTrace?.recordStage("session:limited", { messages: noOrphanTools });
+        if (noOrphanTools.length > 0) {
+          activeSession.agent.replaceMessages(noOrphanTools);
+        } else {
+          activeSession.agent.replaceMessages([]);
         }
       } catch (err) {
         sessionManager.flushPendingToolResults?.();


### PR DESCRIPTION
## Problem

When `limitHistoryTurns()` trims the message list by dropping an initial chunk, the kept portion can start with `toolResult` messages whose corresponding `tool_use` was in the dropped chunk. The Anthropic Messages API requires each `tool_result` to reference a `tool_use_id` that appears in the immediately previous message, so these orphan tool results cause:

```
HTTP 400 invalid_request_error: unexpected tool_use_id found in tool_result blocks
```

This crashes the agent session — no responses can be sent until the session is manually reset.

### Root cause

1. Session history is loaded and sanitized (`repairToolUseResultPairing` strips leading orphans at load time)
2. History is then limited by turns via `limitHistoryTurns()`
3. **After** limiting, the kept list can start with orphan `toolResult` messages — but `repairToolUseResultPairing` already ran before limiting, so it never sees this post-limit state
4. The trimmed list is sent to the API → 400

### Same risk in `pruneHistoryForContextShare`

When `pruneHistoryForContextShare` drops a chunk, the remaining messages can also start with orphan tool results.

## Fix

- Add `dropLeadingOrphanToolMessages()` to `compaction.ts` — strips leading `toolResult` messages from a message array
- Call it **after** `limitHistoryTurns()` in both the **run** (`attempt.ts`) and **compact** (`compact.ts`) paths
- Also call it inside `pruneHistoryForContextShare` after each chunk drop
- In the run path, handle the edge case where all remaining messages are orphan tool results by calling `replaceMessages([])`

## Tests

- Unit test for `dropLeadingOrphanToolMessages` (no-op when no orphans, strips leading toolResult only)
- Integration test for `pruneHistoryForContextShare` verifying no leading toolResult after pruning
