### PR TITLE
feat(gohighlevel): add GoHighLevel CRM channel extension

### DIFF
--- a/extensions/gohighlevel/index.ts
+++ b/extensions/gohighlevel/index.ts
@@ -1,0 +1,19 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { gohighlevelDock, gohighlevelPlugin } from "./src/channel.js";
+import { handleGoHighLevelWebhookRequest } from "./src/monitor.js";
+import { setGoHighLevelRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "gohighlevel",
+  name: "GoHighLevel",
+  description: "OpenClaw GoHighLevel channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setGoHighLevelRuntime(api.runtime);
+    api.registerChannel({ plugin: gohighlevelPlugin, dock: gohighlevelDock });
+    api.registerHttpHandler(handleGoHighLevelWebhookRequest);
+  },
+};
+
+export default plugin;

--- a/extensions/gohighlevel/openclaw.plugin.json
+++ b/extensions/gohighlevel/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "gohighlevel",
+  "channels": ["gohighlevel"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/gohighlevel/package.json
+++ b/extensions/gohighlevel/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/gohighlevel",
+  "version": "2026.2.27",
+  "private": true,
+  "description": "OpenClaw GoHighLevel channel plugin",
+  "type": "module",
+  "dependencies": {},
+  "peerDependencies": {
+    "openclaw": ">=2026.1.26"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "gohighlevel",
+      "label": "GoHighLevel",
+      "selectionLabel": "GoHighLevel (CRM)",
+      "detailLabel": "GoHighLevel",
+      "docsPath": "/channels/gohighlevel",
+      "docsLabel": "gohighlevel",
+      "blurb": "GoHighLevel CRM — AI chatbot for SMS, webchat, email, IG, FB, and GMB.",
+      "aliases": [
+        "ghl",
+        "highlevel"
+      ],
+      "order": 70
+    },
+    "install": {
+      "npmSpec": "@openclaw/gohighlevel",
+      "localPath": "extensions/gohighlevel",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/gohighlevel/src/accounts.test.ts
+++ b/extensions/gohighlevel/src/accounts.test.ts
@@ -5,6 +5,7 @@ import { resolveGoHighLevelAccount, listGoHighLevelAccountIds } from "./accounts
 describe("resolveGoHighLevelAccount", () => {
   afterEach(() => {
     delete process.env.GHL_API_KEY;
+    delete process.env.GHL_TOKEN;
     delete process.env.GHL_LOCATION_ID;
   });
 
@@ -52,6 +53,36 @@ describe("resolveGoHighLevelAccount", () => {
     const account = resolveGoHighLevelAccount({ cfg });
     expect(account.credentialSource).toBe("none");
     expect(account.apiKey).toBeUndefined();
+  });
+
+  it("resolves from GHL_TOKEN env var as fallback", () => {
+    process.env.GHL_TOKEN = "token-key";
+    process.env.GHL_LOCATION_ID = "token-loc";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("env");
+    expect(account.apiKey).toBe("token-key");
+    expect(account.locationId).toBe("token-loc");
+  });
+
+  it("prefers GHL_API_KEY over GHL_TOKEN", () => {
+    process.env.GHL_API_KEY = "api-key";
+    process.env.GHL_TOKEN = "token-key";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.apiKey).toBe("api-key");
   });
 
   it("does not use env vars for non-default account", () => {

--- a/extensions/gohighlevel/src/accounts.test.ts
+++ b/extensions/gohighlevel/src/accounts.test.ts
@@ -1,0 +1,94 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { resolveGoHighLevelAccount, listGoHighLevelAccountIds } from "./accounts.js";
+
+describe("resolveGoHighLevelAccount", () => {
+  afterEach(() => {
+    delete process.env.GHL_API_KEY;
+    delete process.env.GHL_LOCATION_ID;
+  });
+
+  it("resolves from inline config", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          enabled: true,
+          apiKey: "pit-test-key",
+          locationId: "loc123",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("inline");
+    expect(account.apiKey).toBe("pit-test-key");
+    expect(account.locationId).toBe("loc123");
+    expect(account.enabled).toBe(true);
+  });
+
+  it("resolves from env vars for default account", () => {
+    process.env.GHL_API_KEY = "env-key";
+    process.env.GHL_LOCATION_ID = "env-loc";
+
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("env");
+    expect(account.apiKey).toBe("env-key");
+    expect(account.locationId).toBe("env-loc");
+  });
+
+  it("returns none when no credentials are available", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: { enabled: true },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg });
+    expect(account.credentialSource).toBe("none");
+    expect(account.apiKey).toBeUndefined();
+  });
+
+  it("does not use env vars for non-default account", () => {
+    process.env.GHL_API_KEY = "env-key";
+
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          enabled: true,
+          accounts: {
+            secondary: { enabled: true },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const account = resolveGoHighLevelAccount({ cfg, accountId: "secondary" });
+    expect(account.credentialSource).toBe("none");
+  });
+});
+
+describe("listGoHighLevelAccountIds", () => {
+  it("returns default when no accounts configured", () => {
+    const cfg = {
+      channels: { gohighlevel: { enabled: true } },
+    } as unknown as OpenClawConfig;
+    expect(listGoHighLevelAccountIds(cfg)).toEqual(["default"]);
+  });
+
+  it("returns configured account ids sorted", () => {
+    const cfg = {
+      channels: {
+        gohighlevel: {
+          accounts: { beta: {}, alpha: {} },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(listGoHighLevelAccountIds(cfg)).toEqual(["alpha", "beta"]);
+  });
+});

--- a/extensions/gohighlevel/src/accounts.ts
+++ b/extensions/gohighlevel/src/accounts.ts
@@ -1,0 +1,126 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { GoHighLevelAccountConfig } from "./config-schema.js";
+
+export type GoHighLevelCredentialSource = "env" | "inline" | "none";
+
+export type ResolvedGoHighLevelAccount = {
+  accountId: string;
+  name?: string;
+  enabled: boolean;
+  config: GoHighLevelAccountConfig;
+  credentialSource: GoHighLevelCredentialSource;
+  apiKey?: string;
+  locationId?: string;
+};
+
+const ENV_API_KEY = "GHL_API_KEY";
+const ENV_LOCATION_ID = "GHL_LOCATION_ID";
+
+function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = cfg.channels?.["gohighlevel"]?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return [];
+  }
+  return Object.keys(accounts).filter(Boolean);
+}
+
+export function listGoHighLevelAccountIds(cfg: OpenClawConfig): string[] {
+  const ids = listConfiguredAccountIds(cfg);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+  return ids.toSorted((a, b) => a.localeCompare(b));
+}
+
+export function resolveDefaultGoHighLevelAccountId(cfg: OpenClawConfig): string {
+  const channel = cfg.channels?.["gohighlevel"];
+  if (channel?.defaultAccount?.trim()) {
+    return channel.defaultAccount.trim();
+  }
+  const ids = listGoHighLevelAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): GoHighLevelAccountConfig | undefined {
+  const accounts = cfg.channels?.["gohighlevel"]?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  return accounts[accountId];
+}
+
+function mergeGoHighLevelAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): GoHighLevelAccountConfig {
+  const raw = cfg.channels?.["gohighlevel"] ?? {};
+  const { accounts: _ignored, defaultAccount: _ignored2, ...base } = raw;
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account } as GoHighLevelAccountConfig;
+}
+
+function resolveCredentials(params: { accountId: string; account: GoHighLevelAccountConfig }): {
+  apiKey?: string;
+  locationId?: string;
+  source: GoHighLevelCredentialSource;
+} {
+  const { account, accountId } = params;
+
+  // Inline config takes priority
+  if (account.apiKey?.trim()) {
+    return {
+      apiKey: account.apiKey.trim(),
+      locationId: account.locationId?.trim(),
+      source: "inline",
+    };
+  }
+
+  // Fall back to env vars for default account
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    const envKey = process.env[ENV_API_KEY]?.trim();
+    if (envKey) {
+      return {
+        apiKey: envKey,
+        locationId: account.locationId?.trim() || process.env[ENV_LOCATION_ID]?.trim(),
+        source: "env",
+      };
+    }
+  }
+
+  return { source: "none" };
+}
+
+export function resolveGoHighLevelAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedGoHighLevelAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = params.cfg.channels?.["gohighlevel"]?.enabled !== false;
+  const merged = mergeGoHighLevelAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const credentials = resolveCredentials({ accountId, account: merged });
+
+  return {
+    accountId,
+    name: merged.name?.trim() || undefined,
+    enabled,
+    config: merged,
+    credentialSource: credentials.source,
+    apiKey: credentials.apiKey,
+    locationId: credentials.locationId,
+  };
+}
+
+export function listEnabledGoHighLevelAccounts(cfg: OpenClawConfig): ResolvedGoHighLevelAccount[] {
+  return listGoHighLevelAccountIds(cfg)
+    .map((accountId) => resolveGoHighLevelAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/gohighlevel/src/accounts.ts
+++ b/extensions/gohighlevel/src/accounts.ts
@@ -14,7 +14,8 @@ export type ResolvedGoHighLevelAccount = {
   locationId?: string;
 };
 
-const ENV_API_KEY = "GHL_API_KEY";
+/** Env var names — check GHL_API_KEY first, fall back to GHL_TOKEN for compat. */
+const ENV_API_KEY_NAMES = ["GHL_API_KEY", "GHL_TOKEN"] as const;
 const ENV_LOCATION_ID = "GHL_LOCATION_ID";
 
 function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
@@ -84,7 +85,7 @@ function resolveCredentials(params: { accountId: string; account: GoHighLevelAcc
 
   // Fall back to env vars for default account
   if (accountId === DEFAULT_ACCOUNT_ID) {
-    const envKey = process.env[ENV_API_KEY]?.trim();
+    const envKey = ENV_API_KEY_NAMES.map((n) => process.env[n]?.trim()).find(Boolean);
     if (envKey) {
       return {
         apiKey: envKey,

--- a/extensions/gohighlevel/src/api.ts
+++ b/extensions/gohighlevel/src/api.ts
@@ -1,0 +1,112 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk";
+import type { ResolvedGoHighLevelAccount } from "./accounts.js";
+import type { GHLContact, GHLConversation, GHLSendMessageResponse } from "./types.js";
+
+const GHL_API_BASE = "https://services.leadconnectorhq.com";
+const GHL_API_VERSION = "2021-07-28";
+
+function buildHeaders(account: ResolvedGoHighLevelAccount): Record<string, string> {
+  if (!account.apiKey) {
+    throw new Error("GoHighLevel API key is not configured");
+  }
+  return {
+    Authorization: `Bearer ${account.apiKey}`,
+    Version: GHL_API_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+async function fetchJson<T>(
+  account: ResolvedGoHighLevelAccount,
+  url: string,
+  init: RequestInit,
+): Promise<T> {
+  const headers = buildHeaders(account);
+  const { response: res } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers as Record<string, string> | undefined),
+      },
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`GHL API ${res.status}: ${text || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** Send a message via GHL Conversations API. */
+export async function sendGHLMessage(params: {
+  account: ResolvedGoHighLevelAccount;
+  conversationId: string;
+  message: string;
+  messageType?: string;
+}): Promise<GHLSendMessageResponse> {
+  const { account, conversationId, message, messageType } = params;
+  const url = `${GHL_API_BASE}/conversations/messages`;
+  return await fetchJson<GHLSendMessageResponse>(account, url, {
+    method: "POST",
+    body: JSON.stringify({
+      type: messageType ?? "SMS",
+      contactId: conversationId,
+      message,
+    }),
+  });
+}
+
+/** Retrieve a contact by ID. */
+export async function getGHLContact(params: {
+  account: ResolvedGoHighLevelAccount;
+  contactId: string;
+}): Promise<GHLContact> {
+  const { account, contactId } = params;
+  const url = `${GHL_API_BASE}/contacts/${contactId}`;
+  const result = await fetchJson<{ contact?: GHLContact }>(account, url, { method: "GET" });
+  return result.contact ?? {};
+}
+
+/** Retrieve a conversation by ID. */
+export async function getGHLConversation(params: {
+  account: ResolvedGoHighLevelAccount;
+  conversationId: string;
+}): Promise<GHLConversation> {
+  const { account, conversationId } = params;
+  const url = `${GHL_API_BASE}/conversations/${conversationId}`;
+  const result = await fetchJson<{ conversation?: GHLConversation }>(account, url, {
+    method: "GET",
+  });
+  return result.conversation ?? {};
+}
+
+/** Probe the GHL API to verify credentials are valid. */
+export async function probeGoHighLevel(account: ResolvedGoHighLevelAccount): Promise<{
+  ok: boolean;
+  status?: number;
+  error?: string;
+}> {
+  try {
+    if (!account.apiKey) {
+      return { ok: false, error: "no API key configured" };
+    }
+    const url = `${GHL_API_BASE}/locations/${account.locationId ?? "unknown"}`;
+    const headers = buildHeaders(account);
+    const { response: res } = await fetchWithSsrFGuard({
+      url,
+      init: { method: "GET", headers },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      return { ok: false, status: res.status, error: text || res.statusText };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/extensions/gohighlevel/src/auth.test.ts
+++ b/extensions/gohighlevel/src/auth.test.ts
@@ -1,0 +1,40 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { verifyGHLSignature } from "./auth.js";
+
+function sign(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+describe("verifyGHLSignature", () => {
+  const secret = "test-webhook-secret";
+  const body = '{"type":"InboundMessage","contactId":"abc123"}';
+
+  it("accepts a valid signature", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body, secret })).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body: body + "x", secret })).toBe(false);
+  });
+
+  it("rejects a wrong secret", () => {
+    const signature = sign(body, "wrong-secret");
+    expect(verifyGHLSignature({ signature, body, secret })).toBe(false);
+  });
+
+  it("rejects empty signature", () => {
+    expect(verifyGHLSignature({ signature: "", body, secret })).toBe(false);
+  });
+
+  it("rejects empty secret", () => {
+    const signature = sign(body, secret);
+    expect(verifyGHLSignature({ signature, body, secret: "" })).toBe(false);
+  });
+
+  it("rejects signature with wrong length", () => {
+    expect(verifyGHLSignature({ signature: "abc", body, secret })).toBe(false);
+  });
+});

--- a/extensions/gohighlevel/src/auth.ts
+++ b/extensions/gohighlevel/src/auth.ts
@@ -1,0 +1,28 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verify the HMAC-SHA256 signature of an incoming GHL webhook request.
+ * GHL signs the raw body with the webhook secret.
+ */
+export function verifyGHLSignature(params: {
+  signature: string;
+  body: string;
+  secret: string;
+}): boolean {
+  const { signature, body, secret } = params;
+  if (!signature || !secret) {
+    return false;
+  }
+
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+
+  if (signature.length !== expected.length) {
+    return false;
+  }
+
+  try {
+    return timingSafeEqual(Buffer.from(signature, "utf8"), Buffer.from(expected, "utf8"));
+  } catch {
+    return false;
+  }
+}

--- a/extensions/gohighlevel/src/channel.ts
+++ b/extensions/gohighlevel/src/channel.ts
@@ -1,0 +1,410 @@
+import type {
+  ChannelDock,
+  ChannelPlugin,
+  ChannelStatusIssue,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk";
+import {
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  missingTargetError,
+  PAIRING_APPROVED_MESSAGE,
+  setAccountEnabledInConfigSection,
+  applyAccountNameToChannelSection,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+} from "openclaw/plugin-sdk";
+import {
+  listGoHighLevelAccountIds,
+  resolveDefaultGoHighLevelAccountId,
+  resolveGoHighLevelAccount,
+  type ResolvedGoHighLevelAccount,
+} from "./accounts.js";
+import { sendGHLMessage, probeGoHighLevel } from "./api.js";
+import { GoHighLevelConfigSchema } from "./config-schema.js";
+import { resolveGoHighLevelWebhookPath, startGoHighLevelMonitor } from "./monitor.js";
+import { gohighlevelOnboardingAdapter } from "./onboarding.js";
+import { getGoHighLevelRuntime } from "./runtime.js";
+
+const meta = {
+  id: "gohighlevel",
+  label: "GoHighLevel",
+  selectionLabel: "GoHighLevel (CRM)",
+  docsPath: "/channels/gohighlevel",
+  docsLabel: "gohighlevel",
+  blurb: "GoHighLevel CRM — AI chatbot for SMS, webchat, email, IG, FB, and GMB.",
+  aliases: ["ghl", "highlevel"],
+  order: 70,
+} as const;
+
+const formatAllowFromEntry = (entry: string) =>
+  entry
+    .trim()
+    .replace(/^(gohighlevel|ghl|highlevel):/i, "")
+    .toLowerCase();
+
+function resolveAllowFrom(account: ResolvedGoHighLevelAccount): string[] {
+  return (account.config.dm?.allowFrom ?? account.config.allowFrom ?? []).map((v) => String(v));
+}
+
+function resolveDmPolicyValue(account: ResolvedGoHighLevelAccount): string {
+  return account.config.dm?.policy ?? account.config.dmPolicy ?? "open";
+}
+
+export const gohighlevelDock: ChannelDock = {
+  id: "gohighlevel",
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    media: true,
+    threads: false,
+    blockStreaming: true,
+  },
+  outbound: { textChunkLimit: 1600 },
+  config: {
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveAllowFrom(resolveGoHighLevelAccount({ cfg, accountId })),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+  },
+};
+
+export const gohighlevelPlugin: ChannelPlugin<ResolvedGoHighLevelAccount> = {
+  id: "gohighlevel",
+  meta: {
+    ...meta,
+    aliases: [...meta.aliases],
+  },
+  onboarding: gohighlevelOnboardingAdapter,
+  pairing: {
+    idLabel: "gohighlevelContactId",
+    normalizeAllowEntry: (entry) => formatAllowFromEntry(entry),
+    notifyApproval: async ({ cfg, id }) => {
+      const account = resolveGoHighLevelAccount({ cfg });
+      if (account.credentialSource === "none") {
+        return;
+      }
+      await sendGHLMessage({
+        account,
+        conversationId: id,
+        message: PAIRING_APPROVED_MESSAGE,
+      });
+    },
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    threads: false,
+    media: true,
+    nativeCommands: false,
+    blockStreaming: true,
+  },
+  streaming: {
+    blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+  },
+  reload: { configPrefixes: ["channels.gohighlevel"] },
+  configSchema: buildChannelConfigSchema(GoHighLevelConfigSchema),
+  config: {
+    listAccountIds: (cfg) => listGoHighLevelAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveGoHighLevelAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultGoHighLevelAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "gohighlevel",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "gohighlevel",
+        accountId,
+        clearBaseFields: [
+          "apiKey",
+          "locationId",
+          "webhookPath",
+          "webhookUrl",
+          "webhookSecret",
+          "name",
+        ],
+      }),
+    isConfigured: (account) => account.credentialSource !== "none",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveAllowFrom(resolveGoHighLevelAccount({ cfg, accountId })),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry))
+        .filter(Boolean)
+        .map(formatAllowFromEntry),
+    resolveDefaultTo: ({ cfg, accountId }) =>
+      resolveGoHighLevelAccount({ cfg, accountId }).config.defaultTo?.trim() || undefined,
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(cfg.channels?.["gohighlevel"]?.accounts?.[resolvedAccountId]);
+      const allowFromPath = useAccountPath
+        ? `channels.gohighlevel.accounts.${resolvedAccountId}.dm.`
+        : "channels.gohighlevel.dm.";
+      return {
+        policy: resolveDmPolicyValue(account),
+        allowFrom: resolveAllowFrom(account),
+        allowFromPath,
+        approveHint: formatPairingApproveHint("gohighlevel"),
+        normalizeEntry: (raw: string) => formatAllowFromEntry(raw),
+      };
+    },
+    collectWarnings: ({ account }) => {
+      const warnings: string[] = [];
+      if (resolveDmPolicyValue(account) === "open") {
+        warnings.push(
+          `- GoHighLevel DMs are open to anyone. Set channels.gohighlevel.dm.policy="pairing" or "allowlist" for tighter control.`,
+        );
+      }
+      return warnings;
+    },
+  },
+  messaging: {
+    normalizeTarget: (raw) => raw?.trim() || undefined,
+    targetResolver: {
+      looksLikeId: (raw) => Boolean(raw.trim()),
+      hint: "<contactId>",
+    },
+  },
+  directory: {
+    self: async () => null,
+    listPeers: async ({ cfg, accountId, query, limit }) => {
+      const account = resolveGoHighLevelAccount({ cfg, accountId });
+      const q = query?.trim().toLowerCase() || "";
+      const allowFromList = resolveAllowFrom(account);
+      const peers = Array.from(
+        new Set(
+          allowFromList
+            .map((entry) => String(entry).trim())
+            .filter((entry) => Boolean(entry) && entry !== "*"),
+        ),
+      )
+        .filter((id) => (q ? id.toLowerCase().includes(q) : true))
+        .slice(0, limit && limit > 0 ? limit : undefined)
+        .map((id) => ({ kind: "user" as const, id }));
+      return peers;
+    },
+  },
+  resolver: {
+    resolveTargets: async ({ inputs }) => {
+      return inputs.map((input) => {
+        const normalized = input.trim();
+        if (!normalized) {
+          return { input, resolved: false, note: "empty target" };
+        }
+        return { input, resolved: true, id: normalized };
+      });
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "gohighlevel",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "GHL_API_KEY env var can only be used for the default account.";
+      }
+      if (!input.useEnv && !input.token) {
+        return "GoHighLevel requires --token (API key).";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "gohighlevel",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({ cfg: namedConfig, channelKey: "gohighlevel" })
+          : namedConfig;
+      const patch = input.useEnv ? {} : input.token ? { apiKey: input.token } : {};
+      const locationId = input.audience?.trim();
+      const webhookPath = input.webhookPath?.trim();
+      const webhookUrl = input.webhookUrl?.trim();
+      const configPatch = {
+        ...patch,
+        ...(locationId ? { locationId } : {}),
+        ...(webhookPath ? { webhookPath } : {}),
+        ...(webhookUrl ? { webhookUrl } : {}),
+      };
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return {
+          ...next,
+          channels: {
+            ...next.channels,
+            gohighlevel: {
+              ...next.channels?.["gohighlevel"],
+              enabled: true,
+              ...configPatch,
+            },
+          },
+        } as OpenClawConfig;
+      }
+      return {
+        ...next,
+        channels: {
+          ...next.channels,
+          gohighlevel: {
+            ...next.channels?.["gohighlevel"],
+            enabled: true,
+            accounts: {
+              ...next.channels?.["gohighlevel"]?.accounts,
+              [accountId]: {
+                ...next.channels?.["gohighlevel"]?.accounts?.[accountId],
+                enabled: true,
+                ...configPatch,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => getGoHighLevelRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "markdown",
+    textChunkLimit: 1600,
+    resolveTarget: ({ to }) => {
+      const trimmed = to?.trim() ?? "";
+      if (!trimmed) {
+        return { ok: false, error: missingTargetError("GoHighLevel", "<contactId>") };
+      }
+      return { ok: true, to: trimmed };
+    },
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveGoHighLevelAccount({ cfg, accountId });
+      const result = await sendGHLMessage({
+        account,
+        conversationId: to,
+        message: text,
+      });
+      return {
+        channel: "gohighlevel",
+        messageId: result?.messageId ?? "",
+        chatId: to,
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts): ChannelStatusIssue[] =>
+      accounts.flatMap((entry) => {
+        const accountId = String(entry.accountId ?? DEFAULT_ACCOUNT_ID);
+        const enabled = entry.enabled !== false;
+        const configured = entry.configured === true;
+        if (!enabled || !configured) {
+          return [];
+        }
+        const issues: ChannelStatusIssue[] = [];
+        if (!entry.audience) {
+          issues.push({
+            channel: "gohighlevel",
+            accountId,
+            kind: "config",
+            message: "GoHighLevel locationId is missing (set channels.gohighlevel.locationId).",
+            fix: "Set channels.gohighlevel.locationId to your GHL Location ID.",
+          });
+        }
+        return issues;
+      }),
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      credentialSource: snapshot.credentialSource ?? "none",
+      webhookPath: snapshot.webhookPath ?? null,
+      running: snapshot.running ?? false,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt ?? null,
+    }),
+    probeAccount: async ({ account }) => probeGoHighLevel(account),
+    buildAccountSnapshot: ({ account, runtime, probe }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.credentialSource !== "none",
+      credentialSource: account.credentialSource,
+      audience: account.locationId,
+      webhookPath: account.config.webhookPath,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+      dmPolicy: resolveDmPolicyValue(account),
+      probe,
+    }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      ctx.log?.info(`[${account.accountId}] starting GoHighLevel webhook`);
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+        webhookPath: resolveGoHighLevelWebhookPath({ account }),
+        audience: account.locationId,
+      });
+      const unregister = await startGoHighLevelMonitor({
+        account,
+        config: ctx.cfg,
+        runtime: ctx.runtime,
+        abortSignal: ctx.abortSignal,
+        webhookPath: account.config.webhookPath,
+        webhookUrl: account.config.webhookUrl,
+        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+      });
+      // Keep the promise pending until abort (webhook mode is passive).
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      unregister?.();
+      ctx.setStatus({
+        accountId: account.accountId,
+        running: false,
+        lastStopAt: Date.now(),
+      });
+    },
+  },
+};

--- a/extensions/gohighlevel/src/config-schema.ts
+++ b/extensions/gohighlevel/src/config-schema.ts
@@ -1,0 +1,65 @@
+import {
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+  ReplyRuntimeConfigSchemaShape,
+  requireOpenAllowFrom,
+} from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+/** DM config specific to GoHighLevel (policy + allowFrom). */
+const GoHighLevelDmSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    policy: DmPolicySchema.optional().default("open"),
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .strict()
+  .optional();
+
+export const GoHighLevelAccountSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    markdown: MarkdownConfigSchema,
+    apiKey: z.string().optional(),
+    locationId: z.string().optional(),
+    webhookPath: z.string().optional(),
+    webhookUrl: z.string().optional(),
+    webhookSecret: z.string().optional(),
+    dm: GoHighLevelDmSchema,
+    dmPolicy: DmPolicySchema.optional().default("open"),
+    groupPolicy: GroupPolicySchema.optional().default("open"),
+    allowFrom: z.array(z.string()).optional(),
+    groupAllowFrom: z.array(z.string()).optional(),
+    defaultTo: z.string().optional(),
+    ...ReplyRuntimeConfigSchemaShape,
+  })
+  .strict();
+
+export const GoHighLevelAccountSchema = GoHighLevelAccountSchemaBase.superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.gohighlevel.dmPolicy="open" requires channels.gohighlevel.allowFrom to include "*"',
+  });
+});
+
+export const GoHighLevelConfigSchema = GoHighLevelAccountSchemaBase.extend({
+  accounts: z.record(z.string(), GoHighLevelAccountSchema.optional()).optional(),
+}).superRefine((value, ctx) => {
+  requireOpenAllowFrom({
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    path: ["allowFrom"],
+    message:
+      'channels.gohighlevel.dmPolicy="open" requires channels.gohighlevel.allowFrom to include "*"',
+  });
+});
+
+export type GoHighLevelAccountConfig = z.infer<typeof GoHighLevelAccountSchemaBase>;
+export type GoHighLevelConfig = z.infer<typeof GoHighLevelConfigSchema>;

--- a/extensions/gohighlevel/src/monitor.test.ts
+++ b/extensions/gohighlevel/src/monitor.test.ts
@@ -1,0 +1,192 @@
+import { createHmac } from "node:crypto";
+import { type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the runtime and API before importing
+vi.mock("./runtime.js", () => ({
+  getGoHighLevelRuntime: () => ({
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "default",
+          accountId: "default",
+          sessionKey: "test-session",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/test",
+        readSessionUpdatedAt: () => undefined,
+        recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: () => ({}),
+        formatAgentEnvelope: ({ body }: { body: string }) => body,
+        finalizeInboundContext: (ctx: Record<string, unknown>) => ctx,
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue(undefined),
+      },
+      text: {
+        chunkMarkdownText: (text: string) => [text],
+        chunkMarkdownTextWithMode: (text: string) => [text],
+        resolveChunkMode: () => "markdown",
+      },
+      pairing: {
+        buildPairingReply: () => "pairing reply",
+      },
+      media: {
+        fetchRemoteMedia: vi.fn(),
+        saveMediaBuffer: vi.fn(),
+      },
+    },
+  }),
+}));
+
+vi.mock("./api.js", () => ({
+  sendGHLMessage: vi.fn().mockResolvedValue({ messageId: "msg-1" }),
+}));
+
+// Import after mocks
+import { handleGoHighLevelWebhookRequest, registerGoHighLevelWebhookTarget } from "./monitor.js";
+
+function createMockReq(options: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}): IncomingMessage {
+  const { method = "POST", url = "/gohighlevel", headers = {}, body = "" } = options;
+  const req = {
+    method,
+    url,
+    headers: { ...headers, host: "localhost" },
+    on: vi.fn((event: string, cb: (chunk?: Buffer) => void) => {
+      if (event === "data" && body) {
+        cb(Buffer.from(body));
+      }
+      if (event === "end") {
+        cb();
+      }
+      return req;
+    }),
+    removeListener: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    destroyed: false,
+  } as unknown as IncomingMessage;
+  return req;
+}
+
+function createMockRes(): ServerResponse & { _status: number; _body: string } {
+  const res = {
+    _status: 200,
+    _body: "",
+    statusCode: 200,
+    headersSent: false,
+    setHeader: vi.fn(),
+    end: vi.fn(function (this: { _body: string }, body?: string) {
+      this._body = body ?? "";
+    }),
+  } as unknown as ServerResponse & { _status: number; _body: string };
+  Object.defineProperty(res, "statusCode", {
+    get() {
+      return res._status;
+    },
+    set(v: number) {
+      res._status = v;
+    },
+  });
+  return res;
+}
+
+describe("handleGoHighLevelWebhookRequest", () => {
+  const account = {
+    accountId: "default",
+    enabled: true,
+    config: {
+      dmPolicy: "open",
+      webhookSecret: "test-secret",
+    },
+    credentialSource: "inline" as const,
+    apiKey: "test-key",
+    locationId: "loc-123",
+  };
+
+  let unregister: () => void;
+
+  beforeEach(async () => {
+    // Register a webhook target using the actual runtime mock
+    const { getGoHighLevelRuntime } = vi.mocked(await import("./runtime.js"));
+    unregister = registerGoHighLevelWebhookTarget({
+      account: account as never,
+      config: {} as never,
+      runtime: { log: vi.fn(), error: vi.fn() },
+      core: getGoHighLevelRuntime() as never,
+      path: "/gohighlevel",
+    });
+  });
+
+  it("returns false for unregistered paths", async () => {
+    const req = createMockReq({ url: "/unknown" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("rejects non-POST requests with 405", async () => {
+    const req = createMockReq({ method: "GET" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(405);
+  });
+
+  it("rejects requests with invalid signature", async () => {
+    const body = JSON.stringify({
+      direction: "inbound",
+      contactId: "c1",
+      conversationId: "conv1",
+      body: "hello",
+    });
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": "invalid-sig" },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(401);
+  });
+
+  it("accepts requests with valid signature and returns 200", async () => {
+    const body = JSON.stringify({
+      direction: "inbound",
+      contactId: "c1",
+      conversationId: "conv1",
+      body: "hello",
+    });
+    const signature = createHmac("sha256", "test-secret").update(body).digest("hex");
+    const req = createMockReq({
+      body,
+      headers: { "x-ghl-signature": signature },
+    });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(200);
+  });
+
+  it("rejects empty body", async () => {
+    const req = createMockReq({ body: "" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(400);
+  });
+
+  it("rejects invalid JSON", async () => {
+    const req = createMockReq({ body: "not json{" });
+    const res = createMockRes();
+    const handled = await handleGoHighLevelWebhookRequest(req, res);
+    expect(handled).toBe(true);
+    expect(res._status).toBe(400);
+  });
+});

--- a/extensions/gohighlevel/src/monitor.ts
+++ b/extensions/gohighlevel/src/monitor.ts
@@ -1,0 +1,436 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import {
+  createScopedPairingAccess,
+  createReplyPrefixOptions,
+  readRequestBodyWithLimit,
+  registerWebhookTarget,
+  rejectNonPostWebhookRequest,
+  resolveWebhookPath,
+  resolveWebhookTargets,
+  requestBodyErrorToText,
+  isRequestBodyLimitError,
+} from "openclaw/plugin-sdk";
+import type { ResolvedGoHighLevelAccount } from "./accounts.js";
+import { sendGHLMessage } from "./api.js";
+import { verifyGHLSignature } from "./auth.js";
+import { getGoHighLevelRuntime } from "./runtime.js";
+import type { GHLWebhookPayload } from "./types.js";
+
+export type GoHighLevelRuntimeEnv = {
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type GoHighLevelMonitorOptions = {
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  abortSignal: AbortSignal;
+  webhookPath?: string;
+  webhookUrl?: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+type GoHighLevelCoreRuntime = ReturnType<typeof getGoHighLevelRuntime>;
+
+type WebhookTarget = {
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  path: string;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+};
+
+const webhookTargets = new Map<string, WebhookTarget[]>();
+
+function logVerbose(core: GoHighLevelCoreRuntime, runtime: GoHighLevelRuntimeEnv, message: string) {
+  if (core.logging.shouldLogVerbose()) {
+    runtime.log?.(`[gohighlevel] ${message}`);
+  }
+}
+
+export function registerGoHighLevelWebhookTarget(target: WebhookTarget): () => void {
+  return registerWebhookTarget(webhookTargets, target).unregister;
+}
+
+export async function handleGoHighLevelWebhookRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const resolved = resolveWebhookTargets(req, webhookTargets);
+  if (!resolved) {
+    return false;
+  }
+  const { targets } = resolved;
+
+  if (rejectNonPostWebhookRequest(req, res)) {
+    return true;
+  }
+
+  // Read raw body for signature verification before JSON parsing
+  let rawBody: string;
+  try {
+    rawBody = await readRequestBodyWithLimit(req, {
+      maxBytes: 1024 * 1024,
+      timeoutMs: 30_000,
+    });
+  } catch (err) {
+    if (isRequestBodyLimitError(err)) {
+      res.statusCode = 413;
+      res.end(requestBodyErrorToText("PAYLOAD_TOO_LARGE"));
+      return true;
+    }
+    res.statusCode = 400;
+    res.end("invalid request body");
+    return true;
+  }
+
+  if (!rawBody.trim()) {
+    res.statusCode = 400;
+    res.end("empty body");
+    return true;
+  }
+
+  let payload: GHLWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as GHLWebhookPayload;
+  } catch {
+    res.statusCode = 400;
+    res.end("invalid JSON");
+    return true;
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    res.statusCode = 400;
+    res.end("invalid payload");
+    return true;
+  }
+
+  // Find matching target; verify signature if webhook secret is configured
+  const signatureHeader = String(req.headers["x-ghl-signature"] ?? "");
+  let matchedTarget: WebhookTarget | null = null;
+
+  for (const target of targets) {
+    const secret = target.account.config.webhookSecret?.trim();
+    if (secret) {
+      if (!verifyGHLSignature({ signature: signatureHeader, body: rawBody, secret })) {
+        continue;
+      }
+    }
+    matchedTarget = target;
+    break;
+  }
+
+  if (!matchedTarget) {
+    res.statusCode = 401;
+    res.end("unauthorized");
+    return true;
+  }
+
+  matchedTarget.statusSink?.({ lastInboundAt: Date.now() });
+  processGHLWebhook(payload, matchedTarget).catch((err) => {
+    matchedTarget.runtime.error?.(
+      `[${matchedTarget.account.accountId}] GHL webhook failed: ${String(err)}`,
+    );
+  });
+
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end("{}");
+  return true;
+}
+
+async function processGHLWebhook(payload: GHLWebhookPayload, target: WebhookTarget) {
+  // Only process inbound messages
+  if (payload.direction !== "inbound") {
+    return;
+  }
+
+  const body = payload.body?.trim();
+  const hasAttachments = (payload.attachments?.length ?? 0) > 0;
+  const rawBody = body || (hasAttachments ? "<media:attachment>" : "");
+  if (!rawBody) {
+    return;
+  }
+
+  const contactId = payload.contactId ?? "";
+  const conversationId = payload.conversationId ?? "";
+  if (!contactId || !conversationId) {
+    return;
+  }
+
+  await processMessageWithPipeline({
+    payload,
+    rawBody,
+    account: target.account,
+    config: target.config,
+    runtime: target.runtime,
+    core: target.core,
+    statusSink: target.statusSink,
+  });
+}
+
+async function processMessageWithPipeline(params: {
+  payload: GHLWebhookPayload;
+  rawBody: string;
+  account: ResolvedGoHighLevelAccount;
+  config: OpenClawConfig;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { payload, rawBody, account, config, runtime, core, statusSink } = params;
+
+  const contactId = payload.contactId ?? "";
+  const conversationId = payload.conversationId ?? "";
+  const messageType = payload.messageType ?? "SMS";
+  const senderPhone = payload.from ?? contactId;
+  const senderName = payload.from ?? "";
+
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: "gohighlevel",
+    accountId: account.accountId,
+  });
+
+  // GHL is always DM-like (CRM conversations are 1:1 with contacts)
+  const dmPolicy = account.config.dm?.policy ?? account.config.dmPolicy ?? "open";
+
+  if (dmPolicy === "allowlist") {
+    const allowFrom = (account.config.dm?.allowFrom ?? account.config.allowFrom ?? []).map(
+      (v: string | number) => String(v),
+    );
+    const allowed = allowFrom.includes("*") || allowFrom.includes(contactId);
+    if (!allowed) {
+      logVerbose(core, runtime, `blocked GHL message from ${contactId} (allowlist)`);
+      return;
+    }
+  } else if (dmPolicy === "pairing") {
+    const storeAllowFrom: string[] = await pairing.readAllowFromStore().catch(() => []);
+    const allowed =
+      storeAllowFrom.includes("*") ||
+      storeAllowFrom.includes(contactId) ||
+      storeAllowFrom.includes(senderPhone);
+    if (!allowed) {
+      const { code, created } = await pairing.upsertPairingRequest({
+        id: contactId,
+        meta: { name: senderName || undefined, phone: senderPhone },
+      });
+      if (created) {
+        logVerbose(core, runtime, `GHL pairing request contact=${contactId}`);
+        try {
+          await sendGHLMessage({
+            account,
+            conversationId: contactId,
+            message: core.channel.pairing.buildPairingReply({
+              channel: "gohighlevel",
+              idLine: `Your GHL contact id: ${contactId}`,
+              code,
+            }),
+            messageType,
+          });
+          statusSink?.({ lastOutboundAt: Date.now() });
+        } catch (err) {
+          logVerbose(core, runtime, `pairing reply failed for ${contactId}: ${String(err)}`);
+        }
+      }
+      return;
+    }
+  }
+  // dmPolicy === "open" — allow all
+
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg: config,
+    channel: "gohighlevel",
+    accountId: account.accountId,
+    peer: { kind: "direct", id: contactId },
+  });
+
+  // Handle media attachments
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
+  if (payload.attachments && payload.attachments.length > 0) {
+    const first = payload.attachments[0];
+    if (first.url) {
+      try {
+        const maxBytes = (account.config.mediaMaxMb ?? 20) * 1024 * 1024;
+        const loaded = await core.channel.media.fetchRemoteMedia({
+          url: first.url,
+          maxBytes,
+        });
+        const saved = await core.channel.media.saveMediaBuffer(
+          loaded.buffer,
+          loaded.contentType ?? first.contentType,
+          "inbound",
+          maxBytes,
+          first.fileName,
+        );
+        mediaPath = saved.path;
+        mediaType = saved.contentType;
+      } catch (err) {
+        runtime.error?.(`GHL attachment download failed: ${String(err)}`);
+      }
+    }
+  }
+
+  const fromLabel = senderName || `contact:${contactId}`;
+  const storePath = core.channel.session.resolveStorePath(config.session?.store, {
+    agentId: route.agentId,
+  });
+  const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(config);
+  const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+  const bodyFormatted = core.channel.reply.formatAgentEnvelope({
+    channel: `GoHighLevel (${messageType})`,
+    from: fromLabel,
+    timestamp: payload.dateAdded ? Date.parse(payload.dateAdded) : undefined,
+    previousTimestamp,
+    envelope: envelopeOptions,
+    body: rawBody,
+  });
+
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: bodyFormatted,
+    BodyForAgent: rawBody,
+    RawBody: rawBody,
+    CommandBody: rawBody,
+    From: `gohighlevel:${contactId}`,
+    To: `gohighlevel:${conversationId}`,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: "direct",
+    ConversationLabel: fromLabel,
+    SenderName: senderName || undefined,
+    SenderId: contactId,
+    Provider: "gohighlevel",
+    Surface: "gohighlevel",
+    MessageSid: payload.messageId,
+    MessageSidFull: payload.messageId,
+    MediaPath: mediaPath,
+    MediaType: mediaType,
+    MediaUrl: mediaPath,
+    OriginatingChannel: "gohighlevel",
+    OriginatingTo: `gohighlevel:${conversationId}`,
+  });
+
+  void core.channel.session
+    .recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+    })
+    .catch((err) => {
+      runtime.error?.(`gohighlevel: failed updating session meta: ${String(err)}`);
+    });
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg: config,
+    agentId: route.agentId,
+    channel: "gohighlevel",
+    accountId: route.accountId,
+  });
+
+  await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx: ctxPayload,
+    cfg: config,
+    dispatcherOptions: {
+      ...prefixOptions,
+      deliver: async (replyPayload) => {
+        await deliverGHLReply({
+          payload: replyPayload,
+          account,
+          contactId,
+          conversationId,
+          messageType,
+          runtime,
+          core,
+          config,
+          statusSink,
+        });
+      },
+      onError: (err, info) => {
+        runtime.error?.(`[${account.accountId}] GHL ${info.kind} reply failed: ${String(err)}`);
+      },
+    },
+    replyOptions: { onModelSelected },
+  });
+}
+
+async function deliverGHLReply(params: {
+  payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string };
+  account: ResolvedGoHighLevelAccount;
+  contactId: string;
+  conversationId: string;
+  messageType: string;
+  runtime: GoHighLevelRuntimeEnv;
+  core: GoHighLevelCoreRuntime;
+  config: OpenClawConfig;
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const { payload, account, contactId, messageType, runtime, core, config, statusSink } = params;
+
+  if (payload.text) {
+    const chunkLimit = account.config.textChunkLimit ?? 1600;
+    const chunkMode = core.channel.text.resolveChunkMode(config, "gohighlevel", account.accountId);
+    const chunks = core.channel.text.chunkMarkdownTextWithMode(payload.text, chunkLimit, chunkMode);
+    for (const chunk of chunks) {
+      try {
+        await sendGHLMessage({
+          account,
+          conversationId: contactId,
+          message: chunk,
+          messageType,
+        });
+        statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        runtime.error?.(`GHL message send failed: ${String(err)}`);
+      }
+    }
+  }
+}
+
+export function monitorGoHighLevelProvider(options: GoHighLevelMonitorOptions): () => void {
+  const core = getGoHighLevelRuntime();
+  const webhookPath = resolveWebhookPath({
+    webhookPath: options.webhookPath,
+    webhookUrl: options.webhookUrl,
+    defaultPath: "/gohighlevel",
+  });
+  if (!webhookPath) {
+    options.runtime.error?.(`[${options.account.accountId}] invalid webhook path`);
+    return () => {};
+  }
+
+  const unregister = registerGoHighLevelWebhookTarget({
+    account: options.account,
+    config: options.config,
+    runtime: options.runtime,
+    core,
+    path: webhookPath,
+    statusSink: options.statusSink,
+  });
+
+  return unregister;
+}
+
+export async function startGoHighLevelMonitor(
+  params: GoHighLevelMonitorOptions,
+): Promise<() => void> {
+  return monitorGoHighLevelProvider(params);
+}
+
+export function resolveGoHighLevelWebhookPath(params: {
+  account: ResolvedGoHighLevelAccount;
+}): string {
+  return (
+    resolveWebhookPath({
+      webhookPath: params.account.config.webhookPath,
+      webhookUrl: params.account.config.webhookUrl,
+      defaultPath: "/gohighlevel",
+    }) ?? "/gohighlevel"
+  );
+}

--- a/extensions/gohighlevel/src/onboarding.ts
+++ b/extensions/gohighlevel/src/onboarding.ts
@@ -1,0 +1,230 @@
+import type { OpenClawConfig, DmPolicy } from "openclaw/plugin-sdk";
+import {
+  addWildcardAllowFrom,
+  formatDocsLink,
+  mergeAllowFromEntries,
+  promptAccountId,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type WizardPrompter,
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+} from "openclaw/plugin-sdk";
+import {
+  listGoHighLevelAccountIds,
+  resolveDefaultGoHighLevelAccountId,
+  resolveGoHighLevelAccount,
+} from "./accounts.js";
+
+const channel = "gohighlevel" as const;
+
+const ENV_API_KEY = "GHL_API_KEY";
+
+function setGoHighLevelDmPolicy(cfg: OpenClawConfig, policy: DmPolicy) {
+  const allowFrom =
+    policy === "open"
+      ? addWildcardAllowFrom(cfg.channels?.["gohighlevel"]?.dm?.allowFrom)
+      : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gohighlevel: {
+        ...cfg.channels?.["gohighlevel"],
+        dm: {
+          ...cfg.channels?.["gohighlevel"]?.dm,
+          policy,
+          ...(allowFrom ? { allowFrom } : {}),
+        },
+      },
+    },
+  };
+}
+
+function parseAllowFromInput(raw: string): string[] {
+  return raw
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function promptAllowFrom(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<OpenClawConfig> {
+  const current = params.cfg.channels?.["gohighlevel"]?.dm?.allowFrom ?? [];
+  const entry = await params.prompter.text({
+    message: "GoHighLevel allowFrom (contact IDs or phone numbers)",
+    placeholder: "contactId1, +15551234567",
+    initialValue: current[0] ? String(current[0]) : undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  const parts = parseAllowFromInput(String(entry));
+  const unique = mergeAllowFromEntries(undefined, parts);
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      gohighlevel: {
+        ...params.cfg.channels?.["gohighlevel"],
+        enabled: true,
+        dm: {
+          ...params.cfg.channels?.["gohighlevel"]?.dm,
+          policy: "allowlist",
+          allowFrom: unique,
+        },
+      },
+    },
+  };
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "GoHighLevel",
+  channel,
+  policyKey: "channels.gohighlevel.dm.policy",
+  allowFromKey: "channels.gohighlevel.dm.allowFrom",
+  getCurrent: (cfg) => cfg.channels?.["gohighlevel"]?.dm?.policy ?? "open",
+  setPolicy: (cfg, policy) => setGoHighLevelDmPolicy(cfg, policy),
+  promptAllowFrom,
+};
+
+function applyAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  patch: Record<string, unknown>;
+}): OpenClawConfig {
+  const { cfg, accountId, patch } = params;
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        gohighlevel: {
+          ...cfg.channels?.["gohighlevel"],
+          enabled: true,
+          ...patch,
+        },
+      },
+    };
+  }
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      gohighlevel: {
+        ...cfg.channels?.["gohighlevel"],
+        enabled: true,
+        accounts: {
+          ...cfg.channels?.["gohighlevel"]?.accounts,
+          [accountId]: {
+            ...cfg.channels?.["gohighlevel"]?.accounts?.[accountId],
+            enabled: true,
+            ...patch,
+          },
+        },
+      },
+    },
+  };
+}
+
+async function promptCredentials(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId: string;
+}): Promise<OpenClawConfig> {
+  const { cfg, prompter, accountId } = params;
+  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(process.env[ENV_API_KEY]);
+  if (envReady) {
+    const useEnv = await prompter.confirm({
+      message: "Use GHL_API_KEY env var?",
+      initialValue: true,
+    });
+    if (useEnv) {
+      return applyAccountConfig({ cfg, accountId, patch: {} });
+    }
+  }
+
+  const apiKey = await prompter.text({
+    message: "GoHighLevel API key (Private Integration Token)",
+    placeholder: "pit-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  return applyAccountConfig({
+    cfg,
+    accountId,
+    patch: { apiKey: String(apiKey).trim() },
+  });
+}
+
+async function promptLocationId(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountId: string;
+}): Promise<OpenClawConfig> {
+  const account = resolveGoHighLevelAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const currentLocation = account.locationId ?? "";
+  const locationId = await params.prompter.text({
+    message: "GoHighLevel Location ID",
+    placeholder: "xxxxxxxxxxxxxxxxxxxxxxxx",
+    initialValue: currentLocation || undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+  return applyAccountConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    patch: { locationId: String(locationId).trim() },
+  });
+}
+
+async function noteGoHighLevelSetup(prompter: WizardPrompter) {
+  await prompter.note(
+    [
+      "GoHighLevel uses a Private Integration Token for API access.",
+      "Create one in Settings > Integrations > Private Integrations.",
+      "Configure a GHL Workflow with 'Customer Replied' trigger to send webhooks.",
+      `Docs: ${formatDocsLink("/channels/gohighlevel", "channels/gohighlevel")}`,
+    ].join("\n"),
+    "GoHighLevel setup",
+  );
+}
+
+export const gohighlevelOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  dmPolicy,
+  getStatus: async ({ cfg }) => {
+    const configured = listGoHighLevelAccountIds(cfg).some(
+      (accountId) => resolveGoHighLevelAccount({ cfg, accountId }).credentialSource !== "none",
+    );
+    return {
+      channel,
+      configured,
+      statusLines: [`GoHighLevel: ${configured ? "configured" : "needs API key"}`],
+      selectionHint: configured ? "configured" : "needs auth",
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides["gohighlevel"]?.trim();
+    const defaultAccountId = resolveDefaultGoHighLevelAccountId(cfg);
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "GoHighLevel",
+        currentId: accountId,
+        listAccountIds: listGoHighLevelAccountIds,
+        defaultAccountId,
+      });
+    }
+
+    let next = cfg;
+    await noteGoHighLevelSetup(prompter);
+    next = await promptCredentials({ cfg: next, prompter, accountId });
+    next = await promptLocationId({ cfg: next, prompter, accountId });
+
+    return { cfg: next, accountId };
+  },
+};

--- a/extensions/gohighlevel/src/onboarding.ts
+++ b/extensions/gohighlevel/src/onboarding.ts
@@ -18,7 +18,7 @@ import {
 
 const channel = "gohighlevel" as const;
 
-const ENV_API_KEY = "GHL_API_KEY";
+const ENV_API_KEY_NAMES = ["GHL_API_KEY", "GHL_TOKEN"] as const;
 
 function setGoHighLevelDmPolicy(cfg: OpenClawConfig, policy: DmPolicy) {
   const allowFrom =
@@ -133,10 +133,11 @@ async function promptCredentials(params: {
   accountId: string;
 }): Promise<OpenClawConfig> {
   const { cfg, prompter, accountId } = params;
-  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(process.env[ENV_API_KEY]);
+  const envKeyName = ENV_API_KEY_NAMES.find((n) => process.env[n]?.trim());
+  const envReady = accountId === DEFAULT_ACCOUNT_ID && Boolean(envKeyName);
   if (envReady) {
     const useEnv = await prompter.confirm({
-      message: "Use GHL_API_KEY env var?",
+      message: `Use ${envKeyName} env var?`,
       initialValue: true,
     });
     if (useEnv) {

--- a/extensions/gohighlevel/src/runtime.ts
+++ b/extensions/gohighlevel/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setGoHighLevelRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getGoHighLevelRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("GoHighLevel runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/gohighlevel/src/types.ts
+++ b/extensions/gohighlevel/src/types.ts
@@ -1,0 +1,54 @@
+/** GHL webhook payload for inbound messages (InboundMessage event). */
+export type GHLWebhookPayload = {
+  type?: string;
+  locationId?: string;
+  contactId?: string;
+  conversationId?: string;
+  messageId?: string;
+  body?: string;
+  dateAdded?: string;
+  messageType?: string;
+  direction?: string;
+  status?: string;
+  contentType?: string;
+  attachments?: GHLAttachment[];
+  from?: string;
+  to?: string;
+};
+
+export type GHLAttachment = {
+  url?: string;
+  contentType?: string;
+  fileName?: string;
+};
+
+/** GHL Conversations API: send message response. */
+export type GHLSendMessageResponse = {
+  conversationId?: string;
+  messageId?: string;
+  message?: string;
+  msg?: string;
+};
+
+/** GHL contact record. */
+export type GHLContact = {
+  id?: string;
+  contactName?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  locationId?: string;
+  tags?: string[];
+};
+
+/** GHL conversation record. */
+export type GHLConversation = {
+  id?: string;
+  contactId?: string;
+  locationId?: string;
+  lastMessageBody?: string;
+  lastMessageDate?: string;
+  type?: string;
+  unreadCount?: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/gohighlevel:
+    dependencies:
+      openclaw:
+        specifier: '>=2026.1.26'
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
+
   extensions/google-gemini-cli-auth: {}
 
   extensions/googlechat:
@@ -981,15 +987,6 @@ packages:
 
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
-
-  '@google/genai@1.42.0':
-    resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@google/genai@1.43.0':
     resolution: {integrity: sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==}
@@ -6561,17 +6558,6 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
-  '@google/genai@1.42.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.43.0':
     dependencies:
       google-auth-library: 10.6.1
@@ -6919,7 +6905,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6945,7 +6931,7 @@ snapshots:
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.998.0
-      '@google/genai': 1.42.0
+      '@google/genai': 1.43.0
       '@mistralai/mistralai': 1.10.0
       '@sinclair/typebox': 0.34.48
       ajv: 8.18.0
@@ -6992,9 +6978,9 @@ snapshots:
   '@mariozechner/pi-coding-agent@0.55.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.0
+      '@mariozechner/pi-agent-core': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11

--- a/skills/gohighlevel/SKILL.md
+++ b/skills/gohighlevel/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gohighlevel
+description: Use when you need to interact with GoHighLevel CRM — look up contacts, manage conversations, book appointments, and manage pipeline opportunities.
+metadata: { "openclaw": { "emoji": "📊", "requires": { "config": ["channels.gohighlevel"] } } }
+---
+
+# GoHighLevel CRM
+
+## Overview
+
+Use curl-based API calls to interact with GoHighLevel's REST API for CRM operations: contact lookup, conversation management, calendar/appointment booking, and pipeline/opportunity management.
+
+## Authentication
+
+All requests require:
+
+- `Authorization: Bearer <GHL_API_KEY>` header
+- `Version: 2021-07-28` header
+- Base URL: `https://services.leadconnectorhq.com`
+
+The API key is the Private Integration Token configured in GHL Settings > Integrations.
+
+## Contact Management
+
+### Get a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Search contacts
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/search" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"locationId": "LOCATION_ID", "query": "John Doe", "limit": 10}'
+```
+
+### Create a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "locationId": "LOCATION_ID",
+    "firstName": "John",
+    "lastName": "Doe",
+    "email": "john@example.com",
+    "phone": "+15551234567",
+    "tags": ["new-lead"]
+  }'
+```
+
+### Update a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}" \
+  -X PUT \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"firstName": "Jane", "tags": ["updated"]}'
+```
+
+### Add tags to a contact
+
+```bash
+curl -s "https://services.leadconnectorhq.com/contacts/{contactId}/tags" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"tags": ["hot-lead", "follow-up"]}'
+```
+
+## Conversations
+
+### Send a message
+
+```bash
+curl -s "https://services.leadconnectorhq.com/conversations/messages" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "SMS",
+    "contactId": "CONTACT_ID",
+    "message": "Hello from OpenClaw!"
+  }'
+```
+
+Message types: `SMS`, `Email`, `WhatsApp`, `GMB`, `IG`, `FB`, `Custom`, `Live_Chat`.
+
+### Get conversation messages
+
+```bash
+curl -s "https://services.leadconnectorhq.com/conversations/{conversationId}/messages" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+## Calendar & Appointments
+
+### List calendars
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/?locationId=LOCATION_ID" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Get free slots
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/{calendarId}/free-slots?startDate=2026-03-01&endDate=2026-03-07" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Book an appointment
+
+```bash
+curl -s "https://services.leadconnectorhq.com/calendars/events/appointments" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "calendarId": "CALENDAR_ID",
+    "locationId": "LOCATION_ID",
+    "contactId": "CONTACT_ID",
+    "startTime": "2026-03-05T10:00:00-08:00",
+    "endTime": "2026-03-05T11:00:00-08:00",
+    "title": "Consultation",
+    "appointmentStatus": "confirmed"
+  }'
+```
+
+## Pipeline & Opportunities
+
+### List pipelines
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/pipelines?locationId=LOCATION_ID" \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28"
+```
+
+### Create an opportunity
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/" \
+  -X POST \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pipelineId": "PIPELINE_ID",
+    "locationId": "LOCATION_ID",
+    "name": "New Deal",
+    "pipelineStageId": "STAGE_ID",
+    "contactId": "CONTACT_ID",
+    "monetaryValue": 5000,
+    "status": "open"
+  }'
+```
+
+### Update an opportunity
+
+```bash
+curl -s "https://services.leadconnectorhq.com/opportunities/{opportunityId}" \
+  -X PUT \
+  -H "Authorization: Bearer $GHL_API_KEY" \
+  -H "Version: 2021-07-28" \
+  -H "Content-Type: application/json" \
+  -d '{"pipelineStageId": "NEW_STAGE_ID", "status": "won", "monetaryValue": 7500}'
+```
+
+## Important Notes
+
+- All IDs (locationId, contactId, calendarId, pipelineId) are GHL-internal identifiers.
+- The `contactId` from an inbound webhook payload maps directly to the GHL contact record.
+- SMS character limit is ~1600 characters; longer messages may be split.
+- Rate limits apply; space bulk operations with reasonable delays.

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -314,4 +314,41 @@ describe("packNpmSpecToArchive", () => {
       error: "npm pack failed: network timeout",
     });
   });
+
+  it("selects newest archive by mtime when multiple tgz files exist in cwd", async () => {
+    const cwd = await createTempDir("openclaw-install-source-utils-");
+
+    // Create an older archive first
+    const olderArchive = path.join(cwd, "openclaw-plugin-old-1.0.0.tgz");
+    await fs.writeFile(olderArchive, "old", "utf-8");
+
+    // Set the older file's mtime to 10 seconds in the past
+    const pastTime = new Date(Date.now() - 10_000);
+    await fs.utimes(olderArchive, pastTime, pastTime);
+
+    // Create a newer archive
+    const newerArchive = path.join(cwd, "openclaw-plugin-new-2.0.0.tgz");
+    await fs.writeFile(newerArchive, "new", "utf-8");
+
+    // npm pack returns empty stdout so the fallback dir scan triggers
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: " \n\n",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await packNpmSpecToArchive({
+      spec: "openclaw-plugin@2.0.0",
+      timeoutMs: 5000,
+      cwd,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Should pick the newer archive (most recent mtime)
+      expect(result.archivePath).toBe(newerArchive);
+    }
+  });
 });

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -462,6 +462,46 @@ describe("runGatewayUpdate", () => {
     ]);
   });
 
+  it("returns error when both primary and --omit=optional fallback fail", async () => {
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    await seedGlobalPackageRoot(pkgRoot);
+
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      if (key === `git -C ${pkgRoot} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === "npm root -g") {
+        return { stdout: nodeModules, stderr: "", code: 0 };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (key === "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error") {
+        return { stdout: "", stderr: "node-gyp failed", code: 1 };
+      }
+      if (
+        key === "npm i -g openclaw@latest --omit=optional --no-fund --no-audit --loglevel=error"
+      ) {
+        return { stdout: "", stderr: "permission denied", code: 1 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    const result = await runWithCommand(runCommand, { cwd: pkgRoot });
+
+    expect(result.status).toBe("error");
+    expect(result.mode).toBe("npm");
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps.map((s) => s.name)).toEqual([
+      "global update",
+      "global update (omit optional)",
+    ]);
+    expect(result.steps[0]?.exitCode).toBe(1);
+    expect(result.steps[1]?.exitCode).toBe(1);
+  });
+
   it("updates global bun installs when detected", async () => {
     const bunInstall = path.join(tempDir, "bun-install");
     await withEnvAsync({ BUN_INSTALL: bunInstall }, async () => {


### PR DESCRIPTION
## Summary

- Add GoHighLevel (GHL) channel extension (`extensions/gohighlevel/`) — webhook-based channel plugin enabling AI chatbot support across all GHL message channels (SMS, webchat, email, IG, FB, GMB)
- Add GHL agent skill (`skills/gohighlevel/SKILL.md`) with curl-based API reference for contacts, calendars, and pipeline management
- Includes HMAC-SHA256 webhook signature verification, CLI onboarding wizard, and full channel lifecycle (status, gateway, outbound)

## Test plan

- [x] `pnpm tsgo` — zero type errors
- [x] `pnpm check` — lint/format passes (including `fetchWithSsrFGuard` policy)
- [x] `pnpm test extensions/gohighlevel` — 3 test files, 18 tests, all pass (auth, accounts, monitor)
- [ ] Configure GHL webhook to point at gateway URL + `/gohighlevel` and verify end-to-end
- [ ] `openclaw channels status` shows gohighlevel channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)