### PR TITLE
fix(memory): MMR tokenize() returns empty set for CJK text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1925,6 +1925,7 @@ Docs: https://docs.openclaw.ai
 - FS/Sandbox workspace boundaries: add a dedicated `outside-workspace` safe-open error code for root-escape checks, and propagate specific outside-workspace messages across edit/browser/media consumers instead of generic not-found/invalid-path fallbacks. (#29715) Thanks @YuzuruS.
 - Diagnostics/Stuck session signal: add configurable stuck-session warning threshold via `diagnostics.stuckSessionWarnMs` (default 120000ms) to reduce false-positive warnings on long multi-tool turns. (#31032)
 - Agents/error classification: check billing errors before context overflow heuristics in the agent runner catch block so spend-limit and quota errors show the billing-specific message instead of being misclassified as "Context overflow: prompt too large". (#40409) Thanks @ademczuk.
+- Memory/MMR CJK tokenization: add Han, kana, and hangul tokens plus adjacent bigrams so memory-search reranking can detect overlap for CJK text instead of treating unrelated snippets as identical. (#29396) Thanks @buyitsydney.
 
 ## 2026.2.26
 


### PR DESCRIPTION
## Problem

`tokenize()` in `src/memory/mmr.ts` only matches `[a-z0-9_]+`, returning an **empty set for any CJK-only text**. This makes Jaccard similarity always 0 between CJK content, effectively **disabling MMR diversity detection** for Chinese, Japanese, and Korean users.

When MMR cannot detect content overlap, search results contain near-duplicate snippets instead of diverse results.

## Fix

Extract individual CJK characters (U+4E00–U+9FFF, U+3400–U+4DBF) **and** character bigrams, merged with the existing ASCII tokens. This gives MMR meaningful tokens to compute similarity on CJK content.

**Before:** `tokenize("你好世界")` → `Set(0) {}` (empty)
**After:** `tokenize("你好世界")` → `Set(7) {"你","好","世","界","你好","好世","世界"}`

## Tests

Added 3 test cases:
- Pure CJK tokenization (characters + bigrams)
- Mixed CJK + ASCII
- Real-world Traditional Chinese text (from #20730 user report)

All 28 tests pass.

## Context

This is part of a cluster of CJK search issues:
- **#20730** — FTS5 BM25 does not work for CJK text (tokenization)
- **#14005** — BM25 score collapses to constant 1.0 (scoring)
- **#5767** — bm25RankToScore always returns same value (report)

This PR addresses the MMR layer; the others address the BM25 layer. Together they would significantly improve memory search quality for CJK users.

/cc @Takhoffman @steipete — would appreciate a review when you have a moment. Small change (2 files, +35/−4), all tests green.