### PR TITLE
Fix #28337: Resolve scope mismatch in tokensAfter sanity check

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -782,3 +782,5 @@ export async function compactEmbeddedPiSession(
     enqueueGlobal(async () => compactEmbeddedPiSessionDirect(params)),
   );
 }
+
+// CI trigger: Updated to fix token count scope mismatch

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -689,13 +689,7 @@ export async function compactEmbeddedPiSessionDirect(
           // Sanity check: tokensAfter should be less than the full session token count before compaction
           // We use tokensBeforeFull instead of result.tokensBefore to ensure we're comparing
           // values from the same scope (full session vs full session)
-          if (
-            tokensBeforeFull !== undefined &&
-            tokensAfter > tokensBeforeFull
-          ) {
-            tokensAfter = undefined; // Don't trust the estimate
-          }
-          if (tokensAfter > result.tokensBefore) {
+          if (tokensBeforeFull !== undefined && tokensAfter > tokensBeforeFull) {
             tokensAfter = undefined; // Don't trust the estimate
           }
         } catch {


### PR DESCRIPTION
## Description

This PR fixes the issue where post-compaction token count shows `?` instead of the actual value.

## Problem

The sanity check in `compact.ts` was comparing two incompatible measurements:
- `tokensAfter` - calculated from the full session (`session.messages`)
- `result.tokensBefore` - calculated from only the summarizable history subset (`messagesToSummarize`)

This scope mismatch caused the sanity check to frequently fail, resulting in the token count being displayed as `?`.

## Solution

- Record the full session token count **before** compaction (`tokensBeforeFull`)
- Use `tokensBeforeFull` for the sanity check comparison instead of `result.tokensBefore`
- This ensures both values being compared are from the same scope (full session)

## Changes

- Modified `src/agents/pi-embedded-runner/compact.ts`:
  - Added `tokensBeforeFull` calculation before compaction
  - Updated sanity check to use `tokensBeforeFull` instead of `result.tokensBefore`
  - Added detailed comments explaining the fix

## Code Changes

```typescript
// Before:
const result = await compactWithSafetyTimeout(() =>
  session.compact(params.customInstructions),
);
// ... calculate tokensAfter ...
// Sanity check: tokensAfter should be less than tokensBefore
if (tokensAfter > result.tokensBefore) {
  tokensAfter = undefined;
}

// After:
// Record full session token count before compaction
let tokensBeforeFull: number | undefined;
try {
  tokensBeforeFull = 0;
  for (const message of session.messages) {
    tokensBeforeFull += estimateTokens(message);
  }
} catch {
  tokensBeforeFull = undefined;
}

const result = await compactWithSafetyTimeout(() =>
  session.compact(params.customInstructions),
);
// ... calculate tokensAfter ...
// Sanity check: use tokensBeforeFull for comparison
if (
  tokensBeforeFull !== undefined &&
  tokensAfter > tokensBeforeFull
) {
  tokensAfter = undefined;
}
```

## Testing

- [x] Verified token count displays correctly after compaction
- [x] Tested with various session sizes
- [x] Tested edge cases where tokensBeforeFull might fail
- [x] Verified backward compatibility

## Fixes

Fixes #28337

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Changes are well-documented with comments
- [x] No new warnings generated
- [x] Backward compatible with existing functionality