### PR TITLE
fix: failover preserves explicit provider when primary/fallback share model slug

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -146,10 +146,17 @@ function shouldUseOpenAICodexProvider(provider: string, model: string): boolean 
   );
 }
 
-export function normalizeModelRef(provider: string, model: string): ModelRef {
+export function normalizeModelRef(
+  provider: string,
+  model: string,
+  options?: { preserveProvider?: boolean },
+): ModelRef {
   const normalizedProvider = normalizeProviderId(provider);
   const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim());
-  if (shouldUseOpenAICodexProvider(normalizedProvider, normalizedModel)) {
+  if (
+    !options?.preserveProvider &&
+    shouldUseOpenAICodexProvider(normalizedProvider, normalizedModel)
+  ) {
     return { provider: "openai-codex", model: normalizedModel };
   }
   return { provider: normalizedProvider, model: normalizedModel };


### PR DESCRIPTION
## Summary

Fixes #29007.

When primary is `openai-codex/gpt-5.3-codex` and fallback is `openai/gpt-5.3-codex`, the fallback never fires because `normalizeModelRef()` rewrites `openai` → `openai-codex` for codex model patterns, making the fallback identical to the primary. The dedup logic then skips it.

## Root Cause

`normalizeModelRef()` unconditionally calls `shouldUseOpenAICodexProvider()`, which remaps `openai` to `openai-codex` for any model matching codex prefixes. This is correct for primary model resolution but wrong when the user explicitly chose `openai` as a fallback provider.

## Fix

- `normalizeModelRef()` now accepts an optional `{ preserveProvider: true }` flag that skips the codex provider rewrite
- `resolveFallbackCandidates()` uses this flag when the fallback string contains an explicit `provider/model` format — preserving the user's provider intent

## Testing

- New test: "preserves explicit provider in fallback even when model slug matches codex pattern"
- All 44 model-fallback tests pass
- All 31 model-selection tests pass
- `pnpm build` succeeds