### PR TITLE
fix: Telegram gateway reads HTTP_PROXY/HTTPS_PROXY env vars for proxy

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import {
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
@@ -380,7 +381,11 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       getTelegramRuntime().channel.telegram.probeTelegram(
         account.token,
         timeoutMs,
-        account.config.proxy,
+        account.config.proxy ||
+          process.env.HTTPS_PROXY ||
+          process.env.https_proxy ||
+          process.env.HTTP_PROXY ||
+          process.env.http_proxy,
       ),
     auditAccount: async ({ account, timeoutMs, probe, cfg }) => {
       const groups =
@@ -471,7 +476,11 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         const probe = await getTelegramRuntime().channel.telegram.probeTelegram(
           token,
           2500,
-          account.config.proxy,
+          account.config.proxy ||
+            process.env.HTTPS_PROXY ||
+            process.env.https_proxy ||
+            process.env.HTTP_PROXY ||
+            process.env.http_proxy,
         );
         const username = probe.ok ? probe.bot?.username?.trim() : null;
         if (username) {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -13,7 +13,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeProxyFetch, resolveProxyUrl } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -134,8 +134,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     }
 
-    const proxyFetch =
-      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+    const proxyUrl = resolveProxyUrl(account.config.proxy);
+    const proxyFetch = opts.proxyFetch ?? (proxyUrl ? makeProxyFetch(proxyUrl) : undefined);
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -25,10 +25,10 @@ export function resolveProxyUrl(configProxy?: string): string | undefined {
     return explicit;
   }
   return (
-    process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    process.env.HTTP_PROXY ||
-    process.env.http_proxy ||
+    process.env.HTTPS_PROXY?.trim() ||
+    process.env.https_proxy?.trim() ||
+    process.env.HTTP_PROXY?.trim() ||
+    process.env.http_proxy?.trim() ||
     undefined
   );
 }

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
@@ -12,4 +13,22 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   // Return raw proxy fetch; call sites that need AbortSignal normalization
   // should opt into resolveFetch/wrapFetchWithAbortSignal once at the edge.
   return fetcher;
+}
+
+/**
+ * Resolve the proxy URL from config or standard environment variables.
+ * Priority: explicit config > HTTPS_PROXY > HTTP_PROXY (case-insensitive).
+ */
+export function resolveProxyUrl(configProxy?: string): string | undefined {
+  const explicit = configProxy?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  return (
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    undefined
+  );
 }

--- a/src/telegram/send.proxy.test.ts
+++ b/src/telegram/send.proxy.test.ts
@@ -31,6 +31,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("./proxy.js", () => ({
   makeProxyFetch,
+  resolveProxyUrl: (configProxy?: string) => configProxy?.trim() || undefined,
 }));
 
 vi.mock("./fetch.js", () => ({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -27,7 +27,7 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeProxyFetch, resolveProxyUrl } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 import { maybePersistResolvedTelegramTarget } from "./target-writeback.js";
 import {
@@ -121,7 +121,7 @@ function createTelegramHttpLogger(cfg: ReturnType<typeof loadConfig>) {
 function resolveTelegramClientOptions(
   account: ResolvedTelegramAccount,
 ): ApiClientOptions | undefined {
-  const proxyUrl = account.config.proxy?.trim();
+  const proxyUrl = resolveProxyUrl(account.config.proxy);
   const proxyFetch = proxyUrl ? makeProxyFetch(proxyUrl) : undefined;
   const fetchImpl = resolveTelegramFetch(proxyFetch, {
     network: account.config.network,


### PR DESCRIPTION
## Summary

Fixes #29133.

The Telegram gateway only respected the explicit `channels.telegram.proxy` config setting. Users in restricted networks (e.g. mainland China) who set standard `HTTPS_PROXY`/`HTTP_PROXY` environment variables couldn't route Telegram API requests through their proxy.

## Changes

- **`proxy.ts`**: New `resolveProxyUrl(configProxy?)` helper — checks explicit config first, then falls back to `HTTPS_PROXY` / `https_proxy` / `HTTP_PROXY` / `http_proxy` env vars
- **`monitor.ts`**: Bot polling uses `resolveProxyUrl()` instead of only checking config
- **`send.ts`**: Outbound messages use `resolveProxyUrl()` instead of only checking config
- **`send.proxy.test.ts`**: Updated mock to include new export

## Testing

- All 568 Telegram tests pass
- `pnpm build` succeeds