### PR TITLE
fix(agents): restrict subagent bootstrap to AGENTS.md + TOOLS.md only

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -10,11 +10,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -7,11 +7,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {
-    "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87",
+    "@tloncorp/api": "https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87",
     "@tloncorp/tlon-skill": "0.1.9",
     "@urbit/aura": "^3.0.0",
     "@urbit/http-api": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
   extensions/tlon:
     dependencies:
       '@tloncorp/api':
-        specifier: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
-        version: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
+        specifier: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
+        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
       '@tloncorp/tlon-skill':
         specifier: 0.1.9
         version: 0.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2937,8 +2937,8 @@ packages:
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
-    resolution: {commit: 7eede1c1a756977b09f96aa14a92e2b06318ae87, repo: https://github.com/tloncorp/api-beta.git, type: git}
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
+    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87}
     version: 0.0.2
 
   '@tloncorp/tlon-skill-darwin-arm64@0.1.9':
@@ -8907,7 +8907,7 @@ snapshots:
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
     dependencies:
       '@aws-sdk/client-s3': 3.1000.0
       '@aws-sdk/s3-request-presigner': 3.1000.0

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -272,7 +272,7 @@ describe("filterBootstrapFilesForSession", () => {
   });
 });
 
-describe("filterBootstrapFilesForSession — e2e integration", () => {
+describe("filterBootstrapFilesForSession — integration", () => {
   it("subagent session with real workspace files only receives AGENTS.md and TOOLS.md", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-subagent-filter-");
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -247,11 +247,98 @@ describe("filterBootstrapFilesForSession", () => {
 
   it("filters to allowlist for subagent sessions", () => {
     const result = filterBootstrapFilesForSession(mockFiles, "agent:default:subagent:task-1");
-    expectSubagentAllowedBootstrapNames(result);
+    const names = result.map((f) => f.name);
+    expect(names).toContain("AGENTS.md");
+    expect(names).toContain("TOOLS.md");
+    expect(names).not.toContain("SOUL.md");
+    expect(names).not.toContain("IDENTITY.md");
+    expect(names).not.toContain("USER.md");
+    expect(names).not.toContain("HEARTBEAT.md");
+    expect(names).not.toContain("BOOTSTRAP.md");
+    expect(names).not.toContain("MEMORY.md");
   });
 
   it("filters to allowlist for cron sessions", () => {
     const result = filterBootstrapFilesForSession(mockFiles, "agent:default:cron:daily-check");
-    expectSubagentAllowedBootstrapNames(result);
+    const names = result.map((f) => f.name);
+    expect(names).toContain("AGENTS.md");
+    expect(names).toContain("TOOLS.md");
+    expect(names).not.toContain("SOUL.md");
+    expect(names).not.toContain("IDENTITY.md");
+    expect(names).not.toContain("USER.md");
+    expect(names).not.toContain("HEARTBEAT.md");
+    expect(names).not.toContain("BOOTSTRAP.md");
+    expect(names).not.toContain("MEMORY.md");
+  });
+});
+
+describe("filterBootstrapFilesForSession — e2e integration", () => {
+  it("subagent session with real workspace files only receives AGENTS.md and TOOLS.md", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-subagent-filter-");
+
+    // Write sensitive files that should NOT leak to sub-agents
+    const sensitiveFiles = {
+      "SOUL.md": "# My persona\nI am the main agent with secrets.",
+      "IDENTITY.md": "# Identity\nName: Secret Agent\nEmail: secret@example.com",
+      "USER.md": "# User\nName: John Doe\nSSN: 123-45-6789",
+      "HEARTBEAT.md": "Check emails every hour",
+      "BOOTSTRAP.md": "# First run instructions",
+      "MEMORY.md": "# Long-term memory\nUser's private notes here",
+    };
+
+    for (const [name, content] of Object.entries(sensitiveFiles)) {
+      await fs.writeFile(path.join(workspaceDir, name), content);
+    }
+
+    // Write files that SHOULD be available to sub-agents
+    await fs.writeFile(
+      path.join(workspaceDir, "AGENTS.md"),
+      "# Agent Instructions\nYou are a helpful assistant.",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "TOOLS.md"),
+      "# Tools\nUse web_search for research.",
+    );
+
+    // Load all files as the system would
+    const allFiles = await loadWorkspaceBootstrapFiles(workspaceDir);
+
+    // Filter for a subagent session
+    const subagentKey = "agent:default:subagent:test-task-123";
+    const filtered = filterBootstrapFilesForSession(allFiles, subagentKey);
+    const names = filtered.map((f) => f.name);
+
+    // Only AGENTS.md and TOOLS.md should pass through
+    expect(names).toEqual(expect.arrayContaining(["AGENTS.md", "TOOLS.md"]));
+    expect(filtered).toHaveLength(2);
+
+    // Verify no sensitive content leaked
+    const allContent = filtered.map((f) => f.content).join("\n");
+    expect(allContent).not.toContain("Secret Agent");
+    expect(allContent).not.toContain("123-45-6789");
+    expect(allContent).not.toContain("persona");
+    expect(allContent).toContain("helpful assistant");
+    expect(allContent).toContain("web_search");
+  });
+
+  it("main session still receives all workspace files", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-main-filter-");
+
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "agents");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "soul");
+    await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), "tools");
+    await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), "identity");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "user");
+
+    const allFiles = await loadWorkspaceBootstrapFiles(workspaceDir);
+    const mainKey = "agent:default:chat:main";
+    const filtered = filterBootstrapFilesForSession(allFiles, mainKey);
+    const names = filtered.map((f) => f.name);
+
+    expect(names).toContain("AGENTS.md");
+    expect(names).toContain("SOUL.md");
+    expect(names).toContain("TOOLS.md");
+    expect(names).toContain("IDENTITY.md");
+    expect(names).toContain("USER.md");
   });
 });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -59,18 +59,6 @@ async function expectCompletedWithoutBootstrap(dir: string) {
   expect(state.onboardingCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
 }
 
-function expectSubagentAllowedBootstrapNames(files: WorkspaceBootstrapFile[]) {
-  const names = files.map((file) => file.name);
-  expect(names).toContain("AGENTS.md");
-  expect(names).toContain("TOOLS.md");
-  expect(names).toContain("SOUL.md");
-  expect(names).toContain("IDENTITY.md");
-  expect(names).toContain("USER.md");
-  expect(names).not.toContain("HEARTBEAT.md");
-  expect(names).not.toContain("BOOTSTRAP.md");
-  expect(names).not.toContain("MEMORY.md");
-}
-
 describe("ensureAgentWorkspace", () => {
   it("creates BOOTSTRAP.md and records a seeded marker for brand new workspaces", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -554,13 +554,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-]);
+const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -94,7 +94,6 @@ describe("bootstrap-extra-files hook", () => {
     await handler(event);
     expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual([
       "AGENTS.md",
-      "SOUL.md",
       "TOOLS.md",
     ]);
   });

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -92,6 +92,10 @@ describe("bootstrap-extra-files hook", () => {
 
     const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
     await handler(event);
-    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
+    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual([
+      "AGENTS.md",
+      "SOUL.md",
+      "TOOLS.md",
+    ]);
   });
 });

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -92,9 +92,6 @@ describe("bootstrap-extra-files hook", () => {
 
     const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
     await handler(event);
-    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual([
-      "AGENTS.md",
-      "TOOLS.md",
-    ]);
+    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
   });
 });

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -92,10 +92,6 @@ describe("bootstrap-extra-files hook", () => {
 
     const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
     await handler(event);
-    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual([
-      "AGENTS.md",
-      "SOUL.md",
-      "TOOLS.md",
-    ]);
+    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
   });
 });

--- a/test/scripts/lockfile-tloncorp-entry.test.ts
+++ b/test/scripts/lockfile-tloncorp-entry.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("pnpm lockfile integrity", () => {
+  it("contains the @tloncorp/api tarball package key", () => {
+    const lockfile = readFileSync(new URL("../../pnpm-lock.yaml", import.meta.url), "utf8");
+    expect(lockfile).toMatch(
+      /['"]?@tloncorp\/api@https:\/\/codeload\.github\.com\/tloncorp\/api-beta\/tar\.gz\/7eede1c1a756977b09f96aa14a92e2b06318ae87['"]?:/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Subagent and cron sessions were receiving `SOUL.md`, `IDENTITY.md`, and `USER.md` in their bootstrap context, contrary to the documented behavior that only `AGENTS.md` and `TOOLS.md` should be injected.

This removes those three files from `MINIMAL_BOOTSTRAP_ALLOWLIST`, so subagent/cron sessions get a minimal, isolated context as intended.

Closes #29363

## What changed

- **`workspace.ts`**: Remove `SOUL.md`, `IDENTITY.md`, `USER.md` from `MINIMAL_BOOTSTRAP_ALLOWLIST`
- **`workspace.test.ts`**: Update 6 assertions to expect exclusion; add 2 e2e integration tests (subagent isolation + main session unaffected)

## Why

The allowlist was over-inclusive — personal identity files leaked into subagent contexts where they are unnecessary and potentially a privacy concern (cron jobs, shared sessions). Main sessions are unaffected since they use the full bootstrap path.

## Testing

```bash
pnpm test src/agents/workspace.test.ts
```