### PR TITLE
memory: respect explicit provider=local when resolved provider is auto (fixes #29318)

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { type FSWatcher } from "chokidar";
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope.js";
 import type { ResolvedMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -126,16 +130,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return pending;
     }
     const createPromise = (async () => {
-      // #8131 fixed auth: when provider is "local" we no longer require remote API keys.
-      // When the resolved provider is "auto" (e.g. defaults missing in merge, or tool path),
-      // createEmbeddingProvider("auto") tries local then remote; if a remote profile (e.g.
-      // google:default) has a key, Gemini wins and explicit memorySearch.provider=local is
-      // ignored. Force "local" when config explicitly requests it so we never prefer remote
-      // over explicit local (fixes #29318; workaround was renaming auth profile to avoid
-      // auto-selecting Gemini).
+      // #8131: when provider is "local" we do not require remote API keys.
+      // When resolved provider is "auto" (e.g. defaults missing in merge), createEmbeddingProvider
+      // may pick a remote provider and ignore explicit local. Only force "local" when the global
+      // default is local and the agent did NOT override provider (fixes #29318; see PR review P1).
       const requestedDefault = cfg.agents?.defaults?.memorySearch?.provider;
+      const agentProviderOverride = resolveAgentConfig(cfg, agentId)?.memorySearch?.provider;
       const effectiveProvider =
-        requestedDefault === "local" && settings.provider === "auto" ? "local" : settings.provider;
+        requestedDefault === "local" &&
+        settings.provider === "auto" &&
+        agentProviderOverride === undefined
+          ? "local"
+          : settings.provider;
+
       const providerResult = await createEmbeddingProvider({
         config: cfg,
         agentDir: resolveAgentDir(cfg, agentId),

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -126,10 +126,20 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return pending;
     }
     const createPromise = (async () => {
+      // #8131 fixed auth: when provider is "local" we no longer require remote API keys.
+      // When the resolved provider is "auto" (e.g. defaults missing in merge, or tool path),
+      // createEmbeddingProvider("auto") tries local then remote; if a remote profile (e.g.
+      // google:default) has a key, Gemini wins and explicit memorySearch.provider=local is
+      // ignored. Force "local" when config explicitly requests it so we never prefer remote
+      // over explicit local (fixes #29318; workaround was renaming auth profile to avoid
+      // auto-selecting Gemini).
+      const requestedDefault = cfg.agents?.defaults?.memorySearch?.provider;
+      const effectiveProvider =
+        requestedDefault === "local" && settings.provider === "auto" ? "local" : settings.provider;
       const providerResult = await createEmbeddingProvider({
         config: cfg,
         agentDir: resolveAgentDir(cfg, agentId),
-        provider: settings.provider,
+        provider: effectiveProvider,
         remote: settings.remote,
         model: settings.model,
         fallback: settings.fallback,


### PR DESCRIPTION
## Summary

- **Problem:** With `agents.defaults.memorySearch.provider: "local"` set, the CLI (`openclaw memory status` / `memory index`) correctly uses local embeddings, but the `memory_search` tool returns results with `provider: "gemini"` because the effective requested provider becomes `"auto"` on the tool path; `createEmbeddingProvider("auto")` then tries local then remote and picks a remote provider (e.g. Gemini) when it has an API key (e.g. from `google:default` auth profile).
- **Why it matters:** Users who explicitly configure local embeddings expect the tool to use local; the workaround (renaming the Google auth profile) confirms the issue is provider resolution priority ignoring explicit `provider: "local"`.
- **What changed:** In `MemoryIndexManager.get`, when `cfg.agents?.defaults?.memorySearch?.provider === "local"` but the merged `settings.provider === "auto"`, we now pass `effectiveProvider: "local"` into `createEmbeddingProvider` so the explicit setting is honored and we never prefer a remote provider over it.
- **What did NOT change:** No change when the resolved provider is already `"local"` or when the user has not set defaults to local; no change to embeddings auth or to the `"auto"` branch behavior when there is no explicit local default.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue/PR

- Closes #29318
- Related #8131 (see "Difference from #8131" below)

## User-visible / Behavior Changes

When `agents.defaults.memorySearch.provider` is set to `"local"` and the merged memory search config would otherwise resolve to `"auto"` (e.g. on the tool/gateway path), the memory_search tool now uses the local embedding provider instead of a remote one (e.g. Gemini). CLI behavior is unchanged.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (reduces unintended remote embedding calls when local is explicitly configured)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

- Config: `agents.defaults.memorySearch: { provider: "local", fallback: "none", local: { modelPath: "..." } }`.
- Before: `memory_search` tool could return `provider: "gemini"` when a Google auth profile (e.g. `google:default`) had a key.
- After: Same config yields `provider: "local"` and the configured local model for the tool, consistent with the CLI.
- Ran: `pnpm test --run src/memory/` (33 test files, 226 tests) — all pass.

## Background and difference from #8131

**Issue #8131** was about the memory_search/memory_get tools failing with an auth error (requiring OpenAI/Google API keys) even when `memorySearch.provider: "local"`. The fix (per closing comment) was to ensure that when the requested provider is already `"local"`, we do not require or validate remote API keys: `memory-search.ts` keeps `remote` unset for local, and `embeddings.ts` only invokes remote key resolution for remote providers.

**Issue #29318** is different: the tools do not fail with an auth error; they succeed but use a remote provider (Gemini) instead of local. The root cause is that on some code paths (e.g. tool/gateway) the **resolved** provider is `"auto"` rather than `"local"` (e.g. because `cfg.agents?.defaults?.memorySearch` is missing in the merge or not applied in that context). Then `createEmbeddingProvider("auto")` runs: it tries local only when `canAutoSelectLocal(options)` is true, then tries remote providers in order; if Gemini has an API key (e.g. from auth profile `google:default`), it is chosen and the explicit `provider: "local"` is effectively ignored.

So #8131 fixed **auth behavior** (when we pass `"local"`, do not ask for remote keys). #29318 is fixed by **provider resolution**: when the config explicitly requests `"local"`, we must not pass `"auto"` into `createEmbeddingProvider`, so that the #8131 path (local without remote key checks) is used and we never prefer a remote provider over the explicit local setting. This PR enforces that in `MemoryIndexManager.get` by forcing the effective provider to `"local"` when defaults say local but the merged settings say `"auto"`.
