### PR TITLE
feat(skills): probe sandbox for skill eligibility

### DIFF
--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -86,9 +86,12 @@ export function shouldIncludeSkill(params: {
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,
+    sandboxPlatforms: eligibility?.sandbox ? [eligibility.sandbox.platform] : undefined,
     always: entry.metadata?.always,
     requires: entry.metadata?.requires,
     hasBin: hasBinary,
+    hasSandboxBin: eligibility?.sandbox?.hasBin,
+    hasAnySandboxBin: eligibility?.sandbox?.hasAnyBin,
     hasRemoteBin: eligibility?.remote?.hasBin,
     hasAnyRemoteBin: eligibility?.remote?.hasAnyBin,
     hasEnv: (envName) =>

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -8,7 +8,7 @@ import { resolvePluginSkillDirs } from "./plugin-skills.js";
 
 type SkillsChangeEvent = {
   workspaceDir?: string;
-  reason: "watch" | "manual" | "remote-node";
+  reason: "watch" | "manual" | "remote-node" | "sandbox";
   changedPath?: string;
 };
 

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -77,6 +77,12 @@ export type SkillEligibilityContext = {
     hasAnyBin: (bins: string[]) => boolean;
     note?: string;
   };
+  sandbox?: {
+    hasBin: (bin: string) => boolean;
+    hasAnyBin: (bins: string[]) => boolean;
+    /** Platform reported by the sandbox container (e.g. "linux"). */
+    platform: string;
+  };
 };
 
 export type SkillSnapshot = {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -12,6 +12,7 @@ import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import { buildToolSummaryMap } from "../../agents/tool-summaries.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -38,7 +39,7 @@ export async function resolveCommandsSystemPromptBundle(
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
-        eligibility: { remote: getRemoteSkillEligibility() },
+        eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
     } catch {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -35,11 +35,18 @@ export async function resolveCommandsSystemPromptBundle(
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+  });
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
-        eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
+        eligibility: {
+          remote: getRemoteSkillEligibility(),
+          ...(sandboxRuntime.sandboxed ? { sandbox: getSandboxSkillEligibility() } : {}),
+        },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
     } catch {
@@ -47,10 +54,6 @@ export async function resolveCommandsSystemPromptBundle(
     }
   })();
   const skillsPrompt = skillsSnapshot.prompt ?? "";
-  const sandboxRuntime = resolveSandboxRuntimeStatus({
-    cfg: params.cfg,
-    sessionKey: params.ctx.SessionKey ?? params.sessionKey,
-  });
   const tools = (() => {
     try {
       return createOpenClawCodingTools({

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -188,6 +188,7 @@ export async function resolveReplyDirectives(params: {
           workspaceDir,
           cfg,
           skillFilter,
+          sessionKey,
         })
       : [];
   for (const command of skillCommands) {

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -172,6 +172,7 @@ export async function handleInlineActions(params: {
             workspaceDir,
             cfg,
             skillFilter,
+            sessionKey,
           })
         : [];
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { resolveUserTimezone } from "../../agents/date-time.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -153,7 +154,8 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
-  const sandboxEligibility = getSandboxSkillEligibility();
+  const sandboxRuntime = resolveSandboxRuntimeStatus({ cfg, sessionKey });
+  const sandboxEligibility = sandboxRuntime.sandboxed ? getSandboxSkillEligibility() : undefined;
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -11,6 +11,7 @@ import {
   formatZonedTimestamp,
 } from "../../infra/format-time/format-datetime.ts";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 
 export async function prependSystemEvents(params: {
@@ -152,6 +153,7 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
+  const sandboxEligibility = getSandboxSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
   const shouldRefreshSnapshot =
@@ -168,7 +170,7 @@ export async function ensureSkillSnapshot(params: {
         ? buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
             snapshotVersion,
           })
         : current.skillsSnapshot;
@@ -192,7 +194,7 @@ export async function ensureSkillSnapshot(params: {
     ? buildWorkspaceSkillSnapshot(workspaceDir, {
         config: cfg,
         skillFilter,
-        eligibility: { remote: remoteEligibility },
+        eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
         snapshotVersion,
       })
     : (nextEntry?.skillsSnapshot ??
@@ -201,7 +203,7 @@ export async function ensureSkillSnapshot(params: {
         : buildWorkspaceSkillSnapshot(workspaceDir, {
             config: cfg,
             skillFilter,
-            eligibility: { remote: remoteEligibility },
+            eligibility: { remote: remoteEligibility, sandbox: sandboxEligibility },
             snapshotVersion,
           })));
   if (

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
 import { buildWorkspaceSkillCommandSpecs, type SkillCommandSpec } from "../agents/skills.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { listChatCommands } from "./commands-registry.js";
 
 export function listReservedChatSlashCommandNames(extraNames: string[] = []): Set<string> {
@@ -32,11 +34,19 @@ export function listSkillCommandsForWorkspace(params: {
   workspaceDir: string;
   cfg: OpenClawConfig;
   skillFilter?: string[];
+  sessionKey?: string;
 }): SkillCommandSpec[] {
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+  });
   return buildWorkspaceSkillCommandSpecs(params.workspaceDir, {
     config: params.cfg,
     skillFilter: params.skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: {
+      remote: getRemoteSkillEligibility(),
+      ...(sandboxRuntime.sandboxed ? { sandbox: getSandboxSkillEligibility() } : {}),
+    },
     reservedNames: listReservedChatSlashCommandNames(),
   });
 }

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -27,6 +27,7 @@ import {
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
@@ -61,6 +62,7 @@ import {
 } from "../infra/agent-events.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
@@ -492,10 +494,14 @@ export async function agentCommand(
     const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
+    const sandboxRuntime = resolveSandboxRuntimeStatus({ cfg, sessionKey });
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {
           config: cfg,
-          eligibility: { remote: getRemoteSkillEligibility() },
+          eligibility: {
+            remote: getRemoteSkillEligibility(),
+            ...(sandboxRuntime.sandboxed ? { sandbox: getSandboxSkillEligibility() } : {}),
+          },
           snapshotVersion: skillsSnapshotVersion,
           skillFilter,
         })

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -16,6 +16,7 @@ import { resolveOsSummary } from "../infra/os-summary.js";
 import { inspectPortUsage } from "../infra/ports.js";
 import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../infra/skills-sandbox.js";
 import { readTailscaleStatusJson } from "../infra/tailscale.js";
 import { normalizeUpdateChannel, resolveUpdateChannelDisplay } from "../infra/update-channels.js";
 import { checkUpdateStatus, formatGitInstallLabel } from "../infra/update-check.js";
@@ -214,7 +215,10 @@ export async function statusAllCommand(
             try {
               return buildWorkspaceSkillStatus(defaultWorkspace, {
                 config: cfg,
-                eligibility: { remote: getRemoteSkillEligibility() },
+                eligibility: {
+                  remote: getRemoteSkillEligibility(),
+                  sandbox: getSandboxSkillEligibility(),
+                },
               });
             } catch {
               return null;

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -142,6 +142,28 @@ vi.mock("../../infra/skills-remote.js", () => ({
   getRemoteSkillEligibility: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock("../../infra/skills-sandbox.js", () => ({
+  getSandboxSkillEligibility: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../agents/sandbox.js", () => ({
+  resolveSandboxRuntimeStatus: vi.fn().mockReturnValue({
+    agentId: "default",
+    sessionKey: "",
+    mainSessionKey: "main:default",
+    mode: "off",
+    sandboxed: false,
+    toolPolicy: {
+      allow: [],
+      deny: [],
+      sources: {
+        allow: { source: "default", key: "" },
+        deny: { source: "default", key: "" },
+      },
+    },
+  }),
+}));
+
 vi.mock("../../logger.js", () => ({
   logWarn: (...args: unknown[]) => logWarnMock(...args),
 }));

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -370,6 +370,7 @@ export async function runCronIsolatedAgentTurn(params: {
     workspaceDir,
     config: cfgWithAgentDefaults,
     agentId,
+    sessionKey: agentSessionKey,
     existingSnapshot: existingSkillsSnapshot,
     isFastTestEnv,
   });

--- a/src/cron/isolated-agent/skills-snapshot.ts
+++ b/src/cron/isolated-agent/skills-snapshot.ts
@@ -1,14 +1,17 @@
 import { resolveAgentSkillsFilter } from "../../agents/agent-scope.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot, type SkillSnapshot } from "../../agents/skills.js";
 import { matchesSkillFilter } from "../../agents/skills/filter.js";
 import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 
 export function resolveCronSkillsSnapshot(params: {
   workspaceDir: string;
   config: OpenClawConfig;
   agentId: string;
+  sessionKey?: string;
   existingSnapshot?: SkillSnapshot;
   isFastTestEnv: boolean;
 }): SkillSnapshot {
@@ -28,10 +31,17 @@ export function resolveCronSkillsSnapshot(params: {
     return existingSnapshot;
   }
 
+  const sandboxRuntime = resolveSandboxRuntimeStatus({
+    cfg: params.config,
+    sessionKey: params.sessionKey,
+  });
   return buildWorkspaceSkillSnapshot(params.workspaceDir, {
     config: params.config,
     skillFilter,
-    eligibility: { remote: getRemoteSkillEligibility() },
+    eligibility: {
+      remote: getRemoteSkillEligibility(),
+      ...(sandboxRuntime.sandboxed ? { sandbox: getSandboxSkillEligibility() } : {}),
+    },
     snapshotVersion,
   });
 }

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -10,6 +10,7 @@ import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { getSandboxSkillEligibility } from "../../infra/skills-sandbox.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
@@ -84,7 +85,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
     const report = buildWorkspaceSkillStatus(workspaceDir, {
       config: cfg,
-      eligibility: { remote: getRemoteSkillEligibility() },
+      eligibility: { remote: getRemoteSkillEligibility(), sandbox: getSandboxSkillEligibility() },
     });
     respond(true, report, undefined);
   },

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -39,6 +39,7 @@ import {
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
+import { refreshSandboxBinsCache } from "../infra/skills-sandbox.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
@@ -572,6 +573,7 @@ export async function startGatewayServer(
   if (!minimalTestGateway) {
     setSkillsRemoteRegistry(nodeRegistry);
     void primeRemoteSkillsCache();
+    void refreshSandboxBinsCache(cfgAtStart);
   }
   // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
   // Skills changes can happen in bursts (e.g., file watcher events), and each probe
@@ -581,7 +583,7 @@ export async function startGatewayServer(
   const skillsChangeUnsub = minimalTestGateway
     ? () => {}
     : registerSkillsChangeListener((event) => {
-        if (event.reason === "remote-node") {
+        if (event.reason === "remote-node" || event.reason === "sandbox") {
           return;
         }
         if (skillsRefreshTimer) {
@@ -591,6 +593,7 @@ export async function startGatewayServer(
           skillsRefreshTimer = null;
           const latest = loadConfig();
           void refreshRemoteBinsForConnectedNodes(latest);
+          void refreshSandboxBinsCache(latest);
         }, skillsRefreshDelayMs);
       });
 
@@ -861,6 +864,9 @@ export async function startGatewayServer(
             });
             try {
               await applyHotReload(plan, prepared.config);
+              // Re-evaluate sandbox eligibility when config changes (e.g.
+              // sandbox mode/image toggled) that do not emit skills events.
+              void refreshSandboxBinsCache(prepared.config);
             } catch (err) {
               if (previousSnapshot) {
                 activateSecretsRuntimeSnapshot(previousSnapshot);

--- a/src/infra/skills-sandbox.ts
+++ b/src/infra/skills-sandbox.ts
@@ -1,0 +1,363 @@
+import type { SkillEligibilityContext, SkillEntry } from "../agents/skills.js";
+import { loadWorkspaceSkillEntries } from "../agents/skills.js";
+import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh.js";
+import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("gateway/skills-sandbox");
+
+/** Cached set of binaries found in the sandbox container/image. */
+let cachedBins: Set<string> | null = null;
+/** The sandbox image that was used to populate the cache. */
+let cachedImage: string | null = null;
+/** Platform of the sandbox (always "linux" for Docker containers). */
+const SANDBOX_PLATFORM = "linux";
+/**
+ * Monotonically increasing generation counter.  Each call to
+ * `refreshSandboxBinsCache` captures the current generation at the start
+ * and only commits results when the generation has not been superseded by
+ * a newer invocation.  This prevents a slow, stale refresh from
+ * overwriting a more recent result.
+ */
+let refreshGeneration = 0;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all bins required by skills that could run in the sandbox.
+ * Unlike the remote-node variant this does NOT filter by OS because the
+ * sandbox is always Linux and we want to know about every binary the
+ * sandbox could provide.
+ */
+function collectRequiredBins(entries: SkillEntry[]): string[] {
+  const bins = new Set<string>();
+  for (const entry of entries) {
+    for (const bin of entry.metadata?.requires?.bins ?? []) {
+      if (bin.trim()) {
+        bins.add(bin.trim());
+      }
+    }
+    for (const bin of entry.metadata?.requires?.anyBins ?? []) {
+      if (bin.trim()) {
+        bins.add(bin.trim());
+      }
+    }
+  }
+  return [...bins];
+}
+
+function buildBinProbeScript(bins: string[]): string {
+  const escaped = bins.map((bin) => `'${bin.replace(/'/g, `'\\''`)}'`).join(" ");
+  return `for b in ${escaped}; do if command -v "$b" >/dev/null 2>&1; then echo "$b"; fi; done`;
+}
+
+function parseBinProbeOutput(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function areSetsEqual(a: Set<string> | null, b: Set<string>): boolean {
+  if (!a) {
+    return false;
+  }
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const v of b) {
+    if (!a.has(v)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Probing (lazy-imports docker to avoid pulling STATE_DIR at module level)
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe binaries inside a running sandbox container (cheapest path) or
+ * fall back to `docker run --rm` against the sandbox image.
+ *
+ * Returns the list of found binaries, or `null` when probing fails
+ * entirely (so the caller can distinguish "nothing found" from "probe
+ * error" and preserve a previous cache).
+ */
+async function probeSandboxBins(
+  image: string,
+  bins: string[],
+  containerName?: string,
+): Promise<string[] | null> {
+  if (bins.length === 0) {
+    return [];
+  }
+
+  const { execDockerRaw } = await import("../agents/sandbox/docker.js");
+  const script = buildBinProbeScript(bins);
+
+  // 1. Try the running container first (no startup cost).
+  if (containerName) {
+    try {
+      const result = await execDockerRaw(["exec", "-i", containerName, "/bin/sh", "-lc", script], {
+        allowFailure: true,
+      });
+      if (result.code === 0) {
+        return parseBinProbeOutput(result.stdout.toString("utf8"));
+      }
+    } catch {
+      // Container not running or unreachable — fall through to image probe.
+    }
+  }
+
+  // 2. Fall back to a disposable container from the image.
+  try {
+    const result = await execDockerRaw(
+      ["run", "--rm", "--entrypoint", "/bin/sh", image, "-lc", script],
+      { allowFailure: true },
+    );
+    if (result.code === 0) {
+      return parseBinProbeOutput(result.stdout.toString("utf8"));
+    }
+  } catch (err) {
+    log.warn(`sandbox bin probe failed for image ${image}: ${String(err)}`);
+  }
+
+  // Both paths failed — signal to the caller that probing was unsuccessful.
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers (lazy-imported to avoid pulling in STATE_DIR at module level)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the sandbox Docker image from config. Returns `undefined` when
+ * sandbox mode is disabled.
+ */
+async function resolveSandboxImage(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): Promise<string | undefined> {
+  const { resolveSandboxConfigForAgent } = await import("../agents/sandbox/config.js");
+  const { DEFAULT_SANDBOX_IMAGE } = await import("../agents/sandbox/constants.js");
+  const sandboxCfg = resolveSandboxConfigForAgent(cfg, agentId);
+  if (sandboxCfg.mode === "off") {
+    return undefined;
+  }
+  return sandboxCfg.docker?.image ?? DEFAULT_SANDBOX_IMAGE;
+}
+
+/**
+ * Attempt to find a running sandbox container for the configured prefix.
+ *
+ * Sandbox scope defaults to `"agent"` and can also be `"session"` or
+ * `"shared"`, so the running container name is not always `…shared`.
+ * We use `docker ps --filter name=<prefix>` to find any container whose
+ * name starts with the configured prefix, regardless of scope.
+ */
+async function resolveRunningContainerName(
+  cfg: OpenClawConfig,
+  agentId?: string,
+  expectedImage?: string,
+): Promise<string | undefined> {
+  const { resolveSandboxConfigForAgent } = await import("../agents/sandbox/config.js");
+  const { execDockerRaw } = await import("../agents/sandbox/docker.js");
+  const sandboxCfg = resolveSandboxConfigForAgent(cfg, agentId);
+  if (sandboxCfg.mode === "off") {
+    return undefined;
+  }
+  const prefix = sandboxCfg.docker?.containerPrefix;
+  if (!prefix) {
+    return undefined;
+  }
+  // The browser container prefix (e.g. "openclaw-sbx-browser-") also starts
+  // with the tool sandbox prefix (e.g. "openclaw-sbx-"), so we must exclude
+  // browser containers to avoid probing the wrong environment.
+  const browserPrefix = sandboxCfg.browser?.containerPrefix;
+  try {
+    // List running containers whose name starts with the configured prefix.
+    // Include the image column so we can verify the container runs the
+    // expected image and avoid probing a stale or unrelated container.
+    const result = await execDockerRaw(
+      [
+        "ps",
+        "--filter",
+        `name=^${prefix}`,
+        "--filter",
+        "status=running",
+        "--format",
+        "{{.ID}}\t{{.Names}}\t{{.Image}}",
+      ],
+      { allowFailure: true },
+    );
+    if (result.code === 0) {
+      const lines = result.stdout.toString("utf8").trim().split(/\r?\n/).filter(Boolean);
+      for (const line of lines) {
+        const parts = line.split("\t");
+        const id = parts[0];
+        const name = parts[1];
+        const containerImage = parts[2];
+        if (!id?.trim()) {
+          continue;
+        }
+        // Skip browser containers.
+        if (browserPrefix && name && name.startsWith(browserPrefix)) {
+          continue;
+        }
+        // Skip containers whose image does not match the configured one.
+        // This prevents probing bins from a stale container that was
+        // started with a different image or runtime setup.
+        if (expectedImage && containerImage?.trim() && containerImage.trim() !== expectedImage) {
+          continue;
+        }
+        // If --format gave us the name directly, use it.
+        if (name?.trim()) {
+          return name.trim();
+        }
+        // Otherwise resolve the full container name from the short ID.
+        const inspectResult = await execDockerRaw(["inspect", "--format", "{{.Name}}", id.trim()], {
+          allowFailure: true,
+        });
+        if (inspectResult.code === 0) {
+          const resolved = inspectResult.stdout.toString("utf8").trim().replace(/^\//, "");
+          // Double-check the resolved name is not a browser container.
+          if (browserPrefix && resolved.startsWith(browserPrefix)) {
+            continue;
+          }
+          return resolved;
+        }
+        return id.trim();
+      }
+    }
+  } catch {
+    // Docker not available or no matching container — fall through.
+  }
+  return undefined;
+}
+
+/**
+ * Commit a new cache state and bump the skills snapshot version when the
+ * eligibility context has actually changed.
+ */
+function commitCache(nextBins: Set<string>, image: string): void {
+  const changed = cachedImage !== image || !areSetsEqual(cachedBins, nextBins);
+  cachedBins = nextBins;
+  cachedImage = image;
+  if (changed) {
+    bumpSkillsSnapshotVersion({ reason: "sandbox" });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Refresh the cached set of binaries available in the sandbox
+ * container/image.  Call on gateway startup, whenever sandbox config
+ * or skill definitions change, and on config hot-reload.
+ *
+ * Uses a generation counter to guard against stale results from
+ * concurrent fire-and-forget invocations overwriting newer state.
+ */
+export async function refreshSandboxBinsCache(cfg: OpenClawConfig, agentId?: string) {
+  const gen = ++refreshGeneration;
+
+  const image = await resolveSandboxImage(cfg, agentId);
+  if (!image) {
+    if (gen !== refreshGeneration) {
+      return;
+    }
+    const changed = cachedBins !== null || cachedImage !== null;
+    cachedBins = null;
+    cachedImage = null;
+    if (changed) {
+      bumpSkillsSnapshotVersion({ reason: "sandbox" });
+    }
+    return;
+  }
+
+  const workspaceDirs = listAgentWorkspaceDirs(cfg);
+  const allBins = new Set<string>();
+  for (const dir of workspaceDirs) {
+    const entries = loadWorkspaceSkillEntries(dir, { config: cfg });
+    for (const bin of collectRequiredBins(entries)) {
+      allBins.add(bin);
+    }
+  }
+
+  if (allBins.size === 0) {
+    // No skills require any binaries, but we still need to expose the
+    // sandbox platform for OS-only constraints.  Bump the snapshot if
+    // this is a transition from a previous state.
+    if (gen !== refreshGeneration) {
+      return;
+    }
+    commitCache(new Set(), image);
+    return;
+  }
+
+  const containerName = await resolveRunningContainerName(cfg, agentId, image);
+
+  // Check generation before the potentially slow Docker probe.
+  if (gen !== refreshGeneration) {
+    return;
+  }
+
+  const found = await probeSandboxBins(image, [...allBins], containerName);
+
+  // When probing fails entirely, keep the previous cache to avoid
+  // incorrectly filtering out skills during transient Docker issues —
+  // but only when the image has not changed.  If the configured image
+  // switched (hot-reload), the old cache is invalid and must not be
+  // served under the new image.
+  if (found === null) {
+    if (cachedBins !== null && cachedImage === image) {
+      log.warn("sandbox bin probe failed; keeping previous cache");
+      return;
+    }
+    // Cold start (no prior cache) or image changed — commit an empty
+    // set so that the sandbox platform is still reported for OS-only
+    // skill constraints.
+    log.warn("sandbox bin probe failed on cold start or image change; exposing platform only");
+    if (gen !== refreshGeneration) {
+      return;
+    }
+    commitCache(new Set(), image);
+    return;
+  }
+
+  // Final generation check after the async probe completes.
+  if (gen !== refreshGeneration) {
+    return;
+  }
+
+  commitCache(new Set(found), image);
+}
+
+/**
+ * Return the sandbox eligibility context for skill filtering, or
+ * `undefined` when sandbox mode is off or no bins have been probed yet.
+ *
+ * Uses strict `=== null` check so that an empty `Set` (probed, but no
+ * bins found) still reports the sandbox platform for OS-only constraints.
+ */
+export function getSandboxSkillEligibility(): SkillEligibilityContext["sandbox"] | undefined {
+  if (cachedBins === null) {
+    return undefined;
+  }
+  // Capture the current set in a local constant so that the returned
+  // predicate closures remain stable even if a concurrent refresh
+  // sets cachedBins to null (e.g. sandbox mode toggled off via hot-reload).
+  const snapshotBins = cachedBins;
+  return {
+    hasBin: (bin) => snapshotBins.has(bin),
+    hasAnyBin: (bins) => bins.some((b) => snapshotBins.has(b)),
+    platform: SANDBOX_PLATFORM,
+  };
+}

--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -50,4 +50,109 @@ describe("evaluateRuntimeEligibility", () => {
     });
     expect(result).toBe(true);
   });
+
+  // --- sandbox eligibility tests ---
+
+  it("accepts entries when sandbox platform satisfies OS requirements", () => {
+    const result = evaluateRuntimeEligibility({
+      os: ["linux"],
+      remotePlatforms: [],
+      sandboxPlatforms: ["linux"],
+      hasBin: () => true,
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("rejects entries when neither local, remote, nor sandbox platform matches OS", () => {
+    const result = evaluateRuntimeEligibility({
+      os: ["darwin"],
+      remotePlatforms: [],
+      sandboxPlatforms: ["linux"],
+      hasBin: () => true,
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("falls back to sandbox bin check when local hasBin returns false (requires.bins)", () => {
+    const result = evaluateRuntimeEligibility({
+      requires: { bins: ["gh"] },
+      hasBin: () => false,
+      hasSandboxBin: (bin) => bin === "gh",
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("falls back to sandbox bin check when local hasBin returns false (requires.anyBins)", () => {
+    const result = evaluateRuntimeEligibility({
+      requires: { anyBins: ["claude", "codex", "pi"] },
+      hasBin: () => false,
+      hasAnySandboxBin: (bins) => bins.includes("codex"),
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("rejects when bin is missing from local, sandbox, and remote", () => {
+    const result = evaluateRuntimeEligibility({
+      requires: { bins: ["gh"] },
+      hasBin: () => false,
+      hasSandboxBin: () => false,
+      hasRemoteBin: () => false,
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("checks sandbox before remote for bins (sandbox wins)", () => {
+    const calls: string[] = [];
+    const result = evaluateRuntimeEligibility({
+      requires: { bins: ["gh"] },
+      hasBin: () => false,
+      hasSandboxBin: (bin) => {
+        calls.push(`sandbox:${bin}`);
+        return true;
+      },
+      hasRemoteBin: (bin) => {
+        calls.push(`remote:${bin}`);
+        return true;
+      },
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+    // Sandbox should be checked first; remote should not be reached.
+    expect(calls).toEqual(["sandbox:gh"]);
+  });
+
+  it("falls through sandbox to remote for bins when sandbox misses", () => {
+    const result = evaluateRuntimeEligibility({
+      requires: { bins: ["memo"] },
+      hasBin: () => false,
+      hasSandboxBin: () => false,
+      hasRemoteBin: (bin) => bin === "memo",
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("falls through sandbox to remote for anyBins when sandbox misses", () => {
+    const result = evaluateRuntimeEligibility({
+      requires: { anyBins: ["claude", "codex"] },
+      hasBin: () => false,
+      hasAnySandboxBin: () => false,
+      hasAnyRemoteBin: (bins) => bins.includes("claude"),
+      hasEnv: () => true,
+      isConfigPathTruthy: () => true,
+    });
+    expect(result).toBe(true);
+  });
 });

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -51,6 +51,8 @@ export type RuntimeRequires = {
 type RuntimeRequirementEvalParams = {
   requires?: RuntimeRequires;
   hasBin: (bin: string) => boolean;
+  hasSandboxBin?: (bin: string) => boolean;
+  hasAnySandboxBin?: (bins: string[]) => boolean;
   hasAnyRemoteBin?: (bins: string[]) => boolean;
   hasRemoteBin?: (bin: string) => boolean;
   hasEnv: (envName: string) => boolean;
@@ -69,6 +71,9 @@ export function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): b
       if (params.hasBin(bin)) {
         continue;
       }
+      if (params.hasSandboxBin?.(bin)) {
+        continue;
+      }
       if (params.hasRemoteBin?.(bin)) {
         continue;
       }
@@ -79,8 +84,10 @@ export function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): b
   const requiredAnyBins = requires.anyBins ?? [];
   if (requiredAnyBins.length > 0) {
     const anyFound = requiredAnyBins.some((bin) => params.hasBin(bin));
-    if (!anyFound && !params.hasAnyRemoteBin?.(requiredAnyBins)) {
-      return false;
+    if (!anyFound && !params.hasAnySandboxBin?.(requiredAnyBins)) {
+      if (!params.hasAnyRemoteBin?.(requiredAnyBins)) {
+        return false;
+      }
     }
   }
 
@@ -109,14 +116,17 @@ export function evaluateRuntimeEligibility(
   params: {
     os?: string[];
     remotePlatforms?: string[];
+    sandboxPlatforms?: string[];
     always?: boolean;
   } & RuntimeRequirementEvalParams,
 ): boolean {
   const osList = params.os ?? [];
   const remotePlatforms = params.remotePlatforms ?? [];
+  const sandboxPlatforms = params.sandboxPlatforms ?? [];
   if (
     osList.length > 0 &&
     !osList.includes(resolveRuntimePlatform()) &&
+    !sandboxPlatforms.some((platform) => osList.includes(platform)) &&
     !remotePlatforms.some((platform) => osList.includes(platform))
   ) {
     return false;
@@ -127,6 +137,8 @@ export function evaluateRuntimeEligibility(
   return evaluateRuntimeRequires({
     requires: params.requires,
     hasBin: params.hasBin,
+    hasSandboxBin: params.hasSandboxBin,
+    hasAnySandboxBin: params.hasAnySandboxBin,
     hasRemoteBin: params.hasRemoteBin,
     hasAnyRemoteBin: params.hasAnyRemoteBin,
     hasEnv: params.hasEnv,


### PR DESCRIPTION
## Summary

When the gateway runs inside a Docker container (the default self-hosted topology), skill eligibility checks for `requires.bins`, `requires.anyBins`, and `os` are evaluated on the **gateway** host rather than inside the **sandbox** container where the skill actually executes. This causes skills like `coding-agent` (which requires `gh`) to be silently dropped from the system prompt even though `gh` is available in the sandbox image.

This PR adds a sandbox bin-probing layer — mirroring the existing remote-node pattern — so that the sandbox container/image is queried for available binaries and its platform is included in OS eligibility checks.

## Changes

| File | Change |
|------|--------|
| `src/infra/skills-sandbox.ts` | **New** — sandbox bin probing via `docker exec` / `docker run`, with caching and generation counter |
| `src/gateway/server.impl.ts` | Wire `refreshSandboxBinsCache` into gateway startup, skills change, and config hot-reload |
| `src/agents/skills/types.ts` | Add `sandbox` field to `SkillEligibilityContext` |
| `src/shared/config-eval.ts` | Add `hasSandboxBin` / `hasAnySandboxBin` / `sandboxPlatforms` to eligibility evaluation |
| `src/agents/skills/config.ts` | Wire sandbox eligibility into `shouldIncludeSkill` |
| `src/agents/skills/refresh.ts` | Add `"sandbox"` to `SkillsChangeEvent.reason` enum |
| `src/commands/agent.ts` | Pass sandbox eligibility, gated by session sandbox status |
| `src/auto-reply/reply/commands-system-prompt.ts` | Pass sandbox eligibility, gated by session sandbox status |
| `src/auto-reply/reply/session-updates.ts` | Pass sandbox eligibility, gated by session sandbox status |
| `src/auto-reply/reply/get-reply-directives.ts` | Pass `sessionKey` for sandbox status resolution |
| `src/auto-reply/reply/get-reply-inline-actions.ts` | Pass `sessionKey` for sandbox status resolution |
| `src/auto-reply/skill-commands.ts` | Pass sandbox eligibility, gated by session sandbox status |
| `src/commands/status-all.ts` | Pass sandbox eligibility |
| `src/cron/isolated-agent/skills-snapshot.ts` | Pass sandbox eligibility, gated by session sandbox status |
| `src/cron/isolated-agent/run.ts` | Pass `sessionKey` for sandbox status resolution |
| `src/gateway/server-methods/skills.ts` | Pass sandbox eligibility |
| `src/shared/config-eval.test.ts` | Add 8 new test cases covering sandbox platform and bin checks |
| `src/cron/isolated-agent/run.skill-filter.test.ts` | Add mocks for `agents/sandbox.js` and `infra/skills-sandbox.js` |

## How it works

1. `skills-sandbox.ts` collects all `requires.bins` / `requires.anyBins` from workspace skills.
2. It discovers a running sandbox container by matching the configured `containerPrefix` and **verifying the container's image** to avoid probing stale or incorrect containers.
3. It probes the sandbox by first trying `docker exec` on a running container, then falling back to `docker run --rm` against the configured image.
4. The probed binary set is cached and exposed via `getSandboxSkillEligibility()`. A generation counter prevents race conditions from concurrent refreshes. The cache distinguishes `null` (not yet probed) from empty set (probed, nothing found) so that OS-only skills are not incorrectly filtered.
5. `evaluateRuntimeEligibility` now checks sandbox bins **between** local and remote, and includes the sandbox platform in OS matching.
6. All call sites conditionally inject sandbox eligibility only when the session is actually sandboxed (`sandboxRuntime.sandboxed`), preventing skills from being advertised in non-sandboxed sessions.

## Testing

8 new test cases in `config-eval.test.ts` covering:
- Sandbox platform satisfying OS requirements
- Sandbox bin fallback for `requires.bins` and `requires.anyBins`
- Correct priority order: local → sandbox → remote
- Rejection when all three sources miss

Sandbox mocks added to `run.skill-filter.test.ts` to ensure CI passes.

Fixes #29254

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added tests for my changes.

