### PR TITLE
Session: add reset mode "off" (manual /new only, no auto rollover)

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_RESET_TRIGGER,
   DEFAULT_RESET_TRIGGERS,
   resolveChannelResetConfig,
+  resolveGroupSessionKey,
   resolveSessionResetPolicy,
   resolveSessionResetType,
   resolveThreadFlag,
@@ -50,28 +51,36 @@ let HANDLERS: CommandHandler[] | null = null;
 export type ResetCommandAction = "new" | "reset";
 
 function resolveResetCommandAction(params: HandleCommandsParams): ResetCommandAction | null {
+  const targetSessionKey =
+    params.ctx.CommandSource === "native" ? params.ctx.CommandTargetSessionKey?.trim() : undefined;
+  const sessionCtxForState =
+    targetSessionKey && targetSessionKey !== params.ctx.SessionKey
+      ? { ...params.ctx, SessionKey: targetSessionKey }
+      : params.ctx;
+  const groupResolution = resolveGroupSessionKey(sessionCtxForState) ?? undefined;
   const sessionCfg = params.cfg.session;
   const configuredResetTriggers = sessionCfg?.resetTriggers?.length
     ? sessionCfg.resetTriggers
     : DEFAULT_RESET_TRIGGERS;
   const isThread = resolveThreadFlag({
     sessionKey: params.sessionKey,
-    messageThreadId: params.ctx.MessageThreadId,
-    threadLabel: params.ctx.ThreadLabel,
-    threadStarterBody: params.ctx.ThreadStarterBody,
-    parentSessionKey: params.ctx.ParentSessionKey,
+    messageThreadId: sessionCtxForState.MessageThreadId,
+    threadLabel: sessionCtxForState.ThreadLabel,
+    threadStarterBody: sessionCtxForState.ThreadStarterBody,
+    parentSessionKey: sessionCtxForState.ParentSessionKey,
   });
   const resetType = resolveSessionResetType({
     sessionKey: params.sessionKey,
-    isGroup: params.isGroup,
+    isGroup: params.isGroup || Boolean(groupResolution),
     isThread,
   });
   const channelReset = resolveChannelResetConfig({
     sessionCfg,
     channel:
-      (params.ctx.OriginatingChannel as string | undefined) ??
-      params.ctx.Surface ??
-      params.ctx.Provider,
+      groupResolution?.channel ??
+      (sessionCtxForState.OriginatingChannel as string | undefined) ??
+      sessionCtxForState.Surface ??
+      sessionCtxForState.Provider,
   });
   const resetPolicy = resolveSessionResetPolicy({
     sessionCfg,

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,4 +1,12 @@
 import fs from "node:fs/promises";
+import {
+  DEFAULT_RESET_TRIGGER,
+  DEFAULT_RESET_TRIGGERS,
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+  resolveThreadFlag,
+} from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -40,6 +48,51 @@ import { routeReply } from "./route-reply.js";
 let HANDLERS: CommandHandler[] | null = null;
 
 export type ResetCommandAction = "new" | "reset";
+
+function resolveResetCommandAction(params: HandleCommandsParams): ResetCommandAction | null {
+  const sessionCfg = params.cfg.session;
+  const configuredResetTriggers = sessionCfg?.resetTriggers?.length
+    ? sessionCfg.resetTriggers
+    : DEFAULT_RESET_TRIGGERS;
+  const isThread = resolveThreadFlag({
+    sessionKey: params.sessionKey,
+    messageThreadId: params.ctx.MessageThreadId,
+    threadLabel: params.ctx.ThreadLabel,
+    threadStarterBody: params.ctx.ThreadStarterBody,
+    parentSessionKey: params.ctx.ParentSessionKey,
+  });
+  const resetType = resolveSessionResetType({
+    sessionKey: params.sessionKey,
+    isGroup: params.isGroup,
+    isThread,
+  });
+  const channelReset = resolveChannelResetConfig({
+    sessionCfg,
+    channel:
+      (params.ctx.OriginatingChannel as string | undefined) ??
+      params.ctx.Surface ??
+      params.ctx.Provider,
+  });
+  const resetPolicy = resolveSessionResetPolicy({
+    sessionCfg,
+    resetType,
+    resetOverride: channelReset,
+  });
+  const allowedResetTriggers =
+    resetPolicy.mode === "off" ? [DEFAULT_RESET_TRIGGER] : configuredResetTriggers;
+
+  const commandBody = params.command.commandBodyNormalized.trim().toLowerCase();
+  for (const trigger of allowedResetTriggers) {
+    if (!trigger) {
+      continue;
+    }
+    const triggerLower = trigger.toLowerCase();
+    if (commandBody === triggerLower || commandBody.startsWith(`${triggerLower} `)) {
+      return triggerLower === "/reset" || triggerLower === "reset" ? "reset" : "new";
+    }
+  }
+  return null;
+}
 
 export async function emitResetCommandHooks(params: {
   action: ResetCommandAction;
@@ -158,8 +211,8 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleAbortTrigger,
     ];
   }
-  const resetMatch = params.command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
-  const resetRequested = Boolean(resetMatch);
+  const resetAction = resolveResetCommandAction(params);
+  const resetRequested = resetAction !== null;
   if (resetRequested && !params.command.isAuthorizedSender) {
     logVerbose(
       `Ignoring /reset from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
@@ -169,9 +222,8 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
 
   // Trigger internal hook for reset/new commands
   if (resetRequested && params.command.isAuthorizedSender) {
-    const commandAction: ResetCommandAction = resetMatch?.[1] === "reset" ? "reset" : "new";
     await emitResetCommandHooks({
-      action: commandAction,
+      action: resetAction ?? "new",
       ctx: params.ctx,
       cfg: params.cfg,
       command: params.command,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -906,6 +906,29 @@ describe("handleCommands hooks", () => {
     spy.mockRestore();
   });
 
+  it("does not trigger reset hooks for channel-off /reset when channel is inferred from group sender", async () => {
+    const cfg = {
+      commands: { text: true },
+      session: {
+        resetByChannel: {
+          discord: { mode: "off" },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildParams("/reset", cfg, {
+      Provider: undefined,
+      Surface: undefined,
+      From: "discord:group:123456",
+      ChatType: "group",
+    });
+    const spy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
+
+    await handleCommands(params);
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
   it("triggers hooks for native /new routed to target sessions", async () => {
     const cfg = {
       commands: { text: true },

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -891,6 +891,21 @@ describe("handleCommands hooks", () => {
     spy.mockRestore();
   });
 
+  it("does not trigger reset hooks for /reset when reset mode is off", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { reset: { mode: "off" } },
+    } as OpenClawConfig;
+    const params = buildParams("/reset", cfg);
+    const spy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
+
+    await handleCommands(params);
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
   it("triggers hooks for native /new routed to target sessions", async () => {
     const cfg = {
       commands: { text: true },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -546,6 +546,36 @@ describe("initSessionState reset policy", () => {
     expect(result.sessionId).not.toBe(existingSessionId);
   });
 
+  it("does not auto-reset sessions when reset mode is off", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+    const root = await makeCaseDir("openclaw-reset-off-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:whatsapp:dm:off";
+    const existingSessionId = "off-session-id";
+
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: new Date(2026, 0, 16, 3, 0, 0).getTime(),
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        reset: { mode: "off", atHour: 4, idleMinutes: 1 },
+      },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+  });
+
   it("uses per-type overrides for thread sessions", async () => {
     vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
     const root = await makeCaseDir("openclaw-reset-thread-");
@@ -1016,6 +1046,73 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.isNewSession, testCase.name).toBe(true);
       expect(result.resetTriggered, testCase.name).toBe(true);
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry, testCase.name).toMatchObject(overrides);
+    }
+  });
+
+  it("only resets on /new when reset mode is off", async () => {
+    const storePath = await createStorePath("openclaw-reset-off-trigger-");
+    const sessionKey = "agent:main:telegram:dm:user-off";
+    const existingSessionId = "existing-session-off";
+    const overrides = {
+      verboseLevel: "on",
+      thinkingLevel: "high",
+      reasoningLevel: "low",
+      label: "telegram-priority",
+    } as const;
+    const cases = [
+      {
+        name: "/new still resets in off mode",
+        body: "/new",
+        expectedIsNewSession: true,
+        expectedResetTriggered: true,
+      },
+      {
+        name: "/reset does not reset in off mode",
+        body: "/reset",
+        expectedIsNewSession: false,
+        expectedResetTriggered: false,
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...overrides },
+      });
+
+      const cfg = {
+        session: {
+          store: storePath,
+          reset: { mode: "off" },
+        },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "user-off",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(testCase.expectedIsNewSession);
+      expect(result.resetTriggered, testCase.name).toBe(testCase.expectedResetTriggered);
+      if (testCase.expectedIsNewSession) {
+        expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      } else {
+        expect(result.sessionId, testCase.name).toBe(existingSessionId);
+      }
       expect(result.sessionEntry, testCase.name).toMatchObject(overrides);
     }
   });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -6,6 +6,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  DEFAULT_RESET_TRIGGER,
   DEFAULT_RESET_TRIGGERS,
   deriveSessionMetaPatch,
   evaluateSessionFreshness,
@@ -183,7 +184,7 @@ export async function initSessionState(params: {
     config: cfg,
   });
   const groupResolution = resolveGroupSessionKey(sessionCtxForState) ?? undefined;
-  const resetTriggers = sessionCfg?.resetTriggers?.length
+  const configuredResetTriggers = sessionCfg?.resetTriggers?.length
     ? sessionCfg.resetTriggers
     : DEFAULT_RESET_TRIGGERS;
   const parentForkMaxTokens = resolveParentForkMaxTokens(cfg);
@@ -197,7 +198,7 @@ export async function initSessionState(params: {
   const sessionStore: Record<string, SessionEntry> = loadSessionStore(storePath, {
     skipCache: true,
   });
-  let sessionKey: string | undefined;
+  const sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
   let sessionEntry: SessionEntry;
 
   let sessionId: string | undefined;
@@ -218,6 +219,32 @@ export async function initSessionState(params: {
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
     normalizedChatType != null && normalizedChatType !== "direct" ? true : Boolean(groupResolution);
+  const now = Date.now();
+  const isThread = resolveThreadFlag({
+    sessionKey,
+    messageThreadId: ctx.MessageThreadId,
+    threadLabel: ctx.ThreadLabel,
+    threadStarterBody: ctx.ThreadStarterBody,
+    parentSessionKey: ctx.ParentSessionKey,
+  });
+  const resetType = resolveSessionResetType({ sessionKey, isGroup, isThread });
+  const channelReset = resolveChannelResetConfig({
+    sessionCfg,
+    channel:
+      groupResolution?.channel ??
+      (ctx.OriginatingChannel as string | undefined) ??
+      ctx.Surface ??
+      ctx.Provider,
+  });
+  const resetPolicy = resolveSessionResetPolicy({
+    sessionCfg,
+    resetType,
+    resetOverride: channelReset,
+  });
+  // In off mode, only /new is allowed to rotate session state manually.
+  const resetTriggers =
+    resetPolicy.mode === "off" ? [DEFAULT_RESET_TRIGGER] : configuredResetTriggers;
+
   // Prefer CommandBody/RawBody (clean message) for command detection; fall back
   // to Body which may contain structural context (history, sender labels).
   const commandSource = ctx.BodyForCommands ?? ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "";
@@ -272,31 +299,8 @@ export async function initSessionState(params: {
     }
   }
 
-  sessionKey = resolveSessionKey(sessionScope, sessionCtxForState, mainKey);
   const entry = sessionStore[sessionKey];
   const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
-  const now = Date.now();
-  const isThread = resolveThreadFlag({
-    sessionKey,
-    messageThreadId: ctx.MessageThreadId,
-    threadLabel: ctx.ThreadLabel,
-    threadStarterBody: ctx.ThreadStarterBody,
-    parentSessionKey: ctx.ParentSessionKey,
-  });
-  const resetType = resolveSessionResetType({ sessionKey, isGroup, isThread });
-  const channelReset = resolveChannelResetConfig({
-    sessionCfg,
-    channel:
-      groupResolution?.channel ??
-      (ctx.OriginatingChannel as string | undefined) ??
-      ctx.Surface ??
-      ctx.Provider,
-  });
-  const resetPolicy = resolveSessionResetPolicy({
-    sessionCfg,
-    resetType,
-    resetOverride: channelReset,
-  });
   const freshEntry = entry
     ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
     : false;

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -369,6 +369,7 @@ const TARGET_KEYS = [
 
 const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "memory.citations": ['"auto"', '"on"', '"off"'],
+  "session.reset.mode": ['"daily"', '"idle"', '"off"'],
   "memory.backend": ['"builtin"', '"qmd"'],
   "memory.qmd.searchMode": ['"query"', '"search"', '"vsearch"'],
   "models.mode": ['"merge"', '"replace"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -950,7 +950,7 @@ export const FIELD_HELP: Record<string, string> = {
   "session.reset":
     "Defines the default reset policy object used when no type-specific or channel-specific override applies. Set this first, then layer resetByType or resetByChannel only where behavior must differ.",
   "session.reset.mode":
-    'Selects reset strategy: "daily" resets at a configured hour and "idle" resets after inactivity windows. Keep one clear mode per policy to avoid surprising context turnover patterns.',
+    'Selects reset strategy: "daily" resets at a configured hour, "idle" resets after inactivity windows, and "off" disables automatic resets (manual /new only). Keep one clear mode per policy to avoid surprising context turnover patterns.',
   "session.reset.atHour":
     "Sets local-hour boundary (0-23) for daily reset mode so sessions roll over at predictable times. Use with mode=daily and align to operator timezone expectations for human-readable behavior.",
   "session.reset.idleMinutes":

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -2,7 +2,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { SessionConfig, SessionResetConfig } from "../types.base.js";
 import { DEFAULT_IDLE_MINUTES } from "./types.js";
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "off";
 export type SessionResetType = "direct" | "group" | "thread";
 
 export type SessionResetPolicy = {
@@ -107,13 +107,15 @@ export function resolveSessionResetPolicy(params: {
   const idleMinutesRaw = typeReset?.idleMinutes ?? baseReset?.idleMinutes ?? legacyIdleMinutes;
 
   let idleMinutes: number | undefined;
-  if (idleMinutesRaw != null) {
-    const normalized = Math.floor(idleMinutesRaw);
-    if (Number.isFinite(normalized)) {
-      idleMinutes = Math.max(normalized, 1);
+  if (mode !== "off") {
+    if (idleMinutesRaw != null) {
+      const normalized = Math.floor(idleMinutesRaw);
+      if (Number.isFinite(normalized)) {
+        idleMinutes = Math.max(normalized, 1);
+      }
+    } else if (mode === "idle") {
+      idleMinutes = DEFAULT_IDLE_MINUTES;
     }
-  } else if (mode === "idle") {
-    idleMinutes = DEFAULT_IDLE_MINUTES;
   }
 
   return { mode, atHour, idleMinutes };
@@ -141,6 +143,14 @@ export function evaluateSessionFreshness(params: {
   now: number;
   policy: SessionResetPolicy;
 }): SessionFreshness {
+  if (params.policy.mode === "off") {
+    return {
+      fresh: true,
+      dailyResetAt: undefined,
+      idleExpiresAt: undefined,
+    };
+  }
+
   const dailyResetAt =
     params.policy.mode === "daily"
       ? resolveDailyResetAtMs(params.now, params.policy.atHour)

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -16,7 +16,7 @@ import {
   resolveSessionTranscriptPathInDir,
   validateSessionId,
 } from "./paths.js";
-import { resolveSessionResetPolicy } from "./reset.js";
+import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js";
 import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
 import type { SessionEntry } from "./types.js";
 
@@ -134,6 +134,36 @@ describe("resolveSessionResetPolicy", () => {
 
       expect(groupPolicy.mode).toBe("daily");
     });
+  });
+
+  it("supports off mode and ignores idleMinutes for auto-freshness checks", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {
+        reset: { mode: "off", idleMinutes: 1 },
+      } as SessionConfig,
+      resetType: "direct",
+    });
+
+    expect(policy.mode).toBe("off");
+    expect(policy.idleMinutes).toBeUndefined();
+  });
+
+  it("treats sessions as fresh in off mode even across daily/idle boundaries", () => {
+    const now = new Date(2026, 0, 18, 5, 0, 0).getTime();
+    const updatedAt = new Date(2026, 0, 17, 0, 0, 0).getTime();
+    const freshness = evaluateSessionFreshness({
+      updatedAt,
+      now,
+      policy: {
+        mode: "off",
+        atHour: 4,
+        idleMinutes: 1,
+      },
+    });
+
+    expect(freshness.fresh).toBe(true);
+    expect(freshness.dailyResetAt).toBeUndefined();
+    expect(freshness.idleExpiresAt).toBeUndefined();
   });
 });
 

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -68,7 +68,7 @@ export type SessionSendPolicyConfig = {
   rules?: SessionSendPolicyRule[];
 };
 
-export type SessionResetMode = "daily" | "idle";
+export type SessionResetMode = "daily" | "idle" | "off";
 export type SessionResetConfig = {
   mode?: SessionResetMode;
   /** Local hour (0-23) for the daily reset boundary. */

--- a/src/config/zod-schema.session-reset-mode.test.ts
+++ b/src/config/zod-schema.session-reset-mode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { SessionSchema } from "./zod-schema.session.js";
+
+describe("SessionSchema reset mode", () => {
+  it("accepts off mode for manual-only session resets", () => {
+    expect(() =>
+      SessionSchema.parse({
+        reset: {
+          mode: "off",
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -15,7 +15,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const SessionResetConfigSchema = z
   .object({
-    mode: z.union([z.literal("daily"), z.literal("idle")]).optional(),
+    mode: z.union([z.literal("daily"), z.literal("idle"), z.literal("off")]).optional(),
     atHour: z.number().int().min(0).max(23).optional(),
     idleMinutes: z.number().int().positive().optional(),
   })


### PR DESCRIPTION
## Summary

This PR adds session.reset.mode: "off" to support long-running context without automatic daily/idle session rollover.

In off mode:

- automatic daily reset is disabled
- automatic idle reset is disabled
- only /new triggers session reset
- /reset does not trigger reset behavior in off mode

This is important for users running long-lived projects and persistent-context workflows where automatic rollover is disruptive.

Closes #29536

## Changes

- add "off" to session reset mode type + config schema
- update reset policy evaluation so off bypasses daily/idle stale checks
- in session init, enforce /new as the only reset trigger when mode is off
- align command reset hook behavior in off mode (/reset no-op for reset semantics)
- update session reset help text to document off
- add tests for new mode and behavior

## Validation

- pnpm test src/auto-reply/reply/commands.test.ts src/auto-reply/reply/session.test.ts src/config/sessions/sessions.test.ts src/config/zod-schema.session-reset-mode.test.ts src/config/schema.help.quality.test.ts
- pnpm tsgo
- pnpm exec oxfmt --check on touched files
- pnpm exec oxlint --type-aware on touched files

Note: full pnpm check currently fails on unrelated pre-existing formatting/lint issues under ui/.