### PR TITLE
fix(model): preserve reasoning in provider fallback resolution

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -200,6 +200,32 @@ describe("resolveModel", () => {
     expect(result.model?.maxTokens).toBe(32768);
   });
 
+  it("propagates reasoning from matching configured fallback model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                reasoning: false,
+              },
+              {
+                ...makeModel("model-b"),
+                reasoning: true,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("custom", "model-b", "/tmp/agent", cfg);
+
+    expect(result.model?.reasoning).toBe(true);
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -103,7 +103,7 @@ export function resolveModel(
         api: providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
+        reasoning: configuredModel?.reasoning ?? false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow:


### PR DESCRIPTION
## Summary

- Problem: provider fallback in `resolveModel()` still hardcoded `reasoning: false` even when a matching configured provider model has `reasoning: true`.
- Why it matters: reasoning-capable models lose reasoning effort propagation in fallback paths.
- What changed:
  - use `configuredModel?.reasoning ?? false` in provider fallback model construction.
  - add regression test proving matched fallback model propagates `reasoning: true`.
- Scope boundary:
  - no additional context-window/max-token behavior changes (covered in #29205).

## Linked Issue/PR

- Fixes #25636
- Related #25641
- Related #29205
- Context from superseded pieces: #24146, #26475, #27292

## Verification

- `pnpm vitest run src/agents/pi-embedded-runner/model.test.ts`
- `pnpm tsgo`
