### PR TITLE
test: narrow openai responses mock cast to Model type

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -878,7 +878,7 @@ describe("applyExtraParamsToAgent", () => {
         contextWindow: 128_000,
         maxTokens: 16_384,
         compat: { supportsStore: false },
-      } as Model<"openai-responses"> & { compat?: { supportsStore?: boolean } },
+      } as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });


### PR DESCRIPTION
## Summary
- remove a redundant intersection cast from the OpenAI Responses `supportsStore=false` regression test
- keep the change to one line in one file for a minimal, explicit scope

## Intent
The previous fix branch was based on an older `main` tip and had ambiguous scope over time. This PR is a fresh branch from current `origin/main` with a single, intentional typing cleanup.

## Validation
- `pnpm format:check`
- `pnpm tsgo`
- `pnpm test -- src/agents/pi-embedded-runner-extraparams.test.ts`
- `pnpm check`
