### PR TITLE
fix(memory): honor legacy top-level memorySearch defaults

### DIFF
--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -253,4 +253,38 @@ describe("memory search config", () => {
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expect(resolved?.sources).toContain("sessions");
   });
+
+  it("honors legacy top-level memorySearch defaults when agent defaults are absent", () => {
+    const cfg = {} as OpenClawConfig;
+    (cfg as OpenClawConfig & { memorySearch?: unknown }).memorySearch = {
+      provider: "local",
+      fallback: "none",
+      local: {
+        modelPath: "/tmp/local-model.gguf",
+      },
+    };
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+    expect(resolved?.provider).toBe("local");
+    expect(resolved?.fallback).toBe("none");
+    expect(resolved?.local.modelPath).toBe("/tmp/local-model.gguf");
+  });
+
+  it("keeps agent defaults authoritative and only fills missing fields from legacy top-level memorySearch", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+          },
+        },
+      },
+    });
+    (cfg as OpenClawConfig & { memorySearch?: unknown }).memorySearch = {
+      provider: "local",
+      fallback: "none",
+    };
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+    expect(resolved?.provider).toBe("openai");
+    expect(resolved?.fallback).toBe("none");
+  });
 });


### PR DESCRIPTION
## Summary

- **Problem:** `memory_search` could ignore an explicit local embedding preference when config consumers passed an unmigrated/raw config shape that still used top-level `memorySearch`.
- **Why it matters:** Tool/runtime behavior diverged from user intent, causing unexpected remote provider selection (for example Gemini) in real workflows.
- **What changed:** `resolveMemorySearchConfig` now merges top-level legacy `memorySearch` as fallback defaults while keeping `agents.defaults.memorySearch` authoritative; added regression tests for legacy-only config and precedence semantics.
- **What did NOT change:** Embedding provider selection order/fallback logic in `createEmbeddingProvider` was not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29318

## User-visible / Behavior Changes

- `memory_search` now respects legacy top-level memory-search defaults when runtime code receives raw/unmigrated config objects.
- Precedence is explicit: `agents.defaults.memorySearch` stays primary; legacy top-level fields only fill missing values.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: gateway `memory_search` tool path

### Steps

1. Use a config input where `memorySearch` exists only at top level (legacy shape), with `provider: "local"`.
2. Trigger memory config resolution via `memory_search` runtime path.

### Expected

- Resolved memory settings keep `provider: "local"` and do not silently fall back to `auto` due to missing nested defaults.

### Actual

- Before fix: top-level legacy defaults could be ignored by the resolver when migration was bypassed by raw config consumers.
- After fix: top-level legacy defaults are merged as fallback values; nested `agents.defaults` still wins when present.

## Evidence

- `pnpm test -- --run src/agents/memory-search.test.ts`
- `pnpm test -- --run src/agents/tools/memory-tool.citations.test.ts`

## Human Verification (required)

- Verified scenarios:
  - legacy-only top-level `memorySearch` resolves expected provider/fallback/local model fields
  - nested `agents.defaults.memorySearch` remains authoritative over legacy top-level values
- Edge cases checked:
  - no regression in existing memory tool citation behavior tests
- What I did **not** verify:
  - full end-to-end gateway run with external provider credentials on a live account

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit
- Files/config to restore: `src/agents/memory-search.ts`, `src/agents/memory-search.test.ts`
- Known bad symptoms: legacy top-level `memorySearch` would again be ignored in raw config call paths

## Risks and Mitigations

- Risk: low; change is scoped to config-merge behavior.
- Mitigation: added targeted regression tests for both compatibility and precedence.

