### PR TITLE
docs(showcase): add VoiceOps — full-duplex Discord voice pipeline [AI-assisted]

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -337,7 +337,7 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 <Card title="VoiceOps — Discord Voice Pipeline" icon="discord" href="https://github.com/GreyforgeLabs/voiceops">
   **@GreyforgeLabs** • `voice` `discord` `tts` `asr` `full-duplex`
 
-  Full-duplex Discord voice bot for OpenClaw. Speak naturally into a voice channel — Whisper ASR transcribes, your OpenClaw agent responds, kokoro-js neural TTS speaks back. 3–7s end-to-end. Zero cloud TTS cost. MIT licensed.
+Full-duplex Discord voice bot for OpenClaw. Speak naturally into a voice channel — Whisper ASR transcribes, your OpenClaw agent responds, kokoro-js neural TTS speaks back. 3–7s end-to-end. Zero cloud TTS cost. MIT licensed.
 </Card>
 
 </CardGroup>

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -334,6 +334,12 @@ Watches company Slack channel, responds helpfully, and forwards notifications to
 Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on ClawHub.
 </Card>
 
+<Card title="VoiceOps — Discord Voice Pipeline" icon="discord" href="https://github.com/GreyforgeLabs/voiceops">
+  **@GreyforgeLabs** • `voice` `discord` `tts` `asr` `full-duplex`
+
+  Full-duplex Discord voice bot for OpenClaw. Speak naturally into a voice channel — Whisper ASR transcribes, your OpenClaw agent responds, kokoro-js neural TTS speaks back. 3–7s end-to-end. Zero cloud TTS cost. MIT licensed.
+</Card>
+
 </CardGroup>
 
 ## 🏗️ Infrastructure & Deployment


### PR DESCRIPTION
## What is this?

**VoiceOps** is a full-duplex Discord voice pipeline for OpenClaw — the first Discord voice bot built specifically for the OpenClaw Gateway.

**Repo:** https://github.com/GreyforgeLabs/voiceops  
**Chronicle / write-up:** https://greyforge.tech/chronicles/voiceops-integration

## What it does

- You speak into a Discord voice channel
- Whisper ASR transcribes your speech
- The transcript is sent to your OpenClaw agent via Gateway v3 (`chat.send`)
- The agent's response is synthesized with **kokoro-js** (local neural TTS, 82MB ONNX model, ~300ms warm)
- The audio is played back through the voice channel
- End-to-end latency: **3–7 seconds**

Full-duplex means no push-to-talk, no mode switching — the bot is always listening, always responding, like a phone call rather than a walkie-talkie.

## Key details

- **Zero cloud TTS cost** — kokoro-js runs entirely locally via ONNX Runtime
- **ASR**: OpenAI `whisper-1` (~$0.0005/turn) or local `whisper.cpp` ($0.00)
- **Gateway integration**: standard v3 WebSocket protocol, no OpenClaw internals modified
- **MIT licensed**
- Built by [Greyforge Labs](https://greyforge.tech)

## AI-assisted disclosure

Per CONTRIBUTING.md transparency requirements: this project was built with AI assistance (Claude Code / Anthropic). The architecture was pre-validated by an adversarial multi-agent audit before implementation. All code has been reviewed and tested by the author.

## Change

Adds a `<Card>` entry to the existing `🎙️ Voice & Phone` section of `docs/start/showcase.md`. No other files touched.