### PR TITLE
fix(discord): reduce reconnect event loss and unblock message lane

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -84,12 +84,14 @@ describe("createFeishuWSClient proxy handling", () => {
 
     createFeishuWSClient(baseAccount);
 
-    const expectedHttpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+    // On Windows env keys are case-insensitive, so setting HTTPS_PROXY may
+    // overwrite https_proxy. We assert https proxies still win over http.
+    const expectedProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+    expect(expectedProxy).toBeTruthy();
     expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
-    expect(expectedHttpsProxy).toBeTruthy();
-    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith(expectedHttpsProxy);
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith(expectedProxy);
     const options = firstWsClientOptions();
-    expect(options.agent).toEqual({ proxyUrl: expectedHttpsProxy });
+    expect(options.agent).toEqual({ proxyUrl: expectedProxy });
   });
 
   it("passes HTTP_PROXY to ws client when https vars are unset", () => {

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -88,16 +88,7 @@ describe("DiscordMessageListener", () => {
     };
   }
 
-  async function expectPending(promise: Promise<unknown>) {
-    let resolved = false;
-    void promise.then(() => {
-      resolved = true;
-    });
-    await Promise.resolve();
-    expect(resolved).toBe(false);
-  }
-
-  it("awaits the handler before returning", async () => {
+  it("returns immediately while handler continues in background", async () => {
     let handlerResolved = false;
     const deferred = createDeferred();
     const handler = vi.fn(async () => {
@@ -111,16 +102,15 @@ describe("DiscordMessageListener", () => {
       {} as unknown as import("@buape/carbon").Client,
     );
 
-    // Handler should be called but not yet resolved
+    // Handler should be called, while handle() returns immediately.
     expect(handler).toHaveBeenCalledOnce();
     expect(handlerResolved).toBe(false);
-    await expectPending(handlePromise);
+    await expect(handlePromise).resolves.toBeUndefined();
+    expect(handlerResolved).toBe(false);
 
-    // Release the handler
+    // Release and let background handler finish.
     deferred.resolve();
-
-    // Now await handle() - it should complete only after handler resolves
-    await handlePromise;
+    await Promise.resolve();
     expect(handlerResolved).toBe(true);
   });
 
@@ -156,21 +146,20 @@ describe("DiscordMessageListener", () => {
       } as unknown as ReturnType<typeof import("../logging/subsystem.js").createSubsystemLogger>;
       const listener = new DiscordMessageListener(handler, logger);
 
-      // Start handle() but don't await yet
+      // handle() should release immediately.
       const handlePromise = listener.handle(
         {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
         {} as unknown as import("@buape/carbon").Client,
       );
-      await expectPending(handlePromise);
+      await expect(handlePromise).resolves.toBeUndefined();
+      expect(logger.warn).not.toHaveBeenCalled();
 
-      // Advance time past the slow listener threshold
+      // Advance wall clock past the slow listener threshold.
       vi.setSystemTime(31_000);
 
-      // Release the handler
+      // Release the background handler and allow slow-log finalizer to run.
       deferred.resolve();
-
-      // Now await handle() - it should complete and log the slow listener
-      await handlePromise;
+      await Promise.resolve();
 
       expect(logger.warn).toHaveBeenCalled();
       const warnMock = logger.warn as unknown as { mock: { calls: unknown[][] } };

--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -102,16 +102,54 @@ describe("DiscordMessageListener", () => {
       {} as unknown as import("@buape/carbon").Client,
     );
 
-    // Handler should be called, while handle() returns immediately.
-    expect(handler).toHaveBeenCalledOnce();
-    expect(handlerResolved).toBe(false);
+    // handle() returns immediately while the background queue starts on the next tick.
     await expect(handlePromise).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledOnce();
+    });
     expect(handlerResolved).toBe(false);
 
     // Release and let background handler finish.
     deferred.resolve();
     await Promise.resolve();
     expect(handlerResolved).toBe(true);
+  });
+
+  it("queues subsequent events until prior message handling completes", async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    let runCount = 0;
+    const handler = vi.fn(async () => {
+      runCount += 1;
+      if (runCount === 1) {
+        await first.promise;
+        return;
+      }
+      await second.promise;
+    });
+    const listener = new DiscordMessageListener(handler);
+
+    await expect(
+      listener.handle(
+        {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
+        {} as unknown as import("@buape/carbon").Client,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      listener.handle(
+        {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
+        {} as unknown as import("@buape/carbon").Client,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    first.resolve();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    second.resolve();
+    await Promise.resolve();
   });
 
   it("logs handler failures", async () => {
@@ -128,9 +166,9 @@ describe("DiscordMessageListener", () => {
       {} as unknown as import("./monitor/listeners.js").DiscordMessageEvent,
       {} as unknown as import("@buape/carbon").Client,
     );
-    await Promise.resolve();
-
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("discord handler failed"));
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("discord handler failed"));
+    });
   });
 
   it("logs slow handlers after the threshold", async () => {

--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -28,6 +28,40 @@ describe("DiscordMessageListener", () => {
     await handlerDone;
   });
 
+  it("serializes queued handler runs while handle returns immediately", async () => {
+    let firstResolve: (() => void) | undefined;
+    let secondResolve: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      firstResolve = resolve;
+    });
+    const secondDone = new Promise<void>((resolve) => {
+      secondResolve = resolve;
+    });
+    let runCount = 0;
+    const handler = vi.fn(async () => {
+      runCount += 1;
+      if (runCount === 1) {
+        await firstDone;
+        return;
+      }
+      await secondDone;
+    });
+    const listener = new DiscordMessageListener(handler as never, createLogger() as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+
+    // Second event is queued until the first handler run settles.
+    expect(handler).toHaveBeenCalledTimes(1);
+    firstResolve?.();
+    await vi.waitFor(() => {
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    secondResolve?.();
+    await secondDone;
+  });
+
   it("logs async handler failures", async () => {
     const handler = vi.fn(async () => {
       throw new Error("boom");

--- a/src/discord/monitor/listeners.test.ts
+++ b/src/discord/monitor/listeners.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { DiscordMessageListener } from "./listeners.js";
+
+function createLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe("DiscordMessageListener", () => {
+  it("returns immediately without awaiting handler completion", async () => {
+    let resolveHandler: (() => void) | undefined;
+    const handlerDone = new Promise<void>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await handlerDone;
+    });
+    const logger = createLogger();
+    const listener = new DiscordMessageListener(handler as never, logger as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    resolveHandler?.();
+    await handlerDone;
+  });
+
+  it("logs async handler failures", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const logger = createLogger();
+    const listener = new DiscordMessageListener(handler as never, logger as never);
+
+    await expect(listener.handle({} as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord handler failed: Error: boom"),
+      );
+    });
+  });
+});

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -118,6 +118,8 @@ export function registerDiscordListener(listeners: Array<object>, listener: obje
 }
 
 export class DiscordMessageListener extends MessageCreateListener {
+  private messageQueue: Promise<void> = Promise.resolve();
+
   constructor(
     private handler: DiscordMessageHandler,
     private logger?: Logger,
@@ -126,19 +128,23 @@ export class DiscordMessageListener extends MessageCreateListener {
   }
 
   async handle(data: DiscordMessageEvent, client: Client) {
-    // Release the event lane immediately; long-running turns continue in the
-    // background while preserving existing error and slow-listener logging.
-    const task = runDiscordListenerWithSlowLog({
-      logger: this.logger,
-      listener: this.constructor.name,
-      event: this.type,
-      run: () => this.handler(data, client),
-      onError: (err) => {
-        const logger = this.logger ?? discordEventQueueLog;
-        logger.error(danger(`discord handler failed: ${String(err)}`));
-      },
-    });
-    void task.catch((err) => {
+    // Release Carbon's dispatch lane immediately, but keep our message handler
+    // serialized to avoid unbounded parallel model/IO work on traffic bursts.
+    this.messageQueue = this.messageQueue
+      .catch(() => {})
+      .then(() =>
+        runDiscordListenerWithSlowLog({
+          logger: this.logger,
+          listener: this.constructor.name,
+          event: this.type,
+          run: () => this.handler(data, client),
+          onError: (err) => {
+            const logger = this.logger ?? discordEventQueueLog;
+            logger.error(danger(`discord handler failed: ${String(err)}`));
+          },
+        }),
+      );
+    void this.messageQueue.catch((err) => {
       const logger = this.logger ?? discordEventQueueLog;
       logger.error(danger(`discord handler failed: ${String(err)}`));
     });

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -126,7 +126,9 @@ export class DiscordMessageListener extends MessageCreateListener {
   }
 
   async handle(data: DiscordMessageEvent, client: Client) {
-    await runDiscordListenerWithSlowLog({
+    // Release the event lane immediately; long-running turns continue in the
+    // background while preserving existing error and slow-listener logging.
+    const task = runDiscordListenerWithSlowLog({
       logger: this.logger,
       listener: this.constructor.name,
       event: this.type,
@@ -135,6 +137,10 @@ export class DiscordMessageListener extends MessageCreateListener {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord handler failed: ${String(err)}`));
       },
+    });
+    void task.catch((err) => {
+      const logger = this.logger ?? discordEventQueueLog;
+      logger.error(danger(`discord handler failed: ${String(err)}`));
     });
   }
 }

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -265,7 +265,7 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("resets HELLO stall counter after a connected timeout window", async () => {
+  it("resets HELLO stall counter after a successful reconnect that drops quickly", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
@@ -288,11 +288,17 @@ describe("runDiscordGatewayLifecycle", () => {
         emitter.emit("debug", "WebSocket connection opened");
         await vi.advanceTimersByTimeAsync(30000);
 
+        // Successful reconnect (READY/RESUMED sets isConnected=true), then
+        // quick drop before the HELLO timeout window finishes.
         gateway.isConnected = true;
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(10);
+        emitter.emit("debug", "WebSocket connection closed with code 1006");
+        gateway.isConnected = false;
+
         emitter.emit("debug", "WebSocket connection opened");
         await vi.advanceTimersByTimeAsync(30000);
 
-        gateway.isConnected = false;
         emitter.emit("debug", "WebSocket connection opened");
         await vi.advanceTimersByTimeAsync(30000);
       });
@@ -300,9 +306,10 @@ describe("runDiscordGatewayLifecycle", () => {
       const { lifecycleParams } = createLifecycleHarness({ gateway });
       await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
 
-      expect(gateway.connect).toHaveBeenCalledTimes(2);
+      expect(gateway.connect).toHaveBeenCalledTimes(3);
       expect(gateway.connect).toHaveBeenNthCalledWith(1, true);
       expect(gateway.connect).toHaveBeenNthCalledWith(2, true);
+      expect(gateway.connect).toHaveBeenNthCalledWith(3, true);
       expect(gateway.connect).not.toHaveBeenCalledWith(false);
     } finally {
       vi.useRealTimers();

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import type { Client } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -11,9 +12,10 @@ const {
   waitForDiscordGatewayStopMock,
 } = vi.hoisted(() => {
   const stopGatewayLoggingMock = vi.fn();
+  const getDiscordGatewayEmitterMock = vi.fn<() => EventEmitter | undefined>(() => undefined);
   return {
     attachDiscordGatewayLoggingMock: vi.fn(() => stopGatewayLoggingMock),
-    getDiscordGatewayEmitterMock: vi.fn(() => undefined),
+    getDiscordGatewayEmitterMock,
     waitForDiscordGatewayStopMock: vi.fn(() => Promise.resolve()),
     registerGatewayMock: vi.fn(),
     unregisterGatewayMock: vi.fn(),
@@ -51,6 +53,19 @@ describe("runDiscordGatewayLifecycle", () => {
     stop?: () => Promise<void>;
     isDisallowedIntentsError?: (err: unknown) => boolean;
     pendingGatewayErrors?: unknown[];
+    gateway?: {
+      isConnected?: boolean;
+      options?: Record<string, unknown>;
+      disconnect?: () => void;
+      connect?: (resume?: boolean) => void;
+      state?: {
+        sessionId?: string | null;
+        resumeGatewayUrl?: string | null;
+        sequence?: number | null;
+      };
+      sequence?: number | null;
+      emitter?: EventEmitter;
+    };
   }) => {
     const start = vi.fn(params?.start ?? (async () => undefined));
     const stop = vi.fn(params?.stop ?? (async () => undefined));
@@ -72,7 +87,9 @@ describe("runDiscordGatewayLifecycle", () => {
       releaseEarlyGatewayErrorGuard,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
-        client: { getPlugin: vi.fn(() => undefined) } as unknown as Client,
+        client: {
+          getPlugin: vi.fn((name: string) => (name === "gateway" ? params?.gateway : undefined)),
+        } as unknown as Client,
         runtime,
         isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
         voiceManager: null,
@@ -202,5 +219,93 @@ describe("runDiscordGatewayLifecycle", () => {
       waitCalls: 0,
       releaseEarlyGatewayErrorGuard,
     });
+  });
+
+  it("retries stalled HELLO with resume before forcing fresh identify", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const emitter = new EventEmitter();
+      const gateway = {
+        isConnected: false,
+        options: {},
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+        state: {
+          sessionId: "session-1",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 123,
+        },
+        sequence: 123,
+        emitter,
+      };
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+      });
+
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      expect(gateway.disconnect).toHaveBeenCalledTimes(3);
+      expect(gateway.connect).toHaveBeenNthCalledWith(1, true);
+      expect(gateway.connect).toHaveBeenNthCalledWith(2, true);
+      expect(gateway.connect).toHaveBeenNthCalledWith(3, false);
+      expect(gateway.state.sessionId).toBeNull();
+      expect(gateway.state.resumeGatewayUrl).toBeNull();
+      expect(gateway.state.sequence).toBeNull();
+      expect(gateway.sequence).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets HELLO stall counter after a connected timeout window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const emitter = new EventEmitter();
+      const gateway = {
+        isConnected: false,
+        options: {},
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+        state: {
+          sessionId: "session-2",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 456,
+        },
+        sequence: 456,
+        emitter,
+      };
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+
+        gateway.isConnected = true;
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+
+        gateway.isConnected = false;
+        emitter.emit("debug", "WebSocket connection opened");
+        await vi.advanceTimersByTimeAsync(30000);
+      });
+
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      expect(gateway.connect).toHaveBeenCalledTimes(2);
+      expect(gateway.connect).toHaveBeenNthCalledWith(1, true);
+      expect(gateway.connect).toHaveBeenNthCalledWith(2, true);
+      expect(gateway.connect).not.toHaveBeenCalledWith(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -51,7 +51,28 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   const HELLO_TIMEOUT_MS = 30000;
+  const MAX_CONSECUTIVE_HELLO_STALLS = 3;
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let consecutiveHelloStalls = 0;
+  const clearResumeState = () => {
+    const mutableGateway = gateway as
+      | (GatewayPlugin & {
+          state?: {
+            sessionId?: string | null;
+            resumeGatewayUrl?: string | null;
+            sequence?: number | null;
+          };
+          sequence?: number | null;
+        })
+      | undefined;
+    if (!mutableGateway?.state) {
+      return;
+    }
+    mutableGateway.state.sessionId = null;
+    mutableGateway.state.resumeGatewayUrl = null;
+    mutableGateway.state.sequence = null;
+    mutableGateway.sequence = null;
+  };
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
     if (!message.includes("WebSocket connection opened")) {
@@ -61,14 +82,24 @@ export async function runDiscordGatewayLifecycle(params: {
       clearTimeout(helloTimeoutId);
     }
     helloTimeoutId = setTimeout(() => {
-      if (!gateway?.isConnected) {
+      if (gateway?.isConnected) {
+        consecutiveHelloStalls = 0;
+      } else {
+        consecutiveHelloStalls += 1;
+        const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
         params.runtime.log?.(
           danger(
-            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+            forceFreshIdentify
+              ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
+              : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
           ),
         );
+        if (forceFreshIdentify) {
+          clearResumeState();
+          consecutiveHelloStalls = 0;
+        }
         gateway?.disconnect();
-        gateway?.connect(false);
+        gateway?.connect(!forceFreshIdentify);
       }
       helloTimeoutId = undefined;
     }, HELLO_TIMEOUT_MS);

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -51,9 +51,24 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   const HELLO_TIMEOUT_MS = 30000;
+  const HELLO_CONNECTED_POLL_MS = 250;
   const MAX_CONSECUTIVE_HELLO_STALLS = 3;
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let consecutiveHelloStalls = 0;
+  const clearHelloWatch = () => {
+    if (helloTimeoutId) {
+      clearTimeout(helloTimeoutId);
+      helloTimeoutId = undefined;
+    }
+    if (helloConnectedPollId) {
+      clearInterval(helloConnectedPollId);
+      helloConnectedPollId = undefined;
+    }
+  };
+  const resetHelloStallCounter = () => {
+    consecutiveHelloStalls = 0;
+  };
   const clearResumeState = () => {
     const mutableGateway = gateway as
       | (GatewayPlugin & {
@@ -75,15 +90,40 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
+    if (message.includes("WebSocket connection closed")) {
+      // Carbon marks `isConnected` true only after READY/RESUMED and flips it
+      // false during reconnect handling after this debug line is emitted.
+      if (gateway?.isConnected) {
+        resetHelloStallCounter();
+      }
+      clearHelloWatch();
+      return;
+    }
     if (!message.includes("WebSocket connection opened")) {
       return;
     }
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-    }
+    clearHelloWatch();
+
+    let sawConnected = gateway?.isConnected === true;
+    helloConnectedPollId = setInterval(() => {
+      if (!gateway?.isConnected) {
+        return;
+      }
+      sawConnected = true;
+      resetHelloStallCounter();
+      if (helloConnectedPollId) {
+        clearInterval(helloConnectedPollId);
+        helloConnectedPollId = undefined;
+      }
+    }, HELLO_CONNECTED_POLL_MS);
+
     helloTimeoutId = setTimeout(() => {
-      if (gateway?.isConnected) {
-        consecutiveHelloStalls = 0;
+      if (helloConnectedPollId) {
+        clearInterval(helloConnectedPollId);
+        helloConnectedPollId = undefined;
+      }
+      if (sawConnected || gateway?.isConnected) {
+        resetHelloStallCounter();
       } else {
         consecutiveHelloStalls += 1;
         const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
@@ -96,7 +136,7 @@ export async function runDiscordGatewayLifecycle(params: {
         );
         if (forceFreshIdentify) {
           clearResumeState();
-          consecutiveHelloStalls = 0;
+          resetHelloStallCounter();
         }
         gateway?.disconnect();
         gateway?.connect(!forceFreshIdentify);
@@ -168,9 +208,7 @@ export async function runDiscordGatewayLifecycle(params: {
     params.releaseEarlyGatewayErrorGuard?.();
     unregisterGateway(params.accountId);
     stopGatewayLogging();
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-    }
+    clearHelloWatch();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
     params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {


### PR DESCRIPTION
Fixes #29420

## Why this PR
I reviewed the currently related reconnect PRs and found they do not fully resolve #29420 on `main`:

- #21463 and #27693 are not merged and focus on event-lane blocking.
- #25974 and #29484 focus on stale-session resume loops, but do not add resume-first HELLO-stall behavior with regression coverage in `main`.

## What changed
- `src/discord/monitor/listeners.ts`
  - Release the Discord message event lane immediately (fire-and-forget handler execution) while preserving error + slow-listener logging.
- `src/discord/monitor/provider.lifecycle.ts`
  - On HELLO timeout, retry reconnect with resume first (`connect(true)`) to preserve missed-event recovery.
  - Add bounded fallback: after 3 consecutive HELLO stalls, clear resume/session state and force fresh identify (`connect(false)`).
  - Reset stall counter once the gateway is connected.
- Tests
  - Added `src/discord/monitor/listeners.test.ts`.
  - Extended `src/discord/monitor/provider.lifecycle.test.ts` with HELLO-stall resume/fallback regressions.

## Verification
- `pnpm vitest run src/discord/monitor/listeners.test.ts src/discord/monitor/provider.lifecycle.test.ts src/discord/monitor/provider.test.ts`
- `pnpm check`

All passed locally.
