### PR TITLE
fix(subagents): raise sessions_spawn gateway timeout budget

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.gateway-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.gateway-timeout.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const callGatewayMock = getCallGatewayMock();
+
+describe("sessions_spawn gateway timeout", () => {
+  beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockClear();
+  });
+
+  it("uses a 30s gateway timeout for spawn setup and dispatch calls", async () => {
+    const requests: Array<{ method?: string; timeoutMs?: number }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; timeoutMs?: number };
+      requests.push(request);
+      if (request.method === "agent") {
+        return { runId: "run-timeout", status: "accepted" };
+      }
+      return { ok: true };
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-timeout", {
+      task: "do thing",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-timeout",
+    });
+
+    const spawnRequests = requests.filter(
+      (request) => request.method === "sessions.patch" || request.method === "agent",
+    );
+    expect(spawnRequests.length).toBeGreaterThan(0);
+    expect(spawnRequests.every((request) => request.timeoutMs === 30_000)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `sessions_spawn` control-plane gateway calls used a hardcoded 10s timeout, which is too tight under embedded mode/load and can fail subagent spawn.
- **Why it matters:** Subagent orchestration becomes flaky; callers get timeout errors instead of spawned runs.
- **What changed:** Raised `sessions_spawn` gateway call timeout budget from 10s to 30s for setup/dispatch calls in spawn flow, and added a focused test to ensure the new timeout budget is used.
- **What did NOT change:** `runTimeoutSeconds` semantics, subagent lifecycle logic, and agent wait/polling behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29186

## User-visible / Behavior Changes

- `sessions_spawn` is less likely to fail during busy gateway periods due to longer gateway timeout budget.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: subagent sessions spawn tool

### Steps

1. Trigger `sessions_spawn` under mocked gateway calls.
2. Inspect outbound `callGateway` options for `sessions.patch` and `agent`.

### Expected

- Spawn setup/dispatch calls use a 30s timeout budget.

### Actual

- Before fix: hardcoded 10s.
- After fix: 30s is applied consistently.

## Evidence

- `pnpm vitest run src/agents/openclaw-tools.subagents.sessions-spawn.gateway-timeout.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- New assertion in `openclaw-tools.subagents.sessions-spawn.gateway-timeout.test.ts`.

## Human Verification (required)

- Verified scenarios: spawn setup and dispatch timeout values.
- Edge cases checked: existing model/thinking spawn tests still pass.
- What I did **not** verify: live overloaded gateway behavior in Docker/remote deployment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/agents/subagent-spawn.ts`, new timeout test file.
- Known bad symptoms: slower failure reporting if gateway is fully unavailable.

## Risks and Mitigations

- Risk: longer timeout can delay error return in hard-failure cases.
- Mitigation: timeout remains bounded and only changes spawn control-plane calls.

