### PR TITLE
fix(feishu): add reactionNotifications mode gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
+- Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)
 - Feishu/Group session routing: add configurable group session scopes (`group`, `group_sender`, `group_topic`, `group_topic_sender`) with legacy `topicSessionMode=enabled` compatibility so Feishu group conversations can isolate sessions by sender/topic as configured. (#17798)
 - Feishu/Reply-in-thread routing: add `replyInThread` config (`disabled|enabled`) for group replies, propagate `reply_in_thread` across text/card/media/streaming sends, and align topic-scoped session routing so newly created reply threads stay on the same session root. (#27325)
 - Feishu/Typing backoff: re-throw Feishu typing add/remove rate-limit and quota errors (`429`, `99991400`, `99991403`) and detect SDK non-throwing backoff responses so the typing keepalive circuit breaker can stop retries instead of looping indefinitely. (#28494)

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -110,6 +110,7 @@ const GroupSessionScopeSchema = z
  * - "enabled": Messages in different topics get separate sessions
  */
 const TopicSessionModeSchema = z.enum(["disabled", "enabled"]).optional();
+const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
 
 /**
  * Reply-in-thread mode for group chats.
@@ -159,6 +160,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  reactionNotifications: ReactionNotificationModeSchema,
 };
 
 /**
@@ -195,6 +197,7 @@ export const FeishuConfigSchema = z
     webhookPath: z.string().optional().default("/feishu/events"),
     ...FeishuSharedConfigShape,
     dmPolicy: DmPolicySchema.optional().default("pairing"),
+    reactionNotifications: ReactionNotificationModeSchema.optional().default("own"),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     requireMention: z.boolean().optional().default(true),
     groupSessionScope: GroupSessionScopeSchema,

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -49,6 +49,31 @@ describe("resolveReactionSyntheticEvent", () => {
     expect(result).toBeNull();
   });
 
+  it("drops reactions when reactionNotifications is off", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg: {
+        channels: {
+          feishu: {
+            reactionNotifications: "off",
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group",
+        senderOpenId: "ou_bot",
+        senderType: "app",
+        content: "hello",
+        contentType: "text",
+      }),
+    });
+    expect(result).toBeNull();
+  });
+
   it("filters reactions on non-bot messages", async () => {
     const event = makeReactionEvent();
     const result = await resolveReactionSyntheticEvent({
@@ -66,6 +91,32 @@ describe("resolveReactionSyntheticEvent", () => {
       }),
     });
     expect(result).toBeNull();
+  });
+
+  it("allows non-bot reactions when reactionNotifications is all", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg: {
+        channels: {
+          feishu: {
+            reactionNotifications: "all",
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group",
+        senderOpenId: "ou_other",
+        senderType: "user",
+        content: "hello",
+        contentType: "text",
+      }),
+      uuid: () => "fixed-uuid",
+    });
+    expect(result?.message.message_id).toBe("om_msg1:reaction:THUMBSUP:fixed-uuid");
   });
 
   it("drops unverified reactions when sender verification times out", async () => {


### PR DESCRIPTION
## Summary
- add `channels.feishu.reactionNotifications` config (`off | own | all`) with default `own`
- gate reaction synthetic-event dispatch in `monitor.ts` by that mode
- add focused reaction-mode regression tests
- update changelog

## Why
- preserves current secure default behavior (`own`)
- allows operators to disable reaction ingress (`off`) or opt into all verified reactions (`all`)
- replaces the stale/superseded overlap from #28529 with a minimal forward-only patch

## Verification
- `pnpm test extensions/feishu/src/monitor.reaction.test.ts`
