### PR TITLE
feat(feishu): embed media in streaming cards instead of sending separately

### DIFF
--- a/extensions/feishu/src/active-streams.ts
+++ b/extensions/feishu/src/active-streams.ts
@@ -1,0 +1,41 @@
+/**
+ * In-memory registry for active streaming sessions.
+ *
+ * During streaming, the reply-dispatcher registers an appender function keyed
+ * by chatId. Other modules (e.g. the outbound adapter) can look up the
+ * appender to inject content into the card instead of sending separate messages.
+ *
+ * Alias keys allow lookup by alternative IDs (e.g. the normalized outbound
+ * target `ou_xxx` for P2P chats where chatId is `oc_xxx`).
+ */
+
+export type StreamAppender = (content: string) => void;
+
+const activeStreams = new Map<string, StreamAppender>();
+const aliases = new Map<string, string>();
+
+export function registerStreamAppender(
+  primaryKey: string,
+  appender: StreamAppender,
+  aliasKeys?: string[],
+): void {
+  activeStreams.set(primaryKey, appender);
+  if (aliasKeys) {
+    for (const alias of aliasKeys) {
+      aliases.set(alias, primaryKey);
+    }
+  }
+}
+
+export function unregisterStreamAppender(primaryKey: string): void {
+  activeStreams.delete(primaryKey);
+  for (const [alias, target] of aliases) {
+    if (target === primaryKey) {
+      aliases.delete(alias);
+    }
+  }
+}
+
+export function getStreamAppender(key: string): StreamAppender | undefined {
+  return activeStreams.get(key) ?? activeStreams.get(aliases.get(key) ?? "");
+}

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -33,6 +33,7 @@ import { parsePostContent } from "./post.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { normalizeFeishuTarget } from "./targets.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -1112,11 +1113,13 @@ export async function handleFeishuMessage(params: {
       ...mediaPayload,
     });
 
+    const outboundTo = normalizeFeishuTarget(feishuTo) ?? undefined;
     const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
       cfg,
       agentId: route.agentId,
       runtime: runtime as RuntimeEnv,
       chatId: ctx.chatId,
+      outboundTo,
       replyToMessageId: ctx.messageId,
       skipReplyToInMessages: !isGroup,
       replyInThread,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,11 +1,15 @@
 import fs from "fs";
 import path from "path";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
+import { resolveFeishuAccount } from "./accounts.js";
 import { getStreamAppender } from "./active-streams.js";
 import { sendMediaFeishu, uploadImageFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
 import { normalizeFeishuTarget } from "./targets.js";
+
+/** Content was embedded in an active streaming card; no discrete message was created. */
+const STREAM_EMBEDDED_RESULT = { channel: "feishu" as const, messageId: "stream-embedded" };
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -64,7 +68,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
           });
           appender(`\n![image](${imageKey})\n`);
-          return { channel: "feishu" };
+          return STREAM_EMBEDDED_RESULT;
         } catch {
           // fall through to separate message
         }
@@ -87,7 +91,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     const appender = normalizedTo ? getStreamAppender(normalizedTo) : undefined;
     if (appender) {
       appender(text);
-      return { channel: "feishu" };
+      return STREAM_EMBEDDED_RESULT;
     }
 
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
@@ -104,7 +108,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       }
       if (mediaUrl) {
         try {
-          const mediaMaxBytes = 30 * 1024 * 1024;
+          const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
+          const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
           const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
             maxBytes: mediaMaxBytes,
             optimizeImages: false,
@@ -137,7 +142,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           appender(`\n📎 ${mediaUrl}\n`);
         }
       }
-      return { channel: "feishu" };
+      return STREAM_EMBEDDED_RESULT;
     }
 
     // Send text first if provided

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,9 +1,11 @@
 import fs from "fs";
 import path from "path";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
-import { sendMediaFeishu } from "./media.js";
+import { getStreamAppender } from "./active-streams.js";
+import { sendMediaFeishu, uploadImageFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
+import { normalizeFeishuTarget } from "./targets.js";
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -44,11 +46,29 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId }) => {
+    const normalizedTo = normalizeFeishuTarget(to);
+
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
     const localImagePath = normalizePossibleLocalImagePath(text);
     if (localImagePath) {
+      // If streaming is active, upload image and embed in card
+      const appender = normalizedTo ? getStreamAppender(normalizedTo) : undefined;
+      if (appender) {
+        try {
+          const buf = await fs.promises.readFile(localImagePath);
+          const { imageKey } = await uploadImageFeishu({
+            cfg,
+            image: buf,
+            accountId: accountId ?? undefined,
+          });
+          appender(`\n![image](${imageKey})\n`);
+          return { channel: "feishu" };
+        } catch {
+          // fall through to separate message
+        }
+      }
       try {
         const result = await sendMediaFeishu({
           cfg,
@@ -63,10 +83,63 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       }
     }
 
+    // If streaming is active, append text to card instead of sending separate message
+    const appender = normalizedTo ? getStreamAppender(normalizedTo) : undefined;
+    if (appender) {
+      appender(text);
+      return { channel: "feishu" };
+    }
+
     const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
     return { channel: "feishu", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
+    const normalizedTo = normalizeFeishuTarget(to);
+    const appender = normalizedTo ? getStreamAppender(normalizedTo) : undefined;
+
+    // When streaming is active, embed everything in the card
+    if (appender) {
+      if (text?.trim()) {
+        appender(text);
+      }
+      if (mediaUrl) {
+        try {
+          const mediaMaxBytes = 30 * 1024 * 1024;
+          const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+            maxBytes: mediaMaxBytes,
+            optimizeImages: false,
+            localRoots: mediaLocalRoots?.length ? [...mediaLocalRoots] : undefined,
+          });
+          const ext = path.extname(loaded.fileName ?? "file").toLowerCase();
+          const isImage = [
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".webp",
+            ".bmp",
+            ".ico",
+            ".tiff",
+          ].includes(ext);
+
+          if (isImage) {
+            const { imageKey } = await uploadImageFeishu({
+              cfg,
+              image: loaded.buffer,
+              accountId: accountId ?? undefined,
+            });
+            appender(`\n![image](${imageKey})\n`);
+          } else {
+            appender(`\n📎 [${loaded.fileName ?? "file"}](${mediaUrl})\n`);
+          }
+        } catch (err) {
+          console.error(`[feishu] stream media embed failed:`, err);
+          appender(`\n📎 ${mediaUrl}\n`);
+        }
+      }
+      return { channel: "feishu" };
+    }
+
     // Send text first if provided
     if (text?.trim()) {
       await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -271,7 +271,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               }
             }
             if (info?.kind === "final") {
-              streamText = committedText + text;
+              // streamText is already maintained by onPartialReply (committedText + AI text);
+              // only reconstruct when no partials were received (streamText is empty/stale).
+              if (!streamText) {
+                streamText = text;
+              }
               await closeStreaming();
             }
             return;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   createReplyPrefixContext,
   createTypingCallbacks,
@@ -9,7 +10,7 @@ import {
 import { resolveFeishuAccount } from "./accounts.js";
 import { registerStreamAppender, unregisterStreamAppender } from "./active-streams.js";
 import { createFeishuClient } from "./client.js";
-import { sendMediaFeishu } from "./media.js";
+import { sendMediaFeishu, uploadImageFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -108,6 +109,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
+  /** Persisted content (prior AI text + embedded media) that must survive onPartialReply rewrites */
+  let committedText = "";
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
 
@@ -136,7 +139,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         registerStreamAppender(
           chatId,
           (content) => {
-            streamText += content;
+            // Commit pending AI partial text so external content doesn't displace it
+            if (lastPartial) {
+              committedText += lastPartial;
+              lastPartial = "";
+            }
+            committedText += content;
+            streamText = committedText;
             partialUpdateQueue = partialUpdateQueue.then(async () => {
               if (streamingStartPromise) await streamingStartPromise;
               if (streaming?.isActive()) await streaming.update(streamText);
@@ -168,6 +177,45 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    committedText = "";
+  };
+
+  /** Upload media and embed as markdown in the streaming card. Returns true on success. */
+  const embedMediaInStream = async (mediaUrl: string): Promise<boolean> => {
+    if (!streaming?.isActive()) return false;
+    try {
+      const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
+      const loaded = await core.media.loadWebMedia(mediaUrl, {
+        maxBytes: mediaMaxBytes,
+        optimizeImages: false,
+      });
+      const ext = path.extname(loaded.fileName ?? "file").toLowerCase();
+      const isImage = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
+        ext,
+      );
+
+      if (lastPartial) {
+        committedText += lastPartial;
+        lastPartial = "";
+      }
+
+      if (isImage) {
+        const { imageKey } = await uploadImageFeishu({ cfg, image: loaded.buffer, accountId });
+        committedText += `\n![image](${imageKey})\n`;
+      } else {
+        committedText += `\n📎 [${loaded.fileName ?? "file"}](${mediaUrl})\n`;
+      }
+
+      streamText = committedText;
+      partialUpdateQueue = partialUpdateQueue.then(async () => {
+        if (streamingStartPromise) await streamingStartPromise;
+        if (streaming?.isActive()) await streaming.update(streamText);
+      });
+      return true;
+    } catch (err) {
+      params.runtime.error?.(`feishu: embed media in stream failed: ${String(err)}`);
+      return false;
+    }
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -207,22 +255,24 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
 
           if (streaming?.isActive()) {
-            if (info?.kind === "final") {
-              streamText = text;
-              await closeStreaming();
-            }
-            // Send media even when streaming handled the text
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
-                  cfg,
-                  to: chatId,
-                  mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread,
-                  accountId,
-                });
+                const embedded = await embedMediaInStream(mediaUrl);
+                if (!embedded) {
+                  await sendMediaFeishu({
+                    cfg,
+                    to: chatId,
+                    mediaUrl,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread,
+                    accountId,
+                  });
+                }
               }
+            }
+            if (info?.kind === "final") {
+              streamText = committedText + text;
+              await closeStreaming();
             }
             return;
           }
@@ -306,7 +356,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               return;
             }
             lastPartial = payload.text;
-            streamText = payload.text;
+            streamText = committedText + payload.text;
             partialUpdateQueue = partialUpdateQueue.then(async () => {
               if (streamingStartPromise) {
                 await streamingStartPromise;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -152,10 +152,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
-    unregisterStreamAppender(chatId);
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
+    unregisterStreamAppender(chatId);
     await partialUpdateQueue;
     if (streaming?.isActive()) {
       let text = streamText;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeEnv,
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
+import { registerStreamAppender, unregisterStreamAppender } from "./active-streams.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
@@ -27,6 +28,8 @@ export type CreateFeishuReplyDispatcherParams = {
   agentId: string;
   runtime: RuntimeEnv;
   chatId: string;
+  /** Normalized outbound target (e.g. `ou_xxx` for P2P). Used as alias key for stream lookup. */
+  outboundTo?: string;
   replyToMessageId?: string;
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
@@ -42,6 +45,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     cfg,
     agentId,
     chatId,
+    outboundTo,
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
@@ -129,6 +133,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyInThread,
           rootId,
         });
+        registerStreamAppender(
+          chatId,
+          (content) => {
+            streamText += content;
+            partialUpdateQueue = partialUpdateQueue.then(async () => {
+              if (streamingStartPromise) await streamingStartPromise;
+              if (streaming?.isActive()) await streaming.update(streamText);
+            });
+          },
+          outboundTo ? [outboundTo] : undefined,
+        );
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
@@ -137,6 +152,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
+    unregisterStreamAppender(chatId);
     if (streamingStartPromise) {
       await streamingStartPromise;
     }


### PR DESCRIPTION
## Summary

- When a streaming card is active, embed media content directly in the card instead of sending separate messages:
  - Images: uploaded to Feishu, embedded as `![image](image_key)` markdown
  - Non-image files: embedded as `📎 [filename](url)` markdown links
  - Upload failures: graceful fallback to link or separate message
- Applies to both the **deliver callback** (AI response media) and the **outbound adapter** (`sendText`/`sendMedia` from the agent's `message` tool)
- Adds `committedText` tracking so embedded media persists across `onPartialReply` rewrites
- **No-op when streaming is not active** — existing separate-message behavior is preserved

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Depends on #29481 (stream registry)
- Part of the split requested in #26368

## User-visible / Behavior Changes

During Feishu streaming, media now appears inline in the card rather than as separate messages. Users see a single coherent card with text + images instead of interleaved messages.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same upload APIs, just different timing)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: Image embedding in streaming card, non-image media as markdown link, fallback to separate message when streaming is not active
- What you did **not** verify: Edge cases with very large files or concurrent tool calls

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert changes to `reply-dispatcher.ts` and `outbound.ts`
- Known bad symptoms: Media not appearing in card → would fall back to separate messages (graceful degradation)

Made with [Cursor](https://cursor.com)