### PR TITLE
feat(tts): add Google Gemini as native TTS provider

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -248,7 +248,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
           "• On – Enable TTS for responses\n" +
           "• Off – Disable TTS\n" +
           "• Status – Show current settings\n" +
-          "• Provider – Set voice provider (edge, elevenlabs, openai)\n" +
+          "• Provider – Set voice provider (edge, elevenlabs, openai, gemini)\n" +
           "• Limit – Set max characters for TTS\n" +
           "• Summary – Toggle AI summary for long texts\n" +
           "• Audio – Generate TTS from custom text\n" +

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -171,13 +171,13 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Usage: /tts provider openai | elevenlabs | edge | gemini`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge" && requested !== "gemini") {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -177,7 +177,12 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge" && requested !== "gemini") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "gemini"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "gemini";
 
 export type TtsMode = "final" | "all";
 
@@ -57,6 +57,15 @@ export type TtsConfig = {
   openai?: {
     apiKey?: string;
     model?: string;
+    voice?: string;
+  };
+  /** Google Gemini TTS configuration. */
+  gemini?: {
+    /** API key for Google Gemini. Falls back to GOOGLE_API_KEY env var. */
+    apiKey?: string;
+    /** Gemini TTS model (default: gemini-2.5-flash-preview-tts). */
+    model?: string;
+    /** Voice name (e.g. Puck, Charon, Fenrir, Orus, Kore, Aoede, Leda, Zephyr). */
     voice?: string;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -352,7 +352,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "gemini"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -398,6 +398,14 @@ export const TtsConfigSchema = z
       .strict()
       .optional(),
     openai: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        model: z.string().optional(),
+        voice: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    gemini: z
       .object({
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -100,7 +100,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge" && provider !== "gemini") {
+    if (
+      provider !== "openai" &&
+      provider !== "elevenlabs" &&
+      provider !== "edge" &&
+      provider !== "gemini"
+    ) {
       respond(
         false,
         undefined,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -100,13 +100,13 @@ export const ttsHandlers: GatewayRequestHandlers = {
   },
   "tts.setProvider": async ({ params, respond }) => {
     const provider = typeof params.provider === "string" ? params.provider.trim() : "";
-    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge") {
+    if (provider !== "openai" && provider !== "elevenlabs" && provider !== "edge" && provider !== "gemini") {
       respond(
         false,
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use openai, elevenlabs, or edge.",
+          "Invalid provider. Use openai, elevenlabs, edge, or gemini.",
         ),
       );
       return;

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -139,7 +139,12 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge" || rawValue === "gemini") {
+            if (
+              rawValue === "openai" ||
+              rawValue === "elevenlabs" ||
+              rawValue === "edge" ||
+              rawValue === "gemini"
+            ) {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -139,7 +139,7 @@ export function parseTtsDirectives(
             if (!policy.allowProvider) {
               break;
             }
-            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge") {
+            if (rawValue === "openai" || rawValue === "elevenlabs" || rawValue === "edge" || rawValue === "gemini") {
               overrides.provider = rawValue;
             } else {
               warnings.push(`unsupported provider "${rawValue}"`);

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -671,3 +671,143 @@ export async function edgeTTS(params: {
   });
   await tts.ttsPromise(text, outputPath);
 }
+
+// ── Gemini TTS ──────────────────────────────────────────────────────────────
+
+export const GEMINI_TTS_VOICES = [
+  "Puck",
+  "Charon",
+  "Fenrir",
+  "Orus",
+  "Kore",
+  "Aoede",
+  "Leda",
+  "Zephyr",
+] as const;
+
+export type GeminiTtsVoice = (typeof GEMINI_TTS_VOICES)[number];
+
+const DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts";
+const DEFAULT_GEMINI_TTS_VOICE: GeminiTtsVoice = "Puck";
+
+export function isValidGeminiVoice(voice: string): voice is GeminiTtsVoice {
+  return GEMINI_TTS_VOICES.includes(voice as GeminiTtsVoice);
+}
+
+export async function geminiTTS(params: {
+  text: string;
+  apiKey: string;
+  model?: string;
+  voice?: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const {
+    text,
+    apiKey,
+    model = DEFAULT_GEMINI_TTS_MODEL,
+    voice = DEFAULT_GEMINI_TTS_VOICE,
+    timeoutMs,
+  } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              {
+                text: `Say the following text exactly as written: ${text}`,
+              },
+            ],
+          },
+        ],
+        generationConfig: {
+          responseModalities: ["AUDIO"],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: voice },
+            },
+          },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(`Gemini TTS API error (${response.status}): ${errorBody.slice(0, 200)}`);
+    }
+
+    const data = (await response.json()) as {
+      candidates?: Array<{
+        content?: {
+          parts?: Array<{
+            inlineData?: { data: string; mimeType: string };
+            text?: string;
+          }>;
+        };
+      }>;
+    };
+
+    const candidates = data.candidates ?? [];
+    for (const candidate of candidates) {
+      const parts = candidate.content?.parts ?? [];
+      for (const part of parts) {
+        if (part.inlineData?.data) {
+          // Gemini returns raw PCM (L16, 24kHz, mono). Convert to WAV.
+          const pcmBuffer = Buffer.from(part.inlineData.data, "base64");
+          return pcmToWav(pcmBuffer, 24000, 1, 16);
+        }
+      }
+    }
+
+    throw new Error("Gemini TTS returned no audio data");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Convert raw PCM data to a WAV buffer.
+ */
+function pcmToWav(
+  pcmData: Buffer,
+  sampleRate: number,
+  numChannels: number,
+  bitsPerSample: number,
+): Buffer {
+  const byteRate = (sampleRate * numChannels * bitsPerSample) / 8;
+  const blockAlign = (numChannels * bitsPerSample) / 8;
+  const dataSize = pcmData.length;
+  const headerSize = 44;
+  const buffer = Buffer.alloc(headerSize + dataSize);
+
+  // RIFF header
+  buffer.write("RIFF", 0);
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write("WAVE", 8);
+
+  // fmt sub-chunk
+  buffer.write("fmt ", 12);
+  buffer.writeUInt32LE(16, 16); // sub-chunk size
+  buffer.writeUInt16LE(1, 20); // PCM format
+  buffer.writeUInt16LE(numChannels, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(byteRate, 28);
+  buffer.writeUInt16LE(blockAlign, 32);
+  buffer.writeUInt16LE(bitsPerSample, 34);
+
+  // data sub-chunk
+  buffer.write("data", 36);
+  buffer.writeUInt32LE(dataSize, 40);
+  pcmData.copy(buffer, headerSize);
+
+  return buffer;
+}

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -36,11 +36,14 @@ import {
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   openaiTTS,
+  geminiTTS,
+  GEMINI_TTS_VOICES,
+  isValidGeminiVoice,
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
 } from "./tts-core.js";
-export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
+export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES, GEMINI_TTS_VOICES } from "./tts-core.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -55,6 +58,8 @@ const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-preview-tts";
+const DEFAULT_GEMINI_VOICE = "Puck";
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -111,6 +116,11 @@ export type ResolvedTtsConfig = {
     };
   };
   openai: {
+    apiKey?: string;
+    model: string;
+    voice: string;
+  };
+  gemini: {
     apiKey?: string;
     model: string;
     voice: string;
@@ -290,6 +300,11 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
     },
+    gemini: {
+      apiKey: raw.gemini?.apiKey,
+      model: raw.gemini?.model ?? DEFAULT_GEMINI_MODEL,
+      voice: raw.gemini?.voice ?? DEFAULT_GEMINI_VOICE,
+    },
     edge: {
       enabled: raw.edge?.enabled ?? true,
       voice: raw.edge?.voice?.trim() || DEFAULT_EDGE_VOICE,
@@ -441,6 +456,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "gemini")) {
+    return "gemini";
+  }
   return "edge";
 }
 
@@ -505,10 +523,13 @@ export function resolveTtsApiKey(
   if (provider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (provider === "gemini") {
+    return config.gemini.apiKey || process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "edge", "gemini"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
   return [primary, ...TTS_PROVIDERS.filter((provider) => provider !== primary)];
@@ -558,6 +579,45 @@ export async function textToSpeech(params: {
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
+      if (provider === "gemini") {
+        const apiKey = resolveTtsApiKey(config, "gemini");
+        if (!apiKey) {
+          errors.push("gemini: no API key");
+          continue;
+        }
+
+        const providerStart = Date.now();
+        try {
+          const audioBuffer = await geminiTTS({
+            text: params.text,
+            apiKey,
+            model: config.gemini.model,
+            voice: config.gemini.voice,
+            timeoutMs: config.timeoutMs,
+          });
+
+          const latencyMs = Date.now() - providerStart;
+          const tempRoot = resolvePreferredOpenClawTmpDir();
+          mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
+          const tempDir = mkdtempSync(path.join(tempRoot, "tts-"));
+          const audioPath = path.join(tempDir, `voice-${Date.now()}.wav`);
+          writeFileSync(audioPath, audioBuffer);
+          scheduleCleanup(tempDir);
+
+          return {
+            success: true,
+            audioPath,
+            latencyMs,
+            provider,
+            outputFormat: "wav",
+            voiceCompatible: false,
+          };
+        } catch (err) {
+          errors.push(formatTtsProviderError(provider, err));
+          continue;
+        }
+      }
+
       if (provider === "edge") {
         if (!config.edge.enabled) {
           errors.push("edge: disabled");

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -536,7 +536,7 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 }
 
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
-  if (provider === "edge") {
+  if (provider === "edge" || provider === "gemini") {
     return config.edge.enabled;
   }
   return Boolean(resolveTtsApiKey(config, provider));
@@ -586,7 +586,6 @@ export async function textToSpeech(params: {
           continue;
         }
 
-        const providerStart = Date.now();
         try {
           const audioBuffer = await geminiTTS({
             text: params.text,
@@ -618,7 +617,7 @@ export async function textToSpeech(params: {
         }
       }
 
-      if (provider === "edge") {
+      if (provider === "edge" || provider === "gemini") {
         if (!config.edge.enabled) {
           errors.push("edge: disabled");
           continue;
@@ -782,8 +781,8 @@ export async function textToSpeechTelephony(params: {
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
-      if (provider === "edge") {
-        errors.push("edge: unsupported for telephony");
+      if (provider === "edge" || provider === "gemini") {
+        errors.push(`${provider}: unsupported for telephony`);
         continue;
       }
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -38,7 +38,6 @@ import {
   openaiTTS,
   geminiTTS,
   GEMINI_TTS_VOICES,
-  isValidGeminiVoice,
   parseTtsDirectives,
   scheduleCleanup,
   summarizeText,
@@ -536,7 +535,7 @@ export function resolveTtsProviderOrder(primary: TtsProvider): TtsProvider[] {
 }
 
 export function isTtsProviderConfigured(config: ResolvedTtsConfig, provider: TtsProvider): boolean {
-  if (provider === "edge" || provider === "gemini") {
+  if (provider === "edge") {
     return config.edge.enabled;
   }
   return Boolean(resolveTtsApiKey(config, provider));
@@ -617,7 +616,7 @@ export async function textToSpeech(params: {
         }
       }
 
-      if (provider === "edge" || provider === "gemini") {
+      if (provider === "edge") {
         if (!config.edge.enabled) {
           errors.push("edge: disabled");
           continue;


### PR DESCRIPTION
## Summary

Adds **Google Gemini TTS** as a fourth native TTS provider alongside ElevenLabs, OpenAI, and Edge TTS.

Closes #23080

## Configuration

```json5
{
  messages: {
    tts: {
      provider: "gemini",
      gemini: {
        apiKey: "...",  // or GOOGLE_API_KEY / GEMINI_API_KEY env var
        model: "gemini-2.5-flash-preview-tts",
        voice: "Puck"
      }
    }
  }
}
```
Supported Voices

Puck, Charon, Fenrir, Orus, Kore, Aoede, Leda, Zephyr

Changes

| File                          | Change                                                                          |
| ----------------------------- | ------------------------------------------------------------------------------- |
| src/config/types.tts.ts       | Add "gemini" to TtsProvider union type, add gemini config interface             |
| src/config/zod-schema.core.ts | Add gemini to provider enum and config validation schema                        |
| src/tts/tts-core.ts           | Add geminiTTS() function with PCM-to-WAV conversion                             |
| src/tts/tts.ts                | Integrate gemini into provider resolution, API key fallback, and textToSpeech() |


How it works

1. Calls the Gemini generateContent API with responseModalities: ["AUDIO"] and speechConfig
2. Receives raw PCM audio (L16, 24kHz, mono) as base64
3. Converts PCM to WAV in-memory (44-byte header + raw samples)
4. Returns WAV buffer for playback/delivery

Testing

• Tested the exact code path in a standalone Node.js script against live Gemini API
• All 8 voices verified with Russian and English text
• WAV output validated: correct RIFF/WAVE header, 24kHz, 16-bit, mono
• ~5s latency, ~9s audio for a typical sentence

AI Disclosure

🤖 AI-assisted: Code written with Claude Opus 4, manually tested against live Gemini API. The authors understand all changes made.

Future improvements (not in this PR)

• languageCode parameter for explicit language hints
• stylePrompt for expressive style instructions (as suggested in #23080)
• Opus/OGG output for Telegram voice-note compatibility (currently outputs WAV)
• Telephony support