### PR TITLE
fix(daemon): avoid stale launchagent token precedence drift

### DIFF
--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -233,12 +233,12 @@ export async function gatherDaemonStatus(
         url: probeUrl,
         token:
           opts.rpc.token ||
-          mergedDaemonEnv.OPENCLAW_GATEWAY_TOKEN ||
-          daemonCfg.gateway?.auth?.token,
+          daemonCfg.gateway?.auth?.token ||
+          mergedDaemonEnv.OPENCLAW_GATEWAY_TOKEN,
         password:
           opts.rpc.password ||
-          mergedDaemonEnv.OPENCLAW_GATEWAY_PASSWORD ||
-          daemonCfg.gateway?.auth?.password,
+          daemonCfg.gateway?.auth?.password ||
+          mergedDaemonEnv.OPENCLAW_GATEWAY_PASSWORD,
         tlsFingerprint:
           shouldUseLocalTlsRuntime && tlsRuntime?.enabled
             ? tlsRuntime.fingerprintSha256

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -100,6 +100,23 @@ describe("auditGatewayServiceConfig", () => {
       audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
     ).toBe(false);
   });
+
+  it("does not flag gateway token mismatch when service token is missing", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(false);
+  });
 });
 
 describe("checkTokenDrift", () => {
@@ -125,10 +142,9 @@ describe("checkTokenDrift", () => {
     expect(result?.message).toContain("differs from service token");
   });
 
-  it("detects drift when config has token but service has no token", () => {
+  it("does not treat missing service token as drift", () => {
     const result = checkTokenDrift({ serviceToken: undefined, configToken: "new-token" });
-    expect(result).not.toBeNull();
-    expect(result?.code).toBe(SERVICE_AUDIT_CODES.gatewayTokenDrift);
+    expect(result).toBeNull();
   });
 
   it("returns null when service has token but config does not", () => {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -260,27 +260,34 @@ describe("buildMinimalServicePath", () => {
 });
 
 describe("buildServiceEnvironment", () => {
-  it("sets minimal PATH and gateway vars", () => {
+  it("sets minimal PATH and gateway vars on linux services", () => {
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user" },
       port: 18789,
       token: "secret",
+      platform: "linux",
     });
     expect(env.HOME).toBe("/home/user");
-    if (process.platform === "win32") {
-      expect(env.PATH).toBe("");
-    } else {
-      expect(env.PATH).toContain("/usr/bin");
-    }
+    expect(env.PATH).toContain("/usr/bin");
     expect(env.OPENCLAW_GATEWAY_PORT).toBe("18789");
     expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("secret");
     expect(env.OPENCLAW_SERVICE_MARKER).toBe("openclaw");
     expect(env.OPENCLAW_SERVICE_KIND).toBe("gateway");
     expect(typeof env.OPENCLAW_SERVICE_VERSION).toBe("string");
     expect(env.OPENCLAW_SYSTEMD_UNIT).toBe("openclaw-gateway.service");
-    if (process.platform === "darwin") {
-      expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.gateway");
-    }
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBeUndefined();
+  });
+
+  it("does not embed gateway token in darwin launchd environment", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/Users/test" },
+      port: 18789,
+      token: "secret",
+      platform: "darwin",
+    });
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("18789");
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.gateway");
   });
 
   it("forwards TMPDIR from the host environment", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -254,6 +254,10 @@ export function buildServiceEnvironment(params: {
   // works correctly when running as a LaunchAgent without extra user configuration.
   const nodeCaCerts =
     env.NODE_EXTRA_CA_CERTS ?? (platform === "darwin" ? "/etc/ssl/cert.pem" : undefined);
+  // On macOS LaunchAgents, avoid persisting OPENCLAW_GATEWAY_TOKEN in plist env.
+  // The gateway server resolves auth from config first, so embedding a token here
+  // can drift from openclaw.json and break CLI probes that read LaunchAgent env.
+  const embeddedGatewayToken = platform === "darwin" ? undefined : token;
   return {
     HOME: env.HOME,
     TMPDIR: tmpDir,
@@ -264,7 +268,7 @@ export function buildServiceEnvironment(params: {
     OPENCLAW_STATE_DIR: stateDir,
     OPENCLAW_CONFIG_PATH: configPath,
     OPENCLAW_GATEWAY_PORT: String(port),
-    OPENCLAW_GATEWAY_TOKEN: token,
+    OPENCLAW_GATEWAY_TOKEN: embeddedGatewayToken,
     OPENCLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
     OPENCLAW_SYSTEMD_UNIT: systemdUnit,
     OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,


### PR DESCRIPTION
## Summary

- **Problem:** macOS LaunchAgent plists could retain a stale `OPENCLAW_GATEWAY_TOKEN`, and daemon status probing preferred that stale service env token over the current config token.
- **Why it matters:** After `gateway.auth.token` changes, users can see false auth failures (`token mismatch` / `device token mismatch`) even though config is correct.
- **What changed:** LaunchAgent service env no longer embeds `OPENCLAW_GATEWAY_TOKEN` on darwin, daemon status probing now prefers config token/password before service env values, and service token drift audit treats a missing service token as acceptable (still flags stale mismatched token values).
- **What did NOT change:** Non-darwin service token embedding behavior and explicit user-provided RPC auth overrides remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29373

## User-visible / Behavior Changes

- On macOS LaunchAgent installs, token updates in config no longer get shadowed by stale service env tokens during daemon status probing.
- Service drift checks continue to flag stale mismatched embedded tokens, but no longer warn when service token is simply absent.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` (darwin LaunchAgent no longer persists gateway token env by default)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (LaunchAgent path) + unit tests
- Runtime: Node.js + pnpm monorepo tests
- Integration/channel: Gateway daemon status and service audit

### Steps

1. Have a LaunchAgent with stale `OPENCLAW_GATEWAY_TOKEN` in plist env and a newer `gateway.auth.token` in config.
2. Run daemon status probe flow.

### Expected

- Probe auth prefers config token and succeeds when config is correct.

### Actual

- Before fix: stale service env token could be used first for probe auth.
- After fix: config token/password takes precedence; stale service env token no longer masks config.

## Evidence

- Updated files:
  - `src/daemon/service-env.ts`
  - `src/cli/daemon-cli/status.gather.ts`
  - `src/daemon/service-audit.ts`
  - tests in corresponding `*.test.ts`
- Test runs:
  - `pnpm test -- --run src/daemon/service-env.test.ts src/daemon/service-audit.test.ts src/cli/daemon-cli/status.gather.test.ts src/cli/daemon-cli/lifecycle-core.test.ts`
  - `pnpm test -- --run src/commands/doctor-gateway-services.test.ts`

## Human Verification (required)

- Verified scenarios: stale service env token vs config token precedence, missing service token audit behavior, darwin environment embedding rules.
- Edge cases checked: stale token still flagged when present and mismatched.
- What I did **not** verify: live LaunchAgent end-to-end on a real user machine after token rotation.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` required (behavioral hardening only)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit/PR.
- Files/config to restore: `src/daemon/service-env.ts`, `src/cli/daemon-cli/status.gather.ts`, `src/daemon/service-audit.ts`.
- Known bad symptoms: daemon status may again select stale service env token over current config token.

## Risks and Mitigations

- Risk: changing token precedence in status probe could alter behavior for setups relying on service env overrides.
- Mitigation: explicit RPC token override remains highest priority; stale service env values are still used as fallback after config values.