### PR TITLE
fix(auto-reply): pass sessionKey through outbound delivery routing

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -384,6 +384,7 @@ describe("routeReply", () => {
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
+        sessionKey: "agent:main:main",
         mirror: expect.objectContaining({
           sessionKey: "agent:main:main",
           text: "hi",
@@ -404,6 +405,7 @@ describe("routeReply", () => {
     });
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
+        sessionKey: "agent:main:main",
         mirror: undefined,
       }),
     );

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -127,6 +127,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      sessionKey: params.sessionKey,
       payloads: [normalized],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,


### PR DESCRIPTION
## Summary

- **Problem:** Auto-reply routing did not pass top-level `sessionKey` into `deliverOutboundPayloads`, so `message:sent` internal hooks could be skipped when mirror mode was disabled.
- **Why it matters:** Bundled and custom internal hooks relying on outbound `message:sent` events miss sends from this path.
- **What changed:** `routeReply` now forwards `sessionKey` directly to outbound delivery in addition to mirror metadata. Tests assert the value is present both with mirror enabled and disabled.
- **What did NOT change:** Channel routing logic, payload normalization, and mirror opt-in/out behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29203

## User-visible / Behavior Changes

- Internal `message:sent` hooks now receive the session context for auto-reply routed sends even when mirror is off.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: auto-reply outbound routing

### Steps

1. Trigger `routeReply` with `sessionKey` and `mirror: false`.
2. Inspect `deliverOutboundPayloads` call arguments.

### Expected

- `sessionKey` is present in the outbound delivery call.

### Actual

- Before fix: only mirror carried session info; with mirror disabled, top-level session key was absent.
- After fix: `sessionKey` is forwarded consistently.

## Evidence

- `pnpm vitest run src/auto-reply/reply/route-reply.test.ts`
- Added expectations for `sessionKey` propagation in mirror-on and mirror-off cases.

## Human Verification (required)

- Verified scenarios: mirror enabled, mirror disabled.
- Edge cases checked: no change to mirror payload contents.
- What I did **not** verify: full integration with every internal hook implementation.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/route-reply.ts`, `src/auto-reply/reply/route-reply.test.ts`.
- Known bad symptoms: duplicate or missing hook events in custom setups.

## Risks and Mitigations

- Risk: duplicate context pathways (mirror + sessionKey) could be misread by custom code.
- Mitigation: this change only adds missing top-level session context; mirror semantics are unchanged.

