### PR TITLE
fix: remove hardcoded WORKFLOW_AUTO.md from post-compaction audit

### DIFF
--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -14,7 +14,7 @@ describe("extractReadPaths", () => {
           {
             type: "tool_use",
             name: "read",
-            input: { file_path: "WORKFLOW_AUTO.md" },
+            input: { file_path: "AGENTS.md" },
           },
         ],
       },
@@ -31,7 +31,7 @@ describe("extractReadPaths", () => {
     ];
 
     const paths = extractReadPaths(messages);
-    expect(paths).toEqual(["WORKFLOW_AUTO.md", "memory/2026-02-16.md"]);
+    expect(paths).toEqual(["AGENTS.md", "memory/2026-02-16.md"]);
   });
 
   it("handles path parameter (alternative to file_path)", () => {
@@ -110,7 +110,7 @@ describe("auditPostCompactionReads", () => {
   const workspaceDir = "/Users/test/workspace";
 
   it("passes when all required files are read", () => {
-    const readPaths = ["WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -121,16 +121,14 @@ describe("auditPostCompactionReads", () => {
     const result = auditPostCompactionReads([], workspaceDir);
 
     expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
     expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
   });
 
-  it("reports only missing files", () => {
-    const readPaths = ["WORKFLOW_AUTO.md"];
+  it("reports only missing patterns", () => {
+    const readPaths = ["AGENTS.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(false);
-    expect(result.missingPatterns).not.toContain("WORKFLOW_AUTO.md");
     expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
   });
 
@@ -138,13 +136,12 @@ describe("auditPostCompactionReads", () => {
     const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
-    expect(result.passed).toBe(false);
-    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
-    expect(result.missingPatterns.length).toBe(1);
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
   });
 
   it("normalizes relative paths when matching", () => {
-    const readPaths = ["./WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const readPaths = ["memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -152,10 +149,7 @@ describe("auditPostCompactionReads", () => {
   });
 
   it("normalizes absolute paths when matching", () => {
-    const readPaths = [
-      "/Users/test/workspace/WORKFLOW_AUTO.md",
-      "/Users/test/workspace/memory/2026-02-16.md",
-    ];
+    const readPaths = ["/Users/test/workspace/memory/2026-02-16.md"];
     const result = auditPostCompactionReads(readPaths, workspaceDir);
 
     expect(result.passed).toBe(true);
@@ -174,24 +168,24 @@ describe("auditPostCompactionReads", () => {
 
 describe("formatAuditWarning", () => {
   it("formats warning message with missing patterns", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
+    const missingPatterns = ["SOUL.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
     const message = formatAuditWarning(missingPatterns);
 
     expect(message).toContain("⚠️ Post-Compaction Audit");
-    expect(message).toContain("WORKFLOW_AUTO.md");
+    expect(message).toContain("SOUL.md");
     expect(message).toContain("memory");
     expect(message).toContain("Please read them now");
   });
 
   it("formats single missing pattern", () => {
-    const missingPatterns = ["WORKFLOW_AUTO.md"];
+    const missingPatterns = ["SOUL.md"];
     const message = formatAuditWarning(missingPatterns);
 
-    expect(message).toContain("WORKFLOW_AUTO.md");
-    // Check that the missing patterns list only contains WORKFLOW_AUTO.md
+    expect(message).toContain("SOUL.md");
+    // Check that the missing patterns list only contains SOUL.md
     const lines = message.split("\n");
     const patternLines = lines.filter((l) => l.trim().startsWith("- "));
     expect(patternLines).toHaveLength(1);
-    expect(patternLines[0]).toContain("WORKFLOW_AUTO.md");
+    expect(patternLines[0]).toContain("SOUL.md");
   });
 });

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -1,11 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-// Default required files — constants, extensible to config later
-const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
-  "WORKFLOW_AUTO.md",
-  /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
-];
+const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [/memory\/\d{4}-\d{2}-\d{2}\.md/];
 
 /**
  * Audit whether agent read required startup files after compaction.
@@ -22,6 +18,11 @@ export function auditPostCompactionReads(
   for (const required of requiredReads) {
     if (typeof required === "string") {
       const requiredResolved = path.resolve(workspaceDir, required);
+      // Skip files that don't exist in the workspace — avoids false alerts
+      // for hardcoded or user-configured paths that aren't present.
+      if (!fs.existsSync(requiredResolved)) {
+        continue;
+      }
       const found = normalizedReads.some((r) => r === requiredResolved);
       if (!found) {
         missingPatterns.push(required);


### PR DESCRIPTION
## Problem

The post-compaction audit hardcodes `WORKFLOW_AUTO.md` as a required startup file, but this file does not exist in any standard agent workspace (#29243). After context compaction, agents receive a system message telling them to read a non-existent file, which:

1. **Wastes tokens** — agents try to read the file and fail
2. **Confuses agents** — some flag it as suspicious/injection
3. **Shows raw regex** — `memory/\d{4}-\d{2}-\d{2}\.md` is shown literally instead of resolved

## Fix

- Remove `WORKFLOW_AUTO.md` from `DEFAULT_REQUIRED_READS` (it was never a real file)
- Add `fs.existsSync()` guard for string entries so non-existent files are silently skipped
- Keep the `memory/` daily file regex pattern (the actually useful check)
- Updated all tests

## Testing

- All 15 existing tests pass (updated to reflect new defaults)
- Full `tsc --noEmit` passes with no new errors
- `oxfmt` clean

Fixes #29243
