### PR TITLE
fix(msteams): preserve multi-block top-level replies in personal chats

### DIFF
--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -470,6 +470,13 @@ export async function sendMSTeamsMessages(params: {
     return await sendMessagesInContext(ctx);
   }
 
+  const conversationType = params.conversationRef.conversation?.conversationType?.toLowerCase();
+  const canUseCurrentTurnContextForTopLevel =
+    conversationType === "personal" && params.context !== undefined;
+  if (canUseCurrentTurnContextForTopLevel) {
+    return await sendMessagesInContext(params.context);
+  }
+
   const baseRef = buildConversationReference(params.conversationRef);
   const proactiveRef: MSTeamsConversationReference = {
     ...baseRef,


### PR DESCRIPTION
## Summary

- **Problem:** In MS Teams personal chats, multi-block agent replies could drop later text blocks when each block was sent via separate proactive `continueConversation` calls.
- **Why it matters:** Users may only see the first filler block and miss the actual final answer.
- **What changed:** For `replyStyle=top-level` + `conversationType=personal`, message sending now reuses the current `TurnContext`; non-personal top-level paths still use proactive `continueConversation`. Added focused tests for both paths.
- **What did NOT change:** Thread reply flow and non-personal top-level proactive behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29379

## User-visible / Behavior Changes

- In Teams personal chats, multi-block replies now deliver subsequent blocks reliably in top-level mode.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm monorepo tests
- Integration/channel: MS Teams (`@openclaw/msteams`)

### Steps

1. Send a Teams DM message that causes block + final reply output.
2. Ensure the dispatcher emits multiple outbound deliveries.

### Expected

- All text blocks in the turn are delivered.

### Actual

- Before fix: later blocks may be dropped in personal top-level flow.
- After fix: personal top-level flow reuses current turn context and delivers subsequent blocks.

## Evidence

- Added tests in `extensions/msteams/src/messenger.test.ts`:
  - Personal top-level path uses current context and avoids `continueConversation`.
  - Non-personal top-level path still uses `continueConversation`.
- Test run:
  - `pnpm test -- --run extensions/msteams/src/messenger.test.ts`

## Human Verification (required)

- Verified scenarios: personal top-level send path, non-personal top-level send path.
- Edge cases checked: repeated sends in same personal conversation context.
- What I did **not** verify: live Microsoft Graph/Bot Framework end-to-end in a real tenant.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit/PR.
- Files/config to restore: `extensions/msteams/src/messenger.ts` and related tests.
- Known bad symptoms: personal top-level replies may again drop later blocks.

## Risks and Mitigations

- Risk: changing send path for top-level may affect behavior outside DMs.
- Mitigation: scope limited to `conversationType=personal`, with explicit test coverage preserving non-personal proactive path.