### PR TITLE
fix(telegram): preserve HTTP proxy when replacing global undici dispatcher

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -5,8 +5,8 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const AgentCtor = vi.hoisted(() =>
-  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
     this.options = options;
   }),
 );
@@ -28,7 +28,7 @@ vi.mock("node:dns", async () => {
 });
 
 vi.mock("undici", () => ({
-  Agent: AgentCtor,
+  EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
   setGlobalDispatcher,
 }));
 
@@ -39,7 +39,7 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
-  AgentCtor.mockClear();
+  EnvHttpProxyAgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -152,7 +152,7 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenCalledWith({
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledWith({
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -174,13 +174,13 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(1, {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(2, {
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -46,7 +46,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
   ) {
     try {
       setGlobalDispatcher(
-        new Agent({
+        new EnvHttpProxyAgent({
           connect: {
             autoSelectFamily: autoSelectDecision.value,
             autoSelectFamilyAttemptTimeout: 300,


### PR DESCRIPTION
## Summary
- Telegram's `autoSelectFamily` workaround called `setGlobalDispatcher(new Agent({...}))`, which replaced the `EnvHttpProxyAgent` previously set by pi-ai's `http-proxy` module
- This caused all LLM API requests to bypass the configured HTTP proxy (`HTTPS_PROXY`/`HTTP_PROXY` env vars), resulting in `403 This model is not available in your region` errors from providers like OpenRouter
- Fix: switch from `Agent` to `EnvHttpProxyAgent` so the replacement dispatcher still honours proxy environment variables while carrying the `autoSelectFamily` connect option

## Test plan
- [x] `src/telegram/fetch.test.ts` updated and passing (11/11)
- [x] Verified LLM API calls route through proxy after gateway restart with `HTTPS_PROXY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)