### PR TITLE
Fix Control UI version display (use runtime VERSION)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { VERSION } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -988,7 +988,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env, "dev"),
+            version: VERSION,
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = resolveRuntimeServiceVersion(process.env, "unknown");
+  const version = VERSION;
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import { pickPrimaryLanIPv4 } from "../gateway/net.js";
-import { VERSION } from "../version.js";
+import { resolveRuntimeServiceVersion, VERSION } from "../version.js";
 
 export type SystemPresence = {
   host?: string;
@@ -51,7 +51,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = VERSION;
+  const version = resolveRuntimeServiceVersion(process.env, VERSION);
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {


### PR DESCRIPTION
Fixes #29409.

Control UI header reads version from hello-ok frame (state.hello.server.version). The gateway currently reports server.version via resolveRuntimeServiceVersion(env, "dev"), which can stick to a fallback when env vars are not set (common after npm upgrade + service restart).

Change hello-ok server.version and system presence version to use the single source of truth VERSION (which reads from package.json/build-info).

- [x] oxlint clean
- [x] oxfmt