### PR TITLE
fix(message): keep stable user message id for reaction fallback

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -53,6 +53,8 @@ export function createOpenClawTools(options?: {
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
   currentMessageId?: string | number;
+  /** User message id that triggered this run; stable fallback for reactions. */
+  lastUserMessageId?: string | number;
   /** Reply-to mode for Slack auto-threading. */
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
@@ -102,6 +104,7 @@ export function createOpenClawTools(options?: {
         currentChannelProvider: options?.agentChannel,
         currentThreadTs: options?.currentThreadTs,
         currentMessageId: options?.currentMessageId,
+        lastUserMessageId: options?.lastUserMessageId ?? options?.currentMessageId,
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
         sandboxRoot: options?.sandboxRoot,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -588,6 +588,7 @@ export async function runEmbeddedPiAgent(
             currentChannelId: params.currentChannelId,
             currentThreadTs: params.currentThreadTs,
             currentMessageId: params.currentMessageId,
+            lastUserMessageId: params.lastUserMessageId ?? params.currentMessageId,
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
             sessionFile: params.sessionFile,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -415,6 +415,7 @@ export async function runEmbeddedAttempt(
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,
           currentMessageId: params.currentMessageId,
+          lastUserMessageId: params.lastUserMessageId ?? params.currentMessageId,
           replyToMode: params.replyToMode,
           hasRepliedRef: params.hasRepliedRef,
           modelHasVision,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -50,6 +50,8 @@ export type RunEmbeddedPiAgentParams = {
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
   currentMessageId?: string | number;
+  /** User message id that triggered this run; stable fallback for reactions. */
+  lastUserMessageId?: string | number;
   /** Reply-to mode for Slack auto-threading. */
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -192,6 +192,8 @@ export function createOpenClawCodingTools(options?: {
   currentThreadTs?: string;
   /** Current inbound message id for action fallbacks (e.g. Telegram react). */
   currentMessageId?: string | number;
+  /** User message id that triggered this run; stable fallback for reactions. */
+  lastUserMessageId?: string | number;
   /** Group id for channel-level tool policy resolution. */
   groupId?: string | null;
   /** Group channel label (e.g. #general) for channel-level tool policy resolution. */
@@ -470,6 +472,7 @@ export function createOpenClawCodingTools(options?: {
       currentChannelId: options?.currentChannelId,
       currentThreadTs: options?.currentThreadTs,
       currentMessageId: options?.currentMessageId,
+      lastUserMessageId: options?.lastUserMessageId ?? options?.currentMessageId,
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
       modelHasVision: options?.modelHasVision,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -438,6 +438,7 @@ type MessageToolOptions = {
   currentChannelProvider?: string;
   currentThreadTs?: string;
   currentMessageId?: string | number;
+  lastUserMessageId?: string | number;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
@@ -663,6 +664,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
               currentChannelProvider: options?.currentChannelProvider,
               currentThreadTs: options?.currentThreadTs,
               currentMessageId: options?.currentMessageId,
+              lastUserMessageId: options?.lastUserMessageId ?? options?.currentMessageId,
               replyToMode: options?.replyToMode,
               hasRepliedRef: options?.hasRepliedRef,
               // Direct tool invocations should not add cross-context decoration.

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 const {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
+  buildThreadingToolContext,
   resolveModelFallbackOptions,
   resolveProviderScopedAuthProfile,
 } = await import("./agent-runner-utils.js");
@@ -172,5 +173,21 @@ describe("agent-runner-utils", () => {
 
     expect(resolved.embeddedContext.messageProvider).toBe("telegram");
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
+  });
+
+  it("keeps lastUserMessageId aligned with inbound message id", () => {
+    const threading = buildThreadingToolContext({
+      sessionCtx: {
+        Provider: "Telegram",
+        MessageSid: "msg-user-1",
+      },
+      config: undefined,
+      hasRepliedRef: undefined,
+    });
+
+    expect(threading).toMatchObject({
+      currentMessageId: "msg-user-1",
+      lastUserMessageId: "msg-user-1",
+    });
   });
 });

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -23,15 +23,18 @@ export function buildThreadingToolContext(params: {
 }): ChannelThreadingToolContext {
   const { sessionCtx, config, hasRepliedRef } = params;
   const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  const lastUserMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   if (!config) {
     return {
       currentMessageId,
+      lastUserMessageId,
     };
   }
   const rawProvider = sessionCtx.Provider?.trim().toLowerCase();
   if (!rawProvider) {
     return {
       currentMessageId,
+      lastUserMessageId,
     };
   }
   const provider = normalizeChannelId(rawProvider) ?? normalizeAnyChannelId(rawProvider);
@@ -42,6 +45,7 @@ export function buildThreadingToolContext(params: {
       currentChannelId: sessionCtx.To?.trim() || undefined,
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
       currentMessageId,
+      lastUserMessageId,
       hasRepliedRef,
     };
   }
@@ -55,6 +59,7 @@ export function buildThreadingToolContext(params: {
         To: sessionCtx.To,
         ChatType: sessionCtx.ChatType,
         CurrentMessageId: currentMessageId,
+        LastUserMessageId: lastUserMessageId,
         ReplyToId: sessionCtx.ReplyToId,
         ThreadLabel: sessionCtx.ThreadLabel,
         MessageThreadId: sessionCtx.MessageThreadId,
@@ -65,6 +70,7 @@ export function buildThreadingToolContext(params: {
     ...context,
     currentChannelProvider: provider!, // guaranteed non-null since dock exists
     currentMessageId: context.currentMessageId ?? currentMessageId,
+    lastUserMessageId: context.lastUserMessageId ?? lastUserMessageId,
   };
 }
 

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -725,6 +725,31 @@ describe("telegramMessageActions", () => {
     expect(String(callPayload.messageId)).toBe("9001");
   });
 
+  it("prefers toolContext.lastUserMessageId over currentMessageId for reactions", async () => {
+    const cfg = telegramCfg();
+
+    await telegramMessageActions.handleAction?.({
+      channel: "telegram",
+      action: "react",
+      params: {
+        chatId: "123",
+        emoji: "ok",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: { currentMessageId: "assistant-42", lastUserMessageId: "user-7" },
+    });
+
+    expect(handleTelegramAction).toHaveBeenCalledTimes(1);
+    const call = handleTelegramAction.mock.calls[0]?.[0];
+    if (!call) {
+      throw new Error("missing telegram action call");
+    }
+    const callPayload = call as Record<string, unknown>;
+    expect(callPayload.action).toBe("react");
+    expect(String(callPayload.messageId)).toBe("user-7");
+  });
+
   it("forwards missing reaction messageId to telegram-actions for soft-fail handling", async () => {
     const cfg = telegramCfg();
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -123,7 +123,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "react") {
       const messageId =
-        readStringOrNumberParam(params, "messageId") ?? toolContext?.currentMessageId;
+        readStringOrNumberParam(params, "messageId") ??
+        toolContext?.lastUserMessageId ??
+        toolContext?.currentMessageId;
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
       const remove = typeof params.remove === "boolean" ? params.remove : undefined;
       return await handleTelegramAction(

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -250,6 +250,7 @@ export type ChannelThreadingContext = {
   To?: string;
   ChatType?: string;
   CurrentMessageId?: string | number;
+  LastUserMessageId?: string | number;
   ReplyToId?: string;
   ReplyToIdFull?: string;
   ThreadLabel?: string;
@@ -261,6 +262,8 @@ export type ChannelThreadingToolContext = {
   currentChannelProvider?: ChannelId;
   currentThreadTs?: string;
   currentMessageId?: string | number;
+  /** User message id that triggered this run (stable fallback for reactions). */
+  lastUserMessageId?: string | number;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   /**


### PR DESCRIPTION
## Summary

- **Problem:** Reaction fallback used `currentMessageId`, which can drift from the triggering user message id in multi-step runs.
- **Why it matters:** Reactions may target assistant/system messages instead of the user message that initiated the run.
- **What changed:** Added `lastUserMessageId` to threading tool context, populated it from inbound context in `agent-runner-utils`, propagated through message tool wiring, and made Telegram reaction fallback prefer `lastUserMessageId` over `currentMessageId`.
- **What did NOT change:** No change to explicit `messageId` behavior, no transport/API changes, and no change to non-reaction actions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29470

## User-visible / Behavior Changes

- Telegram `message` tool reactions without explicit `messageId` now prefer the stable triggering user message id.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + pnpm/vitest
- Integration/channel: message tool + Telegram actions

### Steps

1. Run a flow where assistant sends messages and then calls reaction action without explicit `messageId`.
2. Inspect reaction target resolution.

### Expected

- Reaction fallback uses the original user-trigger message id.

### Actual

- Before fix: fallback could use drifting `currentMessageId`.
- After fix: fallback prefers stable `lastUserMessageId`.

## Evidence

- `pnpm vitest run src/channels/plugins/actions/actions.test.ts src/auto-reply/reply/agent-runner-utils.test.ts`
- Added test: `prefers toolContext.lastUserMessageId over currentMessageId for reactions`.

## Human Verification (required)

- Verified scenarios: Telegram reaction fallback selection order; threading context carries both ids.
- Edge cases checked: still falls back to `currentMessageId` when `lastUserMessageId` is absent.
- What I did **not** verify: live Telegram bot E2E reaction routing against production API.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR/commit.
- Files/config to restore: message tool/threading context and Telegram action fallback files.
- Known bad symptoms: fallback reactions could again target non-user messages.

## Risks and Mitigations

- Risk: added context field propagation could be inconsistently handled by custom adapters.
- Mitigation: `lastUserMessageId` is optional and defaults to existing behavior when absent.

