### PR TITLE
fix(plugins): preserve plugin-registered internal hooks across gateway startup

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -16,6 +16,7 @@ import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import {
   clearInternalHooks,
   createInternalHookEvent,
+  registerInternalHook,
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
@@ -117,6 +118,24 @@ export async function startGatewaySidecars(params: {
       params.logHooks.info(
         `loaded ${loadedCount} internal hook handler${loadedCount > 1 ? "s" : ""}`,
       );
+    }
+
+    // Re-register plugin-provided internal hooks (wiped by clearInternalHooks above).
+    if (params.cfg.hooks?.internal?.enabled) {
+      let pluginHookCount = 0;
+      for (const hook of params.pluginRegistry.hooks) {
+        if (hook.handler) {
+          for (const event of hook.events) {
+            registerInternalHook(event, hook.handler);
+            pluginHookCount++;
+          }
+        }
+      }
+      if (pluginHookCount > 0) {
+        params.logHooks.info(
+          `re-registered ${pluginHookCount} plugin hook${pluginHookCount > 1 ? "s" : ""}`,
+        );
+      }
     }
   } catch (err) {
     params.logHooks.error(`failed to load hooks: ${String(err)}`);

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -501,5 +501,32 @@ describe("hooks", () => {
       expect(handler).toHaveBeenCalledOnce();
       expect(handler).toHaveBeenCalledWith(event);
     });
+
+    it("should skip hooks with undefined handler (register:false)", async () => {
+      // Simulate the re-registration loop in startGatewaySidecars — hooks
+      // registered with opts.register=false have handler=undefined and must
+      // not become active after clearInternalHooks().
+      const hooks = [
+        { events: ["agent:bootstrap"], handler: undefined },
+        { events: ["agent:bootstrap"], handler: vi.fn() },
+      ];
+
+      for (const hook of hooks) {
+        if (hook.handler) {
+          for (const event of hook.events) {
+            registerInternalHook(event, hook.handler);
+          }
+        }
+      }
+
+      const event = createInternalHookEvent("agent", "bootstrap", "test-session", {
+        workspaceDir: "/tmp",
+        bootstrapFiles: [],
+      });
+      await triggerInternalHook(event);
+
+      // Only the hook with a defined handler should fire (1 call, not 2).
+      expect(hooks[1].handler).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -474,4 +474,32 @@ describe("hooks", () => {
       expect(keys).toEqual([]);
     });
   });
+
+  describe("plugin hook re-registration after clear", () => {
+    it("should survive clearInternalHooks when re-registered from registry", async () => {
+      const handler = vi.fn();
+
+      // Simulate plugin registering a hook during loadGatewayPlugins
+      registerInternalHook("agent:bootstrap", handler);
+
+      // Simulate startGatewaySidecars clearing all hooks
+      clearInternalHooks();
+
+      // Handler should be gone
+      const event = createInternalHookEvent("agent", "bootstrap", "test-session", {
+        workspaceDir: "/tmp",
+        bootstrapFiles: [],
+      });
+      await triggerInternalHook(event);
+      expect(handler).not.toHaveBeenCalled();
+
+      // Simulate re-registration from plugin registry (the fix)
+      registerInternalHook("agent:bootstrap", handler);
+
+      // Now handler should fire
+      await triggerInternalHook(event);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+  });
 });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -6,7 +6,7 @@ import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
 } from "../gateway/server-methods/types.js";
-import { registerInternalHook } from "../hooks/internal-hooks.js";
+import { registerInternalHook, type InternalHookHandler } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand, validatePluginCommandDefinition } from "./commands.js";
@@ -116,6 +116,8 @@ export type PluginHookRegistration = {
   events: string[];
   source: string;
   rootDir?: string;
+  /** Stored so plugin hooks survive clearInternalHooks() and can be re-registered. */
+  handler?: InternalHookHandler;
 };
 
 export type PluginServiceRegistration = {
@@ -334,6 +336,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       entry: hookEntry,
       events: normalizedEvents,
       source: record.source,
+      handler,
     });
 
     const hookSystemEnabled = config?.hooks?.internal?.enabled === true;

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -331,16 +331,22 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         };
 
     record.hookNames.push(name);
+
+    const hookSystemEnabled = config?.hooks?.internal?.enabled === true;
+    const shouldRegister = hookSystemEnabled && opts?.register !== false;
+
     registry.hooks.push({
       pluginId: record.id,
       entry: hookEntry,
       events: normalizedEvents,
       source: record.source,
-      handler,
+      // Only store handler when it was actually registered — hooks with
+      // register:false are metadata-only and must not become active after
+      // clearInternalHooks() re-registration.
+      handler: shouldRegister ? handler : undefined,
     });
 
-    const hookSystemEnabled = config?.hooks?.internal?.enabled === true;
-    if (!hookSystemEnabled || opts?.register === false) {
+    if (!shouldRegister) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Fix plugin hooks (e.g. `agent:bootstrap`) being wiped during gateway startup: `clearInternalHooks()` in `startGatewaySidecars` destroyed hooks registered by plugins during `loadGatewayPlugins`
- Store the handler function in `PluginHookRegistration` so it survives the clear, then re-register plugin hooks after `loadInternalHooks()`
- Without this fix, plugins cannot use `api.registerHook("agent:bootstrap", handler)` — the only way to inject content into the system prompt once per session

## Test plan

- [x] `pnpm tsgo` — no new type errors
- [x] `pnpm vitest run src/hooks/internal-hooks.test.ts` — 30/30 pass (includes new test)
- [ ] Gateway restart with plugin using `registerHook("agent:bootstrap")` → "re-registered 1 plugin hook" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)