### PR TITLE
fix(gateway): honor message channel header in openai chat

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -133,6 +133,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
             sessionKey?: string;
             message?: string;
             extraSystemPrompt?: string;
+            messageChannel?: string;
           }
         | undefined;
     const getFirstAgentMessage = () => getFirstAgentCall()?.message ?? "";
@@ -202,6 +203,29 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect((opts as { sessionKey?: string } | undefined)?.sessionKey).toBe(
           "agent:beta:openai:custom",
         );
+        await res.text();
+      }
+
+      {
+        mockAgentOnce([{ text: "hello" }]);
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-message-channel": "custom-client-channel" },
+        );
+        expect(res.status).toBe(200);
+        expect(getFirstAgentCall()?.messageChannel).toBe("custom-client-channel");
+        await res.text();
+      }
+
+      {
+        mockAgentOnce([{ text: "hello" }]);
+        const res = await postChatCompletions(port, {
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(res.status).toBe(200);
+        expect(getFirstAgentCall()?.messageChannel).toBe("webchat");
         await res.text();
       }
 


### PR DESCRIPTION
## Summary

- **Problem:** `/v1/chat/completions` always set `messageChannel` to `webchat`, ignoring `x-openclaw-message-channel`.
- **Why it matters:** Custom HTTP clients cannot identify themselves by channel, and behavior differs from `/v1/tools/*`.
- **What changed:** The OpenAI-compatible chat path now reads `x-openclaw-message-channel`, normalizes it, and falls back to `webchat` only when missing/empty. Added e2e tests for header and fallback behavior.
- **What did NOT change:** Session-key resolution and OpenAI response payload structure.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29449

## User-visible / Behavior Changes

- `/v1/chat/completions` now honors `x-openclaw-message-channel` when setting command `messageChannel`.
- If header is absent/empty, behavior remains `webchat`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: OpenAI-compatible HTTP endpoint

### Steps

1. POST `/v1/chat/completions` with header `x-openclaw-message-channel: custom-client-channel`.
2. Inspect the command input used by `agentCommand`.

### Expected

- `messageChannel` equals `custom-client-channel`.

### Actual

- Before fix: `messageChannel` was always `webchat`.
- After fix: header value is respected, fallback remains `webchat`.

## Evidence

- `pnpm vitest run src/gateway/openai-http.test.ts`
- Added assertions in `openai-http.test.ts` for both custom header and default fallback.

## Human Verification (required)

- Verified scenarios: custom header value, missing header fallback.
- Edge cases checked: header normalization via existing `normalizeMessageChannel` path.
- What I did **not** verify: full end-to-end behavior with every third-party client.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/gateway/openai-http.ts`, `src/gateway/openai-http.test.ts`.
- Known bad symptoms: custom channel IDs being mapped unexpectedly.

## Risks and Mitigations

- Risk: unexpected channel normalization for unusual custom IDs.
- Mitigation: reused shared normalization and explicit fallback test coverage.

