### PR TITLE
test(cron): fix Windows CI flake in abort signal test

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1060,12 +1060,19 @@ describe("Cron issue regressions", () => {
   it("respects abort signals while retrying main-session wake-now heartbeat runs", async () => {
     vi.useRealTimers();
     const abortController = new AbortController();
-    const runHeartbeatOnce = vi.fn(
-      async (): Promise<HeartbeatRunResult> => ({
+    let callCount = 0;
+    const runHeartbeatOnce = vi.fn(async (): Promise<HeartbeatRunResult> => {
+      callCount++;
+      // Deterministic abort: trigger on 3rd call instead of relying on
+      // setTimeout precision (Windows timer granularity ~15.6ms caused flakes).
+      if (callCount >= 3) {
+        abortController.abort();
+      }
+      return {
         status: "skipped",
         reason: "requests-in-flight",
-      }),
-    );
+      };
+    });
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeatNow = vi.fn();
     const mainJob: CronJob = {
@@ -1088,14 +1095,10 @@ describe("Cron issue regressions", () => {
       enqueueSystemEvent,
       requestHeartbeatNow,
       runHeartbeatOnce,
-      wakeNowHeartbeatBusyMaxWaitMs: 30,
+      wakeNowHeartbeatBusyMaxWaitMs: 10_000,
       wakeNowHeartbeatBusyRetryDelayMs: 5,
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
-
-    setTimeout(() => {
-      abortController.abort();
-    }, 10);
 
     const result = await executeJobCore(state, mainJob, abortController.signal);
 


### PR DESCRIPTION
## Problem / 问题

The test `respects abort signals while retrying main-session wake-now heartbeat runs` in `service.issue-regressions.test.ts` is flaky on Windows CI.

**Root cause**: The test uses `setTimeout(() => abortController.abort(), 10)` with `maxWaitMs=30` and `retryDelayMs=5`. Windows timer granularity (~15.6ms) means the retry loop can exhaust `maxWaitMs` before the abort timer fires, causing it to take the fallback path and return `"ok"` instead of the expected `"error"`.

**根因**：测试用 `setTimeout(abort, 10)` 配合 `maxWaitMs=30`。Windows 定时器粗粒度（~15.6ms）导致 retry 循环可能在 abort 触发前就因 `maxWaitMs` 超时走了 fallback 路径，返回 `"ok"` 而非 `"error"`。

## Fix / 修复

Replace the timing-dependent `setTimeout` with a deterministic approach:

1. Trigger `abortController.abort()` inside the `runHeartbeatOnce` mock on the 3rd invocation
2. Increase `maxWaitMs` to `10_000` to prevent accidental timeout fallback

This ensures the abort is triggered at a deterministic point in the retry loop, eliminating any dependency on real timer precision.

**修复方案**：在 `runHeartbeatOnce` mock 的第 3 次调用中直接触发 `abortController.abort()`，并将 `maxWaitMs` 增大到 `10_000`，消除对真实定时器精度的依赖。

## Changes / 改动

- Only test code modified, no production logic changes
- 仅修改测试代码，未改动生产逻辑