### PR TITLE
fix(tools): normalize quoted edit/read file paths

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -129,6 +129,17 @@ describe("createOpenClawCodingTools", () => {
         undefined,
       );
 
+      await wrapped.execute("tool-quoted", {
+        file_path: ' "C:/Users/test/workspace/src/Layout.jsx" ',
+        content: "x",
+      });
+      expect(execute).toHaveBeenCalledWith(
+        "tool-quoted",
+        { path: "C:/Users/test/workspace/src/Layout.jsx", content: "x" },
+        undefined,
+        undefined,
+      );
+
       await expect(wrapped.execute("tool-2", { content: "x" })).rejects.toThrow(
         /Missing required parameter/,
       );


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: fs tool path args can include extra channel/model formatting (outer quotes/backticks + whitespace), causing false `File not found` on valid files.
- Why it matters: edit/write operations fail in chat-driven channels even when read/dir prove the file exists.
- What changed: normalize tool `path` values by trimming whitespace and removing matching outer quotes/backticks before execution.
- What did NOT change (scope boundary): no changes to workspace boundary checks, path escaping protections, or tool permission policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29304
- Related #

## User-visible / Behavior Changes

Edit/read/write-style file tools now accept path arguments like `"C:/..."`, `'...` or `` `...` `` without failing on false ENOENT.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): tool param normalization layer
- Relevant config (redacted): default tool config

### Steps

1. Invoke wrapped file tool with `file_path`/`path` that includes outer quotes and surrounding spaces.
2. Ensure required params validation still works.
3. Check executed args passed to underlying tool.

### Expected

- Path is normalized to raw filesystem path, then executed.

### Actual

- Before fix: quoted path could pass through and fail with file-not-found.
- After fix: normalized path is used.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test -- --run src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: quoted+space-padded `file_path` gets normalized and forwarded as clean `path`.
- Edge cases checked: existing required-parameter validation behavior remains unchanged.
- What you did **not** verify: full live Slack E2E invocation against a Windows host path.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/pi-tools.read.ts`, related normalization test file.
- Known bad symptoms reviewers should watch for: unexpected trimming of intentionally quote-prefixed path literals.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a path intentionally beginning/ending with matching quote/backtick characters could be normalized.
  - Mitigation: normalization only strips one matching outer pair after trim; internal characters are untouched.

