### PR TITLE
fix(models): detect AWS SDK auth for Bedrock in `models status` display

### DIFF
--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -138,4 +138,25 @@ describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
       }
     }
   });
+
+  it("does not show AWS SDK auth when Bedrock provider has auth override", () => {
+    const original = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "test-token-value";
+    try {
+      const overview = resolveProviderAuthOverview({
+        provider: "amazon-bedrock",
+        cfg: { models: { providers: { "amazon-bedrock": { auth: "api-key" } } } },
+        store: { version: 1, profiles: {} } as never,
+        modelsPath: "/tmp/models.json",
+      });
+      expect(overview.effective.kind).toBe("missing");
+      expect(overview.env).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      }
+    }
+  });
 });

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -145,7 +145,9 @@ describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
     try {
       const overview = resolveProviderAuthOverview({
         provider: "amazon-bedrock",
-        cfg: { models: { providers: { "amazon-bedrock": { auth: "api-key" } } } },
+        cfg: {
+          models: { providers: { "amazon-bedrock": { auth: "api-key", baseUrl: "", models: [] } } },
+        } as never,
         store: { version: 1, profiles: {} } as never,
         modelsPath: "/tmp/models.json",
       });

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -22,3 +22,52 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.profiles.labels[0]).toContain("token:ref(env:GITHUB_TOKEN)");
   });
 });
+
+describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
+  it("detects AWS_BEARER_TOKEN_BEDROCK as effective auth for amazon-bedrock", () => {
+    const original = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "test-token-value";
+    try {
+      const overview = resolveProviderAuthOverview({
+        provider: "amazon-bedrock",
+        cfg: {},
+        store: { version: 1, profiles: {} } as never,
+        modelsPath: "/tmp/models.json",
+      });
+      expect(overview.effective.kind).toBe("env");
+      expect(overview.effective.detail).toContain("aws-sdk");
+      expect(overview.effective.detail).toContain("AWS_BEARER_TOKEN_BEDROCK");
+      expect(overview.env).toBeDefined();
+      expect(overview.env?.source).toBe("env: AWS_BEARER_TOKEN_BEDROCK");
+    } finally {
+      if (original === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      else process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+    }
+  });
+
+  it("shows missing auth for amazon-bedrock when no AWS env vars are set", () => {
+    const original = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const origAccess = process.env.AWS_ACCESS_KEY_ID;
+    const origSecret = process.env.AWS_SECRET_ACCESS_KEY;
+    const origProfile = process.env.AWS_PROFILE;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_PROFILE;
+    try {
+      const overview = resolveProviderAuthOverview({
+        provider: "amazon-bedrock",
+        cfg: {},
+        store: { version: 1, profiles: {} } as never,
+        modelsPath: "/tmp/models.json",
+      });
+      expect(overview.effective.kind).toBe("missing");
+      expect(overview.env).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      if (origAccess !== undefined) process.env.AWS_ACCESS_KEY_ID = origAccess;
+      if (origSecret !== undefined) process.env.AWS_SECRET_ACCESS_KEY = origSecret;
+      if (origProfile !== undefined) process.env.AWS_PROFILE = origProfile;
+    }
+  });
+});

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -42,7 +42,9 @@ describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
     } finally {
       if (original === undefined) {
         delete process.env.AWS_BEARER_TOKEN_BEDROCK;
-      } else process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      }
     }
   });
 

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -40,8 +40,9 @@ describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
       expect(overview.env).toBeDefined();
       expect(overview.env?.source).toBe("env: AWS_BEARER_TOKEN_BEDROCK");
     } finally {
-      if (original === undefined) delete process.env.AWS_BEARER_TOKEN_BEDROCK;
-      else process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      if (original === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else process.env.AWS_BEARER_TOKEN_BEDROCK = original;
     }
   });
 
@@ -64,10 +65,18 @@ describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {
       expect(overview.effective.kind).toBe("missing");
       expect(overview.env).toBeUndefined();
     } finally {
-      if (original !== undefined) process.env.AWS_BEARER_TOKEN_BEDROCK = original;
-      if (origAccess !== undefined) process.env.AWS_ACCESS_KEY_ID = origAccess;
-      if (origSecret !== undefined) process.env.AWS_SECRET_ACCESS_KEY = origSecret;
-      if (origProfile !== undefined) process.env.AWS_PROFILE = origProfile;
+      if (original !== undefined) {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      }
+      if (origAccess !== undefined) {
+        process.env.AWS_ACCESS_KEY_ID = origAccess;
+      }
+      if (origSecret !== undefined) {
+        process.env.AWS_SECRET_ACCESS_KEY = origSecret;
+      }
+      if (origProfile !== undefined) {
+        process.env.AWS_PROFILE = origProfile;
+      }
     }
   });
 });

--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -21,6 +21,63 @@ describe("resolveProviderAuthOverview", () => {
 
     expect(overview.profiles.labels[0]).toContain("token:ref(env:GITHUB_TOKEN)");
   });
+
+  it("detects AWS SDK auth when provider is alias bedrock", () => {
+    const original = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_BEARER_TOKEN_BEDROCK = "test-token-value";
+    try {
+      const overview = resolveProviderAuthOverview({
+        provider: "bedrock",
+        cfg: {},
+        store: { version: 1, profiles: {} } as never,
+        modelsPath: "/tmp/models.json",
+      });
+      expect(overview.effective.kind).toBe("env");
+      expect(overview.effective.detail).toContain("aws-sdk");
+    } finally {
+      if (original === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = original;
+      }
+    }
+  });
+
+  it("shows full IAM key pair in env source label", () => {
+    const origBearer = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const origAccess = process.env.AWS_ACCESS_KEY_ID;
+    const origSecret = process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    process.env.AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+    process.env.AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    try {
+      const overview = resolveProviderAuthOverview({
+        provider: "amazon-bedrock",
+        cfg: {},
+        store: { version: 1, profiles: {} } as never,
+        modelsPath: "/tmp/models.json",
+      });
+      expect(overview.effective.kind).toBe("env");
+      expect(overview.effective.detail).toContain("AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY");
+      expect(overview.env?.source).toContain("AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY");
+    } finally {
+      if (origBearer === undefined) {
+        delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+      } else {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = origBearer;
+      }
+      if (origAccess === undefined) {
+        delete process.env.AWS_ACCESS_KEY_ID;
+      } else {
+        process.env.AWS_ACCESS_KEY_ID = origAccess;
+      }
+      if (origSecret === undefined) {
+        delete process.env.AWS_SECRET_ACCESS_KEY;
+      } else {
+        process.env.AWS_SECRET_ACCESS_KEY = origSecret;
+      }
+    }
+  });
 });
 
 describe("resolveProviderAuthOverview — Bedrock AWS SDK auth", () => {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -96,7 +96,14 @@ export function resolveProviderAuthOverview(params: {
 
   const envKey = resolveEnvApiKey(provider);
   const customKey = getCustomProviderApiKey(cfg, provider);
-  const awsSdkEnvVar = normalizeProviderId(provider) === "amazon-bedrock" ? resolveAwsSdkEnvVarName() : undefined;
+  const isBedrock = normalizeProviderId(provider) === "amazon-bedrock";
+  const bedrockProviderCfg = isBedrock
+    ? Object.entries(cfg?.models?.providers ?? {}).find(
+        ([key]) => normalizeProviderId(key) === "amazon-bedrock",
+      )?.[1] as { auth?: string } | undefined
+    : undefined;
+  const bedrockAuthOverride = bedrockProviderCfg?.auth;
+  const awsSdkEnvVar = isBedrock && (bedrockAuthOverride === "aws-sdk" || bedrockAuthOverride === undefined) ? resolveAwsSdkEnvVarName() : undefined;
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (profiles.length > 0) {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -11,8 +11,8 @@ import {
   resolveAwsSdkEnvVarName,
   resolveEnvApiKey,
 } from "../../agents/model-auth.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";
 import type { ProviderAuthOverview } from "./list.types.js";
@@ -99,12 +99,19 @@ export function resolveProviderAuthOverview(params: {
   const isBedrock = normalizeProviderId(provider) === "amazon-bedrock";
   const bedrockProviderCfg = isBedrock
     ? ((cfg?.models?.providers?.[provider] as { auth?: string } | undefined) ??
-        Object.entries(cfg?.models?.providers ?? {}).find(
-          ([key]) => normalizeProviderId(key) === "amazon-bedrock",
-        )?.[1] as { auth?: string } | undefined)
+      (Object.entries(cfg?.models?.providers ?? {}).find(
+        ([key]) => normalizeProviderId(key) === "amazon-bedrock",
+      )?.[1] as { auth?: string } | undefined))
     : undefined;
   const bedrockAuthOverride = bedrockProviderCfg?.auth;
-  const awsSdkEnvVar = isBedrock && (bedrockAuthOverride === "aws-sdk" || bedrockAuthOverride === undefined) ? resolveAwsSdkEnvVarName() : undefined;
+  const awsSdkEnvVar =
+    isBedrock && (bedrockAuthOverride === "aws-sdk" || bedrockAuthOverride === undefined)
+      ? resolveAwsSdkEnvVarName()
+      : undefined;
+  const awsEnvLabel =
+    awsSdkEnvVar === "AWS_ACCESS_KEY_ID"
+      ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY"
+      : awsSdkEnvVar;
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (profiles.length > 0) {
@@ -125,8 +132,7 @@ export function resolveProviderAuthOverview(params: {
       return { kind: "models.json", detail: maskApiKey(customKey) };
     }
     if (awsSdkEnvVar) {
-      const awsLabel = awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar;
-      return { kind: "env", detail: `aws-sdk (${awsLabel})` };
+      return { kind: "env", detail: `aws-sdk (${awsEnvLabel})` };
     }
     return { kind: "missing", detail: "missing" };
   })();
@@ -154,8 +160,8 @@ export function resolveProviderAuthOverview(params: {
       : awsSdkEnvVar
         ? {
             env: {
-              value: `aws-sdk (${awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar})`,
-              source: `env: ${awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar}`,
+              value: `aws-sdk (${awsEnvLabel})`,
+              source: `env: ${awsEnvLabel}`,
             },
           }
         : {}),

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -6,7 +6,11 @@ import {
   resolveAuthStorePathForDisplay,
   resolveProfileUnusableUntilForDisplay,
 } from "../../agents/auth-profiles.js";
-import { getCustomProviderApiKey, resolveAwsSdkEnvVarName, resolveEnvApiKey } from "../../agents/model-auth.js";
+import {
+  getCustomProviderApiKey,
+  resolveAwsSdkEnvVarName,
+  resolveEnvApiKey,
+} from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -6,7 +6,7 @@ import {
   resolveAuthStorePathForDisplay,
   resolveProfileUnusableUntilForDisplay,
 } from "../../agents/auth-profiles.js";
-import { getCustomProviderApiKey, resolveEnvApiKey } from "../../agents/model-auth.js";
+import { getCustomProviderApiKey, resolveAwsSdkEnvVarName, resolveEnvApiKey } from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";
@@ -91,6 +91,7 @@ export function resolveProviderAuthOverview(params: {
 
   const envKey = resolveEnvApiKey(provider);
   const customKey = getCustomProviderApiKey(cfg, provider);
+  const awsSdkEnvVar = provider === "amazon-bedrock" ? resolveAwsSdkEnvVarName() : undefined;
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (profiles.length > 0) {
@@ -109,6 +110,9 @@ export function resolveProviderAuthOverview(params: {
     }
     if (customKey) {
       return { kind: "models.json", detail: maskApiKey(customKey) };
+    }
+    if (awsSdkEnvVar) {
+      return { kind: "env", detail: `aws-sdk (${awsSdkEnvVar})` };
     }
     return { kind: "missing", detail: "missing" };
   })();
@@ -133,7 +137,14 @@ export function resolveProviderAuthOverview(params: {
             source: envKey.source,
           },
         }
-      : {}),
+      : awsSdkEnvVar
+        ? {
+            env: {
+              value: `aws-sdk (${awsSdkEnvVar})`,
+              source: `env: ${awsSdkEnvVar}`,
+            },
+          }
+        : {}),
     ...(customKey
       ? {
           modelsJson: {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -12,6 +12,7 @@ import {
   resolveEnvApiKey,
 } from "../../agents/model-auth.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import { shortenHomePath } from "../../utils.js";
 import { maskApiKey } from "./list.format.js";
 import type { ProviderAuthOverview } from "./list.types.js";
@@ -95,7 +96,7 @@ export function resolveProviderAuthOverview(params: {
 
   const envKey = resolveEnvApiKey(provider);
   const customKey = getCustomProviderApiKey(cfg, provider);
-  const awsSdkEnvVar = provider === "amazon-bedrock" ? resolveAwsSdkEnvVarName() : undefined;
+  const awsSdkEnvVar = normalizeProviderId(provider) === "amazon-bedrock" ? resolveAwsSdkEnvVarName() : undefined;
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (profiles.length > 0) {
@@ -116,7 +117,8 @@ export function resolveProviderAuthOverview(params: {
       return { kind: "models.json", detail: maskApiKey(customKey) };
     }
     if (awsSdkEnvVar) {
-      return { kind: "env", detail: `aws-sdk (${awsSdkEnvVar})` };
+      const awsLabel = awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar;
+      return { kind: "env", detail: `aws-sdk (${awsLabel})` };
     }
     return { kind: "missing", detail: "missing" };
   })();
@@ -144,8 +146,8 @@ export function resolveProviderAuthOverview(params: {
       : awsSdkEnvVar
         ? {
             env: {
-              value: `aws-sdk (${awsSdkEnvVar})`,
-              source: `env: ${awsSdkEnvVar}`,
+              value: `aws-sdk (${awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar})`,
+              source: `env: ${awsSdkEnvVar === "AWS_ACCESS_KEY_ID" ? "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY" : awsSdkEnvVar}`,
             },
           }
         : {}),

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -98,9 +98,10 @@ export function resolveProviderAuthOverview(params: {
   const customKey = getCustomProviderApiKey(cfg, provider);
   const isBedrock = normalizeProviderId(provider) === "amazon-bedrock";
   const bedrockProviderCfg = isBedrock
-    ? Object.entries(cfg?.models?.providers ?? {}).find(
-        ([key]) => normalizeProviderId(key) === "amazon-bedrock",
-      )?.[1] as { auth?: string } | undefined
+    ? ((cfg?.models?.providers?.[provider] as { auth?: string } | undefined) ??
+        Object.entries(cfg?.models?.providers ?? {}).find(
+          ([key]) => normalizeProviderId(key) === "amazon-bedrock",
+        )?.[1] as { auth?: string } | undefined)
     : undefined;
   const bedrockAuthOverride = bedrockProviderCfg?.auth;
   const awsSdkEnvVar = isBedrock && (bedrockAuthOverride === "aws-sdk" || bedrockAuthOverride === undefined) ? resolveAwsSdkEnvVarName() : undefined;


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw models status` shows "Missing auth" for `amazon-bedrock` even when `AWS_BEARER_TOKEN_BEDROCK` (or `AWS_ACCESS_KEY_ID`+`AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE`) is set and the provider works fine at runtime.
- **Root cause:** `resolveProviderAuthOverview()` only calls `resolveEnvApiKey()`, which handles standard `PROVIDER_API_KEY` env vars but does not handle Bedrock's AWS SDK credential chain. The runtime auth path (`resolveAuthModeForModel`) correctly calls `resolveAwsSdkEnvVarName()` — the status display does not.
- **Fix:** Add `resolveAwsSdkEnvVarName()` check to `resolveProviderAuthOverview()` for `amazon-bedrock` so AWS SDK env vars are surfaced in both the effective auth display and the env section.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs

## Scope

- [x] Auth / tokens
- [x] UI / DX

## User-visible Changes

Before:
```
Missing auth
- amazon-bedrock Run `openclaw configure` or set an API key env var.
```

After (when `AWS_BEARER_TOKEN_BEDROCK` is set):
```
- amazon-bedrock effective=env:aws-sdk (AWS_BEARER_TOKEN_BEDROCK) | env=aws-sdk (AWS_BEARER_TOKEN_BEDROCK) | source=env: AWS_BEARER_TOKEN_BEDROCK
```

## Files Changed

- `src/commands/models/list.auth-overview.ts` — import `resolveAwsSdkEnvVarName`, add Bedrock-specific AWS SDK auth detection
- `src/commands/models/list.auth-overview.test.ts` — add test cases for detected and missing Bedrock auth

## Repro

1. Set `AWS_BEARER_TOKEN_BEDROCK` in env (or `.env`)
2. Configure `amazon-bedrock/...` as primary or fallback model
3. Run `openclaw models status`
4. Observe "Missing auth" for amazon-bedrock despite it working at runtime

## Related

- Existing PR #19841 adds Bedrock to onboarding wizard (complementary, not overlapping)
- Existing PR #8963 fixes inference profile ID matching (different issue)
