### PR TITLE
fix(line): download file-type inbound media

### DIFF
--- a/src/line/bot-handlers.file-media.test.ts
+++ b/src/line/bot-handlers.file-media.test.ts
@@ -1,0 +1,137 @@
+import type { MessageEvent } from "@line/bot-sdk";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  downloadLineMedia: vi.fn(),
+  buildLineMessageContext: vi.fn(async () => ({
+    ctxPayload: { From: "line:user:user-1" },
+    replyToken: "reply-token",
+    route: { agentId: "default" },
+    isGroup: false,
+    accountId: "default",
+  })),
+  buildLinePostbackContext: vi.fn(async () => null),
+  readAllowFromStore: vi.fn(async () => [] as string[]),
+  upsertPairingRequest: vi.fn(async () => ({ code: "CODE", created: true })),
+}));
+
+vi.mock("../globals.js", () => ({
+  danger: (text: string) => text,
+  logVerbose: () => {},
+}));
+
+vi.mock("../pairing/pairing-labels.js", () => ({
+  resolvePairingIdLabel: () => "lineUserId",
+}));
+
+vi.mock("../pairing/pairing-messages.js", () => ({
+  buildPairingReply: () => "pairing-reply",
+}));
+
+vi.mock("../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: (...args: unknown[]) =>
+    mocks.readAllowFromStore(...(args as Parameters<typeof mocks.readAllowFromStore>)),
+  upsertChannelPairingRequest: (...args: unknown[]) =>
+    mocks.upsertPairingRequest(...(args as Parameters<typeof mocks.upsertPairingRequest>)),
+}));
+
+vi.mock("./send.js", () => ({
+  pushMessageLine: async () => {
+    throw new Error("pushMessageLine should not be called in media tests");
+  },
+  replyMessageLine: async () => {
+    throw new Error("replyMessageLine should not be called in media tests");
+  },
+}));
+
+vi.mock("./download.js", () => ({
+  downloadLineMedia: (...args: unknown[]) =>
+    mocks.downloadLineMedia(...(args as Parameters<typeof mocks.downloadLineMedia>)),
+}));
+
+vi.mock("./bot-message-context.js", () => ({
+  buildLineMessageContext: (...args: unknown[]) =>
+    mocks.buildLineMessageContext(...(args as Parameters<typeof mocks.buildLineMessageContext>)),
+  buildLinePostbackContext: (...args: unknown[]) =>
+    mocks.buildLinePostbackContext(...(args as Parameters<typeof mocks.buildLinePostbackContext>)),
+  getLineSourceInfo: (source: {
+    type?: string;
+    userId?: string;
+    groupId?: string;
+    roomId?: string;
+  }) => ({
+    userId: source.userId,
+    groupId: source.type === "group" ? source.groupId : undefined,
+    roomId: source.type === "room" ? source.roomId : undefined,
+    isGroup: source.type === "group" || source.type === "room",
+  }),
+}));
+
+let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
+
+const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
+
+describe("handleLineWebhookEvents LINE media download", () => {
+  beforeAll(async () => {
+    ({ handleLineWebhookEvents } = await import("./bot-handlers.js"));
+  });
+
+  beforeEach(() => {
+    mocks.downloadLineMedia.mockReset();
+    mocks.buildLineMessageContext.mockClear();
+    mocks.buildLinePostbackContext.mockClear();
+    mocks.readAllowFromStore.mockClear();
+    mocks.upsertPairingRequest.mockClear();
+    mocks.downloadLineMedia.mockResolvedValue({
+      path: "/tmp/line-file.pdf",
+      contentType: "application/pdf",
+    });
+  });
+
+  it("downloads LINE file messages and forwards media refs", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: {
+        id: "file-1",
+        type: "file",
+        fileName: "demo.pdf",
+        fileSize: "123",
+      },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "user", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "evt-file-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { dmPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { dmPolicy: "open" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1024,
+      processMessage,
+    });
+
+    expect(mocks.downloadLineMedia).toHaveBeenCalledWith("file-1", "token", 1024);
+    const calls = mocks.buildLineMessageContext.mock.calls as unknown[][];
+    const firstCallArg = calls[0]?.[0] as
+      | { allMedia?: Array<{ path: string; contentType?: string }> }
+      | undefined;
+    expect(firstCallArg?.allMedia).toEqual([
+      {
+        path: "/tmp/line-file.pdf",
+        contentType: "application/pdf",
+      },
+    ]);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -224,7 +224,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (
+    message.type === "image" ||
+    message.type === "video" ||
+    message.type === "audio" ||
+    message.type === "file"
+  ) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({


### PR DESCRIPTION
## Summary

- **Problem:** LINE inbound handler only downloaded `image`/`video`/`audio`, so `file` uploads stayed as placeholders without media refs.
- **Why it matters:** Agents cannot access attached documents (PDF/doc/etc.) from LINE file messages.
- **What changed:** Added `message.type === "file"` to LINE media download gate in `src/line/bot-handlers.ts`, and added regression coverage in `src/line/bot-handlers.file-media.test.ts`.
- **What did NOT change:** No changes to outbound LINE sending, message formatting, or download size/error handling paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29490

## User-visible / Behavior Changes

- LINE users sending `file` messages now produce media refs (`MediaPath`/`MediaUrl`/`MediaPaths`) like other media types.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + pnpm/vitest
- Integration/channel: LINE

### Steps

1. Send a LINE `file` message to the bot.
2. Inspect the built inbound context passed to auto-reply.

### Expected

- File content is downloaded and attached as media refs.

### Actual

- Before fix: file type skipped download branch, no media refs populated.
- After fix: file type is downloaded and media refs are populated.

## Evidence

- `pnpm vitest run src/line/bot-handlers.file-media.test.ts`
- Added assertion that `downloadLineMedia("file-1", "token", 1024)` is called and forwarded media refs include `/tmp/line-file.pdf`.

## Human Verification (required)

- Verified scenarios: inbound LINE `file` message path downloads media and forwards to context builder.
- Edge cases checked: existing media types (`image`/`video`/`audio`) still use same branch.
- What I did **not** verify: live LINE webhook end-to-end against real LINE API.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR/commit.
- Files/config to restore: `src/line/bot-handlers.ts`, remove new test file.
- Known bad symptoms: LINE file uploads no longer expose media refs.

## Risks and Mitigations

- Risk: expanding download gate could alter handling of LINE file payloads.
- Mitigation: regression test asserts only file-type entry path and existing error handling remains unchanged.

