### PR TITLE
fix(gateway): exit 0 on EADDRINUSE port conflict to prevent crash-loops (#28191)

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -12,6 +12,7 @@ import {
 } from "../../config/config.js";
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
+import { probeGateway } from "../../gateway/probe.js";
 import { startGatewayServer } from "../../gateway/server.js";
 import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
@@ -449,16 +450,25 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         // ignore diagnostics failures
       }
       await maybeExplainGatewayServiceStop();
-      // If the port is already bound by another gateway instance, exit 0 so
-      // service managers (systemd, launchd) with Restart=on-failure do not
-      // spin in a tight crash-loop.  Any other lock-acquisition failure is
-      // still a real error and warrants a non-zero exit.
+      // Only exit 0 when the port is held by an already-running OpenClaw
+      // gateway instance (confirmed by a live probe).  If an unrelated process
+      // is on the port, startup genuinely failed and we must exit non-zero so
+      // supervisors with Restart=on-failure keep retrying instead of silently
+      // accepting a downed gateway.
       const lockCause = (err as GatewayLockError).cause;
       const isPortConflict =
         lockCause != null &&
         typeof lockCause === "object" &&
         (lockCause as NodeJS.ErrnoException).code === "EADDRINUSE";
-      defaultRuntime.exit(isPortConflict ? 0 : 1);
+      if (isPortConflict) {
+        const probe = await probeGateway({
+          url: `ws://127.0.0.1:${port}`,
+          timeoutMs: 3000,
+        }).catch(() => null);
+        defaultRuntime.exit(probe?.ok ? 0 : 1);
+      } else {
+        defaultRuntime.exit(1);
+      }
       return;
     }
     defaultRuntime.error(`Gateway failed to start: ${String(err)}`);

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -449,7 +449,16 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         // ignore diagnostics failures
       }
       await maybeExplainGatewayServiceStop();
-      defaultRuntime.exit(1);
+      // If the port is already bound by another gateway instance, exit 0 so
+      // service managers (systemd, launchd) with Restart=on-failure do not
+      // spin in a tight crash-loop.  Any other lock-acquisition failure is
+      // still a real error and warrants a non-zero exit.
+      const lockCause = (err as GatewayLockError).cause;
+      const isPortConflict =
+        lockCause != null &&
+        typeof lockCause === "object" &&
+        (lockCause as NodeJS.ErrnoException).code === "EADDRINUSE";
+      defaultRuntime.exit(isPortConflict ? 0 : 1);
       return;
     }
     defaultRuntime.error(`Gateway failed to start: ${String(err)}`);


### PR DESCRIPTION
## Problem

When a second gateway instance tries to start and finds the port already bound (`EADDRINUSE`), it throws a `GatewayLockError` which propagates as a non-zero exit (code 1). Under systemd with `Restart=on-failure` (the default), exit 1 triggers an immediate restart — which hits the same error — creating a tight crash-loop that burns CPU and floods logs.

Reproduced in `openclaw-lab:2026.2.26` (Docker): second gateway exits code 1 on port conflict.

## Root Cause

`src/gateway/server/http-listen.ts:26-31` throws `GatewayLockError` (with `cause.code === "EADDRINUSE"`) on port conflict. This is caught in `src/cli/gateway-cli/run.ts` and unconditionally calls `defaultRuntime.exit(1)`.

Introduced by commit `bcbfb357be` (Peter Steinberger, 2026-01-14). Partially mitigated by `16ccd5a87` (ThrottleInterval for launchd) and `dd07c06d0` (tighter restart loop), but the core EADDRINUSE → clean exit was never addressed.

## Fix

In the `GatewayLockError` catch block in `run.ts`, inspect `err.cause.code`. If it is `EADDRINUSE`, the port is already owned by a live gateway — this process has nothing to do, so exit 0. The error message and diagnostics are still printed. All other `GatewayLockError` variants (lock-file timeout, stale lock, etc.) continue to exit 1.

```ts
const lockCause = (err as GatewayLockError).cause;
const isPortConflict =
  lockCause != null &&
  typeof lockCause === "object" &&
  (lockCause as NodeJS.ErrnoException).code === "EADDRINUSE";
defaultRuntime.exit(isPortConflict ? 0 : 1);
```

## Testing

- Existing `gateway-cli.coverage.test.ts` GatewayLockError tests still pass (they do not set `cause.code === EADDRINUSE`).
- Port-conflict path now exits 0 — service managers with `Restart=on-failure` will not restart the gateway.

Fixes #28191