### PR TITLE
fix: tighten billing error detection for long text to prevent false-positive rewrites

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -128,6 +128,23 @@ describe("isBillingErrorMessage", () => {
     expect(longStructuredError.length).toBeGreaterThan(512);
     expect(isBillingErrorMessage(longStructuredError)).toBe(true);
   });
+  it("does not false-positive on long assistant text discussing HTTP 402 errors", () => {
+    const longDiscussion =
+      "Here's what I found about the billing error detection in the codebase.\n\n" +
+      "The `isBillingErrorMessage` function checks for patterns like http 402, " +
+      "error code 402, and payment required. The ERROR_PATTERNS.billing array " +
+      "includes terms like 'insufficient credits' and 'credit balance'. When " +
+      "an API returns HTTP 402 Payment Required, the response is rewritten to " +
+      "a user-friendly billing error message. This affects all channels.\n\n" +
+      "The BILLING_ERROR_HEAD_RE regex matches patterns at the start of text, " +
+      "while BILLING_ERROR_HARD_402_RE is used for longer payloads. Both need " +
+      "to be careful not to match assistant content that merely discusses these " +
+      "error patterns in an analytical or educational context.\n\n" +
+      "Related issues: #19258, #13935, #15055. The error code 402 check was " +
+      "too broad and matched normal conversation about billing systems.";
+    expect(longDiscussion.length).toBeGreaterThan(512);
+    expect(isBillingErrorMessage(longDiscussion)).toBe(false);
+  });
   it("does not match long numeric text that is not a billing error", () => {
     const longNonError =
       "Quarterly report summary: subsystem A returned 402 records after retry. " +

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -161,8 +161,13 @@ const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const BILLING_ERROR_HEAD_RE =
   /^(?:error[:\s-]+)?billing(?:\s+error)?(?:[:\s-]+|$)|^(?:error[:\s-]+)?(?:credit balance|insufficient credits?|payment required|http\s*402\b)/i;
+/**
+ * Strict 402 pattern for long text (>512 chars).  Only matches structured
+ * JSON-style markers like `"code":402` or `"status":402`, not casual mentions
+ * such as `http 402` that appear in assistant content discussing error handling.
+ */
 const BILLING_ERROR_HARD_402_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|^\s*402\s+payment/i;
+  /["'](?:status|code)["']\s*[:=]\s*402\b/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;


### PR DESCRIPTION
## Summary

Fixes #29234

**Problem:**
`BILLING_ERROR_HARD_402_RE` (used by `isBillingErrorMessage` for text >512 chars) was too broad. It matched casual mentions like `http 402` or `error code 402` in normal assistant responses that discuss billing, error handling, or API error patterns. This caused legitimate assistant replies to be silently replaced with:

> ⚠️ API provider returned a billing error — your API key has run out of credits...

We reproduced this today: asking the assistant to analyze OpenClaw's own `sanitizeUserFacingText` code triggered the false positive because the response quoted billing-related regex patterns and error codes from the source.

**Root cause:**
The regex `/["'"]?(?:status|code)["'"]?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|^\s*402\s+payment/i` matches unstructured text containing `http 402` or `error code 402` — patterns that commonly appear in assistant content discussing HTTP errors.

**Fix:**
Tighten `BILLING_ERROR_HARD_402_RE` to only match **JSON-structured 402 markers**: `"code":402` or `"status":402`. Real API billing error payloads >512 chars are always structured JSON with quoted keys. Casual prose mentions of `http 402` are not real billing errors at that length.

Short text (<512 chars) is **unaffected** — it still goes through `ERROR_PATTERNS.billing` and `BILLING_ERROR_HEAD_RE` which correctly catch short-form billing errors like `HTTP 402 Payment Required`.

## Changes

- `src/agents/pi-embedded-helpers/errors.ts`: Replaced broad `BILLING_ERROR_HARD_402_RE` with strict JSON-only pattern
- `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`: Added test for long assistant text discussing HTTP 402 that should not false-positive

## Test plan

- [x] Existing `isBillingErrorMessage` tests pass (JSON-structured `"code":402` still detected)
- [x] New test: long assistant text mentioning `http 402`, `error code 402` → returns `false`
- [x] Short billing errors (`HTTP 402 Payment Required`, `insufficient credits`, etc.) still detected
- [x] Real long JSON error payloads with `"code":402` still detected

## Related

- #19258 (closed but fix never merged — PRs #19547 and #19271 both closed)
- #13935 (open — intermittent billing error swallows actual response)
- #15055 (open — billing error message generic/misleading)