### PR TITLE
fix(tui): ignore setRawMode EBADF during SIGTERM shutdown

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCtrlCAction,
   resolveFinalAssistantText,
   resolveGatewayDisconnectState,
+  shouldIgnoreTuiStopError,
   resolveTuiSessionKey,
 } from "./tui.js";
 
@@ -148,5 +149,18 @@ describe("resolveCtrlCAction", () => {
       action: "warn",
       nextLastCtrlCAt: 3501,
     });
+  });
+});
+
+describe("shouldIgnoreTuiStopError", () => {
+  it("ignores setRawMode EBADF errors during shutdown", () => {
+    const err = new Error("setRawMode EBADF") as Error & { code?: string };
+    err.code = "EBADF";
+    expect(shouldIgnoreTuiStopError(err)).toBe(true);
+  });
+
+  it("does not ignore unrelated errors", () => {
+    expect(shouldIgnoreTuiStopError(new Error("socket closed"))).toBe(false);
+    expect(shouldIgnoreTuiStopError("setRawMode EBADF")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: TUI shutdown on SIGTERM can throw `setRawMode EBADF` from pi-tui when stdin fd is already invalid.
- Why it matters: this uncaught exception crashes the process during shutdown and causes noisy terminal behavior.
- What changed: added a targeted shutdown guard that ignores known `setRawMode EBADF` stop errors.
- What did NOT change (scope boundary): normal TUI lifecycle and non-EBADF stop errors are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29430
- Related #

## User-visible / Behavior Changes

- SIGTERM-driven TUI exits no longer crash on known `setRawMode EBADF` shutdown races.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + pnpm monorepo
- Model/provider: N/A
- Integration/channel (if any): TUI process shutdown
- Relevant config (redacted): default TUI startup

### Steps

1. Simulate `tui.stop()` throwing `setRawMode EBADF` in exit path.
2. Evaluate shutdown guard behavior.
3. Run TUI unit tests.

### Expected

- Known EBADF raw-mode errors are ignored on shutdown.

### Actual

- Guard now suppresses expected EBADF shutdown race while keeping unrelated errors non-ignored.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm vitest run src/tui/tui.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `shouldIgnoreTuiStopError` returns true for `setRawMode EBADF` and false for unrelated errors.
- Edge cases checked: message-only EBADF matching and code-based matching.
- What you did **not** verify: long-duration live macOS terminal session reproducing SIGTERM race end-to-end.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/tui/tui.ts` and `src/tui/tui.test.ts`.
- Known bad symptoms reviewers should watch for: shutdown path still throwing uncaught TTY errors.

## Risks and Mitigations

- Risk: over-broad error suppression during shutdown.
  - Mitigation: guard only matches explicit `setRawMode EBADF` signature.