### PR TITLE
fix(deps): add strip-ansi runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
+    "strip-ansi": "^7.2.0",
     "tar": "7.5.9",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       sqlite-vec:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
+      strip-ansi:
+        specifier: ^7.2.0
+        version: 7.2.0
       tar:
         specifier: 7.5.9
         version: 7.5.9


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: runtime startup can fail with `ERR_MODULE_NOT_FOUND: Cannot find package 'strip-ansi'` from `@mariozechner/pi-coding-agent` in strict pnpm installs.
- Why it matters: CLI entrypoints (for example `openclaw doctor`) can fail before normal diagnostics/load flow.
- What changed: added `strip-ansi` as an explicit root runtime dependency and updated lockfile.
- What did NOT change (scope boundary): no behavior changes in runtime logic/tooling code paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #29071
- Related #

## User-visible / Behavior Changes

Install/startup environments using strict dependency resolution no longer fail on missing `strip-ansi` at runtime.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): CLI startup path
- Relevant config (redacted): default local config

### Steps

1. Install with strict pnpm layout where undeclared transitive deps are not hoisted for runtime resolution.
2. Run a CLI command that loads pi-coding-agent runtime path (`openclaw doctor`, etc.).
3. Observe startup import resolution.

### Expected

- CLI starts normally without `strip-ansi` module-not-found crash.

### Actual

- Before fix: startup failed with `ERR_MODULE_NOT_FOUND` for `strip-ansi`.
- After fix: dependency is explicitly installed and available.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands:

- `node -e "import('@mariozechner/pi-coding-agent').then(()=>console.log('ok'))"`
- `node scripts/run-node.mjs doctor --help`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: package import succeeds and doctor CLI help path starts normally after dependency add.
- Edge cases checked: lockfile updated together with package manifest.
- What you did **not** verify: every downstream plugin runtime boot path in a fresh container image.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `package.json`, `pnpm-lock.yaml`.
- Known bad symptoms reviewers should watch for: install/lockfile drift if dependency pinning policies differ locally.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: adding a new direct dependency can create version-resolution differences across environments.
  - Mitigation: lockfile is updated in the same PR; runtime behavior only relies on module presence.

