### PR TITLE
fix(cron): treat transient tool error payloads as recoverable

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -570,17 +570,29 @@ export async function runCronIsolatedAgentTurn(params: {
     Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
   const deliveryBestEffort = resolveCronDeliveryBestEffort(params.job);
   const hasErrorPayload = payloads.some((payload) => payload?.isError === true);
+  const runLevelError = runResult.meta?.error;
+  const lastErrorPayloadIndex = payloads.findLastIndex((payload) => payload?.isError === true);
+  const hasSuccessfulPayloadAfterLastError =
+    !runLevelError &&
+    lastErrorPayloadIndex >= 0 &&
+    payloads
+      .slice(lastErrorPayloadIndex + 1)
+      .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
+  // Tool wrappers can emit transient/false-positive error payloads before a valid final
+  // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
+  // did not report a model/context-level error and (b) a non-error payload follows.
+  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
   const lastErrorPayloadText = [...payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
     ?.text?.trim();
-  const embeddedRunError = hasErrorPayload
+  const embeddedRunError = hasFatalErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
   const resolveRunOutcome = (params?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     withRunSession({
-      status: hasErrorPayload ? "error" : "ok",
-      ...(hasErrorPayload
+      status: hasFatalErrorPayload ? "error" : "ok",
+      ...(hasFatalErrorPayload
         ? { error: embeddedRunError ?? "cron isolated run returned an error payload" }
         : {}),
       summary,
@@ -637,7 +649,7 @@ export async function runCronIsolatedAgentTurn(params: {
       deliveryAttempted:
         deliveryResult.result.deliveryAttempted ?? deliveryResult.deliveryAttempted,
     };
-    if (!hasErrorPayload || deliveryResult.result.status !== "ok") {
+    if (!hasFatalErrorPayload || deliveryResult.result.status !== "ok") {
       return resultWithDeliveryMeta;
     }
     return resolveRunOutcome({


### PR DESCRIPTION
## Summary

- **Problem:** Isolated cron runs marked status as `error` whenever any payload had `isError=true`, even if a later successful final payload existed.
- **Why it matters:** False-positive tool errors (for example write-tool misclassification) can mark successful cron jobs as failed despite files being written.
- **What changed:** In `src/cron/isolated-agent/run.ts`, payload-error handling now treats error payloads as terminal only when no later successful payload follows; added regression test in `src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`.
- **What did NOT change:** No change to pure error runs (still `error`), no delivery routing changes, and no changes to write tool implementation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29462

## User-visible / Behavior Changes

- Cron jobs with transient tool error payloads followed by successful final output now report `ok` instead of `error`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + pnpm/vitest
- Integration/channel: cron isolated agent turn

### Steps

1. Run isolated cron turn returning an `isError=true` payload.
2. Follow it with a later non-error payload containing successful text.

### Expected

- Final run status should be `ok` with successful summary.

### Actual

- Before fix: any error payload forced `error` status.
- After fix: only terminal error payloads force `error`; recovered runs are `ok`.

## Evidence

- `pnpm vitest run src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
- Added test: `treats transient error payloads as non-fatal when a later success payload exists`.

## Human Verification (required)

- Verified scenarios: pure error payload still returns `error`; error-then-success returns `ok`.
- Edge cases checked: summary still uses later success payload text.
- What I did **not** verify: live cron execution against real write tool in production environment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR/commit.
- Files/config to restore: `src/cron/isolated-agent/run.ts` and its test file.
- Known bad symptoms: cron runs with mixed payloads may be incorrectly classified.

## Risks and Mitigations

- Risk: recovered runs could mask genuinely failed tasks that emit a misleading success payload later.
- Mitigation: behavior only changes when a later non-error payload exists; pure-error paths remain unchanged and covered by tests.

