### PR TITLE
fix(irc): keep provider alive after connecting to prevent restart loop

### DIFF
--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -137,6 +137,24 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${client.nick}`,
   );
 
+  // Keep the provider alive until the connection drops or the abort signal fires.
+  // Without this, the async function resolves immediately after connecting,
+  // causing the gateway framework to interpret it as "provider exited" and
+  // trigger an auto-restart loop.
+  await new Promise<void>((resolve) => {
+    const check = () => {
+      if (!client || !client.isReady()) {
+        clearInterval(timer);
+        resolve();
+      }
+    };
+    const timer = setInterval(check, 2000);
+    opts.abortSignal?.addEventListener("abort", () => {
+      clearInterval(timer);
+      resolve();
+    }, { once: true });
+  });
+
   return {
     stop: () => {
       client?.quit("shutdown");

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -149,10 +149,14 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
       }
     };
     const timer = setInterval(check, 2000);
-    opts.abortSignal?.addEventListener("abort", () => {
-      clearInterval(timer);
-      resolve();
-    }, { once: true });
+    opts.abortSignal?.addEventListener(
+      "abort",
+      () => {
+        clearInterval(timer);
+        resolve();
+      },
+      { once: true },
+    );
   });
 
   return {


### PR DESCRIPTION
## Summary

- Problem: the IRC provider promise resolves immediately after connect, so the gateway restarts it.
- Why it matters: this creates a restart loop and can trigger IRC 433 nickname-in-use errors.
- What changed: keep the provider alive until disconnect or abort.
- What did NOT change (scope boundary): IRC login/message handling and non-IRC providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

IRC connections stay up after a successful connect instead of immediately entering an auto-restart loop.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Not recorded
- Runtime/container: OpenClaw gateway
- Model/provider: N/A
- Integration/channel (if any): IRC against Ergo
- Relevant config (redacted): configured IRC account

### Steps

1. Start the gateway with IRC configured.
2. Confirm the provider stays connected.
3. Stop the gateway and simulate a disconnect.

### Expected

- Provider stays alive after connect.
- Abort disconnects cleanly.
- Server disconnect allows framework restart.

### Actual

Before this change, the provider resolved immediately and restarted.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: manual gateway start, clean shutdown, disconnect handling.
- Edge cases checked: abort path and post-connect disconnect detection.
- What you did **not** verify: automated regression coverage and non-Ergo IRC servers.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `extensions/irc/src/monitor.ts`
- Known bad symptoms reviewers should watch for: immediate restart loop or a provider that never exits after disconnect.

## Risks and Mitigations

- Risk: disconnect detection is polling-based.
  - Mitigation: short interval and immediate abort handling.
- Risk: no automated regression test in this PR.
  - Mitigation: manual verification is documented.

## AI Assistance

- [x] AI-assisted in the PR description
- Testing performed: lightly tested with manual verification
- Tooling used: Claude Code
- Author confirms understanding of the change: Yes
