### PR TITLE
fix(agents): normalize catch-all tool schemas for anthropic

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { cleanSchemaForAnthropic, normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function createTool(parameters: Record<string, unknown>): AnyAgentTool {
+  return {
+    name: "test_tool",
+    description: "test",
+    parameters,
+    execute: async () => ({ content: [] }),
+  } as unknown as AnyAgentTool;
+}
+
+describe("cleanSchemaForAnthropic", () => {
+  it("replaces catch-all patternProperties with additionalProperties", () => {
+    const cleaned = cleanSchemaForAnthropic({
+      type: "object",
+      properties: {
+        fields: {
+          type: "object",
+          patternProperties: {
+            "^(.*)$": {},
+          },
+        },
+      },
+    }) as {
+      properties?: { fields?: { patternProperties?: unknown; additionalProperties?: unknown } };
+    };
+
+    expect(cleaned.properties?.fields?.patternProperties).toBeUndefined();
+    expect(cleaned.properties?.fields?.additionalProperties).toBe(true);
+  });
+
+  it("preserves non-catch-all patternProperties when present", () => {
+    const cleaned = cleanSchemaForAnthropic({
+      type: "object",
+      properties: {
+        fields: {
+          type: "object",
+          additionalProperties: false,
+          patternProperties: {
+            "^x-": { type: "string" },
+          },
+        },
+      },
+    }) as {
+      properties?: { fields?: { patternProperties?: unknown; additionalProperties?: unknown } };
+    };
+
+    expect(cleaned.properties?.fields?.patternProperties).toEqual({
+      "^x-": { type: "string" },
+    });
+    expect(cleaned.properties?.fields?.additionalProperties).toBe(false);
+  });
+});
+
+describe("normalizeToolParameters", () => {
+  it("applies anthropic schema cleaning for tool parameters", () => {
+    const tool = createTool({
+      type: "object",
+      properties: {
+        fields: {
+          type: "object",
+          patternProperties: {
+            "^(.*)$": {},
+          },
+        },
+      },
+    });
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "anthropic" });
+    const schema = normalized.parameters as {
+      properties?: { fields?: { patternProperties?: unknown; additionalProperties?: unknown } };
+    };
+
+    expect(schema.properties?.fields?.patternProperties).toBeUndefined();
+    expect(schema.properties?.fields?.additionalProperties).toBe(true);
+  });
+
+  it("cleans anthropic schemas even when they do not need structural normalization", () => {
+    const tool = createTool({
+      type: "object",
+      patternProperties: {
+        "^(.*)$": {},
+      },
+    });
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "anthropic" });
+    const schema = normalized.parameters as {
+      patternProperties?: unknown;
+      additionalProperties?: unknown;
+    };
+
+    expect(schema.patternProperties).toBeUndefined();
+    expect(schema.additionalProperties).toBe(true);
+  });
+
+  it("does not clean patternProperties for non-anthropic providers", () => {
+    const tool = createTool({
+      type: "object",
+      properties: {
+        fields: {
+          type: "object",
+          patternProperties: {
+            "^(.*)$": {},
+          },
+        },
+      },
+    });
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "openai" });
+    const schema = normalized.parameters as {
+      properties?: { fields?: { patternProperties?: unknown; additionalProperties?: unknown } };
+    };
+
+    expect(schema.properties?.fields?.patternProperties).toEqual({
+      "^(.*)$": {},
+    });
+    expect(schema.properties?.fields?.additionalProperties).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic requests can fail with `tools.*.custom.input_schema` validation errors when a tool schema contains catch-all `patternProperties` (for example `{"^(.*)$": {}}`).
- **Why it matters:** This causes hard `HTTP 400` failures for otherwise valid tool calls (reported in `#29416`) and blocks execution for Anthropic-backed sessions.
- **What changed:** Added Anthropic-specific schema normalization in `src/agents/pi-tools.schema.ts` to convert catch-all `patternProperties` into equivalent `additionalProperties`, preserved non-catch-all patterns, and applied this normalization across all provider-normalization branches. Added focused regression coverage in `src/agents/pi-tools.schema.test.ts`.
- **What did NOT change:** Gemini/OpenAI schema cleaning behavior and non-catch-all `patternProperties` semantics were not broadened or removed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29416

## User-visible / Behavior Changes

- Anthropic tool calls no longer fail when generated tool schemas include catch-all `patternProperties` shapes.
- Non-catch-all `patternProperties` entries are preserved.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev machine)
- Runtime: Node.js + pnpm monorepo tests
- Integration/channel: Anthropic provider tool schema normalization path

### Steps

1. Build/create tool schema containing catch-all `patternProperties` (e.g. `{"^(.*)$": {}}`).
2. Normalize tools for Anthropic provider and send request payload.

### Expected

- Anthropic accepts the tool schema payload and request proceeds.

### Actual

- Before fix: Anthropic may reject with `HTTP 400: tools.*.custom.input_schema`.
- After fix: catch-all pattern schema is normalized to `additionalProperties`, avoiding that validation failure.

## Evidence

- `pnpm test -- --run src/agents/pi-tools.schema.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-b.test.ts`
- `pnpm test -- --run src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`

## Human Verification (required)

- Verified scenarios: catch-all `patternProperties` conversion, preservation of non-catch-all patterns, provider-scoped normalization behavior.
- Edge cases checked: schema path that skips union flattening still gets Anthropic cleanup.
- What I did **not** verify: live Anthropic API call in an end-to-end runtime environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit on the PR branch.
- Files/config to restore: `src/agents/pi-tools.schema.ts`, remove `src/agents/pi-tools.schema.test.ts` if needed.
- Known bad symptoms: unexpected schema differences in Anthropic tool payloads.

## Risks and Mitigations

- Risk: some callers might rely on catch-all `patternProperties` being serialized exactly as-is.
- Mitigation: transformation is limited to Anthropic provider path and preserves non-catch-all patterns.
