### PR TITLE
fix(skills): clear hasBinary cache after successful skill install

### DIFF
--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig, writeConfigFile } from "../../config/config.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { clearHasBinaryCache } from "../../shared/config-eval.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import {
   ErrorCodes,
@@ -137,6 +138,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
       timeoutMs: p.timeoutMs,
       config: cfg,
     });
+    if (result.ok) {
+      clearHasBinaryCache();
+    }
     respond(
       result.ok,
       result,

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -178,3 +178,9 @@ export function hasBinary(bin: string): boolean {
   hasBinaryCache.set(bin, false);
   return false;
 }
+
+export function clearHasBinaryCache(): void {
+  hasBinaryCache.clear();
+  cachedHasBinaryPath = undefined;
+  cachedHasBinaryPathExt = undefined;
+}


### PR DESCRIPTION
## Summary

- Add `clearHasBinaryCache()` export to `src/shared/config-eval.ts`
- Call it in `skills.install` handler after a successful installation

## Problem

When a user installs a skill dependency via `skills.install` (e.g. installing an npm package that provides a CLI binary), the `hasBinary()` function continues to return `false` for the newly installed binary. This is because `hasBinaryCache` holds stale entries from a previous PATH scan, and since `process.env.PATH` hasn't changed, the cache is never invalidated.

**Reproduction steps:**
1. Check `skills.status` — a skill shows "missing requirements" for binary `foo`
2. Call `skills.install` to install the package providing `foo` — install succeeds
3. Check `skills.status` again — skill **still** shows "missing requirements" for `foo`
4. Restart the Gateway — skill now correctly shows as eligible

## Fix

Add a `clearHasBinaryCache()` function that resets the internal cache map and the cached PATH/PATHEXT values. Call it after a successful `installSkill()` so the next `skills.status` evaluation re-scans PATH and discovers the newly installed binary.

## Changes

**`src/shared/config-eval.ts`**
```typescript
export function clearHasBinaryCache(): void {
  hasBinaryCache.clear();
  cachedHasBinaryPath = undefined;
  cachedHasBinaryPathExt = undefined;
}
```

**`src/gateway/server-methods/skills.ts`**
```typescript
if (result.ok) {
  clearHasBinaryCache();
}
```

## Test plan

- [x] Install a skill dependency via `skills.install`, then immediately call `skills.status` — the skill should show as eligible without a Gateway restart
- [x] Existing tests pass (no changes to existing behavior when install fails)

Made with [Cursor](https://cursor.com)