### PR TITLE
fix(ui): retry connect with token-only auth on stale device signatures

### DIFF
--- a/src/gateway/connect-auth-fallback.test.ts
+++ b/src/gateway/connect-auth-fallback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { shouldRetryConnectWithoutDeviceAuth } from "../../ui/src/ui/gateway.ts";
+
+describe("shouldRetryConnectWithoutDeviceAuth", () => {
+  it("retries without device auth for stale signature when token is available", () => {
+    expect(
+      shouldRetryConnectWithoutDeviceAuth({
+        detailCode: "device-signature-stale",
+        hasSharedToken: true,
+        alreadyRetriedWithoutDeviceAuth: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("retries without device auth for invalid signature when token is available", () => {
+    expect(
+      shouldRetryConnectWithoutDeviceAuth({
+        detailCode: "device-signature",
+        hasSharedToken: true,
+        alreadyRetriedWithoutDeviceAuth: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry without token", () => {
+    expect(
+      shouldRetryConnectWithoutDeviceAuth({
+        detailCode: "device-signature-stale",
+        hasSharedToken: false,
+        alreadyRetriedWithoutDeviceAuth: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry more than once", () => {
+    expect(
+      shouldRetryConnectWithoutDeviceAuth({
+        detailCode: "device-signature-stale",
+        hasSharedToken: true,
+        alreadyRetriedWithoutDeviceAuth: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores unrelated error detail codes", () => {
+    expect(
+      shouldRetryConnectWithoutDeviceAuth({
+        detailCode: "AUTH_TOKEN_MISMATCH",
+        hasSharedToken: true,
+        alreadyRetriedWithoutDeviceAuth: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: dashboard can get stuck in reconnect loops when gateway rejects connect with `device signature expired/invalid` even though token auth is otherwise valid.
- Why it matters: Control UI appears unresponsive (`Health Offline`, disabled controls) despite correct token setup.
- What changed: add a guarded fallback path that retries connect once without device auth when detail code is `device-signature-stale`/`device-signature` and a shared token is available.
- What did NOT change (scope boundary): no changes to gateway auth policy, signature validation, or normal device-auth happy path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29298
- Related #29286

## User-visible / Behavior Changes

When device signature validation fails due stale/invalid signature but URL token is valid, dashboard retries with token-only auth once instead of staying in a failing reconnect loop.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): Control UI gateway websocket connect
- Relevant config (redacted): token auth mode with dashboard URL token

### Steps

1. Attempt connect where gateway returns `device-signature-stale` or `device-signature` detail code.
2. Ensure dashboard has shared token available in URL/settings.
3. Observe reconnect behavior.

### Expected

- Client retries once without device auth and can proceed with token-only connect if token is valid.

### Actual

- Before fix: repeated reconnect failures keep UI offline.
- After fix: stale signature path can recover via token-only retry.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test -- --run src/gateway/connect-auth-fallback.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: fallback decision logic for stale/invalid signature detail codes with/without token and retry guard.
- Edge cases checked: unrelated auth errors do not trigger device-auth bypass.
- What you did **not** verify: full browser E2E against remote host with real skewed clocks.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/gateway.ts`, `src/gateway/connect-auth-fallback.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected token-only fallback on non-signature errors.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback could reduce preference for device-auth in edge cases with persistent signature issues.
  - Mitigation: only activates for explicit signature detail codes, requires token presence, and is retry-guarded.

