### PR TITLE
fix(agents): load bootstrap files from explicit agentDir with proper safeguards

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -279,3 +279,15 @@ export function resolveAgentDir(cfg: OpenClawConfig, agentId: string) {
   const root = resolveStateDir(process.env);
   return path.join(root, "agents", id, "agent");
 }
+
+/**
+ * Returns the resolved agentDir path **only** when the agent has an explicit
+ * `agentDir` value in its config entry.  Returns `undefined` when the agent
+ * relies on the default state-directory fallback, so callers can distinguish
+ * intentional per-agent overrides from accidental file presence.
+ */
+export function resolveExplicitAgentDir(cfg: OpenClawConfig, agentId: string): string | undefined {
+  const id = normalizeAgentId(agentId);
+  const configured = resolveAgentConfig(cfg, id)?.agentDir?.trim();
+  return configured ? resolveUserPath(configured) : undefined;
+}

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   clearInternalHooks,
   registerInternalHook,
@@ -79,6 +81,183 @@ describe("resolveBootstrapFilesForRun", () => {
     ).toBe(true);
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
+  });
+});
+
+describe("resolveBootstrapFilesForRun agentDir overrides (#29387)", () => {
+  beforeEach(() => clearInternalHooks());
+  afterEach(() => clearInternalHooks());
+
+  it("prefers agentDir SOUL.md over workspace SOUL.md when agentDir is explicitly configured", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.missing).toBe(false);
+    expect(soul?.content).toBe("agentdir soul");
+  });
+
+  it("falls back to workspace file when agentDir does not contain an override", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace agents", "utf-8");
+    // agentDir has no AGENTS.md
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+    const agents = files.find((f) => f.name === "AGENTS.md");
+    expect(agents?.missing).toBe(false);
+    expect(agents?.content).toBe("workspace agents");
+  });
+
+  it("skips agentDir lookup when agentId is not provided", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.content).toBe("workspace soul");
+  });
+
+  it("does NOT apply agentDir overrides when agentDir is not explicitly configured", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+
+    // Config has an agent entry but no explicit agentDir
+    const config = {
+      agents: { list: [{ id: "myagent" }] },
+    } as unknown as OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.content).toBe("workspace soul");
+  });
+
+  it("emits a diagnostic warning when agentDir files override workspace copies", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    const warnings: string[] = [];
+    await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+      warn: (msg) => warnings.push(msg),
+    });
+    expect(warnings.some((w) => w.includes("agentDir override"))).toBe(true);
+    expect(warnings.some((w) => w.includes("SOUL.md"))).toBe(true);
+  });
+
+  it("includes agentDir-only files not present in workspace (union merge)", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    // Workspace has SOUL.md but NOT MEMORY.md
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    // agentDir has both SOUL.md and MEMORY.md
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "MEMORY.md"), "agentdir memory", "utf-8");
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.content).toBe("agentdir soul");
+    // MEMORY.md should be included even though workspace doesn't have it
+    const memory = files.find((f) => f.name === "MEMORY.md");
+    expect(memory).toBeDefined();
+    expect(memory?.missing).toBe(false);
+    expect(memory?.content).toBe("agentdir memory");
+  });
+
+  it("filters agentDir-only files through session allowlist for cron/subagent sessions", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    // agentDir has SOUL.md (allowed) and MEMORY.md (not in minimal allowlist)
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "MEMORY.md"), "agentdir memory", "utf-8");
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    // Use a cron session key — filterBootstrapFilesForSession should apply
+    // the minimal allowlist, which does NOT include MEMORY.md
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+      sessionKey: "agent:default:cron:daily-check",
+    });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    expect(soul?.content).toBe("agentdir soul");
+    // MEMORY.md must NOT appear — it is outside the minimal allowlist
+    const memory = files.find((f) => f.name === "MEMORY.md");
+    expect(memory).toBeUndefined();
+  });
+
+  it("preserves hook overrides even when agentDir files exist", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-workspace-");
+    const agentDir = await makeTempWorkspace("openclaw-bootstrap-agentdir-");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "workspace soul", "utf-8");
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "agentdir soul", "utf-8");
+
+    // Register a hook that overrides SOUL.md
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      context.bootstrapFiles = context.bootstrapFiles.map((f) =>
+        f.name === "SOUL.md"
+          ? ({ ...f, content: "hook soul", missing: false } as WorkspaceBootstrapFile)
+          : f,
+      );
+    });
+
+    const config = {
+      agents: { list: [{ id: "myagent", agentDir }] },
+    } as unknown as OpenClawConfig;
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config,
+      agentId: "myagent",
+    });
+    const soul = files.find((f) => f.name === "SOUL.md");
+    // Hook should win over agentDir because hooks are applied last
+    expect(soul?.content).toBe("hook soul");
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -88,8 +88,13 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey,
       );
       merged = [...merged, ...added];
-      const overrideNames = Array.from(overrides.keys()).join(", ");
-      params.warn?.(`bootstrap files from agentDir override workspace copies: ${overrideNames}`);
+      const actualOverrides = Array.from(overrides.keys()).filter((name) =>
+        existingNames.has(name),
+      );
+      if (actualOverrides.length > 0) {
+        const overrideNames = actualOverrides.join(", ");
+        params.warn?.(`bootstrap files from agentDir override workspace copies: ${overrideNames}`);
+      }
     }
   }
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveExplicitAgentDir } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -58,8 +59,45 @@ export async function resolveBootstrapFilesForRun(params: {
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = filterBootstrapFilesForSession(rawFiles, sessionKey);
 
+  // When the agent has an *explicit* agentDir in its config, load bootstrap
+  // files from that directory and let them override the shared workspace
+  // copies.  This allows per-agent customisation (e.g. a distinct SOUL.md or
+  // AGENTS.md) without touching the shared workspace directory.  We only
+  // honour explicitly configured paths to avoid accidental overrides from
+  // files that happen to exist under the default state directory.  See: #29387
+  const agentDir =
+    params.agentId && params.config
+      ? resolveExplicitAgentDir(params.config, params.agentId)
+      : undefined;
+  let merged = bootstrapFiles;
+  if (agentDir) {
+    const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);
+    const overrides = new Map(agentDirFiles.filter((f) => !f.missing).map((f) => [f.name, f]));
+    if (overrides.size > 0) {
+      const existingNames = new Set(bootstrapFiles.map((f) => f.name));
+      // Replace workspace files that have an agentDir counterpart
+      merged = bootstrapFiles.map((f) => overrides.get(f.name) ?? f);
+      // Append agentDir-only files that don't exist in the workspace at all
+      // (e.g. MEMORY.md present only in the agent directory).  We must honour
+      // the same session-level allowlist that was applied to the workspace
+      // files above, otherwise agentDir-only files like MEMORY.md or
+      // HEARTBEAT.md would bypass the minimal-session guard for subagent/cron
+      // sessions.
+      const added = filterBootstrapFilesForSession(
+        [...overrides.values()].filter((f) => !existingNames.has(f.name)),
+        sessionKey,
+      );
+      merged = [...merged, ...added];
+      const overrideNames = Array.from(overrides.keys()).join(", ");
+      params.warn?.(`bootstrap files from agentDir override workspace copies: ${overrideNames}`);
+    }
+  }
+
+  // Apply hook overrides *after* agentDir merging so that hooks always have
+  // the final say — this preserves the existing hook-based customisation
+  // contract even when agentDir files are present.
   const updated = await applyBootstrapHookOverrides({
-    files: bootstrapFiles,
+    files: merged,
     workspaceDir: params.workspaceDir,
     config: params.config,
     sessionKey: params.sessionKey,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -91,6 +91,7 @@ export async function runCliAgent(params: {
     config: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
+    agentId: params.agentId,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
   });
   const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -252,7 +252,7 @@ async function discoverOllamaModels(baseUrl?: string): Promise<ModelDefinitionCo
     }
     const data = (await response.json()) as OllamaTagsResponse;
     if (!data.models || data.models.length === 0) {
-      log.warn("No Ollama models found on local instance");
+      log.debug("No Ollama models found on local instance");
       return [];
     }
     return data.models.map((model) => {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -106,6 +106,8 @@ export type CompactEmbeddedPiSessionParams = {
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
+  /** Effective agent id for the run; used for agentDir bootstrap resolution. */
+  agentId?: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
   provider?: string;
@@ -359,7 +361,9 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
-      agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.config }),
+      agentId:
+        params.agentId ??
+        resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.config }),
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -24,7 +24,7 @@ import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveSessionAgentId, resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
@@ -359,6 +359,7 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
+      agentId: resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.config }),
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -740,6 +740,7 @@ export async function runEmbeddedPiAgent(
                 sessionFile: params.sessionFile,
                 workspaceDir: resolvedWorkspace,
                 agentDir,
+                agentId: workspaceResolution.agentId,
                 config: params.config,
                 skillsSnapshot: params.skillsSnapshot,
                 senderIsOwner: params.senderIsOwner,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -311,6 +311,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        agentId: params.agentId,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -93,6 +93,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     ),
     workspaceDir: params.workspaceDir,
     agentDir: params.agentDir,
+    agentId: params.agentId,
     config: params.cfg,
     skillsSnapshot: params.sessionEntry.skillsSnapshot,
     provider: params.provider,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -33,6 +33,7 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    agentId: params.agentId,
   });
   const skillsSnapshot = (() => {
     try {


### PR DESCRIPTION
### Summary

Bootstrap files (`SOUL.md`, `AGENTS.md`, etc.) placed in an agent's configured `agentDir` are silently ignored. Only workspace directory files are injected into the system prompt, making per-agent customization impossible. This is especially dangerous for security-critical rules in `AGENTS.md`.

### Root Cause

`resolveBootstrapFilesForRun` in `bootstrap-files.ts` only loads files from the workspace directory. It never consults the agent's `agentDir`, even when one is explicitly configured.

### Fix

This change adds `agentDir` bootstrap file loading, implementing the preferred fix from #29387. It incorporates extensive feedback from multiple review cycles to ensure the implementation is robust and safe.

The key changes are:

1.  **`agentDir` Overrides Workspace**: Bootstrap files from an explicitly configured `agentDir` now override and merge with workspace files, allowing per-agent customization.

2.  **Explicit Configuration Only**: A new `resolveExplicitAgentDir` helper ensures that overrides only apply when `agentDir` is explicitly set in the agent's config. This prevents accidental overrides from files in the default state directory.

3.  **Hooks Always Win**: The `agentDir` merge happens *before* `applyBootstrapHookOverrides`, so `agent:bootstrap` hooks retain the final say, preserving the existing customization contract.

4.  **Union Merge & Allowlist Filtering**: The merge logic now correctly includes files that exist only in `agentDir` (union merge). These added files are also filtered through the session-specific allowlist, preventing files like `MEMORY.md` from bypassing the minimal-session guard for cron/subagent runs.

5.  **Full Caller Coverage**: All 6 runtime paths that resolve bootstrap files (CLI, embedded runner, compaction, etc.) have been updated to correctly pass the `agentId`, ensuring the `agentDir` logic is effective everywhere.

6.  **Clear Diagnostics**: A warning is logged when `agentDir` files override workspace copies, making the behavior transparent.

### Testing

This PR adds a comprehensive test suite with 8 new tests for the `agentDir` override functionality, covering:

-   `agentDir` file overriding a workspace file.
-   Falling back to the workspace file when no override exists in `agentDir`.
-   Correctly performing a union merge to include `agentDir`-only files.
-   Filtering `agentDir`-only files through the session allowlist for cron/subagent sessions.
-   Skipping `agentDir` lookup when `agentId` is not provided.
-   Ignoring `agentDir` when it's not explicitly configured.
-   Ensuring diagnostic warnings are emitted on override.
-   Verifying that hook overrides have priority over `agentDir` files.

Fixes #29387
