### PR TITLE
fix(acpx): wrap spawn commands with cmd /c on Windows

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -38,7 +38,6 @@ function resolveSpawnCommand(params: { command: string; args: string[] }): Resol
   return {
     command: "cmd",
     args: ["/c", params.command, ...params.args],
-    shell: true,
   };
 }
 

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -36,8 +36,9 @@ function resolveSpawnCommand(params: { command: string; args: string[] }): Resol
   }
 
   return {
-    command: params.command,
-    args: params.args,
+    command: "cmd",
+    args: ["/c", params.command, ...params.args],
+    shell: true,
   };
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the 'spawn npx ENOENT' error on Windows by wrapping commands without extensions (like 'npx') with 'cmd /c' to ensure proper shell interpretation.

## The Problem

Windows spawn() does NOT invoke a shell by default. It tries to run npx directly as an executable, but npx is a Node.js script that requires shell interpretation.

## The Fix

In extensions/acpx/src/runtime-internals/process.ts, the resolveSpawnCommand function now wraps commands with cmd /c on Windows:

Before (fails on Windows):
return {
  command: params.command,
  args: params.args,
};

After (works on Windows):
return {
  command: "cmd",
  args: ["/c", params.command, ...params.args],
  shell: true,
};

## Related Issue

Fixes #29134
