### PR TITLE
fix: add requireAgentId to block sessions_spawn without explicit agen…

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1463,6 +1463,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
+- `subagents.requireAgentId`: when true, block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection; default: false).
 
 ---
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -127,6 +127,7 @@ Allowlist:
 
 - `agents.list[].subagents.allowAgents`: list of agent ids that can be targeted via `agentId` (`["*"]` to allow any). Default: only the requester agent.
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
+- `agents.defaults.subagents.requireAgentId` / `agents.list[].subagents.requireAgentId`: when true, block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection). Default: false.
 
 Discovery:
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -232,6 +232,92 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
   // agentId format validation (#31311)
   // ---------------------------------------------------------------------------
 
+  it("sessions_spawn forbids omit agentId when requireAgentId is configured", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: { requireAgentId: true },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call13", { task: "do thing" });
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+      error: expect.stringContaining("sessions_spawn requires explicit agentId"),
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("sessions_spawn allows omit agentId when requireAgentId is false", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        defaults: {
+          subagents: { requireAgentId: false },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+
+    const getChildSessionKey = mockAcceptedSpawn(5300);
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call14", { task: "do thing" });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:main:subagent:")).toBe(true);
+  });
+
+  it("sessions_spawn allows explicit agentId when requireAgentId is configured", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              allowAgents: ["worker"],
+              requireAgentId: true,
+            },
+          },
+        ],
+      },
+    });
+
+    mockAcceptedSpawn(5400);
+
+    const result = await executeSpawn("call15", "worker");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(callGatewayMock).toHaveBeenCalled();
+  });
+
   it("rejects error-message-like strings as agentId (#31311)", async () => {
     setSessionsSpawnConfigOverride({
       session: { mainKey: "main", scope: "per-sender" },

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -432,6 +432,17 @@ export async function spawnSubagentDirect(
   const requesterAgentId = normalizeAgentId(
     ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
   );
+  const requireAgentId =
+    resolveAgentConfig(cfg, requesterAgentId)?.subagents?.requireAgentId ??
+    cfg.agents?.defaults?.subagents?.requireAgentId ??
+    false;
+  if (requireAgentId && !requestedAgentId?.trim()) {
+    return {
+      status: "forbidden",
+      error:
+        "sessions_spawn requires explicit agentId when requireAgentId is configured. Use agents_list to see allowed agent ids.",
+    };
+  }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
     const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2823,6 +2823,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
                   },
+                  requireAgentId: {
+                    type: "boolean",
+                  },
                 },
                 additionalProperties: false,
               },
@@ -3978,6 +3981,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                     },
                     thinking: {
                       type: "string",
+                    },
+                    requireAgentId: {
+                      type: "boolean",
                     },
                   },
                   additionalProperties: false,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -292,6 +292,8 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
     announceTimeoutMs?: number;
+    /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
+    requireAgentId?: boolean;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -85,6 +85,8 @@ export type AgentConfig = {
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
+    /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
+    requireAgentId?: boolean;
   };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -203,6 +203,7 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        requireAgentId: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -796,6 +796,7 @@ export const AgentEntrySchema = z
           ])
           .optional(),
         thinking: z.string().optional(),
+        requireAgentId: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem:** In multi-layer subagent setups (e.g., separate work vs research agents with different tools and workspaces), `sessions_spawn` without `agentId` falls back to the caller’s agent, bypassing `allowAgents` and isolation.
- **Why it matters:** This can spawn default subagents that ignore intended isolation and tool boundaries.
- **What changed:** Added `requireAgentId: true` (in `agents.defaults.subagents` and `agents.list[].subagents`) so `sessions_spawn` calls without an explicit `agentId` are rejected.
- **What did NOT change:** Existing behavior when `requireAgentId` is unset (default `false`). `/subagents spawn` still requires `agentId`. ACP runtime is unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29368
- Related #

## User-visible / Behavior Changes

- New config: `agents.defaults.subagents.requireAgentId` and `agents.list[].subagents.requireAgentId` (default: `false`).
- When `requireAgentId: true`, `sessions_spawn` without `agentId` returns `forbidden` with: `sessions_spawn requires explicit agentId when requireAgentId is configured. Use agents_list to see allowed agent ids.`
- No change when `requireAgentId` is omitted or `false`.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (only adds a stricter check when configured)
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):

{
  agents: {
    defaults: { subagents: { requireAgentId: true } },
    list: [{ id: "main" }]
  }
}
