### PR TITLE
fix(bluebubbles): prefer private API for plain sends

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -448,6 +448,25 @@ describe("send", () => {
       expect(body.method).toBeUndefined();
     });
 
+    it("uses private-api for plain sends when private API is enabled", async () => {
+      mockBlueBubblesPrivateApiStatusOnce(
+        privateApiStatusMock,
+        BLUE_BUBBLES_PRIVATE_API_STATUS.enabled,
+      );
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-private-plain" } });
+
+      const result = await sendMessageBlueBubbles("+15551234567", "Hello world!", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      expect(result.messageId).toBe("msg-uuid-private-plain");
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.method).toBe("private-api");
+    });
+
     it("strips markdown formatting from outbound messages", async () => {
       mockResolvedHandleTarget();
       mockSendResponse({ data: { guid: "msg-uuid-stripped" } });

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -87,11 +87,11 @@ function resolvePrivateApiDecision(params: {
   wantsEffect: boolean;
 }): PrivateApiDecision {
   const { privateApiStatus, wantsReplyThread, wantsEffect } = params;
-  const needsPrivateApi = wantsReplyThread || wantsEffect;
-  const canUsePrivateApi =
-    needsPrivateApi && isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const needsPrivateApiFeatures = wantsReplyThread || wantsEffect;
+  // Prefer Private API for all sends when we know it is available.
+  const canUsePrivateApi = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
   const throwEffectDisabledError = wantsEffect && privateApiStatus === false;
-  if (!needsPrivateApi || privateApiStatus !== null) {
+  if (!needsPrivateApiFeatures || privateApiStatus !== null) {
     return { canUsePrivateApi, throwEffectDisabledError };
   }
   const requested = [


### PR DESCRIPTION
## Summary

- Problem: plain BlueBubbles messages omitted `method=private-api`, so BlueBubbles could fall back to AppleScript.
- Why it matters: on macOS Tahoe, AppleScript delivery can fail, breaking auto-replies even when Private API is healthy.
- What changed: send logic now uses Private API for all sends when cached status is enabled; added regression test for plain-message path.
- What did NOT change (scope boundary): unknown/disabled status handling for reply threading and effects remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29389
- Related #

## User-visible / Behavior Changes

- When BlueBubbles Private API status is `enabled`, plain text sends now include `method=private-api`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm monorepo
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): BlueBubbles account with server URL/password

### Steps

1. Mock resolved BlueBubbles chat target and cached Private API status as `enabled`.
2. Call `sendMessageBlueBubbles(..., "Hello world!")` without reply/effect options.
3. Inspect outbound `/api/v1/message/text` payload.

### Expected

- Payload includes `method: "private-api"` for plain sends.

### Actual

- Payload now includes `method: "private-api"` when status is enabled.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm vitest run extensions/bluebubbles/src/send.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: plain send with status `enabled` now sets `method=private-api`.
- Edge cases checked: default unknown status still avoids forced private-only metadata paths.
- What you did **not** verify: live Tahoe + BlueBubbles instance end-to-end send.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `extensions/bluebubbles/src/send.ts` and related test.
- Known bad symptoms reviewers should watch for: plain sends unexpectedly fail if BlueBubbles rejects `private-api` despite enabled status.

## Risks and Mitigations

- Risk: status cache could be stale and mark Private API enabled when server state changed.
  - Mitigation: existing status probe/refresh path remains; unknown status behavior unchanged.