### PR TITLE
fix(logging): child loggers inherit parent minLevel; fix tslog level mapping

### DIFF
--- a/src/logging/levels.ts
+++ b/src/logging/levels.ts
@@ -23,7 +23,9 @@ export function normalizeLogLevel(level?: string, fallback: LogLevel = "info") {
 }
 
 export function levelToMinLevel(level: LogLevel): number {
-  // tslog level ordering: fatal=0, error=1, warn=2, info=3, debug=4, trace=5
+  // OpenClaw internal ordering used for comparisons (e.g. isFileLogLevelEnabled):
+  // fatal=0 (highest severity) … trace=5 (lowest severity).
+  // Do NOT pass this directly to tslog — use levelToTslogMinLevel() instead.
   const map: Record<LogLevel, number> = {
     fatal: 0,
     error: 1,
@@ -31,6 +33,23 @@ export function levelToMinLevel(level: LogLevel): number {
     info: 3,
     debug: 4,
     trace: 5,
+    silent: Number.POSITIVE_INFINITY,
+  };
+  return map[level];
+}
+
+export function levelToTslogMinLevel(level: LogLevel): number {
+  // tslog's actual logLevelId ordering: silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6.
+  // tslog filters with `if (logLevelId < minLevel) { return; }`, so passing minLevel=3
+  // allows info(3), warn(4), error(5), fatal(6) and suppresses trace(1) and debug(2).
+  // This is the correct mapping to use when constructing a TsLogger or calling getSubLogger.
+  const map: Record<LogLevel, number> = {
+    trace: 1,
+    debug: 2,
+    info: 3,
+    warn: 4,
+    error: 5,
+    fatal: 6,
     silent: Number.POSITIVE_INFINITY,
   };
   return map[level];

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -7,6 +7,7 @@ import {
   resetLogger,
   setLoggerOverride,
 } from "../logging.js";
+import { getChildLogger, registerLogTransport } from "./logger.js";
 import { loggingState } from "./state.js";
 
 const testLogPath = path.join(os.tmpdir(), "openclaw-test-env-log-level.log");
@@ -77,5 +78,85 @@ describe("OPENCLAW_LOG_LEVEL", () => {
       .filter((line) => line.includes("OPENCLAW_LOG_LEVEL"));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('Ignoring invalid OPENCLAW_LOG_LEVEL="nope"');
+  });
+});
+
+// tslog stores log arguments positionally: record["0"] is the first arg, or the prefix
+// when using a sub-logger with bindings prefix. The level name is in _meta.logLevelName.
+type TsLogRecord = Record<string, unknown> & {
+  _meta?: { logLevelName?: string; logLevelId?: number };
+};
+
+describe("getChildLogger level inheritance", () => {
+  beforeEach(() => {
+    delete process.env.OPENCLAW_LOG_LEVEL;
+    loggingState.invalidEnvLogLevelValue = null;
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_LOG_LEVEL;
+    loggingState.invalidEnvLogLevelValue = null;
+    resetLogger();
+    setLoggerOverride(null);
+    vi.restoreAllMocks();
+  });
+
+  it("child logger without level override inherits parent minLevel — debug is suppressed when parent is info", () => {
+    // Regression test for: child loggers created via getChildLogger() ignoring the
+    // configured log level. Root cause: passing `minLevel: undefined` to tslog's
+    // getSubLogger() causes it to override the parent minLevel with 0 (allow-all).
+    setLoggerOverride({ level: "info", file: testLogPath });
+
+    const captured: TsLogRecord[] = [];
+    const unregister = registerLogTransport((record) => {
+      captured.push(record as TsLogRecord);
+    });
+
+    try {
+      const child = getChildLogger({ module: "test-child" });
+      child.debug("should be filtered by parent level");
+      child.info("should pass parent level");
+
+      const debugRecords = captured.filter((r) => r._meta?.logLevelName === "DEBUG");
+      const infoRecords = captured.filter((r) => r._meta?.logLevelName === "INFO");
+
+      // DEBUG must be suppressed when parent is configured at "info" level
+      expect(debugRecords).toHaveLength(0);
+      // INFO must still pass through
+      expect(infoRecords).toHaveLength(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("child logger without bindings also inherits parent minLevel", () => {
+    setLoggerOverride({ level: "info", file: testLogPath });
+
+    const captured: TsLogRecord[] = [];
+    const unregister = registerLogTransport((record) => {
+      captured.push(record as TsLogRecord);
+    });
+
+    try {
+      const child = getChildLogger(); // no bindings, no level override
+      child.debug("debug — should be filtered");
+      child.info("info — should pass");
+      child.warn("warn — should pass");
+
+      const debugRecords = captured.filter((r) => r._meta?.logLevelName === "DEBUG");
+      const infoOrAbove = captured.filter(
+        (r) =>
+          r._meta?.logLevelName === "INFO" ||
+          r._meta?.logLevelName === "WARN" ||
+          r._meta?.logLevelName === "ERROR",
+      );
+
+      expect(debugRecords).toHaveLength(0);
+      expect(infoOrAbove.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      unregister();
+    }
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -6,7 +6,12 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
-import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
+import {
+  type LogLevel,
+  levelToMinLevel,
+  levelToTslogMinLevel,
+  normalizeLogLevel,
+} from "./levels.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 
@@ -107,7 +112,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   let warnedAboutSizeCap = false;
   const logger = new TsLogger<LogObj>({
     name: "openclaw",
-    minLevel: levelToMinLevel(settings.level),
+    minLevel: levelToTslogMinLevel(settings.level),
     type: "hidden", // no ansi formatting
   });
 
@@ -188,11 +193,15 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
+  const minLevel = opts?.level ? levelToTslogMinLevel(opts.level) : undefined;
   const name = bindings ? JSON.stringify(bindings) : undefined;
+  // Do NOT pass `minLevel: undefined` — spreading an explicit `undefined` value
+  // into getSubLogger's settings object overrides the parent logger's minLevel,
+  // and tslog resolves `undefined` as 0 (allow-all), breaking level filtering
+  // for all child loggers when no explicit level override is requested.
   return base.getSubLogger({
     name,
-    minLevel,
+    ...(minLevel !== undefined ? { minLevel } : {}),
     prefix: bindings ? [name ?? ""] : [],
   });
 }


### PR DESCRIPTION
## Summary

- **Problem:** `OPENCLAW_LOG_LEVEL=info` / `logging.level: info` had no effect — DEBUG entries (e.g. `cron: timer armed`) kept appearing in the log file every minute.
- **Why it matters:** Log files bloated with noise; users' level config was silently ignored everywhere child loggers were used (which is nearly all logging paths).
- **What changed:** Two related bugs fixed together in `src/logging/`:
  1. `getChildLogger()` no longer passes `minLevel: undefined` to tslog's `getSubLogger()` — previously this was overriding the parent's `minLevel` with `undefined`, which tslog resolves to `0` (allow-all).
  2. Added `levelToTslogMinLevel()` in `levels.ts` so the correct tslog-compatible numeric mapping is used when constructing a `TsLogger`. The existing `levelToMinLevel()` uses an OpenClaw-internal ordering (fatal=0, trace=5) that only coincidentally matches tslog for `"info"` (both = 3), but is wrong for every other level.
- **What did NOT change:** Public config API, `levelToMinLevel()` (still used for internal `isFileLogLevelEnabled` comparisons), behaviour for the root logger when level = `"info"`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #29448

## User-visible / Behavior Changes

Setting `OPENCLAW_LOG_LEVEL=info` (or `logging.level: "info"` in `openclaw.json`) now actually suppresses DEBUG log entries from being written to the log file. Previously the setting was silently ignored for all child loggers.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node.js v25.4.0
- Model/provider: N/A (logging layer)
- Integration/channel: N/A
- Relevant config: `logging: { "level": "info" }` in `openclaw.json`

### Steps

1. Add `"logging": { "level": "info" }` to `openclaw.json` (or set `OPENCLAW_LOG_LEVEL=info`)
2. Restart the gateway
3. Wait 60 seconds for the cron timer to tick
4. Run: `grep logLevelName:DEBUG /tmp/openclaw/openclaw-*.log`

### Expected

- No output — DEBUG entries suppressed

### Actual (before fix)

- `{"logLevelName":"DEBUG","message":"cron: timer armed",...}` appears every ~60 s

## Evidence

- [x] Failing test/log before + passing after

Two regression tests added to `logger-env.test.ts`:
- Child logger without level override: DEBUG suppressed when parent = `"info"` ✓
- Child logger without bindings: same inheritance behaviour ✓

Full suite: 11 422 passed / 8 pre-existing failures (unrelated — same failures exist on `main`).

## Human Verification (required)

> ⚠️ This PR was AI-assisted (Claude Sonnet). The author reviewed all changes.

- Verified scenarios: `level: "info"` suppresses DEBUG in child loggers; `level: "trace"` still logs everything; regression tests green
- Edge cases checked: child logger with no bindings, child logger with explicit level override
- What you did **not** verify: live gateway restart on Linux / systemd

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert` the commit or remove `logging.level` from config
- Files/config to restore: `src/logging/logger.ts`, `src/logging/levels.ts`
- Known bad symptoms: log file stops being written entirely

## Risks and Mitigations

- Risk: `levelToTslogMinLevel` mapping table has a typo
  - Mitigation: Cross-checked against tslog source (`silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6`); regression tests confirm debug is suppressed and info passes