### PR TITLE
fix(matrix): render markdown tables as HTML table markup

### DIFF
--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -30,4 +30,13 @@ describe("markdownToMatrixHtml", () => {
     const html = markdownToMatrixHtml("line1\nline2");
     expect(html).toContain("<br");
   });
+
+  it("renders markdown tables as HTML tables", () => {
+    const html = markdownToMatrixHtml(
+      "| # | Issue | Status |\n| - | ----- | ------ |\n| 1 | Fix bug | Done |",
+    );
+    expect(html).toContain("<table>");
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<tbody>");
+  });
 });

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -8,6 +8,7 @@ const md = new MarkdownIt({
 });
 
 md.enable("strikethrough");
+md.enable("table");
 
 const { escapeHtml } = md.utils;
 

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkdownTableMode } from "./markdown-tables.js";
+
+describe("resolveMarkdownTableMode defaults", () => {
+  it("defaults matrix to off", () => {
+    expect(resolveMarkdownTableMode({ channel: "matrix" })).toBe("off");
+  });
+
+  it("keeps signal and whatsapp defaults as bullets", () => {
+    expect(resolveMarkdownTableMode({ channel: "signal" })).toBe("bullets");
+    expect(resolveMarkdownTableMode({ channel: "whatsapp" })).toBe("bullets");
+  });
+
+  it("falls back to code for channels without explicit defaults", () => {
+    expect(resolveMarkdownTableMode({ channel: "telegram" })).toBe("code");
+  });
+});
+
+describe("resolveMarkdownTableMode config overrides", () => {
+  it("respects explicit matrix markdown.tables override", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          markdown: {
+            tables: "code",
+          },
+        },
+      },
+    };
+    expect(resolveMarkdownTableMode({ cfg, channel: "matrix" })).toBe("code");
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -15,6 +15,7 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
 };
 
 const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
+  ["matrix", "off"],
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
 ]);
@@ -47,7 +48,12 @@ export function resolveMarkdownTableMode(params: {
   channel?: string | null;
   accountId?: string | null;
 }): MarkdownTableMode {
-  const channel = normalizeChannelId(params.channel);
+  const normalizedChannel = normalizeChannelId(params.channel);
+  const fallbackChannel =
+    typeof params.channel === "string" && params.channel.trim().length > 0
+      ? params.channel.trim().toLowerCase()
+      : null;
+  const channel = normalizedChannel ?? fallbackChannel;
   const defaultMode = channel ? (DEFAULT_TABLE_MODES.get(channel) ?? "code") : "code";
   if (!channel || !params.cfg) {
     return defaultMode;


### PR DESCRIPTION
## Summary

- **Problem:** Matrix outbound formatting could wrap markdown tables in `<pre><code>` blocks due table conversion defaults, so clients rendered plain monospace text instead of real tables.
- **Why it matters:** Users lose readability for tabular outputs (issues, commits, lists) in Element/Matrix clients.
- **What changed:** Set Matrix default markdown table mode to `off` (preserve table markdown for downstream HTML rendering), added fallback channel normalization in table mode resolution for extension channels, and explicitly enabled table rendering in Matrix markdown formatter.
- **What did NOT change:** Signal/WhatsApp defaults (`bullets`) and other channel table defaults/overrides remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29377

## User-visible / Behavior Changes

- Matrix `formatted_body` now renders markdown tables as actual HTML `<table>` markup by default instead of preformatted code blocks.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm monorepo tests
- Integration/channel: Matrix outbound formatting

### Steps

1. Send a Matrix response containing markdown table syntax.
2. Inspect generated `formatted_body` output.

### Expected

- `formatted_body` contains `<table>`, `<thead>`, `<tbody>` markup.

### Actual

- Before fix: table markdown could be converted into code-block style output, yielding `<pre><code>` rendering.
- After fix: matrix default table mode preserves markdown table syntax and formatter emits HTML table markup.

## Evidence

- Added/updated tests:
  - `src/config/markdown-tables.test.ts`
  - `extensions/matrix/src/matrix/format.test.ts`
  - `extensions/matrix/src/matrix/send.test.ts` (regression safety run)
- Test run:
  - `pnpm test -- --run src/config/markdown-tables.test.ts extensions/matrix/src/matrix/format.test.ts extensions/matrix/src/matrix/send.test.ts`

## Human Verification (required)

- Verified scenarios: matrix default table mode, extension-channel fallback normalization, HTML table rendering path.
- Edge cases checked: channel-specific override can still force `code` mode for matrix.
- What I did **not** verify: live homeserver + Element end-to-end rendering with real room traffic.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit/PR.
- Files/config to restore: `src/config/markdown-tables.ts` and `extensions/matrix/src/matrix/format.ts`.
- Known bad symptoms: matrix tables may revert to code-block rendering.

## Risks and Mitigations

- Risk: default mode change may alter formatting for users who preferred code-block tables.
- Mitigation: explicit per-channel config override (`channels.matrix.markdown.tables`) remains supported.