### PR TITLE
feat: declarative skill permissions in OpenClawSkillMetadata

### DIFF
--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -9,6 +9,7 @@ import {
   resolveOpenClawManifestInstall,
   resolveOpenClawManifestOs,
   resolveOpenClawManifestRequires,
+  resolveOpenClawManifestPermissions,
 } from "../../shared/frontmatter.js";
 import type {
   OpenClawSkillMetadata,
@@ -88,6 +89,7 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  const permissions = resolveOpenClawManifestPermissions(metadataObj);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: typeof metadataObj.emoji === "string" ? metadataObj.emoji : undefined,
@@ -97,6 +99,7 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    permissions: permissions,
   };
 }
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -16,6 +16,27 @@ export type SkillInstallSpec = {
   targetDir?: string;
 };
 
+/**
+ * Declared permission scopes for a skill. Declarative only — not enforced at runtime.
+ * Agents can inspect these to apply proportionality judgments before invoking a skill.
+ */
+export type SkillPermissions = {
+  /** Skill may read files from the workspace or filesystem. */
+  readFiles?: boolean;
+  /** Skill may write or delete files. */
+  writeFiles?: boolean;
+  /** Skill may execute shell commands or subprocesses. */
+  execCommands?: boolean;
+  /** Skill may make outbound network requests. */
+  network?: boolean;
+  /** Skill may send messages to external channels (email, Discord, etc.). */
+  sendMessages?: boolean;
+  /** Skill may access or modify memory files (MEMORY.md, memory/*.md). */
+  memory?: boolean;
+  /** Free-form list of additional permission notes. */
+  notes?: string[];
+};
+
 export type OpenClawSkillMetadata = {
   always?: boolean;
   skillKey?: string;
@@ -30,6 +51,8 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  /** Declared permissions this skill requires. Declarative only — not enforced. */
+  permissions?: SkillPermissions;
 };
 
 export type SkillInvocationPolicy = {

--- a/src/shared/frontmatter.ts
+++ b/src/shared/frontmatter.ts
@@ -98,6 +98,31 @@ export function resolveOpenClawManifestOs(metadataObj: Record<string, unknown>):
   return normalizeStringList(metadataObj.os);
 }
 
+export function resolveOpenClawManifestPermissions(
+  metadataObj: Record<string, unknown>,
+): { readFiles?: boolean; writeFiles?: boolean; execCommands?: boolean; network?: boolean; sendMessages?: boolean; memory?: boolean; notes?: string[] } | undefined {
+  const p = metadataObj.permissions;
+  if (!p || typeof p !== "object") {
+    return undefined;
+  }
+  const obj = p as Record<string, unknown>;
+  const boolField = (key: string) =>
+    typeof obj[key] === "boolean" ? (obj[key] as boolean) : undefined;
+  const notes = normalizeStringList(obj.notes);
+  const result = {
+    readFiles: boolField("readFiles"),
+    writeFiles: boolField("writeFiles"),
+    execCommands: boolField("execCommands"),
+    network: boolField("network"),
+    sendMessages: boolField("sendMessages"),
+    memory: boolField("memory"),
+    notes: notes.length > 0 ? notes : undefined,
+  };
+  // Return undefined if no fields are set
+  const hasAny = Object.values(result).some((v) => v !== undefined);
+  return hasAny ? result : undefined;
+}
+
 export type ParsedOpenClawManifestInstallBase = {
   raw: Record<string, unknown>;
   kind: string;


### PR DESCRIPTION
## Summary

Adds a declarative `permissions` field to `OpenClawSkillMetadata` so skills can declare what capabilities they require. This is **declarative only — not enforced at runtime** — but gives agents visibility into what a skill will do before invoking it.

## Motivation

Skills are injected directly into the agent system prompt and treated as authoritative instructions. Without any permission declaration, an agent has no way to apply proportionality judgments (e.g. "this skill runs shell commands — should I confirm first?"). This is improvement item #3 from the openclaw security hardening backlog.

## Changes

**`src/agents/skills/types.ts`**
- New `SkillPermissions` type with boolean fields: `readFiles`, `writeFiles`, `execCommands`, `network`, `sendMessages`, `memory`, plus optional `notes[]`
- `OpenClawSkillMetadata.permissions?: SkillPermissions`

**`src/shared/frontmatter.ts`**
- New `resolveOpenClawManifestPermissions()` — parses the `permissions` key from the openclaw manifest block; returns `undefined` if no fields are set (zero cost for existing skills)

**`src/agents/skills/frontmatter.ts`**
- `resolveOpenClawMetadata()` now populates `permissions` from parsed frontmatter

## Usage

Skill authors can declare permissions in their `SKILL.md` frontmatter:

```yaml
---
openclaw:
  permissions:
    execCommands: true
    network: true
    notes:
      - Runs gh CLI commands to interact with GitHub API
---
```

## Non-breaking

- All fields are optional; existing skills without a `permissions` block are unaffected
- No enforcement logic added — purely additive metadata