### PR TITLE
fix(agents): load bootstrap files from agentDir to allow per-agent overrides

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -79,6 +80,59 @@ describe("resolveBootstrapFilesForRun", () => {
     ).toBe(true);
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
+  });
+});
+
+describe("resolveBootstrapFilesForRun agentDir overrides", () => {
+  it("prefers agentDir SOUL.md over workspace SOUL.md when agentDir is configured", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.missing).toBe(false);
+    expect(soul?.content).toBe("agentdir soul");
+  });
+
+  it("falls back to workspace file when agentDir does not contain an override", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace agents", "utf-8");
+    // agentDir has no AGENTS.md
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+
+    const agents = files.find((f) => f.name === "AGENTS.md");
+    expect(agents?.missing).toBe(false);
+    expect(agents?.content).toBe("workspace agents");
+  });
+
+  it("skips agentDir lookup when agentId is not provided", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.content).toBe("workspace soul");
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentDir } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -66,6 +67,23 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionId: params.sessionId,
     agentId: params.agentId,
   });
+
+  // When an agentDir is configured for this agent, load bootstrap files from
+  // that directory and let them override the shared workspace copies. This
+  // allows per-agent customisation (e.g. a distinct SOUL.md or AGENTS.md)
+  // without touching the shared workspace directory.
+  if (params.agentId && params.config) {
+    const agentDir = resolveAgentDir(params.config, params.agentId);
+    const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);
+    const overrides = new Map(agentDirFiles.filter((f) => !f.missing).map((f) => [f.name, f]));
+    if (overrides.size > 0) {
+      return sanitizeBootstrapFiles(
+        updated.map((f) => overrides.get(f.name) ?? f),
+        params.warn,
+      );
+    }
+  }
+
   return sanitizeBootstrapFiles(updated, params.warn);
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -475,12 +475,18 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
+    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: params.sessionKey,
+      config: params.config,
+      agentId: params.agentId,
+    });
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
       await resolveBootstrapContextForRun({
         workspaceDir: effectiveWorkspace,
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        agentId: sessionAgentId,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(
@@ -490,12 +496,6 @@ export async function runEmbeddedAttempt(
       : undefined;
 
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-
-    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-      agentId: params.agentId,
-    });
     const effectiveFsWorkspaceOnly = resolveAttemptFsWorkspaceOnly({
       config: params.config,
       sessionAgentId,


### PR DESCRIPTION
## Summary

Fixes #29387

When a per-agent `agentDir` is configured in the agents list, bootstrap files placed there (`SOUL.md`, `AGENTS.md`, `TOOLS.md`, `USER.md`, etc.) were silently ignored. Only the shared `workspace` directory was searched, making it impossible to customise an agent's system prompt context without modifying the shared workspace.

## Root Cause

`resolveBootstrapFilesForRun` already accepted an `agentId` parameter and forwarded it to `applyBootstrapHookOverrides`, but never used it to resolve and check the `agentDir` configured for that agent. The `resolveAgentDir` helper existed but was not called from the bootstrap loading path.

Additionally, the primary call site in `runAgentAttempt` (attempt.ts) called `resolveBootstrapContextForRun` without passing `agentId` because `sessionAgentId` was computed after the bootstrap call.

## Fix

**`bootstrap-files.ts`** — after applying hook overrides, resolve `agentDir` via `resolveAgentDir(config, agentId)` when both are available. Load bootstrap files from `agentDir` using the existing `loadWorkspaceBootstrapFiles` helper. Non-missing `agentDir` files override the corresponding workspace files; absent files fall back to the workspace copy transparently.

**`attempt.ts`** — move the `resolveSessionAgentIds` call before `resolveBootstrapContextForRun` so the resolved `sessionAgentId` can be passed as `agentId`, enabling the agentDir lookup.

## Changes

- `src/agents/bootstrap-files.ts`: import `resolveAgentDir`; add agentDir override logic after hook application
- `src/agents/pi-embedded-runner/run/attempt.ts`: hoist `resolveSessionAgentIds` before bootstrap context resolution; pass `agentId: sessionAgentId`
- `src/agents/bootstrap-files.test.ts`: three new tests covering agentDir override, workspace fallback, and no-agentId bypass