### PR TITLE
Onboard: use endpoint-aware verification timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Onboarding/Custom providers: use shared local-network endpoint detection to keep verification probes alive longer for localhost, RFC1918, and `host.docker.internal` endpoints without slowing hosted API checks. (#29155) Thanks @bmendonca3.
 - Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.
 - Telegram/Reply media context: include replied media files in inbound context when replying to media, defer reply-media downloads to debounce flush, gate reply-media fetch behind DM authorization, and preserve replied media when non-vision sticker fallback runs (including cached-sticker paths). (#28488) Thanks @obviyus.
 - Gateway/WS: close repeated post-handshake `unauthorized role:*` request floods per connection and sample duplicate rejection logs, preventing a single misbehaving client from degrading gateway responsiveness. (#20168) Thanks @acy103, @vibecodooor, and @vincentkoc.

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -2,7 +2,9 @@ import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isLocalishHost,
+  isPrivateOrLoopbackHost,
   isPrivateOrLoopbackAddress,
+  isPrivateOrLoopbackUrl,
   isSecureWebSocketUrl,
   isTrustedProxyAddress,
   pickPrimaryLanIPv4,
@@ -44,6 +46,32 @@ describe("isLocalishHost", () => {
     for (const host of rejected) {
       expect(isLocalishHost(host), host).toBe(false);
     }
+  });
+});
+
+describe("isPrivateOrLoopbackHost", () => {
+  it("accepts loopback, private IPs, and docker host aliases", () => {
+    const accepted = ["localhost", "127.0.0.1", "172.17.0.1", "10.0.0.8", "host.docker.internal"];
+    for (const host of accepted) {
+      expect(isPrivateOrLoopbackHost(host), host).toBe(true);
+    }
+  });
+
+  it("rejects public hosts", () => {
+    const rejected = ["example.com", "203.0.113.5"];
+    for (const host of rejected) {
+      expect(isPrivateOrLoopbackHost(host), host).toBe(false);
+    }
+  });
+});
+
+describe("isPrivateOrLoopbackUrl", () => {
+  it("classifies local and private endpoint urls", () => {
+    expect(isPrivateOrLoopbackUrl("http://localhost:11434/v1")).toBe(true);
+    expect(isPrivateOrLoopbackUrl("http://127.0.0.1:11434/v1")).toBe(true);
+    expect(isPrivateOrLoopbackUrl("http://172.17.0.1:11434/v1")).toBe(true);
+    expect(isPrivateOrLoopbackUrl("http://host.docker.internal:11434/v1")).toBe(true);
+    expect(isPrivateOrLoopbackUrl("https://example.com/v1")).toBe(false);
   });
 });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -335,6 +335,34 @@ export function isLoopbackHost(host: string): boolean {
 }
 
 /**
+ * Check if a host points at loopback, a private-network IP, or a common local
+ * host alias that should be treated like a self-hosted endpoint.
+ */
+export function isPrivateOrLoopbackHost(host: string): boolean {
+  if (!host) {
+    return false;
+  }
+  const normalized = resolveHostName(host);
+  if (!normalized) {
+    return false;
+  }
+  const lower = normalized.toLowerCase();
+  if (lower === "host.docker.internal") {
+    return true;
+  }
+  return isLoopbackHost(lower) || isPrivateOrLoopbackAddress(lower);
+}
+
+export function isPrivateOrLoopbackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return isPrivateOrLoopbackHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Local-facing host check for inbound requests:
  * - loopback hosts (localhost/127.x/::1 and mapped forms)
  * - Tailscale Serve/Funnel hostnames (*.ts.net)


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: custom-provider verification in onboarding still used a flat 30s timeout for every endpoint, so slow self-hosted targets on localhost/private networks timed out as aggressively as hosted APIs.
- Why it matters: local and Docker-adjacent model endpoints often need more warm-up time, but we do not want to slow hosted API verification for normal cloud endpoints.
- What changed: onboarding now routes timeout selection through shared network helpers in `src/gateway/net.ts`, using a longer timeout for loopback/private-network endpoints and preserving the existing 30s timeout for hosted endpoints.
- What did NOT change (scope boundary): verification request shape, compatibility detection flow, retry UX, and hosted endpoint behavior all stay the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29155
- Related #27380
- Related #29062
- Related #27346
- Related #28972

## User-visible / Behavior Changes

Custom-provider verification during onboarding now allows more time for localhost/private-network endpoints such as `localhost`, `127.0.0.1`, `172.17.x.x`, and `host.docker.internal`, while hosted endpoints still fail fast on the existing timeout.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS Sequoia 15.x
- Runtime/container: Node 22 + pnpm workspace tests
- Model/provider: onboarding custom provider
- Integration/channel (if any): CLI onboarding
- Relevant config (redacted): mocked custom-provider base URLs for localhost, `127.0.0.1`, `172.17.0.1`, `host.docker.internal`, and `https://example.com/v1`

### Steps

1. Start onboarding custom-provider verification against a slow endpoint that never resolves until the timeout aborts.
2. Use a local/private base URL such as `http://localhost:11434/v1`.
3. Advance time to 30 seconds.

### Expected

- Local/private endpoints should still be in flight at 30 seconds and only time out on the longer local timeout.
- Hosted endpoints should still abort at 30 seconds.

### Actual

- Before this patch, all endpoints aborted at 30 seconds because onboarding used a single `VERIFY_TIMEOUT_MS = 30_000` constant.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the current bug with new failing tests showing localhost, `127.0.0.1`, `172.17.0.1`, and `host.docker.internal` all retried at 30 seconds before the fix.
  - Verified those same endpoints now remain in flight past 30 seconds and only time out on the longer local timeout.
  - Verified hosted endpoints still time out at 30 seconds.
  - Verified shared helper coverage in `src/gateway/net.test.ts` for the new host/url categories.
- Edge cases checked:
  - Loopback hosts and RFC1918 IPs.
  - `host.docker.internal` alias.
  - Public hosted URL remains on the fast timeout path.
- What you did **not** verify:
  - A live onboard flow against a real local LLM server.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the previous flat 30s verification timeout.
- Files/config to restore: `src/commands/onboard-custom.ts`, `src/gateway/net.ts`
- Known bad symptoms reviewers should watch for: hosted endpoints unexpectedly waiting 120s, or local/private endpoints still timing out at 30s.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the new host classifier could accidentally treat a hosted endpoint as local and lengthen its timeout.
  - Mitigation: classification is deliberately narrow and covered for loopback, RFC1918 IPs, `host.docker.internal`, and a public control case.
- Risk: onboarding could reintroduce bespoke host parsing later.
  - Mitigation: timeout selection now goes through shared network helpers in `src/gateway/net.ts`, with direct helper tests locking the behavior down.
