### PR TITLE
fix(followup): preserve queued messages across abort paths

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -246,7 +246,7 @@ describe("abort detection", () => {
     expect(result.handled).toBe(true);
   });
 
-  it("fast-abort clears queued followups and session lane", async () => {
+  it("fast-abort preserves queued followups but clears session lane", async () => {
     const sessionKey = "telegram:123";
     const sessionId = "session-123";
     const { root, cfg } = await createAbortConfig({
@@ -287,7 +287,7 @@ describe("abort detection", () => {
     });
 
     expect(result.handled).toBe(true);
-    expect(getFollowupQueueDepth(sessionKey)).toBe(0);
+    expect(getFollowupQueueDepth(sessionKey)).toBe(1);
     expect(commandQueueMocks.clearCommandLane).toHaveBeenCalledWith(`session:${sessionKey}`);
   });
 

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -296,7 +296,9 @@ export async function tryFastAbortFromMessage(params: {
     const { entry, key } = resolveSessionEntryForKey(store, targetKey);
     const sessionId = entry?.sessionId;
     const aborted = sessionId ? abortEmbeddedPiRun(sessionId) : false;
-    const cleared = clearSessionQueues([key ?? targetKey, sessionId]);
+    const cleared = clearSessionQueues([key ?? targetKey, sessionId], {
+      clearFollowups: false,
+    });
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
       logVerbose(
         `abort: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -492,7 +492,9 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
   });
-  const cleared = clearSessionQueues([abortTarget.key, abortTarget.sessionId]);
+  const cleared = clearSessionQueues([abortTarget.key, abortTarget.sessionId], {
+    clearFollowups: false,
+  });
   if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
     logVerbose(
       `stop: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -8,7 +8,15 @@ export type ClearSessionQueueResult = {
   keys: string[];
 };
 
-export function clearSessionQueues(keys: Array<string | undefined>): ClearSessionQueueResult {
+export function clearSessionQueues(
+  keys: Array<string | undefined>,
+  options?: {
+    clearFollowups?: boolean;
+    clearLanes?: boolean;
+  },
+): ClearSessionQueueResult {
+  const clearFollowups = options?.clearFollowups ?? true;
+  const clearLanes = options?.clearLanes ?? true;
   const seen = new Set<string>();
   let followupCleared = 0;
   let laneCleared = 0;
@@ -21,8 +29,12 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     }
     seen.add(cleaned);
     clearedKeys.push(cleaned);
-    followupCleared += clearFollowupQueue(cleaned);
-    laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
+    if (clearFollowups) {
+      followupCleared += clearFollowupQueue(cleaned);
+    }
+    if (clearLanes) {
+      laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
+    }
   }
 
   return { followupCleared, laneCleared, keys: clearedKeys };


### PR DESCRIPTION
## Summary

- **Problem:** `/stop` and fast-abort cleanup cleared followup queues, which could silently drop user messages queued while a run was active.
- **Why it matters:** Users can lose queued messages during timeout/abort flows with no feedback, especially in async channels.
- **What changed:** Added selective queue cleanup options and updated abort paths to clear command lanes but preserve followup queues (`abort.ts`, `commands-session.ts`, `queue/cleanup.ts`); updated abort regression test accordingly.
- **What did NOT change:** No change to command-lane clearing, no delivery transport changes, and no change to subagent explicit cleanup behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29497

## User-visible / Behavior Changes

- Queued followup messages are preserved when abort commands stop active runs, reducing silent message loss in timeout/abort scenarios.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + pnpm/vitest
- Integration/channel: auto-reply followup queue / abort flow

### Steps

1. Queue a followup message while a run is active.
2. Trigger `/stop` or fast-abort path.

### Expected

- Command lane is cleared, but queued followups are retained for subsequent processing.

### Actual

- Before fix: abort cleanup cleared both lane and followup queue (silent drop).
- After fix: abort cleanup clears lane only; followup queue remains.

## Evidence

- `pnpm vitest run src/auto-reply/reply/abort.test.ts src/auto-reply/reply/commands.test.ts`
- Updated test: `fast-abort preserves queued followups but clears session lane`.

## Human Verification (required)

- Verified scenarios: fast-abort keeps queued followups; command lane cleanup still executes.
- Edge cases checked: existing command tests continue to pass.
- What I did **not** verify: full live Discord thread timeout path end-to-end in production.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR/commit.
- Files/config to restore: abort handlers and queue cleanup module.
- Known bad symptoms: abort may still clear queued followups if reverted.

## Risks and Mitigations

- Risk: preserved followups may run after an abort in cases where operators expected hard-drop semantics.
- Mitigation: command lane is still cleared immediately; only queued followup payloads are preserved to prevent silent loss.

