### PR TITLE
feat(feishu): add stream appender registry for active streaming sessions

### DIFF
--- a/extensions/feishu/src/active-streams.ts
+++ b/extensions/feishu/src/active-streams.ts
@@ -1,0 +1,41 @@
+/**
+ * In-memory registry for active streaming sessions.
+ *
+ * During streaming, the reply-dispatcher registers an appender function keyed
+ * by chatId. Other modules (e.g. the outbound adapter) can look up the
+ * appender to inject content into the card instead of sending separate messages.
+ *
+ * Alias keys allow lookup by alternative IDs (e.g. the normalized outbound
+ * target `ou_xxx` for P2P chats where chatId is `oc_xxx`).
+ */
+
+export type StreamAppender = (content: string) => void;
+
+const activeStreams = new Map<string, StreamAppender>();
+const aliases = new Map<string, string>();
+
+export function registerStreamAppender(
+  primaryKey: string,
+  appender: StreamAppender,
+  aliasKeys?: string[],
+): void {
+  activeStreams.set(primaryKey, appender);
+  if (aliasKeys) {
+    for (const alias of aliasKeys) {
+      aliases.set(alias, primaryKey);
+    }
+  }
+}
+
+export function unregisterStreamAppender(primaryKey: string): void {
+  activeStreams.delete(primaryKey);
+  for (const [alias, target] of aliases) {
+    if (target === primaryKey) {
+      aliases.delete(alias);
+    }
+  }
+}
+
+export function getStreamAppender(key: string): StreamAppender | undefined {
+  return activeStreams.get(key) ?? activeStreams.get(aliases.get(key) ?? "");
+}

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -33,6 +33,7 @@ import { parsePostContent } from "./post.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { normalizeFeishuTarget } from "./targets.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -1112,11 +1113,13 @@ export async function handleFeishuMessage(params: {
       ...mediaPayload,
     });
 
+    const outboundTo = normalizeFeishuTarget(feishuTo) ?? undefined;
     const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
       cfg,
       agentId: route.agentId,
       runtime: runtime as RuntimeEnv,
       chatId: ctx.chatId,
+      outboundTo,
       replyToMessageId: ctx.messageId,
       skipReplyToInMessages: !isGroup,
       replyInThread,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -152,10 +152,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
-    unregisterStreamAppender(chatId);
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
+    unregisterStreamAppender(chatId);
     await partialUpdateQueue;
     if (streaming?.isActive()) {
       let text = streamText;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeEnv,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
+import { registerStreamAppender, unregisterStreamAppender } from "./active-streams.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
@@ -27,6 +28,8 @@ export type CreateFeishuReplyDispatcherParams = {
   agentId: string;
   runtime: RuntimeEnv;
   chatId: string;
+  /** Normalized outbound target (e.g. `ou_xxx` for P2P). Used as alias key for stream lookup. */
+  outboundTo?: string;
   replyToMessageId?: string;
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
@@ -42,6 +45,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     cfg,
     agentId,
     chatId,
+    outboundTo,
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
@@ -129,6 +133,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyInThread,
           rootId,
         });
+        registerStreamAppender(
+          chatId,
+          (content) => {
+            streamText += content;
+            partialUpdateQueue = partialUpdateQueue.then(async () => {
+              if (streamingStartPromise) await streamingStartPromise;
+              if (streaming?.isActive()) await streaming.update(streamText);
+            });
+          },
+          outboundTo ? [outboundTo] : undefined,
+        );
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -137,6 +152,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
+    unregisterStreamAppender(chatId);
     if (streamingStartPromise) {
       await streamingStartPromise;
     }


### PR DESCRIPTION
## Summary

- Add an in-memory registry (`active-streams.ts`) that maps `chatId` to stream appender functions, with alias key support for P2P chats where `chatId` differs from the outbound target.
- Wire `registerStreamAppender`/`unregisterStreamAppender` into reply-dispatcher's `startStreaming`/`closeStreaming` lifecycle.
- Pass normalized `outboundTo` from `bot.ts` as an alias key for stream lookup.
- **No behavior change** to existing streaming or message delivery paths — this is infrastructure for upcoming outbound media embedding.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Part of the split requested in #26368

## User-visible / Behavior Changes

None. The registry is registered/unregistered during streaming lifecycle but no consumer reads from it yet.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: Gateway starts, streaming card opens and closes without errors
- What you did **not** verify: Outbound media embedding (not wired yet)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 3 changed files
- Known bad symptoms: None expected — registry is passive infrastructure

Made with [Cursor](https://cursor.com)