### PR TITLE
fix(feishu): prevent duplicate dispatch for concurrent same message_id events

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -944,4 +944,39 @@ describe("handleFeishuMessage command authorization", () => {
       }),
     );
   });
+
+  it("does not dispatch twice for the same image message_id (regression #28574)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-image-dedup",
+        },
+      },
+      message: {
+        message_id: "msg-image-dedup-28574",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "image",
+        content: JSON.stringify({
+          image_key: "img_dedup_payload",
+        }),
+      },
+    };
+
+    // Dispatch same image event twice concurrently to simulate rapid event delivery
+    await Promise.all([dispatchMessage({ cfg, event }), dispatchMessage({ cfg, event })]);
+
+    // Only one dispatch should occur despite receiving the same image message_id twice
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -13,7 +13,7 @@ import {
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
-import { tryRecordMessagePersistent } from "./dedup.js";
+import { tryRecordMessage, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { downloadMessageResourceFeishu } from "./media.js";
@@ -698,8 +698,15 @@ export async function handleFeishuMessage(params: {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
 
-  // Dedup check: skip if this message was already processed (memory + disk).
+  // Dedup: synchronous memory guard prevents concurrent duplicate dispatch
+  // (e.g. audio/image events retried before the async persistent check completes).
   const messageId = event.message.message_id;
+  const memoryDedupeKey = `${account.accountId}:${messageId}`;
+  if (!tryRecordMessage(memoryDedupeKey)) {
+    log(`feishu: skipping duplicate message ${messageId} (memory dedup)`);
+    return;
+  }
+  // Persistent dedup survives process restarts and WebSocket reconnects.
   if (!(await tryRecordMessagePersistent(messageId, account.accountId, log))) {
     log(`feishu: skipping duplicate message ${messageId}`);
     return;


### PR DESCRIPTION
## Summary

Fixes a race in Feishu message handling where the same `message_id` can be processed twice under concurrent delivery (e.g. image-related event paths), causing duplicate agent replies.

## Root cause

`handleFeishuMessage` previously relied on async persistent dedup (`tryRecordMessagePersistent`) only.
When two handlers for the same `message_id` enter concurrently, both can pass before the first async write completes.

## What changed

- Added a synchronous in-memory dedup guard before the async persistent dedup check.
- Keyed the memory guard by `${accountId}:${messageId}` to avoid cross-account collisions.
- Kept persistent dedup intact for restart/reconnect durability.
- Added regression test for issue #28574:
  - concurrent duplicate image events with the same `message_id` should dispatch exactly once.

## Files changed

- `extensions/feishu/src/bot.ts`
- `extensions/feishu/src/bot.test.ts`

## Why this is safe

- Minimal, localized change in Feishu channel only.
- No behavior change for unique messages.
- Existing persistent dedup path remains unchanged.

## Testing

- `pnpm exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts`
- `pnpm exec vitest run extensions/feishu/src/bot.test.ts`
- Manual Feishu validation:
  - mixed text+image message responds once ✅
  - multi-image sends are split by Feishu into multiple distinct messages (each one response, expected) ✅

## AI-assisted transparency

- AI-assisted implementation and review (OpenClaw + Claude Code)
- Final patch reviewed and validated manually

Closes #28574.
