### PR TITLE
fix(routing): change default dmScope from "main" to "per-channel-peer"

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -106,7 +106,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
       allowFrom: params.allowFrom,
       normalizeEntry: params.normalizeEntry,
     });
-    const dmScope = cfg.session?.dmScope ?? "main";
+    const dmScope = cfg.session?.dmScope ?? "per-channel-peer";
 
     if (dmPolicy === "open") {
       const allowFromPath = `${params.allowFromPath}allowFrom`;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -970,7 +970,7 @@ export const FIELD_HELP: Record<string, string> = {
   "session.scope":
     'Sets base session grouping strategy: "per-sender" isolates by sender and "global" shares one session per channel context. Keep "per-sender" for safer multi-user behavior unless deliberate shared context is required.',
   "session.dmScope":
-    'DM session scoping: "main" keeps continuity, while "per-peer", "per-channel-peer", and "per-account-channel-peer" increase isolation. Use isolated modes for shared inboxes or multi-account deployments.',
+    'DM session scoping. Default: "per-channel-peer" (each DM sender gets an isolated session per channel). Use "main" to collapse all DMs into the main session (legacy behavior), "per-peer" for cross-channel sender isolation, or "per-account-channel-peer" for multi-account deployments.',
   "session.identityLinks":
     "Maps canonical identities to provider-prefixed peer IDs so equivalent users resolve to one DM thread (example: telegram:123456). Use this when the same human appears across multiple channels or accounts.",
   "session.resetTriggers":

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -112,7 +112,7 @@ function buildBaseSessionKey(params: {
     channel: params.channel,
     accountId: params.accountId,
     peer: params.peer,
-    dmScope: params.cfg.session?.dmScope ?? "main",
+    dmScope: params.cfg.session?.dmScope ?? "per-channel-peer",
     identityLinks: params.cfg.session?.identityLinks,
   });
 }

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentRoute } from "./resolve-route.js";
 
 describe("resolveAgentRoute", () => {
-  test("defaults to main/default when no bindings exist", () => {
+  test("defaults to per-channel-peer isolation when no bindings exist", () => {
     const cfg: OpenClawConfig = {};
     const route = resolveAgentRoute({
       cfg,
@@ -14,7 +14,7 @@ describe("resolveAgentRoute", () => {
     });
     expect(route.agentId).toBe("main");
     expect(route.accountId).toBe("default");
-    expect(route.sessionKey).toBe("agent:main:main");
+    expect(route.sessionKey).toBe("agent:main:whatsapp:direct:+15551234567");
     expect(route.matchedBy).toBe("default");
   });
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -304,7 +304,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
 
-  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.cfg.session?.dmScope ?? "per-channel-peer";
   const identityLinks = input.cfg.session?.identityLinks;
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -125,7 +125,7 @@ export function buildAgentPeerSessionKey(params: {
 }): string {
   const peerKind = params.peerKind ?? "direct";
   if (peerKind === "direct") {
-    const dmScope = params.dmScope ?? "main";
+    const dmScope = params.dmScope ?? "per-channel-peer";
     let peerId = (params.peerId ?? "").trim();
     const linkedPeerId =
       dmScope === "main"

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -129,7 +129,7 @@ export async function collectChannelSecurityFindings(params: {
       allowFrom: input.allowFrom,
       normalizeEntry: input.normalizeEntry,
     });
-    const dmScope = params.cfg.session?.dmScope ?? "main";
+    const dmScope = params.cfg.session?.dmScope ?? "per-channel-peer";
 
     if (input.dmPolicy === "open") {
       const allowFromKey = `${input.allowFromPath}allowFrom`;

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -368,8 +368,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expectInboundContextContract(prepared!.ctxPayload as any);
     // Should be classified as DM, not channel
     expect(prepared!.isDirectMessage).toBe(true);
-    // DM with dmScope: "main" should route to the main session
-    expect(prepared!.route.sessionKey).toBe("agent:main:main");
+    // DM with default dmScope (per-channel-peer) should route to isolated session
+    expect(prepared!.route.sessionKey).toBe("agent:main:slack:direct:u1");
     // ChatType should be "direct", not "channel"
     expect(prepared!.ctxPayload.ChatType).toBe("direct");
     // From should use user ID (DM pattern), not channel ID
@@ -449,7 +449,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     expectInboundContextContract(prepared!.ctxPayload as any);
     expect(prepared!.isDirectMessage).toBe(true);
-    expect(prepared!.route.sessionKey).toBe("agent:main:main");
+    expect(prepared!.route.sessionKey).toBe("agent:main:slack:direct:u1");
     expect(prepared!.ctxPayload.ChatType).toBe("direct");
   });
 


### PR DESCRIPTION
## Summary

Change the default `session.dmScope` from `"main"` to `"per-channel-peer"`, so DMs from different senders get isolated sessions by default.

## Problem

The current default (`"main"`) collapses **all** DM senders into a single session. This causes:

1. **Context bleed** — User A's private conversation context leaks into replies to User B
2. **Cron misdirection** — Cron jobs with `delivery.channel: "last"` route output to the wrong sender
3. **Privacy violation** — Task progress updates intended for one user get delivered to another

This affects all channel plugins that handle DMs (Telegram, WhatsApp, Feishu, Slack, Discord, etc.).

## Solution

The infrastructure for per-sender DM isolation already exists:
- `buildAgentPeerSessionKey()` supports `dmScope: "per-channel-peer"` ✅
- Onboarding wizard already defaults to `"per-channel-peer"` ✅  
- Security audit (`openclaw doctor`) already flags `"main"` as a warning ✅

This PR simply aligns the **runtime fallback default** to match what onboarding and security already recommend. Existing users who never explicitly configured `dmScope` will automatically get proper isolation.

### Opt-out

Users who intentionally want the old behavior can set:
```yaml
session:
  dmScope: "main"
```

## Changes

- `src/routing/resolve-route.ts` — default `"main"` → `"per-channel-peer"`
- `src/routing/session-key.ts` — default `"main"` → `"per-channel-peer"` 
- `src/infra/outbound/outbound-session.ts` — default `"main"` → `"per-channel-peer"`
- `src/security/audit-channel.ts` — align audit default
- `src/commands/doctor-security.ts` — align doctor default
- `src/config/schema.help.ts` — update help text to reflect new default
- Tests updated to match new behavior

## Testing

- [x] Updated `resolve-route.test.ts` — DM without explicit dmScope now expects isolated key
- [x] Updated `slack/prepare.test.ts` — Slack DM assertions updated
- [ ] AI-assisted (🤖 built with OpenClaw agent)
- [ ] Needs integration testing with live Feishu/Telegram/Slack DMs

Closes #29237