### PR TITLE
Fix #29243: Resolve post-compaction startup files to existing paths

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { readPostCompactionContext } from "./post-compaction-context.js";
+import {
+  extractStartupFileCandidates,
+  readPostCompactionContext,
+  resolveExistingStartupFiles,
+} from "./post-compaction-context.js";
 
 describe("readPostCompactionContext", () => {
   const tmpDir = path.join("/tmp", "test-post-compaction-" + Date.now());
@@ -165,5 +169,96 @@ Never do Y.
     expect(result).toContain("Rule 1");
     expect(result).toContain("Rule 2");
     expect(result).not.toContain("Other Section");
+  });
+
+  it("appends list of existing startup files when Session Startup references files", async () => {
+    fs.mkdirSync(path.join(tmpDir, "memory"), { recursive: true });
+    const today = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(path.join(tmpDir, "SOUL.md"), "# Soul");
+    fs.writeFileSync(path.join(tmpDir, "memory", `${today}.md`), "# Today");
+    const content = `# Agent
+
+## Session Startup
+
+1. Read \`SOUL.md\`
+2. Read \`memory/YYYY-MM-DD.md\`
+3. Read \`WORKFLOW_AUTO.md\`
+
+## Red Lines
+
+Never delete files.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("The following startup files exist in your workspace");
+    expect(result).toContain("- SOUL.md");
+    expect(result).toContain(`- memory/${today}.md`);
+    expect(result).not.toMatch(/- WORKFLOW_AUTO\.md\b/);
+  });
+});
+
+describe("extractStartupFileCandidates", () => {
+  it("extracts backtick-wrapped .md paths", () => {
+    const text = "Read `SOUL.md` and `USER.md`.";
+    expect(extractStartupFileCandidates(text)).toContain("SOUL.md");
+    expect(extractStartupFileCandidates(text)).toContain("USER.md");
+  });
+
+  it("extracts Read X.md patterns", () => {
+    const text = "Read WORKFLOW_AUTO.md before starting.";
+    expect(extractStartupFileCandidates(text)).toContain("WORKFLOW_AUTO.md");
+  });
+
+  it("extracts numbered list items", () => {
+    const text = "1. WORKFLOW_AUTO.md\n2. memory/today.md";
+    const out = extractStartupFileCandidates(text);
+    expect(out).toContain("WORKFLOW_AUTO.md");
+    expect(out).toContain("memory/today.md");
+  });
+
+  it("adds memory/YYYY-MM-DD.md when placeholder appears", () => {
+    const text = "Read memory/YYYY-MM-DD.md (today).";
+    expect(extractStartupFileCandidates(text)).toContain("memory/YYYY-MM-DD.md");
+  });
+});
+
+describe("resolveExistingStartupFiles", () => {
+  const workspaceDir = path.join("/tmp", "test-resolve-startup-" + Date.now());
+
+  beforeEach(() => {
+    fs.mkdirSync(workspaceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("returns only paths that exist under workspace", () => {
+    fs.writeFileSync(path.join(workspaceDir, "SOUL.md"), "");
+    const out = resolveExistingStartupFiles(
+      workspaceDir,
+      ["SOUL.md", "WORKFLOW_AUTO.md"],
+      "UTC",
+      Date.now(),
+    );
+    expect(out).toEqual(["SOUL.md"]);
+  });
+
+  it("expands memory/YYYY-MM-DD.md to today and yesterday when they exist", () => {
+    fs.mkdirSync(path.join(workspaceDir, "memory"), { recursive: true });
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const yesterday = new Date(now.getTime() - 86400 * 1000).toISOString().slice(0, 10);
+    fs.writeFileSync(path.join(workspaceDir, "memory", `${today}.md`), "");
+    fs.writeFileSync(path.join(workspaceDir, "memory", `${yesterday}.md`), "");
+    const out = resolveExistingStartupFiles(
+      workspaceDir,
+      ["memory/YYYY-MM-DD.md"],
+      "UTC",
+      now.getTime(),
+    );
+    expect(out).toContain(`memory/${today}.md`);
+    expect(out).toContain(`memory/${yesterday}.md`);
   });
 });

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -145,8 +145,9 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
         ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
         : combined;
 
-    // Resolve actual existing startup files from Session Startup section (first section)
-    const sessionStartupText = sections[0] ?? "";
+    // Resolve actual existing startup files from the Session Startup section only
+    const sessionStartupSections = extractSections(content, ["Session Startup"]);
+    const sessionStartupText = sessionStartupSections.length > 0 ? sessionStartupSections[0] : "";
     const candidates = extractStartupFileCandidates(sessionStartupText);
     const timezone = resolveUserTimezone();
     const nowMs = Date.now();
@@ -164,7 +165,7 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
       "[Post-compaction context refresh]\n\n" +
       "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
       "Execute your Session Startup sequence now — read the required files before responding to the user. " +
-      "If a file listed below does not exist in your workspace, skip it and continue." +
+      "If a file listed below does not exist in your workspace, skip it and continue.\n" +
       existingFilesBlock +
       "Critical rules from AGENTS.md:\n\n" +
       safeContent

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,10 +1,125 @@
 import fs from "node:fs";
 import path from "node:path";
+import { resolveUserTimezone } from "../../agents/date-time.js";
+import { isPathWithinRoot } from "../../shared/avatar-policy.js";
 
 const MAX_CONTEXT_CHARS = 3000;
 
+/** Pattern for memory/YYYY-MM-DD.md (case-insensitive) in Session Startup. */
+const MEMORY_DATE_PLACEHOLDER = /memory\/yyyy-mm-dd\.md/i;
+
+function formatDateStampInTimezone(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((p) => p.type === "year")?.value;
+  const month = parts.find((p) => p.type === "month")?.value;
+  const day = parts.find((p) => p.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Extract file-path-like candidates from Session Startup section text.
+ * Matches backtick-wrapped paths, "Read path", numbered list items, and memory/YYYY-MM-DD.md.
+ */
+export function extractStartupFileCandidates(sectionText: string): string[] {
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+
+  // Backtick-wrapped: `file.md` or `path/file.md`
+  const backtickRe = /`([^`]+\.md)`/gi;
+  let m: RegExpExecArray | null;
+  while ((m = backtickRe.exec(sectionText)) !== null) {
+    const raw = m[1].trim();
+    if (raw && !seen.has(raw)) {
+      seen.add(raw);
+      candidates.push(raw);
+    }
+  }
+
+  // "Read path" or "read path" (path may contain / and .md)
+  const readRe = /\bread\s+([^\s\n]+\.md)\b/gi;
+  while ((m = readRe.exec(sectionText)) !== null) {
+    const raw = m[1].trim();
+    if (raw && !seen.has(raw)) {
+      seen.add(raw);
+      candidates.push(raw);
+    }
+  }
+
+  // Numbered list: 1. path, 2. path/file.md
+  const numberedRe = /^\s*\d+\.\s+([^\s\n]+(?:\.md|\/[^\s\n]*\.md)?)\s*$/gm;
+  while ((m = numberedRe.exec(sectionText)) !== null) {
+    const raw = m[1].trim();
+    if (raw && !seen.has(raw)) {
+      seen.add(raw);
+      candidates.push(raw);
+    }
+  }
+
+  // Literal memory/YYYY-MM-DD.md placeholder (add a sentinel so we resolve it later)
+  if (MEMORY_DATE_PLACEHOLDER.test(sectionText) && !seen.has("memory/YYYY-MM-DD.md")) {
+    seen.add("memory/YYYY-MM-DD.md");
+    candidates.push("memory/YYYY-MM-DD.md");
+  }
+
+  return candidates;
+}
+
+/**
+ * Resolve candidates to paths that actually exist under workspaceDir.
+ * Expands memory/YYYY-MM-DD.md to today and yesterday (timezone-aware); keeps only existing files.
+ * Returns relative paths (safe, within workspace).
+ */
+export function resolveExistingStartupFiles(
+  workspaceDir: string,
+  candidates: string[],
+  timezone: string,
+  nowMs: number,
+): string[] {
+  const root = path.resolve(workspaceDir);
+  const existing: string[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (candidate === "memory/YYYY-MM-DD.md" || MEMORY_DATE_PLACEHOLDER.test(candidate)) {
+      const today = formatDateStampInTimezone(nowMs, timezone);
+      const yesterdayMs = nowMs - 86400 * 1000;
+      const yesterday = formatDateStampInTimezone(yesterdayMs, timezone);
+      for (const dateStr of [today, yesterday]) {
+        const rel = `memory/${dateStr}.md`;
+        const abs = path.join(root, rel);
+        if (fs.existsSync(abs) && !seen.has(rel)) {
+          seen.add(rel);
+          existing.push(rel);
+        }
+      }
+      continue;
+    }
+
+    const abs = path.resolve(root, candidate);
+    if (!isPathWithinRoot(root, abs)) {
+      continue;
+    }
+    if (fs.existsSync(abs) && !seen.has(candidate)) {
+      seen.add(candidate);
+      existing.push(candidate);
+    }
+  }
+
+  return existing;
+}
+
 /**
  * Read critical sections from workspace AGENTS.md for post-compaction injection.
+ * Resolves startup file references to actual existing paths (e.g. memory/YYYY-MM-DD.md → memory/2026-02-28.md)
+ * and appends a list of existing startup files so the agent reads real files only.
  * Returns formatted system event text, or null if no AGENTS.md or no relevant sections.
  */
 export async function readPostCompactionContext(workspaceDir: string): Promise<string | null> {
@@ -18,7 +133,6 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
     const content = await fs.promises.readFile(agentsPath, "utf-8");
 
     // Extract "## Session Startup" and "## Red Lines" sections
-    // Each section ends at the next "## " heading or end of file
     const sections = extractSections(content, ["Session Startup", "Red Lines"]);
 
     if (sections.length === 0) {
@@ -31,10 +145,27 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
         ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
         : combined;
 
+    // Resolve actual existing startup files from Session Startup section (first section)
+    const sessionStartupText = sections[0] ?? "";
+    const candidates = extractStartupFileCandidates(sessionStartupText);
+    const timezone = resolveUserTimezone();
+    const nowMs = Date.now();
+    const existingFiles = resolveExistingStartupFiles(workspaceDir, candidates, timezone, nowMs);
+
+    let existingFilesBlock = "";
+    if (existingFiles.length > 0) {
+      existingFilesBlock =
+        "\nThe following startup files exist in your workspace; read them as needed:\n" +
+        existingFiles.map((f) => `- ${f}`).join("\n") +
+        "\n\n";
+    }
+
     return (
       "[Post-compaction context refresh]\n\n" +
       "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-      "Execute your Session Startup sequence now — read the required files before responding to the user.\n\n" +
+      "Execute your Session Startup sequence now — read the required files before responding to the user. " +
+      "If a file listed below does not exist in your workspace, skip it and continue." +
+      existingFilesBlock +
       "Critical rules from AGENTS.md:\n\n" +
       safeContent
     );


### PR DESCRIPTION
Closes #29243

## Summary

After context compaction, the post-compaction context injection told the agent to "read the required files" from the Session Startup section of AGENTS.md. Those references often pointed to files that do not exist in the workspace (e.g. `WORKFLOW_AUTO.md`, or the literal placeholder `memory/YYYY-MM-DD.md`), causing agents to waste tokens or flag the message as suspicious. This PR makes the injection reference **actual existing startup files** and instructs the agent to skip any listed file that does not exist.

## Problem background

- **Issue #29243**: The post-compaction audit message referenced non-existent files such as `WORKFLOW_AUTO.md` and showed the pattern `memory/\d{4}-\d{2}-\d{2}.md` literally instead of resolving it to real dates.
- Agents either tried to read missing files (wasting tokens) or treated the message as a prompt-injection risk.
- The injection content was taken verbatim from AGENTS.md (Session Startup + Red Lines) without checking which referenced files actually exist in the workspace.

## Approach

1. **Keep the “skip if missing” instruction**  
   The injected message still tells the agent: *"If a file listed below does not exist in your workspace, skip it and continue."*

2. **Parse startup file references from Session Startup**  
   - New helper `extractStartupFileCandidates(sectionText)` parses the Session Startup section for:
     - Backtick-wrapped paths (e.g. `SOUL.md`, `memory/YYYY-MM-DD.md`)
     - "Read X.md" style lines
     - Numbered list items (e.g. `1. WORKFLOW_AUTO.md`)
     - The placeholder `memory/YYYY-MM-DD.md` (case-insensitive)

3. **Resolve to existing paths only**  
   - New helper `resolveExistingStartupFiles(workspaceDir, candidates, timezone, nowMs)`:
     - Expands `memory/YYYY-MM-DD.md` to timezone-aware today and yesterday (e.g. `memory/2026-02-28.md`) and keeps only paths that exist on disk.
     - For other candidates, resolves paths under `workspaceDir`, enforces containment via `isPathWithinRoot`, and keeps only existing files.
   - Returns a list of **relative paths** that actually exist.

4. **Append an “existing startup files” list**  
   When the list is non-empty, the injected message now includes a block:
   *"The following startup files exist in your workspace; read them as needed:"* followed by a bullet list of those paths. Non-existent references (e.g. `WORKFLOW_AUTO.md`) are never listed there, so the agent is guided to real files only.

5. **Timezone**  
   Date expansion uses `resolveUserTimezone()` (host timezone when config is not available), consistent with existing memory-flush date handling.

## Testing

- **Unit tests** in `post-compaction-context.test.ts`:
  - `readPostCompactionContext`: with AGENTS.md that references SOUL.md, `memory/YYYY-MM-DD.md`, and WORKFLOW_AUTO.md, and only SOUL.md and today’s `memory/<date>.md` present on disk, the result contains the “existing startup files” block with only SOUL.md and `memory/<date>.md` (not WORKFLOW_AUTO.md).
  - `extractStartupFileCandidates`: backtick paths, “Read X.md”, numbered list, and `memory/YYYY-MM-DD.md` placeholder extraction.
  - `resolveExistingStartupFiles`: only existing paths returned; `memory/YYYY-MM-DD.md` expanded to today/yesterday when those files exist.
- **Existing tests**: `pnpm test -- src/auto-reply/reply/post-compaction-context.test.ts` (17 tests) and the “does not enqueue legacy post-compaction audit warnings” test in `agent-runner.misc.runreplyagent.test.ts` all pass.

## Files changed

- `src/auto-reply/reply/post-compaction-context.ts`: added extraction and resolution of startup file candidates, date expansion, and the “existing startup files” block in the injected message.
- `src/auto-reply/reply/post-compaction-context.test.ts`: new and updated tests for the above behavior.
