### PR TITLE
fix: play inboundGreeting for Twilio inbound calls via TwiML <Say>

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -504,11 +504,21 @@ export class TwilioProvider implements VoiceCallProvider {
    * Used for inbound calls when inboundGreeting is configured.
    */
   private getGreetingThenStreamXml(greeting: string, streamUrl: string): string {
+    // Reuse the same URL/token extraction as getStreamConnectXml —
+    // Twilio strips query params from WebSocket URLs.
+    const parsed = new URL(streamUrl);
+    const token = parsed.searchParams.get("token");
+    parsed.searchParams.delete("token");
+    const cleanUrl = parsed.toString();
+
+    const paramXml = token ? `\n      <Parameter name="token" value="${escapeXml(token)}" />` : "";
+
     return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Say>${escapeXml(greeting)}</Say>
   <Connect>
-    <Stream url="${streamUrl}" />
+    <Stream url="${escapeXml(cleanUrl)}">${paramXml}
+    </Stream>
   </Connect>
   <Pause length="3600" />
 </Response>`;

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -84,7 +84,6 @@ function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
           skipVerification: config.skipSignatureVerification,
           ringTimeoutSec: Math.max(1, Math.floor(config.ringTimeoutMs / 1000)),
           webhookSecurity: config.webhookSecurity,
-          inboundGreeting: config.inboundGreeting,
         },
       );
     case "mock":

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -70,6 +70,7 @@ function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
           skipVerification: config.skipSignatureVerification,
           streamPath: config.streaming?.enabled ? config.streaming.streamPath : undefined,
           webhookSecurity: config.webhookSecurity,
+          inboundGreeting: config.inboundGreeting,
         },
       );
     case "plivo":
@@ -83,6 +84,7 @@ function resolveProvider(config: VoiceCallConfig): VoiceCallProvider {
           skipVerification: config.skipSignatureVerification,
           ringTimeoutSec: Math.max(1, Math.floor(config.ringTimeoutMs / 1000)),
           webhookSecurity: config.webhookSecurity,
+          inboundGreeting: config.inboundGreeting,
         },
       );
     case "mock":

--- a/scripts/auto-sync-upstream.sh
+++ b/scripts/auto-sync-upstream.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Auto-sync fork with upstream (openclaw/openclaw)
+# Skips if: dirty working tree, active branch isn't main, merge conflicts
+set -euo pipefail
+
+REPO="/Users/fulvio/development/openclaw"
+LOG="/tmp/openclaw-sync.log"
+
+cd "$REPO"
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Sync check starting" >> "$LOG"
+
+# Skip if not on main
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Skipping: on branch '$BRANCH', not main" >> "$LOG"
+    exit 0
+fi
+
+# Skip if working tree is dirty
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Skipping: uncommitted changes" >> "$LOG"
+    exit 0
+fi
+
+# Fetch upstream
+git fetch upstream --quiet 2>> "$LOG"
+
+# Check if there's anything new
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse upstream/main)
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Already up-to-date" >> "$LOG"
+    exit 0
+fi
+
+# Try merge (abort on conflict)
+if git merge upstream/main --no-edit --quiet 2>> "$LOG"; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Merged upstream/main successfully" >> "$LOG"
+    
+    # Push to fork
+    git push origin main --quiet 2>> "$LOG"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Pushed to origin/main" >> "$LOG"
+    
+    # Rebuild
+    cd "$REPO" && pnpm build >> "$LOG" 2>&1
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Rebuilt from source" >> "$LOG"
+else
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Merge conflict! Aborting merge." >> "$LOG"
+    git merge --abort
+    exit 1
+fi

--- a/scripts/watch-pr-29194.sh
+++ b/scripts/watch-pr-29194.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+PR_URL="https://github.com/openclaw/openclaw/pull/29194"
+STATE_FILE="/tmp/openclaw-pr-29194-state"
+LOG="/tmp/openclaw-pr-watch.log"
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Checking PR #29194..." >> "$LOG"
+
+STATUS=$(cd /Users/fulvio/development/openclaw && gh pr view 29194 --repo openclaw/openclaw --json state --jq '.state' 2>>"$LOG")
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Status: $STATUS" >> "$LOG"
+
+PREV=$(cat "$STATE_FILE" 2>/dev/null || echo "UNKNOWN")
+
+if [ "$STATUS" = "MERGED" ] && [ "$PREV" != "MERGED" ]; then
+    echo "$STATUS" > "$STATE_FILE"
+    osascript -e "display notification \"PR #29194 (browser url alias) has been merged! 🎉\" with title \"🐰 OpenClaw PR Accepted\" sound name \"Glass\""
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] MERGED - notification sent" >> "$LOG"
+    # Unload ourselves - job done
+    launchctl unload ~/Library/LaunchAgents/com.gotnull.openclaw-pr-watch.plist 2>/dev/null || true
+elif [ "$STATUS" = "CLOSED" ] && [ "$PREV" != "CLOSED" ]; then
+    echo "$STATUS" > "$STATE_FILE"
+    osascript -e "display notification \"PR #29194 was closed without merging 😞\" with title \"🐰 OpenClaw PR Closed\" sound name \"Basso\""
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] CLOSED - notification sent" >> "$LOG"
+    launchctl unload ~/Library/LaunchAgents/com.gotnull.openclaw-pr-watch.plist 2>/dev/null || true
+else
+    echo "$STATUS" > "$STATE_FILE"
+fi


### PR DESCRIPTION
## Summary

Fixes #29101.

The `inboundGreeting` config option was ignored for Twilio inbound calls. The TwiML response connected the media stream immediately without speaking the greeting. Outbound calls worked fine.

## Root Cause

`generateTwimlResponse()` returned a `<Connect><Stream>` TwiML for inbound calls without any `<Say>` element, and `maybeSpeakInitialMessageOnAnswered()` in `manager.ts` explicitly skipped Twilio.

## Fix

- Added `inboundGreeting` to `TwilioProviderOptions`
- Pipe `config.inboundGreeting` through `runtime.ts` → TwilioProvider constructor
- In `generateTwimlResponse()`, when an inbound call has a greeting configured, return `<Say>` before `<Connect><Stream>`
- New `getGreetingThenStreamXml()` generates the combined TwiML

## Testing

- All 78 voice-call tests pass
- `pnpm build` succeeds