### PR TITLE
fix bug: exec tool accepts cmd alias and empty args (#29458)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.schema.test.ts
+++ b/src/agents/bash-tools.exec-runtime.schema.test.ts
@@ -1,0 +1,14 @@
+import AjvPkg from "ajv";
+import { describe, expect, it } from "vitest";
+import { execSchema } from "./bash-tools.exec-runtime.js";
+
+describe("execSchema", () => {
+  it("accepts empty args so tool can return a helpful error at runtime", () => {
+    const ajv = new (AjvPkg as unknown as new (opts?: object) => import("ajv").default)({
+      allErrors: true,
+      strict: false,
+    });
+    const validate = ajv.compile(execSchema);
+    expect(validate({})).toBe(true);
+  });
+});

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -90,7 +90,12 @@ const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 
 export const execSchema = Type.Object({
-  command: Type.String({ description: "Shell command to execute" }),
+  command: Type.Optional(Type.String({ description: "Shell command to execute" })),
+  cmd: Type.Optional(
+    Type.String({
+      description: "Alias for command (some providers/models emit cmd instead of command).",
+    }),
+  ),
   workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
   env: Type.Optional(Type.Record(Type.String(), Type.String())),
   yieldMs: Type.Optional(

--- a/src/agents/bash-tools.exec.cmd-alias.test.ts
+++ b/src/agents/bash-tools.exec.cmd-alias.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createExecTool } from "./bash-tools.exec.js";
+
+describe("exec tool cmd alias", () => {
+  it("treats cmd as an alias for command", async () => {
+    const tool = createExecTool();
+    try {
+      await tool.execute("call_1", { cmd: "echo hi", elevated: true });
+      throw new Error("expected exec to fail");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toMatch(/elevated is not available/i);
+      expect(message).not.toMatch(/Provide a command to start/i);
+    }
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -208,7 +208,8 @@ export function createExecTool(
     parameters: execSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {
-        command: string;
+        command?: string;
+        cmd?: string;
         workdir?: string;
         env?: Record<string, string>;
         yieldMs?: number;
@@ -221,6 +222,10 @@ export function createExecTool(
         ask?: string;
         node?: string;
       };
+
+      if (!params.command && typeof params.cmd === "string") {
+        params.command = params.cmd;
+      }
 
       if (!params.command) {
         throw new Error("Provide a command to start.");


### PR DESCRIPTION
## **Summary**

- Problem: Some providers/models emit exec tool calls with {} or with cmd instead of command, triggering schema validation failures like “must have required property 'command'” (and making consecutive exec calls unreliable).
- Why it matters: exec becomes flaky and fails before it can return a useful, actionable error message to users.
- What changed: Made command optional in the exec tool schema, added cmd as an alias, and mapped cmd -> command at runtime before execution; added regression tests.
- What did NOT change (scope boundary): No changes to exec security/approval gates, sandboxing, allowed hosts, or command execution behavior once a command is present.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [x]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #29458
- Related #

## **User-visible / Behavior Changes**

- exec accepts cmd as an alias for command.
- exec no longer fails schema validation when arguments are {}; it returns the existing helpful runtime error (“Provide a command to start.”) instead.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS (local)
- Runtime/container: Node.js + pnpm + Vitest
- Model/provider: N/A (unit tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): default

### **Steps**

1. bash-tools.exec.cmd-alias.test.ts
2. pnpm check

### **Expected**

- Tool schema accepts {} and runtime returns a useful error for missing command.
- Tool accepts { cmd: "..." } without treating it as missing command.

### **Actual**

- Pass.

## **Evidence**

- [x]  Failing test/log before + passing after
- [ ]  Trace/log snippets
- [ ]  Screenshot/recording
- [ ]  Perf numbers (if relevant)

## **Human Verification (required)**

- Verified scenarios: Ran the new unit tests and pnpm check.
- Edge cases checked: {} args, cmd alias mapping.
- What you did **not** verify: Live reproduction on MiniMax/webchat.

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: bash-tools.exec-runtime.ts, bash-tools.exec.ts
- Known bad symptoms reviewers should watch for: Unexpected provider-side schema rejection (should be unlikely since this loosens requirements).

## **Risks and Mitigations**

- Risk: Allowing {} to pass schema validation could defer failures to runtime.
    - Mitigation: Runtime already rejects missing command with a clear error; security/approval gates remain unchanged.