### PR TITLE
agent: preemptive context overflow detection during tool loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ Docs: https://docs.openclaw.ai
 - Agents/usage tracking: stop forcing `supportsUsageInStreaming: false` on non-native OpenAI-completions providers so compatible backends report token usage and cost again instead of showing all zeros. (#46500) Fixes #46142. Thanks @ademczuk.
 - Plugins/subagents: preserve gateway-owned plugin subagent access across runtime, tool, and embedded-runner load paths so gateway plugin tools and context engines can still spawn and manage subagents after the loader cache split. (#46648) Thanks @jalehman.
 - Control UI/overview: keep the language dropdown aligned with the persisted locale during dashboard startup so refreshing the page does not fall back to English before locale hydration completes. (#48019) Thanks @git-jxj.
+- Agents/compaction: rerun transcript repair after `session.compact()` so orphaned `tool_result` blocks cannot survive compaction and break later Anthropic requests. (#16095) thanks @claw-sylphx.
+- Agents/compaction: trigger overflow recovery from the tool-result guard once post-compaction context still exceeds the safe threshold, so long tool loops compact before the next model call hard-fails. (#29371) thanks @keshav55.
 
 ## 2026.3.13
 

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,3 +1,4 @@
+import type { Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramThreadParams,
@@ -404,8 +405,59 @@ describe("hasBotMention", () => {
       ),
     ).toBe(true);
   });
-});
 
+  it("matches mention followed by punctuation", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "@gaian, what's up?",
+          chat: { id: 1, type: "supergroup" },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        "gaian",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches mention followed by space", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "@gaian how are you",
+          chat: { id: 1, type: "supergroup" },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        "gaian",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match substring of a longer username", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "@gaianchat_bot hello",
+          chat: { id: 1, type: "supergroup" },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        "gaian",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match when mention is a prefix of another word", () => {
+    expect(
+      hasBotMention(
+        {
+          text: "@gaianbot do something",
+          chat: { id: 1, type: "supergroup" },
+          // oxlint-disable-next-line typescript/no-explicit-any
+        } as any,
+        "gaian",
+      ),
+    ).toBe(false);
+  });
+});
 describe("expandTextLinks", () => {
   it("returns text unchanged when no entities are provided", () => {
     expect(expandTextLinks("Hello world")).toBe("Hello world");

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
+  PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
   PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER,
   installToolResultContextGuard,
 } from "./tool-result-context-guard.js";
@@ -267,5 +268,64 @@ describe("installToolResultContextGuard", () => {
     expect(newResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(oldResult.details).toBeUndefined();
     expect(newResult.details).toBeUndefined();
+  });
+
+  it("throws preemptive context overflow when context exceeds 90% after tool-result compaction", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      // contextBudgetChars = 1000 * 4 * 0.75 = 3000
+      // preemptiveOverflowChars = 1000 * 4 * 0.9 = 3600
+      contextWindowTokens: 1_000,
+    });
+
+    // Large user message (non-compactable) pushes context past 90% threshold.
+    const contextForNextCall = [makeUser("u".repeat(3_700)), makeToolResult("call_1", "small")];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+  });
+
+  it("does not throw when context is under 90% after tool-result compaction", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    // Context well under the 3600-char preemptive threshold.
+    const contextForNextCall = [makeUser("u".repeat(1_000)), makeToolResult("call_1", "small")];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).resolves.not.toThrow();
+  });
+
+  it("compacts tool results before checking the preemptive overflow threshold", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    // Large user message + large tool result. The guard should compact the tool
+    // result first, then check the overflow threshold. Even after compaction the
+    // user content alone pushes past 90%, so the overflow error fires.
+    const contextForNextCall = [
+      makeUser("u".repeat(3_700)),
+      makeToolResult("call_old", "x".repeat(2_000)),
+    ];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+
+    // Tool result should have been compacted before the overflow check.
+    const toolResultText = getToolResultText(contextForNextCall[1]);
+    expect(toolResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
   });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -14,12 +14,18 @@ import {
 // Keep a conservative input budget to absorb tokenizer variance and provider framing overhead.
 const CONTEXT_INPUT_HEADROOM_RATIO = 0.75;
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
+// High-water mark: if context exceeds this ratio after tool-result compaction,
+// trigger full session compaction via the existing overflow recovery cascade.
+const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
 
 export const CONTEXT_LIMIT_TRUNCATION_NOTICE = "[truncated: output exceeded context limit]";
 const CONTEXT_LIMIT_TRUNCATION_SUFFIX = `\n${CONTEXT_LIMIT_TRUNCATION_NOTICE}`;
 
 export const PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER =
   "[compacted: tool output removed to free context]";
+
+export const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
+  "Preemptive context overflow: estimated context size exceeds safe threshold during tool loop";
 
 type GuardableTransformContext = (
   messages: AgentMessage[],
@@ -196,6 +202,10 @@ export function installToolResultContextGuard(params: {
       contextWindowTokens * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE * SINGLE_TOOL_RESULT_CONTEXT_SHARE,
     ),
   );
+  const preemptiveOverflowChars = Math.max(
+    contextBudgetChars,
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+  );
 
   // Agent.transformContext is private in pi-coding-agent, so access it via a
   // narrow runtime view to keep callsites type-safe while preserving behavior.
@@ -213,6 +223,15 @@ export function installToolResultContextGuard(params: {
       contextBudgetChars,
       maxSingleToolResultChars,
     });
+
+    // After tool-result compaction, check if context still exceeds the high-water mark.
+    // If it does, non-tool-result content dominates and only full LLM-based session
+    // compaction can reduce context size. Throwing a context overflow error triggers
+    // the existing overflow recovery cascade in run.ts.
+    const postEnforcementChars = estimateContextChars(contextMessages);
+    if (postEnforcementChars > preemptiveOverflowChars) {
+      throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+    }
 
     return contextMessages;
   }) as GuardableTransformContext;

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -228,7 +228,10 @@ export function installToolResultContextGuard(params: {
     // If it does, non-tool-result content dominates and only full LLM-based session
     // compaction can reduce context size. Throwing a context overflow error triggers
     // the existing overflow recovery cascade in run.ts.
-    const postEnforcementChars = estimateContextChars(contextMessages);
+    const postEnforcementChars = estimateContextChars(
+      contextMessages,
+      createMessageCharEstimateCache(),
+    );
     if (postEnforcementChars > preemptiveOverflowChars) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
     }


### PR DESCRIPTION
## Summary

Fixes #24800 — auto-compaction is not triggered during tool-use loops.

During long tool loops (LLM call → tool exec → tool result → repeat), context grows continuously but compaction only triggers on `agent_end` events or the next user `prompt()`. If context fills the window mid-loop, the API rejects the request — wasting the call and surfacing an error to the user.

This PR adds a preemptive overflow check to the `transformContext` hook in `tool-result-context-guard.ts`, which already runs before every LLM call (even mid-tool-loop). After the existing tool-result compaction (targets 75% of the context window), we re-estimate context size. If it still exceeds 90% of the window, we throw a context overflow error that triggers the existing overflow recovery cascade in `run.ts`.

### How it works (zero changes to `run.ts` or `attempt.ts`)

1. `transformContext` compacts tool results as before (75% budget)
2. **New:** Post-enforcement check — if context still exceeds 90%, throws `Error` with message `"Preemptive context overflow: ..."`
3. Error propagates through `prompt()` → caught as `promptError` in `attempt.ts`
4. `run.ts` detects it via `isLikelyContextOverflowError()` (matches `"context overflow:"` at `errors.ts:79`)
5. `isCompactionFailureError()` returns false (message avoids the word "compaction")
6. Takes the explicit compaction branch → `compactEmbeddedPiSessionDirect()` runs full LLM-based session compaction
7. On success, retries the prompt with compacted context
8. `MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3` prevents infinite loops

### Why 90%

- The guard already aggressively compacts tool results at 75%
- If context is still at 90%+ after that, non-tool-result content (assistant messages, thinking blocks) dominates — only full LLM compaction can reduce those
- Better to compact proactively at 90% than waste a failing API call at ~100%

### Changes

- `src/agents/pi-embedded-runner/tool-result-context-guard.ts` — add `PREEMPTIVE_OVERFLOW_RATIO` (0.9), `PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE`, and post-enforcement overflow check (+19 lines)
- `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` — 3 new tests: throws at 90%+, doesn't throw under 90%, verifies tool results are compacted before overflow check (+60 lines)

## Test plan

- [x] `pnpm test src/agents/pi-embedded-runner/tool-result-context-guard.test.ts` — 11/11 pass (8 existing + 3 new)
- [x] `pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts` — 11/11 pass (unchanged)
- [x] `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` — 41/41 pass (error classifier tests)
- [x] `pnpm check` — format, typecheck, lint all clean
- [x] Hand-verified all 8 existing tests stay under 90% threshold after enforcement (no false triggers)
- [x] Verified error message matches `isLikelyContextOverflowError` but NOT `isCompactionFailureError`