### PR TITLE
fix(logging): honor OPENCLAW_LOG_LEVEL/logging.level for child file logger

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -295,7 +295,7 @@ export async function doctorCommand(
     if (fs.existsSync(backupPath)) {
       runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
     }
-  } else {
+  } else if (!prompter.shouldRepair) {
     runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -58,6 +58,180 @@ describe("resolvePreflightMentionRequirement", () => {
 });
 
 describe("preflightDiscordMessage", () => {
+  it("drops bound-thread bot system messages to prevent ACP self-loop", async () => {
+    const threadBinding = createThreadBinding({
+      targetKind: "acp",
+      targetSessionKey: "agent:main:acp:discord-thread-1",
+    });
+    const threadId = "thread-system-1";
+    const parentId = "channel-parent-1";
+    const client = {
+      fetchChannel: async (channelId: string) => {
+        if (channelId === threadId) {
+          return {
+            id: threadId,
+            type: ChannelType.PublicThread,
+            name: "focus",
+            parentId,
+            ownerId: "owner-1",
+          };
+        }
+        if (channelId === parentId) {
+          return {
+            id: parentId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-system-1",
+      content:
+        "⚙️ codex-acp session active (auto-unfocus in 24h). Messages here go directly to this session.",
+      timestamp: new Date().toISOString(),
+      channelId: threadId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "OpenClaw",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {
+        allowBots: true,
+      } as NonNullable<import("../../config/config.js").OpenClawConfig["channels"]>["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: {
+        getByThreadId: (id: string) => (id === threadId ? threadBinding : undefined),
+      } as import("./thread-bindings.js").ThreadBindingManager,
+      data: {
+        channel_id: threadId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps bound-thread regular bot messages flowing when allowBots=true", async () => {
+    const threadBinding = createThreadBinding({
+      targetKind: "acp",
+      targetSessionKey: "agent:main:acp:discord-thread-1",
+    });
+    const threadId = "thread-bot-regular-1";
+    const parentId = "channel-parent-regular-1";
+    const client = {
+      fetchChannel: async (channelId: string) => {
+        if (channelId === threadId) {
+          return {
+            id: threadId,
+            type: ChannelType.PublicThread,
+            name: "focus",
+            parentId,
+            ownerId: "owner-1",
+          };
+        }
+        if (channelId === parentId) {
+          return {
+            id: parentId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-bot-regular-1",
+      content: "here is tool output chunk",
+      timestamp: new Date().toISOString(),
+      channelId: threadId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "Relay",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {
+        allowBots: true,
+      } as NonNullable<import("../../config/config.js").OpenClawConfig["channels"]>["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: {
+        getByThreadId: (id: string) => (id === threadId ? threadBinding : undefined),
+      } as import("./thread-bindings.js").ThreadBindingManager,
+      data: {
+        channel_id: threadId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.boundSessionKey).toBe(threadBinding.targetSessionKey);
+  });
+
   it("bypasses mention gating in bound threads for allowed bot senders", async () => {
     const threadBinding = createThreadBinding();
     const threadId = "thread-bot-focus";

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -67,7 +67,7 @@ export type {
   DiscordMessagePreflightParams,
 } from "./message-handler.preflight.types.js";
 
-const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖"];
+const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
 
 function isBoundThreadBotSystemMessage(params: {
   isBoundThreadSession: boolean;

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -1,4 +1,8 @@
 import { ChannelType, MessageType, type User } from "@buape/carbon";
+import type {
+  DiscordMessagePreflightContext,
+  DiscordMessagePreflightParams,
+} from "./message-handler.preflight.types.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import { shouldHandleTextCommands } from "../../auto-reply/commands-registry.js";
 import {
@@ -45,10 +49,6 @@ import {
   resolveDiscordSystemLocation,
   resolveTimestampMs,
 } from "./format.js";
-import type {
-  DiscordMessagePreflightContext,
-  DiscordMessagePreflightParams,
-} from "./message-handler.preflight.types.js";
 import {
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,
@@ -66,6 +66,23 @@ export type {
   DiscordMessagePreflightContext,
   DiscordMessagePreflightParams,
 } from "./message-handler.preflight.types.js";
+
+const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖"];
+
+function isBoundThreadBotSystemMessage(params: {
+  isBoundThreadSession: boolean;
+  isBotAuthor: boolean;
+  text?: string;
+}): boolean {
+  if (!params.isBoundThreadSession || !params.isBotAuthor) {
+    return false;
+  }
+  const text = params.text?.trim();
+  if (!text) {
+    return false;
+  }
+  return DISCORD_BOUND_THREAD_SYSTEM_PREFIXES.some((prefix) => text.startsWith(prefix));
+}
 
 export function resolvePreflightMentionRequirement(params: {
   shouldRequireMention: boolean;
@@ -317,6 +334,17 @@ export async function preflightDiscordMessage(
         agentId: boundAgentId ?? route.agentId,
       }
     : route;
+  const isBoundThreadSession = Boolean(boundSessionKey && earlyThreadChannel);
+  if (
+    isBoundThreadBotSystemMessage({
+      isBoundThreadSession,
+      isBotAuthor: Boolean(author.bot),
+      text: messageText,
+    })
+  ) {
+    logVerbose(`discord: drop bound-thread bot system message ${message.id}`);
+    return null;
+  }
   const mentionRegexes = buildMentionRegexes(params.cfg, effectiveRoute.agentId);
   const explicitlyMentioned = Boolean(
     botId && message.mentionedUsers?.some((user: User) => user.id === botId),
@@ -480,7 +508,6 @@ export async function preflightDiscordMessage(
     channelConfig,
     guildInfo,
   });
-  const isBoundThreadSession = Boolean(boundSessionKey && threadChannel);
   const shouldRequireMention = resolvePreflightMentionRequirement({
     shouldRequireMention: shouldRequireMentionByConfig,
     isBoundThreadSession,

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -33,6 +33,7 @@ describe("exec approvals allowlist matching", () => {
   it("handles wildcard/path matching semantics", () => {
     const cases: Array<{ entries: ExecAllowlistEntry[]; expectedPattern: string | null }> = [
       { entries: [{ pattern: "RG" }], expectedPattern: null },
+      { entries: [{ pattern: "*" }], expectedPattern: "*" },
       { entries: [{ pattern: "/opt/**/rg" }], expectedPattern: "/opt/**/rg" },
       { entries: [{ pattern: "/opt/*/rg" }], expectedPattern: null },
     ];

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -212,6 +212,9 @@ export function matchAllowlist(
     if (!pattern) {
       continue;
     }
+    if (pattern === "*" || pattern === "**") {
+      return entry;
+    }
     const hasPath = pattern.includes("/") || pattern.includes("\\") || pattern.includes("~");
     if (!hasPath) {
       continue;

--- a/src/logging/logger-child-level.test.ts
+++ b/src/logging/logger-child-level.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getChildLogger, resetLogger, setLoggerOverride } from "./logger.js";
+
+const logPath = path.join(os.tmpdir(), "openclaw-test-child-level.log");
+
+afterEach(() => {
+  setLoggerOverride(null);
+  resetLogger();
+  try {
+    fs.rmSync(logPath, { force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+describe("getChildLogger", () => {
+  it("inherits configured file level when explicit child level is not provided", () => {
+    setLoggerOverride({ level: "info", file: logPath, consoleLevel: "silent" });
+    const logger = getChildLogger({ module: "cron" });
+
+    logger.debug("cron: timer armed");
+    logger.info("cron: started");
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("cron: started");
+    expect(content).not.toContain("cron: timer armed");
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -188,7 +188,11 @@ export function getChildLogger(
   opts?: { level?: LogLevel },
 ): TsLogger<LogObj> {
   const base = getLogger();
-  const minLevel = opts?.level ? levelToMinLevel(opts.level) : undefined;
+  const effectiveLevel =
+    opts?.level ??
+    (loggingState.cachedSettings as ResolvedSettings | null)?.level ??
+    resolveSettings().level;
+  const minLevel = levelToMinLevel(effectiveLevel);
   const name = bindings ? JSON.stringify(bindings) : undefined;
   return base.getSubLogger({
     name,

--- a/src/logging/subsystem-file-level.test.ts
+++ b/src/logging/subsystem-file-level.test.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetLogger, setLoggerOverride } from "./logger.js";
+import { createSubsystemLogger } from "./subsystem.js";
+
+const logPath = path.join(os.tmpdir(), "openclaw-test-subsystem-file-level.log");
+
+afterEach(() => {
+  setLoggerOverride(null);
+  resetLogger();
+  try {
+    fs.rmSync(logPath, { force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+describe("createSubsystemLogger file level gating", () => {
+  it("does not write debug entries to file when file level is info", () => {
+    setLoggerOverride({ level: "info", file: logPath, consoleLevel: "silent" });
+    const log = createSubsystemLogger("cron");
+
+    log.debug("cron: timer armed");
+    log.info("cron: started");
+
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(content).toContain("cron: started");
+    expect(content).not.toContain("cron: timer armed");
+  });
+});

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -246,6 +246,9 @@ function logToFile(
   if (level === "silent") {
     return;
   }
+  if (!isFileLogLevelEnabled(level)) {
+    return;
+  }
   const safeLevel = level;
   const method = (fileLogger as unknown as Record<string, unknown>)[safeLevel] as
     | ((...args: unknown[]) => void)


### PR DESCRIPTION
## Summary
- fix child logger construction to inherit the resolved global file log level when no explicit child level is provided
- this ensures callers like cron (`getChildLogger({ module: "cron" })`) respect `OPENCLAW_LOG_LEVEL` / `logging.level`
- add regression test proving `debug` lines are filtered when configured level is `info`

## Root cause
`getChildLogger()` was creating tslog sub-loggers without `minLevel` unless an explicit `opts.level` was passed. In tslog, that causes the sub-logger to default to its own permissive level, so debug logs (e.g. `cron: timer armed`) bypassed configured parent level and still reached file transport.

## Validation
- `pnpm exec vitest run src/logging/logger-env.test.ts src/logging/logger-child-level.test.ts src/logging/subsystem.test.ts`
