### PR TITLE
fix(auto-reply): sanitize stale post-compaction startup hints

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -42,7 +42,8 @@ Not relevant.
     const result = await readPostCompactionContext(tmpDir);
     expect(result).not.toBeNull();
     expect(result).toContain("Session Startup");
-    expect(result).toContain("WORKFLOW_AUTO.md");
+    expect(result).not.toContain("WORKFLOW_AUTO.md");
+    expect(result).toContain("memory/today.md");
     expect(result).toContain("Post-compaction context refresh");
     expect(result).not.toContain("Other Section");
   });
@@ -109,7 +110,23 @@ Read WORKFLOW_AUTO.md
     fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
     const result = await readPostCompactionContext(tmpDir);
     expect(result).not.toBeNull();
-    expect(result).toContain("WORKFLOW_AUTO.md");
+    expect(result).not.toContain("WORKFLOW_AUTO.md");
+    expect(result).toContain("Session Startup");
+  });
+
+  it("strips deprecated regex placeholder startup hints", async () => {
+    const content = `# Rules
+
+## Session Startup
+
+- memory/\\d{4}-\\d{2}-\\d{2}\\.md
+- memory/today.md
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("memory/\\d{4}-\\d{2}-\\d{2}\\.md");
+    expect(result).toContain("memory/today.md");
   });
 
   it("matches H3 headings", async () => {

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -104,6 +104,7 @@ Ignore this.
 ## session startup
 
 Read WORKFLOW_AUTO.md
+Read memory/today.md
 
 ## Other
 `;
@@ -111,6 +112,7 @@ Read WORKFLOW_AUTO.md
     const result = await readPostCompactionContext(tmpDir);
     expect(result).not.toBeNull();
     expect(result).not.toContain("WORKFLOW_AUTO.md");
+    expect(result).toContain("memory/today.md");
     expect(result).toContain("Session Startup");
   });
 
@@ -127,6 +129,19 @@ Read WORKFLOW_AUTO.md
     expect(result).not.toBeNull();
     expect(result).not.toContain("memory/\\d{4}-\\d{2}-\\d{2}\\.md");
     expect(result).toContain("memory/today.md");
+  });
+
+  it("returns null when only deprecated startup hints remain", async () => {
+    const content = `# Rules
+
+## Session Startup
+
+1. WORKFLOW_AUTO.md
+2. memory/\\d{4}-\\d{2}-\\d{2}\\.md
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).toBeNull();
   });
 
   it("matches H3 headings", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: post-compaction context refresh can include stale startup lines copied from `AGENTS.md` (for example `WORKFLOW_AUTO.md` and regex-placeholder paths).
- Why it matters: these stale references ask the agent to read files that do not exist, which creates confusing follow-up behavior after compaction.
- What changed: filter deprecated startup-hint patterns before injecting context, drop sections that become heading-only after filtering, and add regression tests covering both behaviors.
- What did NOT change (scope boundary): section extraction semantics and heading parsing remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29243
- Related #

## User-visible / Behavior Changes

Post-compaction context refresh no longer includes deprecated startup hints such as `WORKFLOW_AUTO.md` or legacy regex-placeholder memory paths.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: local Node.js + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): auto-reply post-compaction pipeline
- Relevant config (redacted): default test config

### Steps

1. Add `WORKFLOW_AUTO.md` and/or `memory/\\d{4}-\\d{2}-\\d{2}\\.md` lines under `## Session Startup` in `AGENTS.md`.
2. Trigger post-compaction context refresh (`readPostCompactionContext`).
3. Inspect injected system event text.

### Expected

- Deprecated startup-hint lines are removed.
- If a target section only contains deprecated hints after filtering, it is not injected.

### Actual

- Before this PR: stale lines were injected and could reference non-existent files.
- After this PR: stale lines are filtered and heading-only sections are omitted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test -- --run src/auto-reply/reply/post-compaction-context.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: stale `WORKFLOW_AUTO.md` and regex-placeholder memory lines are excluded from injected context while valid startup hints remain.
- Edge cases checked: section that becomes heading-only after filtering is dropped entirely (returns `null` when no eligible sections remain).
- What you did **not** verify: end-to-end interactive Telegram/CLI session compaction in live environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or temporarily bypass `stripDeprecatedPostCompactionHints` usage in `readPostCompactionContext`.
- Files/config to restore: `src/auto-reply/reply/post-compaction-context.ts`, associated tests.
- Known bad symptoms reviewers should watch for: missing expected startup guidance in post-compaction event when AGENTS content is sparse.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-filtering could remove legitimate lines that happen to match deprecated patterns.
  - Mitigation: Patterns are narrowly scoped to known stale references; tests assert valid hints are retained.

