### PR TITLE
fix(secrets): prevent keyRef downgrade on runtime writeback

### DIFF
--- a/src/agents/auth-profiles.runtime-snapshot-save.test.ts
+++ b/src/agents/auth-profiles.runtime-snapshot-save.test.ts
@@ -7,7 +7,11 @@ import {
   clearSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
 } from "../secrets/runtime.js";
-import { ensureAuthProfileStore, markAuthProfileUsed } from "./auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  markAuthProfileGood,
+  markAuthProfileUsed,
+} from "./auth-profiles.js";
 
 describe("auth profile runtime snapshot persistence", () => {
   it("does not write resolved plaintext keys during usage updates", async () => {
@@ -64,6 +68,69 @@ describe("auth profile runtime snapshot persistence", () => {
         provider: "default",
         id: "OPENAI_API_KEY",
       });
+    } finally {
+      clearSecretsRuntimeSnapshot();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves openrouter keyRef during runtime good-profile writeback", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-runtime-openrouter-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openrouter:default": {
+                type: "api_key",
+                provider: "openrouter",
+                keyRef: { source: "env", provider: "default", id: "OPENROUTER_API_KEY" },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: {},
+        env: { OPENROUTER_API_KEY: "sk-runtime-openrouter" },
+        agentDirs: [agentDir],
+      });
+      activateSecretsRuntimeSnapshot(snapshot);
+
+      const runtimeStore = ensureAuthProfileStore(agentDir);
+      expect(runtimeStore.profiles["openrouter:default"]).toMatchObject({
+        type: "api_key",
+        key: "sk-runtime-openrouter",
+        keyRef: { source: "env", provider: "default", id: "OPENROUTER_API_KEY" },
+      });
+
+      await markAuthProfileGood({
+        store: runtimeStore,
+        provider: "openrouter",
+        profileId: "openrouter:default",
+        agentDir,
+      });
+
+      const persisted = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        profiles: Record<string, { key?: string; keyRef?: unknown }>;
+        lastGood?: Record<string, string>;
+      };
+      expect(persisted.profiles["openrouter:default"]?.key).toBeUndefined();
+      expect(persisted.profiles["openrouter:default"]?.keyRef).toEqual({
+        source: "env",
+        provider: "default",
+        id: "OPENROUTER_API_KEY",
+      });
+      expect(persisted.lastGood?.openrouter).toBe("openrouter:default");
     } finally {
       clearSecretsRuntimeSnapshot();
       await fs.rm(stateDir, { recursive: true, force: true });

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -254,6 +254,8 @@ function collectApiKeyProfileAssignment(params: {
     expected: "string",
     apply: (value) => {
       params.profile.key = String(value);
+      // Canonicalize the runtime profile so writebacks can preserve ref-based auth.
+      params.profile.keyRef = resolvedKeyRef;
     },
   });
 }
@@ -284,6 +286,8 @@ function collectTokenProfileAssignment(params: {
     expected: "string",
     apply: (value) => {
       params.profile.token = String(value);
+      // Canonicalize the runtime profile so writebacks can preserve ref-based auth.
+      params.profile.tokenRef = resolvedTokenRef;
     },
   });
 }


### PR DESCRIPTION
## Summary

- Problem: runtime secret materialization can populate in-memory `key`/`token` fields for auth profiles, and subsequent writebacks risk persisting plaintext if ref metadata is not kept canonical.
- Why it matters: operators using `keyRef`/`tokenRef` can see secret-hygiene regressions (`PLAINTEXT_FOUND`) after runtime-driven profile metadata updates.
- What changed: when runtime resolves auth profile refs, it now keeps canonical `keyRef`/`tokenRef` on those runtime credentials so save-time sanitization can reliably strip plaintext.
- What did NOT change (scope boundary): auth profile storage schema, secret provider resolution semantics, and API key/token resolution order.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29108
- Related #

## User-visible / Behavior Changes

- Ref-backed auth profiles (`keyRef` / `tokenRef`) remain ref-backed after runtime writeback paths.
- Reduces risk of plaintext key/token persistence caused by runtime metadata updates.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This change strengthens secret hygiene by preserving ref metadata alongside runtime-resolved values, allowing existing save sanitization to remove plaintext before persistence.

## Repro + Verification

### Environment

- OS: macOS (unit-test harness)
- Runtime/container: Node.js + Vitest
- Model/provider: openrouter profile path
- Integration/channel (if any): auth profile runtime snapshot + usage/writeback flow
- Relevant config (redacted): auth-profiles `type=api_key` with `keyRef`

### Steps

1. Start with `auth-profiles.json` entry `openrouter:default` using `keyRef`.
2. Activate runtime secrets so in-memory profile gets resolved key material.
3. Trigger profile writeback (`markAuthProfileGood` / usage updates).

### Expected

- Persisted profile keeps `keyRef` and does not persist plaintext `key`.

### Actual

- Before: runtime writebacks could risk plaintext persistence in affected flows.
- After: runtime profile retains canonical ref fields, and persisted plaintext is stripped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/agents/auth-profiles.runtime-snapshot-save.test.ts src/secrets/runtime.test.ts` (7/7 passing).
- Edge cases checked: existing openai runtime snapshot persistence test still passes; new openrouter writeback regression passes.
- What you did **not** verify: full live gateway restart flow with external secret providers under production workload.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/secrets/runtime.ts`
- Known bad symptoms reviewers should watch for: unexpected auth writeback diffs involving `keyRef`/`tokenRef` normalization.

## Risks and Mitigations

- Risk: runtime snapshot writebacks may normalize ref objects (e.g., legacy shapes) and create unexpected-but-safe diffs.
  - Mitigation: behavior is covered by regression tests and only affects ref-backed credentials where plaintext persistence should be suppressed.
