### PR TITLE
docs(skills): clarify heartbeat target requirement for auto-notify

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -256,6 +256,8 @@ This prevents the user from seeing only "Agent failed before reply" and having n
 
 For long-running background tasks, append a wake trigger to your prompt so OpenClaw gets notified immediately when the agent finishes (instead of waiting for the next heartbeat):
 
+**Prerequisite:** completion notifications are delivered via heartbeat. If `heartbeat.target` is left at the default (`none`), the wake response is generated but not delivered. Set `agents.defaults.heartbeat.target: "last"` (or an explicit channel) before relying on this pattern.
+
 ```
 ... your task here.
 
@@ -271,7 +273,7 @@ bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Buil
 When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
 ```
 
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This triggers an immediate wake event — with heartbeat delivery enabled, Skippy gets pinged in seconds, not 10 minutes.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Problem:** The bundled `coding-agent` skill suggests `openclaw system event --mode now` for completion notifications, but does not mention that default heartbeat target is `none`, so notifications can be silently dropped.
- **Why it matters:** New users follow the skill and expect completion pings, but receive nothing unless they discover heartbeat target configuration themselves.
- **What changed:** Added an explicit prerequisite note in `skills/coding-agent/SKILL.md` stating that heartbeat delivery must be enabled (`agents.defaults.heartbeat.target: \"last\"` or explicit channel) for auto-notify to work.
- **What did NOT change:** Runtime heartbeat behavior and default `heartbeat.target` remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29215

## User-visible / Behavior Changes

- Skill instructions now include the heartbeat-target prerequisite for completion notifications.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: N/A (documentation update)
- Integration/channel: coding-agent skill docs

### Steps

1. Open `skills/coding-agent/SKILL.md` Auto-Notify section.
2. Verify prerequisite guidance for heartbeat target.

### Expected

- The section explicitly states notifications are dropped when `heartbeat.target` is `none` and provides the required config direction.

### Actual

- Before fix: prerequisite was not documented.
- After fix: prerequisite is clear and adjacent to the command pattern.

## Evidence

- Updated `skills/coding-agent/SKILL.md` Auto-Notify section.

## Human Verification (required)

- Verified scenarios: prerequisite note appears before example command.
- Edge cases checked: wording keeps existing auto-notify flow unchanged.
- What I did **not** verify: runtime heartbeat delivery behavior (out of scope for docs-only fix).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `skills/coding-agent/SKILL.md`.
- Known bad symptoms: none (docs only).

## Risks and Mitigations

- Risk: none significant (documentation-only clarification).
- Mitigation: scope intentionally limited to guidance; no runtime changes.

