### PR TITLE
refactor(android): share node capability and command manifest

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ConnectionManager.kt
@@ -7,7 +7,6 @@ import ai.openclaw.android.gateway.GatewayClientInfo
 import ai.openclaw.android.gateway.GatewayConnectOptions
 import ai.openclaw.android.gateway.GatewayEndpoint
 import ai.openclaw.android.gateway.GatewayTlsParams
-import ai.openclaw.android.protocol.OpenClawCapability
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.VoiceWakeMode
 
@@ -73,28 +72,18 @@ class ConnectionManager(
     }
   }
 
-  fun buildInvokeCommands(): List<String> =
-    InvokeCommandRegistry.advertisedCommands(
+  private fun runtimeFlags(): NodeRuntimeFlags =
+    NodeRuntimeFlags(
       cameraEnabled = cameraEnabled(),
       locationEnabled = locationMode() != LocationMode.Off,
       smsAvailable = smsAvailable(),
+      voiceWakeEnabled = voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission(),
       debugBuild = BuildConfig.DEBUG,
     )
 
-  fun buildCapabilities(): List<String> =
-    buildList {
-      add(OpenClawCapability.Canvas.rawValue)
-      add(OpenClawCapability.Screen.rawValue)
-      add(OpenClawCapability.Device.rawValue)
-      if (cameraEnabled()) add(OpenClawCapability.Camera.rawValue)
-      if (smsAvailable()) add(OpenClawCapability.Sms.rawValue)
-      if (voiceWakeMode() != VoiceWakeMode.Off && hasRecordAudioPermission()) {
-        add(OpenClawCapability.VoiceWake.rawValue)
-      }
-      if (locationMode() != LocationMode.Off) {
-        add(OpenClawCapability.Location.rawValue)
-      }
-    }
+  fun buildInvokeCommands(): List<String> = InvokeCommandRegistry.advertisedCommands(runtimeFlags())
+
+  fun buildCapabilities(): List<String> = InvokeCommandRegistry.advertisedCapabilities(runtimeFlags())
 
   fun resolvedVersionName(): String {
     val versionName = BuildConfig.VERSION_NAME.trim().ifEmpty { "dev" }

--- a/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/node/InvokeCommandRegistryTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.node
 
 import ai.openclaw.android.protocol.OpenClawCameraCommand
+import ai.openclaw.android.protocol.OpenClawCapability
 import ai.openclaw.android.protocol.OpenClawDeviceCommand
 import ai.openclaw.android.protocol.OpenClawLocationCommand
 import ai.openclaw.android.protocol.OpenClawNotificationsCommand
@@ -11,13 +12,60 @@ import org.junit.Test
 
 class InvokeCommandRegistryTest {
   @Test
+  fun advertisedCapabilities_respectsFeatureAvailability() {
+    val capabilities =
+      InvokeCommandRegistry.advertisedCapabilities(
+        NodeRuntimeFlags(
+          cameraEnabled = false,
+          locationEnabled = false,
+          smsAvailable = false,
+          voiceWakeEnabled = false,
+          debugBuild = false,
+        ),
+      )
+
+    assertTrue(capabilities.contains(OpenClawCapability.Canvas.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Screen.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Device.rawValue))
+    assertFalse(capabilities.contains(OpenClawCapability.Camera.rawValue))
+    assertFalse(capabilities.contains(OpenClawCapability.Location.rawValue))
+    assertFalse(capabilities.contains(OpenClawCapability.Sms.rawValue))
+    assertFalse(capabilities.contains(OpenClawCapability.VoiceWake.rawValue))
+  }
+
+  @Test
+  fun advertisedCapabilities_includesFeatureCapabilitiesWhenEnabled() {
+    val capabilities =
+      InvokeCommandRegistry.advertisedCapabilities(
+        NodeRuntimeFlags(
+          cameraEnabled = true,
+          locationEnabled = true,
+          smsAvailable = true,
+          voiceWakeEnabled = true,
+          debugBuild = false,
+        ),
+      )
+
+    assertTrue(capabilities.contains(OpenClawCapability.Canvas.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Screen.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Device.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Camera.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Location.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.Sms.rawValue))
+    assertTrue(capabilities.contains(OpenClawCapability.VoiceWake.rawValue))
+  }
+
+  @Test
   fun advertisedCommands_respectsFeatureAvailability() {
     val commands =
       InvokeCommandRegistry.advertisedCommands(
-        cameraEnabled = false,
-        locationEnabled = false,
-        smsAvailable = false,
-        debugBuild = false,
+        NodeRuntimeFlags(
+          cameraEnabled = false,
+          locationEnabled = false,
+          smsAvailable = false,
+          voiceWakeEnabled = false,
+          debugBuild = false,
+        ),
       )
 
     assertFalse(commands.contains(OpenClawCameraCommand.Snap.rawValue))
@@ -40,10 +88,13 @@ class InvokeCommandRegistryTest {
   fun advertisedCommands_includesFeatureCommandsWhenEnabled() {
     val commands =
       InvokeCommandRegistry.advertisedCommands(
-        cameraEnabled = true,
-        locationEnabled = true,
-        smsAvailable = true,
-        debugBuild = true,
+        NodeRuntimeFlags(
+          cameraEnabled = true,
+          locationEnabled = true,
+          smsAvailable = true,
+          voiceWakeEnabled = false,
+          debugBuild = true,
+        ),
       )
 
     assertTrue(commands.contains(OpenClawCameraCommand.Snap.rawValue))


### PR DESCRIPTION
## Summary
- distill Android node advertise surface into one shared manifest
- move capability + command filtering behind shared runtime flags
- keep behavior unchanged, reduce drift risk

## Testing
- ./gradlew :app:testDebugUnitTest --tests ai.openclaw.android.node.InvokeCommandRegistryTest
- ./gradlew :app:testDebugUnitTest --tests ai.openclaw.android.node.ConnectionManagerTest --tests ai.openclaw.android.node.InvokeCommandRegistryTest
