### PR TITLE
fix(agents): avoid billing false-positives in assistant sanitization

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -122,6 +122,16 @@ describe("isBillingErrorMessage", () => {
     expect(longResponse.length).toBeGreaterThan(512);
     expect(isBillingErrorMessage(longResponse)).toBe(false);
   });
+  it("does not match long explanatory prose that mentions HTTP 402 semantics", () => {
+    const longProse =
+      "In API docs, HTTP 402 means Payment Required and is often used for billing checks. " +
+      "This section explains retry strategy, user messaging, and graceful degradation for " +
+      "insufficient credits scenarios in educational context only. " +
+      "Details: " +
+      "x".repeat(700);
+    expect(longProse.length).toBeGreaterThan(512);
+    expect(isBillingErrorMessage(longProse)).toBe(false);
+  });
   it("still matches explicit 402 markers in long payloads", () => {
     const longStructuredError =
       '{"error":{"code":402,"message":"payment required","details":"' + "x".repeat(700) + '"}}';

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -66,6 +66,16 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text, { errorContext: true })).toContain("billing error");
   });
 
+  it("does not rewrite long explanatory billing prose in errorContext", () => {
+    const text =
+      "In this guide, HTTP 402 Payment Required is documented as a billing status code. " +
+      "We explain how to present retry UX and credit top-up hints without treating this as a live API failure. " +
+      "Reference notes: " +
+      "x".repeat(700);
+    expect(text.length).toBeGreaterThan(512);
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toBe(text);
+  });
+
   it("sanitizes raw API error payloads", () => {
     const raw = '{"type":"error","error":{"message":"Something exploded","type":"server_error"}}';
     expect(sanitizeUserFacingText(raw, { errorContext: true })).toBe(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -161,8 +161,9 @@ const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const BILLING_ERROR_HEAD_RE =
   /^(?:error[:\s-]+)?billing(?:\s+error)?(?:[:\s-]+|$)|^(?:error[:\s-]+)?(?:credit balance|insufficient credits?|payment required|http\s*402\b)/i;
-const BILLING_ERROR_HARD_402_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|^\s*402\s+payment/i;
+const BILLING_ERROR_HARD_402_RE = /["']?(?:status|code)["']?\s*[:=]\s*402\b|^\s*402\s+payment/i;
+const BILLING_ERROR_CONTEXT_HINT_RE =
+  /\b(payment required|billing|credits?|quota|insufficient|plan|upgrade)\b/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
@@ -731,9 +732,10 @@ export function isBillingErrorMessage(raw: string): boolean {
   // Long text (e.g. multi-paragraph assistant responses) that happens to mention
   // "billing", "payment", etc. should not be treated as a billing error.
   if (raw.length > BILLING_ERROR_MAX_LENGTH) {
-    // Keep explicit status/code 402 detection for providers that wrap errors in
-    // larger payloads (for example nested JSON bodies or prefixed metadata).
-    return BILLING_ERROR_HARD_402_RE.test(value);
+    // For long payloads, only accept machine-shaped 402 fields (status/code) plus
+    // billing context hints. This avoids clobbering educational prose that merely
+    // discusses HTTP 402/payment semantics.
+    return BILLING_ERROR_HARD_402_RE.test(value) && BILLING_ERROR_CONTEXT_HINT_RE.test(value);
   }
   if (matchesErrorPatterns(value, ERROR_PATTERNS.billing)) {
     return true;

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -133,6 +133,24 @@ describe("extractAssistantText", () => {
     );
   });
 
+  it("does not rewrite billing prose when stopReason is not error", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      stopReason: "stop",
+      errorMessage: "HTTP 402 Payment Required",
+      content: [
+        {
+          type: "text",
+          text: "Docs note: HTTP 402 Payment Required can appear in billing examples.",
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Docs note: HTTP 402 Payment Required can appear in billing examples.");
+  });
+
   it("strips Minimax tool invocations with extra attributes", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -219,7 +219,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
     }) ?? "";
   // Only apply keyword-based error rewrites when the assistant message is actually an error.
   // Otherwise normal prose that *mentions* errors (e.g. "context overflow") can get clobbered.
-  const errorContext = msg.stopReason === "error" || Boolean(msg.errorMessage?.trim());
+  const errorContext = msg.stopReason === "error";
   return sanitizeUserFacingText(extracted, { errorContext });
 }
 

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -162,9 +162,7 @@ export function extractAssistantText(message: unknown): string | undefined {
       normalizeText: (text) => text.trim(),
     }) ?? "";
   const stopReason = (message as { stopReason?: unknown }).stopReason;
-  const errorMessage = (message as { errorMessage?: unknown }).errorMessage;
-  const errorContext =
-    stopReason === "error" || (typeof errorMessage === "string" && Boolean(errorMessage.trim()));
+  const errorContext = stopReason === "error";
 
   return joined ? sanitizeUserFacingText(joined, { errorContext }) : undefined;
 }

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -116,6 +116,23 @@ describe("extractAssistantText", () => {
     expect(extractAssistantText(message)).toBe("HTTP 500: Internal Server Error");
   });
 
+  it("does not force error rewrites when stopReason is non-error", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      errorMessage: "HTTP 402 Payment Required",
+      content: [
+        {
+          type: "text",
+          text: "Docs note: HTTP 402 Payment Required can be returned for billing checks.",
+        },
+      ],
+    };
+    expect(extractAssistantText(message)).toBe(
+      "Docs note: HTTP 402 Payment Required can be returned for billing checks.",
+    );
+  });
+
   it("keeps normal status text that mentions billing", () => {
     const message = {
       role: "assistant",


### PR DESCRIPTION
## Summary

- **Problem:** `sanitizeUserFacingText` could rewrite normal assistant prose into a billing-failure message when text discussed HTTP 402/billing semantics.
- **Why it matters:** This hides valid assistant output and confuses users with a fake “API credits exhausted” error.
- **What changed:** Tightened long-text billing detection in `src/agents/pi-embedded-helpers/errors.ts` and restricted error-context rewrites in assistant text extraction helpers to `stopReason === "error"`; added regression tests in billing/sanitization/session helper suites.
- **What did NOT change:** Provider transport, retry/fallback flow, and non-billing error sanitization logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29234

## User-visible / Behavior Changes

- Assistant replies that discuss billing/HTTP 402 in normal prose no longer get replaced by generic billing-error text unless the message is actually marked as an error.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime: Node.js + pnpm workspace test runner
- Integration/channel: Embedded agent reply sanitization path

### Steps

1. Feed long assistant text that mentions billing/HTTP 402 semantics through `sanitizeUserFacingText(..., { errorContext: true })`.
2. Extract assistant text from transcript/tool helpers where `stopReason !== "error"` but `errorMessage` exists.

### Expected

- Normal prose remains intact; only true error payloads are rewritten.

### Actual

- Before fix: prose could be replaced with billing-failure copy.
- After fix: prose remains unchanged; real billing errors still sanitize.

## Evidence

- `pnpm test -- --run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/tools/sessions.test.ts src/agents/pi-embedded-utils.test.ts`
- Result: 4 test files passed, 144 tests passed.

## Human Verification (required)

- Verified scenarios: Long explanatory billing prose, long structured billing JSON payload, assistant-text extraction in sessions and embedded utils.
- Edge cases checked: `stopReason=stop` with populated `errorMessage`; long payload (>512) with/without machine-shaped 402 fields.
- What I did **not** verify: End-to-end channel UX in live Slack/Discord runtime.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit/PR.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`, `src/agents/tools/sessions-helpers.ts`, `src/agents/pi-embedded-utils.ts`.
- Known bad symptoms: Potential reappearance of false billing rewrites or under-detection for unusual long billing payloads.

## Risks and Mitigations

- Risk: Some non-standard long billing payloads may no longer be rewritten.
- Mitigation: Keep short-payload billing heuristics unchanged and preserve long structured `status/code:402` + billing-hint detection, with regression tests.

