### PR TITLE
fix(hooks): ignore timeout text when generating memory slugs

### DIFF
--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  runEmbeddedPiAgent: vi.fn(),
+  resolveAgentEffectiveModelPrimary: vi.fn(),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw-workspace",
+  resolveAgentDir: () => "/tmp/openclaw-agent",
+  resolveAgentEffectiveModelPrimary: (...args: unknown[]) =>
+    mocks.resolveAgentEffectiveModelPrimary(...args),
+}));
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: (...args: unknown[]) => mocks.runEmbeddedPiAgent(...args),
+}));
+
+const { generateSlugViaLLM } = await import("./llm-slug-generator.js");
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    mocks.runEmbeddedPiAgent.mockReset();
+    mocks.resolveAgentEffectiveModelPrimary.mockReset();
+    mocks.resolveAgentEffectiveModelPrimary.mockReturnValue(undefined);
+  });
+
+  const cfg = {} as OpenClawConfig;
+
+  it("normalizes a short model response into slug format", async () => {
+    mocks.runEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [{ text: "Vendor Pitch" }],
+    });
+
+    const slug = await generateSlugViaLLM({
+      sessionContent: "conversation",
+      cfg,
+    });
+
+    expect(slug).toBe("vendor-pitch");
+  });
+
+  it("ignores timeout/error text responses from the model", async () => {
+    mocks.runEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [{ text: "request timed out before a response" }],
+    });
+
+    const slug = await generateSlugViaLLM({
+      sessionContent: "conversation",
+      cfg,
+    });
+
+    expect(slug).toBeNull();
+  });
+
+  it("accepts prefixed slug labels and strips the prefix", async () => {
+    mocks.runEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [{ text: "slug: bug-fix" }],
+    });
+
+    const slug = await generateSlugViaLLM({
+      sessionContent: "conversation",
+      cfg,
+    });
+
+    expect(slug).toBe("bug-fix");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `/new` could write malformed memory filenames like `YYYY-MM-DD-request-timed-out-before-a-res.md` when slug generation received timeout/error text.
- **Why it matters:** Housekeeping files become noisy and misleading; users see broken-looking memory filenames after slow model runs.
- **What changed:** Slug extraction now accepts only strict 1-2 word slug-shaped responses and rejects timeout/validation/internal error sentences. Added focused unit tests for valid slugs, timeout text rejection, and prefixed slug parsing.
- **What did NOT change:** Session-memory hook write flow and fallback timestamp behavior when slug generation returns null.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29445

## User-visible / Behavior Changes

- Timeout/error text from slug LLM calls no longer becomes part of memory filenames.
- `/new` falls back cleanly to timestamp slug when slug output is not valid.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: hooks/session-memory

### Steps

1. Simulate slug-generation model output as `request timed out before a response`.
2. Run slug normalization via `generateSlugViaLLM`.

### Expected

- Invalid timeout sentence is rejected (`null`) so fallback timestamp naming is used.

### Actual

- Before fix: timeout sentence was sanitized into a malformed slug.
- After fix: timeout/error sentence is ignored.

## Evidence

- `pnpm vitest run src/hooks/llm-slug-generator.test.ts src/hooks/bundled/session-memory/handler.test.ts`
- New tests in `src/hooks/llm-slug-generator.test.ts`.

## Human Verification (required)

- Verified scenarios: normal slug text, timeout text, `slug:`-prefixed text.
- Edge cases checked: strict 1-2 word constraint and sanitizer behavior.
- What I did **not** verify: full live `/new` flow against every external model provider.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/hooks/llm-slug-generator.ts`, `src/hooks/llm-slug-generator.test.ts`.
- Known bad symptoms: slug generation falling back to timestamps more often.

## Risks and Mitigations

- Risk: stricter parsing may reject some verbose but usable model responses.
- Mitigation: timestamp fallback remains in place and is deterministic.

