### PR TITLE
fix bug:Memory: renormalize hybrid weights when one modality is empty (closes #29112)

### DIFF
--- a/src/memory/manager.hybrid-fallback.test.ts
+++ b/src/memory/manager.hybrid-fallback.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryIndexManager } from "./index.js";
+import { createMemoryManagerOrThrow } from "./test-manager.js";
+import "./test-runtime-mocks.js";
+
+const embedBatch = vi.fn(
+  async (input: string[]): Promise<number[][]> => input.map(() => [0, 1, 0]),
+);
+const embedQuery = vi.fn(async (): Promise<number[]> => [0, 0, 0]);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: async () => ({
+    requestedProvider: "local",
+    provider: {
+      id: "local",
+      model: "mock-local",
+      maxInputTokens: 8192,
+      embedQuery,
+      embedBatch,
+    },
+  }),
+}));
+
+describe("MemoryIndexManager hybrid search fallback", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  const buildConfig = (): OpenClawConfig =>
+    ({
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "local",
+            fallback: "none",
+            model: "mock-local",
+            store: { path: indexPath, vector: { enabled: false } },
+            chunking: { tokens: 4000, overlap: 0 },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+            query: {
+              minScore: 0.35,
+              hybrid: { enabled: true, vectorWeight: 0.7, textWeight: 0.3 },
+            },
+            cache: { enabled: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    }) as OpenClawConfig;
+
+  beforeEach(async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "1");
+    embedBatch.mockClear();
+    embedQuery.mockClear();
+
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-hybrid-fallback-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"));
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-02-27.md"),
+      "- canary: qzv91-lime-orbit\n",
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("returns keyword results when query embedding is all zeros", async () => {
+    manager = await createMemoryManagerOrThrow(buildConfig());
+    await manager.sync({ reason: "test", force: true });
+
+    const results = await manager.search("qzv91-lime-orbit");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toBe("memory/2026-02-27.md");
+    expect(results[0]?.score).toBeGreaterThanOrEqual(0.35);
+    expect(embedQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -303,11 +303,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
     }
 
+    // Hybrid scoring combines vector + keyword results using weights. When one
+    // side is unavailable (e.g. query embedding is all zeros, vector search
+    // returns nothing, or FTS is unavailable), renormalize weights to avoid
+    // capping scores (and accidentally filtering everything by minScore).
+    const effectiveVectorWeight = vectorResults.length > 0 ? hybrid.vectorWeight : 0;
+    const effectiveTextWeight = keywordResults.length > 0 ? hybrid.textWeight : 0;
+    const weightSum = effectiveVectorWeight + effectiveTextWeight;
+    const normalizedVectorWeight =
+      weightSum > 0 ? effectiveVectorWeight / weightSum : hybrid.vectorWeight;
+    const normalizedTextWeight =
+      weightSum > 0 ? effectiveTextWeight / weightSum : hybrid.textWeight;
+
     const merged = await this.mergeHybridResults({
       vector: vectorResults,
       keyword: keywordResults,
-      vectorWeight: hybrid.vectorWeight,
-      textWeight: hybrid.textWeight,
+      vectorWeight: normalizedVectorWeight,
+      textWeight: normalizedTextWeight,
       mmr: hybrid.mmr,
       temporalDecay: hybrid.temporalDecay,
     });


### PR DESCRIPTION
## **Summary**

Describe the problem and fix in 2–5 bullets:

- Problem: In hybrid mode, if one modality produces no candidates (e.g. vector search is unavailable because the query embedding is all zeros), the remaining modality’s scores can be capped by its configured weight and then filtered out by minScore, yielding empty memory_search results even though indexing succeeded.
- Why it matters: Freshly indexed memory can become unretrievable, causing silent recall failures.
- What changed: Renormalize hybrid weights when only keyword or only vector results are present; add a regression test covering the zero-embedding query case.
- What did NOT change (scope boundary): No changes when both modalities return results; no config/schema changes.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [x]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #29112
- Related #

## **User-visible / Behavior Changes**

memory_search returns keyword-only (or vector-only) matches when the other modality is empty, instead of returning [] due to weighted score filtering.

## **Security Impact (required)**

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS (local)
- Runtime/container: Node.js + pnpm workspace
- Model/provider: mocked embedding provider (unit test)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. manager.hybrid-fallback.test.ts
2. pnpm check

### **Expected**

- The canary query returns at least one result even when the query embedding is all zeros.

### **Actual**

- Pass.

## **Evidence**

Attach at least one:

- [x]  Failing test/log before + passing after
- [ ]  Trace/log snippets
- [ ]  Screenshot/recording
- [ ]  Perf numbers (if relevant)

## **Human Verification (required)**

What you personally verified (not just CI), and how:

- Verified scenarios: Ran the new regression test and pnpm check.
- Edge cases checked: Keyword-only fallback behavior.
- What you did **not** verify: Full end-to-end reproduction with a real local embedding model.

## **Compatibility / Migration**

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: manager.ts, manager.hybrid-fallback.test.ts
- Known bad symptoms reviewers should watch for: unexpected score shifts when one modality returns no candidates.

## **Risks and Mitigations**

- Risk: Score distribution changes for single-modality searches.
    - Mitigation: Only applies when the other modality returns no results; hybrid behavior remains unchanged when both are present.