### PR TITLE
perf(cli): short-circuit --version in bootstrap

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -63,13 +63,24 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
     }
   }
   if (wantsVersion) {
-    let version = process.env.OPENCLAW_BUNDLED_VERSION;
-    if (!version) {
+    // Match resolveBinaryVersion() priority: package metadata first,
+    // OPENCLAW_BUNDLED_VERSION only as fallback.
+    let version;
+    try {
       const require = module.createRequire(import.meta.url);
       version = require("./package.json").version;
+    } catch {
+      // package.json unreadable — fall through
     }
-    process.stdout.write(`${version}\n`);
-    process.exit(0);
+    if (!version) {
+      version = process.env.OPENCLAW_BUNDLED_VERSION;
+    }
+    if (version) {
+      process.stdout.write(`${version}\n`);
+      process.exit(0);
+    }
+    // Neither source available — fall through to full CLI which has
+    // additional candidates (build-info.json, __OPENCLAW_VERSION__).
   }
 }
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -50,8 +50,8 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   const args = process.argv.slice(2);
   let wantsVersion = false;
   for (const arg of args) {
-    if (arg === "--") break;
-    if (!arg.startsWith("-")) break; // stop at first non-flag (subcommand)
+    if (arg === "--") { break; }
+    if (!arg.startsWith("-")) { break; } // stop at first non-flag (subcommand)
     if (VERSION_FLAGS.has(arg)) {
       wantsVersion = true;
       break;

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -54,7 +54,9 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   const args = process.argv.slice(2);
   let wantsVersion = false;
   for (const arg of args) {
-    if (arg === "--") { break; }
+    if (arg === "--") {
+      break;
+    }
     if (VERSION_FLAGS.has(arg)) {
       wantsVersion = true;
       break;

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -45,15 +45,21 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
 }
 
 // Fast-path: print version and exit without loading the dist bundle.
-// Matches the semantics of hasHelpOrVersion() in src/cli/argv.ts:
-//   --version / -V: argv.some() -- matches anywhere, even after subcommands
-//   -v: hasRootVersionAlias() -- only when no positional command follows
-// The -v alias requires awareness of ROOT_BOOLEAN_FLAGS / ROOT_VALUE_FLAGS
-// to skip correctly, so we leave it to the full CLI parser.
+// Matches the semantics of configureProgramHelp() in src/cli/program/help.ts
+// which uses hasFlag() (respects -- terminator) for --version/-V and
+// hasRootVersionAlias() for -v. We only handle --version/-V here; the -v
+// alias needs the full CLI parser for positional-aware logic.
 {
   const VERSION_FLAGS = new Set(["--version", "-V"]);
   const args = process.argv.slice(2);
-  const wantsVersion = args.some((arg) => VERSION_FLAGS.has(arg));
+  let wantsVersion = false;
+  for (const arg of args) {
+    if (arg === "--") { break; }
+    if (VERSION_FLAGS.has(arg)) {
+      wantsVersion = true;
+      break;
+    }
+  }
   if (wantsVersion) {
     let version = process.env.OPENCLAW_BUNDLED_VERSION;
     if (!version) {

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -44,6 +44,30 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   }
 }
 
+// Fast-path: print version and exit without loading the dist bundle.
+{
+  const VERSION_FLAGS = new Set(["--version", "-v", "-V"]);
+  const args = process.argv.slice(2);
+  let wantsVersion = false;
+  for (const arg of args) {
+    if (arg === "--") break;
+    if (!arg.startsWith("-")) break; // stop at first non-flag (subcommand)
+    if (VERSION_FLAGS.has(arg)) {
+      wantsVersion = true;
+      break;
+    }
+  }
+  if (wantsVersion) {
+    let version = process.env.OPENCLAW_BUNDLED_VERSION;
+    if (!version) {
+      const require = module.createRequire(import.meta.url);
+      version = require("./package.json").version;
+    }
+    process.stdout.write(`${version}\n`);
+    process.exit(0);
+  }
+}
+
 const isModuleNotFoundError = (err) =>
   err && typeof err === "object" && "code" in err && err.code === "ERR_MODULE_NOT_FOUND";
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -63,24 +63,51 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
     }
   }
   if (wantsVersion) {
-    // Match resolveBinaryVersion() priority: package metadata first,
-    // OPENCLAW_BUNDLED_VERSION only as fallback.
-    let version;
-    try {
-      const require = module.createRequire(import.meta.url);
-      version = require("./package.json").version;
-    } catch {
-      // package.json unreadable — fall through
-    }
-    if (!version) {
-      version = process.env.OPENCLAW_BUNDLED_VERSION;
-    }
+    // Mirror resolveBinaryVersion() in src/version.ts:
+    //   1. package.json (name === "openclaw") → 2. build-info.json → 3. env var
+    const require = module.createRequire(import.meta.url);
+    const PACKAGE_JSON_CANDIDATES = [
+      "../package.json",
+      "../../package.json",
+      "../../../package.json",
+      "./package.json",
+    ];
+    const BUILD_INFO_CANDIDATES = [
+      "../build-info.json",
+      "../../build-info.json",
+      "./build-info.json",
+    ];
+
+    const readVersion = (candidates, { requirePackageName = false } = {}) => {
+      for (const candidate of candidates) {
+        try {
+          const pkg = require(candidate);
+          const v = pkg.version?.trim?.();
+          if (!v) {
+            continue;
+          }
+          if (requirePackageName && pkg.name !== "openclaw") {
+            continue;
+          }
+          return v;
+        } catch {
+          // candidate missing or unreadable
+        }
+      }
+      return undefined;
+    };
+
+    const version =
+      readVersion(PACKAGE_JSON_CANDIDATES, { requirePackageName: true }) ||
+      readVersion(BUILD_INFO_CANDIDATES) ||
+      process.env.OPENCLAW_BUNDLED_VERSION;
+
     if (version) {
       process.stdout.write(`${version}\n`);
       process.exit(0);
     }
-    // Neither source available — fall through to full CLI which has
-    // additional candidates (build-info.json, __OPENCLAW_VERSION__).
+    // No source available — fall through to full CLI which also has
+    // the compile-time __OPENCLAW_VERSION__ define.
   }
 }
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -45,18 +45,15 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
 }
 
 // Fast-path: print version and exit without loading the dist bundle.
+// Matches the semantics of hasHelpOrVersion() in src/cli/argv.ts:
+//   --version / -V: argv.some() -- matches anywhere, even after subcommands
+//   -v: hasRootVersionAlias() -- only when no positional command follows
+// The -v alias requires awareness of ROOT_BOOLEAN_FLAGS / ROOT_VALUE_FLAGS
+// to skip correctly, so we leave it to the full CLI parser.
 {
-  const VERSION_FLAGS = new Set(["--version", "-v", "-V"]);
+  const VERSION_FLAGS = new Set(["--version", "-V"]);
   const args = process.argv.slice(2);
-  let wantsVersion = false;
-  for (const arg of args) {
-    if (arg === "--") { break; }
-    if (!arg.startsWith("-")) { break; } // stop at first non-flag (subcommand)
-    if (VERSION_FLAGS.has(arg)) {
-      wantsVersion = true;
-      break;
-    }
-  }
+  const wantsVersion = args.some((arg) => VERSION_FLAGS.has(arg));
   if (wantsVersion) {
     let version = process.env.OPENCLAW_BUNDLED_VERSION;
     if (!version) {


### PR DESCRIPTION
## Summary

Adds a fast-path in `openclaw.mjs` that checks for `--version` / `-v` / `-V` flags before importing the dist bundle. When a version flag is found, reads the version from `OPENCLAW_BUNDLED_VERSION` env var or `package.json` via `createRequire`, prints it, and exits immediately.

This bypasses the full module graph load, process warning filter setup, and CLI initialization -- none of which are needed to print the version string.

Only top-level flags are scanned (stops at the first non-flag argument to avoid `-v` collisions with subcommands).

## Benchmarks

Tested with [chainsaw](https://github.com/rocketman-code/chainsaw) for static analysis and [hyperfine](https://github.com/sharkdp/hyperfine) for runtime:

**1-vCPU VPS (Node 22):**
| Command | Before | After | Speedup |
|---|---|---|---|
| `openclaw --version` | 2.94 s | 33 ms | 90x |
| `openclaw --help` | 2.93 s | 2.97 s | (unchanged) |

**M4 MacBook Pro (Node 22):**
| Command | Before | After | Speedup |
|---|---|---|---|
| `openclaw --version` | 642 ms | 44 ms | 15x |
| `openclaw --help` | 647 ms | 671 ms | (unchanged) |

## Test plan

- [x] `node openclaw.mjs --version` prints version and exits
- [x] `node openclaw.mjs -v` prints version and exits
- [x] `node openclaw.mjs -V` prints version and exits
- [x] `node openclaw.mjs config --version` still works (flag after subcommand)
- [x] `node openclaw.mjs --help` unaffected (no version flag detected)
- [x] `node openclaw.mjs config set foo bar` unaffected (stops scanning at subcommand)