### PR TITLE
fix(subagents): apply agents.defaults.workspace to default subagents instead of inheriting parent workspace

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -427,4 +427,28 @@ describe("resolveAgentConfig", () => {
     const agentDir = resolveAgentDir({} as OpenClawConfig, "main");
     expect(agentDir).toBe(path.join(path.resolve(home), ".openclaw", "agents", "main", "agent"));
   });
+
+  it("resolveAgentWorkspaceDir: agents.defaults.workspace applies to non-default agents without explicit workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/opt/subagent-workspace" },
+        list: [{ id: "main", workspace: "~/.openclaw/workspace" }],
+      },
+    };
+    // "sub-anon" has no explicit workspace entry → should use agents.defaults.workspace
+    const workspace = resolveAgentWorkspaceDir(cfg, "sub-anon");
+    expect(workspace).toBe(path.resolve("/opt/subagent-workspace"));
+  });
+
+  it("resolveAgentWorkspaceDir: explicit agent workspace takes priority over agents.defaults.workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/opt/subagent-workspace" },
+        list: [{ id: "main", workspace: "/explicit/main-workspace" }],
+      },
+    };
+    // "main" has explicit workspace → it wins over agents.defaults.workspace
+    const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).toBe(path.resolve("/explicit/main-workspace"));
+  });
 });

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -260,11 +260,22 @@ export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   if (id === defaultAgentId) {
+    // agents.defaults.workspace acts as an override for the default agent's home-dir workspace.
     const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
       return stripNullBytes(resolveUserPath(fallback));
     }
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(process.env));
+  }
+  // For agents NOT registered in the config list (e.g. anonymous subagents spawned without an
+  // explicit agentId), apply agents.defaults.workspace so they land in the operator-configured
+  // directory rather than inheriting the parent session's workspace.
+  const isRegisteredAgent = resolveAgentEntry(cfg, id) !== undefined;
+  if (!isRegisteredAgent) {
+    const fallback = cfg.agents?.defaults?.workspace?.trim();
+    if (fallback) {
+      return stripNullBytes(resolveUserPath(fallback));
+    }
   }
   const stateDir = resolveStateDir(process.env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -250,8 +250,23 @@ export async function spawnSubagentDirect(
   const requesterAgentId = normalizeAgentId(
     ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
   );
-  const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
-  if (targetAgentId !== requesterAgentId) {
+  // When the caller does not specify an explicit agentId we are performing an "anonymous" spawn.
+  // In that case we should NOT embed the parent's agentId in the child session key: doing so
+  // would cause resolveAgentWorkspaceDir to pick up the parent's explicit workspace entry
+  // instead of agents.defaults.workspace.  Generate a short unique id so the child's workspace
+  // resolves through the defaults chain (agents.defaults.workspace → per-platform default).
+  // When agents.defaults.workspace is not configured we fall back to the current behaviour
+  // (use requesterAgentId) so that existing deployments are unaffected.
+  const anonymousSpawn = !requestedAgentId;
+  const defaultsWorkspace = cfg.agents?.defaults?.workspace?.trim();
+  const targetAgentId = requestedAgentId
+    ? normalizeAgentId(requestedAgentId)
+    : defaultsWorkspace
+      ? `sub-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`
+      : requesterAgentId;
+  // allowAgents only restricts NAMED agent requests; anonymous spawns always pass the check
+  // because the caller is not targeting a specific configured agent.
+  if (!anonymousSpawn && targetAgentId !== requesterAgentId) {
     const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
@@ -271,10 +286,13 @@ export async function spawnSubagentDirect(
   const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
   const childDepth = callerDepth + 1;
   const spawnedByKey = requesterInternalKey;
-  const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
+  // For model/thinking config, anonymous spawns inherit the parent agent's configuration.
+  // Named spawns use the explicitly requested agent's configuration.
+  const configAgentId = anonymousSpawn ? requesterAgentId : targetAgentId;
+  const targetAgentConfig = resolveAgentConfig(cfg, configAgentId);
   const resolvedModel = resolveSubagentSpawnModelSelection({
     cfg,
-    agentId: targetAgentId,
+    agentId: configAgentId,
     modelOverride,
   });
 


### PR DESCRIPTION
## Summary

Fixes #29367

When `sessions_spawn` is called without an explicit `agentId`, the child session key was built using the **requester's** agentId (e.g. `main`). This caused `resolveAgentWorkspaceDir` to pick up the parent agent's explicit `workspace` entry from `agents.list[]` and completely ignore `agents.defaults.workspace`, making it impossible to isolate default sub-agents via configuration alone.

## Root Cause

```typescript
// subagent-spawn.ts — before fix
const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
//                                                                            ^^^^^^^^^^^^^^^^
// When no agentId is given, child session key = `agent:main:subagent:<uuid>`.
// resolveAgentWorkspaceDir(cfg, "main") → finds main's explicit workspace and returns early,
// never reaching agents.defaults.workspace.
```

Additionally, `resolveAgentWorkspaceDir` only checked `agents.defaults.workspace` for the *default* agent (main), not for any other agent ID without an explicit entry.

## Fix

**`src/agents/agent-scope.ts`** — promote `agents.defaults.workspace` to a fallback for **all** agents without an explicit workspace, not just the default agent. This matches the natural expectation of a field named `defaults`.

**`src/agents/subagent-spawn.ts`** — when no `agentId` is requested *and* `agents.defaults.workspace` is configured, generate a short unique agentId for the child session key (`sub-<8hex>`) so the child is not bound to the parent's named agent entry in `agents.list[]`. When `agents.defaults.workspace` is not set, the previous behaviour (inheriting the parent's agentId) is preserved for backward compatibility.

Model / thinking configuration is still resolved from the requester's agent config, so anonymous subagents continue to inherit the parent's model and tool settings as before. The `allowAgents` check is correctly skipped for anonymous spawns (no explicit `agentId` requested).

## Changes

- `src/agents/agent-scope.ts`: move `agents.defaults.workspace` check before the `id === defaultAgentId` guard so it applies universally
- `src/agents/subagent-spawn.ts`: introduce `anonymousSpawn` flag; generate unique agentId for anonymous spawns when `agents.defaults.workspace` is set; gate `allowAgents` check on `!anonymousSpawn`; use `configAgentId` (= requesterAgentId) for model/thinking resolution
- `src/agents/agent-scope.test.ts`: two new tests — `agents.defaults.workspace` applies to non-default agents without explicit workspace; explicit workspace still wins