### PR TITLE
feat(gateway): register operator-ui as accepted client ID

### DIFF
--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -1,6 +1,7 @@
 export const GATEWAY_CLIENT_IDS = {
   WEBCHAT_UI: "webchat-ui",
   CONTROL_UI: "openclaw-control-ui",
+  OPERATOR_UI: "openclaw-operator-ui",
   WEBCHAT: "webchat",
   CLI: "cli",
   GATEWAY_CLIENT: "gateway-client",


### PR DESCRIPTION
## Summary

- Add `openclaw-operator-ui` to `GATEWAY_CLIENT_IDS` in `src/gateway/protocol/client-info.ts`
- This allows third-party operator/admin UI plugins to connect to the Gateway using a dedicated client identity

## Motivation

When building standalone management UI plugins (e.g. for non-technical operators), they currently have to reuse an existing client ID like `webchat-ui` or `openclaw-control-ui` to pass the Gateway's client validation. This is semantically incorrect and can cause confusion in logs and analytics.

Adding a dedicated `operator-ui` client ID enables these plugins to identify themselves properly without requiring any changes to the core validation logic.

## Changes

Single-line addition to the `GATEWAY_CLIENT_IDS` constant:

```typescript
OPERATOR_UI: "openclaw-operator-ui",
```

No breaking changes. Fully backwards-compatible.

## Test plan

- [x] Existing tests pass (no test changes needed — this only adds a new enum value)
- [x] A WebSocket client using `id: "openclaw-operator-ui"` can successfully connect to the Gateway

Made with [Cursor](https://cursor.com)