### PR TITLE
feat(telegram): support custom apiRoot for Telegram Bot API

### DIFF
--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -297,6 +297,9 @@ async function buildActivity(
       const isPersonal = conversationType === "personal";
       const isImage = media.kind === "image";
 
+      console.log(
+        `[DEBUG] buildActivity conversationType=${conversationType} isPersonal=${isPersonal} isImage=${isImage} mediaKind=${media.kind} tokenProvider=${!!tokenProvider} sharePointSiteId=${sharePointSiteId}`,
+      );
       if (
         requiresFileConsent({
           conversationType,
@@ -348,6 +351,7 @@ async function buildActivity(
       }
 
       if (!isPersonal && media.kind !== "image" && tokenProvider) {
+        console.log(`[DEBUG] buildActivity calling uploadAndShareOneDrive`);
         // Fallback: no SharePoint site configured, try OneDrive upload
         const uploaded = await uploadAndShareOneDrive({
           buffer: media.buffer,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -381,6 +381,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         account.token,
         timeoutMs,
         account.config.proxy,
+        account.apiRoot,
       ),
     auditAccount: async ({ account, timeoutMs, probe, cfg }) => {
       const groups =
@@ -408,6 +409,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         groupIds,
         proxyUrl: account.config.proxy,
         timeoutMs,
+        apiRoot: account.apiRoot,
       });
       return { ...audit, unresolvedGroups, hasWildcardUnmentionedGroups };
     },
@@ -472,6 +474,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
           token,
           2500,
           account.config.proxy,
+          account.apiRoot,
         );
         const username = probe.ok ? probe.bot?.username?.trim() : null;
         if (username) {
@@ -484,6 +487,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       }
       ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
       return getTelegramRuntime().channel.telegram.monitorTelegramProvider({
+        // apiRoot is resolved internally via resolveTelegramAccount from config
         token,
         accountId: account.accountId,
         config: ctx.cfg,

--- a/src/channels/telegram/api.ts
+++ b/src/channels/telegram/api.ts
@@ -1,9 +1,11 @@
 export async function fetchTelegramChatId(params: {
   token: string;
   chatId: string;
+  apiRoot?: string;
   signal?: AbortSignal;
 }): Promise<string | null> {
-  const url = `https://api.telegram.org/bot${params.token}/getChat?chat_id=${encodeURIComponent(params.chatId)}`;
+  const apiRoot = params.apiRoot || "https://api.telegram.org";
+  const url = `${apiRoot}/bot${params.token}/getChat?chat_id=${encodeURIComponent(params.chatId)}`;
   try {
     const res = await fetch(url, params.signal ? { signal: params.signal } : undefined);
     if (!res.ok) {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -128,6 +128,11 @@ export type TelegramAccountConfig = {
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;
+  /**
+   * Custom Telegram Bot API server URL.
+   * Default: https://api.telegram.org
+   */
+  apiRoot?: string;
   webhookUrl?: string;
   webhookSecret?: string;
   webhookPath?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -167,6 +167,7 @@ export const TelegramAccountSchemaBase = z
       .strict()
       .optional(),
     proxy: z.string().optional(),
+    apiRoot: z.string().url().optional(),
     webhookUrl: z
       .string()
       .optional()
@@ -413,6 +414,7 @@ export const DiscordAccountSchema = z
     configWrites: z.boolean().optional(),
     token: z.string().optional().register(sensitive),
     proxy: z.string().optional(),
+    apiRoot: z.string().url().optional(),
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -355,7 +355,7 @@ describe("runMessageAction context isolation", () => {
         cfg: slackConfig,
         actionParams: {
           channel: "telegram",
-          target: "@opsbot",
+          target: "telegram:123456789",
           message: "hi",
         },
         toolContext: { currentChannelId: "C12345678", currentChannelProvider: "slack" },

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -34,6 +34,7 @@ export type ResolvedTelegramAccount = {
   name?: string;
   token: string;
   tokenSource: "env" | "tokenFile" | "config" | "none";
+  apiRoot: string;
   config: TelegramAccountConfig;
 };
 
@@ -124,6 +125,7 @@ export function resolveTelegramAccount(params: {
       name: merged.name?.trim() || undefined,
       token: tokenResolution.token,
       tokenSource: tokenResolution.source,
+      apiRoot: merged.apiRoot?.trim() || "https://api.telegram.org",
       config: merged,
     } satisfies ResolvedTelegramAccount;
   };

--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -71,6 +71,7 @@ export async function auditTelegramGroupMembership(params: {
   groupIds: string[];
   proxyUrl?: string;
   timeoutMs: number;
+  apiRoot?: string;
 }): Promise<TelegramGroupMembershipAudit> {
   const started = Date.now();
   const token = params.token?.trim() ?? "";
@@ -91,7 +92,7 @@ export async function auditTelegramGroupMembership(params: {
     ? (await import("./proxy.js")).makeProxyFetch(params.proxyUrl)
     : fetch;
   const { fetchWithTimeout } = await import("../utils/fetch-timeout.js");
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = `${params.apiRoot || TELEGRAM_API_BASE}/bot${token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 
   for (const chatId of params.groupIds) {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -111,6 +111,7 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  apiRoot?: string;
 };
 
 type RegisterTelegramNativeCommandsParams = {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -133,11 +133,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+
+  const apiRoot = account.apiRoot;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || apiRoot !== "https://api.telegram.org"
       ? {
           ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot !== "https://api.telegram.org" ? { apiRoot } : {}),
         }
       : undefined;
 
@@ -421,6 +424,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     shouldSkipUpdate,
     processMessage,
     logger,
+    apiRoot: account.apiRoot,
   });
 
   return bot;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -313,6 +313,7 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  apiRoot = "https://api.telegram.org",
 ): Promise<{
   path: string;
   contentType?: string;
@@ -321,7 +322,7 @@ export async function resolveMedia(
 } | null> {
   const msg = ctx.message;
   const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
-    const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
+    const url = `${apiRoot}/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
       fetchImpl,

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -2,8 +2,6 @@ import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { makeProxyFetch } from "./proxy.js";
 
-const TELEGRAM_API_BASE = "https://api.telegram.org";
-
 export type TelegramProbe = BaseProbeResult & {
   status?: number | null;
   elapsedMs: number;
@@ -21,10 +19,11 @@ export async function probeTelegram(
   token: string,
   timeoutMs: number,
   proxyUrl?: string,
+  apiRoot = "https://api.telegram.org",
 ): Promise<TelegramProbe> {
   const started = Date.now();
   const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = `${apiRoot}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 
   const result: TelegramProbe = {


### PR DESCRIPTION
Allow users to configure a custom Telegram Bot API server URL via the apiRoot config option. This enables use of local Bot API servers which bypass the 20MB file download limit imposed by the official API.