### PR TITLE
fix(reply): stop post-compaction audit memory path loops

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -694,7 +694,7 @@ export async function runReplyAgent(params: {
 
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
-        const workspaceDir = process.cwd();
+        const workspaceDir = followupRun.run.workspaceDir || process.cwd();
         readPostCompactionContext(workspaceDir)
           .then((contextContent) => {
             if (contextContent) {
@@ -729,10 +729,12 @@ export async function runReplyAgent(params: {
         if (sessionFile) {
           const messages = readSessionMessages(sessionFile);
           const readPaths = extractReadPaths(messages);
-          const workspaceDir = process.cwd();
+          const workspaceDir = followupRun.run.workspaceDir || process.cwd();
           const audit = auditPostCompactionReads(readPaths, workspaceDir);
           if (!audit.passed) {
-            enqueueSystemEvent(formatAuditWarning(audit.missingPatterns), { sessionKey });
+            enqueueSystemEvent(formatAuditWarning(audit.missingPatterns, { workspaceDir }), {
+              sessionKey,
+            });
           }
         }
       } catch {


### PR DESCRIPTION
## Summary

- Problem: post-compaction audits reported regex-style placeholders (e.g. `memory/\d{4}-\d{2}-\d{2}\.md`) and used `process.cwd()` for resolution, which could diverge from the actual run workspace.
- Why it matters: users could read the correct startup file but still get repeat audit warnings due to ambiguous path guidance and non-workspace path matching.
- What changed: audit now emits concrete daily memory paths (`memory/YYYY-MM-DD.md`), anchors regex checks to workspace-relative full-path matches, and uses `followupRun.run.workspaceDir` for both context refresh and audit checks.
- What did NOT change (scope boundary): required startup-file policy itself (still requires `WORKFLOW_AUTO.md` + daily memory file).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29022
- Related #

## User-visible / Behavior Changes

- Audit warnings now show concrete expected file paths instead of regex placeholders.
- Warnings include explicit workspace-rooted expected path hints for daily memory files.
- Outside-workspace reads no longer accidentally satisfy the daily-memory requirement.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (unit-test harness)
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): post-compaction context/audit in reply pipeline
- Relevant config (redacted): workspace with `WORKFLOW_AUTO.md` + daily memory file policy

### Steps

1. Trigger compaction and post-compaction audit flow.
2. Include read calls that are outside workspace root (or ambiguous absolute paths).
3. Check warning content and missing-file detection behavior.

### Expected

- Audit lists concrete workspace-relative missing paths and expected absolute workspace paths.
- Reads outside workspace do not satisfy required startup-file checks.

### Actual

- Before: regex placeholders were shown; path guidance was ambiguous; looping warnings could occur.
- After: concrete path reporting and workspace-rooted matching prevent the loop pattern.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm --dir /tmp/openclaw-28770-pr exec vitest src/auto-reply/reply/post-compaction-audit.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts` (52/52 passing).
- Edge cases checked: absolute paths outside workspace no longer match memory requirement; warning includes concrete expected memory path.
- What you did **not** verify: full live WebChat compaction loop reproduction in production environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/post-compaction-audit.ts`, `src/auto-reply/reply/agent-runner.ts`
- Known bad symptoms reviewers should watch for: false negatives in required startup-file checks when valid workspace reads exist.

## Risks and Mitigations

- Risk: anchoring regex matching could reject legacy path shapes that previously passed by substring.
  - Mitigation: this is intentional to enforce workspace-rooted matching; regression tests now cover both valid absolute paths and outside-workspace rejections.
