### PR TITLE
fix(ui): stabilize websocket reconnect auth token selection

### DIFF
--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -13,7 +13,9 @@ function getTypeScript() {
     } catch {
       // Some lightweight CI jobs intentionally do not install full JS deps.
       // Helpers that rely on TS AST should fail lazily only when invoked.
-      throw new Error("typescript dependency is required for AST guard helpers but is not installed");
+      throw new Error(
+        "typescript dependency is required for AST guard helpers but is not installed",
+      );
     }
   }
   return tsCache;

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -7,7 +7,15 @@ const require = createRequire(import.meta.url);
 let tsCache;
 
 function getTypeScript() {
-  tsCache ??= require("typescript");
+  if (!tsCache) {
+    try {
+      tsCache = require("typescript");
+    } catch {
+      // Some lightweight CI jobs intentionally do not install full JS deps.
+      // Helpers that rely on TS AST should fail lazily only when invoked.
+      throw new Error("typescript dependency is required for AST guard helpers but is not installed");
+    }
+  }
   return tsCache;
 }
 
@@ -121,26 +129,26 @@ export function toLine(sourceFile, node) {
 }
 
 export function getPropertyNameText(name) {
-  const ts = getTypeScript();
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+  const tsApi = getTypeScript();
+  if (tsApi.isIdentifier(name) || tsApi.isStringLiteral(name) || tsApi.isNumericLiteral(name)) {
     return name.text;
   }
   return null;
 }
 
 export function unwrapExpression(expression) {
-  const ts = getTypeScript();
+  const tsApi = getTypeScript();
   let current = expression;
   while (true) {
-    if (ts.isParenthesizedExpression(current)) {
+    if (tsApi.isParenthesizedExpression(current)) {
       current = current.expression;
       continue;
     }
-    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+    if (tsApi.isAsExpression(current) || tsApi.isTypeAssertionExpression(current)) {
       current = current.expression;
       continue;
     }
-    if (ts.isNonNullExpression(current)) {
+    if (tsApi.isNonNullExpression(current)) {
       current = current.expression;
       continue;
     }

--- a/src/gateway/gateway-browser-client-auth.test.ts
+++ b/src/gateway/gateway-browser-client-auth.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadDeviceAuthTokenMock,
+  clearDeviceAuthTokenMock,
+  storeDeviceAuthTokenMock,
+  loadOrCreateDeviceIdentityMock,
+  signDevicePayloadMock,
+} = vi.hoisted(() => ({
+  loadDeviceAuthTokenMock: vi.fn(),
+  clearDeviceAuthTokenMock: vi.fn(),
+  storeDeviceAuthTokenMock: vi.fn(),
+  loadOrCreateDeviceIdentityMock: vi.fn(),
+  signDevicePayloadMock: vi.fn(),
+}));
+
+vi.mock("../../ui/src/ui/device-auth.ts", () => ({
+  loadDeviceAuthToken: loadDeviceAuthTokenMock,
+  clearDeviceAuthToken: clearDeviceAuthTokenMock,
+  storeDeviceAuthToken: storeDeviceAuthTokenMock,
+}));
+
+vi.mock("../../ui/src/ui/device-identity.ts", () => ({
+  loadOrCreateDeviceIdentity: loadOrCreateDeviceIdentityMock,
+  signDevicePayload: signDevicePayloadMock,
+}));
+
+import { GatewayBrowserClient } from "../../ui/src/ui/gateway.ts";
+
+describe("GatewayBrowserClient reconnect auth", () => {
+  beforeEach(() => {
+    loadDeviceAuthTokenMock.mockReset();
+    clearDeviceAuthTokenMock.mockReset();
+    storeDeviceAuthTokenMock.mockReset();
+    loadOrCreateDeviceIdentityMock.mockReset();
+    signDevicePayloadMock.mockReset();
+
+    loadOrCreateDeviceIdentityMock.mockResolvedValue({
+      deviceId: "dev-1",
+      publicKey: "pub",
+      privateKey: "priv",
+    });
+    signDevicePayloadMock.mockResolvedValue("sig");
+  });
+
+  it("falls back to shared token when stored device token is blank", async () => {
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "   ",
+      role: "operator",
+      scopes: [],
+      updatedAtMs: Date.now(),
+    });
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+    });
+
+    let connectParams: any;
+    (client as any).request = vi.fn(async (_method: string, params: unknown) => {
+      connectParams = params;
+      return { type: "hello-ok", protocol: 3 };
+    });
+
+    await (client as any).sendConnect();
+
+    expect(connectParams?.auth?.token).toBe("shared-token");
+  });
+
+  it("reuses last known good token when current sources are unavailable", async () => {
+    loadDeviceAuthTokenMock.mockReturnValue(null);
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+    });
+    (client as any).lastGoodAuthToken = "cached-token";
+
+    let connectParams: any;
+    (client as any).request = vi.fn(async (_method: string, params: unknown) => {
+      connectParams = params;
+      return { type: "hello-ok", protocol: 3 };
+    });
+
+    await (client as any).sendConnect();
+
+    expect(connectParams?.auth?.token).toBe("cached-token");
+  });
+});

--- a/src/gateway/gateway-browser-client-auth.test.ts
+++ b/src/gateway/gateway-browser-client-auth.test.ts
@@ -48,7 +48,7 @@ describe("GatewayBrowserClient reconnect auth", () => {
     loadOrCreateDeviceIdentityMock.mockResolvedValue({
       deviceId: "dev-1",
       publicKey: "pub",
-      privateKey: "priv",
+      privateKey: "test-private-key", // pragma: allowlist secret
     });
     signDevicePayloadMock.mockResolvedValue("sig");
   });

--- a/src/gateway/gateway-browser-client-auth.test.ts
+++ b/src/gateway/gateway-browser-client-auth.test.ts
@@ -27,6 +27,16 @@ vi.mock("../../ui/src/ui/device-identity.ts", () => ({
 
 import { GatewayBrowserClient } from "../../ui/src/ui/gateway.ts";
 
+type GatewayBrowserClientPrivate = {
+  request: (method: string, params?: unknown) => Promise<unknown>;
+  sendConnect: () => Promise<void>;
+  lastGoodAuthToken?: string;
+};
+
+function asClientPrivate(client: GatewayBrowserClient): GatewayBrowserClientPrivate {
+  return client as unknown as GatewayBrowserClientPrivate;
+}
+
 describe("GatewayBrowserClient reconnect auth", () => {
   beforeEach(() => {
     loadDeviceAuthTokenMock.mockReset();
@@ -51,38 +61,46 @@ describe("GatewayBrowserClient reconnect auth", () => {
       updatedAtMs: Date.now(),
     });
 
-    const client = new GatewayBrowserClient({
-      url: "ws://127.0.0.1:18789",
-      token: "shared-token",
-    });
+    const client = asClientPrivate(
+      new GatewayBrowserClient({
+        url: "ws://127.0.0.1:18789",
+        token: "shared-token",
+      }),
+    );
 
-    let connectParams: any;
-    (client as any).request = vi.fn(async (_method: string, params: unknown) => {
+    let connectParams: unknown;
+    client.request = vi.fn(async (_method: string, params: unknown) => {
       connectParams = params;
       return { type: "hello-ok", protocol: 3 };
     });
 
-    await (client as any).sendConnect();
+    await client.sendConnect();
 
-    expect(connectParams?.auth?.token).toBe("shared-token");
+    expect((connectParams as { auth?: { token?: string } } | undefined)?.auth?.token).toBe(
+      "shared-token",
+    );
   });
 
   it("reuses last known good token when current sources are unavailable", async () => {
     loadDeviceAuthTokenMock.mockReturnValue(null);
 
-    const client = new GatewayBrowserClient({
-      url: "ws://127.0.0.1:18789",
-    });
-    (client as any).lastGoodAuthToken = "cached-token";
+    const client = asClientPrivate(
+      new GatewayBrowserClient({
+        url: "ws://127.0.0.1:18789",
+      }),
+    );
+    client.lastGoodAuthToken = "cached-token";
 
-    let connectParams: any;
-    (client as any).request = vi.fn(async (_method: string, params: unknown) => {
+    let connectParams: unknown;
+    client.request = vi.fn(async (_method: string, params: unknown) => {
       connectParams = params;
       return { type: "hello-ok", protocol: 3 };
     });
 
-    await (client as any).sendConnect();
+    await client.sendConnect();
 
-    expect(connectParams?.auth?.token).toBe("cached-token");
+    expect((connectParams as { auth?: { token?: string } } | undefined)?.auth?.token).toBe(
+      "cached-token",
+    );
   });
 });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -182,7 +182,7 @@ describe("gateway server chat", () => {
           finish();
           return;
         }
-          opts?.abortSignal?.addEventListener("abort", finish, { once: true });
+        opts?.abortSignal?.addEventListener("abort", finish, { once: true });
       });
       return undefined;
     });

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -444,8 +444,7 @@ export class GatewayBrowserClient {
       this.lastGoodAuthToken = plan.selectedAuth.authToken;
     }
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
-      this.lastGoodAuthToken =
-        normalizeAuthToken(hello.auth.deviceToken) ?? this.lastGoodAuthToken;
+      this.lastGoodAuthToken = normalizeAuthToken(hello.auth.deviceToken) ?? this.lastGoodAuthToken;
       storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,
         role: hello.auth.role ?? plan.role,

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -209,6 +209,11 @@ export type GatewayBrowserClientOptions = {
   onGap?: (info: { expected: number; received: number }) => void;
 };
 
+function normalizeAuthToken(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
 
@@ -284,8 +289,11 @@ export class GatewayBrowserClient {
   private pendingConnectError: GatewayErrorInfo | undefined;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
+  private lastGoodAuthToken: string | undefined;
 
-  constructor(private opts: GatewayBrowserClientOptions) {}
+  constructor(private opts: GatewayBrowserClientOptions) {
+    this.lastGoodAuthToken = normalizeAuthToken(opts.token);
+  }
 
   start() {
     this.closed = false;
@@ -391,7 +399,7 @@ export class GatewayBrowserClient {
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
     let selectedAuth: SelectedConnectAuth = {
-      authToken: explicitGatewayToken,
+      authToken: explicitGatewayToken ?? this.lastGoodAuthToken,
       authPassword: explicitPassword,
       canFallbackToShared: false,
     };
@@ -404,6 +412,9 @@ export class GatewayBrowserClient {
       });
       if (this.pendingDeviceTokenRetry && selectedAuth.authDeviceToken) {
         this.pendingDeviceTokenRetry = false;
+      }
+      if (!selectedAuth.authToken) {
+        selectedAuth.authToken = this.lastGoodAuthToken;
       }
     }
 
@@ -429,7 +440,12 @@ export class GatewayBrowserClient {
   private handleConnectHello(hello: GatewayHelloOk, plan: ConnectPlan) {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
+    if (plan.selectedAuth.authToken) {
+      this.lastGoodAuthToken = plan.selectedAuth.authToken;
+    }
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
+      this.lastGoodAuthToken =
+        normalizeAuthToken(hello.auth.deviceToken) ?? this.lastGoodAuthToken;
       storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,
         role: hello.auth.role ?? plan.role,
@@ -482,6 +498,7 @@ export class GatewayBrowserClient {
       connectErrorCode === ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH
     ) {
       clearDeviceAuthToken({ deviceId: plan.deviceIdentity.deviceId, role: plan.role });
+      this.lastGoodAuthToken = normalizeAuthToken(this.opts.token) ?? this.lastGoodAuthToken;
     }
     this.ws?.close(CONNECT_FAILED_CLOSE_CODE, "connect failed");
   }


### PR DESCRIPTION
Fixes #28997

## Summary
Stabilize Control UI websocket reconnect auth token selection to avoid intermittent unauthenticated reconnect attempts that can trigger auth rate-limits.

## Changes
- normalize auth tokens (treat blank/whitespace as absent)
- cache and reuse last known good auth token across reconnects
- prefer token order: stored device token -> last known good token -> shared token
- preserve fallback behavior when device token is cleared
- add reconnect auth regression tests

## Tests
- pnpm vitest src/gateway/gateway-browser-client-auth.test.ts