### PR TITLE
fix: refresh config meta after successful update

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -381,12 +381,66 @@ describe("update-cli", () => {
       config: cfg,
       resolved: cfg,
     });
-    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    vi.mocked(runGatewayUpdate).mockResolvedValue(
+      makeOkUpdateResult({
+        after: { version: "2026.2.17" },
+      }),
+    );
 
     await updateCommand({});
 
     const lastWrite = vi.mocked(writeConfigFile).mock.calls.at(-1)?.[0] as OpenClawConfig;
     expect(lastWrite).toEqual(cfg);
+    const lastWriteOptions = vi.mocked(writeConfigFile).mock.calls.at(-1)?.[1] as {
+      metaVersionOverride?: string;
+    };
+    expect(lastWriteOptions?.metaVersionOverride).toBe("2026.2.17");
+  });
+
+  it("skips metadata refresh when config uses include directives", async () => {
+    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: { $include: "./shared.json5" },
+      config: cfg,
+      resolved: cfg,
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue(
+      makeOkUpdateResult({
+        after: { version: "2026.2.17" },
+      }),
+    );
+
+    await updateCommand({});
+
+    const metadataTouchCalls = vi
+      .mocked(writeConfigFile)
+      .mock.calls.filter(([, options]) =>
+        Boolean((options as { metaVersionOverride?: string })?.metaVersionOverride),
+      );
+    expect(metadataTouchCalls.length).toBe(0);
+  });
+
+  it("uses resolved target version when update result has no after.version", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.2.17",
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue(
+      makeOkUpdateResult({
+        mode: "npm",
+        after: {},
+      }),
+    );
+
+    await updateCommand({});
+
+    const lastWriteOptions = vi.mocked(writeConfigFile).mock.calls.at(-1)?.[1] as {
+      metaVersionOverride?: string;
+    };
+    expect(lastWriteOptions?.metaVersionOverride).toBe("2026.2.17");
   });
 
   it("updateCommand --dry-run previews without mutating", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -374,6 +374,21 @@ describe("update-cli", () => {
     expect(defaultRuntime.log).toHaveBeenCalled();
   });
 
+  it("refreshes config metadata after successful update", async () => {
+    const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      config: cfg,
+      resolved: cfg,
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+
+    await updateCommand({});
+
+    const lastWrite = vi.mocked(writeConfigFile).mock.calls.at(-1)?.[0] as OpenClawConfig;
+    expect(lastWrite).toEqual(cfg);
+  });
+
   it("updateCommand --dry-run previews without mutating", async () => {
     vi.mocked(defaultRuntime.log).mockClear();
     serviceLoaded.mockResolvedValue(true);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -10,6 +10,7 @@ import {
   resolveGatewayPort,
   writeConfigFile,
 } from "../../config/config.js";
+import { INCLUDE_KEY } from "../../config/includes.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import {
   channelToNpmTag,
@@ -501,7 +502,24 @@ async function updatePluginsAfterCoreUpdate(params: {
   }
 }
 
-async function touchConfigMetaAfterUpdate(params: { jsonMode: boolean }): Promise<void> {
+function hasIncludeDirectives(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasIncludeDirectives(entry));
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(record, INCLUDE_KEY)) {
+    return true;
+  }
+  return Object.values(record).some((entry) => hasIncludeDirectives(entry));
+}
+
+async function touchConfigMetaAfterUpdate(params: {
+  jsonMode: boolean;
+  updatedVersion?: string | null;
+}): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.exists) {
     return;
@@ -514,9 +532,21 @@ async function touchConfigMetaAfterUpdate(params: { jsonMode: boolean }): Promis
     }
     return;
   }
+  if (hasIncludeDirectives(snapshot.parsed)) {
+    if (!params.jsonMode) {
+      defaultRuntime.log(
+        theme.warn(
+          "Skipping config metadata refresh: config uses $include (run openclaw doctor to migrate/update config explicitly).",
+        ),
+      );
+    }
+    return;
+  }
 
   try {
-    await writeConfigFile(snapshot.config);
+    await writeConfigFile(snapshot.config, {
+      metaVersionOverride: params.updatedVersion ?? undefined,
+    });
   } catch (err) {
     if (!params.jsonMode) {
       defaultRuntime.log(theme.warn(`Failed to refresh config metadata: ${String(err)}`));
@@ -930,7 +960,10 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     restartScriptPath,
   });
 
-  await touchConfigMetaAfterUpdate({ jsonMode: Boolean(opts.json) });
+  await touchConfigMetaAfterUpdate({
+    jsonMode: Boolean(opts.json),
+    updatedVersion: result.after?.version ?? targetVersion ?? null,
+  });
 
   if (!opts.json) {
     defaultRuntime.log(theme.muted(pickUpdateQuip()));

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -501,6 +501,29 @@ async function updatePluginsAfterCoreUpdate(params: {
   }
 }
 
+async function touchConfigMetaAfterUpdate(params: { jsonMode: boolean }): Promise<void> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.exists) {
+    return;
+  }
+  if (!snapshot.valid) {
+    if (!params.jsonMode) {
+      defaultRuntime.log(
+        theme.warn("Skipping config metadata refresh: config is invalid (run openclaw doctor)."),
+      );
+    }
+    return;
+  }
+
+  try {
+    await writeConfigFile(snapshot.config);
+  } catch (err) {
+    if (!params.jsonMode) {
+      defaultRuntime.log(theme.warn(`Failed to refresh config metadata: ${String(err)}`));
+    }
+  }
+}
+
 async function maybeRestartService(params: {
   shouldRestart: boolean;
   result: UpdateRunResult;
@@ -906,6 +929,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     gatewayPort: resolveGatewayPort(configSnapshot.valid ? configSnapshot.config : undefined),
     restartScriptPath,
   });
+
+  await touchConfigMetaAfterUpdate({ jsonMode: Boolean(opts.json) });
 
   if (!opts.json) {
     defaultRuntime.log(theme.muted(pickUpdateQuip()));

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -131,6 +131,11 @@ export type ConfigWriteOptions = {
    * even if schema/default normalization reintroduces them.
    */
   unsetPaths?: string[][];
+  /**
+   * Optional version to stamp into meta.lastTouchedVersion.
+   * Defaults to the current runtime VERSION when omitted.
+   */
+  metaVersionOverride?: string;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -559,13 +564,14 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   }
 }
 
-function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
+function stampConfigVersion(cfg: OpenClawConfig, versionOverride?: string): OpenClawConfig {
   const now = new Date().toISOString();
+  const version = versionOverride?.trim() || VERSION;
   return {
     ...cfg,
     meta: {
       ...cfg.meta,
-      lastTouchedVersion: VERSION,
+      lastTouchedVersion: version,
       lastTouchedAt: now,
     },
   };
@@ -1128,7 +1134,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const stampedOutputConfig = stampConfigVersion(outputConfig);
+    const stampedOutputConfig = stampConfigVersion(outputConfig, options.metaVersionOverride);
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);
@@ -1396,5 +1402,6 @@ export async function writeConfigFile(
   await io.writeConfigFile(nextCfg, {
     envSnapshotForRestore: sameConfigPath ? options.envSnapshotForRestore : undefined,
     unsetPaths: options.unsetPaths,
+    metaVersionOverride: options.metaVersionOverride,
   });
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw update` can complete without rewriting `openclaw.json`, so `meta.lastTouchedVersion` / `meta.lastTouchedAt` may remain stale.
- Why it matters: stale version-touch metadata makes update state and diagnostics misleading after successful upgrades.
- What changed: after a successful update flow, `updateCommand` now performs a metadata-only config touch by re-writing the current valid config snapshot.
- What did NOT change (scope boundary): `wizard.lastRun*` behavior is unchanged; doctor still only updates wizard metadata when doctor actually writes config.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<fill-if-any>
- Related #<fill-if-any>

## User-visible / Behavior Changes

- After `openclaw update` succeeds, config metadata is refreshed even when no other config migrations/repairs are applied:
  - `meta.lastTouchedVersion`
  - `meta.lastTouchedAt`
- `wizard.lastRun*` is still not force-written by update.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Raspberry Pi)
- Runtime/container: Node.js CLI install
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): standard `~/.openclaw/openclaw.json`

### Steps

1. Ensure `openclaw.json` is valid and has no pending doctor repairs.
2. Run `openclaw update`.
3. Inspect `openclaw.json` and compare `meta.lastTouchedVersion` / `meta.lastTouchedAt` before/after.

### Expected

- Metadata reflects the updated/touched version/time immediately after successful update.

### Actual

- With this patch: metadata is refreshed after successful update.
- `wizard.lastRun*` remains unchanged unless doctor writes config (existing behavior).

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Snippet to attach:
- `jq '.meta, .wizard' ~/.openclaw/openclaw.json`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Code-path verification for successful update path and post-update metadata touch call.
  - Added unit coverage in `src/cli/update-cli.test.ts` for metadata refresh after success.
- Edge cases checked:
  - Skip when config file does not exist.
  - Skip (with warning) when config snapshot is invalid.
  - Write failure handled as warning in non-JSON mode.
- What you did **not** verify:
  - Full end-to-end runtime execution in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `~/.openclaw/openclaw.json.bak` (auto backup on write).
- Known bad symptoms reviewers should watch for:
  - Unexpected config write churn after update.

## Risks and Mitigations

- Risk: update now performs an additional config write, which updates file mtime and creates backup rotation entries.
  - Mitigation: only runs when config exists and is valid; invalid config path is skipped with explicit warning.
