### PR TITLE
fix(agents): warn when bootstrap files live in agentDir

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -91,6 +91,7 @@ export async function runCliAgent(params: {
     config: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
+    agentId: params.agentId,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
   });
   const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -359,6 +359,8 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      agentId: params.agentId,
+      agentDir,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -474,6 +474,7 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
     });
 
+    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
       await resolveBootstrapContextForRun({
@@ -481,6 +482,8 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        agentId: params.agentId,
+        agentDir,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(
@@ -488,8 +491,6 @@ export async function runEmbeddedAttempt(
     )
       ? ["Reminder: commit your changes in this workspace after edits."]
       : undefined;
-
-    const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 
     const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
       sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -33,6 +33,7 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    agentId: params.agentId,
   });
   const skillsSnapshot = (() => {
     try {


### PR DESCRIPTION
## Summary

- Problem: users can place `SOUL.md`/`AGENTS.md`/etc in per-agent `agentDir`, but those files are ignored silently because bootstrap injection reads only workspace files.
- Why it matters: this creates a hidden safety/config gap in multi-agent setups, especially when users think agent-specific guardrails are active.
- What changed: bootstrap resolution now detects bootstrap-named files under `agentDir` and emits an explicit warning; agent context (`agentId`/`agentDir`) is threaded through major run paths.
- What did NOT change (scope boundary): bootstrap files are still sourced from workspace only; this PR adds diagnostics, not per-agent bootstrap override semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29387
- Related #

## User-visible / Behavior Changes

- Runtime logs now warn when bootstrap filenames are found in `agentDir` because they are not injected into system prompt context from there.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm monorepo
- Model/provider: N/A
- Integration/channel (if any): agent runtime/bootstrap
- Relevant config (redacted): multi-agent config with per-agent `agentDir`

### Steps

1. Create a workspace dir and a separate agentDir.
2. Put `SOUL.md` in agentDir and run bootstrap resolution with warning callback.
3. Inspect warnings emitted by resolver.

### Expected

- Warning explicitly states bootstrap files in agentDir are ignored for prompt injection.

### Actual

- Resolver now emits a warning listing ignored filenames and both paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm vitest run src/agents/bootstrap-files.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/cli-runner.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: warning appears when bootstrap files exist under agentDir; no warning when agentDir equals workspaceDir.
- Edge cases checked: existing malformed-hook warnings remain unchanged.
- What you did **not** verify: full end-to-end interactive runtime logs across every launcher path.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/agents/bootstrap-files.ts` and propagated callsites.
- Known bad symptoms reviewers should watch for: unexpected warning noise in sessions without actual agentDir bootstrap files.

## Risks and Mitigations

- Risk: added diagnostics could be noisy for users intentionally storing markdown in agentDir.
  - Mitigation: warning is specific to recognized bootstrap filenames and clearly explains remediation.