### PR TITLE
Gateway: default config.patch to minimal-diff output + explicit fetch-full

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -446,15 +446,17 @@ Restart or apply updates to the running Gateway process (in-place).
 Core actions:
 
 - `restart` (authorizes + sends `SIGUSR1` for in-process restart; `openclaw gateway` restart in-place)
-- `config.get` / `config.schema`
+- `config.get` / `config.fetch-full` / `config.schema`
 - `config.apply` (validate + write config + restart + wake)
-- `config.patch` (merge partial update + restart + wake)
+- `config.patch` (merge partial update + restart + wake; default response is minimal diff)
 - `update.run` (run update + restart + wake)
 
 Notes:
 
 - Use `delayMs` (defaults to 2000) to avoid interrupting an in-flight reply.
 - `restart` is enabled by default; set `commands.restart: false` to disable it.
+- Use `config.fetch-full` when you explicitly need the full config snapshot.
+- Use `config.patch` with `outputMode: "full"` if you need the full post-write payload.
 
 ### `sessions_list` / `sessions_history` / `sessions_send` / `sessions_spawn` / `session_status`
 

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -1,18 +1,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 
+async function defaultGatewayToolMock(method: string) {
+  if (method === "config.get") {
+    return { hash: "hash-1" };
+  }
+  return { ok: true };
+}
+
 vi.mock("./tools/gateway.js", () => ({
-  callGatewayTool: vi.fn(async (method: string) => {
-    if (method === "config.get") {
-      return { hash: "hash-1" };
-    }
-    return { ok: true };
-  }),
+  callGatewayTool: vi.fn(defaultGatewayToolMock),
   readGatewayCallOptions: vi.fn(() => ({})),
 }));
 
@@ -50,7 +52,64 @@ function expectConfigMutationCall(params: {
   );
 }
 
+function estimateTokenUsageFromText(text: string): number {
+  // Keep benchmark deterministic and dependency-free with the same heuristic
+  // used in compaction/tool-result truncation paths.
+  return Math.ceil(text.length / 4);
+}
+
+function readToolResultText(result: { content?: Array<{ type?: string; text?: string }> }): string {
+  const block = result.content?.find(
+    (entry): entry is { type: string; text: string } =>
+      entry.type === "text" && typeof entry.text === "string",
+  );
+  expect(block).toBeDefined();
+  return block?.text ?? "";
+}
+
+function buildLargeConfigFixture(): Record<string, unknown> {
+  const groups = Object.fromEntries(
+    Array.from({ length: 64 }, (_, index) => [
+      `team-${index}`,
+      {
+        requireMention: index % 2 === 0,
+        allowlist: [`ops-${index}`, `alerts-${index}`, `releases-${index}`],
+      },
+    ]),
+  );
+  return {
+    agents: {
+      defaults: {
+        workspace: "~/openclaw",
+        model: "gpt-5",
+      },
+    },
+    channels: {
+      telegram: {
+        groups,
+      },
+      discord: {
+        guilds: groups,
+      },
+    },
+    tools: {
+      browser: {
+        enabled: true,
+      },
+      web_search: {
+        provider: "brave",
+      },
+    },
+  };
+}
+
 describe("gateway tool", () => {
+  beforeEach(async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    vi.mocked(callGatewayTool).mockReset();
+    vi.mocked(callGatewayTool).mockImplementation(defaultGatewayToolMock);
+  });
+
   it("marks gateway as owner-only", async () => {
     const tool = requireGatewayTool();
     expect(tool.ownerOnly).toBe(true);
@@ -136,6 +195,202 @@ describe("gateway tool", () => {
       raw,
       sessionKey,
     });
+  });
+
+  it("returns minimal-diff output for config.patch by default", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const sessionKey = "agent:main:whatsapp:dm:+15555550123";
+    const tool = requireGatewayTool(sessionKey);
+    const raw = '{ channels: { telegram: { groups: { "*": { requireMention: false } } } } }';
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1" };
+      }
+      if (method === "config.patch") {
+        return {
+          ok: true,
+          path: "~/.openclaw/openclaw.json",
+          changedPaths: ["channels.telegram.groups.*.requireMention"],
+          config: { channels: { telegram: { groups: { "*": { requireMention: false } } } } },
+        };
+      }
+      return { ok: true };
+    });
+
+    const result = await tool.execute("call5", {
+      action: "config.patch",
+      raw,
+    });
+    const details = result.details as {
+      ok?: boolean;
+      result?: Record<string, unknown>;
+    };
+
+    expect(details.ok).toBe(true);
+    expect(details.result).toMatchObject({
+      ok: true,
+      changedPaths: ["channels.telegram.groups.*.requireMention"],
+      outputMode: "minimal-diff",
+      fetchFullConfigAction: "config.fetch-full",
+    });
+    expect(details.result?.config).toBeUndefined();
+  });
+
+  it("derives minimal-diff paths from raw patch when changedPaths is missing", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const sessionKey = "agent:main:whatsapp:dm:+15555550123";
+    const tool = requireGatewayTool(sessionKey);
+    const raw = '{ channels: { telegram: { groups: { "*": { requireMention: false } } } } }';
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1" };
+      }
+      if (method === "config.patch") {
+        return {
+          ok: true,
+          path: "~/.openclaw/openclaw.json",
+          config: { channels: { telegram: { groups: { "*": { requireMention: false } } } } },
+        };
+      }
+      return { ok: true };
+    });
+
+    const result = await tool.execute("call5b", {
+      action: "config.patch",
+      raw,
+    });
+    const details = result.details as {
+      ok?: boolean;
+      result?: Record<string, unknown>;
+    };
+    const changedPaths = details.result?.changedPaths;
+
+    expect(details.ok).toBe(true);
+    expect(Array.isArray(changedPaths)).toBe(true);
+    expect(changedPaths).toContain("channels.telegram.groups.*.requireMention");
+    expect(details.result?.changedPathsSource).toBe("requested-patch");
+  });
+
+  it("returns full config.patch output when outputMode=full", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const sessionKey = "agent:main:whatsapp:dm:+15555550123";
+    const tool = requireGatewayTool(sessionKey);
+    const raw = '{ channels: { telegram: { groups: { "*": { requireMention: false } } } } }';
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1" };
+      }
+      if (method === "config.patch") {
+        return {
+          ok: true,
+          path: "~/.openclaw/openclaw.json",
+          changedPaths: ["channels.telegram.groups.*.requireMention"],
+          config: { channels: { telegram: { groups: { "*": { requireMention: false } } } } },
+        };
+      }
+      return { ok: true };
+    });
+
+    const result = await tool.execute("call6", {
+      action: "config.patch",
+      raw,
+      outputMode: "full",
+    });
+    const details = result.details as {
+      ok?: boolean;
+      result?: Record<string, unknown>;
+    };
+
+    expect(details.ok).toBe(true);
+    expect(details.result?.config).toBeDefined();
+    expect(details.result?.outputMode).toBeUndefined();
+  });
+
+  it("rejects unsupported config.patch outputMode values", async () => {
+    const tool = requireGatewayTool("agent:main:whatsapp:dm:+15555550123");
+    const raw = '{ channels: { telegram: { groups: { "*": { requireMention: false } } } } }';
+
+    await expect(
+      tool.execute("call6b", {
+        action: "config.patch",
+        raw,
+        outputMode: "diff-only",
+      }),
+    ).rejects.toThrow(/Invalid outputMode/i);
+  });
+
+  it("supports explicit full snapshot fetch via config.fetch-full", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const tool = requireGatewayTool();
+    const fullSnapshot = {
+      hash: "hash-2",
+      config: buildLargeConfigFixture(),
+    };
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return fullSnapshot;
+      }
+      return { ok: true };
+    });
+
+    const result = await tool.execute("call7", {
+      action: "config.fetch-full",
+    });
+    const details = result.details as {
+      ok?: boolean;
+      result?: Record<string, unknown>;
+    };
+
+    expect(callGatewayTool).toHaveBeenCalledWith("config.get", expect.any(Object), {});
+    expect(details).toMatchObject({
+      ok: true,
+      result: fullSnapshot,
+    });
+  });
+
+  it("benchmarks lower token usage for minimal-diff vs full config.patch output", async () => {
+    const { callGatewayTool } = await import("./tools/gateway.js");
+    const tool = requireGatewayTool("agent:main:whatsapp:dm:+15555550123");
+    const raw = '{ channels: { telegram: { groups: { "*": { requireMention: false } } } } }';
+    const fullConfig = buildLargeConfigFixture();
+    const patchResult = {
+      ok: true,
+      path: "~/.openclaw/openclaw.json",
+      changedPaths: ["channels.telegram.groups.*.requireMention"],
+      config: fullConfig,
+      restart: { ok: true, pid: 1234, signal: "SIGUSR1", delayMs: 2000 },
+      sentinel: { path: "/tmp/restart-sentinel.json" },
+    };
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: "hash-1" };
+      }
+      if (method === "config.patch") {
+        return patchResult;
+      }
+      return { ok: true };
+    });
+
+    const fullOutput = await tool.execute("call8", {
+      action: "config.patch",
+      raw,
+      outputMode: "full",
+    });
+    const minimalOutput = await tool.execute("call9", {
+      action: "config.patch",
+      raw,
+    });
+
+    const fullTokens = estimateTokenUsageFromText(readToolResultText(fullOutput));
+    const minimalTokens = estimateTokenUsageFromText(readToolResultText(minimalOutput));
+
+    expect(fullTokens).toBeGreaterThan(0);
+    expect(minimalTokens).toBeLessThan(fullTokens);
+    expect(minimalTokens / fullTokens).toBeLessThan(0.5);
   });
 
   it("passes update.run through gateway call", async () => {

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import "./test-helpers/fast-core-tools.js";
@@ -53,9 +54,15 @@ function expectConfigMutationCall(params: {
 }
 
 function estimateTokenUsageFromText(text: string): number {
-  // Keep benchmark deterministic and dependency-free with the same heuristic
-  // used in compaction/tool-result truncation paths.
-  return Math.ceil(text.length / 4);
+  const message = {
+    role: "toolResult",
+    toolCallId: "call_benchmark",
+    toolName: "gateway",
+    isError: false,
+    content: [{ type: "text", text }],
+    timestamp: 0,
+  } as const satisfies Parameters<typeof estimateTokens>[0];
+  return estimateTokens(message);
 }
 
 function readToolResultText(result: { content?: Array<{ type?: string; text?: string }> }): string {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -419,6 +419,8 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## OpenClaw Self-Update");
+    expect(prompt).toContain("config.fetch-full");
+    expect(prompt).toContain("config.patch");
     expect(prompt).toContain("config.apply");
     expect(prompt).toContain("update.run");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -479,7 +479,7 @@ export function buildAgentSystemPrompt(params: {
           "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
           "Use config.schema to fetch the current JSON Schema (includes plugins/channels) before making config changes or answering config-field questions; avoid guessing field names/types.",
-          "Actions: config.get, config.schema, config.apply (validate + write full config, then restart), update.run (update deps or git, then restart).",
+          "Actions: config.get, config.fetch-full, config.schema, config.patch (merge partial config + restart; default output is minimal diff), config.apply (validate + write full config, then restart), update.run (update deps or git, then restart).",
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import { isRestartEnabled } from "../../config/commands.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import { parseConfigJson5, type OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import {
@@ -17,6 +17,82 @@ import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
 const log = createSubsystemLogger("gateway-tool");
 
 const DEFAULT_UPDATE_TIMEOUT_MS = 20 * 60_000;
+const CONFIG_PATCH_OUTPUT_MODES = ["minimal-diff", "full"] as const;
+const DEFAULT_CONFIG_PATCH_OUTPUT_MODE = "minimal-diff";
+type ConfigPatchOutputMode = (typeof CONFIG_PATCH_OUTPUT_MODES)[number];
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item) => typeof item === "string");
+}
+
+function collectPatchLeafPaths(value: unknown, prefix = ""): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return prefix ? [prefix] : [];
+  }
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    return prefix ? [prefix] : [];
+  }
+  const paths: string[] = [];
+  for (const [key, child] of entries) {
+    const childPath = prefix ? `${prefix}.${key}` : key;
+    if (!child || typeof child !== "object" || Array.isArray(child)) {
+      paths.push(childPath);
+      continue;
+    }
+    paths.push(...collectPatchLeafPaths(child, childPath));
+  }
+  return paths;
+}
+
+function summarizeConfigPatchResult(params: {
+  result: unknown;
+  raw: string;
+}): Record<string, unknown> {
+  const resultRecord =
+    params.result && typeof params.result === "object"
+      ? (params.result as Record<string, unknown>)
+      : {};
+  const changedPaths = toStringArray(resultRecord.changedPaths);
+
+  let requestedPatchPaths: string[] = [];
+  if (changedPaths.length === 0) {
+    const parsedPatch = parseConfigJson5(params.raw);
+    if (parsedPatch.ok) {
+      requestedPatchPaths = Array.from(new Set(collectPatchLeafPaths(parsedPatch.parsed)));
+    }
+  }
+
+  const summarizedPaths = changedPaths.length > 0 ? changedPaths : requestedPatchPaths;
+  return {
+    ok: resultRecord.ok !== false,
+    ...(typeof resultRecord.path === "string" ? { path: resultRecord.path } : {}),
+    changedPaths: summarizedPaths,
+    changedPathCount: summarizedPaths.length,
+    ...(resultRecord.restart !== undefined ? { restart: resultRecord.restart } : {}),
+    ...(resultRecord.sentinel !== undefined ? { sentinel: resultRecord.sentinel } : {}),
+    ...(changedPaths.length > 0 ? { changedPathsSource: "validated-config-diff" } : {}),
+    ...(changedPaths.length === 0 && requestedPatchPaths.length > 0
+      ? { changedPathsSource: "requested-patch" }
+      : {}),
+    fetchFullConfigAction: "config.fetch-full",
+    outputMode: "minimal-diff",
+  };
+}
+
+function resolveConfigPatchOutputMode(params: Record<string, unknown>): ConfigPatchOutputMode {
+  const mode = readStringParam(params, "outputMode");
+  if (!mode) {
+    return DEFAULT_CONFIG_PATCH_OUTPUT_MODE;
+  }
+  if (mode === "minimal-diff" || mode === "full") {
+    return mode;
+  }
+  throw new Error(`Invalid outputMode: ${mode}. Expected one of: minimal-diff, full.`);
+}
 
 function resolveBaseHashFromSnapshot(snapshot: unknown): string | undefined {
   if (!snapshot || typeof snapshot !== "object") {
@@ -34,6 +110,7 @@ function resolveBaseHashFromSnapshot(snapshot: unknown): string | undefined {
 const GATEWAY_ACTIONS = [
   "restart",
   "config.get",
+  "config.fetch-full",
   "config.schema",
   "config.apply",
   "config.patch",
@@ -55,6 +132,7 @@ const GatewayToolSchema = Type.Object({
   // config.apply, config.patch
   raw: Type.Optional(Type.String()),
   baseHash: Type.Optional(Type.String()),
+  outputMode: Type.Optional(stringEnum(CONFIG_PATCH_OUTPUT_MODES)),
   // config.apply, config.patch, update.run
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
@@ -74,7 +152,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: true,
     description:
-      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing); by default it returns minimal changed-path diff output to reduce tokens, and you can set outputMode=full for the full payload. Use config.fetch-full to explicitly fetch the full config snapshot. Use config.apply only when replacing entire config. Config writes trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -172,6 +250,10 @@ export function createGatewayTool(opts?: {
         const result = await callGatewayTool("config.get", gatewayOpts, {});
         return jsonResult({ ok: true, result });
       }
+      if (action === "config.fetch-full") {
+        const result = await callGatewayTool("config.get", gatewayOpts, {});
+        return jsonResult({ ok: true, result });
+      }
       if (action === "config.schema") {
         const result = await callGatewayTool("config.schema", gatewayOpts, {});
         return jsonResult({ ok: true, result });
@@ -191,6 +273,7 @@ export function createGatewayTool(opts?: {
       if (action === "config.patch") {
         const { raw, baseHash, sessionKey, note, restartDelayMs } =
           await resolveConfigWriteParams();
+        const outputMode = resolveConfigPatchOutputMode(params);
         const result = await callGatewayTool("config.patch", gatewayOpts, {
           raw,
           baseHash,
@@ -198,7 +281,11 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result });
+        if (outputMode === "full") {
+          return jsonResult({ ok: true, result });
+        }
+        const summarized = summarizeConfigPatchResult({ result, raw });
+        return jsonResult({ ok: true, result: summarized });
       }
       if (action === "update.run") {
         const { sessionKey, note, restartDelayMs } = resolveGatewayWriteMeta();

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -393,6 +393,7 @@ export const configHandlers: GatewayRequestHandlers = {
       {
         ok: true,
         path: CONFIG_PATH,
+        changedPaths,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
         restart,
         sentinel: {


### PR DESCRIPTION
## Why
`gateway` tool calls to `config.patch` returned the full redacted config payload by default. For larger configs this inflates tool-result size, increasing context pressure and token usage in agent loops.

This PR makes `config.patch` responses token-efficient by default while preserving explicit full-payload access when needed.

## What changed
- `gateway` tool: add default `config.patch` output mode `minimal-diff`.
  - Includes `changedPaths`, `changedPathCount`, restart/sentinel metadata, and a `fetchFullConfigAction` hint.
- `gateway` tool: add opt-in `outputMode: "full"` for `config.patch` to preserve previous full payload behavior.
- `gateway` tool: add explicit `config.fetch-full` action (calls `config.get`) for intentional full snapshot retrieval.
- Gateway RPC response: add `changedPaths` to `config.patch` response payload (additive field).
- Docs/system prompt updates to reflect the new action and default behavior.

## Scope boundaries
- Changed: gateway tool config.patch output behavior, explicit fetch-full path, additive changedPaths metadata, docs/tests/prompt guidance.
- Not changed: config validation/write semantics, restart scheduling semantics, auth/scope policy, rate limiting, and `config.apply` behavior.

## Trust/model and safety notes
- This is a response-shape optimization, not a privilege or authorization change.
- `config.fetch-full` uses existing `config.get` permission boundaries.
- `outputMode: "full"` remains available for workflows that require full payloads.

## Evidence
Validated on branch with focused tests:

```bash
pnpm vitest run src/agents/openclaw-gateway-tool.test.ts src/agents/tools/gateway.test.ts src/agents/system-prompt.test.ts src/gateway/server.config-patch.test.ts
```

All passing in local run.

## Regression coverage added
- default minimal-diff output for `config.patch`
- fallback path derivation when `changedPaths` is absent
- explicit `outputMode: "full"`
- invalid `outputMode` rejection
- `config.fetch-full` action
- token-usage benchmark test now uses runtime-consistent `estimateTokens`
