### PR TITLE
fix(plugins): allow bundled hardlinked plugin files

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -78,7 +78,6 @@ describe("createFeishuWSClient proxy handling", () => {
 
   it("prefers HTTPS proxy vars over HTTP proxy vars across runtimes", () => {
     process.env.https_proxy = "http://lower-https:8001";
-    process.env.HTTPS_PROXY = "http://upper-https:8002";
     process.env.http_proxy = "http://lower-http:8003";
     process.env.HTTP_PROXY = "http://upper-http:8004";
 
@@ -90,6 +89,18 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith(expectedHttpsProxy);
     const options = firstWsClientOptions();
     expect(options.agent).toEqual({ proxyUrl: expectedHttpsProxy });
+  });
+
+  it("uses HTTPS_PROXY when https_proxy is unset", () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.http_proxy = "http://lower-http:8003";
+
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://upper-https:8002");
+    const options = firstWsClientOptions();
+    expect(options.agent).toEqual({ proxyUrl: "http://upper-https:8002" });
   });
 
   it("passes HTTP_PROXY to ws client when https vars are unset", () => {

--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -26,6 +26,7 @@ describe("parsePostContent", () => {
       "Daily \\*Plan\\*\n\n**Bold** *Italic* <u>Underline</u> ~~Strike~~ `Code`",
     );
     expect(result.imageKeys).toEqual([]);
+    expect(result.mediaKeys).toEqual([]);
     expect(result.mentionedOpenIds).toEqual([]);
   });
 
@@ -50,6 +51,7 @@ describe("parsePostContent", () => {
     expect(result.textContent).toBe(
       "[Docs \\[v2\\]](https://example.com/guide(a)) @alice\\_bob @ou\\_123 [https://example.com/no\\-text](https://example.com/no-text)",
     );
+    expect(result.mediaKeys).toEqual([]);
     expect(result.mentionedOpenIds).toEqual(["ou_123"]);
   });
 
@@ -70,6 +72,7 @@ describe("parsePostContent", () => {
 
     expect(result.textContent).toBe("Before ![image] after\n![image]");
     expect(result.imageKeys).toEqual(["img_1", "img_2"]);
+    expect(result.mediaKeys).toEqual([]);
     expect(result.mentionedOpenIds).toEqual([]);
   });
 

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -10,6 +10,7 @@ vi.mock("./discovery.js", () => ({
 
 vi.mock("./manifest.js", () => ({
   loadPluginManifest: (...args: unknown[]) => loadPluginManifestMock(...args),
+  shouldRejectHardlinkedPluginFiles: (origin: string) => origin !== "bundled",
 }));
 
 describe("bundled plugin sources", () => {
@@ -66,6 +67,12 @@ describe("bundled plugin sources", () => {
     const map = resolveBundledPluginSources({});
 
     expect(Array.from(map.keys())).toEqual(["feishu", "msteams"]);
+    expect(loadPluginManifestMock).toHaveBeenCalledWith("/app/extensions/feishu", {
+      rejectHardlinks: false,
+    });
+    expect(loadPluginManifestMock).toHaveBeenCalledWith("/app/extensions/msteams", {
+      rejectHardlinks: false,
+    });
     expect(map.get("feishu")).toEqual({
       pluginId: "feishu",
       localPath: "/app/extensions/feishu",

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -1,5 +1,5 @@
 import { discoverOpenClawPlugins } from "./discovery.js";
-import { loadPluginManifest } from "./manifest.js";
+import { loadPluginManifest, shouldRejectHardlinkedPluginFiles } from "./manifest.js";
 
 export type BundledPluginSource = {
   pluginId: string;
@@ -17,7 +17,9 @@ export function resolveBundledPluginSources(params: {
     if (candidate.origin !== "bundled") {
       continue;
     }
-    const manifest = loadPluginManifest(candidate.rootDir);
+    const manifest = loadPluginManifest(candidate.rootDir, {
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
+    });
     if (!manifest.ok) {
       continue;
     }

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -26,6 +26,18 @@ async function withStateDir<T>(stateDir: string, fn: () => Promise<T>) {
   );
 }
 
+async function withBundledDir<T>(bundledDir: string, fn: () => Promise<T>) {
+  const stateDir = makeTempDir();
+  return await withEnvAsync(
+    {
+      OPENCLAW_STATE_DIR: stateDir,
+      CLAWDBOT_STATE_DIR: undefined,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+    },
+    fn,
+  );
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     try {
@@ -121,6 +133,51 @@ describe("discoverOpenClawPlugins", () => {
     const ids = candidates.map((c) => c.idHint);
     expect(ids).toContain("pack/one");
     expect(ids).toContain("pack/two");
+  });
+
+  it("accepts hardlinked package manifests and entries for bundled plugins", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const bundledDir = makeTempDir();
+    const packageDir = path.join(bundledDir, "hardlink-pack");
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "package.json");
+    const outsideEntry = path.join(outsideDir, "entry.ts");
+    const linkedManifest = path.join(packageDir, "package.json");
+    const linkedEntry = path.join(packageDir, "entry.ts");
+
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({
+        name: "@openclaw/hardlink-pack",
+        openclaw: { extensions: ["./entry.ts"] },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(outsideEntry, "export default function bundledHardlinkPack() {}", "utf-8");
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const { candidates, diagnostics } = await withBundledDir(bundledDir, async () => {
+      return discoverOpenClawPlugins({});
+    });
+
+    const bundledIds = candidates
+      .filter((candidate) => candidate.origin === "bundled")
+      .map((candidate) => candidate.idHint);
+    expect(bundledIds).toContain("hardlink-pack");
+    expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
+      false,
+    );
   });
 
   it("derives unscoped ids for scoped packages", async () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -5,6 +5,7 @@ import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
   getPackageManifestMetadata,
+  shouldRejectHardlinkedPluginFiles,
   type OpenClawPackageManifest,
   type PackageManifest,
 } from "./manifest.js";
@@ -223,12 +224,16 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
-function readPackageManifest(dir: string): PackageManifest | null {
+function readPackageManifest(
+  dir: string,
+  options?: { rejectHardlinks?: boolean },
+): PackageManifest | null {
   const manifestPath = path.join(dir, "package.json");
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: options?.rejectHardlinks,
   });
   if (!opened.ok) {
     return null;
@@ -324,12 +329,14 @@ function resolvePackageEntrySource(params: {
   entryPath: string;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
+  rejectHardlinks?: boolean;
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
   const opened = openBoundaryFileSync({
     absolutePath: source,
     rootPath: params.packageDir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: params.rejectHardlinks,
   });
   if (!opened.ok) {
     params.diagnostics.push({
@@ -367,6 +374,7 @@ function discoverInDirectory(params: {
     });
     return;
   }
+  const rejectHardlinks = shouldRejectHardlinkedPluginFiles(params.origin);
 
   for (const entry of entries) {
     const fullPath = path.join(params.dir, entry.name);
@@ -393,7 +401,7 @@ function discoverInDirectory(params: {
       continue;
     }
 
-    const manifest = readPackageManifest(fullPath);
+    const manifest = readPackageManifest(fullPath, { rejectHardlinks });
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -403,6 +411,7 @@ function discoverInDirectory(params: {
           entryPath: extPath,
           sourceLabel: fullPath,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!resolved) {
           continue;
@@ -470,6 +479,7 @@ function discoverFromPath(params: {
   }
 
   const stat = fs.statSync(resolved);
+  const rejectHardlinks = shouldRejectHardlinkedPluginFiles(params.origin);
   if (stat.isFile()) {
     if (!isExtensionFile(resolved)) {
       params.diagnostics.push({
@@ -494,7 +504,7 @@ function discoverFromPath(params: {
   }
 
   if (stat.isDirectory()) {
-    const manifest = readPackageManifest(resolved);
+    const manifest = readPackageManifest(resolved, { rejectHardlinks });
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -504,6 +514,7 @@ function discoverFromPath(params: {
           entryPath: extPath,
           sourceLabel: resolved,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!source) {
           continue;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -204,6 +204,56 @@ describe("loadOpenClawPlugins", () => {
     expectTelegramLoaded(registry);
   });
 
+  it("loads bundled plugins when manifest and entry files are hardlinked", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const bundledDir = makeTempDir();
+    const pluginDir = path.join(bundledDir, "hardlinked-bundled");
+    const storeDir = makeTempDir();
+    const linkedManifest = path.join(pluginDir, "openclaw.plugin.json");
+    const linkedEntry = path.join(pluginDir, "index.js");
+    const outsideManifest = path.join(storeDir, "openclaw.plugin.json");
+    const outsideEntry = path.join(storeDir, "index.js");
+
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "hardlinked-bundled", configSchema: EMPTY_PLUGIN_SCHEMA }, null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      outsideEntry,
+      'export default { id: "hardlinked-bundled", register() {} };',
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          allow: ["hardlinked-bundled"],
+          entries: {
+            "hardlinked-bundled": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "hardlinked-bundled");
+    expect(record?.status).toBe("loaded");
+  });
+
   it("loads bundled channel plugins when channels.<id>.enabled=true", () => {
     setupBundledTelegramPlugin();
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -18,6 +18,7 @@ import {
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { shouldRejectHardlinkedPluginFiles } from "./manifest.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { setActivePluginRegistry } from "./runtime.js";
@@ -530,6 +531,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       absolutePath: candidate.source,
       rootPath: pluginRoot,
       boundaryLabel: "plugin root",
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
       // Discovery stores rootDir as realpath but source may still be a lexical alias
       // (e.g. /var/... vs /private/var/... on macOS). Canonical boundary checks
       // still enforce containment; skip lexical pre-check to avoid false escapes.

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -198,6 +198,40 @@ describe("loadPluginManifestRegistry", () => {
     ).toBe(true);
   });
 
+  it("allows hardlinked manifests for bundled plugins", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = makeTempDir();
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "openclaw.plugin.json");
+    const linkedManifest = path.join(rootDir, "openclaw.plugin.json");
+    fs.writeFileSync(path.join(rootDir, "index.ts"), "export default function () {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "bundled-hardlink", configSchema: { type: "object" } }),
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "bundled-hardlink",
+        rootDir,
+        origin: "bundled",
+      }),
+    ]);
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.id).toBe("bundled-hardlink");
+  });
+
   it("rejects manifest paths that escape plugin root via hardlink", () => {
     if (process.platform === "win32") {
       return;

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -3,7 +3,11 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
-import { loadPluginManifest, type PluginManifest } from "./manifest.js";
+import {
+  loadPluginManifest,
+  shouldRejectHardlinkedPluginFiles,
+  type PluginManifest,
+} from "./manifest.js";
 import { safeRealpathSync } from "./path-safety.js";
 import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } from "./types.js";
 
@@ -167,7 +171,9 @@ export function loadPluginManifestRegistry(params: {
   const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
-    const manifestRes = loadPluginManifest(candidate.rootDir);
+    const manifestRes = loadPluginManifest(candidate.rootDir, {
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
+    });
     if (!manifestRes.ok) {
       diagnostics.push({
         level: "error",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
-import type { PluginConfigUiHint, PluginKind } from "./types.js";
+import type { PluginConfigUiHint, PluginKind, PluginOrigin } from "./types.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 export const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
@@ -42,12 +42,20 @@ export function resolvePluginManifestPath(rootDir: string): string {
   return path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
 }
 
-export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
+export function shouldRejectHardlinkedPluginFiles(origin: PluginOrigin): boolean {
+  return origin !== "bundled";
+}
+
+export function loadPluginManifest(
+  rootDir: string,
+  options?: { rejectHardlinks?: boolean },
+): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: rootDir,
     boundaryLabel: "plugin root",
+    rejectHardlinks: options?.rejectHardlinks,
   });
   if (!opened.ok) {
     if (opened.reason === "path") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled plugin files installed via pnpm/bun can be hardlinked (`nlink > 1`), which caused `unsafe plugin manifest path` / plugin load failures on v2026.2.26.
- Why it matters: fresh global installs fail to load built-in channel/memory plugins, breaking gateway startup or plugin functionality for many users.
- What changed: hardlink rejection is now scoped by plugin origin, with bundled plugins allowed while non-bundled origins continue rejecting hardlinked aliases.
- What did NOT change (scope boundary): no global `openBoundaryFileSync` relaxation, and no changes to workspace/config/global plugin hardlink protections.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28175
- Related #28122
- Related #28404
- Related #28366
- Related #28897

## User-visible / Behavior Changes

- Bundled plugins now load on pnpm/bun global installs where files are hardlinked by package-manager stores.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): plugin loading pipeline
- Relevant config (redacted): N/A

### Steps

1. Create bundled-origin plugin candidates whose `openclaw.plugin.json` and/or entry files are hardlinked.
2. Load discovery/manifest-registry/plugin-loader paths.
3. Validate bundled hardlinked files pass, while existing non-bundled hardlink rejection tests still pass.

### Expected

- Bundled hardlinked plugin files load successfully.
- Non-bundled hardlink alias escapes remain rejected.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/plugins/manifest-registry.test.ts src/plugins/discovery.test.ts src/plugins/loader.test.ts src/plugins/bundled-sources.test.ts`
  - `pnpm check`
- Edge cases checked:
  - bundled hardlinked manifest acceptance
  - bundled hardlinked package.json + extension entry acceptance in discovery
  - bundled hardlinked plugin entry acceptance in loader
  - existing workspace/global hardlink escape tests still green
- What you did **not** verify:
  - full end-to-end global install on pnpm/bun host in this environment

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: plugin pipeline files touched in this PR.
- Known bad symptoms reviewers should watch for: unexpected acceptance of non-bundled hardlinked plugin paths (covered by existing hardlink rejection tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: bundled-origin hardlink allowance could hide mistakes if origin classification is wrong.
  - Mitigation: scope is strictly origin-based (`bundled` only), and tests assert non-bundled hardlink rejection still works.
