### PR TITLE
feat(livekit-stimm-voice): real-time low latency voice conversations — dual-agent LiveKit + OpenClaw supervisor

### DIFF
--- a/extensions/stimm-voice/README.md
+++ b/extensions/stimm-voice/README.md
@@ -1,0 +1,163 @@
+# @openclaw/stimm-voice
+
+Stimm Voice is an OpenClaw extension for real-time voice conversations.
+
+It uses a dual-agent architecture:
+
+- A fast Python voice agent (LiveKit + STT/TTS/LLM) handles low-latency speech.
+- OpenClaw acts as the supervisor for reasoning, tools, and long-context decisions.
+
+## Presentation
+
+What this extension provides:
+
+- Real-time voice sessions backed by LiveKit rooms.
+- Browser entrypoint at `web.path` (default: `/voice`).
+- Claim-token flow for web access (`/voice/claim`) with one-time, short-lived claims.
+- Optional Cloudflare Quick Tunnel for temporary public access.
+- Optional supervisor shared secret for `POST /stimm/supervisor`.
+
+## Install
+
+### Prerequisites
+
+- Node.js 22+
+- Python 3.10+
+- OpenClaw gateway installed and working
+- LiveKit deployment:
+  - local (`ws://localhost:7880`) or
+  - cloud (`wss://<your-project>.livekit.cloud`)
+
+### Local install from this repo
+
+```bash
+openclaw plugins install --link ./extensions/stimm-voice
+cd ./extensions/stimm-voice
+pnpm install
+```
+
+Then restart the OpenClaw gateway.
+
+Python dependencies use Stimm extras as the single installation contract:
+
+- Base/default profile from [python/requirements.txt](python/requirements.txt): `stimm[deepgram,openai]`
+- Additional provider plugins are installed by the setup wizard based on selected STT/TTS/LLM providers (`stimm[...]`).
+
+## Config
+
+Set config under `plugins.entries.stimm-voice.config`.
+
+```json5
+{
+  enabled: true,
+  livekit: {
+    url: "wss://your-project.livekit.cloud",
+    apiKey: "APIxxxxx",
+    apiSecret: "your-secret",
+  },
+  web: {
+    enabled: true,
+    path: "/voice",
+  },
+  access: {
+    mode: "quick-tunnel", // "none" | "quick-tunnel"
+    claimTtlSeconds: 120,
+    livekitTokenTtlSeconds: 300,
+    supervisorSecret: "change-me",
+    allowDirectWebSessionCreate: false,
+    claimRateLimitPerMinute: 20,
+  },
+  voiceAgent: {
+    spawn: { autoSpawn: true },
+    stt: { provider: "deepgram", model: "nova-3" },
+    tts: { provider: "openai", model: "gpt-4o-mini-tts", voice: "ash" },
+    llm: { provider: "openai", model: "gpt-4o-mini" },
+    bufferingLevel: "MEDIUM",
+    mode: "hybrid",
+  },
+}
+```
+
+Notes:
+
+- The extension is disabled by default (`enabled: false`).
+- `access.mode="quick-tunnel"` requires `cloudflared` on PATH.
+- `voiceAgent.tts.voice` is provider-specific: OpenAI uses voice names (`ash`, `alloy`), ElevenLabs uses `voice_id`, and Cartesia uses voice UUIDs.
+- API keys can be set directly in plugin config, or via env fallbacks (`STIMM_STT_API_KEY`, `STIMM_TTS_API_KEY`, `STIMM_LLM_API_KEY`, then provider-specific env vars).
+- `access.supervisorSecret` also supports env fallback (`STIMM_SUPERVISOR_SECRET`, then `OPENCLAW_SUPERVISOR_SECRET`).
+
+## Usage
+
+### Start session from CLI/tool/gateway
+
+```bash
+openclaw voice:start --channel web
+```
+
+### Supervisor logs (high-level)
+
+Use this command to inspect supervisor observability quickly without manual `grep`:
+
+```bash
+openclaw voice:logs --limit 40
+```
+
+Interactive follow mode:
+
+```bash
+openclaw voice:logs --watch --interval 2
+```
+
+Options:
+
+- `--raw`: print raw `OBS_JSON` lines from `/tmp/stimm-agent.log`
+- `--limit <n>`: number of entries to print (default: `40`)
+- `--watch`: keep watching and print new entries continuously (Ctrl+C to stop)
+- `--interval <s>`: refresh interval for watch mode in seconds (default: `2`)
+- `--all-events`: include `inference_started` (hidden by default to reduce noise)
+
+The command prints two sections:
+
+- Stimm supervisor `OBS_JSON` events (`inference_started`, `inference_completed`, `trigger_sent`, `no_action`)
+- Gateway-side synthesized lines (`[stimm-voice:supervisor]`) when available
+
+`stimm.start` / `stimm_voice:start_session` returns:
+
+- room metadata
+- `shareUrl` (when quick tunnel is enabled)
+- one-time `claimToken`
+
+### Browser flow
+
+1. Open the returned `shareUrl` on phone.
+2. The page calls `POST /voice/claim` with the claim token.
+3. Gateway validates claim and returns a short-lived LiveKit token.
+4. Browser joins LiveKit.
+
+### HTTP endpoints
+
+- `GET <web.path>`: serves the web voice UI.
+- `POST <web.path>/claim`: claim exchange endpoint.
+- `POST <web.path>`: disabled by default (`403`) unless `access.allowDirectWebSessionCreate=true`.
+- `POST /stimm/supervisor`: internal supervisor callback (protected if `access.supervisorSecret` is set).
+
+### Gateway methods
+
+- `stimm.start`
+- `stimm.end`
+- `stimm.status`
+- `stimm.instruct`
+- `stimm.mode`
+
+### Tool
+
+Tool name: `stimm_voice`
+
+Actions:
+
+- `start_session`
+- `end_session`
+- `status`
+- `instruct`
+- `add_context`
+- `set_mode`

--- a/extensions/stimm-voice/docker/docker-compose.dev.yml
+++ b/extensions/stimm-voice/docker/docker-compose.dev.yml
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   docker compose -f docker/docker-compose.dev.yml up -d
-#   # Then run the agent: cd $STIMM_REPO && python -m stimm.examples.basic
+#   # Then run the agent: python extensions/stimm-voice/python/agent.py dev
 
 services:
   livekit:

--- a/extensions/stimm-voice/docker/docker-compose.dev.yml
+++ b/extensions/stimm-voice/docker/docker-compose.dev.yml
@@ -1,0 +1,19 @@
+# Stimm Voice — Development Docker Compose
+# Just LiveKit server. Run the Python agent natively for fast iteration.
+#
+# Usage:
+#   docker compose -f docker/docker-compose.dev.yml up -d
+#   # Then run the agent: cd $STIMM_REPO && python -m stimm.examples.basic
+
+services:
+  livekit:
+    # Pinned to v1.9 — latest stable; serves both /rtc/v1 and /rtc paths so
+    # it is compatible with livekit-client JS SDK v2.x used in the browser UI.
+    image: livekit/livekit-server:v1.9
+    command: --config /etc/livekit.yaml --bind 0.0.0.0
+    ports:
+      - "7880:7880" # WebSocket + HTTP
+      - "7881:7881/tcp" # RTC (WebRTC TCP — ICE)
+      - "7881:7881/udp" # RTC (WebRTC UDP — ICE)
+    volumes:
+      - ./livekit.yaml:/etc/livekit.yaml:ro

--- a/extensions/stimm-voice/docker/docker-compose.stimm.yml
+++ b/extensions/stimm-voice/docker/docker-compose.stimm.yml
@@ -1,0 +1,35 @@
+# Stimm Voice — Docker Compose
+#
+# Runs LiveKit server + Stimm voice agent for local development.
+#
+# Usage:
+#   docker compose -f extensions/stimm-voice/docker/docker-compose.stimm.yml up
+#
+# The LiveKit dashboard is available at http://localhost:7880
+# API key: devkey / API secret: secret
+
+services:
+  livekit:
+    image: livekit/livekit-server:latest
+    command: --dev --bind 0.0.0.0
+    ports:
+      - "7880:7880" # WebSocket + HTTP API
+      - "7881:7881" # RTC (WebRTC)
+    environment:
+      LIVEKIT_KEYS: "devkey: secret"
+    restart: unless-stopped
+
+  stimm-voice-agent:
+    build:
+      context: ../python
+      dockerfile: Dockerfile
+    depends_on:
+      - livekit
+    environment:
+      LIVEKIT_URL: ws://livekit:7880
+      LIVEKIT_API_KEY: devkey
+      LIVEKIT_API_SECRET: secret
+      # Provider API keys — pass from host environment
+      DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    restart: unless-stopped

--- a/extensions/stimm-voice/docker/livekit.yaml
+++ b/extensions/stimm-voice/docker/livekit.yaml
@@ -8,10 +8,11 @@ rtc:
   # UDP port range (single port to keep Docker port-mapping simple).
   port_range_start: 7881
   port_range_end: 7881
-  # Advertise the host LAN IP so both local Firefox and phones on the same
-  # network can reach LiveKit via Docker's port mapping (7881 → container).
-  # 127.0.0.1 only works for Node/Python on the host; phones need the LAN IP.
-  node_ip: 192.168.1.195
+  # node_ip controls what ICE candidates LiveKit advertises to clients.
+  # 127.0.0.1 works for Node/Python on the same host (default dev setup).
+  # Change to your LAN IP (e.g. 192.168.1.x) if you need browser/phone
+  # access from other devices on the same network.
+  node_ip: 127.0.0.1
   use_external_ip: false
   # Prefer ICE Lite for simpler negotiation through NAT/Docker.
   use_ice_lite: true

--- a/extensions/stimm-voice/docker/livekit.yaml
+++ b/extensions/stimm-voice/docker/livekit.yaml
@@ -1,0 +1,30 @@
+# LiveKit dev config — works in Docker-on-WSL2 and native Docker.
+# Mounted by docker-compose.dev.yml.
+
+port: 7880
+rtc:
+  # Explicit ICE TCP port — critical for WSL2/Docker where UDP can be flaky.
+  tcp_port: 7881
+  # UDP port range (single port to keep Docker port-mapping simple).
+  port_range_start: 7881
+  port_range_end: 7881
+  # Advertise the host LAN IP so both local Firefox and phones on the same
+  # network can reach LiveKit via Docker's port mapping (7881 → container).
+  # 127.0.0.1 only works for Node/Python on the host; phones need the LAN IP.
+  node_ip: 192.168.1.195
+  use_external_ip: false
+  # Prefer ICE Lite for simpler negotiation through NAT/Docker.
+  use_ice_lite: true
+  # NOTE: We intentionally omit turn_servers here.
+  # LiveKit's built-in TURN relay sends TURN URLs to clients without credentials
+  # unless an external TURN server with explicit username/password is configured.
+  # This causes "TURN server with empty username or password" in the WebRTC ICE
+  # parser, which makes CreatePeerConnectionOrError fail.
+  # For local dev (client and server on the same host/Docker network), ICE
+  # TCP + ICE Lite is sufficient — no TURN relay needed.
+
+keys:
+  devkey: secret
+
+logging:
+  level: info

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -154,6 +154,10 @@ const stimmVoicePlugin = {
     // Keep claim signing stable across different OpenClaw processes (CLI vs gateway).
     // If no explicit supervisor secret is configured, fall back to LiveKit API secret.
     const claimSecret = config.access.supervisorSecret || `livekit:${config.livekit.apiSecret}`;
+    const hasUnsafePublicSupervisorSecret =
+      config.access.mode === "quick-tunnel" &&
+      !config.access.supervisorSecret &&
+      config.livekit.apiSecret === "secret";
     const claimStore = new Map<string, ClaimRecord>();
     const consumedClaims = new Map<string, number>();
     const claimRateWindowMs = 60_000;
@@ -171,6 +175,12 @@ const stimmVoicePlugin = {
 
     const ensureQuickTunnel = async (): Promise<TunnelInfo | null> => {
       if (config.access.mode !== "quick-tunnel") return null;
+      if (hasUnsafePublicSupervisorSecret) {
+        throw new Error(
+          "[stimm-voice] quick-tunnel mode requires a non-default supervisor secret. " +
+            "Set stimm-voice.access.supervisorSecret (recommended) or use a non-default stimm-voice.livekit.apiSecret.",
+        );
+      }
       if (quickTunnel?.running()) {
         return {
           gatewayUrl: quickTunnel.info.voiceUrl,
@@ -428,6 +438,17 @@ const stimmVoicePlugin = {
           consumedClaims.set(id, Math.max(claim.expiresAt, now + 60_000));
           claimStore.delete(id);
         }
+      }
+    };
+
+    // Undo one-time claim consumption after transient failures (for example
+    // issueJoinToken errors) so clients can retry with the same share link.
+    const rollbackClaimConsumption = (claimId: string): void => {
+      consumedClaims.delete(claimId);
+      const claim = claimStore.get(claimId);
+      if (claim && claim.usedAt && !claim.disconnectToken) {
+        claim.usedAt = undefined;
+        claimStore.set(claimId, claim);
       }
     };
 
@@ -836,6 +857,16 @@ const stimmVoicePlugin = {
           return;
         }
         {
+          if (hasUnsafePublicSupervisorSecret) {
+            res.writeHead(503, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                error:
+                  "insecure_default_supervisor_secret: configure stimm-voice.access.supervisorSecret for quick-tunnel mode",
+              }),
+            );
+            return;
+          }
           // Always enforce auth — fall back to derived secret when no explicit one is configured,
           // matching the claimSecret derivation above.
           const provided = req.headers["x-stimm-supervisor-secret"];
@@ -1013,10 +1044,16 @@ const stimmVoicePlugin = {
             }
 
             const rt = await ensureRuntime();
-            const clientToken = await rt.lk.issueJoinToken(record.roomName, {
-              identity: "user",
-              ttlSeconds: config.access.livekitTokenTtlSeconds,
-            });
+            let clientToken: string;
+            try {
+              clientToken = await rt.lk.issueJoinToken(record.roomName, {
+                identity: "user",
+                ttlSeconds: config.access.livekitTokenTtlSeconds,
+              });
+            } catch (issueErr) {
+              rollbackClaimConsumption(record.claimId);
+              throw issueErr;
+            }
 
             const now = Date.now();
             const disconnectToken = randomBytes(24).toString("hex");
@@ -1182,12 +1219,21 @@ export class LiveKitRuntime {
     // abandoned longer than a token would be valid.
     const emptyTimeout = opts.ttlSeconds ?? 600;
     await this.roomService.createRoom({ name: roomName, emptyTimeout });
-    await this.dispatchService.createDispatch(roomName, LiveKitRuntime.AGENT_NAME, {
-      metadata: JSON.stringify({
-        source: "openclaw-stimm-voice",
-        originChannel: opts.originChannel ?? "web",
-      }),
-    });
+    try {
+      await this.dispatchService.createDispatch(roomName, LiveKitRuntime.AGENT_NAME, {
+        metadata: JSON.stringify({
+          source: "openclaw-stimm-voice",
+          originChannel: opts.originChannel ?? "web",
+        }),
+      });
+    } catch (err) {
+      try {
+        await this.roomService.deleteRoom(roomName);
+      } catch {
+        // Room may already be gone.
+      }
+      throw err;
+    }
 
     const clientToken = await this.generateToken({
       identity: "user",
@@ -1209,14 +1255,14 @@ export class LiveKitRuntime {
   }
 
   async endSession(roomName: string): Promise<boolean> {
-    if (!this.sessions.has(roomName)) return false;
-    this.sessions.delete(roomName);
+    const hadLocalSession = this.sessions.delete(roomName);
     try {
       await this.roomService.deleteRoom(roomName);
+      return true;
     } catch {
       // Room may already be gone.
+      return hadLocalSession;
     }
-    return true;
   }
 
   /**

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -1176,7 +1176,11 @@ export class LiveKitRuntime {
     ttlSeconds?: number;
   }): Promise<VoiceSessionInternal> {
     const roomName = opts.roomName ?? `stimm-${randomHex(8)}`;
-    await this.roomService.createRoom({ name: roomName });
+    // emptyTimeout: auto-delete the room on the LiveKit side once all
+    // participants have left. Matches the token TTL so the room is never
+    // abandoned longer than a token would be valid.
+    const emptyTimeout = opts.ttlSeconds ?? 600;
+    await this.roomService.createRoom({ name: roomName, emptyTimeout });
     await this.dispatchService.createDispatch(roomName, LiveKitRuntime.AGENT_NAME, {
       metadata: JSON.stringify({
         source: "openclaw-stimm-voice",

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -483,8 +483,10 @@ const stimmVoicePlugin = {
       roomName?: string;
       channel: string;
     }): Promise<SessionPayload> => {
-      ensureAgentProcessStarted();
+      // ensureRuntime() throws when the plugin is disabled — check it first so
+      // ensureAgentProcessStarted() never spawns a background process when disabled.
       const rt = await ensureRuntime();
+      ensureAgentProcessStarted();
       const session = await rt.lk.createSession({
         roomName: params.roomName,
         originChannel: params.channel,
@@ -767,7 +769,11 @@ const stimmVoicePlugin = {
                   claimToken: payload.claimToken,
                 };
               },
-              endSession: async (room: string) => rt.lk.endSession(room),
+              endSession: async (room: string) => {
+                const ok = await rt.lk.endSession(room);
+                if (ok) purgeClaimsForRoom(room);
+                return ok;
+              },
               listSessions: () =>
                 rt.lk.listSessions().map((s) => ({
                   roomName: s.roomName,

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -388,8 +388,14 @@ const stimmVoicePlugin = {
         return stored;
       }
 
-      // Claim not found in store — either never issued by this process or
-      // already purged by purgeClaimsForRoom (session ended). Reject.
+      // Claim not found in local store — may have been created by a sibling
+      // process (e.g. CLI voice:start). Accept if the signature is valid, the
+      // claim is not expired, and this gateway process has not explicitly
+      // consumed or purged it via consumedClaims.
+      if (!consumedClaims.has(parsed.claimId)) {
+        consumedClaims.set(parsed.claimId, parsed.expiresAt);
+        return parsed;
+      }
       return null;
     };
 
@@ -414,8 +420,14 @@ const stimmVoicePlugin = {
     // Remove all pending and used claims associated with a room so that stale
     // share links cannot be redeemed after a session is intentionally ended.
     const purgeClaimsForRoom = (roomName: string): void => {
+      const now = Date.now();
       for (const [id, claim] of claimStore.entries()) {
-        if (claim.roomName === roomName) claimStore.delete(id);
+        if (claim.roomName === roomName) {
+          // Mark in consumedClaims so the stateless fallback in verifyAndConsumeClaim
+          // also rejects this claim after the session is ended.
+          consumedClaims.set(id, Math.max(claim.expiresAt, now + 60_000));
+          claimStore.delete(id);
+        }
       }
     };
 

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -774,6 +774,7 @@ const stimmVoicePlugin = {
                 if (ok) purgeClaimsForRoom(room);
                 return ok;
               },
+              listRoomParticipants: (room: string) => rt.lk.listRoomParticipants(room),
               listSessions: () =>
                 rt.lk.listSessions().map((s) => ({
                   roomName: s.roomName,
@@ -1216,6 +1217,26 @@ export class LiveKitRuntime {
       // Room may already be gone.
     }
     return true;
+  }
+
+  /**
+   * Lists participants in the room with their identity and kind.
+   * kind values: 0=STANDARD (human), 1=INGRESS, 2=EGRESS, 3=SIP, 4=AGENT
+   * Returns an empty array when the room is gone or on error.
+   */
+  async listRoomParticipants(
+    roomName: string,
+  ): Promise<Array<{ identity: string; kind: number; state: number }>> {
+    try {
+      const participants = await this.roomService.listParticipants(roomName);
+      return participants.map((p) => ({
+        identity: p.identity,
+        kind: p.kind as number,
+        state: p.state as number,
+      }));
+    } catch {
+      return [];
+    }
   }
 
   getSession(roomName: string): VoiceSessionInternal | undefined {

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -223,9 +223,10 @@ const stimmVoicePlugin = {
         // Supervisor callback — Python OpenClawSupervisor posts here.
         OPENCLAW_SUPERVISOR_URL: `http://127.0.0.1:${gatewayPort}/stimm/supervisor`,
       };
-      if (config.access.supervisorSecret) {
-        env.OPENCLAW_SUPERVISOR_SECRET = config.access.supervisorSecret;
-      }
+      // Always pass the secret so the Python agent can authenticate. Falls back to the
+      // same derived secret used by the /stimm/supervisor route.
+      env.OPENCLAW_SUPERVISOR_SECRET =
+        config.access.supervisorSecret || `livekit:${config.livekit.apiSecret}`;
       // Per-pipeline API keys (only set if resolved).
       if (config.voiceAgent.stt.apiKey) env.STIMM_STT_API_KEY = config.voiceAgent.stt.apiKey;
       if (config.voiceAgent.tts.apiKey) env.STIMM_TTS_API_KEY = config.voiceAgent.tts.apiKey;
@@ -815,9 +816,13 @@ const stimmVoicePlugin = {
           res.end();
           return;
         }
-        if (config.access.supervisorSecret) {
+        {
+          // Always enforce auth — fall back to derived secret when no explicit one is configured,
+          // matching the claimSecret derivation above.
           const provided = req.headers["x-stimm-supervisor-secret"];
-          const expected = Buffer.from(config.access.supervisorSecret, "utf8");
+          const effectiveSecret =
+            config.access.supervisorSecret || `livekit:${config.livekit.apiSecret}`;
+          const expected = Buffer.from(effectiveSecret, "utf8");
           const actual = Buffer.from(typeof provided === "string" ? provided : "", "utf8");
           if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
             res.writeHead(401, { "Content-Type": "application/json" });

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -105,10 +105,10 @@ function getRequestIp(req: {
   socket?: { remoteAddress?: string | null };
   headers?: Record<string, unknown>;
 }): string {
-  const xff = req.headers?.["x-forwarded-for"];
-  if (typeof xff === "string" && xff.trim()) {
-    return xff.split(",")[0]?.trim() || "unknown";
-  }
+  // Use the socket's remote address for rate limiting — this is the actual
+  // connecting IP and cannot be spoofed by the client via headers.
+  // X-Forwarded-For is intentionally ignored here to prevent bypass via
+  // forged headers when the gateway is not behind a trusted proxy.
   return req.socket?.remoteAddress ?? "unknown";
 }
 
@@ -387,11 +387,9 @@ const stimmVoicePlugin = {
         return stored;
       }
 
-      // Stateless fallback: allow signed, unexpired claims created by another process.
-      parsed.usedAt = now;
-      claimStore.set(parsed.claimId, parsed);
-      consumedClaims.set(parsed.claimId, parsed.expiresAt);
-      return parsed;
+      // Claim not found in store — either never issued by this process or
+      // already purged by purgeClaimsForRoom (session ended). Reject.
+      return null;
     };
 
     const resolveDisconnectClaim = (

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -905,16 +905,23 @@ const stimmVoicePlugin = {
           for await (const chunk of req) chunks.push(chunk as Buffer);
           const body = Buffer.concat(chunks).toString("utf8");
 
-          // Verify LiveKit HMAC signature (skipAuth=false, uses api key+secret).
+          // Verify LiveKit HMAC signature — always required.
+          // If LiveKit is not configured to sign webhooks, reject early rather
+          // than accepting unsigned payloads (prevents unauthenticated DoS).
           const authHeader = req.headers["authorization"] ?? req.headers["Authorization"];
+          if (!authHeader) {
+            api.logger.warn(
+              "[stimm-voice] Webhook rejected: missing Authorization header. " +
+                "Configure LiveKit webhook signing with the same API key/secret.",
+            );
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "missing_authorization" }));
+            return;
+          }
           const receiver = new WebhookReceiver(config.livekit.apiKey, config.livekit.apiSecret);
-          // skipAuth only if no Authorization header is present (local/dev without
-          // webhook signing configured on the server side).
-          const skipAuth = !authHeader;
           const event = await receiver.receive(
             body,
             typeof authHeader === "string" ? authHeader : undefined,
-            skipAuth,
           );
 
           const roomName = event.room?.name;

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -412,6 +412,14 @@ const stimmVoicePlugin = {
       return null;
     };
 
+    // Remove all pending and used claims associated with a room so that stale
+    // share links cannot be redeemed after a session is intentionally ended.
+    const purgeClaimsForRoom = (roomName: string): void => {
+      for (const [id, claim] of claimStore.entries()) {
+        if (claim.roomName === roomName) claimStore.delete(id);
+      }
+    };
+
     const enforceClaimRateLimit = (ip: string): boolean => {
       const now = Date.now();
       const windowStart = now - claimRateWindowMs;
@@ -539,6 +547,7 @@ const stimmVoicePlugin = {
           }
           const rt = await ensureRuntime();
           const ok = await rt.lk.endSession(room);
+          if (ok) purgeClaimsForRoom(room);
           respond(ok, ok ? { ended: true } : { error: "session not found" });
         } catch (err) {
           sendError(respond, err);
@@ -650,6 +659,7 @@ const stimmVoicePlugin = {
               if (!room) throw new Error("room required");
               const ok = await rt.lk.endSession(room);
               if (!ok) throw new Error("session not found");
+              purgeClaimsForRoom(room);
               return json({ ended: true, room });
             }
 
@@ -917,11 +927,13 @@ const stimmVoicePlugin = {
               // User disconnected — tear down the room immediately.
               api.logger.info(`[stimm-voice] User left room "${roomName}" — ending session.`);
               await lkRuntime.endSession(roomName);
+              purgeClaimsForRoom(roomName);
               await maybeShutdownVoiceStartProcess("webhook participant_left");
             } else if (event.event === "room_finished") {
               // All participants gone (Python agent also done) — clean up map.
               api.logger.info(`[stimm-voice] Room "${roomName}" finished — cleaning up session.`);
               await lkRuntime.endSession(roomName);
+              purgeClaimsForRoom(roomName);
               await maybeShutdownVoiceStartProcess("webhook room_finished");
             }
           }

--- a/extensions/stimm-voice/index.ts
+++ b/extensions/stimm-voice/index.ts
@@ -1,0 +1,1325 @@
+/**
+ * Stimm Voice — OpenClaw plugin entry point.
+ *
+ * Dual-agent voice sessions: a fast VoiceAgent (Python/LiveKit) handles
+ * real-time audio while an OpenClaw Supervisor (TypeScript) provides
+ * reasoning, tools, and context via the Stimm data-channel protocol.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual, webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { deflateRawSync, inflateRawSync } from "node:zlib";
+import { Type } from "@sinclair/typebox";
+import {
+  AccessToken,
+  AgentDispatchClient,
+  RoomServiceClient,
+  WebhookReceiver,
+  type VideoGrant,
+} from "livekit-server-sdk";
+import type { GatewayRequestHandlerOptions, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { AgentProcess } from "./src/agent-process.js";
+import { registerStimmVoiceCli } from "./src/cli.js";
+import { resolveStimmVoiceConfig, type StimmVoiceConfig } from "./src/config.js";
+import type { CoreConfig } from "./src/core-bridge.js";
+import { startQuickTunnel, type QuickTunnelRuntime } from "./src/quick-tunnel.js";
+import { generateStimmResponse, type StimmResponseResult } from "./src/response-generator.js";
+
+// ---------------------------------------------------------------------------
+// Tool schema — flat object, no Type.Union (per repo guardrails).
+// ---------------------------------------------------------------------------
+
+const ACTIONS = [
+  "start_session",
+  "end_session",
+  "instruct",
+  "add_context",
+  "set_mode",
+  "status",
+] as const;
+
+function stringEnum<T extends readonly string[]>(values: T, opts: { description?: string } = {}) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+    ...opts,
+  });
+}
+
+const StimmVoiceToolSchema = Type.Object({
+  action: stringEnum(ACTIONS, {
+    description: `Action: ${ACTIONS.join(", ")}`,
+  }),
+  room: Type.Optional(
+    Type.String({
+      description: "Room name (for end_session, instruct, add_context, set_mode, status)",
+    }),
+  ),
+  channel: Type.Optional(Type.String({ description: "Origin channel for routing (default: web)" })),
+  text: Type.Optional(
+    Type.String({ description: "Text to instruct the voice agent, or context to add" }),
+  ),
+  mode: Type.Optional(
+    stringEnum(["autonomous", "relay", "hybrid"] as const, { description: "Voice agent mode" }),
+  ),
+  speak: Type.Optional(
+    Type.Boolean({ description: "Whether the voice agent should speak the instruction aloud" }),
+  ),
+});
+
+type ClaimRecord = {
+  claimId: string;
+  roomName: string;
+  channel: string;
+  livekitUrl?: string;
+  expiresAt: number;
+  disconnectToken?: string;
+  disconnectExpiresAt?: number;
+  usedAt?: number;
+};
+
+type TunnelInfo = {
+  gatewayUrl: string;
+  livekitUrl: string;
+};
+
+type SessionPayload = {
+  room: string;
+  clientToken: string;
+  channel: string;
+  createdAt: number;
+  disconnectToken?: string;
+  livekitUrl?: string;
+  claimToken?: string;
+  shareUrl?: string;
+};
+
+function getGatewayPort(config: CoreConfig): number {
+  return (
+    (config as Record<string, unknown> & { gateway?: { port?: number } }).gateway?.port ?? 18789
+  );
+}
+
+function getRequestIp(req: {
+  socket?: { remoteAddress?: string | null };
+  headers?: Record<string, unknown>;
+}): string {
+  const xff = req.headers?.["x-forwarded-for"];
+  if (typeof xff === "string" && xff.trim()) {
+    return xff.split(",")[0]?.trim() || "unknown";
+  }
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
+function signClaim(payloadB64: string, secret: string): string {
+  return createHmac("sha256", secret).update(payloadB64).digest("base64url");
+}
+
+function verifyClaimSignature(payloadB64: string, signature: string, secret: string): boolean {
+  const expected = Buffer.from(signClaim(payloadB64, secret));
+  const provided = Buffer.from(signature);
+  if (expected.length !== provided.length) return false;
+  return timingSafeEqual(expected, provided);
+}
+
+// ---------------------------------------------------------------------------
+// Plugin definition
+// ---------------------------------------------------------------------------
+
+const stimmVoicePlugin = {
+  id: "stimm-voice",
+  name: "Stimm Voice",
+  description: "Real-time voice conversations powered by Stimm dual-agent architecture",
+
+  register(api: OpenClawPluginApi) {
+    const config = resolveStimmVoiceConfig(api.pluginConfig);
+
+    // -- Lazy runtime -------------------------------------------------------
+    // Room lifecycle (create, token, delete) is handled here in Node via the
+    // LiveKit server SDK. The Python agent (OpenClawSupervisor) connects to
+    // each room on its own after being dispatched a job by livekit-agents.
+
+    interface VoiceSession {
+      roomName: string;
+      clientToken: string;
+      createdAt: number;
+      originChannel: string;
+    }
+
+    let lkRuntime: LiveKitRuntime | null = null;
+    let agentProcess: AgentProcess | null = null;
+    let tunnelInfo: TunnelInfo | null = null;
+    let quickTunnel: QuickTunnelRuntime | null = null;
+    // Keep claim signing stable across different OpenClaw processes (CLI vs gateway).
+    // If no explicit supervisor secret is configured, fall back to LiveKit API secret.
+    const claimSecret = config.access.supervisorSecret || `livekit:${config.livekit.apiSecret}`;
+    const claimStore = new Map<string, ClaimRecord>();
+    const consumedClaims = new Map<string, number>();
+    const claimRateWindowMs = 60_000;
+    const claimRateByIp = new Map<string, number[]>();
+
+    const ensureRuntime = async (): Promise<{ lk: LiveKitRuntime }> => {
+      if (!config.enabled) {
+        throw new Error("[stimm-voice] Plugin is disabled. Set stimm-voice.enabled=true.");
+      }
+      if (!lkRuntime) {
+        lkRuntime = new LiveKitRuntime(config);
+      }
+      return { lk: lkRuntime };
+    };
+
+    const ensureQuickTunnel = async (): Promise<TunnelInfo | null> => {
+      if (config.access.mode !== "quick-tunnel") return null;
+      if (quickTunnel?.running()) {
+        return {
+          gatewayUrl: quickTunnel.info.voiceUrl,
+          livekitUrl: config.livekit.url,
+        };
+      }
+      const gatewayPort = getGatewayPort(api.config as CoreConfig);
+      const started = await startQuickTunnel({
+        gatewayPort,
+        webPath: config.web.path,
+        logger: api.logger,
+      });
+      if (!started) return null;
+      quickTunnel = started;
+      return {
+        gatewayUrl: started.info.voiceUrl,
+        livekitUrl: config.livekit.url,
+      };
+    };
+
+    const ensureAgentProcessStarted = (): void => {
+      if (!config.voiceAgent.spawn.autoSpawn) return;
+
+      if (agentProcess?.running) return;
+      if (agentProcess) {
+        // Reuse existing process wrapper (restart/backoff state), only re-spawn child.
+        agentProcess.start();
+        return;
+      }
+
+      const pythonPath =
+        config.voiceAgent.spawn.pythonPath || AgentProcess.resolveDefaultPythonPath(extensionDir);
+      const agentScript =
+        config.voiceAgent.spawn.agentScript || AgentProcess.resolveDefaultAgentScript(extensionDir);
+
+      // Forward per-pipeline provider config as STIMM_* env vars.
+      const gatewayPort = getGatewayPort(api.config as CoreConfig);
+      const env: Record<string, string> = {
+        STIMM_AGENT_NAME: "stimm-voice",
+        STIMM_PARTICIPANT_IDENTITY: "user",
+        STIMM_STT_PROVIDER: config.voiceAgent.stt.provider,
+        STIMM_STT_MODEL: config.voiceAgent.stt.model,
+        STIMM_TTS_PROVIDER: config.voiceAgent.tts.provider,
+        STIMM_TTS_MODEL: config.voiceAgent.tts.model,
+        STIMM_TTS_VOICE: config.voiceAgent.tts.voice,
+        STIMM_LLM_PROVIDER: config.voiceAgent.llm.provider,
+        STIMM_LLM_MODEL: config.voiceAgent.llm.model,
+        STIMM_BUFFERING: config.voiceAgent.bufferingLevel,
+        STIMM_MODE: config.voiceAgent.mode,
+        // Supervisor callback — Python OpenClawSupervisor posts here.
+        OPENCLAW_SUPERVISOR_URL: `http://127.0.0.1:${gatewayPort}/stimm/supervisor`,
+      };
+      if (config.access.supervisorSecret) {
+        env.OPENCLAW_SUPERVISOR_SECRET = config.access.supervisorSecret;
+      }
+      // Per-pipeline API keys (only set if resolved).
+      if (config.voiceAgent.stt.apiKey) env.STIMM_STT_API_KEY = config.voiceAgent.stt.apiKey;
+      if (config.voiceAgent.tts.apiKey) env.STIMM_TTS_API_KEY = config.voiceAgent.tts.apiKey;
+      if (config.voiceAgent.llm.apiKey) env.STIMM_LLM_API_KEY = config.voiceAgent.llm.apiKey;
+      // Language (optional).
+      if (config.voiceAgent.stt.language) {
+        env.STIMM_STT_LANGUAGE = config.voiceAgent.stt.language;
+      }
+      if (config.voiceAgent.tts.language) {
+        env.STIMM_TTS_LANGUAGE = config.voiceAgent.tts.language;
+      }
+      // Temperature (optional).
+      if (config.voiceAgent.llm.temperature !== undefined) {
+        env.STIMM_LLM_TEMPERATURE = config.voiceAgent.llm.temperature.toString();
+      }
+
+      agentProcess = new AgentProcess({
+        pythonPath,
+        agentScript,
+        livekitUrl: config.livekit.url,
+        livekitApiKey: config.livekit.apiKey,
+        livekitApiSecret: config.livekit.apiSecret,
+        env,
+        maxRestarts: config.voiceAgent.spawn.maxRestarts,
+        logger: api.logger,
+      });
+      agentProcess.start();
+    };
+
+    const createClaim = (params: {
+      roomName: string;
+      channel: string;
+    }): {
+      token: string;
+      record: ClaimRecord;
+    } => {
+      const now = Date.now();
+      const claim: ClaimRecord = {
+        claimId: randomHex(6),
+        roomName: params.roomName,
+        channel: params.channel,
+        livekitUrl: tunnelInfo?.livekitUrl ?? config.livekit.url,
+        expiresAt: now + config.access.claimTtlSeconds * 1000,
+      };
+      claimStore.set(claim.claimId, claim);
+      const compactPayload = {
+        v: 2,
+        i: claim.claimId,
+        r: claim.roomName,
+        e: claim.expiresAt,
+        ...(claim.channel !== "web" ? { c: claim.channel } : {}),
+      };
+      const payloadB64 = deflateRawSync(
+        Buffer.from(JSON.stringify(compactPayload), "utf8"),
+      ).toString("base64url");
+      const signature = signClaim(payloadB64, claimSecret);
+      return { token: `${payloadB64}.${signature}`, record: claim };
+    };
+
+    const verifyAndConsumeClaim = (token: string): ClaimRecord | null => {
+      const [payloadB64, signature] = token.split(".");
+      if (!payloadB64 || !signature) return null;
+      if (!verifyClaimSignature(payloadB64, signature, claimSecret)) return null;
+      let parsed: ClaimRecord;
+      try {
+        const raw = JSON.parse(
+          inflateRawSync(Buffer.from(payloadB64, "base64url")).toString("utf8"),
+        ) as
+          | {
+              claimId?: string;
+              roomName?: string;
+              channel?: string;
+              livekitUrl?: string;
+              expiresAt?: number;
+              disconnectToken?: string;
+              disconnectExpiresAt?: number;
+            }
+          | { v?: number; i?: string; r?: string; c?: string; e?: number; l?: string };
+        if (
+          typeof raw === "object" &&
+          raw !== null &&
+          "i" in raw &&
+          typeof raw.i === "string" &&
+          typeof raw.r === "string" &&
+          typeof raw.e === "number"
+        ) {
+          parsed = {
+            claimId: raw.i,
+            roomName: raw.r,
+            channel: typeof raw.c === "string" ? raw.c : "web",
+            livekitUrl: typeof raw.l === "string" ? raw.l : undefined,
+            expiresAt: raw.e,
+          };
+        } else {
+          parsed = raw as ClaimRecord;
+        }
+      } catch {
+        // Backward compatibility: uncompressed payload format.
+        try {
+          const raw = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")) as
+            | {
+                claimId?: string;
+                roomName?: string;
+                channel?: string;
+                livekitUrl?: string;
+                expiresAt?: number;
+              }
+            | { v?: number; i?: string; r?: string; c?: string; e?: number; l?: string };
+          if (
+            typeof raw === "object" &&
+            raw !== null &&
+            "i" in raw &&
+            typeof raw.i === "string" &&
+            typeof raw.r === "string" &&
+            typeof raw.e === "number"
+          ) {
+            parsed = {
+              claimId: raw.i,
+              roomName: raw.r,
+              channel: typeof raw.c === "string" ? raw.c : "web",
+              livekitUrl: typeof raw.l === "string" ? raw.l : undefined,
+              expiresAt: raw.e,
+            };
+          } else {
+            parsed = raw as ClaimRecord;
+          }
+        } catch {
+          return null;
+        }
+      }
+      if (
+        typeof parsed.claimId !== "string" ||
+        typeof parsed.roomName !== "string" ||
+        typeof parsed.channel !== "string" ||
+        typeof parsed.expiresAt !== "number"
+      ) {
+        return null;
+      }
+      const now = Date.now();
+      if (parsed.expiresAt < now) return null;
+
+      // Cleanup consumed claim markers.
+      for (const [claimId, expiry] of consumedClaims.entries()) {
+        if (expiry < now) consumedClaims.delete(claimId);
+      }
+
+      // If this process has seen this claim already, reject.
+      if (consumedClaims.has(parsed.claimId)) return null;
+
+      const stored = claimStore.get(parsed.claimId);
+      if (stored) {
+        if (stored.usedAt || stored.expiresAt < now) {
+          claimStore.delete(parsed.claimId);
+          return null;
+        }
+        stored.usedAt = now;
+        claimStore.set(stored.claimId, stored);
+        consumedClaims.set(parsed.claimId, stored.expiresAt);
+        return stored;
+      }
+
+      // Stateless fallback: allow signed, unexpired claims created by another process.
+      parsed.usedAt = now;
+      claimStore.set(parsed.claimId, parsed);
+      consumedClaims.set(parsed.claimId, parsed.expiresAt);
+      return parsed;
+    };
+
+    const resolveDisconnectClaim = (
+      roomName: string,
+      disconnectToken: string,
+    ): ClaimRecord | null => {
+      const now = Date.now();
+      for (const claim of claimStore.values()) {
+        if (
+          claim.roomName === roomName &&
+          claim.disconnectToken === disconnectToken &&
+          typeof claim.disconnectExpiresAt === "number" &&
+          claim.disconnectExpiresAt >= now
+        ) {
+          return claim;
+        }
+      }
+      return null;
+    };
+
+    const enforceClaimRateLimit = (ip: string): boolean => {
+      const now = Date.now();
+      const windowStart = now - claimRateWindowMs;
+      const existing = claimRateByIp.get(ip) ?? [];
+      const recent = existing.filter((ts) => ts >= windowStart);
+      if (recent.length >= config.access.claimRateLimitPerMinute) {
+        claimRateByIp.set(ip, recent);
+        return false;
+      }
+      recent.push(now);
+      claimRateByIp.set(ip, recent);
+      return true;
+    };
+
+    const isVoiceStartProcess = (): boolean => {
+      if (process.title === "openclaw-voice:start") return true;
+      return process.argv.some((arg) => arg.includes("voice:start"));
+    };
+
+    const maybeShutdownVoiceStartProcess = async (reason: string): Promise<void> => {
+      if (!isVoiceStartProcess()) return;
+      if (lkRuntime && lkRuntime.listSessions().length > 0) return;
+
+      api.logger.info(
+        `[stimm-voice] Last voice session ended (${reason}) — stopping voice:start process.`,
+      );
+
+      if (quickTunnel) {
+        quickTunnel.stop();
+        quickTunnel = null;
+      }
+      tunnelInfo = null;
+
+      if (agentProcess) {
+        agentProcess.stop();
+        agentProcess = null;
+      }
+
+      if (lkRuntime) {
+        await lkRuntime.stopAll();
+        lkRuntime = null;
+      }
+
+      setTimeout(() => {
+        process.exit(0);
+      }, 60);
+    };
+
+    const createSessionWithAccess = async (params: {
+      roomName?: string;
+      channel: string;
+    }): Promise<SessionPayload> => {
+      ensureAgentProcessStarted();
+      const rt = await ensureRuntime();
+      const session = await rt.lk.createSession({
+        roomName: params.roomName,
+        originChannel: params.channel,
+        ttlSeconds: config.access.livekitTokenTtlSeconds,
+      });
+
+      if (config.access.mode === "quick-tunnel") {
+        tunnelInfo = await ensureQuickTunnel();
+      }
+
+      const payload = sessionPayload(session, tunnelInfo);
+      const now = Date.now();
+      if (tunnelInfo?.gatewayUrl) {
+        const claim = createClaim({
+          roomName: session.roomName,
+          channel: params.channel,
+        });
+        return {
+          ...payload,
+          claimToken: claim.token,
+          shareUrl: `${tunnelInfo.gatewayUrl}?c=${claim.token}`,
+        };
+      }
+
+      const disconnectRecord: ClaimRecord = {
+        claimId: randomBytes(16).toString("hex"),
+        roomName: session.roomName,
+        channel: params.channel,
+        disconnectToken: randomBytes(24).toString("hex"),
+        livekitUrl: tunnelInfo?.livekitUrl ?? config.livekit.url,
+        expiresAt: now + config.access.claimTtlSeconds * 1000,
+        disconnectExpiresAt: now + config.access.livekitTokenTtlSeconds * 1000,
+        usedAt: now,
+      };
+      claimStore.set(disconnectRecord.claimId, disconnectRecord);
+      return {
+        ...payload,
+        disconnectToken: disconnectRecord.disconnectToken,
+      };
+    };
+
+    // -- Gateway methods ----------------------------------------------------
+
+    const sendError = (respond: (ok: boolean, payload?: unknown) => void, err: unknown) => {
+      respond(false, { error: err instanceof Error ? err.message : String(err) });
+    };
+
+    api.registerGatewayMethod(
+      "stimm.start",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const session = await createSessionWithAccess({
+            roomName: typeof params?.room === "string" ? params.room : undefined,
+            channel: typeof params?.channel === "string" ? params.channel : "web",
+          });
+          respond(true, session);
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    api.registerGatewayMethod(
+      "stimm.end",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const room = typeof params?.room === "string" ? params.room.trim() : "";
+          if (!room) {
+            respond(false, { error: "room required" });
+            return;
+          }
+          const rt = await ensureRuntime();
+          const ok = await rt.lk.endSession(room);
+          respond(ok, ok ? { ended: true } : { error: "session not found" });
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    api.registerGatewayMethod(
+      "stimm.instruct",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const room = typeof params?.room === "string" ? params.room.trim() : "";
+          const text = typeof params?.text === "string" ? params.text.trim() : "";
+          if (!room || !text) {
+            respond(false, { error: "room and text required" });
+            return;
+          }
+          const rt = await ensureRuntime();
+          if (!rt.lk.getSession(room)) {
+            respond(false, { error: "session not found" });
+            return;
+          }
+          // Instructions are now sent via the /stimm/supervisor HTTP endpoint
+          // consumed by the Python OpenClawSupervisor directly.
+          respond(true, { instructed: true, note: "use /stimm/supervisor for direct injection" });
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    api.registerGatewayMethod(
+      "stimm.status",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const rt = await ensureRuntime();
+          const room = typeof params?.room === "string" ? params.room.trim() : "";
+          if (room) {
+            const session = rt.lk.getSession(room);
+            respond(true, session ? sessionPayload(session, tunnelInfo) : { found: false });
+          } else {
+            const sessions = rt.lk.listSessions().map((s) => sessionPayload(s, tunnelInfo));
+            respond(true, {
+              sessions,
+              agent: agentProcess
+                ? { running: agentProcess.running, pid: agentProcess.pid }
+                : { running: false, pid: null },
+            });
+          }
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    api.registerGatewayMethod(
+      "stimm.mode",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const room = typeof params?.room === "string" ? params.room.trim() : "";
+          const mode = typeof params?.mode === "string" ? params.mode.trim() : "";
+          if (!room || !mode) {
+            respond(false, { error: "room and mode required" });
+            return;
+          }
+          if (!["autonomous", "relay", "hybrid"].includes(mode)) {
+            respond(false, { error: `Invalid mode: ${mode}` });
+            return;
+          }
+          // Mode is now managed by the Python OpenClawSupervisor.
+          respond(true, { mode, note: "mode changes are applied on the next supervisor tick" });
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    // -- Tool ---------------------------------------------------------------
+
+    api.registerTool({
+      name: "stimm_voice",
+      label: "Stimm Voice",
+      description:
+        "Start, control, and end real-time voice sessions. " +
+        "Uses Stimm dual-agent architecture: a fast VoiceAgent handles audio " +
+        "while OpenClaw provides reasoning and tools.",
+      parameters: StimmVoiceToolSchema,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const json = (payload: unknown) => ({
+          content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+          details: payload,
+        });
+
+        try {
+          const rt = await ensureRuntime();
+          const action = typeof params?.action === "string" ? params.action : "";
+
+          switch (action) {
+            case "start_session": {
+              const session = await createSessionWithAccess({
+                roomName: typeof params.room === "string" ? params.room : undefined,
+                channel: typeof params.channel === "string" ? params.channel : "web",
+              });
+              return json(session);
+            }
+
+            case "end_session": {
+              const room = String(params.room || "").trim();
+              if (!room) throw new Error("room required");
+              const ok = await rt.lk.endSession(room);
+              if (!ok) throw new Error("session not found");
+              return json({ ended: true, room });
+            }
+
+            case "instruct": {
+              const room = String(params.room || "").trim();
+              const text = String(params.text || "").trim();
+              if (!room || !text) throw new Error("room and text required");
+              if (!rt.lk.getSession(room)) throw new Error("session not found");
+              // Instructions are injected by the Python OpenClawSupervisor via
+              // the /stimm/supervisor HTTP endpoint automatically.
+              return json({
+                instructed: true,
+                room,
+                note: "use /stimm/supervisor for direct injection",
+              });
+            }
+
+            case "add_context": {
+              const room = String(params.room || "").trim();
+              const text = String(params.text || "").trim();
+              if (!room || !text) throw new Error("room and text required");
+              if (!rt.lk.getSession(room)) throw new Error("session not found");
+              return json({
+                context_added: true,
+                room,
+                note: "context is managed by the Python supervisor",
+              });
+            }
+
+            case "set_mode": {
+              const room = String(params.room || "").trim();
+              const mode = String(params.mode || "").trim();
+              if (!room || !mode) throw new Error("room and mode required");
+              if (!["autonomous", "relay", "hybrid"].includes(mode)) {
+                throw new Error(`Invalid mode: ${mode}`);
+              }
+              if (!rt.lk.getSession(room)) throw new Error("session not found");
+              return json({
+                mode,
+                room,
+                note: "mode changes are applied on the next supervisor tick",
+              });
+            }
+
+            case "status": {
+              const room = typeof params.room === "string" ? params.room.trim() : "";
+              if (room) {
+                const session = rt.lk.getSession(room);
+                return json(session ? sessionPayload(session, tunnelInfo) : { found: false });
+              }
+              return json({
+                sessions: rt.lk.listSessions().map((s) => sessionPayload(s, tunnelInfo)),
+                agent: agentProcess
+                  ? { running: agentProcess.running, pid: agentProcess.pid }
+                  : { running: false, pid: null },
+              });
+            }
+
+            default:
+              throw new Error(`Unknown action: ${action}`);
+          }
+        } catch (err) {
+          return json({
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      },
+    });
+
+    // -- CLI ----------------------------------------------------------------
+
+    const extensionDir = resolve(dirname(api.source));
+
+    api.registerCli(
+      ({ program }) =>
+        registerStimmVoiceCli({
+          program,
+          config,
+          ensureRuntime: async () => {
+            const rt = await ensureRuntime();
+            const roomManager = {
+              createSession: async (opts: { roomName?: string; originChannel: string }) => {
+                const payload = await createSessionWithAccess({
+                  roomName: opts.roomName,
+                  channel: opts.originChannel,
+                });
+                return {
+                  roomName: payload.room,
+                  clientToken: payload.clientToken,
+                  createdAt: payload.createdAt,
+                  originChannel: payload.channel,
+                  supervisor: { connected: Boolean(agentProcess?.running) },
+                  shareUrl: payload.shareUrl,
+                  claimToken: payload.claimToken,
+                };
+              },
+              endSession: async (room: string) => rt.lk.endSession(room),
+              listSessions: () =>
+                rt.lk.listSessions().map((s) => ({
+                  roomName: s.roomName,
+                  clientToken: s.clientToken,
+                  createdAt: s.createdAt,
+                  originChannel: s.originChannel,
+                  supervisor: { connected: Boolean(agentProcess?.running) },
+                })),
+            };
+            return { roomManager };
+          },
+          logger: api.logger,
+          extensionDir,
+        }),
+      { commands: ["voice"] },
+    );
+
+    // -- Service lifecycle --------------------------------------------------
+
+    api.registerService({
+      id: "stimm-voice",
+      start: async () => {
+        if (!config.enabled) return;
+        api.logger.info("[stimm-voice] Service started.");
+        ensureAgentProcessStarted();
+
+        // Start the quick tunnel lazily (only when a session is created).
+      },
+      stop: async () => {
+        // Clean up quick tunnel.
+        if (quickTunnel) {
+          quickTunnel.stop();
+          quickTunnel = null;
+        }
+        tunnelInfo = null;
+
+        // Stop the Python agent first.
+        if (agentProcess) {
+          agentProcess.stop();
+          agentProcess = null;
+        }
+
+        if (lkRuntime) {
+          await lkRuntime.stopAll();
+          lkRuntime = null;
+          api.logger.info("[stimm-voice] Service stopped — all sessions ended.");
+        }
+      },
+    });
+
+    // -- HTTP route (supervisor callback — called by Python OpenClawSupervisor) -
+
+    api.registerHttpRoute({
+      path: "/stimm/supervisor",
+      handler: async (req, res) => {
+        if (req.method !== "POST") {
+          res.writeHead(405);
+          res.end();
+          return;
+        }
+        if (config.access.supervisorSecret) {
+          const provided = req.headers["x-stimm-supervisor-secret"];
+          const expected = Buffer.from(config.access.supervisorSecret, "utf8");
+          const actual = Buffer.from(typeof provided === "string" ? provided : "", "utf8");
+          if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "unauthorized" }));
+            return;
+          }
+        }
+        try {
+          const coreConfig = api.config as CoreConfig;
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) chunks.push(chunk as Buffer);
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            roomName: string;
+            channel: string;
+            history: string;
+            systemPrompt?: string;
+          };
+
+          if (!body.roomName || !body.history) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "roomName and history required" }));
+            return;
+          }
+
+          const result = await generateStimmResponse({
+            coreConfig,
+            roomName: body.roomName,
+            channel: body.channel ?? "web",
+            text: body.history,
+            extraSystemPrompt:
+              typeof body.systemPrompt === "string" ? body.systemPrompt : undefined,
+          });
+
+          if (result.error) {
+            api.logger.error(`[stimm-voice] Agent error: ${result.error}`);
+          }
+
+          const supervisorText = normalizeSupervisorResponseText(result);
+          const supervisorDecision = safeParseSupervisorDecision(supervisorText);
+          const preview = truncateSupervisorLogText(
+            supervisorDecision?.text ?? (typeof result.text === "string" ? result.text : ""),
+            220,
+          );
+
+          api.logger.info(
+            `[stimm-voice:supervisor] room=${body.roomName} channel=${body.channel ?? "web"} ` +
+              `structured_json=${supervisorDecision ? "yes" : "no"} ` +
+              `action=${supervisorDecision?.action ?? "n/a"} ` +
+              `reason=${supervisorDecision?.reason ?? "n/a"} ` +
+              `text_preview="${preview || ""}"`,
+          );
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ text: supervisorText, error: result.error }));
+        } catch (err) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+        }
+      },
+    });
+
+    // -- HTTP route (LiveKit webhook — room/participant lifecycle events) ------
+    //
+    // Configure LiveKit server to POST to <gateway-url>/stimm/livekit-webhook.
+    // Events handled:
+    //   • participant_left  (identity="user") → end session immediately
+    //   • room_finished     (all participants gone) → clean up session map
+    //
+    // If LiveKit HMAC auth is enabled (it is by default), the signature is
+    // verified using the API key/secret already configured in this plugin.
+
+    api.registerHttpRoute({
+      path: "/stimm/livekit-webhook",
+      handler: async (req, res) => {
+        if (req.method !== "POST") {
+          res.writeHead(405);
+          res.end();
+          return;
+        }
+
+        try {
+          const chunks: Buffer[] = [];
+          for await (const chunk of req) chunks.push(chunk as Buffer);
+          const body = Buffer.concat(chunks).toString("utf8");
+
+          // Verify LiveKit HMAC signature (skipAuth=false, uses api key+secret).
+          const authHeader = req.headers["authorization"] ?? req.headers["Authorization"];
+          const receiver = new WebhookReceiver(config.livekit.apiKey, config.livekit.apiSecret);
+          // skipAuth only if no Authorization header is present (local/dev without
+          // webhook signing configured on the server side).
+          const skipAuth = !authHeader;
+          const event = await receiver.receive(
+            body,
+            typeof authHeader === "string" ? authHeader : undefined,
+            skipAuth,
+          );
+
+          const roomName = event.room?.name;
+          api.logger.debug?.(
+            `[stimm-voice] Webhook event=${event.event} room=${roomName ?? "(none)"}`,
+          );
+
+          if (roomName && lkRuntime) {
+            if (event.event === "participant_left" && event.participant?.identity === "user") {
+              // User disconnected — tear down the room immediately.
+              api.logger.info(`[stimm-voice] User left room "${roomName}" — ending session.`);
+              await lkRuntime.endSession(roomName);
+              await maybeShutdownVoiceStartProcess("webhook participant_left");
+            } else if (event.event === "room_finished") {
+              // All participants gone (Python agent also done) — clean up map.
+              api.logger.info(`[stimm-voice] Room "${roomName}" finished — cleaning up session.`);
+              await lkRuntime.endSession(roomName);
+              await maybeShutdownVoiceStartProcess("webhook room_finished");
+            }
+          }
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+        } catch (err) {
+          api.logger.warn(
+            `[stimm-voice] Webhook error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          // Return 400 so LiveKit logs the failure, but don't crash.
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+        }
+      },
+    });
+
+    // -- HTTP route (web voice endpoint) ------------------------------------
+
+    if (config.web.enabled) {
+      const claimPath = `${config.web.path.replace(/\/+$/, "")}/claim`;
+      const endPath = `${config.web.path.replace(/\/+$/, "")}/end`;
+
+      api.registerHttpRoute({
+        path: claimPath,
+        handler: async (req, res) => {
+          if (req.method !== "POST") {
+            res.writeHead(405);
+            res.end();
+            return;
+          }
+          const ip = getRequestIp(req);
+          if (!enforceClaimRateLimit(ip)) {
+            res.writeHead(429, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "rate_limited" }));
+            return;
+          }
+          try {
+            const chunks: Buffer[] = [];
+            for await (const chunk of req) chunks.push(chunk as Buffer);
+            const body = JSON.parse(Buffer.concat(chunks).toString()) as { claim?: string };
+            const claim = typeof body.claim === "string" ? body.claim.trim() : "";
+            const record = claim ? verifyAndConsumeClaim(claim) : null;
+            if (!record) {
+              res.writeHead(401, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "invalid_or_expired_claim" }));
+              return;
+            }
+
+            const rt = await ensureRuntime();
+            const clientToken = await rt.lk.issueJoinToken(record.roomName, {
+              identity: "user",
+              ttlSeconds: config.access.livekitTokenTtlSeconds,
+            });
+
+            const now = Date.now();
+            const disconnectToken = randomBytes(24).toString("hex");
+            const disconnectExpiresAt = now + config.access.livekitTokenTtlSeconds * 1000;
+            claimStore.set(record.claimId, {
+              ...record,
+              disconnectToken,
+              disconnectExpiresAt,
+              usedAt: now,
+            });
+
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(
+              JSON.stringify({
+                room: record.roomName,
+                clientToken,
+                channel: record.channel,
+                disconnectToken,
+                livekitUrl: record.livekitUrl ?? config.livekit.url,
+              }),
+            );
+          } catch (err) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+          }
+        },
+      });
+
+      api.registerHttpRoute({
+        path: endPath,
+        handler: async (req, res) => {
+          if (req.method !== "POST") {
+            res.writeHead(405);
+            res.end();
+            return;
+          }
+          try {
+            const chunks: Buffer[] = [];
+            for await (const chunk of req) chunks.push(chunk as Buffer);
+            const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+              room?: string;
+              disconnectToken?: string;
+            };
+            const room = typeof body.room === "string" ? body.room.trim() : "";
+            const disconnectToken =
+              typeof body.disconnectToken === "string" ? body.disconnectToken.trim() : "";
+            if (!room || !disconnectToken) {
+              res.writeHead(400, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "room and disconnectToken required" }));
+              return;
+            }
+
+            const claim = resolveDisconnectClaim(room, disconnectToken);
+            if (!claim) {
+              res.writeHead(401, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "invalid_or_expired_disconnect_token" }));
+              return;
+            }
+
+            const rt = await ensureRuntime();
+            const ended = await rt.lk.endSession(room);
+            claimStore.delete(claim.claimId);
+
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ended: true, room, deletedRoom: ended }));
+            await maybeShutdownVoiceStartProcess("web end route");
+          } catch (err) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+          }
+        },
+      });
+
+      api.registerHttpRoute({
+        path: config.web.path,
+        handler: async (req, res) => {
+          if (req.method === "POST") {
+            // Direct session creation is disabled by default for public safety.
+            if (!config.access.allowDirectWebSessionCreate) {
+              res.writeHead(403, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  error: "direct_web_session_create_disabled",
+                  hint: `Use a claim link and POST ${claimPath} instead.`,
+                }),
+              );
+              return;
+            }
+            try {
+              const session = await createSessionWithAccess({
+                channel: "web",
+              });
+              res.writeHead(200, { "Content-Type": "application/json" });
+              res.end(JSON.stringify(session));
+            } catch (err) {
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+            }
+          } else {
+            // GET — serve the voice web UI.
+            try {
+              const htmlPath = resolve(extensionDir, "src", "web", "voice.html");
+              const html = readFileSync(htmlPath, "utf-8");
+              res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+              res.end(html);
+            } catch {
+              res.writeHead(200, { "Content-Type": "application/json" });
+              res.end(
+                JSON.stringify({
+                  plugin: "stimm-voice",
+                  status: config.enabled ? "enabled" : "disabled",
+                  hint: `Use a claim link and POST ${claimPath} to exchange claim for session token.`,
+                }),
+              );
+            }
+          }
+        },
+      });
+    }
+  },
+};
+
+export default stimmVoicePlugin;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin LiveKit room lifecycle manager — creates rooms, generates tokens,
+ * tracks active sessions. Supervisor logic lives in the Python agent.
+ */
+export class LiveKitRuntime {
+  private sessions = new Map<string, VoiceSessionInternal>();
+  private roomService: RoomServiceClient;
+  private dispatchService: AgentDispatchClient;
+  private config: StimmVoiceConfig;
+  private static readonly AGENT_NAME = "stimm-voice";
+
+  constructor(config: StimmVoiceConfig) {
+    this.config = config;
+    const httpUrl = config.livekit.url.replace("ws://", "http://").replace("wss://", "https://");
+    this.roomService = new RoomServiceClient(
+      httpUrl,
+      config.livekit.apiKey,
+      config.livekit.apiSecret,
+    );
+    this.dispatchService = new AgentDispatchClient(
+      httpUrl,
+      config.livekit.apiKey,
+      config.livekit.apiSecret,
+    );
+  }
+
+  async createSession(opts: {
+    roomName?: string;
+    originChannel?: string;
+    ttlSeconds?: number;
+  }): Promise<VoiceSessionInternal> {
+    const roomName = opts.roomName ?? `stimm-${randomHex(8)}`;
+    await this.roomService.createRoom({ name: roomName });
+    await this.dispatchService.createDispatch(roomName, LiveKitRuntime.AGENT_NAME, {
+      metadata: JSON.stringify({
+        source: "openclaw-stimm-voice",
+        originChannel: opts.originChannel ?? "web",
+      }),
+    });
+
+    const clientToken = await this.generateToken({
+      identity: "user",
+      roomName,
+      canPublish: true,
+      canSubscribe: true,
+      canPublishData: true,
+      ttlSeconds: opts.ttlSeconds,
+    });
+
+    const session: VoiceSessionInternal = {
+      roomName,
+      clientToken,
+      createdAt: Date.now(),
+      originChannel: opts.originChannel ?? "web",
+    };
+    this.sessions.set(roomName, session);
+    return session;
+  }
+
+  async endSession(roomName: string): Promise<boolean> {
+    if (!this.sessions.has(roomName)) return false;
+    this.sessions.delete(roomName);
+    try {
+      await this.roomService.deleteRoom(roomName);
+    } catch {
+      // Room may already be gone.
+    }
+    return true;
+  }
+
+  getSession(roomName: string): VoiceSessionInternal | undefined {
+    return this.sessions.get(roomName);
+  }
+
+  listSessions(): VoiceSessionInternal[] {
+    return [...this.sessions.values()];
+  }
+
+  async issueJoinToken(
+    roomName: string,
+    opts: {
+      ttlSeconds?: number;
+      identity?: string;
+    } = {},
+  ): Promise<string> {
+    return await this.generateToken({
+      identity: opts.identity ?? "user",
+      roomName,
+      canPublish: true,
+      canSubscribe: true,
+      canPublishData: true,
+      ttlSeconds: opts.ttlSeconds,
+    });
+  }
+
+  async issueClientToken(
+    roomName: string,
+    opts: {
+      ttlSeconds?: number;
+      identity?: string;
+    } = {},
+  ): Promise<string> {
+    if (!this.sessions.has(roomName)) {
+      throw new Error("session not found");
+    }
+    return await this.issueJoinToken(roomName, opts);
+  }
+
+  async stopAll(): Promise<void> {
+    const rooms = [...this.sessions.keys()];
+    await Promise.allSettled(rooms.map((r) => this.endSession(r)));
+  }
+
+  private async generateToken(opts: {
+    identity: string;
+    roomName: string;
+    canPublish?: boolean;
+    canSubscribe?: boolean;
+    canPublishData?: boolean;
+    ttlSeconds?: number;
+  }): Promise<string> {
+    const token = new AccessToken(this.config.livekit.apiKey, this.config.livekit.apiSecret, {
+      identity: opts.identity,
+      ttl: opts.ttlSeconds ?? 3600,
+    });
+    const grant: VideoGrant = {
+      roomJoin: true,
+      room: opts.roomName,
+      canPublish: opts.canPublish ?? true,
+      canSubscribe: opts.canSubscribe ?? true,
+      canPublishData: opts.canPublishData ?? true,
+    };
+    token.addGrant(grant);
+    return await token.toJwt();
+  }
+}
+
+interface VoiceSessionInternal {
+  roomName: string;
+  clientToken: string;
+  createdAt: number;
+  originChannel: string;
+}
+
+function randomHex(bytes: number): string {
+  const array = new Uint8Array(bytes);
+  webcrypto.getRandomValues(array);
+  return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function normalizeSupervisorResponseText(result: StimmResponseResult): string {
+  const raw = typeof result.text === "string" ? result.text.trim() : "";
+
+  // If the upstream model already returned structured JSON text, preserve it.
+  if (result.decision && raw.startsWith("{") && raw.endsWith("}")) {
+    return raw;
+  }
+
+  // Non-empty unstructured text should still be actionable for Stimm.
+  if (raw.length > 0) {
+    return JSON.stringify({
+      action: "TRIGGER",
+      text: raw,
+      reason: result.decision?.reason ?? "openclaw_non_json_fallback",
+    });
+  }
+
+  return JSON.stringify({
+    action: "NO_ACTION",
+    text: "",
+    reason: result.decision?.reason ?? result.error ?? "empty_response",
+  });
+}
+
+type NormalizedSupervisorDecision = {
+  action: "TRIGGER" | "NO_ACTION";
+  text: string;
+  reason: string;
+};
+
+function safeParseSupervisorDecision(raw: string): NormalizedSupervisorDecision | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      action?: unknown;
+      text?: unknown;
+      reason?: unknown;
+    };
+    if (parsed.action !== "TRIGGER" && parsed.action !== "NO_ACTION") {
+      return null;
+    }
+    return {
+      action: parsed.action,
+      text: typeof parsed.text === "string" ? parsed.text : "",
+      reason: typeof parsed.reason === "string" ? parsed.reason : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function truncateSupervisorLogText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength)}…`;
+}
+
+/** Serialize a VoiceSession for gateway/tool responses. */
+function sessionPayload(session: VoiceSessionInternal, tunnel?: TunnelInfo | null): SessionPayload {
+  return {
+    room: session.roomName,
+    clientToken: session.clientToken,
+    channel: session.originChannel,
+    createdAt: session.createdAt,
+    // Pass the public LiveKit URL so the web UI uses the tunnel instead of guessing.
+    ...(tunnel?.livekitUrl ? { livekitUrl: tunnel.livekitUrl } : {}),
+  };
+}

--- a/extensions/stimm-voice/openclaw.plugin.json
+++ b/extensions/stimm-voice/openclaw.plugin.json
@@ -1,0 +1,390 @@
+{
+  "id": "stimm-voice",
+  "name": "Stimm Voice",
+  "description": "Real-time voice conversations powered by Stimm dual-agent architecture",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable Stimm voice capabilities"
+      },
+      "livekit": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "default": "ws://localhost:7880",
+            "description": "LiveKit server WebSocket URL"
+          },
+          "apiKey": {
+            "type": "string",
+            "default": "devkey",
+            "description": "LiveKit API key"
+          },
+          "apiSecret": {
+            "type": "string",
+            "description": "LiveKit API secret"
+          }
+        }
+      },
+      "voiceAgent": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "docker": {
+            "type": "boolean",
+            "default": true,
+            "description": "Run voice agent in Docker container"
+          },
+          "image": {
+            "type": "string",
+            "default": "ghcr.io/stimm-ai/stimm-agent:latest",
+            "description": "Docker image for the voice agent"
+          },
+          "stt": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Speech-to-Text pipeline configuration.",
+            "properties": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "deepgram",
+                  "openai",
+                  "google",
+                  "azure",
+                  "assemblyai",
+                  "aws",
+                  "speechmatics",
+                  "clova",
+                  "fal"
+                ],
+                "default": "deepgram",
+                "description": "livekit-plugins-* STT provider"
+              },
+              "model": {
+                "type": "string",
+                "default": "nova-3",
+                "description": "Model name for the STT provider (e.g. nova-3, gpt-4o-mini-transcribe)"
+              },
+              "apiKey": {
+                "type": "string",
+                "description": "API key for the STT provider. Falls back to STIMM_STT_API_KEY env, then to the provider-specific env var (e.g. DEEPGRAM_API_KEY)."
+              },
+              "language": {
+                "type": "string",
+                "description": "Language code (e.g. en, en-US). Provider-dependent."
+              }
+            }
+          },
+          "tts": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Text-to-Speech pipeline configuration.",
+            "properties": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "openai",
+                  "elevenlabs",
+                  "cartesia",
+                  "google",
+                  "azure",
+                  "aws",
+                  "playai",
+                  "rime",
+                  "hume"
+                ],
+                "default": "openai",
+                "description": "livekit-plugins-* TTS provider"
+              },
+              "model": {
+                "type": "string",
+                "default": "gpt-4o-mini-tts",
+                "description": "Model name for the TTS provider (e.g. gpt-4o-mini-tts, eleven_turbo_v2_5, sonic-2)"
+              },
+              "voice": {
+                "type": "string",
+                "default": "ash",
+                "description": "Voice selector. OpenAI: built-in voice name (e.g. ash). ElevenLabs: voice_id. Cartesia: voice UUID."
+              },
+              "language": {
+                "type": "string",
+                "description": "Language code (e.g. en, en-US). Provider-dependent."
+              },
+              "apiKey": {
+                "type": "string",
+                "description": "API key for the TTS provider. Falls back to STIMM_TTS_API_KEY env, then to the provider-specific env var (e.g. OPENAI_API_KEY)."
+              }
+            }
+          },
+          "llm": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Fast LLM provider for the voice agent.",
+            "properties": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "openai",
+                  "anthropic",
+                  "google",
+                  "groq",
+                  "azure",
+                  "cerebras",
+                  "fireworks",
+                  "together",
+                  "sambanova"
+                ],
+                "default": "openai",
+                "description": "livekit-plugins-* LLM provider"
+              },
+              "model": {
+                "type": "string",
+                "default": "gpt-4o-mini",
+                "description": "Model name for the LLM provider (e.g. gpt-4o-mini, claude-sonnet-4-20250514, gemini-2.0-flash)"
+              },
+              "temperature": {
+                "type": "number",
+                "description": "LLM temperature (0..2). Optional."
+              },
+              "apiKey": {
+                "type": "string",
+                "description": "API key for the LLM provider. Falls back to STIMM_LLM_API_KEY env, then to the provider-specific env var (e.g. OPENAI_API_KEY)."
+              }
+            }
+          },
+          "bufferingLevel": {
+            "type": "string",
+            "enum": ["NONE", "LOW", "MEDIUM", "HIGH"],
+            "default": "MEDIUM"
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["autonomous", "relay", "hybrid"],
+            "default": "hybrid"
+          },
+          "spawn": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Auto-spawn configuration for the Python voice agent process.",
+            "properties": {
+              "autoSpawn": {
+                "type": "boolean",
+                "default": true,
+                "description": "Automatically start the Python voice agent when the gateway starts"
+              },
+              "pythonPath": {
+                "type": "string",
+                "description": "Path to the Python executable (defaults to extension venv)"
+              },
+              "agentScript": {
+                "type": "string",
+                "description": "Path to agent.py (defaults to extension python/agent.py)"
+              },
+              "maxRestarts": {
+                "type": "number",
+                "default": 5,
+                "description": "Max automatic restarts before giving up"
+              }
+            }
+          }
+        }
+      },
+      "web": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Expose /voice web endpoint for browser voice sessions"
+          },
+          "path": {
+            "type": "string",
+            "default": "/voice"
+          }
+        }
+      },
+      "access": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Public web access and claim-token security for voice sessions.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["none", "quick-tunnel"],
+            "default": "none",
+            "description": "Access mode. 'none' = no public tunnel, 'quick-tunnel' = Cloudflare Quick Tunnel started on demand."
+          },
+          "claimTtlSeconds": {
+            "type": "number",
+            "default": 120,
+            "description": "One-time claim token lifetime (seconds)."
+          },
+          "livekitTokenTtlSeconds": {
+            "type": "number",
+            "default": 300,
+            "description": "LiveKit token lifetime issued after claim exchange (seconds)."
+          },
+          "supervisorSecret": {
+            "type": "string",
+            "description": "Optional shared secret required by POST /stimm/supervisor.",
+            "sensitive": true
+          },
+          "allowDirectWebSessionCreate": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow direct POST /voice session creation without claim tokens (dev only)."
+          },
+          "claimRateLimitPerMinute": {
+            "type": "number",
+            "default": 20,
+            "description": "Maximum claim exchanges per IP per minute."
+          }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "enabled": {
+      "label": "Enable Stimm Voice"
+    },
+    "livekit.url": {
+      "label": "LiveKit URL",
+      "placeholder": "ws://localhost:7880"
+    },
+    "livekit.apiKey": {
+      "label": "LiveKit API Key"
+    },
+    "livekit.apiSecret": {
+      "label": "LiveKit API Secret",
+      "sensitive": true
+    },
+    "voiceAgent.stt.provider": {
+      "label": "STT Provider",
+      "help": "Speech-to-Text provider: deepgram, openai, google, azure, assemblyai, aws, speechmatics, clova, fal"
+    },
+    "voiceAgent.stt.model": {
+      "label": "STT Model",
+      "help": "Model name for your STT provider (e.g. nova-3, gpt-4o-mini-transcribe)"
+    },
+    "voiceAgent.stt.apiKey": {
+      "label": "STT API Key",
+      "sensitive": true,
+      "help": "API key for the STT provider. Falls back to STIMM_STT_API_KEY → provider env var."
+    },
+    "voiceAgent.stt.language": {
+      "label": "STT Language",
+      "advanced": true,
+      "help": "Language code (e.g. en, en-US)"
+    },
+    "voiceAgent.tts.provider": {
+      "label": "TTS Provider",
+      "help": "Text-to-Speech provider: openai, elevenlabs, cartesia, google, azure, aws, playai, rime, hume"
+    },
+    "voiceAgent.tts.model": {
+      "label": "TTS Model",
+      "help": "Model name (e.g. gpt-4o-mini-tts, eleven_turbo_v2_5, sonic-2)"
+    },
+    "voiceAgent.tts.voice": {
+      "label": "TTS Voice",
+      "help": "OpenAI: voice name (ash, alloy). ElevenLabs: voice_id. Cartesia: voice UUID."
+    },
+    "voiceAgent.tts.language": {
+      "label": "TTS Language",
+      "advanced": true,
+      "help": "Language code (e.g. en, en-US). Provider-dependent."
+    },
+    "voiceAgent.tts.apiKey": {
+      "label": "TTS API Key",
+      "sensitive": true,
+      "help": "API key for the TTS provider. Falls back to STIMM_TTS_API_KEY → provider env var."
+    },
+    "voiceAgent.llm.provider": {
+      "label": "LLM Provider",
+      "help": "Fast LLM provider: openai, anthropic, google, groq, azure, cerebras, fireworks, together, sambanova"
+    },
+    "voiceAgent.llm.model": {
+      "label": "LLM Model",
+      "help": "Model name (e.g. gpt-4o-mini, claude-sonnet-4-20250514, gemini-2.0-flash)"
+    },
+    "voiceAgent.llm.temperature": {
+      "label": "LLM Temperature",
+      "advanced": true,
+      "help": "Sampling temperature (0..2)."
+    },
+    "voiceAgent.llm.apiKey": {
+      "label": "LLM API Key",
+      "sensitive": true,
+      "help": "API key for the LLM provider. Falls back to STIMM_LLM_API_KEY → provider env var."
+    },
+    "voiceAgent.docker": {
+      "label": "Run in Docker",
+      "help": "Run the Python voice agent in a Docker container"
+    },
+    "voiceAgent.image": {
+      "label": "Voice Agent Docker Image",
+      "advanced": true
+    },
+    "voiceAgent.bufferingLevel": {
+      "label": "Buffering Level",
+      "advanced": true
+    },
+    "voiceAgent.mode": {
+      "label": "Voice Agent Mode",
+      "help": "autonomous: voice agent self-directs; relay: speaks supervisor text; hybrid: blends both"
+    },
+    "voiceAgent.spawn.autoSpawn": {
+      "label": "Auto-Start Agent",
+      "help": "Automatically start the Python voice agent when the gateway starts"
+    },
+    "voiceAgent.spawn.pythonPath": {
+      "label": "Python Path",
+      "advanced": true,
+      "help": "Path to the Python executable. Leave empty to use the extension's venv."
+    },
+    "voiceAgent.spawn.maxRestarts": {
+      "label": "Max Restarts",
+      "advanced": true
+    },
+    "web.enabled": {
+      "label": "Enable Web Voice"
+    },
+    "web.path": {
+      "label": "Web Voice Path",
+      "advanced": true
+    },
+    "access.mode": {
+      "label": "Access Mode",
+      "help": "'none' for local-only, 'quick-tunnel' to create a Cloudflare Quick Tunnel on session start"
+    },
+    "access.claimTtlSeconds": {
+      "label": "Claim TTL (s)",
+      "advanced": true
+    },
+    "access.livekitTokenTtlSeconds": {
+      "label": "LiveKit Token TTL (s)",
+      "advanced": true
+    },
+    "access.supervisorSecret": {
+      "label": "Supervisor Secret",
+      "sensitive": true,
+      "help": "Shared secret required on POST /stimm/supervisor."
+    },
+    "access.allowDirectWebSessionCreate": {
+      "label": "Allow Direct /voice POST",
+      "advanced": true,
+      "help": "Enable only for local development."
+    },
+    "access.claimRateLimitPerMinute": {
+      "label": "Claim Rate Limit",
+      "advanced": true,
+      "help": "Maximum claim exchanges per IP per minute."
+    }
+  }
+}

--- a/extensions/stimm-voice/package.json
+++ b/extensions/stimm-voice/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@openclaw/stimm-voice",
+  "version": "2026.2.20",
+  "description": "OpenClaw Stimm voice plugin — dual-agent real-time voice conversations",
+  "type": "module",
+  "dependencies": {
+    "@livekit/rtc-node": "^0.13.24",
+    "@sinclair/typebox": "0.34.48",
+    "@stimm/protocol": "^0.1.8",
+    "livekit-server-sdk": "^2.0.0",
+    "qrcode-terminal": "^0.12.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/stimm-voice/python/.gitignore
+++ b/extensions/stimm-voice/python/.gitignore
@@ -1,0 +1,2 @@
+# Compiled shared objects (rebuild from .c source)
+*.so

--- a/extensions/stimm-voice/python/.gitignore
+++ b/extensions/stimm-voice/python/.gitignore
@@ -1,2 +1,8 @@
 # Compiled shared objects (rebuild from .c source)
 *.so
+
+# Python virtual environment
+.venv/
+venv/
+__pycache__/
+*.pyc

--- a/extensions/stimm-voice/python/Dockerfile
+++ b/extensions/stimm-voice/python/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY agent.py .
+
+CMD ["python", "agent.py", "start"]

--- a/extensions/stimm-voice/python/agent.py
+++ b/extensions/stimm-voice/python/agent.py
@@ -1,0 +1,244 @@
+"""OpenClaw voice agent worker.
+
+Architecture
+────────────
+
+  User/Phone ──► LiveKit Room
+                      │
+               ┌──────┴──────────────────────┐
+               │  VoiceAgent   (fast path)    │  ← stimm.VoiceAgent
+               │  VAD → STT → fast LLM → TTS │
+               └──────┬──────────────────────┘
+                      │  Stimm data-channel protocol
+               ┌──────┴──────────────────────┐
+               │  OpenClawSupervisor          │  ← this file
+               │  extends ConversationSupervisor (stimm)
+               │  data-only, no audio         │
+               └──────┬──────────────────────┘
+                      │  HTTP POST /stimm/supervisor
+               ┌──────┴──────────────────────┐
+               │  OpenClaw gateway            │
+               │  big LLM + tools             │
+               └─────────────────────────────┘
+
+``OpenClawSupervisor`` is the only OpenClaw-specific piece: it implements the
+abstract ``process()`` method by POSTing the conversation history to the
+OpenClaw gateway. All generic worker logic (providers, entrypoint) lives in
+``stimm.worker``.
+
+Environment variables consumed by this file:
+    OPENCLAW_SUPERVISOR_URL  URL of the OpenClaw gateway supervisor endpoint
+                             (default: http://127.0.0.1:18789/stimm/supervisor)
+    OPENCLAW_SUPERVISOR_SECRET
+                             Optional shared secret sent as
+                             X-Stimm-Supervisor-Secret header.
+    OPENCLAW_CHANNEL         channel name sent to the gateway; overrides STIMM_CHANNEL
+                             (default: value of STIMM_CHANNEL, itself defaulting to "default")
+
+All other environment variables (STT/TTS/LLM providers, STIMM_BUFFERING,
+STIMM_MODE, STIMM_INSTRUCTIONS, STIMM_CHANNEL, LIVEKIT_*) are consumed by
+stimm.worker — see stimm/worker.py for the full reference.
+
+Run with:
+    python agent.py dev
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Write stimm.* / openclaw.* diagnostic logs directly to a file so they are
+# visible even when livekit-agents runs entrypoint() in a watchfiles subprocess
+# (whose stdout/stderr are not captured by the Node.js parent process).
+# The FileHandler is inherited by child processes (fork), so it works in both
+# the watcher process and the real worker subprocess.
+_log_level_name = os.environ.get("STIMM_LOG_LEVEL", "INFO").upper()
+_log_level = getattr(logging, _log_level_name, logging.INFO)
+_diag_log_file = os.environ.get("STIMM_DIAG_LOG", "/tmp/stimm-agent.log")
+
+_file_handler = logging.FileHandler(_diag_log_file, mode="a", encoding="utf-8")
+_file_handler.setLevel(_log_level)
+_file_handler.setFormatter(
+    logging.Formatter(
+        fmt="%(asctime)s %(levelname)-5s %(name)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+)
+
+# Apply to stimm.* and openclaw.* — these are the loggers that emit
+# [TRANSCRIPT], [SUPERVISOR], [VOICE_AGENT] markers.
+for _pkg in ("stimm", "openclaw"):
+    _lg = logging.getLogger(_pkg)
+    _lg.setLevel(_log_level)
+    _lg.addHandler(_file_handler)
+    _lg.propagate = False  # don't double-print to root/livekit handlers
+
+import aiohttp  # noqa: E402
+from livekit.agents import WorkerOptions, cli  # noqa: E402
+
+from stimm import ConversationSupervisor  # noqa: E402
+
+logger = logging.getLogger("openclaw.voice")
+_UNKNOWN_SOURCE_PATCHED = False
+
+
+def _patch_unknown_mic_source_fallback() -> None:
+    """Allow SOURCE_UNKNOWN as fallback for mobile/browser mic tracks.
+
+    Some WebRTC clients publish audio tracks that are labeled SOURCE_UNKNOWN.
+    livekit-agents RoomIO input currently filters only SOURCE_MICROPHONE, which
+    drops those tracks and produces a silent pipeline.
+    """
+    global _UNKNOWN_SOURCE_PATCHED
+    if _UNKNOWN_SOURCE_PATCHED:
+        return
+
+    try:
+        from livekit import rtc
+        from livekit.agents.voice.room_io import _input as room_input  # pyright: ignore[reportPrivateImportUsage]
+
+        cls = room_input._ParticipantAudioInputStream  # pyright: ignore[reportAttributeAccessIssue]
+        orig_init = cls.__init__
+
+        def patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            orig_init(self, *args, **kwargs)
+            try:
+                self._accepted_sources.add(rtc.TrackSource.SOURCE_UNKNOWN)
+            except Exception:
+                pass
+
+        cls.__init__ = patched_init
+        _UNKNOWN_SOURCE_PATCHED = True
+        logger.info("Applied SOURCE_UNKNOWN audio-source fallback patch")
+    except Exception as exc:
+        logger.warning("Could not apply SOURCE_UNKNOWN fallback patch: %s", exc)
+
+
+class OpenClawSupervisor(ConversationSupervisor):
+    """Supervisor that POSTs conversation history to an OpenClaw gateway.
+
+    Calls ``POST /stimm/supervisor`` on the OpenClaw gateway and injects
+    the response into the voice agent's context.
+
+    Args:
+        supervisor_url: OpenClaw supervisor endpoint URL.
+        room_name: LiveKit room name (for routing on the gateway side).
+        channel: Origin channel (e.g. ``"web"``, ``"telegram"``).
+        quiet_s / loop_interval_s / max_turns: forwarded to base class.
+    """
+
+    def __init__(
+        self,
+        *,
+        supervisor_url: str,
+        room_name: str,
+        channel: str = "web",
+        quiet_s: float = 2.5,
+        loop_interval_s: float = 1.5,
+        max_turns: int = 40,
+    ) -> None:
+        super().__init__(
+            quiet_s=quiet_s,
+            loop_interval_s=loop_interval_s,
+            max_turns=max_turns,
+            backend_input_preamble=ConversationSupervisor.DEFAULT_AGNOSTIC_DECISION_PREAMBLE,
+        )
+        self.supervisor_url = supervisor_url
+        self.room_name = room_name
+        self.channel = channel
+
+    async def process(self, history: str, system_prompt: str | None) -> str:
+        """POST history + backend system prompt to OpenClaw /stimm/supervisor."""
+        return await self._post_to_openclaw(history=history, system_prompt=system_prompt)
+
+    async def _post_to_openclaw(self, *, history: str, system_prompt: str | None) -> str:
+        """POST payload to the OpenClaw /stimm/supervisor endpoint."""
+        try:
+            timeout_s_raw = os.environ.get("OPENCLAW_SUPERVISOR_TIMEOUT_S", "120").strip()
+            try:
+                timeout_s = max(5.0, float(timeout_s_raw))
+            except ValueError:
+                timeout_s = 120.0
+
+            async with aiohttp.ClientSession() as http:
+                async with http.post(
+                    self.supervisor_url,
+                    json={
+                        "roomName": self.room_name,
+                        "channel": self.channel,
+                        "history": history,
+                        "systemPrompt": system_prompt,
+                    },
+                    headers={
+                        "X-Stimm-Supervisor-Secret": os.environ.get(
+                            "OPENCLAW_SUPERVISOR_SECRET", ""
+                        )
+                    },
+                    timeout=aiohttp.ClientTimeout(total=timeout_s),
+                ) as resp:
+                    data = await resp.json()
+                    if resp.status != 200:
+                        logger.error(
+                            "OpenClaw /stimm/supervisor HTTP %s: %s",
+                            resp.status,
+                            data,
+                        )
+                        return self.NO_ACTION
+                    text = data.get("text") or self.NO_ACTION
+                    if text == self.NO_ACTION:
+                        logger.info("OpenClaw supervisor returned NO_ACTION")
+                    else:
+                        logger.info("OpenClaw supervisor returned context: %s", text)
+                    return text
+        except Exception as exc:
+            logger.error(
+                "OpenClaw supervisor HTTP call failed (%s): %r",
+                type(exc).__name__,
+                exc,
+            )
+            return self.NO_ACTION
+
+
+def _supervisor_factory(room_name: str, channel: str) -> OpenClawSupervisor:
+    return OpenClawSupervisor(
+        supervisor_url=os.environ.get(
+            "OPENCLAW_SUPERVISOR_URL", "http://127.0.0.1:18789/stimm/supervisor"
+        ),
+        room_name=room_name,
+        # STIMM_CHANNEL is set by make_entrypoint; OPENCLAW_CHANNEL is the
+        # OpenClaw-specific override kept for backward compatibility.
+        channel=os.environ.get("OPENCLAW_CHANNEL", channel),
+    )
+
+
+# Top-level function so multiprocessing can pickle it (closures are not picklable).
+async def entrypoint(ctx):  # type: ignore[no-untyped-def]
+    _patch_unknown_mic_source_fallback()
+
+    # Bind audio input to the web client participant identity ("user").
+    # STIMM_PARTICIPANT_IDENTITY can override for other topologies.
+    from livekit.agents import RoomInputOptions
+    from stimm.worker import make_entrypoint
+
+    participant_identity = os.environ.get("STIMM_PARTICIPANT_IDENTITY", "user").strip()
+    room_input_options = RoomInputOptions(participant_identity=participant_identity)
+    logger.info("Room input participant binding: %s", participant_identity or "<auto>")
+
+    # Delegate entirely to stimm.make_entrypoint — dedup, handlers, supervisor
+    # token, and shutdown are all handled there.  OpenClaw only contributes the
+    # supervisor factory (HTTP POST to the gateway) and the SOURCE_UNKNOWN patch.
+    await make_entrypoint(
+        _supervisor_factory,
+        room_input_options=room_input_options,
+    )(ctx)
+
+
+if __name__ == "__main__":
+    cli.run_app(
+        WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            # Named worker to support explicit room dispatch from OpenClaw.
+            agent_name=os.environ.get("STIMM_AGENT_NAME", "stimm-voice"),
+        )
+    )

--- a/extensions/stimm-voice/python/lk_no_hw_video.c
+++ b/extensions/stimm-voice/python/lk_no_hw_video.c
@@ -1,0 +1,76 @@
+/**
+ * lk_no_hw_video — LD_PRELOAD shim to disable Nvidia hardware video codecs.
+ *
+ * LiveKit's embedded libwebrtc uses implib-gen stubs that dlopen() the
+ * Nvidia video encoder/decoder libraries at runtime. On WSL2 (and some
+ * headless Linux setups), these libraries are present but non-functional,
+ * crashing PeerConnectionFactory initialization entirely.
+ *
+ * This shim intercepts dlopen() and blocks loading of:
+ * - libnvidia-encode.so*  (NVEnc — H264/H265 hardware encoding)
+ * - libnvcuvid.so*        (NvDec — hardware video decoding)
+ *
+ * Everything else (libcuda, CUDA compute, PyTorch, etc.) is untouched.
+ *
+ * Build:
+ *   gcc -shared -fPIC -o lk_no_hw_video.so lk_no_hw_video.c -ldl
+ *
+ * Usage:
+ *   LD_PRELOAD=./lk_no_hw_video.so python agent.py dev
+ *
+ * Safe on all platforms:
+ * - Linux + working NVEnc: disables HW video encoding (irrelevant for
+ *   audio-only agents; no video tracks are published).
+ * - Mac: this file is never loaded (no LD_PRELOAD; Mac uses VideoToolbox).
+ * - Windows: not applicable (LD_PRELOAD is Linux-only).
+ * - Docker/CI without GPU: libs already absent; shim is a no-op.
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Real dlopen — resolved once, cached. */
+typedef void *(*dlopen_fn)(const char *, int);
+
+void *dlopen(const char *filename, int flags) {
+    /* Resolve the real dlopen from libc/ld-linux. */
+    static dlopen_fn real_dlopen = NULL;
+    if (!real_dlopen) {
+        real_dlopen = (dlopen_fn)dlsym(RTLD_NEXT, "dlopen");
+    }
+
+    /* Block ALL hardware acceleration libraries loaded via implib-gen.
+     * These are lazy-loaded and can crash PeerConnectionFactory if
+     * partially functional (e.g. WSL2 Nvidia, missing VA-API, etc.).
+     *
+     * For audio-only agents, none of these are needed:
+     * - libcuda.so       → Nvidia CUDA (used by NVEnc encoder detection)
+     * - libnvcuvid.so    → Nvidia hardware video decoder
+     * - libnvidia-encode → NVEnc hardware video encoder
+     * - libva.so         → VA-API video acceleration
+     * - libva-drm.so     → VA-API DRM backend
+     *
+     * We keep libX11.so (not blocked) as it may be needed for display.
+     * Set LK_KEEP_GPU=1 to disable this shim and use all hardware. */
+    if (filename && !getenv("LK_KEEP_GPU")) {
+        if (strstr(filename, "libcuda.so") ||
+            strstr(filename, "libnvcuvid") ||
+            strstr(filename, "libnvidia-encode") ||
+            strstr(filename, "libva.so") ||
+            strstr(filename, "libva-drm")) {
+            fprintf(stderr, "[lk_no_hw_video] BLOCKED dlopen(%s)\n", filename);
+            return NULL;
+        }
+    }
+
+    void *handle = real_dlopen(filename, flags);
+    /* Debug: log failed dlopen calls */
+    if (filename && !handle) {
+        fprintf(stderr, "[lk_no_hw_video] FAILED  dlopen(%s): %s\n", filename, dlerror());
+    }
+
+    return handle;
+}

--- a/extensions/stimm-voice/python/requirements.txt
+++ b/extensions/stimm-voice/python/requirements.txt
@@ -1,0 +1,3 @@
+# Stimm core + default providers used by the default wizard profile.
+# The setup wizard installs additional extras on demand based on the user selection.
+stimm[deepgram,openai]

--- a/extensions/stimm-voice/scripts/dev-setup.sh
+++ b/extensions/stimm-voice/scripts/dev-setup.sh
@@ -51,9 +51,9 @@ fi
 # shellcheck disable=SC1091
 source "$VENV_DIR/bin/activate"
 
-echo "→ Installing stimm in editable mode with dev extras..."
-pip install -q -e "$STIMM_REPO[deepgram,openai,dev]"
-echo "✓ Python venv ready ($(python --version), stimm editable)"
+echo "→ Installing Python dependencies from requirements.txt..."
+pip install -q -r "$EXT_DIR/python/requirements.txt"
+echo "✓ Python venv ready ($(python --version))"
 
 # ── 3) LiveKit via Docker ──────────────────────────────────────
 if [[ "$SKIP_DOCKER" == "false" ]]; then
@@ -77,11 +77,10 @@ echo "│                                                          │"
 echo "│  Quick start:                                            │"
 echo "│    # Terminal 1 — run voice agent:                       │"
 echo "│    source $VENV_DIR/bin/activate                         │"
-echo "│    cd $STIMM_REPO                                        │"
 echo "│    LIVEKIT_URL=ws://localhost:7880 \\                     │"
 echo "│    LIVEKIT_API_KEY=devkey \\                              │"
 echo "│    LIVEKIT_API_SECRET=secret \\                           │"
-echo "│    python -m livekit.agents dev python/agent.py          │"
+echo "│    python $EXT_DIR/python/agent.py dev                   │"
 echo "│                                                          │"
 echo "│    # Terminal 2 — run openclaw with stimm-voice:         │"
 echo "│    pnpm dev                                              │"

--- a/extensions/stimm-voice/scripts/dev-setup.sh
+++ b/extensions/stimm-voice/scripts/dev-setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# ───────────────────────────────────────────────────────────────
+# Stimm Voice — Dev Environment Setup
+#
+# Sets up local development:
+#   1. Installs npm dependencies (including @stimm/protocol from npm)
+#   2. Creates a Python venv with stimm installed in editable mode
+#   3. Starts LiveKit server via Docker
+#
+# Prerequisites:
+#   - Docker running
+#   - Python 3.10+
+#   - pnpm installed
+#
+# Usage:
+#   ./extensions/stimm-voice/scripts/dev-setup.sh
+#   ./extensions/stimm-voice/scripts/dev-setup.sh --no-docker
+# ───────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$EXT_DIR/../.." && pwd)"
+
+VENV_DIR="$EXT_DIR/python/.venv"
+SKIP_DOCKER=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-docker) SKIP_DOCKER=true ;;
+  esac
+done
+
+echo "╔══════════════════════════════════════╗"
+echo "║   Stimm Voice — Dev Setup           ║"
+echo "╚══════════════════════════════════════╝"
+echo
+
+# ── 1) Install npm deps ───────────────────────────────────────
+echo
+echo "→ Installing npm deps for @openclaw/stimm-voice..."
+(cd "$REPO_DIR" && pnpm install --filter @openclaw/stimm-voice --silent)
+echo "✓ npm deps installed (@stimm/protocol from npm)"
+
+# ── 2) Python venv + editable stimm install ────────────────────
+echo
+echo "→ Setting up Python venv at $VENV_DIR..."
+if [[ ! -d "$VENV_DIR" ]]; then
+  python3 -m venv "$VENV_DIR"
+fi
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+echo "→ Installing stimm in editable mode with dev extras..."
+pip install -q -e "$STIMM_REPO[deepgram,openai,dev]"
+echo "✓ Python venv ready ($(python --version), stimm editable)"
+
+# ── 3) LiveKit via Docker ──────────────────────────────────────
+if [[ "$SKIP_DOCKER" == "false" ]]; then
+  echo
+  echo "→ Starting LiveKit server..."
+  docker compose -f "$EXT_DIR/docker/docker-compose.dev.yml" up -d
+  echo "✓ LiveKit running at ws://localhost:7880"
+else
+  echo
+  echo "⊘ Skipping Docker (--no-docker)"
+fi
+
+# ── Summary ────────────────────────────────────────────────────
+echo
+echo "┌──────────────────────────────────────────────────────────┐"
+echo "│  Dev environment ready!                                  │"
+echo "│                                                          │"
+echo "│  LiveKit:   ws://localhost:7880  (devkey / secret)       │"
+echo "│  Python:    source $VENV_DIR/bin/activate                │"
+echo "│                                                          │"
+echo "│  Quick start:                                            │"
+echo "│    # Terminal 1 — run voice agent:                       │"
+echo "│    source $VENV_DIR/bin/activate                         │"
+echo "│    cd $STIMM_REPO                                        │"
+echo "│    LIVEKIT_URL=ws://localhost:7880 \\                     │"
+echo "│    LIVEKIT_API_KEY=devkey \\                              │"
+echo "│    LIVEKIT_API_SECRET=secret \\                           │"
+echo "│    python -m livekit.agents dev python/agent.py          │"
+echo "│                                                          │"
+echo "│    # Terminal 2 — run openclaw with stimm-voice:         │"
+echo "│    pnpm dev                                              │"
+echo "│                                                          │"
+
+echo "└──────────────────────────────────────────────────────────┘"

--- a/extensions/stimm-voice/src/agent-process.test.ts
+++ b/extensions/stimm-voice/src/agent-process.test.ts
@@ -3,23 +3,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Stub child_process.spawn and execSync.
 const mockKill = vi.fn();
-const mockSpawn = vi.fn(() => {
-  const EventEmitter = require("node:events").EventEmitter;
-  const { Readable } = require("node:stream");
-  const proc = new EventEmitter();
-  proc.pid = 12345;
-  proc.killed = false;
-  proc.kill = vi.fn((signal?: string) => {
-    proc.killed = true;
-    if (signal === "SIGTERM") {
-      setTimeout(() => proc.emit("exit", 0, "SIGTERM"), 10);
-    }
-  });
-  proc.stdout = new Readable({ read() {} });
-  proc.stderr = new Readable({ read() {} });
-  proc.stdin = null;
-  return proc;
-});
+const mockSpawn = vi.fn(
+  (_cmd: string, _args: string[], _opts: { env?: Record<string, string> }) => {
+    const EventEmitter = require("node:events").EventEmitter;
+    const { Readable } = require("node:stream");
+    const proc = new EventEmitter();
+    proc.pid = 12345;
+    proc.killed = false;
+    proc.kill = vi.fn((signal?: string) => {
+      proc.killed = true;
+      if (signal === "SIGTERM") {
+        setTimeout(() => proc.emit("exit", 0, "SIGTERM"), 10);
+      }
+    });
+    proc.stdout = new Readable({ read() {} });
+    proc.stderr = new Readable({ read() {} });
+    proc.stdin = null;
+    return proc;
+  },
+);
 
 const mockExecSync = vi.fn(() => "Python 3.12.0");
 
@@ -176,8 +178,8 @@ describe("AgentProcess", () => {
     });
     agent.start();
 
-    const callArgs = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1];
-    const childEnv = callArgs[2].env;
+    const callArgs = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1]!;
+    const childEnv = callArgs[2].env!;
     expect(childEnv.LIVEKIT_URL).toBe("ws://localhost:7880");
     expect(childEnv.LIVEKIT_API_KEY).toBe("devkey");
     expect(childEnv.LIVEKIT_API_SECRET).toBe("secret");

--- a/extensions/stimm-voice/src/agent-process.test.ts
+++ b/extensions/stimm-voice/src/agent-process.test.ts
@@ -1,0 +1,188 @@
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub child_process.spawn and execSync.
+const mockKill = vi.fn();
+const mockSpawn = vi.fn(() => {
+  const EventEmitter = require("node:events").EventEmitter;
+  const { Readable } = require("node:stream");
+  const proc = new EventEmitter();
+  proc.pid = 12345;
+  proc.killed = false;
+  proc.kill = vi.fn((signal?: string) => {
+    proc.killed = true;
+    if (signal === "SIGTERM") {
+      setTimeout(() => proc.emit("exit", 0, "SIGTERM"), 10);
+    }
+  });
+  proc.stdout = new Readable({ read() {} });
+  proc.stderr = new Readable({ read() {} });
+  proc.stdin = null;
+  return proc;
+});
+
+const mockExecSync = vi.fn(() => "Python 3.12.0");
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => (mockSpawn as Function)(...args),
+  execSync: (...args: unknown[]) => (mockExecSync as Function)(...args),
+}));
+
+const mockExistsSync = vi.fn(() => true);
+const mockReadFileSync = vi.fn(() => "stimm[deepgram,openai]>=0.1.0\n");
+vi.mock("node:fs", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>;
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]) => (mockExistsSync as Function)(...args),
+    readFileSync: (...args: unknown[]) => (mockReadFileSync as Function)(...args),
+  };
+});
+
+// Import after mocks.
+const { AgentProcess } = await import("./agent-process.js");
+
+type AgentProcessInstance = InstanceType<typeof AgentProcess>;
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe("AgentProcess", () => {
+  let agent: AgentProcessInstance;
+  const logger = makeLogger();
+
+  const baseOpts = {
+    pythonPath: "/fake/python",
+    agentScript: "/fake/agent.py",
+    livekitUrl: "ws://localhost:7880",
+    livekitApiKey: "devkey",
+    livekitApiSecret: "secret",
+    logger,
+    maxRestarts: 2,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    logger.error.mockClear();
+    logger.debug.mockClear();
+
+    // Reset mocks so queued mockReturnValueOnce / mockImplementationOnce
+    // values don't leak between tests, then restore default implementations.
+    mockExistsSync.mockReset();
+    mockExistsSync.mockImplementation(() => true);
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation(() => "Python 3.12.0");
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation(() => "stimm[deepgram,openai]>=0.1.0\n");
+    mockSpawn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts a process and reports running", () => {
+    agent = new AgentProcess(baseOpts);
+    agent.start();
+    expect(agent.running).toBe(true);
+    expect(agent.pid).toBe(12345);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Voice agent started (PID 12345)"),
+    );
+    agent.stop();
+  });
+
+  it("does not double-start", () => {
+    agent = new AgentProcess(baseOpts);
+    agent.start();
+    agent.start(); // no-op
+    expect(agent.running).toBe(true);
+    agent.stop();
+  });
+
+  it("reports not running after stop", async () => {
+    agent = new AgentProcess(baseOpts);
+    agent.start();
+    agent.stop();
+    // Process receives SIGTERM, emits exit after 10ms.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(agent.running).toBe(false);
+    expect(agent.pid).toBeNull();
+  });
+
+  it("resolves default python path", () => {
+    const p = AgentProcess.resolveDefaultPythonPath("/ext/stimm-voice");
+    expect(p).toBe(join("/ext/stimm-voice", "python", ".venv", "bin", "python"));
+  });
+
+  it("resolves default agent script path", () => {
+    const p = AgentProcess.resolveDefaultAgentScript("/ext/stimm-voice");
+    expect(p).toBe(join("/ext/stimm-voice", "python", "agent.py"));
+  });
+
+  it("errors when python not found and venv creation fails", () => {
+    // existsSync calls: pythonPath=false, then venvPython=false (inside ensureVenv)
+    mockExistsSync.mockReturnValueOnce(false);
+    mockExistsSync.mockReturnValueOnce(false);
+    // execSync for `python3 --version` throws (no system python)
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+    // execSync for `python --version` also throws
+    mockExecSync.mockImplementationOnce(() => {
+      throw new Error("not found");
+    });
+
+    agent = new AgentProcess(baseOpts);
+    agent.start();
+    expect(agent.running).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("python3 not found"));
+  });
+
+  it("auto-creates venv when python path missing", () => {
+    // First existsSync(pythonPath) = false → triggers ensureVenv
+    mockExistsSync.mockReturnValueOnce(false);
+    // ensureVenv: existsSync(venvPython) = false → needs creation
+    mockExistsSync.mockReturnValueOnce(false);
+    // After venv creation, existsSync(pythonPath) = true → proceed to spawn
+    mockExistsSync.mockReturnValueOnce(true);
+    // existsSync(agentScript) = true
+    mockExistsSync.mockReturnValueOnce(true);
+    // execSync calls: python3 --version, then venv create, then requirements check, then pip install
+    mockExecSync
+      .mockReturnValueOnce("Python 3.12.0")
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("");
+
+    agent = new AgentProcess(baseOpts);
+    agent.start();
+    expect(agent.running).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Python venv not found"));
+    agent.stop();
+  });
+
+  it("passes API keys in env", () => {
+    agent = new AgentProcess({
+      ...baseOpts,
+      env: { OPENAI_API_KEY: "sk-test", DEEPGRAM_API_KEY: "dg-test" },
+    });
+    agent.start();
+
+    const callArgs = mockSpawn.mock.calls[mockSpawn.mock.calls.length - 1];
+    const childEnv = callArgs[2].env;
+    expect(childEnv.LIVEKIT_URL).toBe("ws://localhost:7880");
+    expect(childEnv.LIVEKIT_API_KEY).toBe("devkey");
+    expect(childEnv.LIVEKIT_API_SECRET).toBe("secret");
+    expect(childEnv.OPENAI_API_KEY).toBe("sk-test");
+    expect(childEnv.DEEPGRAM_API_KEY).toBe("dg-test");
+    agent.stop();
+  });
+});

--- a/extensions/stimm-voice/src/agent-process.ts
+++ b/extensions/stimm-voice/src/agent-process.ts
@@ -1,0 +1,433 @@
+/**
+ * AgentProcess — manages the Python voice agent as a child process.
+ *
+ * Spawns `python agent.py dev` (or console mode) and monitors it.
+ * Restarts on crash with exponential backoff. Reports health via
+ * LiveKit room presence.
+ *
+ * On first start, auto-creates a Python venv and installs dependencies
+ * if the venv does not exist yet.
+ */
+
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const OBS_JSON_MARKER = "OBS_JSON ";
+
+type SupervisorObsEvent = {
+  component: string;
+  event: string;
+  inference_seq?: number;
+  history_len?: number;
+  processed_up_to?: number;
+  latency_ms?: number;
+  structured_json?: boolean;
+  action?: string;
+  reason?: string;
+  text_chars?: number;
+  preview?: string;
+};
+
+function maybeReadNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function maybeReadString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function maybeReadBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}…`;
+}
+
+function parseSupervisorObsEvent(line: string): SupervisorObsEvent | null {
+  const markerIndex = line.indexOf(OBS_JSON_MARKER);
+  if (markerIndex === -1) return null;
+  const payload = line.slice(markerIndex + OBS_JSON_MARKER.length).trim();
+  if (!payload.startsWith("{")) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+
+  const record = parsed as Record<string, unknown>;
+  const component = maybeReadString(record.component);
+  const event = maybeReadString(record.event);
+  if (component !== "conversation_supervisor" || !event) return null;
+
+  return {
+    component,
+    event,
+    inference_seq: maybeReadNumber(record.inference_seq),
+    history_len: maybeReadNumber(record.history_len),
+    processed_up_to: maybeReadNumber(record.processed_up_to),
+    latency_ms: maybeReadNumber(record.latency_ms),
+    structured_json: maybeReadBoolean(record.structured_json),
+    action: maybeReadString(record.action),
+    reason: maybeReadString(record.reason),
+    text_chars: maybeReadNumber(record.text_chars),
+    preview: maybeReadString(record.preview),
+  };
+}
+
+function formatSupervisorObsEvent(event: SupervisorObsEvent): string {
+  const seq = event.inference_seq ?? "?";
+
+  if (event.event === "inference_started") {
+    return (
+      `[stimm-voice:supervisor] #${seq} inference_started ` +
+      `history_len=${event.history_len ?? "?"} processed_up_to=${event.processed_up_to ?? "?"}`
+    );
+  }
+
+  if (event.event === "inference_completed") {
+    const structured = event.structured_json === true ? "yes" : "no";
+    const action = event.action ?? "n/a";
+    const reason = event.reason && event.reason.trim() ? truncate(event.reason.trim(), 220) : "n/a";
+    return (
+      `[stimm-voice:supervisor] #${seq} inference_completed ` +
+      `latency_ms=${event.latency_ms ?? "?"} structured_json=${structured} action=${action} reason=${reason}`
+    );
+  }
+
+  if (event.event === "trigger_sent") {
+    const preview =
+      event.preview && event.preview.trim() ? truncate(event.preview.trim(), 160) : "";
+    return (
+      `[stimm-voice:supervisor] #${seq} trigger_sent ` +
+      `text_chars=${event.text_chars ?? "?"}${preview ? ` preview=\"${preview}\"` : ""}`
+    );
+  }
+
+  if (event.event === "no_action") {
+    return `[stimm-voice:supervisor] #${seq} no_action`;
+  }
+
+  return `[stimm-voice:supervisor] #${seq} event=${event.event}`;
+}
+
+function shouldSuppressAgentLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (line.includes("ignoring text stream with topic")) return true;
+  if (line.includes("'lk.transcription'")) return true;
+  if (trimmed === "attached") return true;
+  return false;
+}
+
+export interface AgentProcessOptions {
+  /** Path to the Python executable (in the venv). */
+  pythonPath: string;
+  /** Path to agent.py. */
+  agentScript: string;
+  /** LiveKit URL the agent connects to. */
+  livekitUrl: string;
+  /** LiveKit API key. */
+  livekitApiKey: string;
+  /** LiveKit API secret. */
+  livekitApiSecret: string;
+  /** Environment variables to forward (API keys, etc.). */
+  env?: Record<string, string>;
+  /** Max automatic restarts before giving up. */
+  maxRestarts?: number;
+  logger: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+    debug?: (msg: string) => void;
+  };
+}
+
+export class AgentProcess {
+  private proc: ChildProcess | null = null;
+  private options: AgentProcessOptions;
+  private restartCount = 0;
+  private maxRestarts: number;
+  private stopped = false;
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(options: AgentProcessOptions) {
+    this.options = options;
+    this.maxRestarts = options.maxRestarts ?? 5;
+  }
+
+  /** Start the Python voice agent process. */
+  start(): void {
+    if (this.proc) return;
+    this.stopped = false;
+
+    const { pythonPath, agentScript, livekitUrl, livekitApiKey, livekitApiSecret, env, logger } =
+      this.options;
+
+    // Auto-create venv if it doesn't exist yet.
+    if (!existsSync(pythonPath)) {
+      const pythonDir = resolve(agentScript, "..");
+      logger.info("[stimm-voice] Python venv not found — setting up automatically...");
+      const ok = AgentProcess.ensureVenv(pythonDir, logger);
+      if (!ok) return;
+      // Verify the venv was created successfully.
+      if (!existsSync(pythonPath)) {
+        logger.error(
+          `[stimm-voice] Venv created but python not found at: ${pythonPath}\n` +
+            "Run manually: cd extensions/stimm-voice/python && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt",
+        );
+        return;
+      }
+    }
+    if (!existsSync(agentScript)) {
+      logger.error(`[stimm-voice] agent.py not found at: ${agentScript}`);
+      return;
+    }
+
+    const childEnv: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      LIVEKIT_URL: livekitUrl,
+      LIVEKIT_API_KEY: livekitApiKey,
+      LIVEKIT_API_SECRET: livekitApiSecret,
+      // Expose stimm.* / openclaw.* DEBUG logs in gateway output so
+      // transcript dedup, supervisor accept/drop, and generate_reply
+      // triggers are all visible for diagnostics.
+      LIVEKIT_LOG_LEVEL: "debug",
+      ...env,
+    };
+
+    const cwd = resolve(agentScript, "..");
+
+    logger.info(`[stimm-voice] Starting Python voice agent (pid will follow)...`);
+    logger.debug?.(`[stimm-voice] python=${pythonPath} script=${agentScript} cwd=${cwd}`);
+
+    // Kill any zombie Python process holding the livekit-agents HTTP port (8081)
+    // before spawning a new one, to avoid OSError: address already in use.
+    AgentProcess.freePort(8081, logger);
+
+    this.proc = spawn(pythonPath, [agentScript, "dev"], {
+      cwd,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const pid = this.proc.pid;
+    const logFile = "/tmp/stimm-agent.log";
+    logger.info(`[stimm-voice] Voice agent started (PID ${pid}) — Python logs also in ${logFile}`);
+
+    // Write Python logs to a dedicated file for easy grep/tail access.
+    import("node:fs").then(({ createWriteStream }) => {
+      const logStream = createWriteStream(logFile, { flags: "a" });
+      logStream.write(`\n--- stimm-agent PID ${pid} started at ${new Date().toISOString()} ---\n`);
+
+      const forwardLine = (line: string) => {
+        logStream.write(line + "\n");
+        if (shouldSuppressAgentLine(line)) {
+          return;
+        }
+        const supervisorEvent = parseSupervisorObsEvent(line);
+        if (supervisorEvent) {
+          logger.info(formatSupervisorObsEvent(supervisorEvent));
+          return;
+        }
+        logger.info(`[stimm-voice:agent] ${line}`);
+      };
+
+      // Forward stdout/stderr through the plugin logger AND to the log file.
+      this.proc!.stdout?.on("data", (chunk: Buffer) => {
+        for (const line of chunk.toString().split("\n").filter(Boolean)) {
+          forwardLine(line);
+        }
+      });
+
+      this.proc!.stderr?.on("data", (chunk: Buffer) => {
+        for (const line of chunk.toString().split("\n").filter(Boolean)) {
+          // livekit-agents logs to stderr by default — forward as info.
+          forwardLine(line);
+        }
+      });
+
+      this.proc!.on("exit", () => {
+        logStream.write(`--- stimm-agent PID ${pid} exited at ${new Date().toISOString()} ---\n`);
+        logStream.end();
+      });
+    });
+
+    this.proc.on("exit", (code, signal) => {
+      this.proc = null;
+      if (this.stopped) {
+        logger.info(`[stimm-voice] Voice agent stopped.`);
+        return;
+      }
+
+      logger.warn(
+        `[stimm-voice] Voice agent exited (code=${code}, signal=${signal}). ` +
+          `Restarts: ${this.restartCount}/${this.maxRestarts}`,
+      );
+
+      if (this.restartCount >= this.maxRestarts) {
+        logger.error(
+          `[stimm-voice] Max restarts (${this.maxRestarts}) reached. Not restarting. ` +
+            `Check agent logs and restart the gateway.`,
+        );
+        return;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s…
+      const delay = Math.min(1000 * Math.pow(2, this.restartCount), 30_000);
+      this.restartCount++;
+      logger.info(`[stimm-voice] Restarting voice agent in ${delay}ms...`);
+      this.restartTimer = setTimeout(() => this.start(), delay);
+    });
+  }
+
+  /** Stop the Python voice agent process. */
+  stop(): void {
+    this.stopped = true;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    if (!this.proc) return;
+
+    this.options.logger.info(`[stimm-voice] Stopping voice agent (PID ${this.proc.pid})...`);
+    this.proc.kill("SIGTERM");
+
+    // Force kill after 5 seconds if it doesn't exit gracefully.
+    const forceKill = setTimeout(() => {
+      if (this.proc) {
+        this.options.logger.warn("[stimm-voice] Force-killing voice agent (SIGKILL).");
+        this.proc.kill("SIGKILL");
+      }
+    }, 5_000);
+
+    this.proc.once("exit", () => clearTimeout(forceKill));
+  }
+
+  /** Whether the agent process is currently running. */
+  get running(): boolean {
+    return this.proc !== null && !this.proc.killed;
+  }
+
+  /** Current PID, or null if not running. */
+  get pid(): number | null {
+    return this.proc?.pid ?? null;
+  }
+
+  /** Resolve the default python path within the extension venv. */
+  static resolveDefaultPythonPath(extensionDir: string): string {
+    return join(extensionDir, "python", ".venv", "bin", "python");
+  }
+
+  /** Resolve the default agent.py path. */
+  static resolveDefaultAgentScript(extensionDir: string): string {
+    return join(extensionDir, "python", "agent.py");
+  }
+
+  /**
+   * Auto-create and populate the Python venv if it doesn't exist.
+   *
+   * Steps:
+   *   1. Find `python3` on PATH.
+   *   2. Create venv at `<pythonDir>/.venv`.
+   *   3. Install requirements from `<pythonDir>/requirements.txt`.
+   *
+   * Returns `true` if the venv is ready, `false` on failure.
+   */
+  static ensureVenv(
+    pythonDir: string,
+    logger: {
+      info: (msg: string) => void;
+      warn: (msg: string) => void;
+      error: (msg: string) => void;
+    },
+  ): boolean {
+    const venvDir = join(pythonDir, ".venv");
+    const venvPython = join(venvDir, "bin", "python");
+
+    // Already exists? Quick exit.
+    if (existsSync(venvPython)) return true;
+
+    // Find a system Python 3.
+    const systemPython = AgentProcess.findSystemPython();
+    if (!systemPython) {
+      logger.error("[stimm-voice] python3 not found on PATH. Install Python 3.10+ and try again.");
+      return false;
+    }
+
+    try {
+      logger.info(`[stimm-voice] Creating venv at ${venvDir} (using ${systemPython})...`);
+      execSync(`${systemPython} -m venv ${JSON.stringify(venvDir)}`, {
+        cwd: pythonDir,
+        stdio: "pipe",
+        timeout: 60_000,
+      });
+
+      const reqFile = join(pythonDir, "requirements.txt");
+      if (existsSync(reqFile)) {
+        const pip = join(venvDir, "bin", "pip");
+        logger.info("[stimm-voice] Installing Python dependencies (this may take a minute)...");
+        const reqs = readFileSync(reqFile, "utf-8").trim();
+        logger.info(`[stimm-voice] requirements: ${reqs.split("\n").join(", ")}`);
+        execSync(`${JSON.stringify(pip)} install -r ${JSON.stringify(reqFile)}`, {
+          cwd: pythonDir,
+          stdio: "pipe",
+          timeout: 300_000, // 5 min for large installs
+        });
+        logger.info("[stimm-voice] Python dependencies installed.");
+      }
+
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[stimm-voice] Failed to create Python venv: ${msg}`);
+      logger.error(
+        "Try manually: cd extensions/stimm-voice/python && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt",
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Kill any process holding the given TCP port (Linux/macOS).
+   * Used to clean up zombie livekit-agents workers before restart.
+   */
+  static freePort(port: number, logger: { warn: (msg: string) => void }): void {
+    try {
+      const result = execSync(`fuser ${port}/tcp 2>/dev/null`, { encoding: "utf-8" }).trim();
+      if (result) {
+        for (const pid of result.trim().split(/\s+/).filter(Boolean)) {
+          try {
+            execSync(`kill -9 ${pid} 2>/dev/null`);
+            logger.warn(`[stimm-voice] Killed zombie process PID ${pid} holding port ${port}`);
+          } catch {
+            // Already gone.
+          }
+        }
+      }
+    } catch {
+      // fuser not available or port already free — ignore.
+    }
+  }
+
+  /** Find a usable system Python 3 (python3, python). */
+  static findSystemPython(): string | null {
+    for (const cmd of ["python3", "python"]) {
+      try {
+        const version = execSync(`${cmd} --version 2>&1`, { encoding: "utf-8" }).trim();
+        // Ensure it's Python 3.10+.
+        const match = version.match(/Python\s+(\d+)\.(\d+)/);
+        if (match && Number(match[1]) >= 3 && Number(match[2]) >= 10) {
+          return cmd;
+        }
+      } catch {
+        // Not found, try next.
+      }
+    }
+    return null;
+  }
+}

--- a/extensions/stimm-voice/src/agent-process.ts
+++ b/extensions/stimm-voice/src/agent-process.ts
@@ -215,6 +215,13 @@ export class AgentProcess {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
+    // Handle asynchronous spawn failures (EACCES, bad interpreter, etc.)
+    // to avoid crashing the gateway with an unhandled 'error' event.
+    this.proc.on("error", (err) => {
+      logger.error(`[stimm-voice] Failed to start Python voice agent: ${err.message}`);
+      this.proc = null;
+    });
+
     const pid = this.proc.pid;
     const logFile = "/tmp/stimm-agent.log";
     logger.info(`[stimm-voice] Voice agent started (PID ${pid}) — Python logs also in ${logFile}`);
@@ -402,6 +409,31 @@ export class AgentProcess {
       if (result) {
         for (const pid of result.trim().split(/\s+/).filter(Boolean)) {
           try {
+            // Only kill the process if it looks like a Python/livekit-agents worker.
+            // This prevents accidentally killing unrelated services on the same port.
+            let cmdline = "";
+            try {
+              // Linux: /proc/<pid>/cmdline (null-byte separated)
+              cmdline = execSync(
+                `cat /proc/${pid}/cmdline 2>/dev/null || ps -p ${pid} -o args= 2>/dev/null`,
+                {
+                  encoding: "utf-8",
+                },
+              );
+            } catch {
+              // ignore — fall through to skip
+            }
+            const isSafe =
+              cmdline.includes("python") ||
+              cmdline.includes("livekit") ||
+              cmdline.includes("stimm") ||
+              cmdline.includes("agent.py");
+            if (!isSafe) {
+              logger.warn(
+                `[stimm-voice] Skipping kill of PID ${pid} on port ${port} — does not look like a Python/livekit-agents process.`,
+              );
+              continue;
+            }
             execSync(`kill -9 ${pid} 2>/dev/null`);
             logger.warn(`[stimm-voice] Killed zombie process PID ${pid} holding port ${port}`);
           } catch {

--- a/extensions/stimm-voice/src/agent-process.ts
+++ b/extensions/stimm-voice/src/agent-process.ts
@@ -226,6 +226,10 @@ export class AgentProcess {
     const logFile = "/tmp/stimm-agent.log";
     logger.info(`[stimm-voice] Voice agent started (PID ${pid}) — Python logs also in ${logFile}`);
 
+    // Capture proc reference before the async import to avoid a race
+    // where the error handler sets this.proc = null before the .then() runs.
+    const procRef = this.proc;
+
     // Write Python logs to a dedicated file for easy grep/tail access.
     import("node:fs").then(({ createWriteStream }) => {
       const logStream = createWriteStream(logFile, { flags: "a" });
@@ -245,20 +249,20 @@ export class AgentProcess {
       };
 
       // Forward stdout/stderr through the plugin logger AND to the log file.
-      this.proc!.stdout?.on("data", (chunk: Buffer) => {
+      procRef.stdout?.on("data", (chunk: Buffer) => {
         for (const line of chunk.toString().split("\n").filter(Boolean)) {
           forwardLine(line);
         }
       });
 
-      this.proc!.stderr?.on("data", (chunk: Buffer) => {
+      procRef.stderr?.on("data", (chunk: Buffer) => {
         for (const line of chunk.toString().split("\n").filter(Boolean)) {
           // livekit-agents logs to stderr by default — forward as info.
           forwardLine(line);
         }
       });
 
-      this.proc!.on("exit", () => {
+      procRef.on("exit", () => {
         logStream.write(`--- stimm-agent PID ${pid} exited at ${new Date().toISOString()} ---\n`);
         logStream.end();
       });

--- a/extensions/stimm-voice/src/cli.test.ts
+++ b/extensions/stimm-voice/src/cli.test.ts
@@ -152,6 +152,8 @@ describe("registerStimmVoiceCli", () => {
     });
 
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    // Emit SIGINT after event loop tick so the handler is registered first.
+    setTimeout(() => process.emit("SIGINT"), 10);
     await prog.commands["voice:start"].action!({ channel: "web" });
     exitSpy.mockRestore();
 

--- a/extensions/stimm-voice/src/cli.test.ts
+++ b/extensions/stimm-voice/src/cli.test.ts
@@ -125,7 +125,9 @@ describe("registerStimmVoiceCli", () => {
       logger,
     });
 
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     await prog.commands["voice:start"].action!({ channel: "web" });
+    exitSpy.mockRestore();
     expect(rm.createSession).toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Voice session started"));
   });
@@ -149,7 +151,9 @@ describe("registerStimmVoiceCli", () => {
       logger,
     });
 
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     await prog.commands["voice:start"].action!({ channel: "web" });
+    exitSpy.mockRestore();
 
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringContaining("Share URL: https://example.trycloudflare.com/voice?claim=abc"),

--- a/extensions/stimm-voice/src/cli.test.ts
+++ b/extensions/stimm-voice/src/cli.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerStimmVoiceCli } from "./cli.js";
+import type { StimmVoiceConfig } from "./config.js";
+
+type VoiceSession = {
+  roomName: string;
+  clientToken: string;
+  createdAt: number;
+  originChannel: string;
+  supervisor: { connected: boolean };
+  shareUrl?: string;
+  claimToken?: string;
+};
+
+type RoomManager = {
+  createSession: (opts: { roomName?: string; originChannel: string }) => Promise<VoiceSession>;
+  endSession: (room: string) => Promise<boolean>;
+  listSessions: () => VoiceSession[];
+  getSession: (room: string) => VoiceSession | undefined;
+  stopAll: () => Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActionFn = (opts: Record<string, unknown>) => Promise<void>;
+
+function fakeProgram() {
+  const commands: Record<string, { description: string; options: string[]; action?: ActionFn }> =
+    {};
+  return {
+    commands,
+    command(name: string) {
+      const entry = {
+        description: "",
+        options: [] as string[],
+        action: undefined as ActionFn | undefined,
+      };
+      commands[name] = entry;
+      const chain = {
+        description(d: string) {
+          entry.description = d;
+          return chain;
+        },
+        option(flags: string, _desc: string, _defaultValue?: string) {
+          entry.options.push(flags);
+          return chain;
+        },
+        action(fn: ActionFn) {
+          entry.action = fn;
+          return chain;
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+function fakeSession(overrides: Partial<VoiceSession> = {}): VoiceSession {
+  return {
+    roomName: "test-room",
+    clientToken: "fake-token",
+    createdAt: Date.now(),
+    originChannel: "web",
+    supervisor: { connected: true } as VoiceSession["supervisor"],
+    ...overrides,
+  };
+}
+
+function fakeRoomManager(sessions: VoiceSession[] = []): RoomManager {
+  return {
+    createSession: vi.fn(async (opts: { roomName?: string; originChannel: string }) => {
+      return fakeSession({
+        roomName: opts.roomName ?? "auto-room",
+        originChannel: opts.originChannel,
+      });
+    }),
+    endSession: vi.fn(async (room: string) => sessions.some((s) => s.roomName === room)),
+    listSessions: vi.fn(() => sessions),
+    getSession: vi.fn((room: string) => sessions.find((s) => s.roomName === room)),
+    stopAll: vi.fn(async () => {}),
+  } as unknown as RoomManager;
+}
+
+const enabledConfig = {
+  enabled: true,
+  livekit: { url: "ws://localhost:7880", apiKey: "k", apiSecret: "s" },
+  voiceAgent: {} as StimmVoiceConfig["voiceAgent"],
+  web: { enabled: true, path: "/voice" },
+} as StimmVoiceConfig;
+
+const disabledConfig = { ...enabledConfig, enabled: false };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("registerStimmVoiceCli", () => {
+  it("registers voice, voice:start, voice:stop, voice:status commands", () => {
+    const prog = fakeProgram();
+    const rm = fakeRoomManager();
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger: { info: vi.fn(), error: vi.fn() },
+    });
+
+    expect(prog.commands).toHaveProperty("voice");
+    expect(prog.commands).toHaveProperty("voice:start");
+    expect(prog.commands).toHaveProperty("voice:stop");
+    expect(prog.commands).toHaveProperty("voice:status");
+    expect(prog.commands).toHaveProperty("voice:logs");
+  });
+
+  it("voice:start creates a session and logs info", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const rm = fakeRoomManager();
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:start"].action!({ channel: "web" });
+    expect(rm.createSession).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Voice session started"));
+  });
+
+  it("voice:start logs share URL flow when session has web access link", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const rm = fakeRoomManager() as unknown as RoomManager;
+    vi.mocked(rm.createSession).mockResolvedValueOnce(
+      fakeSession({
+        roomName: "share-room",
+        shareUrl: "https://example.trycloudflare.com/voice?claim=abc",
+        claimToken: "abc",
+      }),
+    );
+
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:start"].action!({ channel: "web" });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Share URL: https://example.trycloudflare.com/voice?claim=abc"),
+    );
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Claim token: abc"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Scan this QR code"));
+  });
+
+  it("voice:start refuses when disabled", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const rm = fakeRoomManager();
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: disabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:start"].action!({ channel: "web" });
+    expect(rm.createSession).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("disabled"));
+  });
+
+  it("voice:stop errors without --room", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const rm = fakeRoomManager();
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:stop"].action!({ room: undefined as any });
+    expect(logger.error).toHaveBeenCalledWith("--room is required");
+  });
+
+  it("voice:status shows no sessions message when empty", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const rm = fakeRoomManager([]);
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:status"].action!({});
+    expect(logger.info).toHaveBeenCalledWith("No active voice sessions.");
+  });
+
+  it("voice:status lists active sessions", async () => {
+    const prog = fakeProgram();
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const sessions = [
+      fakeSession({ roomName: "room-a", originChannel: "web" }),
+      fakeSession({ roomName: "room-b", originChannel: "telegram" }),
+    ];
+    const rm = fakeRoomManager(sessions);
+    registerStimmVoiceCli({
+      program: prog as any,
+      config: enabledConfig,
+      ensureRuntime: async () => ({ roomManager: rm }),
+      logger,
+    });
+
+    await prog.commands["voice:status"].action!({});
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("room-a"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("room-b"));
+  });
+});

--- a/extensions/stimm-voice/src/cli.ts
+++ b/extensions/stimm-voice/src/cli.ts
@@ -233,6 +233,12 @@ export function registerStimmVoiceCli(deps: VoiceCliDeps): void {
         logger.info(`  Use this token to connect from a LiveKit client.`);
       }
 
+      if (!opts.wait) {
+        // LiveKit SDK keeps open HTTP/WebSocket handles — exit explicitly so the
+        // CLI doesn't hang after printing the QR code.
+        process.exit(0);
+      }
+
       if (opts.wait) {
         logger.info(`  Press Ctrl+C (or send SIGTERM) to end the session and exit.`);
         let exiting = false;

--- a/extensions/stimm-voice/src/cli.ts
+++ b/extensions/stimm-voice/src/cli.ts
@@ -22,6 +22,13 @@ type RoomManager = {
   createSession: (opts: { roomName?: string; originChannel: string }) => Promise<VoiceSession>;
   endSession: (room: string) => Promise<boolean>;
   listSessions: () => VoiceSession[];
+  /**
+   * Lists participants in the room. kind: 0=STANDARD(human), 4=AGENT.
+   * Returns [] when the room is gone or on error.
+   */
+  listRoomParticipants?: (
+    room: string,
+  ) => Promise<Array<{ identity: string; kind: number; state: number }>>;
 };
 
 type SupervisorObsEvent = {
@@ -272,6 +279,41 @@ export function registerStimmVoiceCli(deps: VoiceCliDeps): void {
         };
         process.once("SIGINT", () => void cleanup());
         process.once("SIGTERM", () => void cleanup());
+
+        // Auto-exit when the last human participant disconnects.
+        // The claim is consumed on first connect so reconnection is impossible
+        // — there is no point keeping the process (and cloudflared tunnel) alive.
+        // We use a consecutive-empty-poll counter so the check works even if the
+        // participant connected and disconnected between two poll ticks.
+        if (rt.roomManager.listRoomParticipants) {
+          const POLL_MS = 15_000;
+          // Two consecutive polls with no human (kind=0 STANDARD) participants
+          // before auto-closing, to avoid false-positives on transient blips.
+          const EMPTY_THRESHOLD = 2;
+          let emptyCount = 0;
+          const poller = setInterval(() => {
+            void rt.roomManager.listRoomParticipants!(session.roomName).then((parts) => {
+              // kind: 0=STANDARD(human), 1=INGRESS, 2=EGRESS, 3=SIP, 4=AGENT
+              // Exclude the stimm supervisor participant (kind=0 but not a real user).
+              const hasHuman = parts.some(
+                (p) => p.kind === 0 && !p.identity.startsWith("stimm-supervisor-"),
+              );
+              if (hasHuman) {
+                emptyCount = 0;
+              } else {
+                emptyCount++;
+                if (emptyCount >= EMPTY_THRESHOLD) {
+                  clearInterval(poller);
+                  logger.info(`[stimm-voice] Room empty — auto-closing session.`);
+                  void cleanup();
+                }
+              }
+            });
+          }, POLL_MS);
+        } else {
+          // listRoomParticipants not available (e.g. in tests) — skip auto-close.
+        }
+
         await keepAlive;
       }
     });

--- a/extensions/stimm-voice/src/cli.ts
+++ b/extensions/stimm-voice/src/cli.ts
@@ -233,15 +233,23 @@ export function registerStimmVoiceCli(deps: VoiceCliDeps): void {
         logger.info(`  Use this token to connect from a LiveKit client.`);
       }
 
-      if (!opts.wait) {
-        // LiveKit SDK keeps open HTTP/WebSocket handles — exit explicitly so the
-        // CLI doesn't hang after printing the QR code.
+      if (!opts.wait && !session.shareUrl) {
+        // No tunnel running in this process — LiveKit SDK keeps open
+        // HTTP/WebSocket handles so we exit explicitly to avoid hanging.
         process.exit(0);
       }
 
-      if (opts.wait) {
-        logger.info(`  Press Ctrl+C (or send SIGTERM) to end the session and exit.`);
+      if (opts.wait || session.shareUrl) {
+        if (session.shareUrl) {
+          logger.info(`  Press Ctrl+C (or send SIGTERM) to end the session and close the tunnel.`);
+        } else {
+          logger.info(`  Press Ctrl+C (or send SIGTERM) to end the session and exit.`);
+        }
         let exiting = false;
+        let resolveKeepAlive!: () => void;
+        const keepAlive = new Promise<void>((res) => {
+          resolveKeepAlive = res;
+        });
         const cleanup = async () => {
           if (exiting) return;
           exiting = true;
@@ -259,14 +267,12 @@ export function registerStimmVoiceCli(deps: VoiceCliDeps): void {
               `[stimm-voice] Failed to end session: ${err instanceof Error ? err.message : String(err)}`,
             );
           }
+          resolveKeepAlive();
           process.exit(0);
         };
         process.once("SIGINT", () => void cleanup());
         process.once("SIGTERM", () => void cleanup());
-        // Keep the event loop alive until a signal fires.
-        await new Promise<void>((_resolve) => {
-          /* intentionally unresolved — exits via signal handlers above */
-        });
+        await keepAlive;
       }
     });
 

--- a/extensions/stimm-voice/src/cli.ts
+++ b/extensions/stimm-voice/src/cli.ts
@@ -1,0 +1,482 @@
+/**
+ * CLI subcommand registration for the stimm-voice plugin.
+ *
+ * Exposes `openclaw voice [start|stop|status|setup]` commands.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import qrcode from "qrcode-terminal";
+import type { StimmVoiceConfig } from "./config.js";
+
+type VoiceSession = {
+  roomName: string;
+  clientToken: string;
+  createdAt: number;
+  originChannel: string;
+  supervisor: { connected: boolean };
+  shareUrl?: string;
+  claimToken?: string;
+};
+
+type RoomManager = {
+  createSession: (opts: { roomName?: string; originChannel: string }) => Promise<VoiceSession>;
+  endSession: (room: string) => Promise<boolean>;
+  listSessions: () => VoiceSession[];
+};
+
+type SupervisorObsEvent = {
+  component: string;
+  event: string;
+  inference_seq?: number;
+  latency_ms?: number;
+  structured_json?: boolean;
+  action?: string;
+  reason?: string;
+  text_chars?: number;
+};
+
+const supportsAnsi =
+  Boolean(process.stdout?.isTTY) &&
+  !Object.prototype.hasOwnProperty.call(process.env, "NO_COLOR") &&
+  process.env.FORCE_COLOR !== "0";
+
+function color(code: string, value: string): string {
+  if (!supportsAnsi) return value;
+  return `\u001b[${code}m${value}\u001b[0m`;
+}
+
+function heading(value: string): string {
+  return color("1;36", value);
+}
+
+function key(value: string): string {
+  return color("2", value);
+}
+
+function ok(value: string): string {
+  return color("32", value);
+}
+
+function warn(value: string): string {
+  return color("33", value);
+}
+
+function info(value: string): string {
+  return color("36", value);
+}
+
+function renderQrAscii(data: string): Promise<string> {
+  return new Promise((resolve) => {
+    qrcode.generate(data, { small: true }, (output: string) => {
+      resolve(output.trimEnd());
+    });
+  });
+}
+
+function parseObsEventFromLine(line: string): SupervisorObsEvent | null {
+  const marker = "OBS_JSON ";
+  const markerIndex = line.indexOf(marker);
+  if (markerIndex === -1) return null;
+  const payload = line.slice(markerIndex + marker.length).trim();
+  try {
+    const parsed = JSON.parse(payload) as SupervisorObsEvent;
+    if (parsed.component !== "conversation_supervisor" || typeof parsed.event !== "string") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function formatObsEvent(event: SupervisorObsEvent): string {
+  const seq = event.inference_seq ?? "?";
+  if (event.event === "inference_started") {
+    return `${heading(`[SUPERVISOR #${seq}]`)} ${info("inference_started")}`;
+  }
+  if (event.event === "inference_completed") {
+    const structured = event.structured_json ? ok("yes") : warn("no");
+    const reason = event.reason && event.reason.trim().length > 0 ? event.reason : "n/a";
+    return [
+      `${heading(`[SUPERVISOR #${seq}]`)} ${info("inference_completed")}`,
+      `  ${key("latency_ms")}: ${event.latency_ms ?? "?"}`,
+      `  ${key("structured_json")}: ${structured}`,
+      `  ${key("action")}: ${event.action ?? "n/a"}`,
+      `  ${key("reason")}: ${reason}`,
+    ].join("\n");
+  }
+  if (event.event === "trigger_sent") {
+    return [
+      `${heading(`[SUPERVISOR #${seq}]`)} ${ok("trigger_sent")}`,
+      `  ${key("text_chars")}: ${event.text_chars ?? "?"}`,
+    ].join("\n");
+  }
+  if (event.event === "no_action") {
+    return `${heading(`[SUPERVISOR #${seq}]`)} ${warn("no_action")}`;
+  }
+  return `${heading(`[SUPERVISOR #${seq}]`)} ${event.event}`;
+}
+
+function takeLast<T>(items: T[], limit: number): T[] {
+  return items.slice(Math.max(0, items.length - limit));
+}
+
+function resolveLatestGatewayLogFile(): string | null {
+  const dir = "/tmp/openclaw";
+  if (!existsSync(dir)) return null;
+  const files = readdirSync(dir)
+    .filter((name) => /^openclaw-\d{4}-\d{2}-\d{2}\.log$/.test(name))
+    .sort();
+  if (files.length === 0) return null;
+  return `${dir}/${files[files.length - 1]}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function extractGatewayMessage(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{")) return line;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const message = parsed["1"];
+    if (typeof message === "string") return message;
+  } catch {
+    /* ignore JSON parse errors */
+  }
+  return line;
+}
+
+function decodeHeavyEscapes(line: string): string {
+  const backslashCount = (line.match(/\\/g) ?? []).length;
+  if (backslashCount < 8) return line;
+  try {
+    return JSON.parse(`"${line.replace(/"/g, '\\"')}"`) as string;
+  } catch {
+    return line.replace(/\\\\/g, "\\");
+  }
+}
+
+function dedupeConsecutive(lines: string[]): string[] {
+  const result: string[] = [];
+  for (const line of lines) {
+    if (result.length === 0 || result[result.length - 1] !== line) {
+      result.push(line);
+    }
+  }
+  return result;
+}
+
+function shouldDisplayObsEvent(event: SupervisorObsEvent, includeStarted: boolean): boolean {
+  if (includeStarted) return true;
+  return event.event !== "inference_started";
+}
+
+interface VoiceCliDeps {
+  program: {
+    command: (name: string) => {
+      description: (d: string) => any;
+      option: (flags: string, desc: string, defaultValue?: string) => any;
+      action: (fn: (...args: any[]) => Promise<void>) => any;
+    };
+  };
+  config: StimmVoiceConfig;
+  ensureRuntime: () => Promise<{ roomManager: RoomManager }>;
+  logger: { info: (message: string) => void; error: (message: string) => void };
+  /** Extension root directory (for venv detection in setup). */
+  extensionDir?: string;
+}
+
+export function registerStimmVoiceCli(deps: VoiceCliDeps): void {
+  const { program, config, ensureRuntime, logger } = deps;
+
+  const voice = program,
+    cmd = voice.command("voice");
+  cmd
+    .description("Stimm voice session management")
+    .option("--channel <channel>", "Origin channel for routing", "web");
+
+  const start = program.command("voice:start");
+  start
+    .description("Start a new voice session")
+    .option("--channel <channel>", "Origin channel", "web")
+    .option("--room <name>", "Custom room name")
+    .option("--wait", "Keep process alive and end the session on exit (Ctrl+C / SIGTERM)")
+    .action(async (opts: { channel: string; room?: string; wait?: boolean }) => {
+      if (!config.enabled) {
+        logger.error("[stimm-voice] Plugin is disabled. Set stimm-voice.enabled=true in config.");
+        return;
+      }
+      const rt = await ensureRuntime();
+      const session = await rt.roomManager.createSession({
+        roomName: opts.room,
+        originChannel: opts.channel,
+      });
+      logger.info(`Voice session started!`);
+      logger.info(`  Room:  ${session.roomName}`);
+      if (session.shareUrl) {
+        logger.info(`  Share URL: ${session.shareUrl}`);
+        if (session.claimToken) {
+          logger.info(`  Claim token: ${session.claimToken}`);
+        }
+        const qr = await renderQrAscii(session.shareUrl);
+        logger.info("  Scan this QR code from your phone:");
+        logger.info("");
+        for (const line of qr.split("\n")) {
+          logger.info(`  ${line}`);
+        }
+        logger.info("");
+        logger.info(`  Open the Share URL on your phone to connect.`);
+      } else {
+        logger.info(`  Token: ${session.clientToken}`);
+        logger.info(`  Use this token to connect from a LiveKit client.`);
+      }
+
+      if (opts.wait) {
+        logger.info(`  Press Ctrl+C (or send SIGTERM) to end the session and exit.`);
+        let exiting = false;
+        const cleanup = async () => {
+          if (exiting) return;
+          exiting = true;
+          logger.info(`\n[stimm-voice] Ending session "${session.roomName}"…`);
+          try {
+            const rt2 = await ensureRuntime();
+            const ok = await rt2.roomManager.endSession(session.roomName);
+            if (ok) {
+              logger.info(`[stimm-voice] Session ended.`);
+            } else {
+              logger.info(`[stimm-voice] Session already gone (remote teardown?).`);
+            }
+          } catch (err) {
+            logger.error(
+              `[stimm-voice] Failed to end session: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          process.exit(0);
+        };
+        process.once("SIGINT", () => void cleanup());
+        process.once("SIGTERM", () => void cleanup());
+        // Keep the event loop alive until a signal fires.
+        await new Promise<void>((_resolve) => {
+          /* intentionally unresolved — exits via signal handlers above */
+        });
+      }
+    });
+
+  const stop = program.command("voice:stop");
+  stop
+    .description("Stop a voice session")
+    .option("--room <name>", "Room name to stop")
+    .action(async (opts: { room: string }) => {
+      if (!opts.room) {
+        logger.error("--room is required");
+        return;
+      }
+      const rt = await ensureRuntime();
+      const ok = await rt.roomManager.endSession(opts.room);
+      if (ok) {
+        logger.info(`Voice session stopped: ${opts.room}`);
+      } else {
+        logger.error(`No active session found: ${opts.room}`);
+      }
+    });
+
+  const status = program.command("voice:status");
+  status.description("List active voice sessions").action(async () => {
+    const rt = await ensureRuntime();
+    const sessions = rt.roomManager.listSessions();
+    if (sessions.length === 0) {
+      logger.info("No active voice sessions.");
+      return;
+    }
+    for (const s of sessions) {
+      const age = Math.round((Date.now() - s.createdAt) / 1000);
+      logger.info(
+        `  ${s.roomName}  channel=${s.originChannel}  age=${age}s  supervisor=${s.supervisor.connected ? "connected" : "disconnected"}`,
+      );
+    }
+  });
+
+  const setup = program.command("voice:setup");
+  setup
+    .description("Interactive setup wizard — choose providers, models, and API keys")
+    .action(async () => {
+      const { runSetupWizard } = await import("./setup-wizard.js");
+      await runSetupWizard({
+        logger,
+        extensionDir: deps.extensionDir ?? "",
+      });
+    });
+
+  const doctor = program.command("voice:doctor");
+  doctor.description("Check voice pipeline prerequisites").action(async () => {
+    const { spawnSync } = await import("node:child_process");
+
+    if (config.access.mode === "quick-tunnel") {
+      const probe = spawnSync("cloudflared", ["--version"], { encoding: "utf8" });
+      if (probe.status === 0) {
+        logger.info("  ✅ cloudflared: installed");
+      } else {
+        logger.info(
+          "  ❌ cloudflared: not installed — https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
+        );
+      }
+      logger.info("  ℹ️  Access mode: quick-tunnel");
+    } else {
+      logger.info("  ℹ️  Access mode: none (no public tunnel)");
+    }
+
+    // Check LiveKit config.
+    logger.info(`  ℹ️  LiveKit: ${config.livekit.url}`);
+
+    // Check plugin enabled.
+    if (config.enabled) {
+      logger.info("  ✅ Plugin: enabled");
+    } else {
+      logger.info("  ❌ Plugin: disabled — set stimm-voice.enabled=true");
+    }
+  });
+
+  const logs = program.command("voice:logs");
+  logs
+    .description("Show supervisor observability logs (OBS_JSON + gateway summary)")
+    .option("--limit <n>", "Number of entries to show", "40")
+    .option("--raw", "Show raw OBS_JSON lines from /tmp/stimm-agent.log")
+    .option("--all-events", "Include inference_started events (default hides them)")
+    .option("--watch", "Watch logs continuously (Ctrl+C to stop)")
+    .option("--interval <s>", "Watch refresh interval in seconds", "2")
+    .action(
+      async (opts: {
+        limit?: string;
+        raw?: boolean;
+        allEvents?: boolean;
+        watch?: boolean;
+        interval?: string;
+      }) => {
+        const limit = Math.max(1, Number.parseInt(opts.limit ?? "40", 10) || 40);
+        const intervalSeconds = Math.max(1, Number.parseInt(opts.interval ?? "2", 10) || 2);
+        const intervalMs = intervalSeconds * 1000;
+        const stimmLogFile = "/tmp/stimm-agent.log";
+
+        if (!existsSync(stimmLogFile)) {
+          logger.error("stimm log file not found: /tmp/stimm-agent.log");
+          return;
+        }
+
+        const printSnapshot = (
+          onlyNew: boolean,
+          previousObsCount = 0,
+          previousGatewayCount = 0,
+        ) => {
+          const stimmLines = readFileSync(stimmLogFile, "utf8").split(/\r?\n/);
+          const obsLines = stimmLines.filter((line) => line.includes("OBS_JSON "));
+          const obsSlice = onlyNew ? obsLines.slice(previousObsCount) : takeLast(obsLines, limit);
+
+          if (!onlyNew) {
+            logger.info(heading(`Supervisor OBS source: ${stimmLogFile}`));
+          }
+          if (obsLines.length === 0) {
+            if (!onlyNew) logger.info("No OBS_JSON lines found yet.");
+          } else if (obsSlice.length === 0 && onlyNew) {
+            // Stay silent during watch when nothing new happened.
+          } else if (opts.raw) {
+            for (const line of dedupeConsecutive(obsSlice).map((entry) =>
+              decodeHeavyEscapes(entry),
+            )) {
+              logger.info(line);
+            }
+          } else {
+            const events = obsSlice
+              .map((line) => parseObsEventFromLine(line))
+              .filter((event): event is SupervisorObsEvent => Boolean(event))
+              .filter((event) => shouldDisplayObsEvent(event, Boolean(opts.allEvents)));
+            if (events.length === 0) {
+              if (!onlyNew) {
+                logger.info(key("No parseable OBS_JSON events."));
+              }
+            } else {
+              for (const event of events) {
+                logger.info(formatObsEvent(event));
+              }
+            }
+          }
+
+          const gatewayLogFile = resolveLatestGatewayLogFile();
+          if (!gatewayLogFile || !existsSync(gatewayLogFile)) {
+            logger.info("Gateway log file not found under /tmp/openclaw.");
+            return {
+              obsCount: obsLines.length,
+              gatewayCount: 0,
+              gatewayPath: null as string | null,
+            };
+          }
+
+          const gatewayLines = readFileSync(gatewayLogFile, "utf8")
+            .split(/\r?\n/)
+            .map((line) => extractGatewayMessage(line))
+            .filter((line) => line.includes("[stimm-voice:supervisor]"));
+          const gatewaySlice = onlyNew
+            ? gatewayLines.slice(previousGatewayCount)
+            : takeLast(gatewayLines, limit);
+
+          if (!onlyNew) {
+            logger.info(heading(`Gateway supervisor source: ${gatewayLogFile}`));
+          }
+          if (gatewayLines.length === 0) {
+            if (!onlyNew) logger.info("No [stimm-voice:supervisor] lines found yet.");
+          } else if (gatewaySlice.length === 0 && onlyNew) {
+            // Stay silent during watch when nothing new happened.
+          } else {
+            for (const line of dedupeConsecutive(gatewaySlice).map((entry) =>
+              decodeHeavyEscapes(entry),
+            )) {
+              logger.info(line);
+            }
+          }
+
+          return {
+            obsCount: obsLines.length,
+            gatewayCount: gatewayLines.length,
+            gatewayPath: gatewayLogFile,
+          };
+        };
+
+        const firstSnapshot = printSnapshot(false);
+
+        if (!opts.watch) {
+          return;
+        }
+
+        logger.info(info(`Watching logs every ${intervalSeconds}s. Press Ctrl+C to stop.`));
+
+        let running = true;
+        let obsCount = firstSnapshot.obsCount;
+        let gatewayCount = firstSnapshot.gatewayCount;
+        let gatewayPath = firstSnapshot.gatewayPath;
+
+        const stop = () => {
+          running = false;
+        };
+        process.once("SIGINT", stop);
+        process.once("SIGTERM", stop);
+
+        try {
+          while (running) {
+            await sleep(intervalMs);
+            if (!running) break;
+
+            const latestGatewayPath = resolveLatestGatewayLogFile();
+            const gatewayRotated = latestGatewayPath !== gatewayPath;
+            const snapshot = printSnapshot(true, obsCount, gatewayRotated ? 0 : gatewayCount);
+            obsCount = snapshot.obsCount;
+            gatewayCount = snapshot.gatewayCount;
+            gatewayPath = snapshot.gatewayPath;
+          }
+        } finally {
+          process.off("SIGINT", stop);
+          process.off("SIGTERM", stop);
+        }
+      },
+    );
+}

--- a/extensions/stimm-voice/src/config.test.ts
+++ b/extensions/stimm-voice/src/config.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveStimmVoiceConfig, StimmVoiceConfigSchema, providerEnvVar } from "./config.js";
+
+// Env vars that may affect config resolution.
+const ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "DEEPGRAM_API_KEY",
+  "ELEVENLABS_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GOOGLE_API_KEY",
+  "GROQ_API_KEY",
+  "CARTESIA_API_KEY",
+  "STIMM_STT_API_KEY",
+  "STIMM_TTS_API_KEY",
+  "STIMM_LLM_API_KEY",
+  "LIVEKIT_URL",
+  "LIVEKIT_API_KEY",
+  "LIVEKIT_API_SECRET",
+  "STIMM_SUPERVISOR_SECRET",
+  "OPENCLAW_SUPERVISOR_SECRET",
+] as const;
+
+describe("config", () => {
+  describe("providerEnvVar", () => {
+    it("maps known providers to env var names", () => {
+      expect(providerEnvVar("openai")).toBe("OPENAI_API_KEY");
+      expect(providerEnvVar("deepgram")).toBe("DEEPGRAM_API_KEY");
+      expect(providerEnvVar("elevenlabs")).toBe("ELEVENLABS_API_KEY");
+      expect(providerEnvVar("anthropic")).toBe("ANTHROPIC_API_KEY");
+      expect(providerEnvVar("google")).toBe("GOOGLE_API_KEY");
+      expect(providerEnvVar("groq")).toBe("GROQ_API_KEY");
+      expect(providerEnvVar("cartesia")).toBe("CARTESIA_API_KEY");
+    });
+
+    it("returns undefined for unknown providers", () => {
+      expect(providerEnvVar("not-a-provider")).toBeUndefined();
+    });
+  });
+
+  describe("resolveStimmVoiceConfig", () => {
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      // Save and clear env vars that affect resolution.
+      for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) {
+        if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+        else delete process.env[key];
+      }
+    });
+
+    // -- Defaults -----------------------------------------------------------
+
+    it("returns sensible defaults when given empty input", () => {
+      const cfg = resolveStimmVoiceConfig({});
+      expect(cfg.enabled).toBe(false);
+      expect(cfg.livekit.url).toBe("ws://localhost:7880");
+      expect(cfg.livekit.apiKey).toBe("devkey");
+      expect(cfg.livekit.apiSecret).toBe("secret");
+      expect(cfg.voiceAgent.docker).toBe(true);
+      expect(cfg.voiceAgent.mode).toBe("hybrid");
+      expect(cfg.voiceAgent.bufferingLevel).toBe("MEDIUM");
+      // STT defaults
+      expect(cfg.voiceAgent.stt.provider).toBe("deepgram");
+      expect(cfg.voiceAgent.stt.model).toBe("nova-3");
+      expect(cfg.voiceAgent.stt.apiKey).toBeUndefined();
+      // TTS defaults
+      expect(cfg.voiceAgent.tts.provider).toBe("openai");
+      expect(cfg.voiceAgent.tts.model).toBe("gpt-4o-mini-tts");
+      expect(cfg.voiceAgent.tts.voice).toBe("ash");
+      expect(cfg.voiceAgent.tts.apiKey).toBeUndefined();
+      // LLM defaults
+      expect(cfg.voiceAgent.llm.provider).toBe("openai");
+      expect(cfg.voiceAgent.llm.model).toBe("gpt-4o-mini");
+      expect(cfg.voiceAgent.llm.apiKey).toBeUndefined();
+      // Web
+      expect(cfg.web.enabled).toBe(true);
+      expect(cfg.web.path).toBe("/voice");
+      // Access
+      expect(cfg.access.mode).toBe("none");
+      expect(cfg.access.claimTtlSeconds).toBe(120);
+      expect(cfg.access.livekitTokenTtlSeconds).toBe(300);
+      expect(cfg.access.supervisorSecret).toBeUndefined();
+      expect(cfg.access.allowDirectWebSessionCreate).toBe(false);
+      expect(cfg.access.claimRateLimitPerMinute).toBe(20);
+    });
+
+    it("accepts null/undefined/non-object input gracefully", () => {
+      expect(resolveStimmVoiceConfig(null).enabled).toBe(false);
+      expect(resolveStimmVoiceConfig(undefined).enabled).toBe(false);
+      expect(resolveStimmVoiceConfig("garbage").enabled).toBe(false);
+      expect(resolveStimmVoiceConfig(42).enabled).toBe(false);
+    });
+
+    // -- Overrides ----------------------------------------------------------
+
+    it("merges partial overrides", () => {
+      const cfg = resolveStimmVoiceConfig({
+        enabled: true,
+        livekit: { url: "wss://my-livekit.example.com" },
+        voiceAgent: {
+          mode: "relay",
+          llm: { model: "claude-sonnet-4-20250514", provider: "anthropic" },
+        },
+      });
+      expect(cfg.enabled).toBe(true);
+      expect(cfg.livekit.url).toBe("wss://my-livekit.example.com");
+      expect(cfg.livekit.apiKey).toBe("devkey");
+      expect(cfg.voiceAgent.mode).toBe("relay");
+      expect(cfg.voiceAgent.llm.model).toBe("claude-sonnet-4-20250514");
+      expect(cfg.voiceAgent.llm.provider).toBe("anthropic");
+      expect(cfg.voiceAgent.stt.provider).toBe("deepgram");
+    });
+
+    it("allows choosing all STT providers", () => {
+      for (const provider of ["deepgram", "openai", "google", "azure", "assemblyai", "aws"]) {
+        const cfg = resolveStimmVoiceConfig({ voiceAgent: { stt: { provider } } });
+        expect(cfg.voiceAgent.stt.provider).toBe(provider);
+      }
+    });
+
+    it("allows choosing all TTS providers", () => {
+      for (const provider of ["openai", "elevenlabs", "cartesia", "google", "azure", "aws"]) {
+        const cfg = resolveStimmVoiceConfig({ voiceAgent: { tts: { provider } } });
+        expect(cfg.voiceAgent.tts.provider).toBe(provider);
+      }
+    });
+
+    it("allows choosing all LLM providers", () => {
+      for (const provider of ["openai", "anthropic", "google", "groq", "azure", "cerebras"]) {
+        const cfg = resolveStimmVoiceConfig({ voiceAgent: { llm: { provider } } });
+        expect(cfg.voiceAgent.llm.provider).toBe(provider);
+      }
+    });
+
+    it("validates provider enum values", () => {
+      expect(() =>
+        StimmVoiceConfigSchema.parse({ voiceAgent: { stt: { provider: "bogus" } } }),
+      ).toThrow();
+      expect(() =>
+        StimmVoiceConfigSchema.parse({ voiceAgent: { tts: { provider: "bogus" } } }),
+      ).toThrow();
+      expect(() =>
+        StimmVoiceConfigSchema.parse({ voiceAgent: { llm: { provider: "bogus" } } }),
+      ).toThrow();
+      expect(() => StimmVoiceConfigSchema.parse({ voiceAgent: { mode: "invalid" } })).toThrow();
+      expect(() =>
+        StimmVoiceConfigSchema.parse({ voiceAgent: { bufferingLevel: "SUPER" } }),
+      ).toThrow();
+    });
+
+    it("accepts per-pipeline API keys in config", () => {
+      const cfg = resolveStimmVoiceConfig({
+        voiceAgent: {
+          stt: { apiKey: "dg-test" },
+          tts: { apiKey: "sk-tts-test" },
+          llm: { apiKey: "sk-llm-test" },
+        },
+      });
+      expect(cfg.voiceAgent.stt.apiKey).toBe("dg-test");
+      expect(cfg.voiceAgent.tts.apiKey).toBe("sk-tts-test");
+      expect(cfg.voiceAgent.llm.apiKey).toBe("sk-llm-test");
+    });
+
+    it("disables web endpoint when overridden", () => {
+      const cfg = resolveStimmVoiceConfig({ web: { enabled: false } });
+      expect(cfg.web.enabled).toBe(false);
+    });
+
+    // -- Per-pipeline env-var fallback chain --------------------------------
+
+    describe("per-pipeline API key env-var fallbacks", () => {
+      it("STT: STIMM_STT_API_KEY takes priority over provider env", () => {
+        process.env.STIMM_STT_API_KEY = "stimm-stt";
+        process.env.DEEPGRAM_API_KEY = "dg-env";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.voiceAgent.stt.apiKey).toBe("stimm-stt");
+      });
+
+      it("STT: falls back to provider-specific env when no STIMM_STT_API_KEY", () => {
+        process.env.DEEPGRAM_API_KEY = "dg-env";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.voiceAgent.stt.apiKey).toBe("dg-env");
+      });
+
+      it("TTS: STIMM_TTS_API_KEY takes priority over provider env", () => {
+        process.env.STIMM_TTS_API_KEY = "stimm-tts";
+        process.env.OPENAI_API_KEY = "sk-env";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.voiceAgent.tts.apiKey).toBe("stimm-tts");
+      });
+
+      it("TTS: falls back to provider-specific env (e.g. ELEVENLABS_API_KEY)", () => {
+        process.env.ELEVENLABS_API_KEY = "el-env";
+        const cfg = resolveStimmVoiceConfig({
+          voiceAgent: { tts: { provider: "elevenlabs" } },
+        });
+        expect(cfg.voiceAgent.tts.apiKey).toBe("el-env");
+      });
+
+      it("LLM: STIMM_LLM_API_KEY takes priority over provider env", () => {
+        process.env.STIMM_LLM_API_KEY = "stimm-llm";
+        process.env.OPENAI_API_KEY = "sk-env";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.voiceAgent.llm.apiKey).toBe("stimm-llm");
+      });
+
+      it("LLM: falls back to ANTHROPIC_API_KEY when provider is anthropic", () => {
+        process.env.ANTHROPIC_API_KEY = "ant-env";
+        const cfg = resolveStimmVoiceConfig({
+          voiceAgent: { llm: { provider: "anthropic" } },
+        });
+        expect(cfg.voiceAgent.llm.apiKey).toBe("ant-env");
+      });
+
+      it("explicit config apiKey takes precedence over all env vars", () => {
+        process.env.STIMM_STT_API_KEY = "stimm-stt";
+        process.env.DEEPGRAM_API_KEY = "dg-env";
+        const cfg = resolveStimmVoiceConfig({
+          voiceAgent: { stt: { apiKey: "explicit-key" } },
+        });
+        expect(cfg.voiceAgent.stt.apiKey).toBe("explicit-key");
+      });
+    });
+
+    // -- LiveKit env fallbacks ----------------------------------------------
+
+    describe("LiveKit env-var fallbacks", () => {
+      it("falls back to LIVEKIT_URL env var", () => {
+        process.env.LIVEKIT_URL = "wss://cloud.livekit.io";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.livekit.url).toBe("wss://cloud.livekit.io");
+      });
+
+      it("falls back to LIVEKIT_API_KEY / LIVEKIT_API_SECRET env vars", () => {
+        process.env.LIVEKIT_API_KEY = "cloud-key";
+        process.env.LIVEKIT_API_SECRET = "cloud-secret";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.livekit.apiKey).toBe("cloud-key");
+        expect(cfg.livekit.apiSecret).toBe("cloud-secret");
+      });
+    });
+
+    describe("access env-var fallbacks", () => {
+      it("falls back to STIMM_SUPERVISOR_SECRET", () => {
+        process.env.STIMM_SUPERVISOR_SECRET = "stimm-secret";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.access.supervisorSecret).toBe("stimm-secret");
+      });
+
+      it("falls back to OPENCLAW_SUPERVISOR_SECRET", () => {
+        process.env.OPENCLAW_SUPERVISOR_SECRET = "openclaw-secret";
+        const cfg = resolveStimmVoiceConfig({});
+        expect(cfg.access.supervisorSecret).toBe("openclaw-secret");
+      });
+    });
+
+    // -- Spawn config -------------------------------------------------------
+
+    it("returns spawn defaults", () => {
+      const cfg = resolveStimmVoiceConfig({});
+      expect(cfg.voiceAgent.spawn.autoSpawn).toBe(true);
+      expect(cfg.voiceAgent.spawn.pythonPath).toBeUndefined();
+      expect(cfg.voiceAgent.spawn.agentScript).toBeUndefined();
+      expect(cfg.voiceAgent.spawn.maxRestarts).toBe(5);
+    });
+
+    it("accepts spawn overrides", () => {
+      const cfg = resolveStimmVoiceConfig({
+        voiceAgent: {
+          spawn: {
+            autoSpawn: false,
+            pythonPath: "/usr/bin/python3",
+            maxRestarts: 10,
+          },
+        },
+      });
+      expect(cfg.voiceAgent.spawn.autoSpawn).toBe(false);
+      expect(cfg.voiceAgent.spawn.pythonPath).toBe("/usr/bin/python3");
+      expect(cfg.voiceAgent.spawn.maxRestarts).toBe(10);
+    });
+  });
+});

--- a/extensions/stimm-voice/src/config.ts
+++ b/extensions/stimm-voice/src/config.ts
@@ -1,0 +1,247 @@
+/**
+ * Stimm Voice plugin configuration — Zod schema + types.
+ *
+ * Each voice pipeline (STT, TTS, LLM) is independently configurable:
+ *   provider  — which livekit-plugins-* to use
+ *   model     — model name string passed to the plugin constructor
+ *   apiKey    — API key for that provider (env-var fallback chain)
+ *
+ * Config path: plugins.entries.stimm-voice.config.*
+ * Example:
+ *   openclaw config set plugins.entries.stimm-voice.config.voiceAgent.tts.provider elevenlabs
+ *   openclaw config set plugins.entries.stimm-voice.config.voiceAgent.tts.model eleven_turbo_v2_5
+ *   openclaw config set plugins.entries.stimm-voice.config.voiceAgent.tts.apiKey sk-...
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Provider lists — all livekit-agents plugins available on PyPI (v1.4.x).
+// Keep these in sync when new plugins are released.
+// ---------------------------------------------------------------------------
+
+/** STT providers supported by livekit-plugins-*. */
+export const STT_PROVIDERS = [
+  "deepgram",
+  "openai",
+  "google",
+  "azure",
+  "assemblyai",
+  "aws",
+  "speechmatics",
+  "clova",
+  "fal",
+] as const;
+
+/** TTS providers supported by livekit-plugins-*. */
+export const TTS_PROVIDERS = [
+  "openai",
+  "elevenlabs",
+  "cartesia",
+  "google",
+  "azure",
+  "aws",
+  "playai",
+  "rime",
+  "hume",
+] as const;
+
+/** LLM providers supported by livekit-plugins-*. */
+export const LLM_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "groq",
+  "azure",
+  "cerebras",
+  "fireworks",
+  "together",
+  "sambanova",
+] as const;
+
+export type SttProvider = (typeof STT_PROVIDERS)[number];
+export type TtsProvider = (typeof TTS_PROVIDERS)[number];
+export type LlmProvider = (typeof LLM_PROVIDERS)[number];
+
+// ---------------------------------------------------------------------------
+// Per-pipeline schemas — provider + model + apiKey.
+// ---------------------------------------------------------------------------
+
+export const SttConfigSchema = z.object({
+  /** livekit-plugins-* STT provider. */
+  provider: z.enum(STT_PROVIDERS).default("deepgram"),
+  /** Model name passed to the provider constructor (e.g. "nova-3", "gpt-4o-mini-transcribe"). */
+  model: z.string().default("nova-3"),
+  /** API key for the STT provider. Falls back to STIMM_STT_API_KEY → provider-specific env. */
+  apiKey: z.string().optional(),
+  /** Language code (e.g. "en", "en-US"). Provider-dependent. */
+  language: z.string().optional(),
+});
+
+export const TtsConfigSchema = z.object({
+  /** livekit-plugins-* TTS provider. */
+  provider: z.enum(TTS_PROVIDERS).default("openai"),
+  /** Model name (e.g. "gpt-4o-mini-tts", "eleven_turbo_v2_5", "sonic-2"). */
+  model: z.string().default("gpt-4o-mini-tts"),
+  /** Voice selector. OpenAI: name (e.g. "ash"); ElevenLabs: voice_id; Cartesia: voice UUID. */
+  voice: z.string().default("ash"),
+  /** Language code (e.g. "en", "fr"). Provider-dependent (useful for Cartesia, Google, etc.). */
+  language: z.string().optional(),
+  /** API key for the TTS provider. Falls back to STIMM_TTS_API_KEY → provider-specific env. */
+  apiKey: z.string().optional(),
+});
+
+export const LlmConfigSchema = z.object({
+  /** livekit-plugins-* LLM provider. */
+  provider: z.enum(LLM_PROVIDERS).default("openai"),
+  /** Model name (e.g. "gpt-4o-mini", "claude-sonnet-4-20250514", "gemini-2.0-flash"). */
+  model: z.string().default("gpt-4o-mini"),
+  /** Temperature for the LLM generation. */
+  temperature: z.number().min(0).max(2).optional(),
+  /** API key for the LLM provider. Falls back to STIMM_LLM_API_KEY → provider-specific env. */
+  apiKey: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// LiveKit, spawn, web, and top-level schemas.
+// ---------------------------------------------------------------------------
+
+export const LiveKitConfigSchema = z.object({
+  url: z.string().default("ws://localhost:7880"),
+  apiKey: z.string().default("devkey"),
+  apiSecret: z.string().default("secret"),
+});
+
+export const AgentSpawnConfigSchema = z.object({
+  /** Auto-spawn the Python voice agent as a child process of the gateway. */
+  autoSpawn: z.boolean().default(true),
+  /** Path to the Python executable. Resolved from the extension venv by default. */
+  pythonPath: z.string().optional(),
+  /** Path to agent.py. Resolved from the extension dir by default. */
+  agentScript: z.string().optional(),
+  /** Max automatic restarts before giving up. */
+  maxRestarts: z.number().default(5),
+});
+
+export const VoiceAgentConfigSchema = z.object({
+  docker: z.boolean().default(true),
+  image: z.string().default("ghcr.io/stimm-ai/stimm-agent:latest"),
+  stt: SttConfigSchema.default(() => SttConfigSchema.parse({})),
+  tts: TtsConfigSchema.default(() => TtsConfigSchema.parse({})),
+  llm: LlmConfigSchema.default(() => LlmConfigSchema.parse({})),
+  bufferingLevel: z.enum(["NONE", "LOW", "MEDIUM", "HIGH"]).default("MEDIUM"),
+  mode: z.enum(["autonomous", "relay", "hybrid"]).default("hybrid"),
+  spawn: AgentSpawnConfigSchema.default(() => AgentSpawnConfigSchema.parse({})),
+});
+
+export const WebConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  path: z.string().default("/voice"),
+});
+
+export const ACCESS_MODES = ["none", "quick-tunnel"] as const;
+export type AccessMode = (typeof ACCESS_MODES)[number];
+
+export const AccessConfigSchema = z.object({
+  /** Public access mode for browser voice sessions. */
+  mode: z.enum(ACCESS_MODES).default("none"),
+  /** One-time claim token lifetime for `/voice/claim` exchange. */
+  claimTtlSeconds: z.number().int().positive().default(120),
+  /** LiveKit client token lifetime for browser join tokens. */
+  livekitTokenTtlSeconds: z.number().int().positive().default(300),
+  /** Optional shared secret for `POST /stimm/supervisor` hardening. */
+  supervisorSecret: z.string().optional(),
+  /** Allow direct `POST /voice` session creation (dev-only). */
+  allowDirectWebSessionCreate: z.boolean().default(false),
+  /** Claim exchange rate limit per IP per minute. */
+  claimRateLimitPerMinute: z.number().int().positive().default(20),
+});
+
+export const StimmVoiceConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  livekit: LiveKitConfigSchema.default(() => LiveKitConfigSchema.parse({})),
+  voiceAgent: VoiceAgentConfigSchema.default(() => VoiceAgentConfigSchema.parse({})),
+  web: WebConfigSchema.default(() => WebConfigSchema.parse({})),
+  access: AccessConfigSchema.default(() => AccessConfigSchema.parse({})),
+});
+
+export type StimmVoiceConfig = z.infer<typeof StimmVoiceConfigSchema>;
+export type LiveKitConfig = z.infer<typeof LiveKitConfigSchema>;
+export type VoiceAgentConfig = z.infer<typeof VoiceAgentConfigSchema>;
+export type AgentSpawnConfig = z.infer<typeof AgentSpawnConfigSchema>;
+export type SttConfig = z.infer<typeof SttConfigSchema>;
+export type TtsConfig = z.infer<typeof TtsConfigSchema>;
+export type LlmConfig = z.infer<typeof LlmConfigSchema>;
+export type AccessConfig = z.infer<typeof AccessConfigSchema>;
+
+// ---------------------------------------------------------------------------
+// Provider → env-var name map. Used for API key fallback resolution.
+// ---------------------------------------------------------------------------
+
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  deepgram: "DEEPGRAM_API_KEY",
+  elevenlabs: "ELEVENLABS_API_KEY",
+  cartesia: "CARTESIA_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GOOGLE_API_KEY",
+  groq: "GROQ_API_KEY",
+  azure: "AZURE_API_KEY",
+  assemblyai: "ASSEMBLYAI_API_KEY",
+  aws: "AWS_ACCESS_KEY_ID",
+  cerebras: "CEREBRAS_API_KEY",
+  fireworks: "FIREWORKS_API_KEY",
+  together: "TOGETHER_API_KEY",
+  sambanova: "SAMBANOVA_API_KEY",
+  playai: "PLAYAI_API_KEY",
+  rime: "RIME_API_KEY",
+  hume: "HUME_API_KEY",
+  speechmatics: "SPEECHMATICS_API_KEY",
+  clova: "CLOVA_API_KEY",
+  fal: "FAL_KEY",
+};
+
+/** Look up the idiomatic env-var name for a provider's API key. */
+export function providerEnvVar(provider: string): string | undefined {
+  return PROVIDER_ENV_MAP[provider];
+}
+
+/**
+ * Parse raw plugin config into a validated StimmVoiceConfig.
+ * Applies env-var fallback chain for per-pipeline API keys:
+ *   config value → STIMM_{STT|TTS|LLM}_API_KEY → provider-specific env
+ */
+export function resolveStimmVoiceConfig(raw: unknown): StimmVoiceConfig {
+  const value =
+    raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  const config = StimmVoiceConfigSchema.parse(value);
+
+  // Per-pipeline API key fallback chain.
+  config.voiceAgent.stt.apiKey ??=
+    process.env.STIMM_STT_API_KEY ?? providerEnvFallback(config.voiceAgent.stt.provider);
+  config.voiceAgent.tts.apiKey ??=
+    process.env.STIMM_TTS_API_KEY ?? providerEnvFallback(config.voiceAgent.tts.provider);
+  config.voiceAgent.llm.apiKey ??=
+    process.env.STIMM_LLM_API_KEY ?? providerEnvFallback(config.voiceAgent.llm.provider);
+
+  // LiveKit env fallbacks.
+  if (config.livekit.url === "ws://localhost:7880" && process.env.LIVEKIT_URL) {
+    config.livekit.url = process.env.LIVEKIT_URL;
+  }
+  if (config.livekit.apiKey === "devkey" && process.env.LIVEKIT_API_KEY) {
+    config.livekit.apiKey = process.env.LIVEKIT_API_KEY;
+  }
+  if (config.livekit.apiSecret === "secret" && process.env.LIVEKIT_API_SECRET) {
+    config.livekit.apiSecret = process.env.LIVEKIT_API_SECRET;
+  }
+  config.access.supervisorSecret ??=
+    process.env.STIMM_SUPERVISOR_SECRET ?? process.env.OPENCLAW_SUPERVISOR_SECRET;
+
+  return config;
+}
+
+/** Resolve provider-specific env var value, or undefined. */
+function providerEnvFallback(provider: string): string | undefined {
+  const envName = PROVIDER_ENV_MAP[provider];
+  return envName ? process.env[envName] : undefined;
+}

--- a/extensions/stimm-voice/src/core-bridge.ts
+++ b/extensions/stimm-voice/src/core-bridge.ts
@@ -1,0 +1,130 @@
+/**
+ * Core bridge — dynamically imports the OpenClaw extensionAPI from
+ * the built dist/ output to access agent, session, and config helpers.
+ *
+ * Same pattern as voice-call/src/core-bridge.ts.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export type CoreConfig = {
+  session?: { store?: string };
+  messages?: { [key: string]: unknown };
+  [key: string]: unknown;
+};
+
+export type CoreAgentDeps = {
+  resolveAgentDir: (cfg: CoreConfig, agentId: string) => string;
+  resolveAgentWorkspaceDir: (cfg: CoreConfig, agentId: string) => string;
+  resolveAgentIdentity: (
+    cfg: CoreConfig,
+    agentId: string,
+  ) => { name?: string | null } | null | undefined;
+  resolveThinkingDefault: (params: {
+    cfg: CoreConfig;
+    provider?: string;
+    model?: string;
+  }) => string;
+  runEmbeddedPiAgent: (params: {
+    sessionId: string;
+    sessionKey?: string;
+    messageProvider?: string;
+    sessionFile: string;
+    workspaceDir: string;
+    config?: CoreConfig;
+    prompt: string;
+    provider?: string;
+    model?: string;
+    thinkLevel?: string;
+    verboseLevel?: string;
+    timeoutMs: number;
+    runId: string;
+    lane?: string;
+    extraSystemPrompt?: string;
+    agentDir?: string;
+  }) => Promise<{
+    payloads?: Array<{ text?: string; isError?: boolean }>;
+    meta?: { aborted?: boolean };
+  }>;
+  resolveAgentTimeoutMs: (opts: { cfg: CoreConfig }) => number;
+  ensureAgentWorkspace: (params?: { dir: string }) => Promise<void>;
+  resolveStorePath: (store?: string, opts?: { agentId?: string }) => string;
+  loadSessionStore: (storePath: string) => Record<string, unknown>;
+  saveSessionStore: (storePath: string, store: Record<string, unknown>) => Promise<void>;
+  resolveSessionFilePath: (
+    sessionId: string,
+    entry: unknown,
+    opts?: { agentId?: string },
+  ) => string;
+  DEFAULT_MODEL: string;
+  DEFAULT_PROVIDER: string;
+};
+
+let coreRootCache: string | null = null;
+let coreDepsPromise: Promise<CoreAgentDeps> | null = null;
+
+function findPackageRoot(startDir: string, name: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      if (fs.existsSync(pkgPath)) {
+        const raw = fs.readFileSync(pkgPath, "utf8");
+        const pkg = JSON.parse(raw) as { name?: string };
+        if (pkg.name === name) return dir;
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function resolveOpenClawRoot(): string {
+  if (coreRootCache) return coreRootCache;
+
+  const override = process.env.OPENCLAW_ROOT?.trim();
+  if (override) {
+    coreRootCache = override;
+    return override;
+  }
+
+  const candidates = new Set<string>();
+  if (process.argv[1]) candidates.add(path.dirname(process.argv[1]));
+  candidates.add(process.cwd());
+  try {
+    candidates.add(path.dirname(fileURLToPath(import.meta.url)));
+  } catch {
+    /* ignore */
+  }
+
+  for (const start of candidates) {
+    const found = findPackageRoot(start, "openclaw");
+    if (found) {
+      coreRootCache = found;
+      return found;
+    }
+  }
+
+  throw new Error("Unable to resolve core root. Set OPENCLAW_ROOT to the package root.");
+}
+
+async function importCoreExtensionAPI(): Promise<CoreAgentDeps> {
+  const distPath = path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js");
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Missing core module at ${distPath}. Run \`pnpm build\` or install the official package.`,
+    );
+  }
+  return await import(pathToFileURL(distPath).href);
+}
+
+export async function loadCoreAgentDeps(): Promise<CoreAgentDeps> {
+  if (coreDepsPromise) return coreDepsPromise;
+  coreDepsPromise = importCoreExtensionAPI();
+  return coreDepsPromise;
+}

--- a/extensions/stimm-voice/src/quick-tunnel.ts
+++ b/extensions/stimm-voice/src/quick-tunnel.ts
@@ -95,15 +95,14 @@ export async function startQuickTunnel(params: {
     });
 
     proc.stdout?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString();
-      stdoutBuffer += text;
-      maybeResolveFromText(text);
+      stdoutBuffer += chunk.toString();
+      // Run detection on the accumulated buffer so URLs split across chunks are found.
+      maybeResolveFromText(stdoutBuffer);
     });
 
     proc.stderr?.on("data", (chunk: Buffer) => {
-      const text = chunk.toString();
-      stderrBuffer += text;
-      maybeResolveFromText(text);
+      stderrBuffer += chunk.toString();
+      maybeResolveFromText(stderrBuffer);
     });
 
     proc.on("close", (code) => {

--- a/extensions/stimm-voice/src/quick-tunnel.ts
+++ b/extensions/stimm-voice/src/quick-tunnel.ts
@@ -1,0 +1,123 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface QuickTunnelInfo {
+  /** Base public URL returned by cloudflared (e.g. https://abc.trycloudflare.com). */
+  publicBaseUrl: string;
+  /** Full voice URL (publicBaseUrl + web path). */
+  voiceUrl: string;
+}
+
+interface QuickTunnelLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+export interface QuickTunnelRuntime {
+  info: QuickTunnelInfo;
+  stop: () => void;
+  running: () => boolean;
+}
+
+const TRY_CLOUDFLARE_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/gi;
+
+function normalizePath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) return "/voice";
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+export async function startQuickTunnel(params: {
+  gatewayPort: number;
+  webPath: string;
+  logger: QuickTunnelLogger;
+  timeoutMs?: number;
+}): Promise<QuickTunnelRuntime | null> {
+  const timeoutMs = params.timeoutMs ?? 20_000;
+  const localUrl = `http://127.0.0.1:${params.gatewayPort}`;
+  const webPath = normalizePath(params.webPath);
+
+  let proc: ChildProcess;
+  try {
+    proc = spawn(
+      "cloudflared",
+      ["tunnel", "--url", localUrl, "--no-autoupdate", "--metrics", "127.0.0.1:0"],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  } catch {
+    params.logger.error(
+      "[stimm-voice] cloudflared binary not found. Install Cloudflare Tunnel (cloudflared).",
+    );
+    return null;
+  }
+
+  const parse = (text: string): string | null => {
+    const matches = text.match(TRY_CLOUDFLARE_URL_RE);
+    if (!matches || matches.length === 0) return null;
+    return matches[0];
+  };
+
+  return await new Promise<QuickTunnelRuntime | null>((resolve) => {
+    let settled = false;
+    let stderrBuffer = "";
+    let stdoutBuffer = "";
+
+    const finish = (value: QuickTunnelRuntime | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const maybeResolveFromText = (text: string) => {
+      const base = parse(text);
+      if (!base) return false;
+      const info: QuickTunnelInfo = {
+        publicBaseUrl: base,
+        voiceUrl: `${base}${webPath}`,
+      };
+      params.logger.info(`[stimm-voice] 🌐 Quick tunnel ready: ${info.voiceUrl}`);
+      finish({
+        info,
+        stop: () => {
+          if (proc && !proc.killed) proc.kill("SIGTERM");
+        },
+        running: () => !proc.killed && proc.exitCode === null,
+      });
+      return true;
+    };
+
+    proc.on("error", () => {
+      params.logger.error("[stimm-voice] Failed to start cloudflared process.");
+      finish(null);
+    });
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdoutBuffer += text;
+      maybeResolveFromText(text);
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderrBuffer += text;
+      maybeResolveFromText(text);
+    });
+
+    proc.on("close", (code) => {
+      if (settled) return;
+      params.logger.warn(`[stimm-voice] cloudflared exited before URL was ready (code=${code}).`);
+      finish(null);
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      const tail = `${stderrBuffer}\n${stdoutBuffer}`.trim().slice(-300);
+      params.logger.error(`[stimm-voice] Timeout while starting cloudflared quick tunnel. ${tail}`);
+      if (!proc.killed) proc.kill("SIGKILL");
+      finish(null);
+    }, timeoutMs);
+  });
+}

--- a/extensions/stimm-voice/src/response-generator.test.ts
+++ b/extensions/stimm-voice/src/response-generator.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock core-bridge — prevent dynamic import of dist/extensionAPI.js.
+// ---------------------------------------------------------------------------
+
+const mockRunEmbeddedPiAgent = vi.fn(async () => ({
+  payloads: [{ text: "Agent reply here", isError: false }],
+  meta: {},
+}));
+
+vi.mock("./core-bridge.js", () => ({
+  loadCoreAgentDeps: vi.fn(async () => ({
+    resolveAgentDir: () => "/tmp/agent",
+    resolveAgentWorkspaceDir: () => "/tmp/agent/workspace",
+    resolveThinkingDefault: () => "off",
+    runEmbeddedPiAgent: mockRunEmbeddedPiAgent,
+    resolveAgentTimeoutMs: () => 30_000,
+    ensureAgentWorkspace: vi.fn(async () => {}),
+    resolveStorePath: () => "/tmp/sessions.json",
+    loadSessionStore: () => ({}),
+    saveSessionStore: vi.fn(async () => {}),
+    resolveSessionFilePath: () => "/tmp/session.jsonl",
+    DEFAULT_MODEL: "gpt-4o-mini",
+    DEFAULT_PROVIDER: "openai",
+  })),
+}));
+
+// Import after mocks.
+const { generateStimmResponse } = await import("./response-generator.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseCoreConfig = {
+  session: { store: "/tmp/store" },
+  messages: {},
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("generateStimmResponse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns text from the agent pipeline", async () => {
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-1",
+      channel: "web",
+      text: "Hello voice agent",
+    });
+
+    expect(result.text).toBe("Agent reply here");
+    expect(result.error).toBeUndefined();
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "Hello voice agent",
+        messageProvider: "stimm-voice",
+        lane: "voice",
+        verboseLevel: "off",
+      }),
+    );
+  });
+
+  it("returns null text when agent has no payloads", async () => {
+    mockRunEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-2",
+      channel: "telegram",
+      text: "Hmm",
+    });
+
+    expect(result.text).toBeNull();
+  });
+
+  it("returns error when agent aborts", async () => {
+    mockRunEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [],
+      meta: { aborted: true },
+    });
+
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-3",
+      channel: "web",
+      text: "timeout test",
+    });
+
+    expect(result.text).toBeNull();
+    expect(result.error).toContain("aborted");
+  });
+
+  it("filters out error payloads", async () => {
+    mockRunEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [
+        { text: "Error happened", isError: true },
+        { text: "Good reply", isError: false },
+      ],
+      meta: {},
+    });
+
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-4",
+      channel: "web",
+      text: "mixed payloads",
+    });
+
+    expect(result.text).toBe("Good reply");
+  });
+
+  it("joins multiple text payloads with space", async () => {
+    mockRunEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [
+        { text: "Part one.", isError: false },
+        { text: "Part two.", isError: false },
+      ],
+      meta: {},
+    });
+
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-5",
+      channel: "web",
+      text: "multi",
+    });
+
+    expect(result.text).toBe("Part one. Part two.");
+  });
+
+  it("returns error on agent exception", async () => {
+    mockRunEmbeddedPiAgent.mockRejectedValueOnce(new Error("LLM timeout"));
+
+    const result = await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-6",
+      channel: "web",
+      text: "fail",
+    });
+
+    expect(result.text).toBeNull();
+    expect(result.error).toBe("LLM timeout");
+  });
+
+  it("uses custom model when provided", async () => {
+    await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "room-7",
+      channel: "web",
+      text: "custom model",
+      model: "anthropic/claude-sonnet-4-20250514",
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+      }),
+    );
+  });
+
+  it("does not inject an extra system prompt by default", async () => {
+    await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "my-room",
+      channel: "whatsapp",
+      text: "test prompt",
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraSystemPrompt: undefined,
+      }),
+    );
+  });
+
+  it("passes through an explicit extra system prompt override", async () => {
+    await generateStimmResponse({
+      coreConfig: baseCoreConfig,
+      roomName: "my-room",
+      channel: "whatsapp",
+      text: "test prompt",
+      extraSystemPrompt: "explicit supervisor override",
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extraSystemPrompt: "explicit supervisor override",
+      }),
+    );
+  });
+});

--- a/extensions/stimm-voice/src/response-generator.ts
+++ b/extensions/stimm-voice/src/response-generator.ts
@@ -1,0 +1,210 @@
+/**
+ * Stimm voice response generator — routes transcripts through the
+ * embedded Pi agent (same agent infra as messaging/voice-call).
+ *
+ * Text in → agent pipeline → text out.
+ */
+
+import crypto from "node:crypto";
+import { loadCoreAgentDeps, type CoreConfig, type CoreAgentDeps } from "./core-bridge.js";
+
+export type StimmResponseParams = {
+  /** Core OpenClaw config. */
+  coreConfig: CoreConfig;
+  /** Unique room name (used as session scope). */
+  roomName: string;
+  /** Originating channel (e.g. "web", "whatsapp"). */
+  channel: string;
+  /** The user's transcribed text. */
+  text: string;
+  /** Optional model override (e.g. "anthropic/claude-sonnet-4-20250514"). */
+  model?: string;
+  /** Optional explicit system prompt override. By default, none is injected here. */
+  extraSystemPrompt?: string;
+};
+
+export type StimmResponseResult = {
+  text: string | null;
+  error?: string;
+  decision?: {
+    action: "NO_ACTION" | "TRIGGER";
+    reason?: string;
+  };
+  debug?: {
+    provider: string;
+    model: string;
+    payloadCount: number;
+    nonErrorTextCount: number;
+    aborted: boolean;
+    payloadPreview: Array<{ isError: boolean; text: string }>;
+  };
+};
+
+type SupervisorStructuredResponse = {
+  action: "NO_ACTION" | "TRIGGER";
+  text?: string;
+  reason?: string;
+};
+
+type SessionEntry = {
+  sessionId: string;
+  updatedAt: number;
+};
+
+function parseSupervisorStructuredResponse(raw: string): SupervisorStructuredResponse | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<SupervisorStructuredResponse>;
+    if (parsed.action !== "NO_ACTION" && parsed.action !== "TRIGGER") {
+      return null;
+    }
+    return {
+      action: parsed.action,
+      text: typeof parsed.text === "string" ? parsed.text : undefined,
+      reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate a response to a voice transcript using the OpenClaw agent pipeline.
+ *
+ * Creates/reuses a session per room, maintains conversation history,
+ * and gives the agent full tool access.
+ */
+export async function generateStimmResponse(
+  params: StimmResponseParams,
+): Promise<StimmResponseResult> {
+  const { coreConfig, roomName, channel, text, extraSystemPrompt } = params;
+
+  let deps: CoreAgentDeps;
+  try {
+    deps = await loadCoreAgentDeps();
+  } catch (err) {
+    return {
+      text: null,
+      error: err instanceof Error ? err.message : "Unable to load core agent deps",
+    };
+  }
+
+  const cfg = coreConfig;
+  const agentId = "main";
+
+  // Session scoped to roomName so each voice session has its own conversation.
+  const sessionKey = `stimm:${roomName}`;
+
+  // Resolve paths.
+  const storePath = deps.resolveStorePath(cfg.session?.store, { agentId });
+  const agentDir = deps.resolveAgentDir(cfg, agentId);
+  const workspaceDir = deps.resolveAgentWorkspaceDir(cfg, agentId);
+
+  await deps.ensureAgentWorkspace({ dir: workspaceDir });
+
+  // Load or create session entry.
+  const sessionStore = deps.loadSessionStore(storePath);
+  const now = Date.now();
+  let sessionEntry = sessionStore[sessionKey] as SessionEntry | undefined;
+
+  if (!sessionEntry) {
+    sessionEntry = { sessionId: crypto.randomUUID(), updatedAt: now };
+    sessionStore[sessionKey] = sessionEntry;
+    await deps.saveSessionStore(storePath, sessionStore);
+  }
+
+  const sessionId = sessionEntry.sessionId;
+  const sessionFile = deps.resolveSessionFilePath(sessionId, sessionEntry, { agentId });
+
+  // Resolve model from param → agent config primary model → core defaults.
+  // Prefer the configured primary model so the voice lane uses the same
+  // provider the user already set up (e.g. openrouter/gemini) rather than
+  // falling back to the hardcoded anthropic default.
+  const configuredPrimary = (
+    cfg as Record<string, unknown> & { agents?: { defaults?: { model?: { primary?: string } } } }
+  )?.agents?.defaults?.model?.primary;
+  const modelRef =
+    params.model ?? configuredPrimary ?? `${deps.DEFAULT_PROVIDER}/${deps.DEFAULT_MODEL}`;
+  const slashIdx = modelRef.indexOf("/");
+  const provider = slashIdx === -1 ? deps.DEFAULT_PROVIDER : modelRef.slice(0, slashIdx);
+  const model = slashIdx === -1 ? modelRef : modelRef.slice(slashIdx + 1);
+
+  const thinkLevel = deps.resolveThinkingDefault({ cfg, provider, model });
+
+  // Keep OpenClaw-side prompt neutral; stimm owns the 3-way conversation policy.
+  const overridePrompt =
+    typeof extraSystemPrompt === "string" && extraSystemPrompt.trim()
+      ? extraSystemPrompt.trim()
+      : undefined;
+
+  const timeoutMs = deps.resolveAgentTimeoutMs({ cfg });
+  const runId = `stimm:${roomName}:${Date.now()}`;
+
+  try {
+    const result = await deps.runEmbeddedPiAgent({
+      sessionId,
+      sessionKey,
+      messageProvider: "stimm-voice",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: text,
+      provider,
+      model,
+      thinkLevel,
+      verboseLevel: "off",
+      timeoutMs,
+      runId,
+      lane: "voice",
+      extraSystemPrompt: overridePrompt,
+      agentDir,
+    });
+
+    const payloads = result.payloads ?? [];
+    const payloadPreview = payloads.slice(0, 5).map((p) => ({
+      isError: Boolean(p.isError),
+      text: String(p.text ?? "")
+        .trim()
+        .slice(0, 200),
+    }));
+
+    // Extract text payloads from agent result.
+    const texts = payloads
+      .filter((p) => p.text && !p.isError)
+      .map((p) => p.text?.trim())
+      .filter(Boolean);
+    const rawReply = texts.join(" ").trim();
+    const structured = rawReply ? parseSupervisorStructuredResponse(rawReply) : null;
+    let decision: StimmResponseResult["decision"] | undefined;
+    if (structured) {
+      decision = {
+        action: structured.action,
+        reason: structured.reason,
+      };
+    }
+    // Forward raw backend text. Decision parsing/enforcement is handled in stimm.
+    const reply = rawReply || null;
+    const debug: NonNullable<StimmResponseResult["debug"]> = {
+      provider,
+      model,
+      payloadCount: payloads.length,
+      nonErrorTextCount: texts.length,
+      aborted: Boolean(result.meta?.aborted),
+      payloadPreview,
+    };
+
+    if (!reply && result.meta?.aborted) {
+      return { text: null, error: "Agent response was aborted", debug, decision };
+    }
+
+    return { text: reply, debug, decision };
+  } catch (err) {
+    return {
+      text: null,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/extensions/stimm-voice/src/room-manager.test.ts
+++ b/extensions/stimm-voice/src/room-manager.test.ts
@@ -97,6 +97,19 @@ describe("LiveKitRuntime", () => {
       expect(found).toBeDefined();
       expect(found!.roomName).toBe(session.roomName);
     });
+
+    it("rolls back the room when dispatch creation fails", async () => {
+      const runtime = createRuntime();
+      mockCreateDispatch.mockRejectedValueOnce(new Error("dispatch unavailable"));
+
+      await expect(
+        runtime.createSession({ roomName: "rollback-room", originChannel: "web" }),
+      ).rejects.toThrow("dispatch unavailable");
+
+      expect(mockCreateRoom).toHaveBeenCalledWith({ name: "rollback-room", emptyTimeout: 600 });
+      expect(mockDeleteRoom).toHaveBeenCalledWith("rollback-room");
+      expect(runtime.getSession("rollback-room")).toBeUndefined();
+    });
   });
 
   describe("endSession", () => {
@@ -113,8 +126,17 @@ describe("LiveKitRuntime", () => {
       expect(runtime.getSession("to-end")).toBeUndefined();
     });
 
-    it("returns false for unknown room", async () => {
+    it("attempts remote teardown for unknown room and returns true when delete succeeds", async () => {
       const runtime = createRuntime();
+      const ok = await runtime.endSession("nonexistent");
+      expect(ok).toBe(true);
+      expect(mockDeleteRoom).toHaveBeenCalledWith("nonexistent");
+    });
+
+    it("returns false when unknown room teardown also fails remotely", async () => {
+      const runtime = createRuntime();
+      mockDeleteRoom.mockRejectedValueOnce(new Error("room not found"));
+
       const ok = await runtime.endSession("nonexistent");
       expect(ok).toBe(false);
     });

--- a/extensions/stimm-voice/src/room-manager.test.ts
+++ b/extensions/stimm-voice/src/room-manager.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateRoom = vi.fn(async () => ({}));
+const mockDeleteRoom = vi.fn(async () => {});
+const mockCreateDispatch = vi.fn(async () => ({}));
+const mockAddGrant = vi.fn();
+const mockToJwt = vi.fn(async () => "mock-jwt-token");
+
+vi.mock("livekit-server-sdk", () => {
+  return {
+    RoomServiceClient: class FakeRoomService {
+      constructor() {}
+      createRoom = mockCreateRoom;
+      deleteRoom = mockDeleteRoom;
+    },
+    AgentDispatchClient: class FakeDispatchClient {
+      constructor() {}
+      createDispatch = mockCreateDispatch;
+    },
+    AccessToken: class FakeAccessToken {
+      constructor() {}
+      addGrant(grant: unknown) {
+        mockAddGrant(grant);
+      }
+      async toJwt() {
+        return mockToJwt();
+      }
+    },
+  };
+});
+
+const { LiveKitRuntime } = await import("../index.ts");
+
+function createRuntime() {
+  return new LiveKitRuntime({
+    enabled: true,
+    livekit: { url: "ws://localhost:7880", apiKey: "devkey", apiSecret: "secret" },
+    voiceAgent: {
+      docker: true,
+      image: "ghcr.io/stimm-ai/stimm-agent:latest",
+      stt: { provider: "deepgram", model: "nova-3" },
+      tts: { provider: "openai", model: "gpt-4o-mini-tts", voice: "ash" },
+      llm: { provider: "openai", model: "gpt-4o-mini" },
+      bufferingLevel: "MEDIUM",
+      mode: "hybrid",
+      spawn: { autoSpawn: false, maxRestarts: 5 },
+    },
+    web: { enabled: true, path: "/voice" },
+    access: {
+      mode: "none",
+      claimTtlSeconds: 120,
+      livekitTokenTtlSeconds: 300,
+      allowDirectWebSessionCreate: false,
+      claimRateLimitPerMinute: 20,
+    },
+  });
+}
+
+describe("LiveKitRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createSession", () => {
+    it("creates a room, dispatches worker, and returns a tokenized session", async () => {
+      const runtime = createRuntime();
+      const session = await runtime.createSession({ originChannel: "web" });
+
+      expect(mockCreateRoom).toHaveBeenCalled();
+      expect(mockCreateDispatch).toHaveBeenCalled();
+      expect(mockAddGrant).toHaveBeenCalled();
+      expect(session.roomName).toMatch(/^stimm-/);
+      expect(session.clientToken).toBe("mock-jwt-token");
+      expect(session.originChannel).toBe("web");
+      expect(session.createdAt).toBeGreaterThan(0);
+    });
+
+    it("uses a custom room name when provided", async () => {
+      const runtime = createRuntime();
+      const session = await runtime.createSession({
+        roomName: "my-custom-room",
+        originChannel: "telegram",
+      });
+
+      expect(session.roomName).toBe("my-custom-room");
+      expect(session.originChannel).toBe("telegram");
+    });
+
+    it("stores the session for later retrieval", async () => {
+      const runtime = createRuntime();
+      const session = await runtime.createSession({
+        roomName: "lookupable",
+        originChannel: "web",
+      });
+
+      const found = runtime.getSession("lookupable");
+      expect(found).toBeDefined();
+      expect(found!.roomName).toBe(session.roomName);
+    });
+  });
+
+  describe("endSession", () => {
+    it("deletes room and removes the session from map", async () => {
+      const runtime = createRuntime();
+      await runtime.createSession({
+        roomName: "to-end",
+        originChannel: "web",
+      });
+
+      const ok = await runtime.endSession("to-end");
+      expect(ok).toBe(true);
+      expect(mockDeleteRoom).toHaveBeenCalledWith("to-end");
+      expect(runtime.getSession("to-end")).toBeUndefined();
+    });
+
+    it("returns false for unknown room", async () => {
+      const runtime = createRuntime();
+      const ok = await runtime.endSession("nonexistent");
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe("listSessions", () => {
+    it("returns all active sessions", async () => {
+      const runtime = createRuntime();
+      await runtime.createSession({ roomName: "a", originChannel: "web" });
+      await runtime.createSession({ roomName: "b", originChannel: "telegram" });
+
+      const list = runtime.listSessions();
+      expect(list).toHaveLength(2);
+      expect(list.map((s) => s.roomName).sort()).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("stopAll", () => {
+    it("ends all sessions", async () => {
+      const runtime = createRuntime();
+      await runtime.createSession({ roomName: "x", originChannel: "web" });
+      await runtime.createSession({ roomName: "y", originChannel: "web" });
+
+      await runtime.stopAll();
+      expect(runtime.listSessions()).toHaveLength(0);
+      expect(mockDeleteRoom).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("issueClientToken", () => {
+    it("issues token for existing session", async () => {
+      const runtime = createRuntime();
+      await runtime.createSession({ roomName: "token-room", originChannel: "web" });
+
+      const token = await runtime.issueClientToken("token-room");
+      expect(token).toBe("mock-jwt-token");
+    });
+
+    it("throws when session is missing", async () => {
+      const runtime = createRuntime();
+      await expect(runtime.issueClientToken("missing-room")).rejects.toThrow("session not found");
+    });
+  });
+
+  describe("getSession", () => {
+    it("returns undefined for missing session", () => {
+      const runtime = createRuntime();
+      expect(runtime.getSession("nope")).toBeUndefined();
+    });
+  });
+});

--- a/extensions/stimm-voice/src/setup-wizard.ts
+++ b/extensions/stimm-voice/src/setup-wizard.ts
@@ -8,6 +8,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
 import { AgentProcess } from "./agent-process.js";
 import {
   ACCESS_MODES,
@@ -485,14 +486,18 @@ async function fetchJson(
 ): Promise<unknown> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: { ...init, signal: controller.signal },
+  });
   try {
-    const response = await fetch(url, { ...init, signal: controller.signal });
+    clearTimeout(timer);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
     return response.json();
   } finally {
-    clearTimeout(timer);
+    await release();
   }
 }
 
@@ -568,13 +573,17 @@ async function fetchVoicesFromLiveKitDocs(lane: ModelLane, provider: string): Pr
   const url = getLiveKitDocsPluginUrl(lane, provider);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: { signal: controller.signal },
+  });
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
     if (!response.ok) return [];
     const html = await response.text();
     return uniq(extractVoiceLikeTokens(html)).slice(0, 80);
   } finally {
-    clearTimeout(timer);
+    await release();
   }
 }
 
@@ -582,13 +591,17 @@ async function fetchLanguagesFromLiveKitDocs(lane: ModelLane, provider: string):
   const url = getLiveKitDocsPluginUrl(lane, provider);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: { signal: controller.signal },
+  });
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
     if (!response.ok) return [];
     const html = await response.text();
     return uniq(extractLanguageLikeTokens(html)).slice(0, 80);
   } finally {
-    clearTimeout(timer);
+    await release();
   }
 }
 

--- a/extensions/stimm-voice/src/setup-wizard.ts
+++ b/extensions/stimm-voice/src/setup-wizard.ts
@@ -1,0 +1,1544 @@
+/**
+ * Interactive setup wizard for the stimm-voice plugin.
+ *
+ * Quick Tunnel only: no Tailscale legacy path.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { AgentProcess } from "./agent-process.js";
+import {
+  ACCESS_MODES,
+  providerEnvVar,
+  type AccessMode,
+  type LlmProvider,
+  type SttProvider,
+  type TtsProvider,
+} from "./config.js";
+
+// ---------------------------------------------------------------------------
+// Config writer — reads/writes ~/.openclaw/openclaw.json directly.
+// ---------------------------------------------------------------------------
+
+function deepSet(obj: Record<string, unknown>, path: string[], value: unknown): void {
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (typeof current[key] !== "object" || current[key] === null) {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[path[path.length - 1]] = value;
+}
+
+/**
+ * Batch-write multiple config keys into ~/.openclaw/openclaw.json.
+ * Reads once, deep-merges, writes once.
+ */
+function saveConfig(entries: Record<string, unknown>): void {
+  const configPath = join(homedir(), ".openclaw", "openclaw.json");
+  let config: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    config = JSON.parse(readFileSync(configPath, "utf-8"));
+  }
+  for (const [dotKey, value] of Object.entries(entries)) {
+    const fullPath = `plugins.entries.stimm-voice.config.${dotKey}`;
+    deepSet(config, fullPath.split("."), value);
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Config reader — load existing stimm-voice config from openclaw.json.
+// ---------------------------------------------------------------------------
+
+interface ExistingConfig {
+  stt?: { provider?: string; model?: string; language?: string; apiKey?: string };
+  tts?: { provider?: string; model?: string; voice?: string; language?: string; apiKey?: string };
+  llm?: { provider?: string; model?: string; apiKey?: string };
+  livekit?: { url?: string; apiKey?: string; apiSecret?: string };
+  access?: { mode?: string; supervisorSecret?: string };
+}
+
+function deepGet(obj: Record<string, unknown>, path: string[]): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (current === null || current === undefined || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function loadExistingConfig(): ExistingConfig {
+  const configPath = join(homedir(), ".openclaw", "openclaw.json");
+  if (!existsSync(configPath)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const base = deepGet(raw, ["plugins", "entries", "stimm-voice", "config"]) as
+      | Record<string, unknown>
+      | undefined;
+    if (!base) return {};
+    const va = base.voiceAgent as Record<string, unknown> | undefined;
+    return {
+      stt: va?.stt as ExistingConfig["stt"],
+      tts: va?.tts as ExistingConfig["tts"],
+      llm: va?.llm as ExistingConfig["llm"],
+      livekit: base.livekit as ExistingConfig["livekit"],
+      access: base.access as ExistingConfig["access"],
+    };
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// StimmProviders — types for providers.json shipped with the stimm package.
+// Data lives in stimm; openclaw only holds fetch/UI logic.
+// ---------------------------------------------------------------------------
+
+type ProviderApiConf = {
+  kind: string;
+  baseUrl?: string;
+  modelsUrl?: string;
+  voicesUrl?: string;
+  probeUrl?: string;
+  authScheme?: string;
+  authHeader?: string;
+  apiVersion?: string;
+  includeFilter?: string;
+  excludeFilter?: string;
+};
+
+type SttEntry = {
+  id: string;
+  label: string;
+  defaultModel: string;
+  presets: string[];
+  /** Actual constructor parameter name (e.g. "model"). Defaults to "model". */
+  modelParam?: string;
+  api: ProviderApiConf;
+};
+type TtsEntry = {
+  id: string;
+  label: string;
+  defaultModel: string;
+  defaultVoice: string;
+  presets: string[];
+  /** Actual constructor parameter name (e.g. "model_version" for Hume). Defaults to "model". */
+  modelParam?: string;
+  api: ProviderApiConf;
+};
+type LlmEntry = {
+  id: string;
+  label: string;
+  defaultModel: string;
+  presets: string[];
+  /** Actual constructor parameter name. Defaults to "model". */
+  modelParam?: string;
+  api: ProviderApiConf;
+};
+
+type StimmProviders = {
+  stt: SttEntry[];
+  tts: TtsEntry[];
+  llm: LlmEntry[];
+};
+
+type RuntimeProviders = {
+  stt: string[];
+  tts: string[];
+  llm: string[];
+};
+
+type StimmProviderData = {
+  catalog: StimmProviders;
+  runtime: RuntimeProviders;
+};
+
+type ProviderSelection = {
+  stt: string;
+  tts: string;
+  llm: string;
+};
+
+type ExtrasResolution = {
+  extras: string[];
+  command: string;
+};
+
+function normalizeProviderEntry(kind: ModelLane, value: unknown): SttEntry | TtsEntry | LlmEntry {
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  const id = typeof record.id === "string" && record.id.trim().length > 0 ? record.id : "unknown";
+  const label =
+    typeof record.label === "string" && record.label.trim().length > 0 ? record.label : id;
+  const defaultModel =
+    typeof record.defaultModel === "string" && record.defaultModel.trim().length > 0
+      ? record.defaultModel
+      : "default";
+  const presets = Array.isArray(record.presets)
+    ? record.presets.filter((item): item is string => typeof item === "string")
+    : [];
+  const apiRecord =
+    record.api && typeof record.api === "object" && !Array.isArray(record.api)
+      ? (record.api as Record<string, unknown>)
+      : {};
+  const api: ProviderApiConf = {
+    kind:
+      typeof apiRecord.kind === "string" && apiRecord.kind.trim().length > 0
+        ? apiRecord.kind
+        : "livekit-docs",
+    ...(typeof apiRecord.baseUrl === "string" ? { baseUrl: apiRecord.baseUrl } : {}),
+    ...(typeof apiRecord.modelsUrl === "string" ? { modelsUrl: apiRecord.modelsUrl } : {}),
+    ...(typeof apiRecord.voicesUrl === "string" ? { voicesUrl: apiRecord.voicesUrl } : {}),
+    ...(typeof apiRecord.probeUrl === "string" ? { probeUrl: apiRecord.probeUrl } : {}),
+    ...(typeof apiRecord.authScheme === "string" ? { authScheme: apiRecord.authScheme } : {}),
+    ...(typeof apiRecord.authHeader === "string" ? { authHeader: apiRecord.authHeader } : {}),
+    ...(typeof apiRecord.apiVersion === "string" ? { apiVersion: apiRecord.apiVersion } : {}),
+    ...(typeof apiRecord.includeFilter === "string"
+      ? { includeFilter: apiRecord.includeFilter }
+      : {}),
+    ...(typeof apiRecord.excludeFilter === "string"
+      ? { excludeFilter: apiRecord.excludeFilter }
+      : {}),
+  };
+
+  const modelParam =
+    typeof record.modelParam === "string" && record.modelParam.trim().length > 0
+      ? record.modelParam
+      : undefined;
+
+  if (kind === "tts") {
+    return {
+      id,
+      label,
+      defaultModel,
+      defaultVoice:
+        typeof record.defaultVoice === "string" && record.defaultVoice.trim().length > 0
+          ? record.defaultVoice
+          : "default",
+      presets,
+      ...(modelParam ? { modelParam } : {}),
+      api,
+    } satisfies TtsEntry;
+  }
+
+  if (kind === "stt") {
+    return {
+      id,
+      label,
+      defaultModel,
+      presets,
+      ...(modelParam ? { modelParam } : {}),
+      api,
+    } satisfies SttEntry;
+  }
+
+  return {
+    id,
+    label,
+    defaultModel,
+    presets,
+    ...(modelParam ? { modelParam } : {}),
+    api,
+  } satisfies LlmEntry;
+}
+
+function normalizeCatalog(value: unknown): StimmProviders {
+  const record =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  const stt = Array.isArray(record.stt)
+    ? record.stt.map((entry) => normalizeProviderEntry("stt", entry) as SttEntry)
+    : [];
+  const tts = Array.isArray(record.tts)
+    ? record.tts.map((entry) => normalizeProviderEntry("tts", entry) as TtsEntry)
+    : [];
+  const llm = Array.isArray(record.llm)
+    ? record.llm.map((entry) => normalizeProviderEntry("llm", entry) as LlmEntry)
+    : [];
+  return { stt, tts, llm };
+}
+
+function normalizeRuntimeIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        const id = (entry as Record<string, unknown>).id;
+        return typeof id === "string" ? id : "";
+      }
+      return "";
+    })
+    .filter((id) => id.length > 0);
+}
+
+function findPythonForWizard(extensionDir: string): string | null {
+  const venvPython = join(extensionDir, "python", ".venv", "bin", "python");
+  if (existsSync(venvPython)) return venvPython;
+  const system = AgentProcess.findSystemPython();
+  return system ?? null;
+}
+
+function loadStimmProviderData(extensionDir: string): StimmProviderData | null {
+  const pythonExe = findPythonForWizard(extensionDir);
+  if (!pythonExe) return null;
+
+  const script = `
+import json
+from stimm import get_provider_catalog, list_runtime_providers
+
+catalog = get_provider_catalog()
+runtime = {
+    "stt": list_runtime_providers("stt"),
+    "tts": list_runtime_providers("tts"),
+    "llm": list_runtime_providers("llm"),
+}
+
+print(json.dumps({"catalog": catalog, "runtime": runtime}))
+`;
+
+  try {
+    const result = spawnSync(pythonExe, ["-c", script], {
+      encoding: "utf8",
+      timeout: 8_000,
+    });
+    if (result.status !== 0) return null;
+    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+    const runtimeRecord =
+      parsed.runtime && typeof parsed.runtime === "object" && !Array.isArray(parsed.runtime)
+        ? (parsed.runtime as Record<string, unknown>)
+        : {};
+    return {
+      catalog: normalizeCatalog(parsed.catalog),
+      runtime: {
+        stt: normalizeRuntimeIds(runtimeRecord.stt),
+        tts: normalizeRuntimeIds(runtimeRecord.tts),
+        llm: normalizeRuntimeIds(runtimeRecord.llm),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveStimmExtras(
+  pythonExe: string,
+  selection: ProviderSelection,
+): ExtrasResolution | null {
+  const script = `
+import json
+from stimm import required_extras_for_selection, extras_install_command
+
+selection = json.loads(${JSON.stringify(JSON.stringify(selection))})
+extras = required_extras_for_selection(
+    stt=selection.get("stt"),
+    tts=selection.get("tts"),
+    llm=selection.get("llm"),
+)
+command = extras_install_command(
+    stt=selection.get("stt"),
+    tts=selection.get("tts"),
+    llm=selection.get("llm"),
+)
+
+print(json.dumps({"extras": extras, "command": command}))
+`;
+
+  try {
+    const result = spawnSync(pythonExe, ["-c", script], {
+      encoding: "utf8",
+      timeout: 8_000,
+    });
+    if (result.status !== 0) return null;
+    const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+    const extras = Array.isArray(parsed.extras)
+      ? parsed.extras.filter((item): item is string => typeof item === "string")
+      : [];
+    const command = typeof parsed.command === "string" ? parsed.command : "";
+    return { extras, command };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cloudflared helpers (Quick Tunnel).
+// ---------------------------------------------------------------------------
+
+function detectCloudflared(): { installed: boolean; version?: string } {
+  const probe = spawnSync("cloudflared", ["--version"], { encoding: "utf8" });
+  if (probe.status !== 0) return { installed: false };
+  const out = `${probe.stdout ?? ""} ${probe.stderr ?? ""}`.trim();
+  const line = out.split("\n").find((l) => l.toLowerCase().includes("cloudflared")) ?? out;
+  return { installed: true, version: line.trim() || undefined };
+}
+
+function runCommandWithInheritedStdio(
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ ok: boolean; code: number }> {
+  return new Promise((resolve) => {
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawn(cmd, args, { stdio: "inherit" });
+    } catch {
+      resolve({ ok: false, code: -1 });
+      return;
+    }
+    let done = false;
+    const finish = (code: number) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ ok: code === 0, code });
+    };
+    proc.on("error", () => finish(-1));
+    proc.on("close", (code) => finish(code ?? -1));
+    const timer = setTimeout(() => {
+      if (!done) {
+        proc.kill("SIGKILL");
+        finish(-1);
+      }
+    }, timeoutMs);
+  });
+}
+
+async function installCloudflared(): Promise<{ ok: boolean; message: string }> {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === "darwin") {
+    const hasBrew = spawnSync("brew", ["--version"], { stdio: "ignore" }).status === 0;
+    if (!hasBrew) {
+      return { ok: false, message: "Homebrew is required on macOS for automatic install." };
+    }
+    const res = await runCommandWithInheritedStdio("brew", ["install", "cloudflared"], 180_000);
+    return res.ok
+      ? { ok: true, message: "cloudflared installed via Homebrew." }
+      : { ok: false, message: `brew install failed (exit ${res.code}).` };
+  }
+
+  if (platform === "linux") {
+    const binUrl =
+      arch === "arm64"
+        ? "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64"
+        : "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64";
+    const cmd =
+      `curl -fsSL ${JSON.stringify(binUrl)} -o /tmp/cloudflared && ` +
+      "chmod +x /tmp/cloudflared && sudo mv /tmp/cloudflared /usr/local/bin/cloudflared";
+    const res = await runCommandWithInheritedStdio("sh", ["-c", cmd], 180_000);
+    return res.ok
+      ? { ok: true, message: "cloudflared installed to /usr/local/bin/cloudflared." }
+      : { ok: false, message: `install command failed (exit ${res.code}).` };
+  }
+
+  return { ok: false, message: `Automatic install not supported on ${platform}.` };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt helpers (dynamic import of @clack/prompts).
+// ---------------------------------------------------------------------------
+
+type Clack = typeof import("@clack/prompts");
+let _clack: Clack | null = null;
+
+async function clack(): Promise<Clack> {
+  if (!_clack) {
+    _clack = await import("@clack/prompts");
+  }
+  return _clack;
+}
+
+function isCancel(value: unknown): value is symbol {
+  return typeof value === "symbol";
+}
+
+type ModelLane = "stt" | "tts" | "llm";
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))];
+}
+
+/** Apply include/exclude filters from a ProviderApiConf to a list of model IDs. */
+function applyModelFilters(models: string[], api: ProviderApiConf): string[] {
+  let result = models;
+  if (api.includeFilter)
+    result = result.filter((id) => new RegExp(api.includeFilter!, "i").test(id));
+  if (api.excludeFilter)
+    result = result.filter((id) => !new RegExp(api.excludeFilter!, "i").test(id));
+  return result;
+}
+
+async function fetchJson(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs = 10_000,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function getHttpStatusFromError(error: unknown): number | null {
+  if (!(error instanceof Error)) return null;
+  const match = error.message.match(/HTTP\s+(\d{3})/i);
+  if (!match) return null;
+  const status = Number(match[1]);
+  return Number.isFinite(status) ? status : null;
+}
+
+function isAuthError(error: unknown): boolean {
+  const status = getHttpStatusFromError(error);
+  return status === 401 || status === 403;
+}
+
+function getLiveKitDocsPluginUrl(lane: ModelLane, provider: string): string {
+  return `https://docs.livekit.io/agents/models/${lane}/plugins/${provider}`;
+}
+
+function extractModelLikeTokens(raw: string): string[] {
+  const tokens = new Set<string>();
+  const quoteRegex = /["'`]([A-Za-z0-9._\-/:]{3,120})["'`]/g;
+  let match: RegExpExecArray | null;
+  while ((match = quoteRegex.exec(raw)) !== null) {
+    const value = match[1] ?? "";
+    if (!value) continue;
+    if (/^https?:\/\//i.test(value)) continue;
+    if (/^(true|false|null|undefined)$/i.test(value)) continue;
+    if (!/[a-z]/i.test(value)) continue;
+    if (!/[0-9]|-|\//.test(value)) continue;
+    tokens.add(value);
+  }
+  return [...tokens];
+}
+
+function extractVoiceLikeTokens(raw: string): string[] {
+  const tokens = new Set<string>();
+  const regexes = [
+    /voice(?:_id|_name)?\s*[:=]\s*["'`]([^"'`]{2,120})["'`]/gi,
+    /speaker\s*[:=]\s*["'`]([^"'`]{2,120})["'`]/gi,
+  ];
+  for (const regex of regexes) {
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(raw)) !== null) {
+      const value = (match[1] ?? "").trim();
+      if (!value) continue;
+      tokens.add(value);
+    }
+  }
+  return [...tokens];
+}
+
+function extractLanguageLikeTokens(raw: string): string[] {
+  const tokens = new Set<string>();
+  const regexes = [
+    /languages?\s*[:=]\s*\[\s*["'`]([^"'`]{2,20})["'`]/gi,
+    /languages?\s*[:=]\s*["'`]([^"'`]{2,20})["'`]/gi,
+    /\b([a-z]{2}-[A-Z]{2})\b/g,
+  ];
+  for (const regex of regexes) {
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(raw)) !== null) {
+      const value = (match[1] ?? "").trim();
+      if (!value) continue;
+      tokens.add(value);
+    }
+  }
+  return [...tokens];
+}
+
+async function fetchVoicesFromLiveKitDocs(lane: ModelLane, provider: string): Promise<string[]> {
+  const url = getLiveKitDocsPluginUrl(lane, provider);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return [];
+    const html = await response.text();
+    return uniq(extractVoiceLikeTokens(html)).slice(0, 80);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchLanguagesFromLiveKitDocs(lane: ModelLane, provider: string): Promise<string[]> {
+  const url = getLiveKitDocsPluginUrl(lane, provider);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return [];
+    const html = await response.text();
+    return uniq(extractLanguageLikeTokens(html)).slice(0, 80);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchOpenAICompatibleModels(params: {
+  baseUrl: string;
+  apiKey: string;
+  headers?: Record<string, string>;
+}): Promise<string[]> {
+  const base = params.baseUrl.replace(/\/$/, "");
+  const json = (await fetchJson(`${base}/v1/models`, {
+    headers: {
+      Authorization: `Bearer ${params.apiKey}`,
+      ...(params.headers ?? {}),
+    },
+  })) as { data?: Array<{ id?: string }> };
+  return uniq((json.data ?? []).map((item) => item.id ?? ""));
+}
+
+/**
+ * Fetch live models from a provider using the API configuration declared in providers.json.
+ * Falls back to LiveKit docs scraping for providers that have no usable model catalog API.
+ */
+async function fetchProviderModels(
+  _lane: ModelLane,
+  entry: SttEntry | TtsEntry | LlmEntry,
+  apiKey: string,
+): Promise<{ models: string[]; warning?: string }> {
+  const presets = uniq(entry.presets);
+  if (entry.api.kind === "livekit-docs") {
+    return {
+      models: presets,
+      warning: `${entry.label}: no live model API (docs-only provider). Showing preset/custom models only.`,
+    };
+  }
+
+  if (apiKey.trim().length === 0) {
+    return {
+      models: presets,
+      warning: `${entry.label}: missing API key. Showing preset/custom models only.`,
+    };
+  }
+
+  const key = apiKey.trim();
+
+  const { api } = entry;
+  let raw: string[] = [];
+  let authRejected = false;
+
+  try {
+    if (api.kind === "openai-compat") {
+      // Support OPENAI_BASE_URL override for openai provider, use entry baseUrl for others.
+      const base =
+        entry.id === "openai"
+          ? (process.env.OPENAI_BASE_URL ?? api.baseUrl ?? "https://api.openai.com")
+          : (api.baseUrl ?? "https://api.openai.com");
+      raw = await fetchOpenAICompatibleModels({ baseUrl: base, apiKey: key });
+    } else if (api.kind === "anthropic") {
+      const url = api.modelsUrl ?? "https://api.anthropic.com/v1/models";
+      const json = (await fetchJson(url, {
+        headers: {
+          "x-api-key": key,
+          "anthropic-version": api.apiVersion ?? "2023-06-01",
+        },
+      })) as { data?: Array<{ id?: string }> };
+      raw = uniq((json.data ?? []).map((item) => item.id ?? ""));
+    } else if (api.kind === "google") {
+      const json = (await fetchJson(
+        `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
+      )) as { models?: Array<{ name?: string }> };
+      raw = uniq(
+        (json.models ?? []).map((item) => {
+          const name = item.name ?? "";
+          return name.startsWith("models/") ? name.slice("models/".length) : name;
+        }),
+      );
+    } else if (api.kind === "elevenlabs") {
+      const url = api.modelsUrl ?? "https://api.elevenlabs.io/v1/models";
+      const authKey = api.authHeader ?? "xi-api-key";
+      const json = (await fetchJson(url, { headers: { [authKey]: key } })) as Array<{
+        model_id?: string;
+      }>;
+      raw = uniq((json ?? []).map((item) => item.model_id ?? ""));
+    } else if (api.kind === "deepgram") {
+      // Deepgram exposes no public model catalog.
+      // Keep a deterministic preset list and avoid docs scraping noise.
+      raw = [...entry.presets];
+
+      // Best-effort key validation via projects probe; never replace presets with scraped HTML.
+      const probeUrl = api.probeUrl ?? "https://api.deepgram.com/v1/projects";
+      const scheme = api.authScheme ?? "token";
+      const authHeader = scheme === "token" ? `Token ${key}` : `Bearer ${key}`;
+      const json = (await fetchJson(probeUrl, { headers: { Authorization: authHeader } })) as {
+        projects?: unknown[];
+      };
+      if (!Array.isArray(json.projects)) raw = [...entry.presets];
+    }
+  } catch (error) {
+    authRejected = isAuthError(error);
+    return {
+      models: presets,
+      warning: authRejected
+        ? `${entry.label}: API key rejected (HTTP 401/403). Showing preset/custom models only.`
+        : `${entry.label}: unable to fetch live model list. Showing preset/custom models only.`,
+    };
+  }
+
+  const filtered = applyModelFilters(uniq(raw), api);
+  if (filtered.length > 0) {
+    return {
+      models: filtered,
+      ...(authRejected
+        ? {
+            warning: `${entry.label}: API key rejected (HTTP 401/403). Showing preset models only.`,
+          }
+        : {}),
+    };
+  }
+
+  if (authRejected) {
+    return {
+      models: presets,
+      warning: `${entry.label}: API key rejected (HTTP 401/403). Showing only preset/custom models.`,
+    };
+  }
+
+  return {
+    models: presets,
+    warning: `${entry.label}: no live models returned. Showing preset/custom models only.`,
+  };
+}
+
+type ProviderCatalog = {
+  models: string[];
+  voices: string[];
+  voiceChoices?: Array<{ value: string; label: string }>;
+  languages: string[];
+  modelWarning?: string;
+};
+
+/**
+ * Fetch the full catalog (models + voices + languages) for a provider entry.
+ * Voice and language sources are declared in providers.json; actual data comes from
+ * provider APIs or LiveKit docs.
+ */
+async function fetchProviderCatalog(
+  lane: ModelLane,
+  entry: SttEntry | TtsEntry | LlmEntry,
+  apiKey: string,
+): Promise<ProviderCatalog> {
+  const { api } = entry;
+  const key = apiKey.trim();
+  const modelFetch = await fetchProviderModels(lane, entry, key);
+  const models = modelFetch.models;
+  let voices: string[] = [];
+  let voiceChoices: Array<{ value: string; label: string }> = [];
+  let languages: string[] = [];
+
+  // Voices — provider APIs that expose a voice catalog.
+  try {
+    if (lane === "tts" && api.kind === "elevenlabs" && key && api.voicesUrl) {
+      const authKey = api.authHeader ?? "xi-api-key";
+      const json = (await fetchJson(api.voicesUrl, { headers: { [authKey]: key } })) as {
+        voices?: Array<{ voice_id?: string; name?: string }>;
+      };
+      const list = (json.voices ?? []).flatMap((voice) => {
+        const id = (voice.voice_id ?? "").trim();
+        if (!id) return [];
+        const name = (voice.name ?? "").trim();
+        return [{ value: id, label: name ? `${name} (${id})` : id }];
+      });
+      voiceChoices = uniqByValue(list);
+      voices = voiceChoices.map((choice) => choice.value);
+    }
+  } catch {
+    voices = [];
+    voiceChoices = [];
+  }
+
+  if (voices.length === 0 && lane === "tts") {
+    voices = await fetchVoicesFromLiveKitDocs(lane, entry.id);
+  }
+
+  if (lane === "stt" || lane === "tts") {
+    languages = await fetchLanguagesFromLiveKitDocs(lane, entry.id);
+  }
+
+  return {
+    models: uniq(models),
+    voices: uniq(voices),
+    ...(voiceChoices.length > 0 ? { voiceChoices } : {}),
+    languages: uniq(languages),
+    ...(modelFetch.warning ? { modelWarning: modelFetch.warning } : {}),
+  };
+}
+
+function uniqByValue(values: Array<{ value: string; label: string }>): Array<{
+  value: string;
+  label: string;
+}> {
+  const seen = new Set<string>();
+  const output: Array<{ value: string; label: string }> = [];
+  for (const item of values) {
+    if (seen.has(item.value)) continue;
+    seen.add(item.value);
+    output.push(item);
+  }
+  return output;
+}
+
+async function promptModelWithChoices(params: {
+  c: Clack;
+  lane: ModelLane;
+  provider: string;
+  message: string;
+  options: string[];
+  initialValue: string;
+  placeholder: string;
+  /** Human-readable param label, e.g. "model version" for Hume. Defaults to "model". */
+  modelParamLabel?: string;
+}): Promise<string | symbol> {
+  const { c, message, initialValue, placeholder, modelParamLabel = "model" } = params;
+  const currentOptions = uniq(params.options);
+  const formatModelLabel = (value: string): string => {
+    if (value === "default") return "Use provider default";
+    return value;
+  };
+  const modelChoice = (await c.select({
+    message,
+    options: [
+      ...currentOptions.map((value) => ({ value, label: formatModelLabel(value) })),
+      { value: "__custom__", label: `Custom ${modelParamLabel}…` },
+    ],
+    initialValue: currentOptions.includes(initialValue) ? initialValue : "__custom__",
+  })) as string | symbol;
+
+  if (isCancel(modelChoice)) return modelChoice;
+  if (modelChoice !== "__custom__") return modelChoice;
+
+  return c.text({
+    message: `Custom ${modelParamLabel}`,
+    initialValue,
+    placeholder,
+  }) as Promise<string | symbol>;
+}
+
+async function promptTextOrChoice(params: {
+  c: Clack;
+  message: string;
+  options: string[];
+  initialValue: string;
+  placeholder: string;
+  customLabel?: string;
+  allowEmpty?: boolean;
+}): Promise<string | symbol> {
+  const { c, message, options, initialValue, placeholder, customLabel, allowEmpty } = params;
+  const values = uniq(options);
+  const selection = (await c.select({
+    message,
+    options: [
+      ...(allowEmpty ? [{ value: "__empty__", label: "Use provider default" }] : []),
+      ...values.map((value) => ({ value, label: value })),
+      { value: "__custom__", label: customLabel ?? "Custom value…" },
+    ],
+    initialValue: values.includes(initialValue) ? initialValue : "__custom__",
+  })) as string | symbol;
+
+  if (isCancel(selection)) return selection;
+  if (selection === "__empty__") return "";
+  if (selection !== "__custom__") return selection;
+
+  return c.text({
+    message,
+    initialValue,
+    placeholder,
+  }) as Promise<string | symbol>;
+}
+
+async function promptMappedTextOrChoice(params: {
+  c: Clack;
+  message: string;
+  options: Array<{ value: string; label: string }>;
+  initialValue: string;
+  placeholder: string;
+  customLabel?: string;
+  allowEmpty?: boolean;
+}): Promise<string | symbol> {
+  const { c, message, options, initialValue, placeholder, customLabel, allowEmpty } = params;
+  const values = uniqByValue(options);
+  const selection = (await c.select({
+    message,
+    options: [
+      ...(allowEmpty ? [{ value: "__empty__", label: "Use provider default" }] : []),
+      ...values,
+      { value: "__custom__", label: customLabel ?? "Custom value…" },
+    ],
+    initialValue: values.some((option) => option.value === initialValue)
+      ? initialValue
+      : "__custom__",
+  })) as string | symbol;
+
+  if (isCancel(selection)) return selection;
+  if (selection === "__empty__") return "";
+  if (selection !== "__custom__") return selection;
+
+  return c.text({
+    message,
+    initialValue,
+    placeholder,
+  }) as Promise<string | symbol>;
+}
+
+// ---------------------------------------------------------------------------
+// Setup wizard
+// ---------------------------------------------------------------------------
+
+export interface SetupWizardDeps {
+  logger: { info: (msg: string) => void; error: (msg: string) => void };
+  extensionDir: string;
+}
+
+export async function runSetupWizard(deps: SetupWizardDeps): Promise<void> {
+  const c = await clack();
+  c.intro("Stimm Voice — Setup Wizard");
+
+  // Load existing config to allow skipping sections.
+  const existing = loadExistingConfig();
+
+  // -- Load provider catalog from stimm (source of truth) -----------------
+
+  await c.log.step("Loading provider catalog/runtime contract from stimm APIs...");
+  const providerData = loadStimmProviderData(deps.extensionDir);
+  if (!providerData) {
+    await c.log.error(
+      "Unable to load stimm provider APIs (get_provider_catalog/list_runtime_providers). Install/update stimm in the runtime environment, then rerun setup.",
+    );
+    return c.outro("Setup cancelled.");
+  }
+
+  const catalog = providerData.catalog;
+
+  // Catalog accessor helpers
+  const sttMeta = (id: string): SttEntry =>
+    catalog?.stt.find((p) => p.id === id) ??
+    ({
+      id,
+      label: id,
+      defaultModel: "default",
+      presets: [],
+      api: { kind: "livekit-docs" },
+    } satisfies SttEntry);
+  const ttsMeta = (id: string): TtsEntry =>
+    catalog?.tts.find((p) => p.id === id) ??
+    ({
+      id,
+      label: id,
+      defaultModel: "default",
+      defaultVoice: "default",
+      presets: [],
+      api: { kind: "livekit-docs" },
+    } satisfies TtsEntry);
+  const llmMeta = (id: string): LlmEntry =>
+    catalog?.llm.find((p) => p.id === id) ??
+    ({
+      id,
+      label: id,
+      defaultModel: "default",
+      presets: [],
+      api: { kind: "livekit-docs" },
+    } satisfies LlmEntry);
+
+  // -- Check Python venv ---------------------------------------------------
+
+  const venvPath = join(deps.extensionDir, "python", ".venv", "bin", "python");
+  if (existsSync(venvPath)) {
+    await c.log.success("Python virtual environment found.");
+  } else {
+    await c.log.warn(
+      "Python virtual environment not found. It will be auto-created on first gateway start.",
+    );
+  }
+
+  // -- cloudflared ---------------------------------------------------------
+
+  const cloudflared = detectCloudflared();
+  if (cloudflared.installed) {
+    await c.log.success(`cloudflared detected: ${cloudflared.version ?? "installed"}`);
+  } else {
+    await c.log.warn("cloudflared is not installed (required for access.mode=quick-tunnel).");
+    const installNow = await c.confirm({
+      message: "Install cloudflared now? (recommended)",
+      initialValue: true,
+    });
+    if (isCancel(installNow)) return c.outro("Setup cancelled.");
+    if (installNow) {
+      await c.log.step("Installing cloudflared (you may be prompted for sudo password)...");
+      const result = await installCloudflared();
+      if (!result.ok) {
+        await c.log.warn(`Automatic install failed: ${result.message}`);
+      }
+      const verify = detectCloudflared();
+      if (!verify.installed) {
+        await c.log.warn(
+          "cloudflared still not available. Quick tunnel mode may fail until it is installed.",
+        );
+      } else {
+        await c.log.success(`cloudflared ready: ${verify.version ?? "installed"}`);
+      }
+    }
+  }
+
+  // -- STT ----------------------------------------------------------------
+
+  let sttProvider!: SttProvider;
+  let sttModel!: string;
+  let sttLanguage: string = "";
+  let sttApiKey: string = "";
+
+  const hasSttConfig = !!(existing.stt?.provider && existing.stt?.model);
+
+  if (hasSttConfig) {
+    await c.log.info(
+      `  Current STT: ${existing.stt!.provider} / ${existing.stt!.model}` +
+        (existing.stt!.language ? ` (${existing.stt!.language})` : ""),
+    );
+    const reconfigureStt = await c.confirm({
+      message: "Reconfigure Speech-to-Text?",
+      initialValue: false,
+    });
+    if (isCancel(reconfigureStt)) return c.outro("Setup cancelled.");
+    if (!reconfigureStt) {
+      sttProvider = existing.stt!.provider as SttProvider;
+      sttModel = existing.stt!.model!;
+      sttLanguage = existing.stt!.language ?? "";
+      sttApiKey = existing.stt!.apiKey ?? "";
+    }
+  }
+
+  if (!hasSttConfig || !sttModel) {
+    const sttCatalogEntries = catalog.stt;
+    if (sttCatalogEntries.length === 0) {
+      await c.log.error("No STT provider found in stimm provider catalog.");
+      return c.outro("Setup cancelled.");
+    }
+    const sttEntries = sttCatalogEntries.map(({ id, label }) => ({ id, label }));
+    const existingSttProvider = existing.stt?.provider;
+    const sttInitial =
+      existingSttProvider && sttEntries.some((entry) => entry.id === existingSttProvider)
+        ? existingSttProvider
+        : sttEntries[0]?.id;
+    const sttProviderResult = (await c.select({
+      message: "Speech-to-Text provider",
+      options: sttEntries.map(({ id, label }) => ({
+        value: id,
+        label,
+        hint: providerEnvVar(id as SttProvider) ?? "",
+      })),
+      initialValue: sttInitial,
+    })) as SttProvider | symbol;
+    if (isCancel(sttProviderResult)) return c.outro("Setup cancelled.");
+    sttProvider = sttProviderResult;
+    const sttEntry = sttMeta(sttProvider);
+
+    const sttEnvName = providerEnvVar(sttProvider);
+    const sttEnvValue = sttEnvName ? process.env[sttEnvName] : undefined;
+
+    if (sttEnvValue) {
+      const useEnv = await c.confirm({
+        message: `${sttEnvName} detected in environment. Use it for STT?`,
+        initialValue: true,
+      });
+      if (isCancel(useEnv)) return c.outro("Setup cancelled.");
+      if (!useEnv) {
+        const keyResult = (await c.text({
+          message: `API key for ${sttEntry.label} STT`,
+          placeholder: "sk-...",
+        })) as string | symbol;
+        if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+        sttApiKey = keyResult;
+      }
+    } else {
+      const keyResult = (await c.text({
+        message: `API key for ${sttEntry.label} STT`,
+        placeholder: "sk-...",
+      })) as string | symbol;
+      if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+      sttApiKey = keyResult;
+    }
+
+    await c.log.step(`Fetching available STT models/languages for ${sttEntry.label}...`);
+    const sttLiveCatalog = await fetchProviderCatalog("stt", sttEntry, sttApiKey);
+    if (sttLiveCatalog.modelWarning) {
+      await c.log.warn(sttLiveCatalog.modelWarning);
+    }
+
+    const sttModelParamLabel = (sttEntry.modelParam ?? "model").replaceAll("_", " ");
+    const sttModelResult = await promptModelWithChoices({
+      c,
+      lane: "stt",
+      provider: sttProvider,
+      message: `STT ${sttModelParamLabel} for ${sttEntry.label}`,
+      options: uniq([...sttLiveCatalog.models, ...sttEntry.presets]),
+      initialValue: existing.stt?.model ?? sttEntry.defaultModel,
+      placeholder: sttEntry.defaultModel,
+      modelParamLabel: sttModelParamLabel,
+    });
+    if (isCancel(sttModelResult)) return c.outro("Setup cancelled.");
+    sttModel = sttModelResult;
+
+    const sttLanguageResult = await promptTextOrChoice({
+      c,
+      message: "STT language code",
+      options: sttLiveCatalog.languages,
+      initialValue: existing.stt?.language ?? "",
+      placeholder: "fr",
+      allowEmpty: true,
+      customLabel: "Custom language code…",
+    });
+    if (isCancel(sttLanguageResult)) return c.outro("Setup cancelled.");
+    sttLanguage = sttLanguageResult;
+  }
+
+  // -- TTS ----------------------------------------------------------------
+
+  let ttsProvider!: TtsProvider;
+  let ttsModel!: string;
+  let ttsVoice!: string;
+  let ttsLanguage: string = "";
+  let ttsApiKey: string = "";
+
+  const hasTtsConfig = !!(existing.tts?.provider && existing.tts?.model);
+
+  if (hasTtsConfig) {
+    await c.log.info(
+      `  Current TTS: ${existing.tts!.provider} / ${existing.tts!.model}` +
+        (existing.tts!.voice ? ` (voice: ${existing.tts!.voice})` : ""),
+    );
+    const reconfigureTts = await c.confirm({
+      message: "Reconfigure Text-to-Speech?",
+      initialValue: false,
+    });
+    if (isCancel(reconfigureTts)) return c.outro("Setup cancelled.");
+    if (!reconfigureTts) {
+      ttsProvider = existing.tts!.provider as TtsProvider;
+      ttsModel = existing.tts!.model!;
+      ttsVoice = existing.tts!.voice ?? ttsMeta(existing.tts!.provider ?? "openai").defaultVoice;
+      ttsLanguage = existing.tts!.language ?? "";
+      ttsApiKey = existing.tts!.apiKey ?? "";
+    }
+  }
+
+  if (!hasTtsConfig || !ttsModel) {
+    const ttsCatalogEntries = catalog.tts;
+    if (ttsCatalogEntries.length === 0) {
+      await c.log.error("No TTS provider found in stimm provider catalog.");
+      return c.outro("Setup cancelled.");
+    }
+    const ttsEntries = ttsCatalogEntries.map(({ id, label }) => ({ id, label }));
+    const existingTtsProvider = existing.tts?.provider;
+    const ttsInitial =
+      existingTtsProvider && ttsEntries.some((entry) => entry.id === existingTtsProvider)
+        ? existingTtsProvider
+        : ttsEntries[0]?.id;
+    const ttsProviderResult = (await c.select({
+      message: "Text-to-Speech provider",
+      options: ttsEntries.map(({ id, label }) => ({
+        value: id,
+        label,
+        hint: providerEnvVar(id as TtsProvider) ?? "",
+      })),
+      initialValue: ttsInitial,
+    })) as TtsProvider | symbol;
+    if (isCancel(ttsProviderResult)) return c.outro("Setup cancelled.");
+    ttsProvider = ttsProviderResult;
+    const ttsEntry = ttsMeta(ttsProvider);
+
+    const ttsEnvName = providerEnvVar(ttsProvider);
+    const ttsEnvValue = ttsEnvName ? process.env[ttsEnvName] : undefined;
+
+    // If same provider as STT, offer to reuse the key.
+    if (sttProvider === ttsProvider && sttApiKey) {
+      const reuse = await c.confirm({
+        message: `Reuse the same ${sttMeta(sttProvider).label} key for TTS?`,
+        initialValue: true,
+      });
+      if (isCancel(reuse)) return c.outro("Setup cancelled.");
+      if (reuse) ttsApiKey = sttApiKey;
+    }
+
+    if (!ttsApiKey) {
+      if (ttsEnvValue) {
+        const useEnv = await c.confirm({
+          message: `${ttsEnvName} detected in environment. Use it for TTS?`,
+          initialValue: true,
+        });
+        if (isCancel(useEnv)) return c.outro("Setup cancelled.");
+        if (!useEnv) {
+          const keyResult = (await c.text({
+            message: `API key for ${ttsEntry.label} TTS`,
+            placeholder: "sk-...",
+          })) as string | symbol;
+          if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+          ttsApiKey = keyResult;
+        }
+      } else {
+        const keyResult = (await c.text({
+          message: `API key for ${ttsEntry.label} TTS`,
+          placeholder: "sk-...",
+        })) as string | symbol;
+        if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+        ttsApiKey = keyResult;
+      }
+    }
+
+    await c.log.step(`Fetching available TTS models/voices/languages for ${ttsEntry.label}...`);
+    const ttsLiveCatalog = await fetchProviderCatalog("tts", ttsEntry, ttsApiKey);
+    if (ttsLiveCatalog.modelWarning) {
+      await c.log.warn(ttsLiveCatalog.modelWarning);
+    }
+
+    const ttsModelParamLabel = (ttsEntry.modelParam ?? "model").replaceAll("_", " ");
+    const ttsModelResult = await promptModelWithChoices({
+      c,
+      lane: "tts",
+      provider: ttsProvider,
+      message: `TTS ${ttsModelParamLabel} for ${ttsEntry.label}`,
+      options: uniq([...ttsLiveCatalog.models, ...ttsEntry.presets]),
+      initialValue: existing.tts?.model ?? ttsEntry.defaultModel,
+      placeholder: ttsEntry.defaultModel,
+      modelParamLabel: ttsModelParamLabel,
+    });
+    if (isCancel(ttsModelResult)) return c.outro("Setup cancelled.");
+    ttsModel = ttsModelResult;
+
+    const ttsVoiceResult = ttsLiveCatalog.voiceChoices?.length
+      ? await promptMappedTextOrChoice({
+          c,
+          message: `Voice for ${ttsEntry.label}`,
+          options: ttsLiveCatalog.voiceChoices,
+          initialValue: existing.tts?.voice ?? ttsEntry.defaultVoice,
+          placeholder: ttsEntry.defaultVoice,
+          customLabel: "Custom voice ID…",
+        })
+      : await promptTextOrChoice({
+          c,
+          message:
+            ttsProvider === "elevenlabs"
+              ? "Voice ID for ElevenLabs (voice_id)"
+              : ttsProvider === "cartesia"
+                ? "Voice ID for Cartesia (UUID)"
+                : `Voice name for ${ttsEntry.label}`,
+          options: ttsLiveCatalog.voices,
+          initialValue: existing.tts?.voice ?? ttsEntry.defaultVoice,
+          placeholder: ttsEntry.defaultVoice,
+          customLabel: "Custom voice…",
+        });
+    if (isCancel(ttsVoiceResult)) return c.outro("Setup cancelled.");
+    ttsVoice = ttsVoiceResult;
+
+    const ttsLanguageResult = await promptTextOrChoice({
+      c,
+      message: "TTS language code",
+      options: ttsLiveCatalog.languages,
+      initialValue: existing.tts?.language ?? "",
+      placeholder: "en-US",
+      allowEmpty: true,
+      customLabel: "Custom language code…",
+    });
+    if (isCancel(ttsLanguageResult)) return c.outro("Setup cancelled.");
+    ttsLanguage = ttsLanguageResult;
+  }
+
+  // -- LLM ----------------------------------------------------------------
+
+  let llmProvider!: LlmProvider;
+  let llmModel!: string;
+  let llmApiKey: string = "";
+
+  const hasLlmConfig = !!(existing.llm?.provider && existing.llm?.model);
+
+  if (hasLlmConfig) {
+    await c.log.info(`  Current LLM: ${existing.llm!.provider} / ${existing.llm!.model}`);
+    const reconfigureLlm = await c.confirm({
+      message: "Reconfigure LLM (voice agent reasoning)?",
+      initialValue: false,
+    });
+    if (isCancel(reconfigureLlm)) return c.outro("Setup cancelled.");
+    if (!reconfigureLlm) {
+      llmProvider = existing.llm!.provider as LlmProvider;
+      llmModel = existing.llm!.model!;
+      llmApiKey = existing.llm!.apiKey ?? "";
+    }
+  }
+
+  if (!hasLlmConfig || !llmModel) {
+    const llmCatalogEntries = catalog.llm;
+    if (llmCatalogEntries.length === 0) {
+      await c.log.error("No LLM provider found in stimm provider catalog.");
+      return c.outro("Setup cancelled.");
+    }
+    const llmEntries = llmCatalogEntries.map(({ id, label }) => ({ id, label }));
+    const existingLlmProvider = existing.llm?.provider;
+    const llmInitial =
+      existingLlmProvider && llmEntries.some((entry) => entry.id === existingLlmProvider)
+        ? existingLlmProvider
+        : llmEntries[0]?.id;
+    const llmProviderResult = (await c.select({
+      message: "LLM provider (for voice agent reasoning)",
+      options: llmEntries.map(({ id, label }) => ({
+        value: id,
+        label,
+        hint: providerEnvVar(id as LlmProvider) ?? "",
+      })),
+      initialValue: llmInitial,
+    })) as LlmProvider | symbol;
+    if (isCancel(llmProviderResult)) return c.outro("Setup cancelled.");
+    llmProvider = llmProviderResult;
+    const llmEntry = llmMeta(llmProvider);
+
+    const llmEnvName = providerEnvVar(llmProvider);
+    const llmEnvValue = llmEnvName ? process.env[llmEnvName] : undefined;
+
+    // Offer reuse if same provider as STT or TTS.
+    const sameAsSTT = llmProvider === sttProvider && sttApiKey;
+    const sameAsTTS = llmProvider === ttsProvider && ttsApiKey;
+
+    if (sameAsSTT || sameAsTTS) {
+      const reuse = await c.confirm({
+        message: `Reuse the same ${llmEntry.label} key for LLM?`,
+        initialValue: true,
+      });
+      if (isCancel(reuse)) return c.outro("Setup cancelled.");
+      if (reuse) llmApiKey = sameAsSTT ? sttApiKey : ttsApiKey;
+    }
+
+    if (!llmApiKey) {
+      if (llmEnvValue) {
+        const useEnv = await c.confirm({
+          message: `${llmEnvName} detected in environment. Use it for LLM?`,
+          initialValue: true,
+        });
+        if (isCancel(useEnv)) return c.outro("Setup cancelled.");
+        if (!useEnv) {
+          const keyResult = (await c.text({
+            message: `API key for ${llmEntry.label} LLM`,
+            placeholder: "sk-...",
+          })) as string | symbol;
+          if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+          llmApiKey = keyResult;
+        }
+      } else {
+        const keyResult = (await c.text({
+          message: `API key for ${llmEntry.label} LLM`,
+          placeholder: "sk-...",
+        })) as string | symbol;
+        if (isCancel(keyResult)) return c.outro("Setup cancelled.");
+        llmApiKey = keyResult;
+      }
+    }
+
+    await c.log.step(`Fetching available LLM models for ${llmEntry.label}...`);
+    const llmLiveCatalog = await fetchProviderCatalog("llm", llmEntry, llmApiKey);
+    if (llmLiveCatalog.modelWarning) {
+      await c.log.warn(llmLiveCatalog.modelWarning);
+    }
+
+    const llmModelParamLabel = (llmEntry.modelParam ?? "model").replaceAll("_", " ");
+    const llmModelResult = await promptModelWithChoices({
+      c,
+      lane: "llm",
+      provider: llmProvider,
+      message: `LLM ${llmModelParamLabel} for ${llmEntry.label}`,
+      options: uniq([...llmLiveCatalog.models, ...llmEntry.presets]),
+      initialValue: existing.llm?.model ?? llmEntry.defaultModel,
+      placeholder: llmEntry.defaultModel,
+      modelParamLabel: llmModelParamLabel,
+    });
+    if (isCancel(llmModelResult)) return c.outro("Setup cancelled.");
+    llmModel = llmModelResult;
+  }
+
+  // -- LiveKit ------------------------------------------------------------
+
+  let livekitUrl!: string;
+  let livekitApiKey!: string;
+  let livekitApiSecret!: string;
+
+  const hasLivekitConfig = !!(existing.livekit?.url && existing.livekit?.apiKey);
+  let skipLivekit = false;
+
+  if (hasLivekitConfig) {
+    await c.log.info(`  Current LiveKit: ${existing.livekit!.url}`);
+    const reconfigureLivekit = await c.confirm({
+      message: "Reconfigure LiveKit?",
+      initialValue: false,
+    });
+    if (isCancel(reconfigureLivekit)) return c.outro("Setup cancelled.");
+    if (!reconfigureLivekit) {
+      livekitUrl = existing.livekit!.url!;
+      livekitApiKey = existing.livekit!.apiKey!;
+      livekitApiSecret = existing.livekit!.apiSecret ?? "";
+      skipLivekit = true;
+    }
+  }
+
+  if (!skipLivekit) {
+    const urlResult = (await c.text({
+      message: "LiveKit URL",
+      initialValue: existing.livekit?.url ?? "wss://your-project.livekit.cloud",
+      placeholder: "wss://your-project.livekit.cloud",
+    })) as string | symbol;
+    if (isCancel(urlResult)) return c.outro("Setup cancelled.");
+    livekitUrl = urlResult;
+
+    const apiKeyResult = (await c.text({
+      message: "LiveKit API Key",
+      placeholder: "APIxxxxx",
+    })) as string | symbol;
+    if (isCancel(apiKeyResult)) return c.outro("Setup cancelled.");
+    livekitApiKey = apiKeyResult;
+
+    const apiSecretResult = (await c.text({
+      message: "LiveKit API Secret",
+      placeholder: "secret...",
+    })) as string | symbol;
+    if (isCancel(apiSecretResult)) return c.outro("Setup cancelled.");
+    livekitApiSecret = apiSecretResult;
+  }
+
+  // -- Access mode --------------------------------------------------------
+
+  const accessMode = (await c.select({
+    message: "Public access mode",
+    options: ACCESS_MODES.map((mode) => ({
+      value: mode,
+      label: mode,
+      hint:
+        mode === "quick-tunnel"
+          ? "Starts cloudflared Quick Tunnel on demand"
+          : "No public tunnel (local/LAN only)",
+    })),
+    initialValue: (existing.access?.mode ??
+      (detectCloudflared().installed ? "quick-tunnel" : "none")) as AccessMode,
+  })) as AccessMode | symbol;
+  if (isCancel(accessMode)) return c.outro("Setup cancelled.");
+
+  const supervisorSecret = (await c.text({
+    message: "Supervisor secret (recommended)",
+    initialValue: existing.access?.supervisorSecret ?? "",
+    placeholder: "leave blank to use env fallback",
+  })) as string | symbol;
+  if (isCancel(supervisorSecret)) return c.outro("Setup cancelled.");
+
+  // -- Install selected Stimm extras -------------------------------------
+
+  const pythonDir = join(deps.extensionDir, "python");
+  let extrasInstalled = false;
+  let pythonExe = join(pythonDir, ".venv", "bin", "python");
+  if (!existsSync(pythonExe)) {
+    const createVenvNow = await c.confirm({
+      message: "Python venv not found. Create it now to install selected Stimm extras?",
+      initialValue: true,
+    });
+    if (isCancel(createVenvNow)) return c.outro("Setup cancelled.");
+    if (createVenvNow) {
+      const ok = AgentProcess.ensureVenv(pythonDir, {
+        info: (message) => deps.logger.info(message),
+        warn: (message) => deps.logger.info(message),
+        error: (message) => deps.logger.error(message),
+      });
+      if (!ok) {
+        await c.log.warn(
+          "Could not create Python venv automatically. Provider extras installation is skipped for now.",
+        );
+      }
+    }
+  }
+
+  pythonExe = existsSync(pythonExe) ? pythonExe : (findPythonForWizard(deps.extensionDir) ?? "");
+  if (pythonExe) {
+    const extrasResolution = resolveStimmExtras(pythonExe, {
+      stt: sttProvider,
+      tts: ttsProvider,
+      llm: llmProvider,
+    });
+    if (!extrasResolution) {
+      await c.log.warn(
+        "Could not resolve required extras via stimm.required_extras_for_selection(); skipping extras install step.",
+      );
+    } else if (extrasResolution.extras.length === 0) {
+      await c.log.info("No additional Stimm extras are required for the selected providers.");
+    } else {
+      await c.log.step(`Installing Stimm extras: ${extrasResolution.extras.join(", ")}...`);
+      const install = spawnSync(
+        pythonExe,
+        ["-m", "pip", "install", `stimm[${extrasResolution.extras.join(",")}]`],
+        {
+          stdio: "inherit",
+          timeout: 300_000,
+        },
+      );
+      if (install.status === 0) {
+        extrasInstalled = true;
+        await c.log.success(
+          `Stimm extras installed (${extrasResolution.command || "pip install"}).`,
+        );
+      } else {
+        await c.log.warn(
+          "Stimm extras install failed. You can retry manually with: " +
+            (extrasResolution.command || `pip install stimm[${extrasResolution.extras.join(",")}]`),
+        );
+      }
+    }
+  } else {
+    await c.log.warn(
+      "No Python interpreter found to resolve/install provider extras. Install Python 3.10+ and rerun setup.",
+    );
+  }
+
+  if (extrasInstalled) {
+    await c.log.info(
+      "Python dependencies changed. Restart the OpenClaw gateway/app process before starting a voice session.",
+    );
+  }
+
+  // -- Save ---------------------------------------------------------------
+
+  saveConfig({
+    enabled: true,
+    "voiceAgent.stt.provider": sttProvider,
+    "voiceAgent.stt.model": sttModel,
+    ...(sttLanguage.trim() ? { "voiceAgent.stt.language": sttLanguage.trim() } : {}),
+    ...(sttApiKey.trim() ? { "voiceAgent.stt.apiKey": sttApiKey.trim() } : {}),
+    "voiceAgent.tts.provider": ttsProvider,
+    "voiceAgent.tts.model": ttsModel,
+    "voiceAgent.tts.voice": ttsVoice,
+    ...(ttsLanguage.trim() ? { "voiceAgent.tts.language": ttsLanguage.trim() } : {}),
+    ...(ttsApiKey.trim() ? { "voiceAgent.tts.apiKey": ttsApiKey.trim() } : {}),
+    "voiceAgent.llm.provider": llmProvider,
+    "voiceAgent.llm.model": llmModel,
+    ...(llmApiKey.trim() ? { "voiceAgent.llm.apiKey": llmApiKey.trim() } : {}),
+    "livekit.url": livekitUrl,
+    "livekit.apiKey": livekitApiKey,
+    "livekit.apiSecret": livekitApiSecret,
+    "access.mode": accessMode,
+    ...(String(supervisorSecret).trim()
+      ? { "access.supervisorSecret": String(supervisorSecret).trim() }
+      : {}),
+  });
+
+  c.outro(
+    "Setup complete. Start a session with `openclaw voice:start` and open the returned shareUrl.",
+  );
+}

--- a/extensions/stimm-voice/src/web/voice.html
+++ b/extensions/stimm-voice/src/web/voice.html
@@ -1023,6 +1023,13 @@
         } catch (error) {
           const message = error?.message || "Could not connect to voice session.";
           showError(message);
+          // Claim was already consumed server-side — end the orphaned session now so the
+          // room is cleaned up and the user can retry with a fresh link.
+          if (currentRoomName && disconnectToken) {
+            try {
+              await endSession(currentRoomName, disconnectToken);
+            } catch {}
+          }
           cleanupConnectionUI();
           updateStatus("error", "Connection failed");
         } finally {

--- a/extensions/stimm-voice/src/web/voice.html
+++ b/extensions/stimm-voice/src/web/voice.html
@@ -1,559 +1,573 @@
 <!doctype html>
 <html lang="en">
-
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Stimm Voice</title>
-  <style>
-    :root {
-      --bg-a: #4a6cf7;
-      --bg-b: #7a3cff;
-      --bg-c: #2f1467;
-      --surface: rgba(20, 16, 52, 0.56);
-      --surface-strong: rgba(20, 16, 52, 0.76);
-      --border: rgba(164, 176, 255, 0.22);
-      --text: #eef1ff;
-      --muted: #c6cbff;
-      --accent: #72e2ff;
-      --accent-strong: #67f6ff;
-      --good: #52d6a0;
-      --warn: #ffbd59;
-      --bad: #ff6b8f;
-      --shadow: 0 24px 64px rgba(3, 3, 20, 0.35);
-    }
-
-    * {
-      box-sizing: border-box;
-      margin: 0;
-      padding: 0;
-    }
-
-    html,
-    body {
-      width: 100%;
-      min-height: 100%;
-    }
-
-    body {
-      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      color: var(--text);
-      background:
-        radial-gradient(140% 120% at 0% 0%, rgba(126, 203, 255, 0.18), transparent 56%),
-        linear-gradient(130deg, var(--bg-a), var(--bg-b) 45%, var(--bg-c));
-    }
-
-    .layout {
-      min-height: 100vh;
-      display: grid;
-      grid-template-columns: 1fr;
-    }
-
-    .layout.show-info {
-      grid-template-columns: 1fr minmax(300px, 360px);
-    }
-
-    .stage {
-      padding: 28px;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .topbar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .topbar-right {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .brand {
-      font-size: 22px;
-      font-weight: 700;
-      letter-spacing: -0.03em;
-    }
-
-    .status-pill {
-      border: 1px solid var(--border);
-      background: var(--surface);
-      border-radius: 999px;
-      padding: 8px 14px;
-      font-size: 12px;
-      color: var(--muted);
-      backdrop-filter: blur(8px);
-    }
-
-    .icon-btn {
-      width: 34px;
-      height: 34px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      color: var(--text);
-      font-size: 16px;
-      font-weight: 700;
-      line-height: 1;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-    }
-
-    .center {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .stage-card {
-      width: 100%;
-      max-width: 560px;
-      text-align: center;
-    }
-
-    .signal-badge {
-      display: inline-block;
-      padding: 6px 12px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      color: var(--accent);
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .visualizer {
-      margin: 24px auto 16px;
-      min-height: 86px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 10px;
-    }
-
-    .bar {
-      width: 20px;
-      height: 24px;
-      border-radius: 12px;
-      background: linear-gradient(180deg, var(--accent-strong), var(--accent));
-      opacity: 0.38;
-    }
-
-    .visualizer.active .bar {
-      opacity: 1;
-      animation: pulse 640ms ease-in-out infinite alternate;
-    }
-
-    .visualizer.active .bar:nth-child(2) {
-      animation-delay: 80ms;
-    }
-
-    .visualizer.active .bar:nth-child(3) {
-      animation-delay: 160ms;
-    }
-
-    .visualizer.active .bar:nth-child(4) {
-      animation-delay: 120ms;
-    }
-
-    @keyframes pulse {
-      from {
-        height: 20px;
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stimm Voice</title>
+    <style>
+      :root {
+        --bg-a: #4a6cf7;
+        --bg-b: #7a3cff;
+        --bg-c: #2f1467;
+        --surface: rgba(20, 16, 52, 0.56);
+        --surface-strong: rgba(20, 16, 52, 0.76);
+        --border: rgba(164, 176, 255, 0.22);
+        --text: #eef1ff;
+        --muted: #c6cbff;
+        --accent: #72e2ff;
+        --accent-strong: #67f6ff;
+        --good: #52d6a0;
+        --warn: #ffbd59;
+        --bad: #ff6b8f;
+        --shadow: 0 24px 64px rgba(3, 3, 20, 0.35);
       }
 
-      to {
-        height: 70px;
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
       }
-    }
 
-    .connection-title {
-      font-size: 16px;
-      font-weight: 600;
-      margin-top: 8px;
-    }
+      html,
+      body {
+        width: 100%;
+        min-height: 100%;
+      }
 
-    .room-info {
-      margin-top: 6px;
-      font-size: 13px;
-      color: var(--muted);
-    }
+      body {
+        font-family:
+          Inter,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        color: var(--text);
+        background:
+          radial-gradient(140% 120% at 0% 0%, rgba(126, 203, 255, 0.18), transparent 56%),
+          linear-gradient(130deg, var(--bg-a), var(--bg-b) 45%, var(--bg-c));
+      }
 
-    .action-row {
-      margin-top: 24px;
-      display: flex;
-      gap: 10px;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-
-    .connect-overlay {
-      position: fixed;
-      inset: 0;
-      z-index: 50;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 24px;
-      background: rgba(8, 8, 28, 0.74);
-      backdrop-filter: blur(8px);
-    }
-
-    .connect-overlay.hidden {
-      display: none;
-    }
-
-    .btn-connect-overlay {
-      width: min(680px, 100%);
-      min-height: 58vh;
-      border-radius: 24px;
-      border: 1px solid rgba(180, 214, 255, 0.62);
-      background: linear-gradient(160deg, rgba(114, 226, 255, 0.22), rgba(95, 131, 255, 0.34));
-      box-shadow: var(--shadow);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 14px;
-      padding: 26px;
-      text-align: center;
-    }
-
-    .btn-connect-overlay-icon {
-      width: 88px;
-      height: 88px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: rgba(12, 16, 40, 0.45);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 44px;
-      line-height: 1;
-    }
-
-    .btn-connect-overlay-title {
-      font-size: clamp(28px, 4.8vw, 52px);
-      font-weight: 700;
-      letter-spacing: -0.03em;
-    }
-
-    .btn-connect-overlay-subtitle {
-      font-size: clamp(15px, 2.2vw, 20px);
-      color: var(--muted);
-    }
-
-    button,
-    select {
-      border: 1px solid var(--border);
-      background: var(--surface);
-      color: var(--text);
-      border-radius: 12px;
-      padding: 10px 14px;
-      font-size: 13px;
-      font-weight: 600;
-    }
-
-    button {
-      cursor: pointer;
-      transition: 150ms ease;
-    }
-
-    button:hover:not(:disabled) {
-      border-color: rgba(255, 255, 255, 0.45);
-      transform: translateY(-1px);
-    }
-
-    button:disabled,
-    select:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    button.primary {
-      background: linear-gradient(160deg, rgba(114, 226, 255, 0.28), rgba(95, 131, 255, 0.35));
-      border-color: rgba(180, 214, 255, 0.5);
-    }
-
-    button.danger {
-      color: #ffd4df;
-      border-color: rgba(255, 128, 164, 0.5);
-      background: rgba(255, 107, 143, 0.2);
-    }
-
-    button.hangup {
-      display: none;
-      min-width: 240px;
-      padding: 14px 20px;
-      border-color: rgba(255, 128, 164, 0.72);
-      background: linear-gradient(170deg, rgba(255, 118, 156, 0.56), rgba(170, 41, 78, 0.6));
-      color: #fff;
-      align-items: center;
-      justify-content: center;
-      gap: 10px;
-      font-size: 16px;
-      font-weight: 700;
-      letter-spacing: 0.01em;
-    }
-
-    .hangup-icon {
-      width: 28px;
-      height: 28px;
-      border-radius: 999px;
-      background: rgba(18, 10, 24, 0.34);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      flex: 0 0 auto;
-    }
-
-    .hangup-icon svg {
-      width: 16px;
-      height: 16px;
-      fill: currentColor;
-    }
-
-    .error {
-      margin-top: 16px;
-      color: #ffd2dd;
-      font-size: 13px;
-    }
-
-    .side {
-      border-left: 1px solid var(--border);
-      background: var(--surface-strong);
-      backdrop-filter: blur(10px);
-      box-shadow: var(--shadow);
-      padding: 20px;
-      display: none;
-      flex-direction: column;
-      gap: 14px;
-    }
-
-    .layout.show-info .side {
-      display: flex;
-    }
-
-    .panel {
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      background: rgba(10, 11, 37, 0.34);
-      padding: 14px;
-    }
-
-    .panel h2 {
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--muted);
-      margin-bottom: 10px;
-    }
-
-    .kv {
-      display: grid;
-      grid-template-columns: 110px 1fr;
-      gap: 8px;
-      font-size: 12px;
-      margin-bottom: 8px;
-    }
-
-    .kv span:first-child {
-      color: var(--muted);
-    }
-
-    .device-grid {
-      display: grid;
-      gap: 10px;
-    }
-
-    .device-row {
-      display: grid;
-      gap: 6px;
-    }
-
-    .device-row label {
-      font-size: 12px;
-      color: var(--muted);
-    }
-
-    .support-note {
-      font-size: 12px;
-      color: var(--muted);
-    }
-
-    .transcript {
-      max-height: 30vh;
-      overflow-y: auto;
-      display: grid;
-      gap: 7px;
-    }
-
-    .entry {
-      font-size: 13px;
-      line-height: 1.45;
-      color: #e8ebff;
-    }
-
-    .entry.user {
-      color: #dce2ff;
-    }
-
-    .entry.agent {
-      color: #aeefff;
-    }
-
-    .dot {
-      width: 9px;
-      height: 9px;
-      border-radius: 999px;
-      display: inline-block;
-      margin-right: 7px;
-      background: var(--warn);
-    }
-
-    .dot.connected {
-      background: var(--good);
-      box-shadow: 0 0 8px rgba(82, 214, 160, 0.9);
-    }
-
-    .dot.error {
-      background: var(--bad);
-    }
-
-    .desktop-only {
-      display: block;
-    }
-
-    .mobile-only {
-      display: none;
-    }
-
-    @media (max-width: 980px) {
       .layout {
+        min-height: 100vh;
+        display: grid;
         grid-template-columns: 1fr;
       }
 
       .layout.show-info {
-        grid-template-columns: 1fr;
+        grid-template-columns: 1fr minmax(300px, 360px);
       }
 
-      .layout.show-info .side {
-        border-left: 0;
-        border-top: 1px solid var(--border);
-      }
-    }
-
-    @media (max-width: 768px) {
       .stage {
-        padding: 16px;
+        padding: 28px;
+        display: flex;
+        flex-direction: column;
       }
 
-      .side {
-        padding: 16px;
+      .topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
       }
 
-      .desktop-only {
+      .topbar-right {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .brand {
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+      }
+
+      .status-pill {
+        border: 1px solid var(--border);
+        background: var(--surface);
+        border-radius: 999px;
+        padding: 8px 14px;
+        font-size: 12px;
+        color: var(--muted);
+        backdrop-filter: blur(8px);
+      }
+
+      .icon-btn {
+        width: 34px;
+        height: 34px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text);
+        font-size: 16px;
+        font-weight: 700;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+      }
+
+      .center {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .stage-card {
+        width: 100%;
+        max-width: 560px;
+        text-align: center;
+      }
+
+      .signal-badge {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--accent);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .visualizer {
+        margin: 24px auto 16px;
+        min-height: 86px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+      }
+
+      .bar {
+        width: 20px;
+        height: 24px;
+        border-radius: 12px;
+        background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+        opacity: 0.38;
+      }
+
+      .visualizer.active .bar {
+        opacity: 1;
+        animation: pulse 640ms ease-in-out infinite alternate;
+      }
+
+      .visualizer.active .bar:nth-child(2) {
+        animation-delay: 80ms;
+      }
+
+      .visualizer.active .bar:nth-child(3) {
+        animation-delay: 160ms;
+      }
+
+      .visualizer.active .bar:nth-child(4) {
+        animation-delay: 120ms;
+      }
+
+      @keyframes pulse {
+        from {
+          height: 20px;
+        }
+
+        to {
+          height: 70px;
+        }
+      }
+
+      .connection-title {
+        font-size: 16px;
+        font-weight: 600;
+        margin-top: 8px;
+      }
+
+      .room-info {
+        margin-top: 6px;
+        font-size: 13px;
+        color: var(--muted);
+      }
+
+      .action-row {
+        margin-top: 24px;
+        display: flex;
+        gap: 10px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .connect-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 50;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background: rgba(8, 8, 28, 0.74);
+        backdrop-filter: blur(8px);
+      }
+
+      .connect-overlay.hidden {
         display: none;
       }
 
-      .mobile-only {
+      .btn-connect-overlay {
+        width: min(680px, 100%);
+        min-height: 58vh;
+        border-radius: 24px;
+        border: 1px solid rgba(180, 214, 255, 0.62);
+        background: linear-gradient(160deg, rgba(114, 226, 255, 0.22), rgba(95, 131, 255, 0.34));
+        box-shadow: var(--shadow);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        padding: 26px;
+        text-align: center;
+      }
+
+      .btn-connect-overlay-icon {
+        width: 88px;
+        height: 88px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: rgba(12, 16, 40, 0.45);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 44px;
+        line-height: 1;
+      }
+
+      .btn-connect-overlay-title {
+        font-size: clamp(28px, 4.8vw, 52px);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+      }
+
+      .btn-connect-overlay-subtitle {
+        font-size: clamp(15px, 2.2vw, 20px);
+        color: var(--muted);
+      }
+
+      button,
+      select {
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text);
+        border-radius: 12px;
+        padding: 10px 14px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      button {
+        cursor: pointer;
+        transition: 150ms ease;
+      }
+
+      button:hover:not(:disabled) {
+        border-color: rgba(255, 255, 255, 0.45);
+        transform: translateY(-1px);
+      }
+
+      button:disabled,
+      select:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      button.primary {
+        background: linear-gradient(160deg, rgba(114, 226, 255, 0.28), rgba(95, 131, 255, 0.35));
+        border-color: rgba(180, 214, 255, 0.5);
+      }
+
+      button.danger {
+        color: #ffd4df;
+        border-color: rgba(255, 128, 164, 0.5);
+        background: rgba(255, 107, 143, 0.2);
+      }
+
+      button.hangup {
+        display: none;
+        min-width: 240px;
+        padding: 14px 20px;
+        border-color: rgba(255, 128, 164, 0.72);
+        background: linear-gradient(170deg, rgba(255, 118, 156, 0.56), rgba(170, 41, 78, 0.6));
+        color: #fff;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        font-size: 16px;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }
+
+      .hangup-icon {
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        background: rgba(18, 10, 24, 0.34);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 auto;
+      }
+
+      .hangup-icon svg {
+        width: 16px;
+        height: 16px;
+        fill: currentColor;
+      }
+
+      .error {
+        margin-top: 16px;
+        color: #ffd2dd;
+        font-size: 13px;
+      }
+
+      .side {
+        border-left: 1px solid var(--border);
+        background: var(--surface-strong);
+        backdrop-filter: blur(10px);
+        box-shadow: var(--shadow);
+        padding: 20px;
+        display: none;
+        flex-direction: column;
+        gap: 14px;
+      }
+
+      .layout.show-info .side {
+        display: flex;
+      }
+
+      .panel {
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: rgba(10, 11, 37, 0.34);
+        padding: 14px;
+      }
+
+      .panel h2 {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--muted);
+        margin-bottom: 10px;
+      }
+
+      .kv {
+        display: grid;
+        grid-template-columns: 110px 1fr;
+        gap: 8px;
+        font-size: 12px;
+        margin-bottom: 8px;
+      }
+
+      .kv span:first-child {
+        color: var(--muted);
+      }
+
+      .device-grid {
+        display: grid;
+        gap: 10px;
+      }
+
+      .device-row {
+        display: grid;
+        gap: 6px;
+      }
+
+      .device-row label {
+        font-size: 12px;
+        color: var(--muted);
+      }
+
+      .support-note {
+        font-size: 12px;
+        color: var(--muted);
+      }
+
+      .transcript {
+        max-height: 30vh;
+        overflow-y: auto;
+        display: grid;
+        gap: 7px;
+      }
+
+      .entry {
+        font-size: 13px;
+        line-height: 1.45;
+        color: #e8ebff;
+      }
+
+      .entry.user {
+        color: #dce2ff;
+      }
+
+      .entry.agent {
+        color: #aeefff;
+      }
+
+      .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 999px;
+        display: inline-block;
+        margin-right: 7px;
+        background: var(--warn);
+      }
+
+      .dot.connected {
+        background: var(--good);
+        box-shadow: 0 0 8px rgba(82, 214, 160, 0.9);
+      }
+
+      .dot.error {
+        background: var(--bad);
+      }
+
+      .desktop-only {
         display: block;
       }
-    }
-  </style>
-</head>
 
-<body>
-  <div class="layout">
-    <main class="stage">
-      <div class="topbar">
-        <div class="brand">Stimm</div>
-        <div class="topbar-right">
-          <div class="status-pill" id="status-pill">Preparing session…</div>
-          <button class="icon-btn" id="btn-info" aria-label="Afficher les détails">i</button>
+      .mobile-only {
+        display: none;
+      }
+
+      @media (max-width: 980px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+
+        .layout.show-info {
+          grid-template-columns: 1fr;
+        }
+
+        .layout.show-info .side {
+          border-left: 0;
+          border-top: 1px solid var(--border);
+        }
+      }
+
+      @media (max-width: 768px) {
+        .stage {
+          padding: 16px;
+        }
+
+        .side {
+          padding: 16px;
+        }
+
+        .desktop-only {
+          display: none;
+        }
+
+        .mobile-only {
+          display: block;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="layout">
+      <main class="stage">
+        <div class="topbar">
+          <div class="brand">Stimm</div>
+          <div class="topbar-right">
+            <div class="status-pill" id="status-pill">Preparing session…</div>
+            <button class="icon-btn" id="btn-info" aria-label="Afficher les détails">i</button>
+          </div>
         </div>
-      </div>
 
-      <div class="center">
-        <section class="stage-card">
-          <div class="signal-badge" id="signal-badge">Agent idle</div>
-          <div class="visualizer" id="visualizer">
-            <div class="bar"></div>
-            <div class="bar"></div>
-            <div class="bar"></div>
-            <div class="bar"></div>
+        <div class="center">
+          <section class="stage-card">
+            <div class="signal-badge" id="signal-badge">Agent idle</div>
+            <div class="visualizer" id="visualizer">
+              <div class="bar"></div>
+              <div class="bar"></div>
+              <div class="bar"></div>
+              <div class="bar"></div>
+            </div>
+            <div class="connection-title" id="status-text">Disconnected</div>
+            <div class="room-info" id="room-info"></div>
+
+            <div class="action-row">
+              <button class="primary" id="btn-connect">Connect</button>
+              <button class="hangup" id="btn-hangup" aria-label="Raccrocher">
+                <span class="hangup-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                    <path
+                      d="M4.4 15.2c2.5 3.8 5.8 6.1 9.8 6.9.6.1 1.2-.1 1.6-.5l2.2-2.2c.4-.4.5-1 .3-1.5l-1-2.9c-.2-.6-.8-.9-1.4-.8l-2.8.5c-1.8-.8-3.2-2.2-4-4l.5-2.8c.1-.6-.2-1.2-.8-1.4l-2.9-1c-.5-.2-1.1-.1-1.5.3L2.1 7.9c-.4.4-.6 1-.5 1.6.8 4 3.1 7.3 6.9 9.8Z"
+                    />
+                  </svg>
+                </span>
+                <span>Raccrocher</span>
+              </button>
+              <button id="btn-mute" disabled>Mute</button>
+              <button id="btn-fullscreen">Fullscreen</button>
+              <button id="btn-mode" class="mobile-only">Mode: Hands-free</button>
+              <button id="btn-proximity" class="mobile-only">Ear detect: off</button>
+            </div>
+
+            <div class="error" id="error-msg" style="display: none"></div>
+          </section>
+        </div>
+      </main>
+
+      <aside class="side">
+        <section class="panel">
+          <h2>Live Status</h2>
+          <div class="kv">
+            <span>State</span><span id="status-line"><span class="dot"></span>Idle</span>
           </div>
-          <div class="connection-title" id="status-text">Disconnected</div>
-          <div class="room-info" id="room-info"></div>
-
-          <div class="action-row">
-            <button class="primary" id="btn-connect">Connect</button>
-            <button class="hangup" id="btn-hangup" aria-label="Raccrocher">
-              <span class="hangup-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
-                  <path
-                    d="M4.4 15.2c2.5 3.8 5.8 6.1 9.8 6.9.6.1 1.2-.1 1.6-.5l2.2-2.2c.4-.4.5-1 .3-1.5l-1-2.9c-.2-.6-.8-.9-1.4-.8l-2.8.5c-1.8-.8-3.2-2.2-4-4l.5-2.8c.1-.6-.2-1.2-.8-1.4l-2.9-1c-.5-.2-1.1-.1-1.5.3L2.1 7.9c-.4.4-.6 1-.5 1.6.8 4 3.1 7.3 6.9 9.8Z" />
-                </svg>
-              </span>
-              <span>Raccrocher</span>
-            </button>
-            <button id="btn-mute" disabled>Mute</button>
-            <button id="btn-fullscreen">Fullscreen</button>
-            <button id="btn-mode" class="mobile-only">Mode: Hands-free</button>
-            <button id="btn-proximity" class="mobile-only">Ear detect: off</button>
-          </div>
-
-          <div class="error" id="error-msg" style="display: none"></div>
+          <div class="kv"><span>Audio Mode</span><span id="audio-mode">Hands-free</span></div>
+          <div class="kv"><span>Room</span><span id="room-side">—</span></div>
+          <div class="kv"><span>Channel</span><span id="channel-side">web</span></div>
         </section>
-      </div>
-    </main>
 
-    <aside class="side">
-      <section class="panel">
-        <h2>Live Status</h2>
-        <div class="kv"><span>State</span><span id="status-line"><span class="dot"></span>Idle</span></div>
-        <div class="kv"><span>Audio Mode</span><span id="audio-mode">Hands-free</span></div>
-        <div class="kv"><span>Room</span><span id="room-side">—</span></div>
-        <div class="kv"><span>Channel</span><span id="channel-side">web</span></div>
-      </section>
-
-      <section class="panel">
-        <h2>Devices</h2>
-        <div class="device-grid">
-          <div class="device-row">
-            <label for="mic-select">Microphone</label>
-            <select id="mic-select"></select>
+        <section class="panel">
+          <h2>Devices</h2>
+          <div class="device-grid">
+            <div class="device-row">
+              <label for="mic-select">Microphone</label>
+              <select id="mic-select"></select>
+            </div>
+            <div class="device-row desktop-only">
+              <label for="speaker-select">Speaker / Headphones</label>
+              <select id="speaker-select"></select>
+            </div>
+            <div class="support-note" id="speaker-support-note"></div>
           </div>
-          <div class="device-row desktop-only">
-            <label for="speaker-select">Speaker / Headphones</label>
-            <select id="speaker-select"></select>
-          </div>
-          <div class="support-note" id="speaker-support-note"></div>
-        </div>
-      </section>
+        </section>
 
-      <section class="panel">
-        <h2>Transcription</h2>
-        <div class="transcript" id="transcript"></div>
-      </section>
-    </aside>
-  </div>
+        <section class="panel">
+          <h2>Transcription</h2>
+          <div class="transcript" id="transcript"></div>
+        </section>
+      </aside>
+    </div>
 
-  <div class="connect-overlay" id="connect-overlay">
-    <button class="btn-connect-overlay" id="btn-connect-overlay" aria-label="Activer l'audio et se connecter">
-      <span class="btn-connect-overlay-icon" aria-hidden="true">🎙️</span>
-      <span class="btn-connect-overlay-title">Appuyer pour parler</span>
-      <span class="btn-connect-overlay-subtitle">Active l'audio et connecte la session</span>
-    </button>
-  </div>
+    <div class="connect-overlay" id="connect-overlay">
+      <button
+        class="btn-connect-overlay"
+        id="btn-connect-overlay"
+        aria-label="Activer l'audio et se connecter"
+      >
+        <span class="btn-connect-overlay-icon" aria-hidden="true">🎙️</span>
+        <span class="btn-connect-overlay-title">Appuyer pour parler</span>
+        <span class="btn-connect-overlay-subtitle">Active l'audio et connecte la session</span>
+      </button>
+    </div>
 
-  <div id="goodbye-screen" style="
+    <div
+      id="goodbye-screen"
+      style="
         display: none;
         width: 100vw;
         height: 100vh;
@@ -562,657 +576,661 @@
         font-size: 42px;
         font-weight: 700;
         letter-spacing: -0.03em;
-      ">
-    A bientôt !
-  </div>
+      "
+    >
+      A bientôt !
+    </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/livekit-client@2/dist/livekit-client.umd.js"></script>
-  <script>
-    let room = null;
-    let localTrack = null;
-    let connected = false;
-    let muted = false;
-    let currentRoomName = "";
-    let currentChannel = "web";
-    let disconnectToken = "";
-    let selectedMicId = "";
-    let selectedSpeakerId = "default";
-    let audioMode = "handsfree";
-    let proximityEnabled = false;
-    let proximitySensor = null;
-    let proximityAutoSwitched = false;
-    let audioUnlockArmed = false;
+    <script src="https://cdn.jsdelivr.net/npm/livekit-client@2/dist/livekit-client.umd.js"></script>
+    <script>
+      let room = null;
+      let localTrack = null;
+      let connected = false;
+      let muted = false;
+      let currentRoomName = "";
+      let currentChannel = "web";
+      let disconnectToken = "";
+      let selectedMicId = "";
+      let selectedSpeakerId = "default";
+      let audioMode = "handsfree";
+      let proximityEnabled = false;
+      let proximitySensor = null;
+      let proximityAutoSwitched = false;
+      let audioUnlockArmed = false;
 
-    const remoteAudioElements = new Map();
-    const remoteAudioByParticipant = new Map();
+      const remoteAudioElements = new Map();
+      const remoteAudioByParticipant = new Map();
 
-    const $ = (id) => document.getElementById(id);
-    const visualizer = $("visualizer");
-    const statusText = $("status-text");
-    const statusPill = $("status-pill");
-    const signalBadge = $("signal-badge");
-    const roomInfo = $("room-info");
-    const statusLine = $("status-line");
-    const audioModeLabel = $("audio-mode");
-    const roomSide = $("room-side");
-    const channelSide = $("channel-side");
-    const transcriptEl = $("transcript");
-    const errorMsg = $("error-msg");
-    const layout = document.querySelector(".layout");
-    const connectOverlay = $("connect-overlay");
-    const goodbyeScreen = $("goodbye-screen");
-    const btnConnect = $("btn-connect");
-    const btnConnectOverlay = $("btn-connect-overlay");
-    const btnHangup = $("btn-hangup");
-    const btnMute = $("btn-mute");
-    const btnFullscreen = $("btn-fullscreen");
-    const btnInfo = $("btn-info");
-    const btnMode = $("btn-mode");
-    const btnProximity = $("btn-proximity");
-    const micSelect = $("mic-select");
-    const speakerSelect = $("speaker-select");
-    const speakerSupportNote = $("speaker-support-note");
+      const $ = (id) => document.getElementById(id);
+      const visualizer = $("visualizer");
+      const statusText = $("status-text");
+      const statusPill = $("status-pill");
+      const signalBadge = $("signal-badge");
+      const roomInfo = $("room-info");
+      const statusLine = $("status-line");
+      const audioModeLabel = $("audio-mode");
+      const roomSide = $("room-side");
+      const channelSide = $("channel-side");
+      const transcriptEl = $("transcript");
+      const errorMsg = $("error-msg");
+      const layout = document.querySelector(".layout");
+      const connectOverlay = $("connect-overlay");
+      const goodbyeScreen = $("goodbye-screen");
+      const btnConnect = $("btn-connect");
+      const btnConnectOverlay = $("btn-connect-overlay");
+      const btnHangup = $("btn-hangup");
+      const btnMute = $("btn-mute");
+      const btnFullscreen = $("btn-fullscreen");
+      const btnInfo = $("btn-info");
+      const btnMode = $("btn-mode");
+      const btnProximity = $("btn-proximity");
+      const micSelect = $("mic-select");
+      const speakerSelect = $("speaker-select");
+      const speakerSupportNote = $("speaker-support-note");
 
-    const isMobile =
-      window.matchMedia("(max-width: 768px)").matches ||
-      /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
-    const canSetSink =
-      typeof HTMLMediaElement !== "undefined" &&
-      typeof HTMLMediaElement.prototype.setSinkId === "function";
+      const isMobile =
+        window.matchMedia("(max-width: 768px)").matches ||
+        /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+      const canSetSink =
+        typeof HTMLMediaElement !== "undefined" &&
+        typeof HTMLMediaElement.prototype.setSinkId === "function";
 
-    async function createSession() {
-      const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
-      const claimPath = `${voicePath}/claim`;
-      const params = new URLSearchParams(window.location.search);
-      const claim = params.get("c") || params.get("claim");
-
-      const res = claim
-        ? await fetch(claimPath, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ claim }),
-        })
-        : await fetch(voicePath, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        });
-
-      if (!res.ok) {
-        const body = await res.text();
-        if (claim) {
-          throw new Error(`Failed to exchange claim: ${res.status} ${body}`);
-        }
-        throw new Error(
-          `Failed to create session: ${res.status} ${body}. Use a claim link, or enable direct web session create in config.`,
-        );
-      }
-
-      return await res.json();
-    }
-
-    async function endSession(roomName, token) {
-      const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
-      const endPath = `${voicePath}/end`;
-      const res = await fetch(endPath, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          room: roomName,
-          disconnectToken: token,
-        }),
-      });
-      if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`Failed to end session: ${res.status} ${body}`);
-      }
-    }
-
-    function showGoodbyeScreen() {
-      setConnectOverlayVisible(false);
-      if (layout) layout.style.display = "none";
-      if (goodbyeScreen) goodbyeScreen.style.display = "flex";
-    }
-
-    function hideGoodbyeScreen() {
-      if (goodbyeScreen) goodbyeScreen.style.display = "none";
-      if (layout) layout.style.display = "grid";
-    }
-
-    function setConnectOverlayVisible(visible) {
-      if (!connectOverlay) return;
-      connectOverlay.classList.toggle("hidden", !visible);
-    }
-
-    function setInfoVisible(visible) {
-      if (!layout) return;
-      layout.classList.toggle("show-info", visible);
-    }
-
-    function updateStatus(state, text) {
-      const dotClass = state === "connected" ? "connected" : state === "error" ? "error" : "";
-      statusText.textContent = text;
-      statusPill.textContent = text;
-      statusLine.innerHTML = `<span class="dot ${dotClass}"></span>${text}`;
-    }
-
-    function setSignal(active) {
-      if (active) {
-        visualizer.classList.add("active");
-        signalBadge.textContent = "Agent speaking";
-      } else {
-        visualizer.classList.remove("active");
-        signalBadge.textContent = "Agent idle";
-      }
-    }
-
-    function showError(message) {
-      errorMsg.textContent = message;
-      errorMsg.style.display = "block";
-    }
-
-    function hideError() {
-      errorMsg.style.display = "none";
-    }
-
-    function addTranscript(role, text) {
-      if (!text || !text.trim()) return;
-      const entry = document.createElement("div");
-      entry.className = `entry ${role}`;
-      entry.textContent = `${role === "user" ? "You" : "Agent"}: ${text}`;
-      transcriptEl.appendChild(entry);
-      transcriptEl.scrollTop = transcriptEl.scrollHeight;
-    }
-
-    async function listDevices() {
-      if (!navigator.mediaDevices?.enumerateDevices) return;
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const inputDevices = devices.filter((d) => d.kind === "audioinput");
-      const outputDevices = devices.filter((d) => d.kind === "audiooutput");
-
-      micSelect.innerHTML = "";
-      for (let index = 0; index < inputDevices.length; index += 1) {
-        const d = inputDevices[index];
-        const option = document.createElement("option");
-        option.value = d.deviceId;
-        option.textContent = d.label || `Microphone ${index + 1}`;
-        micSelect.appendChild(option);
-      }
-
-      if (!selectedMicId && inputDevices.length > 0) {
-        selectedMicId = inputDevices[0].deviceId;
-      }
-      if (selectedMicId) {
-        micSelect.value = selectedMicId;
-      }
-
-      if (canSetSink && speakerSelect) {
-        speakerSelect.innerHTML = "";
-        if (outputDevices.length === 0) {
-          const defaultOption = document.createElement("option");
-          defaultOption.value = "default";
-          defaultOption.textContent = "Default output";
-          speakerSelect.appendChild(defaultOption);
-        }
-        for (let index = 0; index < outputDevices.length; index += 1) {
-          const d = outputDevices[index];
-          const option = document.createElement("option");
-          option.value = d.deviceId || "default";
-          option.textContent = d.label || `Output ${index + 1}`;
-          speakerSelect.appendChild(option);
-        }
-        if (![...speakerSelect.options].some((opt) => opt.value === selectedSpeakerId)) {
-          selectedSpeakerId = speakerSelect.options[0]?.value || "default";
-        }
-        speakerSelect.value = selectedSpeakerId;
-        speakerSupportNote.textContent = "";
-      } else {
-        if (speakerSelect) speakerSelect.disabled = true;
-        speakerSupportNote.textContent = "Speaker routing selector is available on desktop Chromium browsers.";
-      }
-    }
-
-    async function applyOutputToElement(el) {
-      if (!canSetSink) return;
-      const sinkId = audioMode === "handsfree" ? selectedSpeakerId : "default";
-      try {
-        await el.setSinkId(sinkId || "default");
-      } catch { }
-    }
-
-    async function applyOutputToAll() {
-      const actions = [];
-      for (const el of remoteAudioElements.values()) {
-        actions.push(applyOutputToElement(el));
-        el.volume = audioMode === "handsfree" ? 1 : 0.8;
-      }
-      await Promise.all(actions);
-    }
-
-    function armAudioUnlockGesture() {
-      if (audioUnlockArmed) return;
-      audioUnlockArmed = true;
-
-      const handler = async () => {
-        try {
-          await ensureAudioPlayback(true);
-        } catch { }
-        document.removeEventListener("pointerdown", handler, true);
-        document.removeEventListener("touchstart", handler, true);
-        document.removeEventListener("click", handler, true);
-        audioUnlockArmed = false;
-      };
-
-      document.addEventListener("pointerdown", handler, true);
-      document.addEventListener("touchstart", handler, true);
-      document.addEventListener("click", handler, true);
-    }
-
-    async function ensureAudioPlayback(fromUserGesture = false) {
-      if (!room) return;
-
-      let unlocked = false;
-      if (typeof room.startAudio === "function") {
-        try {
-          await room.startAudio();
-          unlocked = true;
-        } catch { }
-      }
-
-      let played = false;
-      for (const el of remoteAudioElements.values()) {
-        try {
-          await el.play();
-          played = true;
-        } catch { }
-      }
-
-      if (!fromUserGesture && !unlocked && !played) {
-        armAudioUnlockGesture();
-        updateStatus("connected", "Tap once to enable audio");
-      }
-    }
-
-    async function setAudioMode(mode, triggeredByProximity = false) {
-      audioMode = mode;
-      audioModeLabel.textContent = mode === "handsfree" ? "Hands-free" : "Standard";
-      if (btnMode) {
-        btnMode.textContent = `Mode: ${mode === "handsfree" ? "Hands-free" : "Standard"}`;
-      }
-      if (triggeredByProximity) {
-        proximityAutoSwitched = true;
-      } else {
-        proximityAutoSwitched = false;
-      }
-      await applyOutputToAll();
-    }
-
-    async function replaceLocalTrack() {
-      if (!room) return;
-      const newTrack = await LivekitClient.createLocalAudioTrack({
-        deviceId: selectedMicId ? { exact: selectedMicId } : undefined,
-        autoGainControl: true,
-        echoCancellation: true,
-        noiseSuppression: true,
-      });
-      const previous = localTrack;
-      const micSource =
-        LivekitClient?.Track?.Source?.Microphone ??
-        LivekitClient?.Track?.Source?.SOURCE_MICROPHONE;
-      const publishOpts = micSource ? { source: micSource } : undefined;
-
-      localTrack = newTrack;
-      await room.localParticipant.publishTrack(newTrack, publishOpts);
-      if (previous) {
-        try {
-          await room.localParticipant.unpublishTrack(previous);
-        } catch { }
-        previous.stop();
-      }
-    }
-
-    async function warmupAudioPermission() {
-      if (!navigator.mediaDevices?.getUserMedia) return;
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      for (const track of stream.getTracks()) {
-        track.stop();
-      }
-    }
-
-    async function connect(fromUserGesture = false) {
-      if (connected) return;
-      updateStatus("connecting", "Connecting…");
-      hideError();
-      btnConnect.disabled = true;
-      if (btnConnectOverlay) btnConnectOverlay.disabled = true;
-
-      try {
-        const session = await createSession();
-        const token = session.clientToken;
-        currentRoomName = session.room;
-        currentChannel = session.channel || "web";
-        disconnectToken = typeof session.disconnectToken === "string" ? session.disconnectToken : "";
+      async function createSession() {
+        const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
+        const claimPath = `${voicePath}/claim`;
         const params = new URLSearchParams(window.location.search);
-        const livekitOverride = params.get("livekit");
-        const serverLivekitUrl = session.livekitUrl || null;
-        let livekitUrl;
-        if (serverLivekitUrl) {
-          livekitUrl = serverLivekitUrl;
-        } else if (livekitOverride) {
-          livekitUrl = livekitOverride;
-        } else {
-          const isSecure = window.location.protocol === "https:";
-          const wsProtocol = isSecure ? "wss:" : "ws:";
-          const livekitPort = isSecure ? "7443" : "7880";
-          livekitUrl = `${wsProtocol}//${window.location.hostname}:${livekitPort}`;
+        const claim = params.get("c") || params.get("claim");
+
+        const res = claim
+          ? await fetch(claimPath, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ claim }),
+            })
+          : await fetch(voicePath, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+            });
+
+        if (!res.ok) {
+          const body = await res.text();
+          if (claim) {
+            throw new Error(`Failed to exchange claim: ${res.status} ${body}`);
+          }
+          throw new Error(
+            `Failed to create session: ${res.status} ${body}. Use a claim link, or enable direct web session create in config.`,
+          );
         }
 
-        room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+        return await res.json();
+      }
 
-        room.on(LivekitClient.RoomEvent.Disconnected, () => {
-          cleanupConnectionUI();
-          updateStatus("disconnected", "Disconnected");
+      async function endSession(roomName, token) {
+        const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
+        const endPath = `${voicePath}/end`;
+        const res = await fetch(endPath, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            room: roomName,
+            disconnectToken: token,
+          }),
         });
-
-        room.on(LivekitClient.RoomEvent.TrackSubscribed, async (track, pub, participant) => {
-          if (track.kind !== LivekitClient.Track.Kind.Audio) return;
-          const participantId = participant?.identity || "unknown";
-          const key = pub?.trackSid || track.sid || `${participantId}:audio`;
-          const previousKey = remoteAudioByParticipant.get(participantId);
-          if (previousKey && previousKey !== key) {
-            const oldEl = remoteAudioElements.get(previousKey);
-            if (oldEl) {
-              try {
-                oldEl.remove();
-              } catch { }
-              remoteAudioElements.delete(previousKey);
-            }
-          }
-          const prev = remoteAudioElements.get(key);
-          if (prev) {
-            try {
-              prev.remove();
-            } catch { }
-            remoteAudioElements.delete(key);
-          }
-          const el = track.attach();
-          el.autoplay = true;
-          el.setAttribute("data-lk-track", key);
-          el.setAttribute("data-lk-participant", participantId);
-          document.body.appendChild(el);
-          remoteAudioElements.set(key, el);
-          remoteAudioByParticipant.set(participantId, key);
-          await applyOutputToElement(el);
-          el.volume = audioMode === "handsfree" ? 1 : 0.8;
-          await ensureAudioPlayback();
-          setSignal(true);
-        });
-
-        room.on(LivekitClient.RoomEvent.TrackUnsubscribed, (track, pub) => {
-          const key = pub?.trackSid || track?.sid;
-          if (!key) return;
-          const el = remoteAudioElements.get(key);
-          if (!el) return;
-          try {
-            track?.detach(el);
-          } catch { }
-          try {
-            el.remove();
-          } catch { }
-          remoteAudioElements.delete(key);
-          const participantId = el.getAttribute("data-lk-participant") || "";
-          if (participantId && remoteAudioByParticipant.get(participantId) === key) {
-            remoteAudioByParticipant.delete(participantId);
-          }
-          if (remoteAudioElements.size === 0) {
-            setSignal(false);
-          }
-        });
-
-        room.on(LivekitClient.RoomEvent.DataReceived, (payload) => {
-          try {
-            const message = JSON.parse(new TextDecoder().decode(payload));
-            if (message.type === "transcript") {
-              if (message.partial === true) return;
-              addTranscript("user", message.text || message.data || "");
-            }
-            if (message.type === "response") {
-              addTranscript("agent", message.text || message.data || "");
-            }
-          } catch { }
-        });
-
-        await room.connect(livekitUrl, token);
-        await ensureAudioPlayback(fromUserGesture);
-        await listDevices();
-        await replaceLocalTrack();
-        if (localTrack?.muted) {
-          localTrack.unmute();
+        if (!res.ok) {
+          const body = await res.text();
+          throw new Error(`Failed to end session: ${res.status} ${body}`);
         }
+      }
 
-        connected = true;
-        muted = false;
+      function showGoodbyeScreen() {
         setConnectOverlayVisible(false);
-        btnConnect.style.display = "none";
-        btnConnect.disabled = false;
-        btnHangup.style.display = "inline-flex";
-        btnMute.disabled = false;
-        btnMute.textContent = "Mute";
-        setSignal(true);
+        if (layout) layout.style.display = "none";
+        if (goodbyeScreen) goodbyeScreen.style.display = "flex";
+      }
 
-        roomInfo.textContent = `Connected to ${currentRoomName}`;
-        roomSide.textContent = currentRoomName;
-        channelSide.textContent = currentChannel;
-        updateStatus("connected", "Connected");
-      } catch (error) {
-        const message = error?.message || "Could not connect to voice session.";
-        showError(message);
-        cleanupConnectionUI();
-        updateStatus("error", "Connection failed");
-      } finally {
-        btnConnect.disabled = false;
-        if (btnConnectOverlay) btnConnectOverlay.disabled = false;
+      function hideGoodbyeScreen() {
+        if (goodbyeScreen) goodbyeScreen.style.display = "none";
+        if (layout) layout.style.display = "grid";
       }
-    }
 
-    async function disconnect() {
-      const roomToClose = currentRoomName;
-      const closeToken = disconnectToken;
-      if (room) {
-        try {
-          await room.disconnect();
-        } catch { }
-        room = null;
+      function setConnectOverlayVisible(visible) {
+        if (!connectOverlay) return;
+        connectOverlay.classList.toggle("hidden", !visible);
       }
-      if (localTrack) {
-        localTrack.stop();
-        localTrack = null;
-      }
-      for (const el of remoteAudioElements.values()) {
-        try {
-          el.remove();
-        } catch { }
-      }
-      remoteAudioElements.clear();
-      remoteAudioByParticipant.clear();
 
-      if (roomToClose && closeToken) {
-        try {
-          await endSession(roomToClose, closeToken);
-        } catch (error) {
-          showError(error?.message || "Session disconnected locally, but cloud room teardown failed.");
+      function setInfoVisible(visible) {
+        if (!layout) return;
+        layout.classList.toggle("show-info", visible);
+      }
+
+      function updateStatus(state, text) {
+        const dotClass = state === "connected" ? "connected" : state === "error" ? "error" : "";
+        statusText.textContent = text;
+        statusPill.textContent = text;
+        statusLine.innerHTML = `<span class="dot ${dotClass}"></span>${text}`;
+      }
+
+      function setSignal(active) {
+        if (active) {
+          visualizer.classList.add("active");
+          signalBadge.textContent = "Agent speaking";
+        } else {
+          visualizer.classList.remove("active");
+          signalBadge.textContent = "Agent idle";
         }
       }
 
-      cleanupConnectionUI();
-      updateStatus("disconnected", "Disconnected");
-      showGoodbyeScreen();
-    }
-
-    function cleanupConnectionUI() {
-      connected = false;
-      muted = false;
-      currentRoomName = "";
-      disconnectToken = "";
-      roomInfo.textContent = "";
-      roomSide.textContent = "—";
-      btnConnect.textContent = "Connect";
-      btnConnect.style.display = "inline-flex";
-      btnConnect.classList.add("primary");
-      btnConnect.classList.remove("danger");
-      setConnectOverlayVisible(true);
-      btnHangup.style.display = "none";
-      btnMute.textContent = "Mute";
-      btnMute.disabled = true;
-      setSignal(false);
-    }
-
-    function toggleMute() {
-      if (!localTrack) return;
-      muted = !muted;
-      if (muted) {
-        localTrack.mute();
-        btnMute.textContent = "Unmute";
-        setSignal(false);
-      } else {
-        localTrack.unmute();
-        btnMute.textContent = "Mute";
-        setSignal(true);
-      }
-    }
-
-    async function toggleFullscreen() {
-      if (!document.fullscreenElement) {
-        await document.documentElement.requestFullscreen?.();
-        btnFullscreen.textContent = "Exit Fullscreen";
-        return;
-      }
-      await document.exitFullscreen?.();
-      btnFullscreen.textContent = "Fullscreen";
-    }
-
-    function setupProximity() {
-      if (!isMobile || typeof window.ProximitySensor !== "function") {
-        btnProximity.textContent = "Ear detect: unavailable";
-        btnProximity.disabled = true;
-        return;
+      function showError(message) {
+        errorMsg.textContent = message;
+        errorMsg.style.display = "block";
       }
 
-      proximityEnabled = true;
-      btnProximity.textContent = "Ear detect: on";
-      proximitySensor = new window.ProximitySensor({ frequency: 5 });
-      proximitySensor.addEventListener("reading", async () => {
-        if (!proximityEnabled) return;
-        const near = Number(proximitySensor.distance) <= 0;
-        if (near && audioMode !== "standard") {
-          await setAudioMode("standard", true);
+      function hideError() {
+        errorMsg.style.display = "none";
+      }
+
+      function addTranscript(role, text) {
+        if (!text || !text.trim()) return;
+        const entry = document.createElement("div");
+        entry.className = `entry ${role}`;
+        entry.textContent = `${role === "user" ? "You" : "Agent"}: ${text}`;
+        transcriptEl.appendChild(entry);
+        transcriptEl.scrollTop = transcriptEl.scrollHeight;
+      }
+
+      async function listDevices() {
+        if (!navigator.mediaDevices?.enumerateDevices) return;
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const inputDevices = devices.filter((d) => d.kind === "audioinput");
+        const outputDevices = devices.filter((d) => d.kind === "audiooutput");
+
+        micSelect.innerHTML = "";
+        for (let index = 0; index < inputDevices.length; index += 1) {
+          const d = inputDevices[index];
+          const option = document.createElement("option");
+          option.value = d.deviceId;
+          option.textContent = d.label || `Microphone ${index + 1}`;
+          micSelect.appendChild(option);
         }
-        if (!near && proximityAutoSwitched && audioMode !== "handsfree") {
-          await setAudioMode("handsfree", true);
+
+        if (!selectedMicId && inputDevices.length > 0) {
+          selectedMicId = inputDevices[0].deviceId;
+        }
+        if (selectedMicId) {
+          micSelect.value = selectedMicId;
+        }
+
+        if (canSetSink && speakerSelect) {
+          speakerSelect.innerHTML = "";
+          if (outputDevices.length === 0) {
+            const defaultOption = document.createElement("option");
+            defaultOption.value = "default";
+            defaultOption.textContent = "Default output";
+            speakerSelect.appendChild(defaultOption);
+          }
+          for (let index = 0; index < outputDevices.length; index += 1) {
+            const d = outputDevices[index];
+            const option = document.createElement("option");
+            option.value = d.deviceId || "default";
+            option.textContent = d.label || `Output ${index + 1}`;
+            speakerSelect.appendChild(option);
+          }
+          if (![...speakerSelect.options].some((opt) => opt.value === selectedSpeakerId)) {
+            selectedSpeakerId = speakerSelect.options[0]?.value || "default";
+          }
+          speakerSelect.value = selectedSpeakerId;
+          speakerSupportNote.textContent = "";
+        } else {
+          if (speakerSelect) speakerSelect.disabled = true;
+          speakerSupportNote.textContent =
+            "Speaker routing selector is available on desktop Chromium browsers.";
+        }
+      }
+
+      async function applyOutputToElement(el) {
+        if (!canSetSink) return;
+        const sinkId = audioMode === "handsfree" ? selectedSpeakerId : "default";
+        try {
+          await el.setSinkId(sinkId || "default");
+        } catch {}
+      }
+
+      async function applyOutputToAll() {
+        const actions = [];
+        for (const el of remoteAudioElements.values()) {
+          actions.push(applyOutputToElement(el));
+          el.volume = audioMode === "handsfree" ? 1 : 0.8;
+        }
+        await Promise.all(actions);
+      }
+
+      function armAudioUnlockGesture() {
+        if (audioUnlockArmed) return;
+        audioUnlockArmed = true;
+
+        const handler = async () => {
+          try {
+            await ensureAudioPlayback(true);
+          } catch {}
+          document.removeEventListener("pointerdown", handler, true);
+          document.removeEventListener("touchstart", handler, true);
+          document.removeEventListener("click", handler, true);
+          audioUnlockArmed = false;
+        };
+
+        document.addEventListener("pointerdown", handler, true);
+        document.addEventListener("touchstart", handler, true);
+        document.addEventListener("click", handler, true);
+      }
+
+      async function ensureAudioPlayback(fromUserGesture = false) {
+        if (!room) return;
+
+        let unlocked = false;
+        if (typeof room.startAudio === "function") {
+          try {
+            await room.startAudio();
+            unlocked = true;
+          } catch {}
+        }
+
+        let played = false;
+        for (const el of remoteAudioElements.values()) {
+          try {
+            await el.play();
+            played = true;
+          } catch {}
+        }
+
+        if (!fromUserGesture && !unlocked && !played) {
+          armAudioUnlockGesture();
+          updateStatus("connected", "Tap once to enable audio");
+        }
+      }
+
+      async function setAudioMode(mode, triggeredByProximity = false) {
+        audioMode = mode;
+        audioModeLabel.textContent = mode === "handsfree" ? "Hands-free" : "Standard";
+        if (btnMode) {
+          btnMode.textContent = `Mode: ${mode === "handsfree" ? "Hands-free" : "Standard"}`;
+        }
+        if (triggeredByProximity) {
+          proximityAutoSwitched = true;
+        } else {
           proximityAutoSwitched = false;
         }
-      });
-      proximitySensor.addEventListener("error", () => {
-        btnProximity.textContent = "Ear detect: unavailable";
-        btnProximity.disabled = true;
-      });
-      try {
-        proximitySensor.start();
-      } catch {
-        btnProximity.textContent = "Ear detect: unavailable";
-        btnProximity.disabled = true;
-      }
-    }
-
-    function toggleProximity() {
-      if (!proximitySensor) return;
-      proximityEnabled = !proximityEnabled;
-      btnProximity.textContent = `Ear detect: ${proximityEnabled ? "on" : "off"}`;
-    }
-
-    async function init() {
-      hideGoodbyeScreen();
-      if (isMobile) {
-        btnMode.style.display = "inline-flex";
-        btnProximity.style.display = "inline-flex";
+        await applyOutputToAll();
       }
 
-      if (navigator.mediaDevices?.addEventListener) {
-        navigator.mediaDevices.addEventListener("devicechange", () => {
-          listDevices().catch(() => { });
+      async function replaceLocalTrack() {
+        if (!room) return;
+        const newTrack = await LivekitClient.createLocalAudioTrack({
+          deviceId: selectedMicId ? { exact: selectedMicId } : undefined,
+          autoGainControl: true,
+          echoCancellation: true,
+          noiseSuppression: true,
         });
+        const previous = localTrack;
+        const micSource =
+          LivekitClient?.Track?.Source?.Microphone ??
+          LivekitClient?.Track?.Source?.SOURCE_MICROPHONE;
+        const publishOpts = micSource ? { source: micSource } : undefined;
+
+        localTrack = newTrack;
+        await room.localParticipant.publishTrack(newTrack, publishOpts);
+        if (previous) {
+          try {
+            await room.localParticipant.unpublishTrack(previous);
+          } catch {}
+          previous.stop();
+        }
       }
 
-      micSelect.addEventListener("change", async (event) => {
-        selectedMicId = event.target.value;
-        if (connected) {
+      async function warmupAudioPermission() {
+        if (!navigator.mediaDevices?.getUserMedia) return;
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        for (const track of stream.getTracks()) {
+          track.stop();
+        }
+      }
+
+      async function connect(fromUserGesture = false) {
+        if (connected) return;
+        updateStatus("connecting", "Connecting…");
+        hideError();
+        btnConnect.disabled = true;
+        if (btnConnectOverlay) btnConnectOverlay.disabled = true;
+
+        try {
+          const session = await createSession();
+          const token = session.clientToken;
+          currentRoomName = session.room;
+          currentChannel = session.channel || "web";
+          disconnectToken =
+            typeof session.disconnectToken === "string" ? session.disconnectToken : "";
+          const params = new URLSearchParams(window.location.search);
+          const livekitOverride = params.get("livekit");
+          const serverLivekitUrl = session.livekitUrl || null;
+          let livekitUrl;
+          if (serverLivekitUrl) {
+            livekitUrl = serverLivekitUrl;
+          } else if (livekitOverride) {
+            livekitUrl = livekitOverride;
+          } else {
+            const isSecure = window.location.protocol === "https:";
+            const wsProtocol = isSecure ? "wss:" : "ws:";
+            const livekitPort = isSecure ? "7443" : "7880";
+            livekitUrl = `${wsProtocol}//${window.location.hostname}:${livekitPort}`;
+          }
+
+          room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+
+          room.on(LivekitClient.RoomEvent.Disconnected, () => {
+            cleanupConnectionUI();
+            updateStatus("disconnected", "Disconnected");
+          });
+
+          room.on(LivekitClient.RoomEvent.TrackSubscribed, async (track, pub, participant) => {
+            if (track.kind !== LivekitClient.Track.Kind.Audio) return;
+            const participantId = participant?.identity || "unknown";
+            const key = pub?.trackSid || track.sid || `${participantId}:audio`;
+            const previousKey = remoteAudioByParticipant.get(participantId);
+            if (previousKey && previousKey !== key) {
+              const oldEl = remoteAudioElements.get(previousKey);
+              if (oldEl) {
+                try {
+                  oldEl.remove();
+                } catch {}
+                remoteAudioElements.delete(previousKey);
+              }
+            }
+            const prev = remoteAudioElements.get(key);
+            if (prev) {
+              try {
+                prev.remove();
+              } catch {}
+              remoteAudioElements.delete(key);
+            }
+            const el = track.attach();
+            el.autoplay = true;
+            el.setAttribute("data-lk-track", key);
+            el.setAttribute("data-lk-participant", participantId);
+            document.body.appendChild(el);
+            remoteAudioElements.set(key, el);
+            remoteAudioByParticipant.set(participantId, key);
+            await applyOutputToElement(el);
+            el.volume = audioMode === "handsfree" ? 1 : 0.8;
+            await ensureAudioPlayback();
+            setSignal(true);
+          });
+
+          room.on(LivekitClient.RoomEvent.TrackUnsubscribed, (track, pub) => {
+            const key = pub?.trackSid || track?.sid;
+            if (!key) return;
+            const el = remoteAudioElements.get(key);
+            if (!el) return;
+            try {
+              track?.detach(el);
+            } catch {}
+            try {
+              el.remove();
+            } catch {}
+            remoteAudioElements.delete(key);
+            const participantId = el.getAttribute("data-lk-participant") || "";
+            if (participantId && remoteAudioByParticipant.get(participantId) === key) {
+              remoteAudioByParticipant.delete(participantId);
+            }
+            if (remoteAudioElements.size === 0) {
+              setSignal(false);
+            }
+          });
+
+          room.on(LivekitClient.RoomEvent.DataReceived, (payload) => {
+            try {
+              const message = JSON.parse(new TextDecoder().decode(payload));
+              if (message.type === "transcript") {
+                if (message.partial === true) return;
+                addTranscript("user", message.text || message.data || "");
+              }
+              if (message.type === "response") {
+                addTranscript("agent", message.text || message.data || "");
+              }
+            } catch {}
+          });
+
+          await room.connect(livekitUrl, token);
+          await ensureAudioPlayback(fromUserGesture);
+          await listDevices();
+          await replaceLocalTrack();
+          if (localTrack?.muted) {
+            localTrack.unmute();
+          }
+
+          connected = true;
+          muted = false;
+          setConnectOverlayVisible(false);
+          btnConnect.style.display = "none";
+          btnConnect.disabled = false;
+          btnHangup.style.display = "inline-flex";
+          btnMute.disabled = false;
+          btnMute.textContent = "Mute";
+          setSignal(true);
+
+          roomInfo.textContent = `Connected to ${currentRoomName}`;
+          roomSide.textContent = currentRoomName;
+          channelSide.textContent = currentChannel;
+          updateStatus("connected", "Connected");
+        } catch (error) {
+          const message = error?.message || "Could not connect to voice session.";
+          showError(message);
+          cleanupConnectionUI();
+          updateStatus("error", "Connection failed");
+        } finally {
+          btnConnect.disabled = false;
+          if (btnConnectOverlay) btnConnectOverlay.disabled = false;
+        }
+      }
+
+      async function disconnect() {
+        const roomToClose = currentRoomName;
+        const closeToken = disconnectToken;
+        if (room) {
           try {
-            await replaceLocalTrack();
+            await room.disconnect();
+          } catch {}
+          room = null;
+        }
+        if (localTrack) {
+          localTrack.stop();
+          localTrack = null;
+        }
+        for (const el of remoteAudioElements.values()) {
+          try {
+            el.remove();
+          } catch {}
+        }
+        remoteAudioElements.clear();
+        remoteAudioByParticipant.clear();
+
+        if (roomToClose && closeToken) {
+          try {
+            await endSession(roomToClose, closeToken);
           } catch (error) {
-            showError(error?.message || "Could not switch microphone.");
+            showError(
+              error?.message || "Session disconnected locally, but cloud room teardown failed.",
+            );
           }
         }
-      });
 
-      if (speakerSelect) {
-        speakerSelect.addEventListener("change", async (event) => {
-          selectedSpeakerId = event.target.value || "default";
-          await applyOutputToAll();
-        });
+        cleanupConnectionUI();
+        updateStatus("disconnected", "Disconnected");
+        showGoodbyeScreen();
       }
 
-      const handleManualConnect = async () => {
-        hideGoodbyeScreen();
-        hideError();
-        setConnectOverlayVisible(false);
-        try {
-          await warmupAudioPermission();
-        } catch {
-          showError("Microphone access is required to start voice.");
-          setConnectOverlayVisible(true);
-          updateStatus("error", "Microphone permission required");
+      function cleanupConnectionUI() {
+        connected = false;
+        muted = false;
+        currentRoomName = "";
+        disconnectToken = "";
+        roomInfo.textContent = "";
+        roomSide.textContent = "—";
+        btnConnect.textContent = "Connect";
+        btnConnect.style.display = "inline-flex";
+        btnConnect.classList.add("primary");
+        btnConnect.classList.remove("danger");
+        setConnectOverlayVisible(true);
+        btnHangup.style.display = "none";
+        btnMute.textContent = "Mute";
+        btnMute.disabled = true;
+        setSignal(false);
+      }
+
+      function toggleMute() {
+        if (!localTrack) return;
+        muted = !muted;
+        if (muted) {
+          localTrack.mute();
+          btnMute.textContent = "Unmute";
+          setSignal(false);
+        } else {
+          localTrack.unmute();
+          btnMute.textContent = "Mute";
+          setSignal(true);
+        }
+      }
+
+      async function toggleFullscreen() {
+        if (!document.fullscreenElement) {
+          await document.documentElement.requestFullscreen?.();
+          btnFullscreen.textContent = "Exit Fullscreen";
           return;
         }
-        await connect(true);
-        if (!connected) {
-          setConnectOverlayVisible(true);
-        }
-      };
-
-      btnConnect.addEventListener("click", handleManualConnect);
-      if (btnConnectOverlay) {
-        btnConnectOverlay.addEventListener("click", handleManualConnect);
+        await document.exitFullscreen?.();
+        btnFullscreen.textContent = "Fullscreen";
       }
-      btnHangup.addEventListener("click", async () => {
-        await disconnect();
-      });
-      btnMute.addEventListener("click", toggleMute);
-      btnFullscreen.addEventListener("click", () => {
-        toggleFullscreen().catch(() => { });
-      });
-      btnMode.addEventListener("click", () => {
-        const nextMode = audioMode === "handsfree" ? "standard" : "handsfree";
-        setAudioMode(nextMode).catch(() => { });
-      });
-      btnProximity.addEventListener("click", toggleProximity);
-      btnInfo.addEventListener("click", () => {
-        const visible = layout?.classList.contains("show-info") ?? false;
-        setInfoVisible(!visible);
-      });
 
-      await listDevices();
-      await setAudioMode(isMobile ? "handsfree" : "standard");
-      setupProximity();
-      setInfoVisible(false);
-      setConnectOverlayVisible(true);
-      updateStatus("disconnected", "Ready");
-      statusPill.textContent = "Ready to connect";
-    }
+      function setupProximity() {
+        if (!isMobile || typeof window.ProximitySensor !== "function") {
+          btnProximity.textContent = "Ear detect: unavailable";
+          btnProximity.disabled = true;
+          return;
+        }
 
-    init().catch((error) => {
-      showError(error?.message || "Initialization failed.");
-      updateStatus("error", "Initialization failed");
-    });
-  </script>
-</body>
+        proximityEnabled = true;
+        btnProximity.textContent = "Ear detect: on";
+        proximitySensor = new window.ProximitySensor({ frequency: 5 });
+        proximitySensor.addEventListener("reading", async () => {
+          if (!proximityEnabled) return;
+          const near = Number(proximitySensor.distance) <= 0;
+          if (near && audioMode !== "standard") {
+            await setAudioMode("standard", true);
+          }
+          if (!near && proximityAutoSwitched && audioMode !== "handsfree") {
+            await setAudioMode("handsfree", true);
+            proximityAutoSwitched = false;
+          }
+        });
+        proximitySensor.addEventListener("error", () => {
+          btnProximity.textContent = "Ear detect: unavailable";
+          btnProximity.disabled = true;
+        });
+        try {
+          proximitySensor.start();
+        } catch {
+          btnProximity.textContent = "Ear detect: unavailable";
+          btnProximity.disabled = true;
+        }
+      }
 
+      function toggleProximity() {
+        if (!proximitySensor) return;
+        proximityEnabled = !proximityEnabled;
+        btnProximity.textContent = `Ear detect: ${proximityEnabled ? "on" : "off"}`;
+      }
+
+      async function init() {
+        hideGoodbyeScreen();
+        if (isMobile) {
+          btnMode.style.display = "inline-flex";
+          btnProximity.style.display = "inline-flex";
+        }
+
+        if (navigator.mediaDevices?.addEventListener) {
+          navigator.mediaDevices.addEventListener("devicechange", () => {
+            listDevices().catch(() => {});
+          });
+        }
+
+        micSelect.addEventListener("change", async (event) => {
+          selectedMicId = event.target.value;
+          if (connected) {
+            try {
+              await replaceLocalTrack();
+            } catch (error) {
+              showError(error?.message || "Could not switch microphone.");
+            }
+          }
+        });
+
+        if (speakerSelect) {
+          speakerSelect.addEventListener("change", async (event) => {
+            selectedSpeakerId = event.target.value || "default";
+            await applyOutputToAll();
+          });
+        }
+
+        const handleManualConnect = async () => {
+          hideGoodbyeScreen();
+          hideError();
+          setConnectOverlayVisible(false);
+          try {
+            await warmupAudioPermission();
+          } catch {
+            showError("Microphone access is required to start voice.");
+            setConnectOverlayVisible(true);
+            updateStatus("error", "Microphone permission required");
+            return;
+          }
+          await connect(true);
+          if (!connected) {
+            setConnectOverlayVisible(true);
+          }
+        };
+
+        btnConnect.addEventListener("click", handleManualConnect);
+        if (btnConnectOverlay) {
+          btnConnectOverlay.addEventListener("click", handleManualConnect);
+        }
+        btnHangup.addEventListener("click", async () => {
+          await disconnect();
+        });
+        btnMute.addEventListener("click", toggleMute);
+        btnFullscreen.addEventListener("click", () => {
+          toggleFullscreen().catch(() => {});
+        });
+        btnMode.addEventListener("click", () => {
+          const nextMode = audioMode === "handsfree" ? "standard" : "handsfree";
+          setAudioMode(nextMode).catch(() => {});
+        });
+        btnProximity.addEventListener("click", toggleProximity);
+        btnInfo.addEventListener("click", () => {
+          const visible = layout?.classList.contains("show-info") ?? false;
+          setInfoVisible(!visible);
+        });
+
+        await listDevices();
+        await setAudioMode(isMobile ? "handsfree" : "standard");
+        setupProximity();
+        setInfoVisible(false);
+        setConnectOverlayVisible(true);
+        updateStatus("disconnected", "Ready");
+        statusPill.textContent = "Ready to connect";
+      }
+
+      init().catch((error) => {
+        showError(error?.message || "Initialization failed.");
+        updateStatus("error", "Initialization failed");
+      });
+    </script>
+  </body>
 </html>

--- a/extensions/stimm-voice/src/web/voice.html
+++ b/extensions/stimm-voice/src/web/voice.html
@@ -1,0 +1,1218 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stimm Voice</title>
+  <style>
+    :root {
+      --bg-a: #4a6cf7;
+      --bg-b: #7a3cff;
+      --bg-c: #2f1467;
+      --surface: rgba(20, 16, 52, 0.56);
+      --surface-strong: rgba(20, 16, 52, 0.76);
+      --border: rgba(164, 176, 255, 0.22);
+      --text: #eef1ff;
+      --muted: #c6cbff;
+      --accent: #72e2ff;
+      --accent-strong: #67f6ff;
+      --good: #52d6a0;
+      --warn: #ffbd59;
+      --bad: #ff6b8f;
+      --shadow: 0 24px 64px rgba(3, 3, 20, 0.35);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html,
+    body {
+      width: 100%;
+      min-height: 100%;
+    }
+
+    body {
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(140% 120% at 0% 0%, rgba(126, 203, 255, 0.18), transparent 56%),
+        linear-gradient(130deg, var(--bg-a), var(--bg-b) 45%, var(--bg-c));
+    }
+
+    .layout {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 1fr;
+    }
+
+    .layout.show-info {
+      grid-template-columns: 1fr minmax(300px, 360px);
+    }
+
+    .stage {
+      padding: 28px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .topbar-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .brand {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+    }
+
+    .status-pill {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      border-radius: 999px;
+      padding: 8px 14px;
+      font-size: 12px;
+      color: var(--muted);
+      backdrop-filter: blur(8px);
+    }
+
+    .icon-btn {
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      font-size: 16px;
+      font-weight: 700;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+
+    .center {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .stage-card {
+      width: 100%;
+      max-width: 560px;
+      text-align: center;
+    }
+
+    .signal-badge {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--accent);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .visualizer {
+      margin: 24px auto 16px;
+      min-height: 86px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+    }
+
+    .bar {
+      width: 20px;
+      height: 24px;
+      border-radius: 12px;
+      background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+      opacity: 0.38;
+    }
+
+    .visualizer.active .bar {
+      opacity: 1;
+      animation: pulse 640ms ease-in-out infinite alternate;
+    }
+
+    .visualizer.active .bar:nth-child(2) {
+      animation-delay: 80ms;
+    }
+
+    .visualizer.active .bar:nth-child(3) {
+      animation-delay: 160ms;
+    }
+
+    .visualizer.active .bar:nth-child(4) {
+      animation-delay: 120ms;
+    }
+
+    @keyframes pulse {
+      from {
+        height: 20px;
+      }
+
+      to {
+        height: 70px;
+      }
+    }
+
+    .connection-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin-top: 8px;
+    }
+
+    .room-info {
+      margin-top: 6px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .action-row {
+      margin-top: 24px;
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .connect-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: rgba(8, 8, 28, 0.74);
+      backdrop-filter: blur(8px);
+    }
+
+    .connect-overlay.hidden {
+      display: none;
+    }
+
+    .btn-connect-overlay {
+      width: min(680px, 100%);
+      min-height: 58vh;
+      border-radius: 24px;
+      border: 1px solid rgba(180, 214, 255, 0.62);
+      background: linear-gradient(160deg, rgba(114, 226, 255, 0.22), rgba(95, 131, 255, 0.34));
+      box-shadow: var(--shadow);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      padding: 26px;
+      text-align: center;
+    }
+
+    .btn-connect-overlay-icon {
+      width: 88px;
+      height: 88px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: rgba(12, 16, 40, 0.45);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 44px;
+      line-height: 1;
+    }
+
+    .btn-connect-overlay-title {
+      font-size: clamp(28px, 4.8vw, 52px);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+    }
+
+    .btn-connect-overlay-subtitle {
+      font-size: clamp(15px, 2.2vw, 20px);
+      color: var(--muted);
+    }
+
+    button,
+    select {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+      border-radius: 12px;
+      padding: 10px 14px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    button {
+      cursor: pointer;
+      transition: 150ms ease;
+    }
+
+    button:hover:not(:disabled) {
+      border-color: rgba(255, 255, 255, 0.45);
+      transform: translateY(-1px);
+    }
+
+    button:disabled,
+    select:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    button.primary {
+      background: linear-gradient(160deg, rgba(114, 226, 255, 0.28), rgba(95, 131, 255, 0.35));
+      border-color: rgba(180, 214, 255, 0.5);
+    }
+
+    button.danger {
+      color: #ffd4df;
+      border-color: rgba(255, 128, 164, 0.5);
+      background: rgba(255, 107, 143, 0.2);
+    }
+
+    button.hangup {
+      display: none;
+      min-width: 240px;
+      padding: 14px 20px;
+      border-color: rgba(255, 128, 164, 0.72);
+      background: linear-gradient(170deg, rgba(255, 118, 156, 0.56), rgba(170, 41, 78, 0.6));
+      color: #fff;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+
+    .hangup-icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 999px;
+      background: rgba(18, 10, 24, 0.34);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 auto;
+    }
+
+    .hangup-icon svg {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
+
+    .error {
+      margin-top: 16px;
+      color: #ffd2dd;
+      font-size: 13px;
+    }
+
+    .side {
+      border-left: 1px solid var(--border);
+      background: var(--surface-strong);
+      backdrop-filter: blur(10px);
+      box-shadow: var(--shadow);
+      padding: 20px;
+      display: none;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .layout.show-info .side {
+      display: flex;
+    }
+
+    .panel {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: rgba(10, 11, 37, 0.34);
+      padding: 14px;
+    }
+
+    .panel h2 {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      margin-bottom: 10px;
+    }
+
+    .kv {
+      display: grid;
+      grid-template-columns: 110px 1fr;
+      gap: 8px;
+      font-size: 12px;
+      margin-bottom: 8px;
+    }
+
+    .kv span:first-child {
+      color: var(--muted);
+    }
+
+    .device-grid {
+      display: grid;
+      gap: 10px;
+    }
+
+    .device-row {
+      display: grid;
+      gap: 6px;
+    }
+
+    .device-row label {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .support-note {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .transcript {
+      max-height: 30vh;
+      overflow-y: auto;
+      display: grid;
+      gap: 7px;
+    }
+
+    .entry {
+      font-size: 13px;
+      line-height: 1.45;
+      color: #e8ebff;
+    }
+
+    .entry.user {
+      color: #dce2ff;
+    }
+
+    .entry.agent {
+      color: #aeefff;
+    }
+
+    .dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 999px;
+      display: inline-block;
+      margin-right: 7px;
+      background: var(--warn);
+    }
+
+    .dot.connected {
+      background: var(--good);
+      box-shadow: 0 0 8px rgba(82, 214, 160, 0.9);
+    }
+
+    .dot.error {
+      background: var(--bad);
+    }
+
+    .desktop-only {
+      display: block;
+    }
+
+    .mobile-only {
+      display: none;
+    }
+
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+
+      .layout.show-info {
+        grid-template-columns: 1fr;
+      }
+
+      .layout.show-info .side {
+        border-left: 0;
+        border-top: 1px solid var(--border);
+      }
+    }
+
+    @media (max-width: 768px) {
+      .stage {
+        padding: 16px;
+      }
+
+      .side {
+        padding: 16px;
+      }
+
+      .desktop-only {
+        display: none;
+      }
+
+      .mobile-only {
+        display: block;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="layout">
+    <main class="stage">
+      <div class="topbar">
+        <div class="brand">Stimm</div>
+        <div class="topbar-right">
+          <div class="status-pill" id="status-pill">Preparing session…</div>
+          <button class="icon-btn" id="btn-info" aria-label="Afficher les détails">i</button>
+        </div>
+      </div>
+
+      <div class="center">
+        <section class="stage-card">
+          <div class="signal-badge" id="signal-badge">Agent idle</div>
+          <div class="visualizer" id="visualizer">
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+          </div>
+          <div class="connection-title" id="status-text">Disconnected</div>
+          <div class="room-info" id="room-info"></div>
+
+          <div class="action-row">
+            <button class="primary" id="btn-connect">Connect</button>
+            <button class="hangup" id="btn-hangup" aria-label="Raccrocher">
+              <span class="hangup-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                  <path
+                    d="M4.4 15.2c2.5 3.8 5.8 6.1 9.8 6.9.6.1 1.2-.1 1.6-.5l2.2-2.2c.4-.4.5-1 .3-1.5l-1-2.9c-.2-.6-.8-.9-1.4-.8l-2.8.5c-1.8-.8-3.2-2.2-4-4l.5-2.8c.1-.6-.2-1.2-.8-1.4l-2.9-1c-.5-.2-1.1-.1-1.5.3L2.1 7.9c-.4.4-.6 1-.5 1.6.8 4 3.1 7.3 6.9 9.8Z" />
+                </svg>
+              </span>
+              <span>Raccrocher</span>
+            </button>
+            <button id="btn-mute" disabled>Mute</button>
+            <button id="btn-fullscreen">Fullscreen</button>
+            <button id="btn-mode" class="mobile-only">Mode: Hands-free</button>
+            <button id="btn-proximity" class="mobile-only">Ear detect: off</button>
+          </div>
+
+          <div class="error" id="error-msg" style="display: none"></div>
+        </section>
+      </div>
+    </main>
+
+    <aside class="side">
+      <section class="panel">
+        <h2>Live Status</h2>
+        <div class="kv"><span>State</span><span id="status-line"><span class="dot"></span>Idle</span></div>
+        <div class="kv"><span>Audio Mode</span><span id="audio-mode">Hands-free</span></div>
+        <div class="kv"><span>Room</span><span id="room-side">—</span></div>
+        <div class="kv"><span>Channel</span><span id="channel-side">web</span></div>
+      </section>
+
+      <section class="panel">
+        <h2>Devices</h2>
+        <div class="device-grid">
+          <div class="device-row">
+            <label for="mic-select">Microphone</label>
+            <select id="mic-select"></select>
+          </div>
+          <div class="device-row desktop-only">
+            <label for="speaker-select">Speaker / Headphones</label>
+            <select id="speaker-select"></select>
+          </div>
+          <div class="support-note" id="speaker-support-note"></div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Transcription</h2>
+        <div class="transcript" id="transcript"></div>
+      </section>
+    </aside>
+  </div>
+
+  <div class="connect-overlay" id="connect-overlay">
+    <button class="btn-connect-overlay" id="btn-connect-overlay" aria-label="Activer l'audio et se connecter">
+      <span class="btn-connect-overlay-icon" aria-hidden="true">🎙️</span>
+      <span class="btn-connect-overlay-title">Appuyer pour parler</span>
+      <span class="btn-connect-overlay-subtitle">Active l'audio et connecte la session</span>
+    </button>
+  </div>
+
+  <div id="goodbye-screen" style="
+        display: none;
+        width: 100vw;
+        height: 100vh;
+        align-items: center;
+        justify-content: center;
+        font-size: 42px;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+      ">
+    A bientôt !
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/livekit-client@2/dist/livekit-client.umd.js"></script>
+  <script>
+    let room = null;
+    let localTrack = null;
+    let connected = false;
+    let muted = false;
+    let currentRoomName = "";
+    let currentChannel = "web";
+    let disconnectToken = "";
+    let selectedMicId = "";
+    let selectedSpeakerId = "default";
+    let audioMode = "handsfree";
+    let proximityEnabled = false;
+    let proximitySensor = null;
+    let proximityAutoSwitched = false;
+    let audioUnlockArmed = false;
+
+    const remoteAudioElements = new Map();
+    const remoteAudioByParticipant = new Map();
+
+    const $ = (id) => document.getElementById(id);
+    const visualizer = $("visualizer");
+    const statusText = $("status-text");
+    const statusPill = $("status-pill");
+    const signalBadge = $("signal-badge");
+    const roomInfo = $("room-info");
+    const statusLine = $("status-line");
+    const audioModeLabel = $("audio-mode");
+    const roomSide = $("room-side");
+    const channelSide = $("channel-side");
+    const transcriptEl = $("transcript");
+    const errorMsg = $("error-msg");
+    const layout = document.querySelector(".layout");
+    const connectOverlay = $("connect-overlay");
+    const goodbyeScreen = $("goodbye-screen");
+    const btnConnect = $("btn-connect");
+    const btnConnectOverlay = $("btn-connect-overlay");
+    const btnHangup = $("btn-hangup");
+    const btnMute = $("btn-mute");
+    const btnFullscreen = $("btn-fullscreen");
+    const btnInfo = $("btn-info");
+    const btnMode = $("btn-mode");
+    const btnProximity = $("btn-proximity");
+    const micSelect = $("mic-select");
+    const speakerSelect = $("speaker-select");
+    const speakerSupportNote = $("speaker-support-note");
+
+    const isMobile =
+      window.matchMedia("(max-width: 768px)").matches ||
+      /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+    const canSetSink =
+      typeof HTMLMediaElement !== "undefined" &&
+      typeof HTMLMediaElement.prototype.setSinkId === "function";
+
+    async function createSession() {
+      const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
+      const claimPath = `${voicePath}/claim`;
+      const params = new URLSearchParams(window.location.search);
+      const claim = params.get("c") || params.get("claim");
+
+      const res = claim
+        ? await fetch(claimPath, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ claim }),
+        })
+        : await fetch(voicePath, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+
+      if (!res.ok) {
+        const body = await res.text();
+        if (claim) {
+          throw new Error(`Failed to exchange claim: ${res.status} ${body}`);
+        }
+        throw new Error(
+          `Failed to create session: ${res.status} ${body}. Use a claim link, or enable direct web session create in config.`,
+        );
+      }
+
+      return await res.json();
+    }
+
+    async function endSession(roomName, token) {
+      const voicePath = window.location.pathname.replace(/\/$/, "") || "/voice";
+      const endPath = `${voicePath}/end`;
+      const res = await fetch(endPath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          room: roomName,
+          disconnectToken: token,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Failed to end session: ${res.status} ${body}`);
+      }
+    }
+
+    function showGoodbyeScreen() {
+      setConnectOverlayVisible(false);
+      if (layout) layout.style.display = "none";
+      if (goodbyeScreen) goodbyeScreen.style.display = "flex";
+    }
+
+    function hideGoodbyeScreen() {
+      if (goodbyeScreen) goodbyeScreen.style.display = "none";
+      if (layout) layout.style.display = "grid";
+    }
+
+    function setConnectOverlayVisible(visible) {
+      if (!connectOverlay) return;
+      connectOverlay.classList.toggle("hidden", !visible);
+    }
+
+    function setInfoVisible(visible) {
+      if (!layout) return;
+      layout.classList.toggle("show-info", visible);
+    }
+
+    function updateStatus(state, text) {
+      const dotClass = state === "connected" ? "connected" : state === "error" ? "error" : "";
+      statusText.textContent = text;
+      statusPill.textContent = text;
+      statusLine.innerHTML = `<span class="dot ${dotClass}"></span>${text}`;
+    }
+
+    function setSignal(active) {
+      if (active) {
+        visualizer.classList.add("active");
+        signalBadge.textContent = "Agent speaking";
+      } else {
+        visualizer.classList.remove("active");
+        signalBadge.textContent = "Agent idle";
+      }
+    }
+
+    function showError(message) {
+      errorMsg.textContent = message;
+      errorMsg.style.display = "block";
+    }
+
+    function hideError() {
+      errorMsg.style.display = "none";
+    }
+
+    function addTranscript(role, text) {
+      if (!text || !text.trim()) return;
+      const entry = document.createElement("div");
+      entry.className = `entry ${role}`;
+      entry.textContent = `${role === "user" ? "You" : "Agent"}: ${text}`;
+      transcriptEl.appendChild(entry);
+      transcriptEl.scrollTop = transcriptEl.scrollHeight;
+    }
+
+    async function listDevices() {
+      if (!navigator.mediaDevices?.enumerateDevices) return;
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const inputDevices = devices.filter((d) => d.kind === "audioinput");
+      const outputDevices = devices.filter((d) => d.kind === "audiooutput");
+
+      micSelect.innerHTML = "";
+      for (let index = 0; index < inputDevices.length; index += 1) {
+        const d = inputDevices[index];
+        const option = document.createElement("option");
+        option.value = d.deviceId;
+        option.textContent = d.label || `Microphone ${index + 1}`;
+        micSelect.appendChild(option);
+      }
+
+      if (!selectedMicId && inputDevices.length > 0) {
+        selectedMicId = inputDevices[0].deviceId;
+      }
+      if (selectedMicId) {
+        micSelect.value = selectedMicId;
+      }
+
+      if (canSetSink && speakerSelect) {
+        speakerSelect.innerHTML = "";
+        if (outputDevices.length === 0) {
+          const defaultOption = document.createElement("option");
+          defaultOption.value = "default";
+          defaultOption.textContent = "Default output";
+          speakerSelect.appendChild(defaultOption);
+        }
+        for (let index = 0; index < outputDevices.length; index += 1) {
+          const d = outputDevices[index];
+          const option = document.createElement("option");
+          option.value = d.deviceId || "default";
+          option.textContent = d.label || `Output ${index + 1}`;
+          speakerSelect.appendChild(option);
+        }
+        if (![...speakerSelect.options].some((opt) => opt.value === selectedSpeakerId)) {
+          selectedSpeakerId = speakerSelect.options[0]?.value || "default";
+        }
+        speakerSelect.value = selectedSpeakerId;
+        speakerSupportNote.textContent = "";
+      } else {
+        if (speakerSelect) speakerSelect.disabled = true;
+        speakerSupportNote.textContent = "Speaker routing selector is available on desktop Chromium browsers.";
+      }
+    }
+
+    async function applyOutputToElement(el) {
+      if (!canSetSink) return;
+      const sinkId = audioMode === "handsfree" ? selectedSpeakerId : "default";
+      try {
+        await el.setSinkId(sinkId || "default");
+      } catch { }
+    }
+
+    async function applyOutputToAll() {
+      const actions = [];
+      for (const el of remoteAudioElements.values()) {
+        actions.push(applyOutputToElement(el));
+        el.volume = audioMode === "handsfree" ? 1 : 0.8;
+      }
+      await Promise.all(actions);
+    }
+
+    function armAudioUnlockGesture() {
+      if (audioUnlockArmed) return;
+      audioUnlockArmed = true;
+
+      const handler = async () => {
+        try {
+          await ensureAudioPlayback(true);
+        } catch { }
+        document.removeEventListener("pointerdown", handler, true);
+        document.removeEventListener("touchstart", handler, true);
+        document.removeEventListener("click", handler, true);
+        audioUnlockArmed = false;
+      };
+
+      document.addEventListener("pointerdown", handler, true);
+      document.addEventListener("touchstart", handler, true);
+      document.addEventListener("click", handler, true);
+    }
+
+    async function ensureAudioPlayback(fromUserGesture = false) {
+      if (!room) return;
+
+      let unlocked = false;
+      if (typeof room.startAudio === "function") {
+        try {
+          await room.startAudio();
+          unlocked = true;
+        } catch { }
+      }
+
+      let played = false;
+      for (const el of remoteAudioElements.values()) {
+        try {
+          await el.play();
+          played = true;
+        } catch { }
+      }
+
+      if (!fromUserGesture && !unlocked && !played) {
+        armAudioUnlockGesture();
+        updateStatus("connected", "Tap once to enable audio");
+      }
+    }
+
+    async function setAudioMode(mode, triggeredByProximity = false) {
+      audioMode = mode;
+      audioModeLabel.textContent = mode === "handsfree" ? "Hands-free" : "Standard";
+      if (btnMode) {
+        btnMode.textContent = `Mode: ${mode === "handsfree" ? "Hands-free" : "Standard"}`;
+      }
+      if (triggeredByProximity) {
+        proximityAutoSwitched = true;
+      } else {
+        proximityAutoSwitched = false;
+      }
+      await applyOutputToAll();
+    }
+
+    async function replaceLocalTrack() {
+      if (!room) return;
+      const newTrack = await LivekitClient.createLocalAudioTrack({
+        deviceId: selectedMicId ? { exact: selectedMicId } : undefined,
+        autoGainControl: true,
+        echoCancellation: true,
+        noiseSuppression: true,
+      });
+      const previous = localTrack;
+      const micSource =
+        LivekitClient?.Track?.Source?.Microphone ??
+        LivekitClient?.Track?.Source?.SOURCE_MICROPHONE;
+      const publishOpts = micSource ? { source: micSource } : undefined;
+
+      localTrack = newTrack;
+      await room.localParticipant.publishTrack(newTrack, publishOpts);
+      if (previous) {
+        try {
+          await room.localParticipant.unpublishTrack(previous);
+        } catch { }
+        previous.stop();
+      }
+    }
+
+    async function warmupAudioPermission() {
+      if (!navigator.mediaDevices?.getUserMedia) return;
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      for (const track of stream.getTracks()) {
+        track.stop();
+      }
+    }
+
+    async function connect(fromUserGesture = false) {
+      if (connected) return;
+      updateStatus("connecting", "Connecting…");
+      hideError();
+      btnConnect.disabled = true;
+      if (btnConnectOverlay) btnConnectOverlay.disabled = true;
+
+      try {
+        const session = await createSession();
+        const token = session.clientToken;
+        currentRoomName = session.room;
+        currentChannel = session.channel || "web";
+        disconnectToken = typeof session.disconnectToken === "string" ? session.disconnectToken : "";
+        const params = new URLSearchParams(window.location.search);
+        const livekitOverride = params.get("livekit");
+        const serverLivekitUrl = session.livekitUrl || null;
+        let livekitUrl;
+        if (serverLivekitUrl) {
+          livekitUrl = serverLivekitUrl;
+        } else if (livekitOverride) {
+          livekitUrl = livekitOverride;
+        } else {
+          const isSecure = window.location.protocol === "https:";
+          const wsProtocol = isSecure ? "wss:" : "ws:";
+          const livekitPort = isSecure ? "7443" : "7880";
+          livekitUrl = `${wsProtocol}//${window.location.hostname}:${livekitPort}`;
+        }
+
+        room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+
+        room.on(LivekitClient.RoomEvent.Disconnected, () => {
+          cleanupConnectionUI();
+          updateStatus("disconnected", "Disconnected");
+        });
+
+        room.on(LivekitClient.RoomEvent.TrackSubscribed, async (track, pub, participant) => {
+          if (track.kind !== LivekitClient.Track.Kind.Audio) return;
+          const participantId = participant?.identity || "unknown";
+          const key = pub?.trackSid || track.sid || `${participantId}:audio`;
+          const previousKey = remoteAudioByParticipant.get(participantId);
+          if (previousKey && previousKey !== key) {
+            const oldEl = remoteAudioElements.get(previousKey);
+            if (oldEl) {
+              try {
+                oldEl.remove();
+              } catch { }
+              remoteAudioElements.delete(previousKey);
+            }
+          }
+          const prev = remoteAudioElements.get(key);
+          if (prev) {
+            try {
+              prev.remove();
+            } catch { }
+            remoteAudioElements.delete(key);
+          }
+          const el = track.attach();
+          el.autoplay = true;
+          el.setAttribute("data-lk-track", key);
+          el.setAttribute("data-lk-participant", participantId);
+          document.body.appendChild(el);
+          remoteAudioElements.set(key, el);
+          remoteAudioByParticipant.set(participantId, key);
+          await applyOutputToElement(el);
+          el.volume = audioMode === "handsfree" ? 1 : 0.8;
+          await ensureAudioPlayback();
+          setSignal(true);
+        });
+
+        room.on(LivekitClient.RoomEvent.TrackUnsubscribed, (track, pub) => {
+          const key = pub?.trackSid || track?.sid;
+          if (!key) return;
+          const el = remoteAudioElements.get(key);
+          if (!el) return;
+          try {
+            track?.detach(el);
+          } catch { }
+          try {
+            el.remove();
+          } catch { }
+          remoteAudioElements.delete(key);
+          const participantId = el.getAttribute("data-lk-participant") || "";
+          if (participantId && remoteAudioByParticipant.get(participantId) === key) {
+            remoteAudioByParticipant.delete(participantId);
+          }
+          if (remoteAudioElements.size === 0) {
+            setSignal(false);
+          }
+        });
+
+        room.on(LivekitClient.RoomEvent.DataReceived, (payload) => {
+          try {
+            const message = JSON.parse(new TextDecoder().decode(payload));
+            if (message.type === "transcript") {
+              if (message.partial === true) return;
+              addTranscript("user", message.text || message.data || "");
+            }
+            if (message.type === "response") {
+              addTranscript("agent", message.text || message.data || "");
+            }
+          } catch { }
+        });
+
+        await room.connect(livekitUrl, token);
+        await ensureAudioPlayback(fromUserGesture);
+        await listDevices();
+        await replaceLocalTrack();
+        if (localTrack?.muted) {
+          localTrack.unmute();
+        }
+
+        connected = true;
+        muted = false;
+        setConnectOverlayVisible(false);
+        btnConnect.style.display = "none";
+        btnConnect.disabled = false;
+        btnHangup.style.display = "inline-flex";
+        btnMute.disabled = false;
+        btnMute.textContent = "Mute";
+        setSignal(true);
+
+        roomInfo.textContent = `Connected to ${currentRoomName}`;
+        roomSide.textContent = currentRoomName;
+        channelSide.textContent = currentChannel;
+        updateStatus("connected", "Connected");
+      } catch (error) {
+        const message = error?.message || "Could not connect to voice session.";
+        showError(message);
+        cleanupConnectionUI();
+        updateStatus("error", "Connection failed");
+      } finally {
+        btnConnect.disabled = false;
+        if (btnConnectOverlay) btnConnectOverlay.disabled = false;
+      }
+    }
+
+    async function disconnect() {
+      const roomToClose = currentRoomName;
+      const closeToken = disconnectToken;
+      if (room) {
+        try {
+          await room.disconnect();
+        } catch { }
+        room = null;
+      }
+      if (localTrack) {
+        localTrack.stop();
+        localTrack = null;
+      }
+      for (const el of remoteAudioElements.values()) {
+        try {
+          el.remove();
+        } catch { }
+      }
+      remoteAudioElements.clear();
+      remoteAudioByParticipant.clear();
+
+      if (roomToClose && closeToken) {
+        try {
+          await endSession(roomToClose, closeToken);
+        } catch (error) {
+          showError(error?.message || "Session disconnected locally, but cloud room teardown failed.");
+        }
+      }
+
+      cleanupConnectionUI();
+      updateStatus("disconnected", "Disconnected");
+      showGoodbyeScreen();
+    }
+
+    function cleanupConnectionUI() {
+      connected = false;
+      muted = false;
+      currentRoomName = "";
+      disconnectToken = "";
+      roomInfo.textContent = "";
+      roomSide.textContent = "—";
+      btnConnect.textContent = "Connect";
+      btnConnect.style.display = "inline-flex";
+      btnConnect.classList.add("primary");
+      btnConnect.classList.remove("danger");
+      setConnectOverlayVisible(true);
+      btnHangup.style.display = "none";
+      btnMute.textContent = "Mute";
+      btnMute.disabled = true;
+      setSignal(false);
+    }
+
+    function toggleMute() {
+      if (!localTrack) return;
+      muted = !muted;
+      if (muted) {
+        localTrack.mute();
+        btnMute.textContent = "Unmute";
+        setSignal(false);
+      } else {
+        localTrack.unmute();
+        btnMute.textContent = "Mute";
+        setSignal(true);
+      }
+    }
+
+    async function toggleFullscreen() {
+      if (!document.fullscreenElement) {
+        await document.documentElement.requestFullscreen?.();
+        btnFullscreen.textContent = "Exit Fullscreen";
+        return;
+      }
+      await document.exitFullscreen?.();
+      btnFullscreen.textContent = "Fullscreen";
+    }
+
+    function setupProximity() {
+      if (!isMobile || typeof window.ProximitySensor !== "function") {
+        btnProximity.textContent = "Ear detect: unavailable";
+        btnProximity.disabled = true;
+        return;
+      }
+
+      proximityEnabled = true;
+      btnProximity.textContent = "Ear detect: on";
+      proximitySensor = new window.ProximitySensor({ frequency: 5 });
+      proximitySensor.addEventListener("reading", async () => {
+        if (!proximityEnabled) return;
+        const near = Number(proximitySensor.distance) <= 0;
+        if (near && audioMode !== "standard") {
+          await setAudioMode("standard", true);
+        }
+        if (!near && proximityAutoSwitched && audioMode !== "handsfree") {
+          await setAudioMode("handsfree", true);
+          proximityAutoSwitched = false;
+        }
+      });
+      proximitySensor.addEventListener("error", () => {
+        btnProximity.textContent = "Ear detect: unavailable";
+        btnProximity.disabled = true;
+      });
+      try {
+        proximitySensor.start();
+      } catch {
+        btnProximity.textContent = "Ear detect: unavailable";
+        btnProximity.disabled = true;
+      }
+    }
+
+    function toggleProximity() {
+      if (!proximitySensor) return;
+      proximityEnabled = !proximityEnabled;
+      btnProximity.textContent = `Ear detect: ${proximityEnabled ? "on" : "off"}`;
+    }
+
+    async function init() {
+      hideGoodbyeScreen();
+      if (isMobile) {
+        btnMode.style.display = "inline-flex";
+        btnProximity.style.display = "inline-flex";
+      }
+
+      if (navigator.mediaDevices?.addEventListener) {
+        navigator.mediaDevices.addEventListener("devicechange", () => {
+          listDevices().catch(() => { });
+        });
+      }
+
+      micSelect.addEventListener("change", async (event) => {
+        selectedMicId = event.target.value;
+        if (connected) {
+          try {
+            await replaceLocalTrack();
+          } catch (error) {
+            showError(error?.message || "Could not switch microphone.");
+          }
+        }
+      });
+
+      if (speakerSelect) {
+        speakerSelect.addEventListener("change", async (event) => {
+          selectedSpeakerId = event.target.value || "default";
+          await applyOutputToAll();
+        });
+      }
+
+      const handleManualConnect = async () => {
+        hideGoodbyeScreen();
+        hideError();
+        setConnectOverlayVisible(false);
+        try {
+          await warmupAudioPermission();
+        } catch {
+          showError("Microphone access is required to start voice.");
+          setConnectOverlayVisible(true);
+          updateStatus("error", "Microphone permission required");
+          return;
+        }
+        await connect(true);
+        if (!connected) {
+          setConnectOverlayVisible(true);
+        }
+      };
+
+      btnConnect.addEventListener("click", handleManualConnect);
+      if (btnConnectOverlay) {
+        btnConnectOverlay.addEventListener("click", handleManualConnect);
+      }
+      btnHangup.addEventListener("click", async () => {
+        await disconnect();
+      });
+      btnMute.addEventListener("click", toggleMute);
+      btnFullscreen.addEventListener("click", () => {
+        toggleFullscreen().catch(() => { });
+      });
+      btnMode.addEventListener("click", () => {
+        const nextMode = audioMode === "handsfree" ? "standard" : "handsfree";
+        setAudioMode(nextMode).catch(() => { });
+      });
+      btnProximity.addEventListener("click", toggleProximity);
+      btnInfo.addEventListener("click", () => {
+        const visible = layout?.classList.contains("show-info") ?? false;
+        setInfoVisible(!visible);
+      });
+
+      await listDevices();
+      await setAudioMode(isMobile ? "handsfree" : "standard");
+      setupProximity();
+      setInfoVisible(false);
+      setConnectOverlayVisible(true);
+      updateStatus("disconnected", "Ready");
+      statusPill.textContent = "Ready to connect";
+    }
+
+    init().catch((error) => {
+      showError(error?.message || "Initialization failed.");
+      updateStatus("error", "Initialization failed");
+    });
+  </script>
+</body>
+
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock':
         specifier: ^3.998.0
-        version: 3.998.0
+        version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
         version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
@@ -71,7 +71,7 @@ importers:
         version: 0.6.0
       '@napi-rs/canvas':
         specifier: ^0.1.89
-        version: 0.1.95
+        version: 0.1.92
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
@@ -216,7 +216,7 @@ importers:
         version: 14.1.2
       '@types/node':
         specifier: ^25.3.1
-        version: 25.3.1
+        version: 25.3.2
       '@types/qrcode-terminal':
         specifier: ^0.12.2
         version: 0.12.2
@@ -228,7 +228,7 @@ importers:
         version: 7.0.0-dev.20260225.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -255,7 +255,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@discordjs/opus':
         specifier: ^0.10.0
@@ -330,7 +330,7 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.2.26(@napi-rs/canvas@0.1.93)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -366,7 +366,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.1.26'
-        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.2.26(@napi-rs/canvas@0.1.93)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -407,6 +407,31 @@ importers:
   extensions/signal: {}
 
   extensions/slack: {}
+
+  extensions/stimm-voice:
+    dependencies:
+      '@livekit/rtc-node':
+        specifier: ^0.13.24
+        version: 0.13.24
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
+      '@stimm/protocol':
+        specifier: ^0.1.8
+        version: 0.1.8(@types/dom-mediacapture-record@1.0.22)
+      livekit-server-sdk:
+        specifier: ^2.0.0
+        version: 2.15.0
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/synology-chat:
     dependencies:
@@ -503,17 +528,17 @@ importers:
         version: 0.21.1(signal-polyfill@0.2.2)
       vite:
         specifier: 7.3.1
-        version: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       '@vitest/browser-playwright':
         specifier: 4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -548,111 +573,206 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.998.0':
-    resolution: {integrity: sha512-orRgpdNmdRLik+en3xDxlGuT5AxQU+GFUTMn97ZdRuPLnAiY7Y6/8VTsod6y97/3NB8xuTZbH9wNXzW97IWNMA==}
+  '@aws-sdk/client-bedrock-runtime@3.992.0':
+    resolution: {integrity: sha512-8P8vjoaxiYYec8e1DNzvN9dV5J4BkRIXU8OuTLux/UIPES3OmaS6FZ+X/0uvAEGIH2Y2kww+yBiXedJymn2v4w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-bedrock@3.998.0':
-    resolution: {integrity: sha512-NeSBIdsJwVtACGHXVoguJOsKhq6oR5Q2B6BUU7LWGqIl1skwPors77aLpOa2240ZFtX3Br/0lJYfxAhB8692KA==}
+  '@aws-sdk/client-bedrock@3.1000.0':
+    resolution: {integrity: sha512-wGU8uJXrPW/hZuHdPNVe1kAFIBiKcslBcoDBN0eYBzS13um8p5jJiQJ9WsD1nSpKCmyx7qZXc6xjcbIQPyOrrA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.14':
-    resolution: {integrity: sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==}
+  '@aws-sdk/client-sso@3.993.0':
+    resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.12':
-    resolution: {integrity: sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==}
+  '@aws-sdk/core@3.973.11':
+    resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.14':
-    resolution: {integrity: sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==}
+  '@aws-sdk/core@3.973.15':
+    resolution: {integrity: sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.12':
-    resolution: {integrity: sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==}
+  '@aws-sdk/credential-provider-env@3.972.13':
+    resolution: {integrity: sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.12':
-    resolution: {integrity: sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==}
+  '@aws-sdk/credential-provider-env@3.972.9':
+    resolution: {integrity: sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.13':
-    resolution: {integrity: sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==}
+  '@aws-sdk/credential-provider-http@3.972.11':
+    resolution: {integrity: sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.12':
-    resolution: {integrity: sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==}
+  '@aws-sdk/credential-provider-http@3.972.15':
+    resolution: {integrity: sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.12':
-    resolution: {integrity: sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==}
+  '@aws-sdk/credential-provider-ini@3.972.13':
+    resolution: {integrity: sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.12':
-    resolution: {integrity: sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==}
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    resolution: {integrity: sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.8':
-    resolution: {integrity: sha512-tVrf8X7hKnqv3HyVraUbsQW5mfHlD++S5NSIbfQEx0sCRvIwUbTPDl/lJCxhNmZ2zjgUyBIXIKrWilFWBxzv+w==}
+  '@aws-sdk/credential-provider-login@3.972.13':
+    resolution: {integrity: sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.5':
-    resolution: {integrity: sha512-j8sFerTrzS9tEJhiW2k+T9hsELE+13D5H+mqMjTRyPSgAOebkiK9d4t8vjbLOXuk7yi5lop40x15MubgcjpLmQ==}
+  '@aws-sdk/credential-provider-login@3.972.9':
+    resolution: {integrity: sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.5':
-    resolution: {integrity: sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==}
+  '@aws-sdk/credential-provider-node@3.972.10':
+    resolution: {integrity: sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-logger@3.972.5':
-    resolution: {integrity: sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==}
+  '@aws-sdk/credential-provider-node@3.972.14':
+    resolution: {integrity: sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.5':
-    resolution: {integrity: sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==}
+  '@aws-sdk/credential-provider-process@3.972.13':
+    resolution: {integrity: sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.14':
-    resolution: {integrity: sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==}
+  '@aws-sdk/credential-provider-process@3.972.9':
+    resolution: {integrity: sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.9':
-    resolution: {integrity: sha512-O+FSwU9UvKd+QNuGLHqvmP33kkH4jh8pAgdMo3wbFLf+u30fS9/2gbSSWWtNCcWkSNFyG6RUlKU7jPSLApFfGw==}
+  '@aws-sdk/credential-provider-sso@3.972.13':
+    resolution: {integrity: sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    resolution: {integrity: sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.13':
+    resolution: {integrity: sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    resolution: {integrity: sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.5':
+    resolution: {integrity: sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.3':
+    resolution: {integrity: sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.6':
+    resolution: {integrity: sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.6':
+    resolution: {integrity: sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.6':
+    resolution: {integrity: sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.15':
+    resolution: {integrity: sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.6':
+    resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.2':
-    resolution: {integrity: sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==}
+  '@aws-sdk/nested-clients@3.992.0':
+    resolution: {integrity: sha512-oL+404BQO80zIhIyIOHPjSKRAL1ONNR5POVQa3asuaflMDE84VrU9MPZl8ZGTf1kmhFYjNvVluPYgtj8yftPOg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.5':
-    resolution: {integrity: sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==}
+  '@aws-sdk/nested-clients@3.993.0':
+    resolution: {integrity: sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.998.0':
-    resolution: {integrity: sha512-JFzi44tQnENZQ+1DYcHfoa/wTRKkccz0VsNMow0rvsxZtqUEkeV2pYFbir35mHTyUKju9995ay1MAGxLt1dpRA==}
+  '@aws-sdk/nested-clients@3.996.3':
+    resolution: {integrity: sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.3':
-    resolution: {integrity: sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==}
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.2':
-    resolution: {integrity: sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==}
+  '@aws-sdk/region-config-resolver@3.972.6':
+    resolution: {integrity: sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-format-url@3.972.5':
-    resolution: {integrity: sha512-PccfrPQVOEQSL8xaSvu988ESMlqdH1Qfk3AWPZksCOYPHyzYeUV988E+DBachXNV7tBVTUvK85cZYEZu7JtPxQ==}
+  '@aws-sdk/token-providers@3.1000.0':
+    resolution: {integrity: sha512-eOI+8WPtWpLdlYBGs8OCK3k5uIMUHVsNG3AFO4kaRaZcKReJ/2OO6+2O2Dd/3vTzM56kRjSKe7mBOCwa4PdYqg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.992.0':
+    resolution: {integrity: sha512-dqKGEw7Ng4+ilq5m6/GYPA70YJJ+J/GxVS/UF6dBv3oMHvAwx/bM/Cg9dAC19Fl8i+/q1t3ivzPv12pmURyBUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.993.0':
+    resolution: {integrity: sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.999.0':
+    resolution: {integrity: sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.4':
+    resolution: {integrity: sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.992.0':
+    resolution: {integrity: sha512-FHgdMVbTZ2Lu7hEIoGYfkd5UazNSsAgPcupEnh15vsWKFKhuw6w/6tM1k/yNaa7l1wx0Wt1UuK0m+gQ0BJpuvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    resolution: {integrity: sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.3':
+    resolution: {integrity: sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.3':
+    resolution: {integrity: sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.4':
     resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.5':
-    resolution: {integrity: sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==}
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
 
-  '@aws-sdk/util-user-agent-node@3.972.13':
-    resolution: {integrity: sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==}
+  '@aws-sdk/util-user-agent-browser@3.972.6':
+    resolution: {integrity: sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==}
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    resolution: {integrity: sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -660,8 +780,21 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.7':
-    resolution: {integrity: sha512-9GF86s6mHuc1TYCbuKatMDWl2PyK3KIkpRaI7ul2/gYZPfaLzKZ+ISHhxzVb9KVeakf75tUQe6CXW2gugSCXNw==}
+  '@aws-sdk/util-user-agent-node@3.973.0':
+    resolution: {integrity: sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.5':
+    resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.8':
+    resolution: {integrity: sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.3':
@@ -740,6 +873,9 @@ packages:
   '@buape/carbon@0.0.0-beta-20260216184201':
     resolution: {integrity: sha512-u5mgYcigfPVqT7D9gVTGd+3YSflTreQmrWog7ORbb0z5w9eT8ft4rJOdw9fGwr75zMu9kXpSBaAcY2eZoJFSdA==}
 
+  '@bufbuild/protobuf@1.10.1':
+    resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
+
   '@cacheable/memory@2.0.7':
     resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
 
@@ -801,6 +937,9 @@ packages:
 
   '@d-fischer/typed-event-emitter@3.3.3':
     resolution: {integrity: sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==}
+
+  '@datastructures-js/deque@1.0.8':
+    resolution: {integrity: sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==}
 
   '@discordjs/node-pre-gyp@0.4.5':
     resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
@@ -982,17 +1121,8 @@ packages:
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
 
-  '@google/genai@1.42.0':
-    resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@google/genai@1.43.0':
-    resolution: {integrity: sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==}
+  '@google/genai@1.41.0':
+    resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1185,6 +1315,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1289,6 +1423,49 @@ packages:
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
+  '@livekit/mutex@1.1.1':
+    resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
+
+  '@livekit/protocol@1.44.0':
+    resolution: {integrity: sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==}
+
+  '@livekit/rtc-node-darwin-arm64@0.13.24':
+    resolution: {integrity: sha512-gm5xOpGu6Rj/mNU2jEijcGhQGN2GdxV2dNYQm3NCKN7ow0BmMFZvXSCAWOWf+9oTutPXHnrc7EN1mt2v+lfqhA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@livekit/rtc-node-darwin-x64@0.13.24':
+    resolution: {integrity: sha512-jZSK5lHDp7+u0jby7PEWMzbxc0F0nLx6FT3FVjuMlT13ZY6QWKDUUCFbfDOtbdhiOZJYc5A4SwvubY6woEJXTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@livekit/rtc-node-linux-arm64-gnu@0.13.24':
+    resolution: {integrity: sha512-I+IeZET2h+viZ48moEFF0EWDHa+kLii5yuEsw38ya4mHZaZtlfbzrYKGKdONqbI9M9ldvv8XXuD0wFPjuH5CZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@livekit/rtc-node-linux-x64-gnu@0.13.24':
+    resolution: {integrity: sha512-vKOxzN/SsrtV8zIVwZCi31bZUhlb6RhJZ0NnY5MwKGSRFPi7Dwt8fmr0Vh0YmsY/p+4eZjKxvFmy7L3WVE54zw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@livekit/rtc-node-win32-x64-msvc@0.13.24':
+    resolution: {integrity: sha512-yTzqwndq2oKLUkXW2i/BkZMJC6kZOpRO/DKvkkKQvqc3Q+JuWz1m48GmyjIwTOKF28QjqEU3+IrnD65Uu+mFOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@livekit/rtc-node@0.13.24':
+    resolution: {integrity: sha512-06pF8YJlJk11R6J7kFXFpwV8etpbmCskoXFvwfwcDDixMqaP6qtS5srq3G23mDaRjx7ofz/PXg2GtiZbqNGT5A==}
+    engines: {node: '>= 18'}
+
+  '@livekit/typed-emitter@3.0.0':
+    resolution: {integrity: sha512-9bl0k4MgBPZu3Qu3R3xy12rmbW17e3bE9yf4YY85gJIQ3ezLEj/uzpKHWBsLaDoL5Mozz8QCgggwIBudYQWeQg==}
+
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.3':
     resolution: {integrity: sha512-owcv+e1/OSu3bf9ZBdUQqJsQF888KyuSIiPYFNn0fLhgkhm9F3Pvha76Kj5mCPnodf7hh3suDe7upw7GPRXftQ==}
     cpu: [arm64]
@@ -1389,26 +1566,12 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.55.0':
-    resolution: {integrity: sha512-8RLaOpmESBSqTSpA/6E9ihxYybhrkNa5LOYNdJst57LuDSDytfvkiTXlKA4DjsHua4PKopG9p0Wgqaem+kKvCA==}
-    engines: {node: '>=20.0.0'}
-
   '@mariozechner/pi-agent-core@0.55.1':
     resolution: {integrity: sha512-t9FAb4ouy8HJSIa8gSRC7j8oeUOb2XDdhvBiHj7FhfpYafj1vRPrvGIEXUV8fPJDCI07vhK9iztP27EPk+yEWw==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.55.0':
-    resolution: {integrity: sha512-G5rutF5h1hFZgU1W2yYktZJegKUZVDhdGCxvl7zPOonrGBczuNBKmM87VXvl1m+t9718rYMsgTSBseGN0RhYug==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
   '@mariozechner/pi-ai@0.55.1':
     resolution: {integrity: sha512-JJX1LrVWPUPMExu0f89XR4nMNP37+FNLjEE4cIHq9Hi6xQtOiiEi7OjDFMx58hWsq81xH1CwmQXqGTWBjbXKTw==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@mariozechner/pi-coding-agent@0.55.0':
-    resolution: {integrity: sha512-neflZvWsbFDph3RG+b3/ItfFtGaQnOFJO+N+fsnIC3BG/FEUu1IK1lcMwrM1FGGSMfJnCv7Q3Zk5MSBiRj4azQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -1416,10 +1579,6 @@ packages:
     resolution: {integrity: sha512-H2M8mbBNyDqhON6+3m4H8CjqJ9taGq/CM3B8dG73+VJJIXFm5SExhU9bdgcw2xh0wWj8yEumsj0of6Tu+F7Ffg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
-
-  '@mariozechner/pi-tui@0.55.0':
-    resolution: {integrity: sha512-qFdBsA0CTIQbUlN5hp1yJOSgJJiuTegx+oNPzpHxaMMBPjwMuh3Y8szBqE/2HxroA6mGSQfp/fzuPinTK1+Iyg==}
-    engines: {node: '>=20.0.0'}
 
   '@mariozechner/pi-tui@0.55.1':
     resolution: {integrity: sha512-rnqDUp2fm/ySevC0Ltj/ZFRbEc1kZ1A4qHESejj9hA8NVrb/pX9g82XwTE762JOieEGrRWAtmHLNOm7/e4dJMw==}
@@ -1444,74 +1603,144 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.95':
-    resolution: {integrity: sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA==}
+  '@napi-rs/canvas-android-arm64@0.1.92':
+    resolution: {integrity: sha512-rDOtq53ujfOuevD5taxAuIFALuf1QsQWZe1yS/N4MtT+tNiDBEdjufvQRPWZ11FubL2uwgP8ApYU3YOaNu1ZsQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.95':
-    resolution: {integrity: sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw==}
+  '@napi-rs/canvas-android-arm64@0.1.93':
+    resolution: {integrity: sha512-xRIoOPFvneR29Dtq5d9p2AJbijDCFeV4jQ+5Ms/xVAXJVb8R0Jlu+pPr/SkhrG+Mouaml4roPSXugTIeRl6CMA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.92':
+    resolution: {integrity: sha512-4PT6GRGCr7yMRehp42x0LJb1V0IEy1cDZDDayv7eKbFUIGbPFkV7CRC9Bee5MPkjg1EB4ZPXXUyy3gjQm7mR8Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.95':
-    resolution: {integrity: sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw==}
+  '@napi-rs/canvas-darwin-arm64@0.1.93':
+    resolution: {integrity: sha512-daNDi76HN5grC6GXDmpxdfP+N2mQPd3sCfg62VyHwUuvbZh32P7R/IUjkzAxtYMtTza+Zvx9hfLJ3J7ENL6WMA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.92':
+    resolution: {integrity: sha512-5e/3ZapP7CqPtDcZPtmowCsjoyQwuNMMD7c0GKPtZQ8pgQhLkeq/3fmk0HqNSD1i227FyJN/9pDrhw/UMTkaWA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.95':
-    resolution: {integrity: sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q==}
+  '@napi-rs/canvas-darwin-x64@0.1.93':
+    resolution: {integrity: sha512-1YfuNPIQLawsg/gSNdJRk4kQWUy9M/Gy8FGsOI79nhQEJ2PZdqpSPl5UNzf4elfuNXuVbEbmmjP68EQdUunDuQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
+    resolution: {integrity: sha512-j6KaLL9iir68lwpzzY+aBGag1PZp3+gJE2mQ3ar4VJVmyLRVOh+1qsdNK1gfWoAVy5w6U7OEYFrLzN2vOFUSng==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.95':
-    resolution: {integrity: sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw==}
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.93':
+    resolution: {integrity: sha512-8kEkOQPZjuyHjupvXExuJZiuiVNecdABGq3DLI7aO1EvQFOOlWMm2d/8Q5qXdV73Tn+nu3m16+kPajsN1oJefQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
+    resolution: {integrity: sha512-s3NlnJMHOSotUYVoTCoC1OcomaChFdKmZg0VsHFeIkeHbwX0uPHP4eCX1irjSfMykyvsGHTQDfBAtGYuqxCxhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.95':
-    resolution: {integrity: sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==}
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.93':
+    resolution: {integrity: sha512-qIKLKkBkYSyWSYAoDThoxf5y1gr4X0g7W8rDU7d2HDeAAcotdVHUwuKkMeNe6+5VNk7/95EIhbslQjSxiCu32g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.95':
-    resolution: {integrity: sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==}
+  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
+    resolution: {integrity: sha512-xV0GQnukYq5qY+ebkAwHjnP2OrSGBxS3vSi1zQNQj0bkXU6Ou+Tw7JjCM7pZcQ28MUyEBS1yKfo7rc7ip2IPFQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.93':
+    resolution: {integrity: sha512-mAwQBGM3qArS9XEO21AK4E1uGvCuUCXjhIZk0dlVvs49MQ6wAAuCkYKNFpSKeSicKrLWwBMfgWX4qZoPh+M00A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
+    resolution: {integrity: sha512-+GKvIFbQ74eB/TopEdH6XIXcvOGcuKvCITLGXy7WLJAyNp3Kdn1ncjxg91ihatBaPR+t63QOE99yHuIWn3UQ9w==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.95':
-    resolution: {integrity: sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==}
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.93':
+    resolution: {integrity: sha512-kaIH5MpPzOZfkM+QMsBxGdM9jlJT+N+fwz2IEaju/S+DL65E5TgPOx4QcD5dQ8vsMxlak6uDrudBc4ns5xzZCw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
+    resolution: {integrity: sha512-tFd6MwbEhZ1g64iVY2asV+dOJC+GT3Yd6UH4G3Hp0/VHQ6qikB+nvXEULskFYZ0+wFqlGPtXjG1Jmv7sJy+3Ww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.95':
-    resolution: {integrity: sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==}
+  '@napi-rs/canvas-linux-x64-gnu@0.1.93':
+    resolution: {integrity: sha512-KtMZJqYWvOSeW5w3VSV2f5iGnwNdKJm4gwgVid4xNy1NFi+NJSyuglA1lX1u4wIPxizyxh8OW5c5Usf6oSOMNQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.95':
-    resolution: {integrity: sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==}
+  '@napi-rs/canvas-linux-x64-musl@0.1.92':
+    resolution: {integrity: sha512-uSuqeSveB/ZGd72VfNbHCSXO9sArpZTvznMVsb42nqPP7gBGEH6NJQ0+hmF+w24unEmxBhPYakP/Wiosm16KkA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.93':
+    resolution: {integrity: sha512-qRZhOvlDBooRLX6V3/t9X9B+plZK+OrPLgfFixu0A1RO/3VHbubOknfnMnocSDAqk/L6cRyKI83VP2ciR9UO7w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
+    resolution: {integrity: sha512-20SK5AU/OUNz9ZuoAPj5ekWai45EIBDh/XsdrVZ8le/pJVlhjFU3olbumSQUXRFn7lBRS+qwM8kA//uLaDx6iQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.95':
-    resolution: {integrity: sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA==}
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.93':
+    resolution: {integrity: sha512-um5XE44vF8bjkQEsH2iRSUP9fDeQGYbn/qjM/v4whXG83qsqapAXlOPOQqSARZB1SiNvPUAuXoRsJLlKFmAEFw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
+    resolution: {integrity: sha512-KEhyZLzq1MXCNlXybz4k25MJmHFp+uK1SIb8yJB0xfrQjz5aogAMhyseSzewo+XxAq3OAOdyKvfHGNzT3w1RPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas@0.1.95':
-    resolution: {integrity: sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w==}
+  '@napi-rs/canvas-win32-x64-msvc@0.1.93':
+    resolution: {integrity: sha512-maHlizZgmKsAPJwjwBZMnsWfq3Ca9QutoteQwKe7YqsmbECoylrLCCOGCDOredstW4BRWqRTfCl6NJaVVeAQvQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.92':
+    resolution: {integrity: sha512-q7ZaUCJkEU5BeOdE7fBx1XWRd2T5Ady65nxq4brMf5L4cE1VV/ACq5w9Z5b/IVJs8CwSSIwc30nlthH0gFo4Ig==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/canvas@0.1.93':
+    resolution: {integrity: sha512-unVFo8CUlUeJCCxt50+j4yy91NF4x6n9zdGcvEsOFAWzowtZm3mgx8X2D7xjwV0cFSfxmpGPoe+JS77uzeFsxg==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.1':
@@ -1646,8 +1875,8 @@ packages:
     resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
     engines: {node: '>= 20'}
 
-  '@octokit/endpoint@11.0.3':
-    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+  '@octokit/endpoint@11.0.2':
+    resolution: {integrity: sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==}
     engines: {node: '>= 20'}
 
   '@octokit/graphql@9.0.3':
@@ -1690,8 +1919,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/plugin-retry@8.1.0':
-    resolution: {integrity: sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==}
+  '@octokit/plugin-retry@8.0.3':
+    resolution: {integrity: sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@octokit/core': '>=7'
@@ -1706,8 +1935,8 @@ packages:
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.8':
-    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+  '@octokit/request@10.0.7':
+    resolution: {integrity: sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==}
     engines: {node: '>= 20'}
 
   '@octokit/types@16.0.0':
@@ -2325,128 +2554,128 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
 
@@ -2498,8 +2727,20 @@ packages:
     resolution: {integrity: sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/config-resolver@4.4.9':
     resolution: {integrity: sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.2':
+    resolution: {integrity: sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.6':
@@ -2510,41 +2751,61 @@ packages:
     resolution: {integrity: sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-codec@4.2.10':
-    resolution: {integrity: sha512-A4ynrsFFfSXUHicfTcRehytppFBcY3HQxEGYiyGktPIOye3Ot7fxpiy4VR42WmtGI4Wfo6OXt/c1Ky1nUFxYYQ==}
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-browser@4.2.10':
-    resolution: {integrity: sha512-0xupsu9yj9oDVuQ50YCTS9nuSYhGlrwqdaKQel9y2Fz7LU9fNErVlw9N0o4pm4qqvWEGbSTI4HKc6XJfB30MVw==}
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-config-resolver@4.3.10':
-    resolution: {integrity: sha512-8kn6sinrduk0yaYHMJDsNuiFpXwQwibR7n/4CDUqn4UgaG+SeBHu5jHGFdU9BLFAM7Q4/gvr9RYxBHz9/jKrhA==}
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-node@4.2.10':
-    resolution: {integrity: sha512-uUrxPGgIffnYfvIOUmBM5i+USdEBRTdh7mLPttjphgtooxQ8CtdO1p6K5+Q4BBAZvKlvtJ9jWyrWpBJYzBKsyQ==}
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-serde-universal@4.2.10':
-    resolution: {integrity: sha512-aArqzOEvcs2dK+xQVCgLbpJQGfZihw8SD4ymhkwNTtwKbnrzdhJsFDKuMQnam2kF69WzgJYOU5eJlCx+CA32bw==}
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.3.11':
     resolution: {integrity: sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-node@4.2.10':
     resolution: {integrity: sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.10':
     resolution: {integrity: sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@4.2.1':
     resolution: {integrity: sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==}
@@ -2554,8 +2815,20 @@ packages:
     resolution: {integrity: sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.16':
+    resolution: {integrity: sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-endpoint@4.4.20':
     resolution: {integrity: sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.33':
+    resolution: {integrity: sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.37':
@@ -2566,12 +2839,28 @@ packages:
     resolution: {integrity: sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-stack@4.2.10':
     resolution: {integrity: sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-config-provider@4.3.10':
     resolution: {integrity: sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.4.12':
@@ -2582,20 +2871,44 @@ packages:
     resolution: {integrity: sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/protocol-http@5.3.10':
     resolution: {integrity: sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-builder@4.2.10':
     resolution: {integrity: sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-parser@4.2.10':
     resolution: {integrity: sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/service-error-classification@4.2.10':
     resolution: {integrity: sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.5':
@@ -2606,8 +2919,20 @@ packages:
     resolution: {integrity: sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.5':
+    resolution: {integrity: sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.0':
     resolution: {integrity: sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.0':
@@ -2618,12 +2943,28 @@ packages:
     resolution: {integrity: sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-base64@4.3.1':
     resolution: {integrity: sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-body-length-browser@4.2.1':
     resolution: {integrity: sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-body-length-node@4.2.2':
@@ -2634,24 +2975,48 @@ packages:
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-buffer-from@4.2.1':
     resolution: {integrity: sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-config-provider@4.2.1':
     resolution: {integrity: sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    resolution: {integrity: sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-browser@4.3.36':
     resolution: {integrity: sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    resolution: {integrity: sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-defaults-mode-node@4.2.39':
     resolution: {integrity: sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-endpoints@3.3.1':
     resolution: {integrity: sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.1':
@@ -2662,12 +3027,28 @@ packages:
     resolution: {integrity: sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.2.10':
     resolution: {integrity: sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-stream@4.5.15':
     resolution: {integrity: sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.1':
@@ -2678,8 +3059,16 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-utf8@4.2.1':
     resolution: {integrity: sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.1':
@@ -2776,8 +3165,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@swc/helpers@0.5.19':
-    resolution: {integrity: sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==}
+  '@stimm/protocol@0.1.8':
+    resolution: {integrity: sha512-F6mfs7MAuoDAnYHWqZmCbKkYU4Uk0VAld9sAjXfsmkybZny/nPzxPZeh77jpFf9qWFDuJqXCYqTE7wIWZLBIYQ==}
+
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
   '@thi.ng/bitstream@2.4.41':
     resolution: {integrity: sha512-treRzw3+7I1YCuilFtznwT3SGtceS9spUXhyBqeuKNTm4nIfMuvg4fNqx4GgpuS6cGPQNPMUJm0OyzKnSe2Emw==}
@@ -2850,6 +3242,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/dom-mediacapture-record@1.0.22':
+    resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2898,14 +3293,14 @@ packages:
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
-  '@types/node@20.19.34':
-    resolution: {integrity: sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==}
+  '@types/node@20.19.33':
+    resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
-  '@types/node@24.10.14':
-    resolution: {integrity: sha512-OowOUbD1lBCOFIPOZ8xnMIhgqA4sCutMiYOmPHL1PTLt5+y1XA+g2+yC9OOyz8p+deMZqPZLxfMjYIfrKsPeFg==}
+  '@types/node@24.10.13':
+    resolution: {integrity: sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==}
 
-  '@types/node@25.3.1':
-    resolution: {integrity: sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==}
+  '@types/node@25.3.2':
+    resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
@@ -3098,8 +3493,8 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3248,9 +3643,9 @@ packages:
       react-native-b4a:
         optional: true
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+  balanced-match@4.0.2:
+    resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
+    engines: {node: 20 || >=22}
 
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -3267,9 +3662,10 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.1.0:
+    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -3303,9 +3699,9 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.3:
-    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -3337,6 +3733,14 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  camelcase-keys@9.1.3:
+    resolution: {integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==}
+    engines: {node: '>=16'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -3417,6 +3821,9 @@ packages:
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3506,6 +3913,9 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3718,6 +4128,10 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3745,11 +4159,17 @@ packages:
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
+  fast-copy@4.0.2:
+    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -3879,6 +4299,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
@@ -3913,9 +4337,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
+  glob@13.0.5:
+    resolution: {integrity: sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==}
+    engines: {node: 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -3970,13 +4394,16 @@ packages:
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
-  hashery@1.5.0:
-    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
+  hashery@1.4.0:
+    resolution: {integrity: sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==}
     engines: {node: '>=20'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -4104,6 +4531,10 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
+    engines: {node: '>=16'}
+
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
@@ -4153,12 +4584,26 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4190,9 +4635,6 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
-  json-with-bigint@3.5.3:
-    resolution: {integrity: sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -4339,6 +4781,15 @@ packages:
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
+  livekit-client@2.17.2:
+    resolution: {integrity: sha512-+67y2EtAWZabARlY7kANl/VT1Uu1EJYR5a8qwpT2ub/uBCltsEgEDOxCIMwE9HFR5w+z41HR6GL9hyEvW/y6CQ==}
+    peerDependencies:
+      '@types/dom-mediacapture-record': ^1
+
+  livekit-server-sdk@2.15.0:
+    resolution: {integrity: sha512-HmzjWnwEwwShu8yUf7VGFXdc+BuMJR5pnIY4qsdlhqI9d9wDgq+4cdTEHg0NEBaiGnc6PCOBiaTYgmIyVJ0S9w==}
+    engines: {node: '>=18'}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -4385,6 +4836,10 @@ packages:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
@@ -4430,6 +4885,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  map-obj@5.0.0:
+    resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -4506,8 +4965,8 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
@@ -4706,8 +5165,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.2.24:
-    resolution: {integrity: sha512-a6zrcS6v5tUWqzsFh5cNtyu5+Tra1UW5yvPtYhRYCKSS/q6lXrLu+dj0ylJPOHRPAho2alZZL1gw1Qd2hAd2sQ==}
+  openclaw@2026.2.26:
+    resolution: {integrity: sha512-SAGBigUXYNGl+zPZCR3XkdMZ3wNEYsDybxnFcTZS90aE7Ztrb/avXEAzxv1XcR8xqDxIZFVZv+abHDRO+Nv1vA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -4762,6 +5221,10 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -4827,9 +5290,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
+  path-scurry@2.0.1:
+    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
+    engines: {node: 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4866,6 +5329,13 @@ packages:
 
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
@@ -4999,6 +5469,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -5102,14 +5576,17 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -5124,8 +5601,18 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.1:
-    resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
+  sanitize-html@2.17.0:
+    resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
+
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
+    hasBin: true
+
+  sdp@3.2.1:
+    resolution: {integrity: sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -5210,8 +5697,8 @@ packages:
     peerDependencies:
       signal-polyfill: ^0.2.0
 
-  simple-git@3.32.3:
-    resolution: {integrity: sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==}
+  simple-git@3.31.1:
+    resolution: {integrity: sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==}
 
   simple-yenc@1.0.4:
     resolution: {integrity: sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==}
@@ -5360,13 +5847,17 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   strnum@2.1.2:
     resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
@@ -5453,6 +5944,9 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  ts-debounce@4.0.0:
+    resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
+
   tsdown@0.20.3:
     resolution: {integrity: sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w==}
     engines: {node: '>=20.19.0'}
@@ -5500,6 +5994,10 @@ packages:
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -5507,6 +6005,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-emitter@2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -5689,6 +6190,10 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webrtc-adapter@9.0.4:
+    resolution: {integrity: sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -5808,7 +6313,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.1
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -5816,7 +6321,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.4
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5824,7 +6329,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.4
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -5833,34 +6338,80 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.998.0':
+  '@aws-sdk/client-bedrock-runtime@3.992.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/credential-provider-node': 3.972.13
-      '@aws-sdk/eventstream-handler-node': 3.972.8
-      '@aws-sdk/middleware-eventstream': 3.972.5
-      '@aws-sdk/middleware-host-header': 3.972.5
-      '@aws-sdk/middleware-logger': 3.972.5
-      '@aws-sdk/middleware-recursion-detection': 3.972.5
-      '@aws-sdk/middleware-user-agent': 3.972.14
-      '@aws-sdk/middleware-websocket': 3.972.9
-      '@aws-sdk/region-config-resolver': 3.972.5
-      '@aws-sdk/token-providers': 3.998.0
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/util-endpoints': 3.996.2
-      '@aws-sdk/util-user-agent-browser': 3.972.5
-      '@aws-sdk/util-user-agent-node': 3.972.13
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-node': 3.972.10
+      '@aws-sdk/eventstream-handler-node': 3.972.5
+      '@aws-sdk/middleware-eventstream': 3.972.3
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/middleware-websocket': 3.972.6
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/token-providers': 3.992.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.992.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-bedrock@3.1000.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/credential-provider-node': 3.972.14
+      '@aws-sdk/middleware-host-header': 3.972.6
+      '@aws-sdk/middleware-logger': 3.972.6
+      '@aws-sdk/middleware-recursion-detection': 3.972.6
+      '@aws-sdk/middleware-user-agent': 3.972.15
+      '@aws-sdk/region-config-resolver': 3.972.6
+      '@aws-sdk/token-providers': 3.1000.0
+      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/util-endpoints': 3.996.3
+      '@aws-sdk/util-user-agent-browser': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
       '@smithy/core': 3.23.6
-      '@smithy/eventstream-serde-browser': 4.2.10
-      '@smithy/eventstream-serde-config-resolver': 4.3.10
-      '@smithy/eventstream-serde-node': 4.2.10
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
@@ -5883,61 +6434,74 @@ snapshots:
       '@smithy/util-endpoints': 3.3.1
       '@smithy/util-middleware': 4.2.10
       '@smithy/util-retry': 4.2.10
-      '@smithy/util-stream': 4.5.15
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-bedrock@3.998.0':
+  '@aws-sdk/client-sso@3.993.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/credential-provider-node': 3.972.13
-      '@aws-sdk/middleware-host-header': 3.972.5
-      '@aws-sdk/middleware-logger': 3.972.5
-      '@aws-sdk/middleware-recursion-detection': 3.972.5
-      '@aws-sdk/middleware-user-agent': 3.972.14
-      '@aws-sdk/region-config-resolver': 3.972.5
-      '@aws-sdk/token-providers': 3.998.0
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/util-endpoints': 3.996.2
-      '@aws-sdk/util-user-agent-browser': 3.972.5
-      '@aws-sdk/util-user-agent-node': 3.972.13
-      '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
-      '@smithy/fetch-http-handler': 5.3.11
-      '@smithy/hash-node': 4.2.10
-      '@smithy/invalid-dependency': 4.2.10
-      '@smithy/middleware-content-length': 4.2.10
-      '@smithy/middleware-endpoint': 4.4.20
-      '@smithy/middleware-retry': 4.4.37
-      '@smithy/middleware-serde': 4.2.11
-      '@smithy/middleware-stack': 4.2.10
-      '@smithy/node-config-provider': 4.3.10
-      '@smithy/node-http-handler': 4.4.12
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.13.0
-      '@smithy/url-parser': 4.2.10
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-body-length-browser': 4.2.1
-      '@smithy/util-body-length-node': 4.2.2
-      '@smithy/util-defaults-mode-browser': 4.3.36
-      '@smithy/util-defaults-mode-node': 4.2.39
-      '@smithy/util-endpoints': 3.3.1
-      '@smithy/util-middleware': 4.2.10
-      '@smithy/util-retry': 4.2.10
-      '@smithy/util-utf8': 4.2.1
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/core@3.973.14':
+  '@aws-sdk/core@3.973.11':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/xml-builder': 3.972.7
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.5
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.973.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/xml-builder': 3.972.8
       '@smithy/core': 3.23.6
       '@smithy/node-config-provider': 4.3.10
       '@smithy/property-provider': 4.2.10
@@ -5950,18 +6514,39 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.12':
+  '@aws-sdk/credential-provider-env@3.972.13':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.14':
+  '@aws-sdk/credential-provider-env@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.15':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/types': 3.973.4
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/node-http-handler': 4.4.12
       '@smithy/property-provider': 4.2.10
@@ -5971,17 +6556,17 @@ snapshots:
       '@smithy/util-stream': 4.5.15
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.12':
+  '@aws-sdk/credential-provider-ini@3.972.13':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/credential-provider-env': 3.972.12
-      '@aws-sdk/credential-provider-http': 3.972.14
-      '@aws-sdk/credential-provider-login': 3.972.12
-      '@aws-sdk/credential-provider-process': 3.972.12
-      '@aws-sdk/credential-provider-sso': 3.972.12
-      '@aws-sdk/credential-provider-web-identity': 3.972.12
-      '@aws-sdk/nested-clients': 3.996.2
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/credential-provider-env': 3.972.13
+      '@aws-sdk/credential-provider-http': 3.972.15
+      '@aws-sdk/credential-provider-login': 3.972.13
+      '@aws-sdk/credential-provider-process': 3.972.13
+      '@aws-sdk/credential-provider-sso': 3.972.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.13
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/types': 3.973.4
       '@smithy/credential-provider-imds': 4.2.10
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -5990,11 +6575,30 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.12':
+  '@aws-sdk/credential-provider-ini@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/nested-clients': 3.996.2
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-login': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.13':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/protocol-http': 5.3.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -6003,15 +6607,45 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.13':
+  '@aws-sdk/credential-provider-login@3.972.9':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.12
-      '@aws-sdk/credential-provider-http': 3.972.14
-      '@aws-sdk/credential-provider-ini': 3.972.12
-      '@aws-sdk/credential-provider-process': 3.972.12
-      '@aws-sdk/credential-provider-sso': 3.972.12
-      '@aws-sdk/credential-provider-web-identity': 3.972.12
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-ini': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.14':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.13
+      '@aws-sdk/credential-provider-http': 3.972.15
+      '@aws-sdk/credential-provider-ini': 3.972.13
+      '@aws-sdk/credential-provider-process': 3.972.13
+      '@aws-sdk/credential-provider-sso': 3.972.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.13
+      '@aws-sdk/types': 3.973.4
       '@smithy/credential-provider-imds': 4.2.10
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
@@ -6020,21 +6654,30 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.12':
+  '@aws-sdk/credential-provider-process@3.972.13':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.12':
+  '@aws-sdk/credential-provider-process@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/nested-clients': 3.996.2
-      '@aws-sdk/token-providers': 3.998.0
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.13':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/token-providers': 3.999.0
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -6042,11 +6685,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.12':
+  '@aws-sdk/credential-provider-sso@3.972.9':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/nested-clients': 3.996.2
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/client-sso': 3.993.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/token-providers': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.13':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -6054,80 +6710,209 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/eventstream-handler-node@3.972.8':
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@smithy/eventstream-codec': 4.2.10
-      '@smithy/types': 4.13.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.5':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.5':
+  '@aws-sdk/middleware-eventstream@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.5':
+  '@aws-sdk/middleware-logger@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@smithy/protocol-http': 5.3.10
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.5':
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.5':
+  '@aws-sdk/middleware-recursion-detection@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.4
       '@aws/lambda-invoke-store': 0.2.3
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.14':
+  '@aws-sdk/middleware-user-agent@3.972.11':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/util-endpoints': 3.996.2
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@smithy/core': 3.23.2
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.15':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/util-endpoints': 3.996.3
       '@smithy/core': 3.23.6
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.9':
+  '@aws-sdk/middleware-websocket@3.972.6':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/util-format-url': 3.972.5
-      '@smithy/eventstream-codec': 4.2.10
-      '@smithy/eventstream-serde-browser': 4.2.10
-      '@smithy/fetch-http-handler': 5.3.11
-      '@smithy/protocol-http': 5.3.10
-      '@smithy/signature-v4': 5.3.10
-      '@smithy/types': 4.13.0
-      '@smithy/util-base64': 4.3.1
-      '@smithy/util-hex-encoding': 4.2.1
-      '@smithy/util-utf8': 4.2.1
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-format-url': 3.972.3
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.2':
+  '@aws-sdk/nested-clients@3.992.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/middleware-host-header': 3.972.5
-      '@aws-sdk/middleware-logger': 3.972.5
-      '@aws-sdk/middleware-recursion-detection': 3.972.5
-      '@aws-sdk/middleware-user-agent': 3.972.14
-      '@aws-sdk/region-config-resolver': 3.972.5
-      '@aws-sdk/types': 3.973.3
-      '@aws-sdk/util-endpoints': 3.996.2
-      '@aws-sdk/util-user-agent-browser': 3.972.5
-      '@aws-sdk/util-user-agent-node': 3.972.13
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.992.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/nested-clients@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/nested-clients@3.996.3':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/middleware-host-header': 3.972.6
+      '@aws-sdk/middleware-logger': 3.972.6
+      '@aws-sdk/middleware-recursion-detection': 3.972.6
+      '@aws-sdk/middleware-user-agent': 3.972.15
+      '@aws-sdk/region-config-resolver': 3.972.6
+      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/util-endpoints': 3.996.3
+      '@aws-sdk/util-user-agent-browser': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
       '@smithy/core': 3.23.6
       '@smithy/fetch-http-handler': 5.3.11
@@ -6157,19 +6942,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/region-config-resolver@3.972.5':
+  '@aws-sdk/region-config-resolver@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/region-config-resolver@3.972.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
       '@smithy/config-resolver': 4.4.9
       '@smithy/node-config-provider': 4.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.998.0':
+  '@aws-sdk/token-providers@3.1000.0':
     dependencies:
-      '@aws-sdk/core': 3.973.14
-      '@aws-sdk/nested-clients': 3.996.2
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
@@ -6177,46 +6970,124 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/types@3.973.3':
+  '@aws-sdk/token-providers@3.992.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.992.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.993.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.999.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.15
+      '@aws-sdk/nested-clients': 3.996.3
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.10
+      '@smithy/shared-ini-file-loader': 4.4.5
+      '@smithy/types': 4.13.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.4':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.2':
+  '@aws-sdk/util-endpoints@3.992.0':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-format-url@3.972.5':
+  '@aws-sdk/util-format-url@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
-      '@smithy/querystring-builder': 4.2.10
-      '@smithy/types': 4.13.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.4':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.5':
+  '@aws-sdk/util-user-agent-browser@3.972.3':
     dependencies:
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.4
       '@smithy/types': 4.13.0
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.972.13':
+  '@aws-sdk/util-user-agent-node@3.972.9':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.14
-      '@aws-sdk/types': 3.973.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.0':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.15
+      '@aws-sdk/types': 3.973.4
       '@smithy/node-config-provider': 4.3.10
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.7':
+  '@aws-sdk/xml-builder@3.972.5':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.6
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.8':
     dependencies:
       '@smithy/types': 4.13.0
       fast-xml-parser: 5.3.6
@@ -6295,7 +7166,7 @@ snapshots:
 
   '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
@@ -6313,6 +7184,8 @@ snapshots:
       - opusscript
       - utf-8-validate
 
+  '@bufbuild/protobuf@1.10.1': {}
+
   '@cacheable/memory@2.0.7':
     dependencies:
       '@cacheable/utils': 2.3.4
@@ -6328,7 +7201,7 @@ snapshots:
 
   '@cacheable/utils@2.3.4':
     dependencies:
-      hashery: 1.5.0
+      hashery: 1.4.0
       keyv: 5.6.0
 
   '@clack/core@1.0.1':
@@ -6423,6 +7296,8 @@ snapshots:
   '@d-fischer/typed-event-emitter@3.3.3':
     dependencies:
       tslib: 2.8.1
+
+  '@datastructures-js/deque@1.0.8': {}
 
   '@discordjs/node-pre-gyp@0.4.5':
     dependencies:
@@ -6561,21 +7436,10 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
+  '@google/genai@1.41.0':
     dependencies:
       google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@google/genai@1.43.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
+      p-retry: 7.1.1
       protobufjs: 7.5.4
       ws: 8.19.0
     transitivePeerDependencies:
@@ -6729,14 +7593,16 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6756,7 +7622,7 @@ snapshots:
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
-      hashery: 1.5.0
+      hashery: 1.4.0
       hookified: 1.15.1
       keyv: 5.6.0
 
@@ -6820,7 +7686,7 @@ snapshots:
 
   '@line/bot-sdk@10.6.0':
     dependencies:
-      '@types/node': 24.10.14
+      '@types/node': 24.10.13
     optionalDependencies:
       axios: 1.13.5
     transitivePeerDependencies:
@@ -6840,6 +7706,44 @@ snapshots:
   '@lit/reactive-element@2.1.2':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.5.1
+
+  '@livekit/mutex@1.1.1': {}
+
+  '@livekit/protocol@1.44.0':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+
+  '@livekit/rtc-node-darwin-arm64@0.13.24':
+    optional: true
+
+  '@livekit/rtc-node-darwin-x64@0.13.24':
+    optional: true
+
+  '@livekit/rtc-node-linux-arm64-gnu@0.13.24':
+    optional: true
+
+  '@livekit/rtc-node-linux-x64-gnu@0.13.24':
+    optional: true
+
+  '@livekit/rtc-node-win32-x64-msvc@0.13.24':
+    optional: true
+
+  '@livekit/rtc-node@0.13.24':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+      '@datastructures-js/deque': 1.0.8
+      '@livekit/mutex': 1.1.1
+      '@livekit/typed-emitter': 3.0.0
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+    optionalDependencies:
+      '@livekit/rtc-node-darwin-arm64': 0.13.24
+      '@livekit/rtc-node-darwin-x64': 0.13.24
+      '@livekit/rtc-node-linux-arm64-gnu': 0.13.24
+      '@livekit/rtc-node-linux-x64-gnu': 0.13.24
+      '@livekit/rtc-node-win32-x64-msvc': 0.13.24
+
+  '@livekit/typed-emitter@3.0.0': {}
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.3':
     optional: true
@@ -6917,18 +7821,6 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@mariozechner/pi-agent-core@0.55.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
@@ -6941,35 +7833,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.0(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
-      '@mistralai/mistralai': 1.10.0
-      '@sinclair/typebox': 0.34.48
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.22.0
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@mariozechner/pi-ai@0.55.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.43.0
+      '@aws-sdk/client-bedrock-runtime': 3.992.0
+      '@google/genai': 1.41.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -6980,35 +7848,6 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.22.0
       zod-to-json-schema: 3.25.1(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.3
-      file-type: 21.3.0
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.4
-      proper-lockfile: 4.1.2
-      yaml: 2.8.2
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7030,7 +7869,7 @@ snapshots:
       diff: 8.0.3
       extract-zip: 2.0.1
       file-type: 21.3.0
-      glob: 13.0.6
+      glob: 13.0.5
       hosted-git-info: 9.0.2
       ignore: 7.0.5
       marked: 15.0.12
@@ -7048,20 +7887,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.55.0':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.5.0
-      koffi: 2.15.1
-      marked: 15.0.12
-      mime-types: 3.0.2
-
   '@mariozechner/pi-tui@0.55.1':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.4.0
       koffi: 2.15.1
       marked: 15.0.12
       mime-types: 3.0.2
@@ -7102,52 +7932,99 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.95':
+  '@napi-rs/canvas-android-arm64@0.1.92':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.95':
+  '@napi-rs/canvas-android-arm64@0.1.93':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.95':
+  '@napi-rs/canvas-darwin-arm64@0.1.92':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.95':
+  '@napi-rs/canvas-darwin-arm64@0.1.93':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.95':
+  '@napi-rs/canvas-darwin-x64@0.1.92':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.95':
+  '@napi-rs/canvas-darwin-x64@0.1.93':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.95':
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.92':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.95':
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.93':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.95':
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.92':
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.95':
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.93':
     optional: true
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.95':
+  '@napi-rs/canvas-linux-arm64-musl@0.1.92':
     optional: true
 
-  '@napi-rs/canvas@0.1.95':
+  '@napi-rs/canvas-linux-arm64-musl@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.92':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.92':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.92':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.92':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.92':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.93':
+    optional: true
+
+  '@napi-rs/canvas@0.1.92':
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.95
-      '@napi-rs/canvas-darwin-arm64': 0.1.95
-      '@napi-rs/canvas-darwin-x64': 0.1.95
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.95
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.95
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.95
-      '@napi-rs/canvas-linux-x64-musl': 0.1.95
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.95
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.95
+      '@napi-rs/canvas-android-arm64': 0.1.92
+      '@napi-rs/canvas-darwin-arm64': 0.1.92
+      '@napi-rs/canvas-darwin-x64': 0.1.92
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.92
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.92
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.92
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.92
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.92
+      '@napi-rs/canvas-linux-x64-musl': 0.1.92
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.92
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.92
+
+  '@napi-rs/canvas@0.1.93':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.93
+      '@napi-rs/canvas-darwin-arm64': 0.1.93
+      '@napi-rs/canvas-darwin-x64': 0.1.93
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.93
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.93
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.93
+      '@napi-rs/canvas-linux-x64-musl': 0.1.93
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.93
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.93
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -7221,7 +8098,7 @@ snapshots:
     dependencies:
       '@octokit/auth-oauth-app': 9.0.3
       '@octokit/auth-oauth-user': 6.0.2
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       toad-cache: 3.7.0
@@ -7232,14 +8109,14 @@ snapshots:
     dependencies:
       '@octokit/auth-oauth-device': 8.0.3
       '@octokit/auth-oauth-user': 6.0.2
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
   '@octokit/auth-oauth-device@8.0.3':
     dependencies:
       '@octokit/oauth-methods': 6.0.2
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -7247,7 +8124,7 @@ snapshots:
     dependencies:
       '@octokit/auth-oauth-device': 8.0.3
       '@octokit/oauth-methods': 6.0.2
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -7262,20 +8139,20 @@ snapshots:
     dependencies:
       '@octokit/auth-token': 6.0.0
       '@octokit/graphql': 9.0.3
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       before-after-hook: 4.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@11.0.3':
+  '@octokit/endpoint@11.0.2':
     dependencies:
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
   '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -7295,7 +8172,7 @@ snapshots:
   '@octokit/oauth-methods@6.0.2':
     dependencies:
       '@octokit/oauth-authorization-url': 8.0.0
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.7
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
 
@@ -7317,7 +8194,7 @@ snapshots:
       '@octokit/core': 7.0.6
       '@octokit/types': 16.0.0
 
-  '@octokit/plugin-retry@8.1.0(@octokit/core@7.0.6)':
+  '@octokit/plugin-retry@8.0.3(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/request-error': 7.1.0
@@ -7334,13 +8211,12 @@ snapshots:
     dependencies:
       '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.8':
+  '@octokit/request@10.0.7':
     dependencies:
-      '@octokit/endpoint': 11.0.3
+      '@octokit/endpoint': 11.0.2
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       fast-content-type-parse: 3.0.0
-      json-with-bigint: 3.5.3
       universal-user-agent: 7.0.3
 
   '@octokit/types@16.0.0':
@@ -7838,79 +8714,79 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
+  '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.59.0':
+  '@rollup/rollup-android-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
+  '@rollup/rollup-darwin-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.59.0':
+  '@rollup/rollup-darwin-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
+  '@rollup/rollup-freebsd-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
+  '@rollup/rollup-freebsd-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
+  '@rollup/rollup-linux-x64-musl@4.57.1':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
+  '@rollup/rollup-openbsd-x64@4.57.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
+  '@rollup/rollup-openharmony-arm64@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
   '@scure/base@2.0.0': {}
@@ -7956,14 +8832,14 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@slack/oauth@3.0.4':
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/web-api': 7.14.1
       '@types/jsonwebtoken': 9.0.10
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
@@ -7972,7 +8848,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/web-api': 7.14.1
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.19.0
@@ -7987,7 +8863,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.20.0
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/retry': 0.12.0
       axios: 1.13.5
       eventemitter3: 5.0.4
@@ -8005,6 +8881,20 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
   '@smithy/config-resolver@4.4.9':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
@@ -8012,6 +8902,19 @@ snapshots:
       '@smithy/util-config-provider': 4.2.1
       '@smithy/util-endpoints': 3.3.1
       '@smithy/util-middleware': 4.2.10
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.2':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
   '@smithy/core@3.23.6':
@@ -8035,34 +8938,42 @@ snapshots:
       '@smithy/url-parser': 4.2.10
       tslib: 2.8.1
 
-  '@smithy/eventstream-codec@4.2.10':
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.0
-      '@smithy/util-hex-encoding': 4.2.1
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-browser@4.2.10':
+  '@smithy/eventstream-serde-browser@4.2.8':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.10
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-config-resolver@4.3.10':
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-node@4.2.10':
+  '@smithy/eventstream-serde-node@4.2.8':
     dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.10
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@smithy/eventstream-serde-universal@4.2.10':
+  '@smithy/eventstream-serde-universal@4.2.8':
     dependencies:
-      '@smithy/eventstream-codec': 4.2.10
-      '@smithy/types': 4.13.0
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.11':
@@ -8073,6 +8984,14 @@ snapshots:
       '@smithy/util-base64': 4.3.1
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
   '@smithy/hash-node@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -8080,12 +8999,28 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/invalid-dependency@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
     dependencies:
       tslib: 2.8.1
 
@@ -8099,6 +9034,23 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.16':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
   '@smithy/middleware-endpoint@4.4.20':
     dependencies:
       '@smithy/core': 3.23.6
@@ -8108,6 +9060,18 @@ snapshots:
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-middleware': 4.2.10
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.33':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.37':
@@ -8128,9 +9092,20 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/middleware-stack@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.10':
@@ -8138,6 +9113,21 @@ snapshots:
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.12':
@@ -8153,9 +9143,19 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/protocol-http@5.3.10':
     dependencies:
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.10':
@@ -8164,14 +9164,34 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/querystring-parser@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/service-error-classification@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.5':
     dependencies:
@@ -8189,6 +9209,27 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.5':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.0':
     dependencies:
       '@smithy/core': 3.23.6
@@ -8197,6 +9238,10 @@ snapshots:
       '@smithy/protocol-http': 5.3.10
       '@smithy/types': 4.13.0
       '@smithy/util-stream': 4.5.15
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.13.0':
@@ -8209,13 +9254,33 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/util-base64@4.3.1':
     dependencies:
       '@smithy/util-buffer-from': 4.2.1
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/util-body-length-browser@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
     dependencies:
       tslib: 2.8.1
 
@@ -8228,13 +9293,29 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/util-buffer-from@4.2.1':
     dependencies:
       '@smithy/is-array-buffer': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/util-config-provider@4.2.1':
     dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.36':
@@ -8242,6 +9323,16 @@ snapshots:
       '@smithy/property-provider': 4.2.10
       '@smithy/smithy-client': 4.12.0
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.39':
@@ -8254,10 +9345,20 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/util-endpoints@3.3.1':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.1':
@@ -8269,10 +9370,32 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/util-retry@4.2.10':
     dependencies:
       '@smithy/service-error-classification': 4.2.10
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.15':
@@ -8286,6 +9409,10 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/util-uri-escape@4.2.1':
     dependencies:
       tslib: 2.8.1
@@ -8295,9 +9422,18 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/util-utf8@4.2.1':
     dependencies:
       '@smithy/util-buffer-from': 4.2.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.1':
@@ -8367,7 +9503,13 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@swc/helpers@0.5.19':
+  '@stimm/protocol@0.1.8(@types/dom-mediacapture-record@1.0.22)':
+    dependencies:
+      livekit-client: 2.17.2(@types/dom-mediacapture-record@1.0.22)
+    transitivePeerDependencies:
+      - '@types/dom-mediacapture-record'
+
+  '@swc/helpers@0.5.18':
     dependencies:
       tslib: 2.8.1
 
@@ -8453,7 +9595,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/bun@1.3.9':
     dependencies:
@@ -8473,22 +9615,24 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/dom-mediacapture-record@1.0.22': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -8513,7 +9657,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/linkify-it@5.0.0': {}
 
@@ -8534,15 +9678,15 @@ snapshots:
 
   '@types/node@10.17.60': {}
 
-  '@types/node@20.19.34':
+  '@types/node@20.19.33':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.10.14':
+  '@types/node@24.10.13':
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.3.1':
+  '@types/node@25.3.2':
     dependencies:
       undici-types: 7.18.2
 
@@ -8555,7 +9699,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.4
 
@@ -8564,22 +9708,22 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -8587,11 +9731,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
     optional: true
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260225.1':
@@ -8655,34 +9799,34 @@ snapshots:
       postgres: 3.4.8
       request: '@cypress/request@3.0.10'
       request-promise: '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(@cypress/request@3.0.10)'
-      sanitize-html: 2.17.1
+      sanitize-html: 2.17.0
     transitivePeerDependencies:
       - '@cypress/request'
       - supports-color
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -8690,7 +9834,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -8702,9 +9846,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -8715,13 +9859,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -8810,11 +9954,11 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.15.0
 
-  acorn@8.16.0: {}
+  acorn@8.15.0: {}
 
   acpx@0.1.13(zod@4.3.6):
     dependencies:
@@ -8866,10 +10010,10 @@ snapshots:
 
   apache-arrow@18.1.0:
     dependencies:
-      '@swc/helpers': 0.5.19
+      '@swc/helpers': 0.5.18
       '@types/command-line-args': 5.2.3
       '@types/command-line-usage': 5.0.4
-      '@types/node': 20.19.34
+      '@types/node': 20.19.33
       command-line-args: 5.2.1
       command-line-usage: 7.0.3
       flatbuffers: 24.12.23
@@ -8963,7 +10107,9 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  balanced-match@4.0.4: {}
+  balanced-match@4.0.2:
+    dependencies:
+      jackspeak: 4.2.3
 
   bare-events@2.8.2: {}
 
@@ -8973,7 +10119,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.1.0: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -9024,9 +10170,9 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.3:
+  brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 4.0.2
 
   buffer-crc32@0.2.13: {}
 
@@ -9036,7 +10182,7 @@ snapshots:
 
   bun-types@1.3.9:
     dependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
     optional: true
 
   bytes@3.1.2: {}
@@ -9060,6 +10206,15 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  camelcase-keys@9.1.3:
+    dependencies:
+      camelcase: 8.0.0
+      map-obj: 5.0.0
+      quick-lru: 6.1.2
+      type-fest: 4.41.0
+
+  camelcase@8.0.0: {}
 
   caseless@0.12.0: {}
 
@@ -9143,6 +10298,8 @@ snapshots:
   color-support@1.1.3:
     optional: true
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -9217,6 +10374,8 @@ snapshots:
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  dateformat@4.6.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -9404,6 +10563,8 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   express@4.22.1:
@@ -9491,9 +10652,13 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
+  fast-copy@4.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
@@ -9643,6 +10808,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.4.0: {}
+
   get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
@@ -9673,7 +10840,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.1.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -9690,15 +10857,15 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 10.2.4
-      minipass: 7.1.3
+      minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@13.0.6:
+  glob@13.0.5:
     dependencies:
       minimatch: 10.2.4
-      minipass: 7.1.3
-      path-scurry: 2.0.2
+      minipass: 7.1.2
+      path-scurry: 2.0.1
 
   glob@7.2.3:
     dependencies:
@@ -9774,13 +10941,15 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
 
-  hashery@1.5.0:
+  hashery@1.4.0:
     dependencies:
       hookified: 1.15.1
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   highlight.js@10.7.3: {}
 
@@ -9875,8 +11044,8 @@ snapshots:
 
   import-in-the-middle@2.0.6:
     dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
@@ -9918,7 +11087,7 @@ snapshots:
       sleep-promise: 9.1.0
       slice-ansi: 7.1.2
       stdout-update: 4.0.1
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
     optionalDependencies:
       '@reflink/reflink': 0.1.19
 
@@ -9941,9 +11110,11 @@ snapshots:
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.4.0
 
   is-interactive@2.0.0: {}
+
+  is-network-error@1.3.0: {}
 
   is-plain-object@5.0.0: {}
 
@@ -9984,9 +11155,19 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jiti@2.6.1: {}
 
   jose@4.15.9: {}
+
+  jose@5.10.0: {}
+
+  jose@6.1.3: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -10010,8 +11191,6 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stringify-safe@5.0.1: {}
-
-  json-with-bigint@3.5.3: {}
 
   json5@2.2.3: {}
 
@@ -10167,6 +11346,27 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
+  livekit-client@2.17.2(@types/dom-mediacapture-record@1.0.22):
+    dependencies:
+      '@livekit/mutex': 1.1.1
+      '@livekit/protocol': 1.44.0
+      '@types/dom-mediacapture-record': 1.0.22
+      events: 3.3.0
+      jose: 6.1.3
+      loglevel: 1.9.2
+      sdp-transform: 2.15.0
+      ts-debounce: 4.0.0
+      tslib: 2.8.1
+      typed-emitter: 2.1.0
+      webrtc-adapter: 9.0.4
+
+  livekit-server-sdk@2.15.0:
+    dependencies:
+      '@bufbuild/protobuf': 1.10.1
+      '@livekit/protocol': 1.44.0
+      camelcase-keys: 9.1.3
+      jose: 5.10.0
+
   lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
@@ -10199,6 +11399,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
+
+  loglevel@1.9.2: {}
 
   long@4.0.0: {}
 
@@ -10250,6 +11452,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  map-obj@5.0.0: {}
+
   markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
@@ -10297,15 +11501,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.3
+      brace-expansion: 5.0.2
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
+  minipass@7.1.2: {}
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   mkdirp@3.0.1: {}
 
@@ -10413,10 +11617,10 @@ snapshots:
       pretty-ms: 9.3.0
       proper-lockfile: 4.1.2
       semver: 7.7.4
-      simple-git: 3.32.3
+      simple-git: 3.31.1
       slice-ansi: 8.0.0
       stdout-update: 4.0.1
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       validate-npm-package-name: 7.0.2
       which: 6.0.1
       yargs: 17.7.2
@@ -10491,7 +11695,7 @@ snapshots:
       '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.6)
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
-      '@octokit/plugin-retry': 8.1.0(@octokit/core@7.0.6)
+      '@octokit/plugin-retry': 8.0.3(@octokit/core@7.0.6)
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
@@ -10535,10 +11739,10 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.2.26(@napi-rs/canvas@0.1.93)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.998.0
+      '@aws-sdk/client-bedrock': 3.1000.0
       '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
@@ -10548,12 +11752,12 @@ snapshots:
       '@larksuiteoapi/node-sdk': 1.59.0
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
+      '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.1
       '@mozilla/readability': 0.6.0
-      '@napi-rs/canvas': 0.1.95
+      '@napi-rs/canvas': 0.1.93
       '@sinclair/typebox': 0.34.48
       '@slack/bolt': 4.6.0(@types/express@5.0.6)
       '@slack/web-api': 7.14.1
@@ -10705,6 +11909,10 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.0
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
@@ -10764,12 +11972,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
+      minipass: 7.1.2
 
-  path-scurry@2.0.2:
+  path-scurry@2.0.1:
     dependencies:
       lru-cache: 11.2.6
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}
 
@@ -10779,7 +11987,7 @@ snapshots:
 
   pdfjs-dist@5.4.624:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.95
+      '@napi-rs/canvas': 0.1.93
       node-readable-to-web-readable-stream: 0.4.2
 
   peberminta@0.9.0: {}
@@ -10797,6 +12005,26 @@ snapshots:
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
 
   pino-std-serializers@7.1.0: {}
 
@@ -10889,7 +12117,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       long: 5.3.2
 
   protobufjs@8.0.0:
@@ -10904,7 +12132,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -10960,6 +12188,8 @@ snapshots:
   querystringify@2.2.0: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  quick-lru@6.1.2: {}
 
   range-parser@1.2.1: {}
 
@@ -11082,35 +12312,35 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
 
-  rollup@4.59.0:
+  rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -11123,6 +12353,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -11131,7 +12366,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.1:
+  sanitize-html@2.17.0:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
@@ -11139,6 +12374,12 @@ snapshots:
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
       postcss: 8.5.6
+
+  sdp-transform@2.15.0: {}
+
+  sdp@3.2.1: {}
+
+  secure-json-parse@4.1.0: {}
 
   selderee@0.11.0:
     dependencies:
@@ -11285,7 +12526,7 @@ snapshots:
     dependencies:
       signal-polyfill: 0.2.2
 
-  simple-git@3.32.3:
+  simple-git@3.31.1:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
@@ -11402,7 +12643,7 @@ snapshots:
       ansi-escapes: 6.2.1
       ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   stealthy-require@1.1.1: {}
 
@@ -11431,18 +12672,18 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
 
   string-width@8.2.0:
     dependencies:
       get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   string_decoder@1.1.1:
     dependencies:
@@ -11457,11 +12698,13 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
+  strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   strnum@2.1.2: {}
 
@@ -11491,7 +12734,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.3
+      minipass: 7.1.2
       minizlib: 3.1.0
       yallist: 5.0.0
 
@@ -11551,6 +12794,8 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-debounce@4.0.0: {}
+
   tsdown@0.20.3(@typescript/native-preview@7.0.0-dev.20260225.1)(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
@@ -11597,6 +12842,8 @@ snapshots:
 
   tweetnacl@0.14.5: {}
 
+  type-fest@4.41.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -11607,6 +12854,10 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-emitter@2.1.0:
+    optionalDependencies:
+      rxjs: 7.8.2
 
   typescript@5.9.3: {}
 
@@ -11672,26 +12923,26 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.59.0
+      rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.1
+      '@types/node': 25.3.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.2)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -11708,12 +12959,12 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.3.1
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@types/node': 25.3.2
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11730,6 +12981,10 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webrtc-adapter@9.0.4:
+    dependencies:
+      sdp: 3.2.1
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11768,7 +13023,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
 

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -214,7 +214,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     );
     for (const hint of renderRuntimeHints(
       service.runtime,
-      (service.command?.environment ?? process.env) as NodeJS.ProcessEnv,
+      service.command?.environment ?? process.env,
     )) {
       defaultRuntime.error(errorText(hint));
     }
@@ -222,7 +222,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   }
 
   if (service.runtime?.cachedLabel) {
-    const env = (service.command?.environment ?? process.env) as NodeJS.ProcessEnv;
+    const env = service.command?.environment ?? process.env;
     const labelValue = resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE);
     defaultRuntime.error(
       errorText(
@@ -265,15 +265,13 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       defaultRuntime.error(`${errorText("Last gateway error:")} ${status.lastError}`);
     }
     if (process.platform === "linux") {
-      const env = (service.command?.environment ?? process.env) as NodeJS.ProcessEnv;
+      const env = service.command?.environment ?? process.env;
       const unit = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
       defaultRuntime.error(
         errorText(`Logs: journalctl --user -u ${unit}.service -n 200 --no-pager`),
       );
     } else if (process.platform === "darwin") {
-      const logs = resolveGatewayLogPaths(
-        (service.command?.environment ?? process.env) as NodeJS.ProcessEnv,
-      );
+      const logs = resolveGatewayLogPaths(service.command?.environment ?? process.env);
       defaultRuntime.error(`${errorText("Logs:")} ${shortenHomePath(logs.stdoutPath)}`);
       defaultRuntime.error(`${errorText("Errors:")} ${shortenHomePath(logs.stderrPath)}`);
     }


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw has no native real-time voice channel — users can't have low-latency spoken conversations with their AI assistant.
- **Why it matters:** Voice is the highest-bandwidth human communication channel; bridging it to OpenClaw's reasoning/tool layer unlocks hands-free, ambient AI interactions.
- **What changed:** New `extensions/stimm-voice` plugin — a voice extension with a dual-agent architecture: a fast Python LiveKit agent (STT/TTS/LLM) delegates complex reasoning to OpenClaw acting as the supervisor.
- **What did NOT change:** No core gateway code modified; self-contained extension with zero impact on existing channels.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

- New plugin `@openclaw/stimm-voice` installable via `openclaw plugins install --link ./extensions/stimm-voice`.
- New CLI commands: `openclaw voice:start`, `openclaw voice:logs`, `openclaw voice:setup`.
- New gateway methods: `stimm.start`, `stimm.end`, `stimm.status`, `stimm.instruct`, `stimm.mode`.
- New tool `stimm_voice` exposed to the AI (actions: `start_session`, `end_session`, `status`, `instruct`, `add_context`, `set_mode`).
- Browser voice UI served at configurable `web.path` (default `/voice`) with claim-token flow.
- Optional Cloudflare Quick Tunnel for instant public access without infra setup.
- Interactive setup wizard (`openclaw voice:setup`) for STT/TTS/LLM provider selection.

## Tested providers

I've personally tested the following LiveKit Agents plugin integrations:

| Role | Provider |
|------|----------|
| LLM  | Groq |
| TTS  | ElevenLabs, Hume |
| STT  | Deepgram |

I'll continue testing other providers, but help would be very much appreciated.

## Security Impact (required)

- New permissions/capabilities? **Yes** — plugin adds HTTP endpoints and a LiveKit room manager.
- Secrets/tokens handling changed? **Yes** — short-lived claim tokens (configurable TTL) and optional supervisor shared secret; no persistent token storage; secrets use env fallbacks (`STIMM_SUPERVISOR_SECRET`, `OPENCLAW_SUPERVISOR_SECRET`).
- New/changed network calls? **Yes** — outbound to LiveKit (configurable URL), optional Cloudflare Quick Tunnel.
- Command/tool execution surface changed? **Yes** — Python subprocess spawned for voice agent (auto-managed venv, scope limited to `/tmp/stimm-agent.log`).
- Data access scope changed? **No** — reads only OpenClaw conversation context already available to the supervisor.
- Risk + mitigation: claim tokens are one-time and short-lived; supervisor endpoint is secret-protected; direct session creation disabled by default (`allowDirectWebSessionCreate: false`); rate-limited claim endpoint (`claimRateLimitPerMinute: 20`).

## Repro + Verification

### Environment

- OS: Linux (WSL2 + Docker)
- Runtime: Node 22 + Python 3.12
- Model/provider: Groq (LLM) + Deepgram nova-3 (STT) + ElevenLabs / Hume (TTS)
- Integration/channel: web
- Relevant config: see `extensions/stimm-voice/README.md`

### Steps

1. `openclaw plugins install --link ./extensions/stimm-voice`
2. `openclaw voice:setup` — interactive wizard (LiveKit URL, STT/TTS/LLM providers, API keys)
3. `openclaw gateway start`
4. `openclaw voice:start --channel web` — returns `shareUrl` + `claimToken`
5. Open `shareUrl` on phone → speak → hear response

### Expected

- Low-latency voice response via LiveKit
- Supervisor logs visible via `openclaw voice:logs`

### Actual

- Working end-to-end on WSL2 + Docker LiveKit with Groq + Deepgram + ElevenLabs

## Evidence

- [x] Unit tests: `agent-process`, `room-manager`, `response-generator`, `config`, `cli` (vitest, colocated `*.test.ts`)
- [x] WSL2/Docker WebRTC fixes (TCP+UDP port mapping, LD_PRELOAD shim for Nvidia HW codec crashes, TURN credential fix)
- [x] `@stimm/protocol@0.1.8` from npm (no local repo symlink required)

---

**Incidental fix (unrelated to stimm-voice)**

Removed 4 unnecessary `as NodeJS.ProcessEnv` type assertions in `src/cli/daemon-cli/status.print.ts` (pre-existing `no-unnecessary-type-assertion` lint errors that blocked CI for this PR). Happy to extract to a separate PR if preferred.

## Follow-up (not blocking)

- [ ] Extract `LiveKitRuntime` from `index.ts` into its own file — `index.ts` is currently ~1300 LOC
- [ ] Rename `room-manager.test.ts` → `livekit-runtime.test.ts` to match what it actually tests
- [ ] Extract `core-bridge.ts` into shared plugin-sdk (same file already duplicated in `voice-call`)
- [ ] Split `setup-wizard.ts` (~1550 LOC) into smaller focused modules
- [ ] Add integration tests for individual STT/TTS/LLM providers