### PR TITLE
Feishu: include quoted/parent message content when forwarding to agen…

### DIFF
--- a/extensions/feishu/src/parse-content.test.ts
+++ b/extensions/feishu/src/parse-content.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseFeishuMessageContent, parsePostContent } from "./parse-content.js";
+
+describe("parseFeishuMessageContent", () => {
+  it("extracts text from text message type", () => {
+    const content = JSON.stringify({ text: "Hello world" });
+    expect(parseFeishuMessageContent(content, "text")).toBe("Hello world");
+  });
+
+  it("extracts textContent from post (rich text) message type", () => {
+    const content = JSON.stringify({
+      title: "Summary",
+      content: [
+        [
+          { tag: "text", text: "Learn from " },
+          { tag: "at", user_name: "Alice", user_id: "ou-alice" },
+          { tag: "text", text: " above." },
+        ],
+      ],
+    });
+    expect(parseFeishuMessageContent(content, "post")).toBe("Summary\n\nLearn from @Alice above.");
+  });
+
+  it("returns raw content for unknown message type", () => {
+    const content = JSON.stringify({ text: "fallback" });
+    expect(parseFeishuMessageContent(content, "image")).toBe(content);
+  });
+
+  it("returns content as-is when JSON parse fails", () => {
+    expect(parseFeishuMessageContent("not json", "text")).toBe("not json");
+  });
+});
+
+describe("parsePostContent", () => {
+  it("returns textContent and imageKeys for post with text and image", () => {
+    const content = JSON.stringify({
+      content: [[{ tag: "text", text: "See image" }], [{ tag: "img", image_key: "img_xxx" }]],
+    });
+    const out = parsePostContent(content);
+    expect(out.textContent).toContain("See image");
+    expect(out.imageKeys).toEqual(["img_xxx"]);
+  });
+});

--- a/extensions/feishu/src/parse-content.ts
+++ b/extensions/feishu/src/parse-content.ts
@@ -1,0 +1,71 @@
+import { normalizeFeishuExternalKey } from "./external-keys.js";
+
+/**
+ * Parse post (rich text) content and extract text and embedded image keys.
+ * Post structure: { title?: string, content: [[{ tag, text?, image_key?, ... }]] }
+ */
+export function parsePostContent(content: string): {
+  textContent: string;
+  imageKeys: string[];
+  mentionedOpenIds: string[];
+} {
+  try {
+    const parsed = JSON.parse(content);
+    const title = parsed.title || "";
+    const contentBlocks = parsed.content || [];
+    let textContent = title ? `${title}\n\n` : "";
+    const imageKeys: string[] = [];
+    const mentionedOpenIds: string[] = [];
+
+    for (const paragraph of contentBlocks) {
+      if (Array.isArray(paragraph)) {
+        for (const element of paragraph) {
+          if (element.tag === "text") {
+            textContent += element.text || "";
+          } else if (element.tag === "a") {
+            textContent += element.text || element.href || "";
+          } else if (element.tag === "at") {
+            textContent += `@${element.user_name || element.user_id || ""}`;
+            if (element.user_id) {
+              mentionedOpenIds.push(element.user_id);
+            }
+          } else if (element.tag === "img" && element.image_key) {
+            const imageKey = normalizeFeishuExternalKey(element.image_key);
+            if (imageKey) {
+              imageKeys.push(imageKey);
+            }
+          }
+        }
+        textContent += "\n";
+      }
+    }
+
+    return {
+      textContent: textContent.trim() || "[Rich text message]",
+      imageKeys,
+      mentionedOpenIds,
+    };
+  } catch {
+    return { textContent: "[Rich text message]", imageKeys: [], mentionedOpenIds: [] };
+  }
+}
+
+/**
+ * Parse Feishu message content by type into plain text for agent context.
+ * Handles text, post (rich text), and falls back to raw content for other types.
+ */
+export function parseFeishuMessageContent(content: string, messageType: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    if (messageType === "text") {
+      return parsed.text ?? "";
+    }
+    if (messageType === "post") {
+      const { textContent } = parsePostContent(content);
+      return textContent;
+    }
+    return content;
+  } catch {
+    return content;
+  }
+}

--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -92,11 +92,13 @@ describe("parsePostContent", () => {
     expect(parsePostContent(wrappedByPost)).toEqual({
       textContent: "标题\n\n内容A",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
     expect(parsePostContent(wrappedByLocale)).toEqual({
       textContent: "标题\n\n内容B",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
   });


### PR DESCRIPTION
## Summary

- **Problem:** When a user quotes a message in Feishu and @mentions the bot, the agent only received the new message text; the quoted (parent) message content was not included, so the agent could not fulfill requests like "learn from this" or "summarize this."
- **Why it matters:** Users explicitly provide context by quoting; without it, they must manually copy-paste, which blocks common group-chat workflows.
- **What changed:** (1) Added shared `parseFeishuMessageContent` in `parse-content.ts` so fetched parent messages (text and post) are parsed to plain text. (2) In `getMessageFeishu`, use this parser and support both API response shapes (`data.items[0]` and `data` as single message object) so quoted content is reliably fetched and passed to the agent.
- **What did NOT change (scope boundary):** No change to bot event handling flow (parent_id fetch was already present); no change to other channels or to Feishu post/merge_forward handling in bot.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29487
- Related N/A

## User-visible / Behavior Changes

- When a user quotes a message in Feishu and @mentions the bot, the agent input now includes the quoted message content (e.g. `[Replying to: "…"]` plus the new message). Previously the quoted text was missing or raw JSON for post-type messages.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` — same GET message API, more robust parsing)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- All No; no security impact expected.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+, pnpm
- Integration/channel: Feishu (webhook or websocket)
- Relevant config: Feishu app with message receive + bot in group

### Steps

1. In a Feishu group, send a message (e.g. "Please remember: meeting at 3pm").
2. Quote that message and @mention the bot with e.g. "Summarize the above."
3. Check agent input / logs.

### Expected

- Agent receives both the quoted message text ("Please remember: meeting at 3pm") and the new message ("Summarize the above") in a single context.

### Actual

- Before: quoted content often missing or raw JSON for post messages. After: quoted content present as plain text.

## Evidence

- [x] Unit tests: `extensions/feishu/src/parse-content.test.ts` for `parseFeishuMessageContent` (text, post, unknown type) and `parsePostContent`.
- [x] Existing bot tests still pass; getMessageFeishu is mocked there; send.ts and parse-content.ts covered by new tests.

## Human Verification (required)

- Verified: `pnpm check` passes; `pnpm test -- extensions/feishu/src/parse-content.test.ts extensions/feishu/src/bot.test.ts` pass.
- Edge cases: post-type parent message now parsed to text; API response shape fallback (items[0] vs single object) in getMessageFeishu.
- Not verified: Live Feishu quote+mention in production (no Feishu app in test env).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- Revert the commit; restore previous `getMessageFeishu` and remove `parse-content.ts` / `parse-content.test.ts` if desired.
- Symptoms: quoted content again missing or raw JSON for rich-text parent messages.

## Risks and Mitigations

- Risk: Different Feishu API response shape in some tenants could still return null for parent message.
  - Mitigation: We support both `data.items[0]` and `data` as single object; if a third shape appears, we can extend the fallback.
