### PR TITLE
fix(telegram): stop dropping peer-bound allowlist groups

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -527,6 +527,26 @@ export const registerTelegramHandlers = ({
     if (!isGroup) {
       return false;
     }
+    const peerId = buildTelegramGroupPeerId(chatId, resolvedThreadId);
+    const parentPeer = buildTelegramParentPeer({
+      isGroup,
+      resolvedThreadId,
+      chatId,
+    });
+    const routeForPolicy = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId,
+      peer: {
+        kind: "group",
+        id: peerId,
+      },
+      parentPeer,
+    });
+    const hasPeerBinding =
+      routeForPolicy.matchedBy === "binding.peer" ||
+      routeForPolicy.matchedBy === "binding.peer.parent";
+    const enforceAllowlistAuthorization = effectiveGroupAllow.hasEntries || !hasPeerBinding;
     const policyAccess = evaluateTelegramGroupPolicyAccess({
       isGroup,
       chatId,
@@ -540,7 +560,7 @@ export const registerTelegramHandlers = ({
       resolveGroupPolicy,
       enforcePolicy: true,
       useTopicAndGroupOverrides: true,
-      enforceAllowlistAuthorization: true,
+      enforceAllowlistAuthorization,
       allowEmptyAllowlistEntries: false,
       requireSenderForAllowlistAuthorization: true,
       checkChatAllowlist: true,

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1416,6 +1416,37 @@ describe("createTelegramBot", () => {
       expect(replySpy.mock.calls.length, testCase.name).toBe(0);
     }
   });
+  it("allows allowlist groups without sender allowlist when peer binding matches", async () => {
+    resetHarnessSpies();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-100123456789" },
+          },
+        },
+      ],
+    });
+
+    await dispatchMessage({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
   it("blocks group sender not in groupAllowFrom even when sender is paired in DM store", async () => {
     resetHarnessSpies();
     loadConfig.mockReturnValue({


### PR DESCRIPTION
## Summary

- **Problem:** Telegram group messages could be silently dropped under `groupPolicy=allowlist` when `groupAllowFrom` was empty, even if the group itself was explicitly bound by peer routing.
- **Why it matters:** Correctly configured group bindings still failed to trigger agent replies, causing confusing “nothing happens” behavior.
- **What changed:** In `src/telegram/bot-handlers.ts`, allowlist sender authorization is now bypassed only when a matching peer binding exists and no sender allowlist entries are configured; added regression test in `src/telegram/bot.create-telegram-bot.test.ts`.
- **What did NOT change:** Existing sender allowlist enforcement when `groupAllowFrom` is configured, per-group explicit empty allowFrom fail-closed behavior, and groupPolicy disabled handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29238

## User-visible / Behavior Changes

- Telegram groups explicitly bound via `bindings.match.peer` can now receive messages under `groupPolicy=allowlist` even when `groupAllowFrom` is not set.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime: Node.js + pnpm workspace test runner
- Integration/channel: Telegram inbound handler authorization path

### Steps

1. Configure Telegram with `groupPolicy: allowlist`, no `groupAllowFrom`, and a matching peer binding for the target group.
2. Send a group message from a non-allowlisted sender.

### Expected

- Peer-bound group message should be processed (not silently dropped).

### Actual

- Before fix: message dropped due allowlist-empty sender authorization gate.
- After fix: peer-bound message is accepted while explicit sender allowlists still enforce when provided.

## Evidence

- `pnpm test -- --run src/telegram/bot.create-telegram-bot.test.ts`
- Result: 1 test file passed, 46 tests passed.

## Human Verification (required)

- Verified scenarios: Existing restrictive edge-case blocks, new peer-binding allowlist pass case, unchanged sender-allowlist enforcement.
- Edge cases checked: per-group explicit empty allowFrom remains blocked, unauthorized senders remain blocked when sender allowlist exists.
- What I did **not** verify: Live Telegram polling/webhook in production bot environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit/PR.
- Files/config to restore: `src/telegram/bot-handlers.ts`.
- Known bad symptoms: Unexpectedly permissive group ingress if peer bindings are broader than intended.

## Risks and Mitigations

- Risk: Bypassing sender allowlist for peer-bound groups may broaden who can trigger in that group.
- Mitigation: Restrict bypass to routes that explicitly matched `binding.peer`/`binding.peer.parent` and only when no sender allowlist entries are configured.

