### PR TITLE
fix: add xAI Grok 4.1/Fast/Code model forward-compat resolution

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -23,7 +23,7 @@ const CODEX_MODELS = [
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
 const MINIMAX_PREFIXES = ["minimax-m2.1", "minimax-m2.5"];
-const XAI_PREFIXES = ["grok-4"];
+const XAI_PREFIXES = ["grok-4", "grok-code-fast"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {
   return prefixes.some((prefix) => id.startsWith(prefix));

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -25,6 +25,11 @@ const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
 
+// xAI Grok 4.1 models are not yet in pi-ai's built-in xai catalog.
+// Clone the grok-4 template so users don't get "Unknown model" errors.
+const XAI_GROK_41_PREFIXES = ["grok-4-1", "grok-4-fast", "grok-code-fast"];
+const XAI_GROK_TEMPLATE_MODEL_IDS = ["grok-4"] as const;
+
 function cloneFirstTemplateModel(params: {
   normalizedProvider: string;
   trimmedModelId: string;
@@ -242,6 +247,53 @@ function resolveZaiGlm5ForwardCompatModel(
   } as Model<Api>);
 }
 
+// xAI's Grok 4.1 / Grok 4 Fast / Grok Code Fast models may not be present
+// in pi-ai's built-in catalog yet. Clone grok-4 as a forward-compat fallback.
+function resolveXaiGrokForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "xai") {
+    return undefined;
+  }
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+  const matchesPrefix = XAI_GROK_41_PREFIXES.some((prefix) => lower.startsWith(prefix));
+  if (!matchesPrefix) {
+    return undefined;
+  }
+
+  for (const templateId of XAI_GROK_TEMPLATE_MODEL_IDS) {
+    const template = modelRegistry.find("xai", templateId) as Model<Api> | null;
+    if (!template) {
+      continue;
+    }
+    const isReasoning = !lower.includes("non-reasoning");
+    return normalizeModelCompat({
+      ...template,
+      id: trimmed,
+      name: trimmed,
+      reasoning: isReasoning,
+      contextWindow: 2_000_000,
+    } as Model<Api>);
+  }
+
+  // Hard-coded fallback when no template is found at all.
+  const isReasoning = !lower.includes("non-reasoning");
+  return normalizeModelCompat({
+    id: trimmed,
+    name: trimmed,
+    api: "openai-completions",
+    provider: "xai",
+    reasoning: isReasoning,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 2_000_000,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
+}
+
 export function resolveForwardCompatModel(
   provider: string,
   modelId: string,
@@ -252,6 +304,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveXaiGrokForwardCompatModel(provider, modelId, modelRegistry)
   );
 }


### PR DESCRIPTION
## Problem

xAI has released several new Grok models that are not yet registered in pi-ai's built-in model catalog:
- `grok-4-1-fast-reasoning` / `grok-4-1-fast-non-reasoning` (2M context)
- `grok-4-fast-reasoning` / `grok-4-fast-non-reasoning` (2M context)  
- `grok-code-fast-1` (256K context, coding-optimized)

Using these models causes `Unknown model: xai/grok-4-1-fast-reasoning` errors.

## Solution

Follows the established forward-compat pattern (same as Anthropic 4.6, Gemini 3.1, ZAI GLM-5):

1. **`model-forward-compat.ts`**: Add `resolveXaiGrokForwardCompatModel()` that clones the existing `grok-4` template for any model matching `grok-4-1-*`, `grok-4-fast-*`, or `grok-code-fast-*` prefixes. Sets 2M context window and detects reasoning vs non-reasoning from model ID.

2. **`live-model-filter.ts`**: Add `grok-code-fast` to `XAI_PREFIXES` so the live filter recognizes all new xAI models (the existing `grok-4` prefix already covers `grok-4-1-*` and `grok-4-fast-*` via `startsWith`).

All existing forward-compat tests pass.

Closes #29311