### PR TITLE
fix(models): honor explicit provider baseUrl updates in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -134,7 +134,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("keeps agent apiKey but applies explicit config baseUrl for matching providers in merge mode", async () => {
     await withTempHome(async () => {
       const agentDir = resolveOpenClawAgentDir();
       await fs.mkdir(agentDir, { recursive: true });
@@ -185,7 +185,7 @@ describe("models-config", () => {
         providers: Record<string, { apiKey?: string; baseUrl?: string }>;
       }>();
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -163,11 +163,15 @@ export async function ensureOpenClawModelsJson(
             })
           | undefined;
         if (existing) {
+          const explicitProvider = explicitProviders[key] as { baseUrl?: unknown } | undefined;
+          const hasExplicitBaseUrl =
+            typeof explicitProvider?.baseUrl === "string" &&
+            explicitProvider.baseUrl.trim().length > 0;
           const preserved: Record<string, unknown> = {};
           if (typeof existing.apiKey === "string" && existing.apiKey) {
             preserved.apiKey = existing.apiKey;
           }
-          if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+          if (typeof existing.baseUrl === "string" && existing.baseUrl && !hasExplicitBaseUrl) {
             preserved.baseUrl = existing.baseUrl;
           }
           mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: changing `models.providers.<id>.baseUrl` via config did not update `agents/main/agent/models.json` in merge mode.
- Why it matters: provider endpoint changes (host/port/base path) silently stayed stale, so runtime still called old URLs.
- What changed: when a provider has an explicit config `baseUrl`, `ensureOpenClawModelsJson` now keeps that configured value instead of preserving stale agent-side `models.json` baseUrl.
- What did NOT change (scope boundary): non-baseUrl merge behavior is unchanged (including apiKey preservation semantics).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28996
- Related #

## User-visible / Behavior Changes

Updating a provider `baseUrl` in config now correctly propagates to agent `models.json` under merge mode.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Node.js + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): models config generation
- Relevant config (redacted): custom provider with explicit `baseUrl`

### Steps

1. Create existing `agents/main/agent/models.json` with provider `custom.baseUrl = https://agent.example/v1`.
2. Set config `models.providers.custom.baseUrl = https://config.example/v1`.
3. Run `ensureOpenClawModelsJson` (or restart gateway).

### Expected

- `models.json` provider `baseUrl` updates to `https://config.example/v1`.

### Actual

- Before fix: stale `https://agent.example/v1` was preserved.
- After fix: explicit config `baseUrl` is applied.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test -- --run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: merge-mode generation now updates provider baseUrl when explicitly configured.
- Edge cases checked: existing apiKey preservation behavior remains unchanged in the same test case.
- What you did **not** verify: full end-to-end dashboard-driven config update flow on Windows/WSL host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/models-config.ts`, `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`.
- Known bad symptoms reviewers should watch for: provider `baseUrl` unexpectedly reverts to stale agent value after config change.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: environments relying on old stale-preservation behavior for `baseUrl` may see endpoint change on next regenerate.
  - Mitigation: only explicit config `baseUrl` now wins; this aligns behavior with user intent and issue report.

