### PR TITLE
fix(telegram): include group allowlist in native command auth for forum topics

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -263,9 +263,16 @@ async function resolveTelegramCommandAuth(params: {
     senderId,
     senderUsername,
   });
+  const groupSenderAllowed = isGroup
+    ? isSenderAllowed({ allow: effectiveGroupAllow, senderId, senderUsername })
+    : false;
+  const authorizers = [{ configured: dmAllow.hasEntries, allowed: senderAllowed }];
+  if (isGroup) {
+    authorizers.push({ configured: effectiveGroupAllow.hasEntries, allowed: groupSenderAllowed });
+  }
   const commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
-    authorizers: [{ configured: dmAllow.hasEntries, allowed: senderAllowed }],
+    authorizers,
     modeWhenAccessGroupsOff: "configured",
   });
   if (requireAuth && !commandAuthorized) {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1017,6 +1017,60 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("allows native commands in forum topic when sender is in group allowFrom", async () => {
+    onSpy.mockClear();
+    sendMessageSpy.mockClear();
+    commandSpy.mockClear();
+    replySpy.mockClear();
+    replySpy.mockResolvedValue({ text: "response" });
+
+    loadConfig.mockReturnValue({
+      commands: { native: true },
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: {
+            "-1001234567890": {
+              allowFrom: [12345],
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = commandSpy.mock.calls.find((call) => call[0] === "status")?.[1] as
+      | ((ctx: Record<string, unknown>) => Promise<void>)
+      | undefined;
+    if (!handler) {
+      throw new Error("status command handler missing");
+    }
+
+    await handler({
+      message: {
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        from: { id: 12345, username: "testuser" },
+        text: "/status",
+        date: 1736380800,
+        message_id: 42,
+        message_thread_id: 99,
+      },
+      match: "",
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(
+      sendMessageSpy.mock.calls.some(
+        (call) => call[1] === "You are not authorized to use this command.",
+      ),
+    ).toBe(false);
+  });
+
   it("registers message_reaction handler", () => {
     onSpy.mockClear();
     createTelegramBot({ token: "tok" });


### PR DESCRIPTION
## Problem

Native slash commands (`/status`, `/reasoning`, etc.) return "You are not authorized to use this command." in Telegram forum topic chats, even when the sender is authorized via per-group `allowFrom` or `groupAllowFrom`.

Regular messages in the same forum work correctly.

## Root Cause

`resolveTelegramCommandAuth` in `bot-native-commands.ts` only passes the DM allowlist (`allowFrom`) as an authorizer to `resolveCommandAuthorizedFromAuthorizers`. For group messages, the DM pairing store is excluded (`storeAllowFrom: isGroup ? [] : storeAllowFrom`), so senders authorized via per-group config are incorrectly rejected.

Compare with `bot-handlers.ts` which correctly checks `effectiveGroupAllow` for group messages.

## Fix

Add `effectiveGroupAllow` as a second authorizer when `isGroup` is true. Since `resolveCommandAuthorizedFromAuthorizers` uses `authorizers.some(e => e.configured && e.allowed)`, either the DM allowlist OR the group allowlist matching is sufficient — mirroring regular message auth behavior.

**+7 lines** in `bot-native-commands.ts`.

## Test

Added test: "allows native commands in forum topic when sender is in group allowFrom" — verifies `/status` succeeds in a forum supergroup when the sender is in the group's `allowFrom` list.

All 41 existing bot tests pass, zero regressions. Formatting clean (`oxfmt --check`).

## AI Disclosure

- [x] AI-assisted (Claude Code for implementation, human-directed root cause analysis and prompt)
- [x] Fully tested — new test + all 41 existing tests pass
- [x] I understand what the code does

Fixes #29135
