### PR TITLE
fix(release): enforce lane floor for calver appcast entries

### DIFF
--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { collectAppcastSparkleVersionErrors } from "../scripts/release-check.ts";
+
+function makeItem(shortVersion: string, sparkleVersion: string): string {
+  return `<item><title>${shortVersion}</title><sparkle:shortVersionString>${shortVersion}</sparkle:shortVersionString><sparkle:version>${sparkleVersion}</sparkle:version></item>`;
+}
+
+describe("collectAppcastSparkleVersionErrors", () => {
+  it("accepts legacy 9-digit calver builds before lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.26", "202602260")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([]);
+  });
+
+  it("requires lane-floor builds on and after lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.27", "202602270")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([
+      "appcast item '2026.2.27' has sparkle:version 202602270 below lane floor 2026022790.",
+    ]);
+  });
+
+  it("accepts canonical stable lane builds on and after lane-floor cutover", () => {
+    const xml = `<rss><channel>${makeItem("2026.2.27", "2026022790")}</channel></rss>`;
+
+    expect(collectAppcastSparkleVersionErrors(xml)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce lane-floor validation for calver appcast items starting at the packaging cutover date (`2026.2.27`) even when appcast is still all 9-digit
- keep observed 10-digit adoption support by using the earlier of observed adoption date and cutover date
- extract appcast sparkle validation into a pure function so regression scenarios are unit-testable

## Testing
- pnpm vitest run test/release-check.test.ts
- pnpm release:check
