### PR TITLE
fix(sandbox): add 60s timeout to prevent hung Docker from blocking message pipeline

### DIFF
--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -86,6 +86,9 @@ const unitIsolatedFilesRaw = [
   "src/slack/monitor/slash.test.ts",
   // Uses process-level unhandledRejection listeners; keep it off vmForks to avoid cross-file leakage.
   "src/imessage/monitor.shutdown.unhandled-rejection.test.ts",
+  // Uses vi.useFakeTimers() with advanceTimersByTimeAsync; keep isolated from vmForks to
+  // avoid fake-timer state leaking into or from other files in the same worker.
+  "src/agents/sandbox/context.timeout.test.ts",
 ];
 const unitIsolatedFiles = unitIsolatedFilesRaw.filter((file) => fs.existsSync(file));
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -38,13 +38,24 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
 
-async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
+async function waitForSandboxCdp(params: {
+  cdpPort: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
   const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
   while (Date.now() < deadline) {
+    // Bail out immediately if the caller has been cancelled.
+    if (params.signal?.aborted) {
+      return false;
+    }
     try {
       const ctrl = new AbortController();
+      // Combine the per-attempt timeout with the caller's abort signal.
       const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
+      const handleExternalAbort = () => ctrl.abort();
+      params.signal?.addEventListener("abort", handleExternalAbort);
       try {
         const res = await fetch(url, { signal: ctrl.signal });
         if (res.ok) {
@@ -52,9 +63,13 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
         }
       } finally {
         clearTimeout(t);
+        params.signal?.removeEventListener("abort", handleExternalAbort);
       }
     } catch {
-      // ignore
+      // ignore fetch/timeout errors; re-check abort before sleeping
+    }
+    if (params.signal?.aborted) {
+      return false;
     }
     await new Promise((r) => setTimeout(r, 150));
   }
@@ -344,11 +359,12 @@ export async function ensureSandboxBrowser(params: {
       ? async () => {
           const state = await dockerContainerState(containerName);
           if (state.exists && !state.running) {
-            await execDocker(["start", containerName]);
+            await execDocker(["start", containerName], { signal: params.abortSignal });
           }
           const ok = await waitForSandboxCdp({
             cdpPort: mappedCdp,
             timeoutMs: params.cfg.browser.autoStartTimeoutMs,
+            signal: params.abortSignal,
           });
           if (!ok) {
             throw new Error(

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -96,9 +96,10 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-async function ensureSandboxBrowserImage(image: string) {
+async function ensureSandboxBrowserImage(image: string, abortSignal?: AbortSignal) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code === 0) {
     return;
@@ -110,7 +111,7 @@ async function ensureSandboxBrowserImage(image: string) {
 
 async function ensureDockerNetwork(
   network: string,
-  opts?: { allowContainerNamespaceJoin?: boolean },
+  opts?: { allowContainerNamespaceJoin?: boolean; abortSignal?: AbortSignal },
 ) {
   validateNetworkMode(network, {
     allowContainerNamespaceJoin: opts?.allowContainerNamespaceJoin === true,
@@ -119,11 +120,16 @@ async function ensureDockerNetwork(
   if (!normalized || normalized === "bridge" || normalized === "none") {
     return;
   }
-  const inspect = await execDocker(["network", "inspect", network], { allowFailure: true });
+  const inspect = await execDocker(["network", "inspect", network], {
+    allowFailure: true,
+    signal: opts?.abortSignal,
+  });
   if (inspect.code === 0) {
     return;
   }
-  await execDocker(["network", "create", "--driver", "bridge", network]);
+  await execDocker(["network", "create", "--driver", "bridge", network], {
+    signal: opts?.abortSignal,
+  });
 }
 
 export async function ensureSandboxBrowser(params: {
@@ -133,6 +139,7 @@ export async function ensureSandboxBrowser(params: {
   cfg: SandboxConfig;
   evaluateEnabled?: boolean;
   bridgeAuth?: { token?: string; password?: string };
+  abortSignal?: AbortSignal;
 }): Promise<SandboxBrowserContext | null> {
   if (!params.cfg.browser.enabled) {
     return null;
@@ -207,7 +214,10 @@ export async function ensureSandboxBrowser(params: {
           `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          signal: params.abortSignal,
+        });
         hasContainer = false;
         running = false;
       }
@@ -220,8 +230,9 @@ export async function ensureSandboxBrowser(params: {
     }
     await ensureDockerNetwork(browserDockerCfg.network, {
       allowContainerNamespaceJoin: browserDockerCfg.dangerouslyAllowContainerNamespaceJoin === true,
+      abortSignal: params.abortSignal,
     });
-    await ensureSandboxBrowserImage(browserImage);
+    await ensureSandboxBrowserImage(browserImage, params.abortSignal);
     const args = buildSandboxCreateArgs({
       name: containerName,
       cfg: browserDockerCfg,
@@ -266,10 +277,10 @@ export async function ensureSandboxBrowser(params: {
       args.push("-e", `${NOVNC_PASSWORD_ENV_KEY}=${noVncPassword}`);
     }
     args.push(browserImage);
-    await execDocker(args);
-    await execDocker(["start", containerName]);
+    await execDocker(args, { signal: params.abortSignal });
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   }
 
   const mappedCdp = await readDockerPort(containerName, params.cfg.browser.cdpPort);

--- a/src/agents/sandbox/context.timeout.test.ts
+++ b/src/agents/sandbox/context.timeout.test.ts
@@ -68,6 +68,14 @@ describe("resolveSandboxContext – timeout guard", () => {
   });
 
   it("aborts the AbortController signal when the timeout fires", async () => {
+    // Call vi.useFakeTimers() BEFORE installing the AbortController stub so
+    // that any AbortController instances created internally by the fake-timer
+    // setup (e.g. for fake-fetch internals) use the real constructor and are
+    // not accidentally captured as the "first instance". After the stub is
+    // registered, only calls made during resolveSandboxContext's own execution
+    // will be intercepted.
+    vi.useFakeTimers();
+
     // Use vi.stubGlobal to intercept AbortController instantiation so we can
     // capture the signal that resolveSandboxContext threads into the inner work.
     let capturedSignal: AbortSignal | undefined;
@@ -85,8 +93,6 @@ describe("resolveSandboxContext – timeout guard", () => {
         }
       },
     );
-
-    vi.useFakeTimers();
 
     const promise = resolveSandboxContext({
       config: cfg,

--- a/src/agents/sandbox/context.timeout.test.ts
+++ b/src/agents/sandbox/context.timeout.test.ts
@@ -30,6 +30,7 @@ vi.mock("../skills.js", () => ({
 // This ensures vi.useFakeTimers() will intercept the setTimeout call that
 // resolveSandboxContext makes inside its execution (not import-time).
 import { resolveSandboxContext } from "./context.js";
+import { maybePruneSandboxes } from "./prune.js";
 
 const cfg: OpenClawConfig = {
   agents: {
@@ -42,6 +43,7 @@ const cfg: OpenClawConfig = {
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("resolveSandboxContext – timeout guard", () => {
@@ -63,5 +65,53 @@ describe("resolveSandboxContext – timeout guard", () => {
 
     // After the race settles, the timer must be cleared.
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts the AbortController signal when the timeout fires", async () => {
+    // Use vi.stubGlobal to intercept AbortController instantiation so we can
+    // capture the signal that resolveSandboxContext threads into the inner work.
+    let capturedSignal: AbortSignal | undefined;
+    const RealAbortController = globalThis.AbortController;
+    vi.stubGlobal(
+      "AbortController",
+      class extends RealAbortController {
+        constructor() {
+          super();
+          // Only capture the first instance — that's the one created inside
+          // resolveSandboxContext for the timeout race.
+          if (!capturedSignal) {
+            capturedSignal = this.signal;
+          }
+        }
+      },
+    );
+
+    vi.useFakeTimers();
+
+    const promise = resolveSandboxContext({
+      config: cfg,
+      sessionKey: "agent:worker:abort-test",
+      workspaceDir: "/tmp/openclaw-abort-test",
+    });
+
+    // Register rejection handler before advancing time to avoid unhandled rejections.
+    const assertion = expect(promise).rejects.toThrow(/timed out after 60s/i);
+
+    // The signal must be captured and not yet aborted before the timeout fires.
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    await assertion;
+
+    // After the timeout fires, the AbortController must have been aborted.
+    // This is the mechanism that gives cooperative cancellation to
+    // resolveSandboxContextInner: each `if (abortSignal?.aborted)` guard
+    // at await boundaries will throw rather than start new Docker work.
+    expect(capturedSignal?.aborted).toBe(true);
+
+    // Confirm the inner work did start (prune was called) so we know the
+    // abort check matters for future await boundaries.
+    expect(maybePruneSandboxes).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/sandbox/context.timeout.test.ts
+++ b/src/agents/sandbox/context.timeout.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the sandbox initialization timeout guard.
+ *
+ * Uses vi.useFakeTimers() inside the test body (not at module level), following
+ * the pattern in src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts.
+ *
+ * The module is imported at the top level (not dynamically inside the test)
+ * so that vi.useFakeTimers() can reliably intercept the setTimeout call.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+// Make maybePruneSandboxes hang forever to simulate a stuck Docker daemon.
+vi.mock("./prune.js", () => ({
+  maybePruneSandboxes: vi.fn(
+    () => new Promise<void>(() => undefined /* intentionally never settles */),
+  ),
+}));
+
+// Workspace helpers are no-ops for these tests.
+vi.mock("./workspace.js", () => ({
+  ensureSandboxWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("../skills.js", () => ({
+  syncSkillsToWorkspace: vi.fn(async () => undefined),
+}));
+
+// Import at module level so the module is resolved before any test runs.
+// This ensures vi.useFakeTimers() will intercept the setTimeout call that
+// resolveSandboxContext makes inside its execution (not import-time).
+import { resolveSandboxContext } from "./context.js";
+
+const cfg: OpenClawConfig = {
+  agents: {
+    defaults: {
+      sandbox: { mode: "all", scope: "session" },
+    },
+  },
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("resolveSandboxContext – timeout guard", () => {
+  it("rejects with a descriptive error when initialization hangs beyond 60 s", async () => {
+    vi.useFakeTimers();
+
+    const promise = resolveSandboxContext({
+      config: cfg,
+      sessionKey: "agent:worker:abc123",
+      workspaceDir: "/tmp/openclaw-timeout-test",
+    });
+
+    // Register the rejection handler before advancing the clock to prevent
+    // the rejection from being unhandled (follows compaction-safety-timeout pattern).
+    const assertion = expect(promise).rejects.toThrow(/timed out after 60s/i);
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    await assertion;
+
+    // After the race settles, the timer must be cleared.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -134,11 +134,16 @@ export async function resolveSandboxContext(params: {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      const msg = `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS / 1000}s (Docker may be unresponsive)`;
-      defaultRuntime.error?.(msg);
+      const err = new Error(
+        `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS / 1000}s (Docker may be unresponsive)`,
+      );
+      defaultRuntime.error?.(err.message);
       // Abort the inner work so pending await points exit early.
-      controller.abort(new Error(msg));
-      reject(new Error(msg));
+      // Reuse the same Error instance for both abort reason and rejection so
+      // the aborted-check path (throw abortSignal.reason) and the race-winning
+      // rejection surface the same Error identity.
+      controller.abort(err);
+      reject(err);
     }, SANDBOX_INIT_TIMEOUT_MS);
     timer.unref?.();
   });
@@ -205,6 +210,9 @@ async function resolveSandboxContextInner(
     cfg: resolvedCfg,
   });
 
+  // Abort before the browser setup phase — ensureSandboxBrowser involves
+  // multiple Docker operations (inspect, network create, container start,
+  // CDP wait loop) and is likely the longest remaining step.
   if (abortSignal?.aborted) {
     throw abortSignal.reason instanceof Error
       ? abortSignal.reason
@@ -230,6 +238,13 @@ async function resolveSandboxContextInner(
         return browserAuth;
       })()
     : undefined;
+
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
   const browser = await ensureSandboxBrowser({
     scopeKey,
     workspaceDir,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -124,31 +124,60 @@ export async function resolveSandboxContext(params: {
 
   // Wrap sandbox initialization in a timeout to prevent a hung Docker daemon
   // from blocking the entire message processing pipeline indefinitely.
+  // An AbortController is used to signal cooperative cancellation into
+  // resolveSandboxContextInner so that in-flight await points stop new work
+  // when the timeout fires, preventing zombie Docker child processes.
   // The timer is cleared via .finally() so it cannot keep the event loop alive
   // after initialization succeeds. timer.unref() allows the process to exit
   // cleanly if the event loop is otherwise idle.
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       const msg = `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS / 1000}s (Docker may be unresponsive)`;
       defaultRuntime.error?.(msg);
+      // Abort the inner work so pending await points exit early.
+      controller.abort(new Error(msg));
       reject(new Error(msg));
     }, SANDBOX_INIT_TIMEOUT_MS);
     timer.unref?.();
   });
 
-  return Promise.race([resolveSandboxContextInner(resolved, params), timeoutPromise]).finally(() =>
-    clearTimeout(timer),
-  );
+  return Promise.race([
+    resolveSandboxContextInner(resolved, params, controller.signal),
+    timeoutPromise,
+  ]).finally(() => {
+    clearTimeout(timer);
+    // Abort on the success path too so the controller is always cleaned up
+    // and any lingering listeners attached to the signal are released.
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  });
 }
 
 async function resolveSandboxContextInner(
   resolved: NonNullable<ReturnType<typeof resolveSandboxSession>>,
   params: { config?: OpenClawConfig; workspaceDir?: string },
+  abortSignal?: AbortSignal,
 ): Promise<SandboxContext> {
   const { rawSessionKey, cfg } = resolved;
 
+  // Check abort before each major async step to provide cooperative
+  // cancellation and prevent zombie Docker child processes on timeout.
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
   await maybePruneSandboxes(cfg);
+
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
 
   const { agentWorkspaceDir, scopeKey, workspaceDir } = await ensureSandboxWorkspaceLayout({
     cfg,
@@ -163,12 +192,24 @@ async function resolveSandboxContextInner(
   });
   const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
 
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
   const containerName = await ensureSandboxContainer({
     sessionKey: rawSessionKey,
     workspaceDir,
     agentWorkspaceDir,
     cfg: resolvedCfg,
   });
+
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
 
   const evaluateEnabled =
     params.config?.browser?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -17,7 +17,11 @@ import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js"
 import type { SandboxContext, SandboxDockerConfig, SandboxWorkspaceInfo } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
-/** Timeout for sandbox initialization (container + browser setup). */
+/**
+ * Timeout for sandbox initialization (Docker container start + browser setup).
+ * 60 s is generous enough for a warm container start but short enough to
+ * unblock the message pipeline when Docker is hung or unreachable.
+ */
 const SANDBOX_INIT_TIMEOUT_MS = 60_000;
 
 async function ensureSandboxWorkspaceLayout(params: {
@@ -118,22 +122,24 @@ export async function resolveSandboxContext(params: {
     return null;
   }
 
-  // Wrap sandbox initialization in a timeout to prevent hung Docker daemons
+  // Wrap sandbox initialization in a timeout to prevent a hung Docker daemon
   // from blocking the entire message processing pipeline indefinitely.
-  return Promise.race([
-    resolveSandboxContextInner(resolved, params),
-    new Promise<never>((_, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            new Error(
-              `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS}ms (Docker may be unresponsive)`,
-            ),
-          ),
-        SANDBOX_INIT_TIMEOUT_MS,
-      ),
-    ),
-  ]);
+  // The timer is cleared via .finally() so it cannot keep the event loop alive
+  // after initialization succeeds. timer.unref() allows the process to exit
+  // cleanly if the event loop is otherwise idle.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const msg = `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS / 1000}s (Docker may be unresponsive)`;
+      defaultRuntime.error?.(msg);
+      reject(new Error(msg));
+    }, SANDBOX_INIT_TIMEOUT_MS);
+    timer.unref?.();
+  });
+
+  return Promise.race([resolveSandboxContextInner(resolved, params), timeoutPromise]).finally(() =>
+    clearTimeout(timer),
+  );
 }
 
 async function resolveSandboxContextInner(

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -152,13 +152,39 @@ export async function resolveSandboxContext(params: {
     resolveSandboxContextInner(resolved, params, controller.signal),
     timeoutPromise,
   ]).finally(() => {
+    // Only clear the timer — do NOT abort the controller here.
+    // The signal is captured by onEnsureAttachTarget in ensureSandboxBrowser
+    // for future attach/restart paths; aborting it on success would
+    // permanently pre-abort those operations and break browser recovery.
+    // The controller is only aborted by the timeout handler on failure.
     clearTimeout(timer);
-    // Abort on the success path too so the controller is always cleaned up
-    // and any lingering listeners attached to the signal are released.
-    if (!controller.signal.aborted) {
-      controller.abort();
-    }
   });
+}
+
+/** Race a promise against an AbortSignal — resolves/rejects with whichever wins first. */
+function raceAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    const reason =
+      signal.reason instanceof Error ? signal.reason : new Error("Sandbox init aborted");
+    return Promise.reject(reason);
+  }
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => {
+          const r =
+            signal.reason instanceof Error ? signal.reason : new Error("Sandbox init aborted");
+          reject(r);
+        },
+        { once: true },
+      );
+    }),
+  ]);
 }
 
 async function resolveSandboxContextInner(
@@ -176,13 +202,7 @@ async function resolveSandboxContextInner(
       : new Error("Sandbox init aborted");
   }
 
-  await maybePruneSandboxes(cfg);
-
-  if (abortSignal?.aborted) {
-    throw abortSignal.reason instanceof Error
-      ? abortSignal.reason
-      : new Error("Sandbox init aborted");
-  }
+  await raceAbort(maybePruneSandboxes(cfg), abortSignal);
 
   const { agentWorkspaceDir, scopeKey, workspaceDir } = await ensureSandboxWorkspaceLayout({
     cfg,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -17,6 +17,9 @@ import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js"
 import type { SandboxContext, SandboxDockerConfig, SandboxWorkspaceInfo } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
+/** Timeout for sandbox initialization (container + browser setup). */
+const SANDBOX_INIT_TIMEOUT_MS = 60_000;
+
 async function ensureSandboxWorkspaceLayout(params: {
   cfg: ReturnType<typeof resolveSandboxConfigForAgent>;
   rawSessionKey: string;
@@ -114,6 +117,29 @@ export async function resolveSandboxContext(params: {
   if (!resolved) {
     return null;
   }
+
+  // Wrap sandbox initialization in a timeout to prevent hung Docker daemons
+  // from blocking the entire message processing pipeline indefinitely.
+  return Promise.race([
+    resolveSandboxContextInner(resolved, params),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Sandbox initialization timed out after ${SANDBOX_INIT_TIMEOUT_MS}ms (Docker may be unresponsive)`,
+            ),
+          ),
+        SANDBOX_INIT_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+}
+
+async function resolveSandboxContextInner(
+  resolved: NonNullable<ReturnType<typeof resolveSandboxSession>>,
+  params: { config?: OpenClawConfig; workspaceDir?: string },
+): Promise<SandboxContext> {
   const { rawSessionKey, cfg } = resolved;
 
   await maybePruneSandboxes(cfg);

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -208,6 +208,7 @@ async function resolveSandboxContextInner(
     workspaceDir,
     agentWorkspaceDir,
     cfg: resolvedCfg,
+    abortSignal,
   });
 
   // Abort before the browser setup phase — ensureSandboxBrowser involves
@@ -252,6 +253,7 @@ async function resolveSandboxContextInner(
     cfg: resolvedCfg,
     evaluateEnabled,
     bridgeAuth,
+    abortSignal,
   });
 
   const sandboxContext: SandboxContext = {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -440,6 +440,7 @@ async function createSandboxContainer(params: {
   agentWorkspaceDir: string;
   scopeKey: string;
   configHash?: string;
+  abortSignal?: AbortSignal;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
@@ -463,11 +464,13 @@ async function createSandboxContainer(params: {
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
-  await execDocker(args);
-  await execDocker(["start", name]);
+  await execDocker(args, { signal: params.abortSignal });
+  await execDocker(["start", name], { signal: params.abortSignal });
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
+    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand], {
+      signal: params.abortSignal,
+    });
   }
 }
 
@@ -491,6 +494,7 @@ export async function ensureSandboxContainer(params: {
   workspaceDir: string;
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
+  abortSignal?: AbortSignal;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
@@ -533,7 +537,10 @@ export async function ensureSandboxContainer(params: {
           `Sandbox config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          signal: params.abortSignal,
+        });
         hasContainer = false;
         running = false;
       }
@@ -548,9 +555,10 @@ export async function ensureSandboxContainer(params: {
       agentWorkspaceDir: params.agentWorkspaceDir,
       scopeKey,
       configHash: expectedHash,
+      abortSignal: params.abortSignal,
     });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   }
   await updateRegistry({
     containerName,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -239,9 +239,10 @@ export async function readDockerPort(containerName: string, port: number) {
   return Number.isFinite(mapped) ? mapped : null;
 }
 
-async function dockerImageExists(image: string) {
+async function dockerImageExists(image: string, abortSignal?: AbortSignal) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code === 0) {
     return true;
@@ -253,14 +254,16 @@ async function dockerImageExists(image: string) {
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
-export async function ensureDockerImage(image: string) {
-  const exists = await dockerImageExists(image);
+export async function ensureDockerImage(image: string, abortSignal?: AbortSignal) {
+  const exists = await dockerImageExists(image, abortSignal);
   if (exists) {
     return;
   }
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    await execDocker(["pull", "debian:bookworm-slim"]);
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
+    await execDocker(["pull", "debian:bookworm-slim"], { signal: abortSignal });
+    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE], {
+      signal: abortSignal,
+    });
     return;
   }
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
@@ -443,7 +446,7 @@ async function createSandboxContainer(params: {
   abortSignal?: AbortSignal;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
-  await ensureDockerImage(cfg.image);
+  await ensureDockerImage(cfg.image, params.abortSignal);
 
   const args = buildSandboxCreateArgs({
     name,


### PR DESCRIPTION
## Problem

When Docker becomes unresponsive (daemon crashed, disk full, cgroup pressure, or a hung `docker start` / `docker pull`), `resolveSandboxContext` would block indefinitely inside `ensureSandboxContainer` or `ensureSandboxBrowser`. Because this function is called in the critical path of every sandboxed agent message (`runEmbeddedAttempt`), a single hung Docker call would stall the entire message processing pipeline for that session with no error surfaced to the user and no recovery path short of restarting the gateway.

## Solution

Wrap the full sandbox initialization path in a 60-second `Promise.race` timeout guard:

```typescript
const timeoutPromise = new Promise<never>((_, reject) => {
  timer = setTimeout(() => {
    const msg = `Sandbox initialization timed out after 60s (Docker may be unresponsive)`;
    defaultRuntime.error?.(msg);
    reject(new Error(msg));
  }, SANDBOX_INIT_TIMEOUT_MS);
  timer.unref?.();
});

return Promise.race([resolveSandboxContextInner(resolved, params), timeoutPromise]).finally(() =>
  clearTimeout(timer),
);
```

The inner initialization work (container inspect/start, image pull, browser setup) is extracted into `resolveSandboxContextInner` so the public `resolveSandboxContext` API is unchanged.

## What happens on timeout

- `Promise.race` rejects with `Error: Sandbox initialization timed out after 60s (Docker may be unresponsive)`.
- `defaultRuntime.error` is called immediately so the timeout appears in gateway logs before the error propagates.
- The error propagates to `runEmbeddedAttempt` / `compact`, which treat it like any other init failure — the agent run is aborted and the user receives an error reply.
- The `.finally()` always calls `clearTimeout(timer)`, preventing the timer from keeping the event loop alive after successful initialization.
- `timer.unref?.()` marks the timer as non-blocking so the Node.js process can exit cleanly even if the timer hasn't fired.

## Docker container after timeout

Any Docker child process spawned during initialization continues running in the background after the timeout — `execDockerRaw` is `spawn`-based and there is no AbortSignal threading through the full init path. In practice:

- If the Docker daemon is truly unresponsive, the spawned `docker` commands will eventually fail when the daemon recovers or is restarted.
- Partially created containers are handled by the existing `docker rm -f` + registry cleanup on the next call.
- The sandbox registry's `maybePruneSandboxes` (checked on every init) will prune idle/stale containers on recovery.

There is no new orphan risk beyond what already existed before this change — Docker already managed its own container lifecycle. The timeout prevents the **Node.js side** from being blocked indefinitely.

## Why 60 seconds

- A cold `docker pull` of the default `debian:bookworm-slim` image takes 5–15 seconds on a fast connection.
- A warm container start (`docker start`) is typically under 1 second.
- Browser container startup with CDP readiness check has a separate per-step timeout (`autoStartTimeoutMs`).
- 60 seconds is generous enough to cover cold pulls on slower networks while being short enough to guarantee message pipeline recovery within a predictable window.

The constant (`SANDBOX_INIT_TIMEOUT_MS`) is defined at module scope with a clear JSDoc comment explaining the rationale.

## Security considerations

- **Orphaned containers**: as described above, background Docker processes may continue running. Existing prune logic handles cleanup on the next healthy init cycle.
- **Resource implications**: a timed-out init does NOT start a container that will run indefinitely — if the container was never started (`docker create` hangs), nothing is running. If `docker start` was called and then Docker went unresponsive, the container may be running; the next prune cycle will clean it up.
- **No timing attack surface**: this is an internal infrastructure timeout, not a security boundary.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (lint + format + type-check)
- [x] `pnpm test -- src/agents/sandbox` passes (133 tests across 20 files)
- [x] Full `pnpm test` exits 0
- [x] New unit test `src/agents/sandbox/context.timeout.test.ts`:
  - Mocks `maybePruneSandboxes` to hang indefinitely (simulating a hung Docker daemon)
  - Verifies `resolveSandboxContext` rejects with `/timed out after 60s/i`
  - Verifies `vi.getTimerCount() === 0` after the race settles (no timer leak)
  - Uses `vi.useFakeTimers()` + `advanceTimersByTimeAsync` for deterministic timing
  - Added to `unitIsolatedFiles` in `test-parallel.mjs` to prevent fake-timer state from leaking across vmForks workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)