### PR TITLE
fix(gateway): avoid crash-loop when controlUi origins are unset

### DIFF
--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -201,18 +201,20 @@ describe("resolveGatewayRuntimeConfig", () => {
       );
     });
 
-    it("rejects non-loopback control UI when allowed origins are missing", async () => {
-      await expect(
-        resolveGatewayRuntimeConfig({
-          cfg: {
-            gateway: {
-              bind: "lan",
-              auth: TOKEN_AUTH,
-            },
+    it("keeps running and warns when non-loopback control UI lacks origin policy", async () => {
+      const result = await resolveGatewayRuntimeConfig({
+        cfg: {
+          gateway: {
+            bind: "lan",
+            auth: TOKEN_AUTH,
           },
-          port: 18789,
-        }),
-      ).rejects.toThrow("non-loopback Control UI requires gateway.controlUi.allowedOrigins");
+        },
+        port: 18789,
+      });
+      expect(result.bindHost).toBe("0.0.0.0");
+      expect(result.controlUiOriginPolicyWarning).toContain(
+        "gateway.controlUi.allowedOrigins is empty",
+      );
     });
 
     it("allows non-loopback control UI without allowed origins when dangerous fallback is enabled", async () => {
@@ -229,6 +231,7 @@ describe("resolveGatewayRuntimeConfig", () => {
         port: 18789,
       });
       expect(result.bindHost).toBe("0.0.0.0");
+      expect(result.controlUiOriginPolicyWarning).toBeUndefined();
     });
   });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -414,6 +414,7 @@ export async function startGatewayServer(
   const {
     bindHost,
     controlUiEnabled,
+    controlUiOriginPolicyWarning,
     openAiChatCompletionsEnabled,
     openResponsesEnabled,
     openResponsesConfig,
@@ -426,6 +427,9 @@ export async function startGatewayServer(
   } = runtimeConfig;
   let hooksConfig = runtimeConfig.hooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
+  if (controlUiOriginPolicyWarning) {
+    log.warn(`gateway: ${controlUiOriginPolicyWarning}`);
+  }
 
   // Create auth rate limiters used by connect/auth flows.
   const rateLimitConfig = cfgAtStart.gateway?.auth?.rateLimit;


### PR DESCRIPTION
## Summary
- Avoid hard-failing gateway startup when `gateway.bind` resolves to a non-loopback host and `gateway.controlUi.allowedOrigins` is unset.
- Keep the gateway process running and emit a clear compatibility warning with remediation steps instead of crashing into a restart loop.
- Add/adjust runtime-config tests to cover the new non-crashing behavior and preserve existing dangerous-fallback behavior.

Closes #29385.

## Test plan
- [x] `pnpm test -- --run src/gateway/server-runtime-config.test.ts`
- [x] `pnpm test -- --run src/gateway/server.config-patch.test.ts`
- [ ] Manual: upgrade an existing `bind=lan` install without `gateway.controlUi.allowedOrigins` and confirm gateway starts without crash-loop.