### PR TITLE
fix(agents): prevent non-vision image history poison loop

### DIFF
--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -1,7 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { PRUNED_HISTORY_IMAGE_MARKER, pruneProcessedHistoryImages } from "./history-image-prune.js";
+import {
+  PRUNED_HISTORY_IMAGE_MARKER,
+  pruneImagesForTextOnlyModels,
+  pruneProcessedHistoryImages,
+} from "./history-image-prune.js";
 
 describe("pruneProcessedHistoryImages", () => {
   const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
@@ -61,5 +65,44 @@ describe("pruneProcessedHistoryImages", () => {
     expect(didMutate).toBe(false);
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
     expect(firstUser?.content).toBe("noop");
+  });
+});
+
+describe("pruneImagesForTextOnlyModels", () => {
+  const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
+
+  it("prunes image blocks even when the latest user turn has no assistant reply", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "latest upload" }, { ...image }],
+      } as AgentMessage,
+    ];
+
+    const didMutate = pruneImagesForTextOnlyModels(messages);
+
+    expect(didMutate).toBe(true);
+    const first = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
+    if (!first || !Array.isArray(first.content)) {
+      throw new Error("expected array content");
+    }
+    expect(first.content[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+  });
+
+  it("does not mutate when user history has no image blocks", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "no images" }],
+      } as AgentMessage,
+      {
+        role: "assistant",
+        content: "ok",
+      } as unknown as AgentMessage,
+    ];
+
+    const didMutate = pruneImagesForTextOnlyModels(messages);
+
+    expect(didMutate).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** Sessions could enter a permanent HTTP 400 loop when transcript image blocks were sent to non-vision models and the failed image turn remained unpruned.
- **Why it matters:** After one failed image turn, every subsequent message could keep failing until users manually reset session state.
- **What changed:** Added `pruneImagesForTextOnlyModels` in `history-image-prune.ts` and invoked it in `run/attempt.ts` when `modelHasVision` is false; expanded pruning tests to cover unanswered latest user turns.
- **What did NOT change:** Vision-capable model behavior and prompt-local image detection pipeline.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29290

## User-visible / Behavior Changes

- For text-only models, stale transcript image blocks are removed from user history automatically, preventing repeated 400 failures after an image upload attempt.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime: Node.js + pnpm workspace test runner
- Integration/channel: Embedded runner transcript history handling

### Steps

1. Simulate a session containing user image blocks and a model without vision support.
2. Run the prune helpers and embedded attempt path.

### Expected

- Processed image blocks are pruned as before, and for text-only models all persisted user image blocks (including latest unanswered turn) are stripped.

### Actual

- Before fix: latest failed image turn could stay and poison subsequent requests.
- After fix: text-only path prunes persisted image blocks and breaks the failure loop.

## Evidence

- `pnpm test -- --run src/agents/pi-embedded-runner/run/history-image-prune.test.ts src/agents/pi-embedded-runner/run/images.test.ts`
- Result: 2 test files passed, 32 tests passed.

## Human Verification (required)

- Verified scenarios: Processed-history pruning, latest-unanswered-turn pruning for non-vision mode, no-op on text-only histories.
- Edge cases checked: Sessions without assistant turns, mixed assistant/user message history.
- What I did **not** verify: Live provider runtime against an external non-vision model endpoint.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit/PR.
- Files/config to restore: `src/agents/pi-embedded-runner/run/history-image-prune.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`.
- Known bad symptoms: Image history pruning might become too aggressive in text-only paths.

## Risks and Mitigations

- Risk: Text-only runs lose historical image payloads sooner.
- Mitigation: Restrict full-history pruning to non-vision models only; keep vision model path unchanged and covered by targeted tests.

