### PR TITLE
fix(discord): add circuit breaker for WebSocket resume loop

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -1,5 +1,5 @@
 import type { Client } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const {
@@ -202,5 +202,225 @@ describe("runDiscordGatewayLifecycle", () => {
       waitCalls: 0,
       releaseEarlyGatewayErrorGuard,
     });
+  });
+});
+
+describe("discord gateway circuit breaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    attachDiscordGatewayLoggingMock.mockClear();
+    waitForDiscordGatewayStopMock.mockClear();
+    registerGatewayMock.mockClear();
+    unregisterGatewayMock.mockClear();
+    stopGatewayLoggingMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createCircuitBreakerHarness() {
+    const { EventEmitter } = require("node:events");
+    const emitter = new EventEmitter();
+    const runtimeLog = vi.fn();
+    const runtimeError = vi.fn();
+    const runtimeExit = vi.fn();
+    const runtime: RuntimeEnv = {
+      log: runtimeLog,
+      error: runtimeError,
+      exit: runtimeExit,
+    };
+    const gatewayState = { sessionId: "test-session", resumeGatewayUrl: "wss://test.discord.gg" };
+    const disconnectMock = vi.fn();
+    const connectMock = vi.fn();
+    const gateway = {
+      isConnected: false,
+      state: gatewayState,
+      disconnect: disconnectMock,
+      connect: connectMock,
+      options: { reconnect: { maxAttempts: 50 } },
+    };
+    const abort = new AbortController();
+
+    // Make getDiscordGatewayEmitter return our real emitter
+    getDiscordGatewayEmitterMock.mockReturnValue(emitter);
+
+    // Make getPlugin return our mock gateway
+    const client = {
+      getPlugin: vi.fn(() => gateway),
+    } as unknown as Client;
+
+    // waitForDiscordGatewayStop should hang until abort
+    waitForDiscordGatewayStopMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          abort.signal.addEventListener("abort", () => resolve(), { once: true });
+        }),
+    );
+
+    const start = vi.fn(async () => undefined);
+    const stop = vi.fn(async () => undefined);
+    const threadStop = vi.fn();
+    const releaseEarlyGatewayErrorGuard = vi.fn();
+
+    return {
+      emitter,
+      gateway,
+      gatewayState,
+      disconnectMock,
+      connectMock,
+      runtimeLog,
+      runtimeError,
+      abort,
+      lifecycleParams: {
+        accountId: "test",
+        client,
+        runtime,
+        isDisallowedIntentsError: () => false,
+        voiceManager: null,
+        voiceManagerRef: { current: null },
+        execApprovalsHandler: { start, stop },
+        threadBindings: { stop: threadStop },
+        releaseEarlyGatewayErrorGuard,
+      },
+    };
+  }
+
+  it("clears session state after 5 consecutive stalls", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const {
+      emitter,
+      gatewayState,
+      disconnectMock,
+      connectMock,
+      runtimeLog,
+      abort,
+      lifecycleParams,
+    } = createCircuitBreakerHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Simulate 5 consecutive stalls: WS opens but no HELLO within 30s
+    for (let i = 0; i < 5; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // After 5 stalls, session state should be cleared
+    expect(gatewayState.sessionId).toBeNull();
+    expect(gatewayState.resumeGatewayUrl).toBeNull();
+
+    // The log should mention clearing session for fresh IDENTIFY
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("clearing session to force fresh IDENTIFY"),
+    );
+
+    // disconnect + connect should have been called on each stall
+    expect(disconnectMock).toHaveBeenCalledTimes(5);
+    expect(connectMock).toHaveBeenCalledTimes(5);
+
+    abort.abort();
+    await lifecyclePromise;
+  });
+
+  it("resets stall counter when HELLO is received", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gatewayState, abort, lifecycleParams } = createCircuitBreakerHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Simulate 3 stalls
+    for (let i = 0; i < 3; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Then a successful HELLO
+    emitter.emit("debug", "Received HELLO from gateway");
+
+    // Then 3 more stalls — should NOT trigger circuit breaker (counter was reset)
+    for (let i = 0; i < 3; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Session state should NOT be cleared (only 3 stalls since reset, not 5)
+    expect(gatewayState.sessionId).toBe("test-session");
+    expect(gatewayState.resumeGatewayUrl).toBe("wss://test.discord.gg");
+
+    abort.abort();
+    await lifecyclePromise;
+  });
+
+  it("resets stall counter on session resume", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gatewayState, abort, lifecycleParams } = createCircuitBreakerHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // 4 stalls
+    for (let i = 0; i < 4; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Session resumed
+    emitter.emit("debug", "Session resumed successfully");
+
+    // 4 more stalls — still under threshold
+    for (let i = 0; i < 4; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Session state should still be intact
+    expect(gatewayState.sessionId).toBe("test-session");
+
+    abort.abort();
+    await lifecyclePromise;
+  });
+
+  it("logs stall count on each non-final stall", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, runtimeLog, abort, lifecycleParams } = createCircuitBreakerHarness();
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Trigger 3 stalls
+    for (let i = 0; i < 3; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Should see stall count in log messages
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("stall 1/5"));
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("stall 2/5"));
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("stall 3/5"));
+
+    abort.abort();
+    await lifecyclePromise;
+  });
+
+  it("does not trigger circuit breaker when gateway is connected", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const harness = createCircuitBreakerHarness();
+    const { emitter, gatewayState, disconnectMock, abort, lifecycleParams } = harness;
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Mark gateway as connected — HELLO timeout should be a no-op
+    harness.gateway.isConnected = true;
+
+    for (let i = 0; i < 10; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
+    // Gateway is connected, so disconnect should never be called
+    expect(disconnectMock).toHaveBeenCalledTimes(0);
+    expect(gatewayState.sessionId).toBe("test-session");
+
+    abort.abort();
+    await lifecyclePromise;
   });
 });

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -323,58 +323,34 @@ describe("discord gateway circuit breaker", () => {
     await lifecyclePromise;
   });
 
-  it("resets stall counter when HELLO is received", async () => {
+  it("resets stall counter when gateway connects before timeout", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { emitter, gatewayState, abort, lifecycleParams } = createCircuitBreakerHarness();
+    const harness = createCircuitBreakerHarness();
+    const { emitter, gatewayState, abort, lifecycleParams } = harness;
 
     const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
 
-    // Simulate 3 stalls
+    // Simulate 3 stalls (gateway stays disconnected)
     for (let i = 0; i < 3; i++) {
       emitter.emit("debug", "WebSocket connection opened");
       await vi.advanceTimersByTimeAsync(30001);
     }
 
-    // Then a successful HELLO
-    emitter.emit("debug", "Received HELLO from gateway");
+    // Next WS open — this time HELLO arrives (gateway becomes connected)
+    emitter.emit("debug", "WebSocket connection opened");
+    harness.gateway.isConnected = true;
+    await vi.advanceTimersByTimeAsync(30001);
 
-    // Then 3 more stalls — should NOT trigger circuit breaker (counter was reset)
+    // Counter should be reset. 3 more stalls should NOT trigger the breaker.
+    harness.gateway.isConnected = false;
     for (let i = 0; i < 3; i++) {
       emitter.emit("debug", "WebSocket connection opened");
       await vi.advanceTimersByTimeAsync(30001);
     }
 
-    // Session state should NOT be cleared (only 3 stalls since reset, not 5)
+    // Only 3 stalls since reset — session state should still be intact
     expect(gatewayState.sessionId).toBe("test-session");
     expect(gatewayState.resumeGatewayUrl).toBe("wss://test.discord.gg");
-
-    abort.abort();
-    await lifecyclePromise;
-  });
-
-  it("resets stall counter on session resume", async () => {
-    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { emitter, gatewayState, abort, lifecycleParams } = createCircuitBreakerHarness();
-
-    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
-
-    // 4 stalls
-    for (let i = 0; i < 4; i++) {
-      emitter.emit("debug", "WebSocket connection opened");
-      await vi.advanceTimersByTimeAsync(30001);
-    }
-
-    // Session resumed
-    emitter.emit("debug", "Session resumed successfully");
-
-    // 4 more stalls — still under threshold
-    for (let i = 0; i < 4; i++) {
-      emitter.emit("debug", "WebSocket connection opened");
-      await vi.advanceTimersByTimeAsync(30001);
-    }
-
-    // Session state should still be intact
-    expect(gatewayState.sessionId).toBe("test-session");
 
     abort.abort();
     await lifecyclePromise;
@@ -408,7 +384,7 @@ describe("discord gateway circuit breaker", () => {
 
     const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
 
-    // Mark gateway as connected — HELLO timeout should be a no-op
+    // Mark gateway as connected — timeout should reset the counter, not stall
     harness.gateway.isConnected = true;
 
     for (let i = 0; i < 10; i++) {
@@ -418,6 +394,16 @@ describe("discord gateway circuit breaker", () => {
 
     // Gateway is connected, so disconnect should never be called
     expect(disconnectMock).toHaveBeenCalledTimes(0);
+    expect(gatewayState.sessionId).toBe("test-session");
+
+    // Even after going disconnected again, counter was reset by successful
+    // connections — 4 stalls should not trigger the breaker
+    harness.gateway.isConnected = false;
+    for (let i = 0; i < 4; i++) {
+      emitter.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(30001);
+    }
+
     expect(gatewayState.sessionId).toBe("test-session");
 
     abort.abort();

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -51,9 +51,19 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   const HELLO_TIMEOUT_MS = 30000;
+  const MAX_CONSECUTIVE_STALLS = 5;
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let consecutiveStalls = 0;
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
+
+    // Reset stall counter when gateway successfully receives HELLO
+    // (indicated by a successful resume or identify completing).
+    if (message.includes("Received HELLO") || message.includes("Session resumed")) {
+      consecutiveStalls = 0;
+      return;
+    }
+
     if (!message.includes("WebSocket connection opened")) {
       return;
     }
@@ -62,11 +72,32 @@ export async function runDiscordGatewayLifecycle(params: {
     }
     helloTimeoutId = setTimeout(() => {
       if (!gateway?.isConnected) {
-        params.runtime.log?.(
-          danger(
-            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
-          ),
-        );
+        consecutiveStalls++;
+        if (consecutiveStalls >= MAX_CONSECUTIVE_STALLS) {
+          params.runtime.log?.(
+            danger(
+              `connection stalled: ${consecutiveStalls} consecutive stalls without HELLO — clearing session to force fresh IDENTIFY`,
+            ),
+          );
+          // Invalidate session state so the next connect() sends a fresh
+          // IDENTIFY instead of trying to resume a dead session.
+          const state = (
+            gateway as unknown as {
+              state?: { sessionId?: string | null; resumeGatewayUrl?: string | null };
+            }
+          ).state;
+          if (state) {
+            state.sessionId = null;
+            state.resumeGatewayUrl = null;
+          }
+          consecutiveStalls = 0;
+        } else {
+          params.runtime.log?.(
+            danger(
+              `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms (stall ${consecutiveStalls}/${MAX_CONSECUTIVE_STALLS}), forcing reconnect`,
+            ),
+          );
+        }
         gateway?.disconnect();
         gateway?.connect(false);
       }

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -57,13 +57,6 @@ export async function runDiscordGatewayLifecycle(params: {
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
 
-    // Reset stall counter when gateway successfully receives HELLO
-    // (indicated by a successful resume or identify completing).
-    if (message.includes("Received HELLO") || message.includes("Session resumed")) {
-      consecutiveStalls = 0;
-      return;
-    }
-
     if (!message.includes("WebSocket connection opened")) {
       return;
     }
@@ -71,7 +64,10 @@ export async function runDiscordGatewayLifecycle(params: {
       clearTimeout(helloTimeoutId);
     }
     helloTimeoutId = setTimeout(() => {
-      if (!gateway?.isConnected) {
+      if (gateway?.isConnected) {
+        // HELLO was received and the gateway is healthy — reset the counter.
+        consecutiveStalls = 0;
+      } else {
         consecutiveStalls++;
         if (consecutiveStalls >= MAX_CONSECUTIVE_STALLS) {
           params.runtime.log?.(
@@ -79,8 +75,10 @@ export async function runDiscordGatewayLifecycle(params: {
               `connection stalled: ${consecutiveStalls} consecutive stalls without HELLO — clearing session to force fresh IDENTIFY`,
             ),
           );
-          // Invalidate session state so the next connect() sends a fresh
-          // IDENTIFY instead of trying to resume a dead session.
+          // Invalidate the protected session state so the next connect()
+          // sends a fresh IDENTIFY instead of resuming a dead session.
+          // GatewayPlugin.state is protected with no public invalidation
+          // method — this cast is pinned to @buape/carbon@1.x internals.
           const state = (
             gateway as unknown as {
               state?: { sessionId?: string | null; resumeGatewayUrl?: string | null };


### PR DESCRIPTION
## Problem

The Discord WebSocket gateway can enter an **infinite resume loop** where it endlessly retries with a stale session token. This has been observed across multiple production deployments, with users reporting **2,142 WebSocket close events in 48 hours** and outages lasting 1-7+ hours requiring manual gateway restarts (#13688).

### Root Cause

When the WebSocket opens but no HELLO is received within 30 seconds, the zombie timeout handler calls `gateway.disconnect()` + `gateway.connect(false)` to force a reconnect. However, `@buape/carbon`'s internal `reconnectAttempts` counter resets to 0 on every WebSocket open event, so the library's `maxAttempts: 50` circuit breaker is never reached.

The loop:
1. Connect → WS opens → library resets counter to 0
2. No HELLO within 30s → zombie timeout fires
3. Disconnect + connect(false) → attempts resume with stale session
4. Session token is stale → resume silently fails → go to 1

### Production impact (from issue reports)

| Metric | Observed |
|--------|----------|
| WebSocket close events (48h) | 2,142 |
| Longest single storm | 7+ hours |
| Recovery method | Manual restart only |

## Solution

Add an **application-level circuit breaker** to the zombie timeout handler in \`provider.lifecycle.ts\`:

- **Track consecutive stalls** (WS opens but no HELLO within 30s)
- **After 5 consecutive stalls**, invalidate session state (\`sessionId\` + \`resumeGatewayUrl\`) and force a fresh \`IDENTIFY\` instead of trying to resume a dead session
- **Reset counter** when \`gateway.isConnected\` is true at timeout (HELLO was received successfully)
- **Log stall progress** (\`stall N/5\`) for observability

This breaks the infinite loop because a fresh IDENTIFY creates a new session rather than endlessly retrying a stale one.

## Changes

**\`src/discord/monitor/provider.lifecycle.ts\`** — 1 file, ~30 lines changed:
- Added \`MAX_CONSECUTIVE_STALLS\` constant (5)
- Added \`consecutiveStalls\` counter
- Circuit breaker logic: clears \`gateway.state.sessionId\` and \`gateway.state.resumeGatewayUrl\` after threshold
- Counter resets when \`gateway.isConnected\` is true at timeout (meaning HELLO was received)
- Documents internal state access (\`GatewayPlugin.state\` is protected, pinned to \`@buape/carbon@1.x\`)

**\`src/discord/monitor/provider.lifecycle.test.ts\`** — 4 new tests:
- Clears session state after 5 consecutive stalls
- Resets stall counter when gateway connects before timeout
- Logs stall count on each non-final stall
- Does not trigger circuit breaker when gateway is connected

## Test Plan

- [x] All 9 tests pass (\`vitest run src/discord/monitor/provider.lifecycle.test.ts\`)
- [x] Lint passes (\`oxlint --type-aware\` — 0 errors)
- [x] No breaking changes — existing behavior preserved for stalls 1-4
- [x] Backwards compatible — no new config options required

Fixes #13688
Supersedes #15762 (closed, merge conflicts)