### PR TITLE
fix(ui): make cron New Job panel scrollable on desktop

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -608,6 +608,16 @@
 .cron-workspace-form {
   position: sticky;
   top: 74px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+}
+
+@supports (height: 100dvh) {
+  .cron-workspace-form {
+    max-height: calc(100dvh - 90px);
+  }
 }
 
 .cron-form {
@@ -924,6 +934,9 @@
   .cron-workspace-form {
     position: static;
     order: -1;
+    max-height: none;
+    overflow: visible;
+    overscroll-behavior: auto;
   }
 
   .cron-form-grid {


### PR DESCRIPTION
## Summary
- make the Cron right-side New Job panel scrollable on desktop layouts
- keep sticky behavior while constraining panel height to viewport
- preserve existing mobile behavior by disabling panel overflow constraints on <=1100px

## User-visible / Behavior Changes
- New Job panel now scrolls internally when form content exceeds viewport height

## Repro + Verification
1. Open /ui/cron on desktop width
2. Scroll inside the New Job panel
3. Confirm sticky + internal scrolling work
4. Resize to mobile width and confirm normal page scrolling

## Files
- ui/src/styles/components.css