### PR TITLE
fix(gateway): allow required Google Fonts origins in Control UI CSP

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -7,6 +7,7 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -8,6 +8,11 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("script-src 'self'");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
     expect(csp).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+  });
+
+  it("allows Google Fonts for style and font loading", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("https://fonts.googleapis.com");
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,8 +1,8 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
   // (UI uses a lot of inline style attributes in templates).
-  // Control UI imports Google Fonts stylesheets in base.css, so allow the
-  // stylesheet origin and corresponding font file CDN explicitly.
+  // Keep Google Fonts origins explicit in CSP for deployments that load
+  // external Google Fonts stylesheets/font files.
   return [
     "default-src 'self'",
     "base-uri 'none'",

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,15 +1,17 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
   // (UI uses a lot of inline style attributes in templates).
+  // Control UI imports Google Fonts stylesheets in base.css, so allow the
+  // stylesheet origin and corresponding font file CDN explicitly.
   return [
     "default-src 'self'",
     "base-uri 'none'",
     "object-src 'none'",
     "frame-ancestors 'none'",
     "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
+    "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");
 }


### PR DESCRIPTION
## Summary

- Problem: Recent reports showed Control UI regressions tied to Google Fonts CSP blocking in affected builds/configurations.
- Why it matters: External font stylesheet/font requests can be blocked unless CSP explicitly allows the required origins.
- What changed: Added only required Google Fonts origins to CSP (`style-src` includes `https://fonts.googleapis.com`, `font-src` includes `https://fonts.gstatic.com`).
- What did NOT change (scope boundary): No script policy changes, no new dynamic sources, no changes outside `control-ui-csp` + its tests.
- Credit: Adopted dedicated test structure from #28202 by @Glucksberg.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #25985
- Related #23050
- Related #28202

## User-visible / Behavior Changes

Control UI CSP now allows the required Google Fonts origins for style/font requests.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Build `buildControlUiCspHeader()`.
2. Verify output includes `style-src ... https://fonts.googleapis.com`.
3. Verify output includes `font-src ... https://fonts.gstatic.com`.
4. Run `pnpm vitest run src/gateway/control-ui-csp.test.ts`.

### Expected

- CSP includes only required Google Fonts origins for style and font directives.

### Actual

- Verified by focused unit tests (2 passing tests).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran `pnpm vitest run src/gateway/control-ui-csp.test.ts` locally after change.
- Edge cases checked: CSP still blocks inline scripts; no extra origins added beyond required style/font domains.
- What you did **not** verify: Full cross-platform CI matrix (pending in PR).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `src/gateway/control-ui-csp.ts`, `src/gateway/control-ui-csp.test.ts`
- Known bad symptoms reviewers should watch for: Browser CSP violations for Google Fonts resources.

## Risks and Mitigations

- Risk: Slight CSP broadening for style/font origins.
  - Mitigation: Strict allowlist with only `fonts.googleapis.com` (style) and `fonts.gstatic.com` (font).
