### PR TITLE
docs(lobster): document workflow file shell quoting limitations

### DIFF
--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -158,9 +158,10 @@ processed by the Lobster pipeline DSL. This means `exec --shell "..."` and other
 pipeline DSL syntax (`|` piping, `approve`, etc.) are only available in inline pipeline
 strings passed via the `pipeline` tool parameter, not in `.lobster` file steps.
 
-Additionally, YAML compact mappings can reject embedded quotes in `command` strings
-(e.g. `bash -c ‘echo "hello"’`), producing errors like
-`Nested mappings are not allowed in compact mappings`.
+Additionally, YAML compact mappings can reject `command` strings that contain a
+colon-space (`: `) in an unquoted value
+(e.g. `bash -c ‘curl -H Content-Type: application/json http://example.com’`),
+producing errors like `Nested mappings are not allowed in compact mappings`.
 
 **Workaround 1 — external script:** Move complex shell logic into a bash script and
 reference it from the workflow file.
@@ -178,7 +179,7 @@ steps:
 ```
 
 **Workaround 2 — JSON format:** Use JSON instead of YAML for the `.lobster` file.
-JSON handles embedded quotes naturally via backslash escaping.
+JSON handles embedded quotes and colons naturally via backslash escaping.
 
 ```json
 {
@@ -186,7 +187,7 @@ JSON handles embedded quotes naturally via backslash escaping.
   "steps": [
     {
       "id": "deploy",
-      "command": "bash -c ‘echo \"deploying\" | tee /tmp/deploy.log’"
+      "command": "bash ./deploy.sh production"
     }
   ]
 }

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -159,7 +159,7 @@ pipeline DSL syntax (`|` piping, `approve`, etc.) are only available in inline p
 strings passed via the `pipeline` tool parameter, not in `.lobster` file steps.
 
 Additionally, YAML compact mappings can reject `command` strings that contain a
-colon-space (`: `) in an unquoted value
+colon-space (`":"`) in an unquoted value
 (e.g. `bash -c ‘curl -H Content-Type: application/json http://example.com’`),
 producing errors like `Nested mappings are not allowed in compact mappings`.
 

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -151,6 +151,47 @@ Notes:
 - `stdin: $step.stdout` and `stdin: $step.json` pass a prior step’s output.
 - `condition` (or `when`) can gate steps on `$step.approved`.
 
+### Shell commands in workflow files
+
+The `command` field in workflow file steps runs as a **direct OS command** — it is not
+processed by the Lobster pipeline DSL. This means `exec --shell "..."` and other
+pipeline DSL syntax (`|` piping, `approve`, etc.) are only available in inline pipeline
+strings passed via the `pipeline` tool parameter, not in `.lobster` file steps.
+
+Additionally, YAML compact mappings can reject embedded quotes in `command` strings
+(e.g. `bash -c ‘echo "hello"’`), producing errors like
+`Nested mappings are not allowed in compact mappings`.
+
+**Workaround 1 — external script:** Move complex shell logic into a bash script and
+reference it from the workflow file.
+
+`deploy.sh`:
+```bash
+#!/bin/bash
+echo "deploying $1" | tee /tmp/deploy.log
+```
+
+```yaml
+steps:
+  - id: deploy
+    command: bash ./deploy.sh production
+```
+
+**Workaround 2 — JSON format:** Use JSON instead of YAML for the `.lobster` file.
+JSON handles embedded quotes naturally via backslash escaping.
+
+```json
+{
+  "name": "deploy",
+  "steps": [
+    {
+      "id": "deploy",
+      "command": "bash -c ‘echo \"deploying\" | tee /tmp/deploy.log’"
+    }
+  ]
+}
+```
+
 ## Install Lobster
 
 Install the Lobster CLI on the **same host** that runs the OpenClaw Gateway (see the [Lobster repo](https://github.com/openclaw/lobster)), and ensure `lobster` is on `PATH`.

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -167,6 +167,7 @@ producing errors like `Nested mappings are not allowed in compact mappings`.
 reference it from the workflow file.
 
 `deploy.sh`:
+
 ```bash
 #!/bin/bash
 echo "deploying $1" | tee /tmp/deploy.log


### PR DESCRIPTION
## Summary

- Document that `command` in `.lobster` workflow file steps runs as a direct OS command, not through the Lobster pipeline DSL
- Clarify that `exec --shell` and pipeline syntax (`|`, `approve`, etc.) are only available in inline `pipeline` strings, not in workflow file steps
- Document YAML compact mapping quoting limitation for `command` strings with embedded quotes
- Add two workarounds with examples: external bash scripts, and JSON format for the workflow file

Closes #29491

## Test plan

- [ ] Verify docs render correctly on Mintlify (no broken links or formatting)
- [ ] Confirm the new section reads clearly alongside existing workflow file docs
