### PR TITLE
fix(skills): avoid host-only bin gating in sandbox mode

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -10,6 +10,7 @@ import {
   loadWorkspaceSkillEntries,
   resolveBundledAllowlist,
   resolveSkillConfig,
+  shouldBypassLocalBinChecks,
   resolveSkillsInstallPreferences,
   type SkillEntry,
   type SkillEligibilityContext,
@@ -190,12 +191,13 @@ function buildSkillStatus(
     bundledNames && bundledNames.size > 0
       ? bundledNames.has(entry.skill.name)
       : entry.skill.source === "openclaw-bundled";
+  const bypassLocalBinChecks = shouldBypassLocalBinChecks(config, eligibility);
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
       always,
       entry,
-      hasLocalBin: hasBinary,
+      hasLocalBin: bypassLocalBinChecks ? () => true : hasBinary,
       remote: eligibility?.remote,
       isEnvSatisfied,
       isConfigSatisfied,

--- a/src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts
@@ -110,6 +110,29 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(defaultPrompt).not.toContain("anybin-skill");
     expect(defaultPrompt).not.toContain("env-skill");
 
+    const sandboxPrompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
+      buildWorkspaceSkillsPrompt(workspaceDir, {
+        managedSkillsDir,
+        config: {
+          agents: {
+            defaults: {
+              sandbox: { mode: "all" },
+            },
+          },
+        },
+        eligibility: {
+          remote: {
+            platforms: ["linux"],
+            hasBin: () => false,
+            hasAnyBin: () => false,
+            note: "",
+          },
+        },
+      }),
+    );
+    expect(sandboxPrompt).toContain("bin-skill");
+    expect(sandboxPrompt).toContain("anybin-skill");
+
     const gatedPrompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
       buildWorkspaceSkillsPrompt(workspaceDir, {
         managedSkillsDir,

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -72,6 +72,32 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.missing.config).toContain("browser.enabled");
     expect(skill?.install[0]?.id).toBe("brew");
   });
+  it("treats requires.bins as satisfied when sandbox mode is enabled", async () => {
+    const entry = makeEntry({
+      name: "sandbox-bin-skill",
+      requires: {
+        bins: ["fakebin"],
+      },
+    });
+
+    const report = withEnv({ PATH: "" }, () =>
+      buildWorkspaceSkillStatus("/tmp/ws", {
+        entries: [entry],
+        config: {
+          agents: {
+            defaults: {
+              sandbox: { mode: "all" },
+            },
+          },
+        },
+      }),
+    );
+    const skill = report.skills.find((reportEntry) => reportEntry.name === "sandbox-bin-skill");
+
+    expect(skill).toBeDefined();
+    expect(skill?.eligible).toBe(true);
+    expect(skill?.missing.bins).toEqual([]);
+  });
   it("respects OS-gated skills", async () => {
     const entry = makeEntry({
       name: "os-skill",

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -9,6 +9,7 @@ export {
   resolveConfigPath,
   resolveRuntimePlatform,
   resolveSkillConfig,
+  shouldBypassLocalBinChecks,
 } from "./skills/config.js";
 export {
   applySkillEnvOverrides,

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -77,6 +77,14 @@ export type SkillEligibilityContext = {
     hasAnyBin: (bins: string[]) => boolean;
     note?: string;
   };
+  sandbox?: {
+    /**
+     * When true, skip host-side requires.bins checks because execution happens
+     * in sandbox/container runtime where bin availability differs from gateway.
+     */
+    assumeBinsAvailable: boolean;
+    note?: string;
+  };
 };
 
 export type SkillSnapshot = {


### PR DESCRIPTION
## Summary

- **Problem:** Skill eligibility checks for `requires.bins` were evaluated against gateway host PATH, causing false "blocked" skills when binaries exist only in sandbox execution environments.
- **Why it matters:** In containerized deployments with sandbox enabled, valid skills were hidden from prompts and `skills check`, reducing agent capabilities.
- **What changed:** Added sandbox-aware bin-check bypass logic in `skills/config.ts` and `skills-status.ts` (`shouldBypassLocalBinChecks`), with skill type support for sandbox eligibility hints and regression tests for prompt/status behavior under sandbox mode.
- **What did NOT change:** Remote-node eligibility checks, env/config requirement checks, and installer selection logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29254

## User-visible / Behavior Changes

- With sandbox mode enabled, skills requiring binaries are no longer incorrectly blocked just because those binaries are absent on the gateway host.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime: Node.js + pnpm workspace test runner
- Integration/channel: Skill eligibility + skill status evaluation

### Steps

1. Define skills with `requires.bins` / `requires.anyBins` and clear host PATH.
2. Evaluate prompt/status generation with and without sandbox mode enabled in config.

### Expected

- Without sandbox mode: missing bins remain blocked.
- With sandbox mode: host-only bin checks are bypassed so skills are not falsely blocked.

### Actual

- Before fix: sandbox deployments could still show skills blocked by host PATH.
- After fix: sandbox-mode config avoids host-only false negatives.

## Evidence

- `pnpm test -- --run src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts src/agents/skills.buildworkspaceskillstatus.test.ts`
- Result: 2 test files passed, 8 tests passed.

## Human Verification (required)

- Verified scenarios: Prompt gating (`buildWorkspaceSkillsPrompt`) and status report (`buildWorkspaceSkillStatus`) with requires.bins under sandbox mode.
- Edge cases checked: `requires.bins`, `requires.anyBins`, and mixed config/env requirement handling.
- What I did **not** verify: Live Docker sandbox probing against a running external sandbox container.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit/PR.
- Files/config to restore: `src/agents/skills/config.ts`, `src/agents/skills-status.ts`, `src/agents/skills/types.ts`, `src/agents/skills.ts`.
- Known bad symptoms: Skills may appear eligible in sandbox mode even if sandbox runtime image is missing expected binaries.

## Risks and Mitigations

- Risk: Bypassing host bin checks in sandbox mode can over-include skills if sandbox images are misconfigured.
- Mitigation: Scope bypass to sandbox-enabled config only, keep env/config/OS checks intact, and preserve current remote eligibility logic.

