### PR TITLE
fix(cron): return accepted run ticket and reconcile timeout (AI-assisted)

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2536,6 +2536,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
+    public let runid: String?
     public let limit: Int?
     public let offset: Int?
     public let statuses: [AnyCodable]?
@@ -2549,6 +2550,7 @@ public struct CronRunsParams: Codable, Sendable {
         scope: AnyCodable?,
         id: String?,
         jobid: String?,
+        runid: String?,
         limit: Int?,
         offset: Int?,
         statuses: [AnyCodable]?,
@@ -2561,6 +2563,7 @@ public struct CronRunsParams: Codable, Sendable {
         self.scope = scope
         self.id = id
         self.jobid = jobid
+        self.runid = runid
         self.limit = limit
         self.offset = offset
         self.statuses = statuses
@@ -2575,6 +2578,7 @@ public struct CronRunsParams: Codable, Sendable {
         case scope
         case id
         case jobid = "jobId"
+        case runid = "runId"
         case limit
         case offset
         case statuses
@@ -2589,6 +2593,7 @@ public struct CronRunsParams: Codable, Sendable {
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
+    public let runid: String?
     public let action: String
     public let status: AnyCodable?
     public let error: String?
@@ -2609,6 +2614,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public init(
         ts: Int,
         jobid: String,
+        runid: String?,
         action: String,
         status: AnyCodable?,
         error: String?,
@@ -2628,6 +2634,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     {
         self.ts = ts
         self.jobid = jobid
+        self.runid = runid
         self.action = action
         self.status = status
         self.error = error
@@ -2649,6 +2656,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case ts
         case jobid = "jobId"
+        case runid = "runId"
         case action
         case status
         case error

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2536,6 +2536,7 @@ public struct CronRunsParams: Codable, Sendable {
     public let scope: AnyCodable?
     public let id: String?
     public let jobid: String?
+    public let runid: String?
     public let limit: Int?
     public let offset: Int?
     public let statuses: [AnyCodable]?
@@ -2549,6 +2550,7 @@ public struct CronRunsParams: Codable, Sendable {
         scope: AnyCodable?,
         id: String?,
         jobid: String?,
+        runid: String?,
         limit: Int?,
         offset: Int?,
         statuses: [AnyCodable]?,
@@ -2561,6 +2563,7 @@ public struct CronRunsParams: Codable, Sendable {
         self.scope = scope
         self.id = id
         self.jobid = jobid
+        self.runid = runid
         self.limit = limit
         self.offset = offset
         self.statuses = statuses
@@ -2575,6 +2578,7 @@ public struct CronRunsParams: Codable, Sendable {
         case scope
         case id
         case jobid = "jobId"
+        case runid = "runId"
         case limit
         case offset
         case statuses
@@ -2589,6 +2593,7 @@ public struct CronRunsParams: Codable, Sendable {
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
+    public let runid: String?
     public let action: String
     public let status: AnyCodable?
     public let error: String?
@@ -2609,6 +2614,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public init(
         ts: Int,
         jobid: String,
+        runid: String?,
         action: String,
         status: AnyCodable?,
         error: String?,
@@ -2628,6 +2634,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     {
         self.ts = ts
         self.jobid = jobid
+        self.runid = runid
         self.action = action
         self.status = status
         self.error = error
@@ -2649,6 +2656,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case ts
         case jobid = "jobId"
+        case runid = "runId"
         case action
         case status
         case error

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -8,13 +8,16 @@ const defaultGatewayMock = async (
   _opts: unknown,
   params?: unknown,
   _timeoutMs?: number,
-) => {
+): Promise<unknown> => {
   if (method === "cron.status") {
     return { enabled: true };
   }
   return { ok: true, params };
 };
-const callGatewayFromCli = vi.fn(defaultGatewayMock);
+const callGatewayFromCli =
+  vi.fn<
+    (method: string, _opts: unknown, params?: unknown, _timeoutMs?: number) => Promise<unknown>
+  >(defaultGatewayMock);
 
 vi.mock("./gateway-rpc.js", async () => {
   const actual = await vi.importActual<typeof import("./gateway-rpc.js")>("./gateway-rpc.js");
@@ -36,6 +39,7 @@ vi.mock("../runtime.js", () => ({
 }));
 
 const { registerCronCli } = await import("./cron-cli.js");
+const { defaultRuntime } = await import("../runtime.js");
 
 type CronUpdatePatch = {
   patch?: {
@@ -121,6 +125,20 @@ function getGatewayCallParams<T>(method: string): T {
   return (call?.[2] ?? {}) as T;
 }
 
+function logArgsToText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
 async function runCronEditWithScheduleLookup(
   schedule: unknown,
   editArgs: string[],
@@ -145,6 +163,58 @@ async function expectCronEditWithScheduleLookupExit(
 }
 
 describe("cron cli", () => {
+  it("reconciles once via cron.runs when cron run times out and latest run is ok", async () => {
+    resetGatewayMock();
+    vi.mocked(defaultRuntime.log).mockClear();
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.run") {
+        throw new Error("gateway timeout after 60000ms");
+      }
+      if (method === "cron.runs") {
+        return { entries: [{ ts: Date.now(), runId: "run-ok-1", status: "ok", summary: "done" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      return { ok: true };
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "run", "job-1"], { from: "user" });
+
+    const methods = callGatewayFromCli.mock.calls.map((call) => call[0]);
+    expect(methods).toContain("cron.run");
+    expect(methods).toContain("cron.runs");
+    const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => logArgsToText(call[0]));
+    expect(logLines.some((line) => line.includes('"status": "transport-timeout"'))).toBe(true);
+    expect(logLines.some((line) => line.includes('"state": "recent-run-observed"'))).toBe(true);
+  });
+
+  it("reconciles once via cron.runs when cron run times out and latest run is error", async () => {
+    resetGatewayMock();
+    vi.mocked(defaultRuntime.log).mockClear();
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.run") {
+        throw new Error("gateway timeout after 60000ms");
+      }
+      if (method === "cron.runs") {
+        return {
+          entries: [{ ts: Date.now(), runId: "run-err-1", status: "error", summary: "failed" }],
+        };
+      }
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      return { ok: true };
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "run", "job-1"], { from: "user" });
+
+    const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => logArgsToText(call[0]));
+    expect(logLines.some((line) => line.includes('"status": "transport-timeout"'))).toBe(true);
+    expect(logLines.some((line) => line.includes('"run-err-1"'))).toBe(true);
+    expect(logLines.some((line) => line.includes('"error"'))).toBe(true);
+  });
+
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -215,6 +215,32 @@ describe("cron cli", () => {
     expect(logLines.some((line) => line.includes('"error"'))).toBe(true);
   });
 
+  it("does not classify timeout reconciliation as recent when latest run predates request", async () => {
+    resetGatewayMock();
+    vi.mocked(defaultRuntime.log).mockClear();
+    const oldTs = Date.now() - 10 * 60_000;
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.run") {
+        throw new Error("gateway timeout after 60000ms");
+      }
+      if (method === "cron.runs") {
+        return {
+          entries: [{ ts: oldTs, runId: "run-old-1", status: "ok", summary: "old run" }],
+        };
+      }
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      return { ok: true };
+    });
+    const program = buildProgram();
+    await program.parseAsync(["cron", "run", "job-1"], { from: "user" });
+
+    const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => logArgsToText(call[0]));
+    expect(logLines.some((line) => line.includes('"status": "transport-timeout"'))).toBe(true);
+    expect(logLines.some((line) => line.includes('"state": "pending-or-older-run"'))).toBe(true);
+  });
+
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -6,6 +6,7 @@ import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { warnIfCronSchedulerDisabled } from "./shared.js";
 
 const CRON_RUN_RECONCILE_RECENT_MS = 2 * 60_000;
+const CRON_RUN_RECONCILE_CLOCK_SKEW_MS = 1_000;
 
 function isCronRunTimeoutLikeError(err: unknown): boolean {
   if (isGatewayTransportTimeoutError(err)) {
@@ -15,8 +16,11 @@ function isCronRunTimeoutLikeError(err: unknown): boolean {
   return /gateway timeout after/i.test(text);
 }
 
-async function reconcileCronRunTimeout(params: { id: string; opts: Record<string, unknown> }) {
-  const startedAt = Date.now();
+async function reconcileCronRunTimeout(params: {
+  id: string;
+  opts: Record<string, unknown>;
+  startedAt: number;
+}) {
   try {
     const runsPayload = (await callGatewayFromCli("cron.runs", params.opts, {
       id: params.id,
@@ -25,11 +29,16 @@ async function reconcileCronRunTimeout(params: { id: string; opts: Record<string
     const latest = Array.isArray(runsPayload.entries) ? runsPayload.entries[0] : undefined;
     const latestTs =
       latest && typeof latest.ts === "number" && Number.isFinite(latest.ts) ? latest.ts : null;
+    const observedAfterStart =
+      latestTs !== null && latestTs >= params.startedAt - CRON_RUN_RECONCILE_CLOCK_SKEW_MS;
     const recent =
-      latestTs !== null && Math.abs(startedAt - latestTs) <= CRON_RUN_RECONCILE_RECENT_MS;
+      observedAfterStart &&
+      latestTs - params.startedAt <=
+        CRON_RUN_RECONCILE_RECENT_MS + CRON_RUN_RECONCILE_CLOCK_SKEW_MS;
     return {
       state: recent ? "recent-run-observed" : "pending-or-older-run",
       checkedAt: Date.now(),
+      startedAt: params.startedAt,
       latest: latest ?? null,
       windowMs: CRON_RUN_RECONCILE_RECENT_MS,
     };
@@ -37,6 +46,7 @@ async function reconcileCronRunTimeout(params: { id: string; opts: Record<string
     return {
       state: "reconcile-failed",
       checkedAt: Date.now(),
+      startedAt: params.startedAt,
       error: String(reconcileErr),
     };
   }
@@ -132,6 +142,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .argument("<id>", "Job id")
       .option("--due", "Run only when due (default behavior in older versions)", false)
       .action(async (id, opts) => {
+        const runStartedAt = Date.now();
         try {
           const res = await callGatewayFromCli("cron.run", opts, {
             id,
@@ -144,6 +155,7 @@ export function registerCronSimpleCommands(cron: Command) {
             const reconciliation = await reconcileCronRunTimeout({
               id: String(id),
               opts: opts as Record<string, unknown>,
+              startedAt: runStartedAt,
             });
             defaultRuntime.log(
               JSON.stringify(

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -1,8 +1,46 @@
 import type { Command } from "commander";
+import { isGatewayTransportTimeoutError } from "../../gateway/call.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { warnIfCronSchedulerDisabled } from "./shared.js";
+
+const CRON_RUN_RECONCILE_RECENT_MS = 2 * 60_000;
+
+function isCronRunTimeoutLikeError(err: unknown): boolean {
+  if (isGatewayTransportTimeoutError(err)) {
+    return true;
+  }
+  const text = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /gateway timeout after/i.test(text);
+}
+
+async function reconcileCronRunTimeout(params: { id: string; opts: Record<string, unknown> }) {
+  const startedAt = Date.now();
+  try {
+    const runsPayload = (await callGatewayFromCli("cron.runs", params.opts, {
+      id: params.id,
+      limit: 1,
+    })) as { entries?: Array<{ ts?: number; runId?: string; status?: string; summary?: string }> };
+    const latest = Array.isArray(runsPayload.entries) ? runsPayload.entries[0] : undefined;
+    const latestTs =
+      latest && typeof latest.ts === "number" && Number.isFinite(latest.ts) ? latest.ts : null;
+    const recent =
+      latestTs !== null && Math.abs(startedAt - latestTs) <= CRON_RUN_RECONCILE_RECENT_MS;
+    return {
+      state: recent ? "recent-run-observed" : "pending-or-older-run",
+      checkedAt: Date.now(),
+      latest: latest ?? null,
+      windowMs: CRON_RUN_RECONCILE_RECENT_MS,
+    };
+  } catch (reconcileErr) {
+    return {
+      state: "reconcile-failed",
+      checkedAt: Date.now(),
+      error: String(reconcileErr),
+    };
+  }
+}
 
 function registerCronToggleCommand(params: {
   cron: Command;
@@ -101,6 +139,30 @@ export function registerCronSimpleCommands(cron: Command) {
           });
           defaultRuntime.log(JSON.stringify(res, null, 2));
         } catch (err) {
+          if (isCronRunTimeoutLikeError(err)) {
+            const mode = opts.due ? "due" : "force";
+            const reconciliation = await reconcileCronRunTimeout({
+              id: String(id),
+              opts: opts as Record<string, unknown>,
+            });
+            defaultRuntime.log(
+              JSON.stringify(
+                {
+                  ok: false,
+                  accepted: true,
+                  status: "transport-timeout",
+                  errorType: "GATEWAY_TRANSPORT_TIMEOUT",
+                  jobId: String(id),
+                  mode,
+                  note: "Request may have been accepted; reconciled once via cron.runs.",
+                  reconciliation,
+                },
+                null,
+                2,
+              ),
+            );
+            return;
+          }
           defaultRuntime.error(danger(String(err)));
           defaultRuntime.exit(1);
         }

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -7,6 +7,7 @@ import type { CronDeliveryStatus, CronRunStatus, CronRunTelemetry } from "./type
 export type CronRunLogEntry = {
   ts: number;
   jobId: string;
+  runId?: string;
   action: "finished";
   status?: CronRunStatus;
   error?: string;
@@ -28,6 +29,7 @@ export type ReadCronRunLogPageOptions = {
   limit?: number;
   offset?: number;
   jobId?: string;
+  runId?: string;
   status?: CronRunLogStatusFilter;
   statuses?: CronRunStatus[];
   deliveryStatus?: CronDeliveryStatus;
@@ -253,6 +255,7 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
       const entry: CronRunLogEntry = {
         ts: obj.ts,
         jobId: obj.jobId,
+        runId: typeof obj.runId === "string" && obj.runId.trim().length > 0 ? obj.runId : undefined,
         action: "finished",
         status: obj.status,
         error: obj.error,
@@ -307,6 +310,7 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
 function filterRunLogEntries(
   entries: CronRunLogEntry[],
   opts: {
+    runId?: string;
     statuses: CronRunStatus[] | null;
     deliveryStatuses: CronDeliveryStatus[] | null;
     query: string;
@@ -314,6 +318,9 @@ function filterRunLogEntries(
   },
 ): CronRunLogEntry[] {
   return entries.filter((entry) => {
+    if (opts.runId && entry.runId !== opts.runId) {
+      return false;
+    }
     if (opts.statuses && (!entry.status || !opts.statuses.includes(entry.status))) {
       return false;
     }
@@ -338,14 +345,17 @@ export async function readCronRunLogEntriesPage(
   const raw = await fs.readFile(path.resolve(filePath), "utf-8").catch(() => "");
   const statuses = normalizeRunStatuses(opts);
   const deliveryStatuses = normalizeDeliveryStatuses(opts);
+  const runId = opts?.runId?.trim() || undefined;
   const query = opts?.query?.trim().toLowerCase() ?? "";
   const sortDir: CronRunLogSortDir = opts?.sortDir === "asc" ? "asc" : "desc";
   const all = parseAllRunLogEntries(raw, { jobId: opts?.jobId });
   const filtered = filterRunLogEntries(all, {
+    runId,
     statuses,
     deliveryStatuses,
     query,
-    queryTextForEntry: (entry) => [entry.summary ?? "", entry.error ?? "", entry.jobId].join(" "),
+    queryTextForEntry: (entry) =>
+      [entry.summary ?? "", entry.error ?? "", entry.jobId, entry.runId ?? ""].join(" "),
   });
   const sorted =
     sortDir === "asc"
@@ -371,6 +381,7 @@ export async function readCronRunLogEntriesPageAll(
   const limit = Math.max(1, Math.min(200, Math.floor(opts.limit ?? 50)));
   const statuses = normalizeRunStatuses(opts);
   const deliveryStatuses = normalizeDeliveryStatuses(opts);
+  const runId = opts.runId?.trim() || undefined;
   const query = opts.query?.trim().toLowerCase() ?? "";
   const sortDir: CronRunLogSortDir = opts.sortDir === "asc" ? "asc" : "desc";
   const runsDir = path.resolve(path.dirname(path.resolve(opts.storePath)), "runs");
@@ -396,12 +407,15 @@ export async function readCronRunLogEntriesPageAll(
   );
   const all = chunks.flat();
   const filtered = filterRunLogEntries(all, {
+    runId,
     statuses,
     deliveryStatuses,
     query,
     queryTextForEntry: (entry) => {
       const jobName = opts.jobNameById?.[entry.jobId] ?? "";
-      return [entry.summary ?? "", entry.error ?? "", entry.jobId, jobName].join(" ");
+      return [entry.summary ?? "", entry.error ?? "", entry.jobId, jobName, entry.runId ?? ""].join(
+        " ",
+      );
     },
   });
   const sorted =

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -42,8 +42,8 @@ export class CronService {
     return await ops.remove(this.state, id);
   }
 
-  async run(id: string, mode?: "due" | "force") {
-    return await ops.run(this.state, id, mode);
+  async run(id: string, mode?: "due" | "force", opts?: { runId?: string }) {
+    return await ops.run(this.state, id, mode, opts);
   }
 
   getJob(id: string): CronJob | undefined {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
   applyJobPatch,
@@ -10,7 +11,7 @@ import {
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import { locked } from "./locked.js";
-import type { CronServiceState } from "./state.js";
+import type { CronRunOptions, CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import {
   applyJobResult,
@@ -333,7 +334,16 @@ export async function remove(state: CronServiceState, id: string) {
   });
 }
 
-export async function run(state: CronServiceState, id: string, mode?: "due" | "force") {
+export async function run(
+  state: CronServiceState,
+  id: string,
+  mode?: "due" | "force",
+  opts?: CronRunOptions,
+) {
+  const runId =
+    typeof opts?.runId === "string" && opts.runId.trim().length > 0
+      ? opts.runId.trim()
+      : randomUUID();
   const prepared = await locked(state, async () => {
     warnIfDisabled(state, "run");
     await ensureLoaded(state, { skipRecompute: true });
@@ -354,7 +364,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
     await persist(state);
-    emit(state, { jobId: job.id, action: "started", runAtMs: now });
+    emit(state, { jobId: job.id, action: "started", runId, runAtMs: now });
     const executionJob = JSON.parse(JSON.stringify(job)) as typeof job;
     return {
       ok: true,
@@ -401,6 +411,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     emit(state, {
       jobId: job.id,
       action: "finished",
+      runId,
       status: coreResult.status,
       error: coreResult.error,
       summary: coreResult.summary,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -14,6 +14,7 @@ import type {
 export type CronEvent = {
   jobId: string;
   action: "added" | "updated" | "removed" | "started" | "finished";
+  runId?: string;
   runAtMs?: number;
   durationMs?: number;
   status?: CronRunStatus;
@@ -120,6 +121,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
 }
 
 export type CronRunMode = "due" | "force";
+export type CronRunOptions = { runId?: string };
 export type CronWakeMode = "now" | "next-heartbeat";
 
 export type CronStatusSummary = {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -55,8 +55,14 @@ vi.mock("./client.js", () => ({
   },
 }));
 
-const { buildGatewayConnectionDetails, callGateway, callGatewayCli, callGatewayScoped } =
-  await import("./call.js");
+const {
+  GatewayTransportTimeoutError,
+  buildGatewayConnectionDetails,
+  callGateway,
+  callGatewayCli,
+  callGatewayScoped,
+  isGatewayTransportTimeoutError,
+} = await import("./call.js");
 
 function resetGatewayCallMocks() {
   loadConfig.mockClear();
@@ -360,8 +366,10 @@ describe("callGateway error details", () => {
     setLocalLoopbackGatewayConfig();
 
     vi.useFakeTimers();
+    let err: unknown;
     let errMessage = "";
     const promise = callGateway({ method: "health", timeoutMs: 5 }).catch((caught) => {
+      err = caught;
       errMessage = caught instanceof Error ? caught.message : String(caught);
     });
 
@@ -369,6 +377,8 @@ describe("callGateway error details", () => {
     await promise;
 
     expect(errMessage).toContain("gateway timeout after 5ms");
+    expect(err).toBeInstanceOf(GatewayTransportTimeoutError);
+    expect(isGatewayTransportTimeoutError(err)).toBe(true);
     expect(errMessage).toContain("Gateway target: ws://127.0.0.1:18789");
     expect(errMessage).toContain("Source: local loopback");
     expect(errMessage).toContain("Bind: loopback");

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -69,6 +69,8 @@ export type GatewayConnectionDetails = {
   message: string;
 };
 
+export const GATEWAY_TRANSPORT_TIMEOUT_ERROR = "GATEWAY_TRANSPORT_TIMEOUT";
+
 export type ExplicitGatewayAuth = {
   token?: string;
   password?: string;
@@ -299,6 +301,29 @@ function formatGatewayTimeoutError(
   return `gateway timeout after ${timeoutMs}ms\n${connectionDetails.message}`;
 }
 
+export class GatewayTransportTimeoutError extends Error {
+  readonly code = GATEWAY_TRANSPORT_TIMEOUT_ERROR;
+  readonly timeoutMs: number;
+  readonly connectionDetails: GatewayConnectionDetails;
+
+  constructor(timeoutMs: number, connectionDetails: GatewayConnectionDetails) {
+    super(formatGatewayTimeoutError(timeoutMs, connectionDetails));
+    this.name = "GatewayTransportTimeoutError";
+    this.timeoutMs = timeoutMs;
+    this.connectionDetails = connectionDetails;
+  }
+}
+
+export function isGatewayTransportTimeoutError(err: unknown): err is GatewayTransportTimeoutError {
+  return (
+    err instanceof GatewayTransportTimeoutError ||
+    (typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code?: unknown }).code === GATEWAY_TRANSPORT_TIMEOUT_ERROR)
+  );
+}
+
 async function executeGatewayRequestWithScopes<T>(params: {
   opts: CallGatewayBaseOptions;
   scopes: OperatorScope[];
@@ -371,7 +396,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
     const timer = setTimeout(() => {
       ignoreClose = true;
       client.stop();
-      stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
+      stop(new GatewayTransportTimeoutError(timeoutMs, params.connectionDetails));
     }, safeTimerTimeoutMs);
 
     client.start();

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -74,6 +74,7 @@ describe("cron protocol validators", () => {
     expect(
       validateCronRunsParams({
         id: "job-1",
+        runId: "run-1",
         limit: 50,
         offset: 0,
         status: "error",

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -281,6 +281,7 @@ export const CronRunsParamsSchema = Type.Object(
     scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
     id: Type.Optional(CronRunLogJobIdSchema),
     jobId: Type.Optional(CronRunLogJobIdSchema),
+    runId: Type.Optional(NonEmptyString),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, { minItems: 1, maxItems: 3 })),
@@ -299,6 +300,7 @@ export const CronRunLogEntrySchema = Type.Object(
   {
     ts: Type.Integer({ minimum: 0 }),
     jobId: NonEmptyString,
+    runId: Type.Optional(NonEmptyString),
     action: Type.Literal("finished"),
     status: Type.Optional(CronRunStatusSchema),
     error: Type.Optional(Type.String()),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -299,6 +299,7 @@ export function buildGatewayCronService(params: {
           {
             ts: Date.now(),
             jobId: evt.jobId,
+            runId: evt.runId,
             action: "finished",
             status: evt.status,
             error: evt.error,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -374,7 +374,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (mode === "force" && typeof job.state.runningAtMs === "number") {
+    if (typeof job.state.runningAtMs === "number") {
       respond(
         true,
         buildNotAcceptedCronRunPayload({
@@ -388,23 +388,29 @@ export const cronHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    if (
-      mode === "due" &&
-      typeof job.state.nextRunAtMs === "number" &&
-      Number.isFinite(job.state.nextRunAtMs) &&
-      job.state.nextRunAtMs > now
-    ) {
-      respond(
-        true,
-        buildNotAcceptedCronRunPayload({
-          jobId,
-          mode,
-          queuedAt: now,
-          errorMessage: `job not due yet (nextRunAtMs=${job.state.nextRunAtMs})`,
-        }),
-        undefined,
-      );
-      return;
+    if (mode === "due") {
+      const nextRunAtMs = job.state.nextRunAtMs;
+      const hasValidNextRun =
+        typeof nextRunAtMs === "number" && Number.isFinite(nextRunAtMs) && nextRunAtMs > 0;
+      const due = job.enabled && hasValidNextRun && now >= nextRunAtMs;
+      if (!due) {
+        const errorMessage = !job.enabled
+          ? `job is disabled: ${jobId}`
+          : hasValidNextRun
+            ? `job not due yet (nextRunAtMs=${nextRunAtMs})`
+            : `job has no due schedule: ${jobId}`;
+        respond(
+          true,
+          buildNotAcceptedCronRunPayload({
+            jobId,
+            mode,
+            queuedAt: now,
+            errorMessage,
+          }),
+          undefined,
+        );
+        return;
+      }
     }
 
     const requestId = randomUUID();

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import {
   readCronRunLogEntriesPage,
@@ -20,6 +21,119 @@ import {
   validateWakeParams,
 } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
+
+const CRON_FORCE_RUN_DEDUPE_WINDOW_MS = 60_000;
+const CRON_TRANSPORT_TIMEOUT_ERROR = "GATEWAY_TRANSPORT_TIMEOUT";
+const CRON_RUN_NOT_ACCEPTED_ERROR = "RUN_NOT_ACCEPTED";
+const CRON_RUN_EXECUTION_FAILURE_ERROR = "CRON_RUN_EXECUTION_FAILURE";
+
+type CronRunAcceptedPayload = {
+  ok: true;
+  ran: true;
+  accepted: true;
+  status: "accepted";
+  requestId: string;
+  runId: string;
+  jobId: string;
+  mode: "due" | "force";
+  queuedAt: number;
+  deduped: boolean;
+  errorType: null;
+  transportErrorType: typeof CRON_TRANSPORT_TIMEOUT_ERROR;
+  enqueueErrorType: typeof CRON_RUN_NOT_ACCEPTED_ERROR;
+  executionErrorType: typeof CRON_RUN_EXECUTION_FAILURE_ERROR;
+  reconcile: {
+    method: "cron.runs";
+    params: { id: string; runId: string; limit: 1 };
+  };
+  note: string;
+};
+
+type CronRunNotAcceptedPayload = {
+  ok: false;
+  ran: false;
+  accepted: false;
+  status: "not-accepted";
+  requestId: null;
+  runId: null;
+  jobId: string;
+  mode: "due" | "force";
+  queuedAt: number;
+  deduped: false;
+  errorType: typeof CRON_RUN_NOT_ACCEPTED_ERROR;
+  errorMessage: string;
+  reconcile: {
+    method: "cron.runs";
+    params: { id: string; limit: 1 };
+  };
+};
+
+function buildAcceptedCronRunPayload(params: {
+  requestId: string;
+  runId: string;
+  jobId: string;
+  mode: "due" | "force";
+  queuedAt: number;
+  deduped?: boolean;
+  note?: string;
+}): CronRunAcceptedPayload {
+  return {
+    ok: true,
+    ran: true,
+    accepted: true,
+    status: "accepted",
+    requestId: params.requestId,
+    runId: params.runId,
+    jobId: params.jobId,
+    mode: params.mode,
+    queuedAt: params.queuedAt,
+    deduped: params.deduped === true,
+    errorType: null,
+    transportErrorType: CRON_TRANSPORT_TIMEOUT_ERROR,
+    enqueueErrorType: CRON_RUN_NOT_ACCEPTED_ERROR,
+    executionErrorType: CRON_RUN_EXECUTION_FAILURE_ERROR,
+    reconcile: {
+      method: "cron.runs",
+      params: {
+        id: params.jobId,
+        runId: params.runId,
+        limit: 1,
+      },
+    },
+    note:
+      params.note ??
+      "If transport times out after acceptance, reconcile once via cron.runs using jobId+runId.",
+  };
+}
+
+function buildNotAcceptedCronRunPayload(params: {
+  jobId: string;
+  mode: "due" | "force";
+  queuedAt: number;
+  errorMessage: string;
+}): CronRunNotAcceptedPayload {
+  return {
+    ok: false,
+    ran: false,
+    accepted: false,
+    status: "not-accepted",
+    requestId: null,
+    runId: null,
+    jobId: params.jobId,
+    mode: params.mode,
+    queuedAt: params.queuedAt,
+    deduped: false,
+    errorType: CRON_RUN_NOT_ACCEPTED_ERROR,
+    errorMessage: params.errorMessage,
+    reconcile: {
+      method: "cron.runs",
+      params: {
+        id: params.jobId,
+        limit: 1,
+      },
+    },
+  };
+}
 
 export const cronHandlers: GatewayRequestHandlers = {
   wake: ({ params, respond, context }) => {
@@ -199,6 +313,8 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     const p = params as { id?: string; jobId?: string; mode?: "due" | "force" };
     const jobId = p.id ?? p.jobId;
+    const mode = p.mode ?? "force";
+    const now = Date.now();
     if (!jobId) {
       respond(
         false,
@@ -207,8 +323,127 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const result = await context.cron.run(jobId, p.mode ?? "force");
-    respond(true, result, undefined);
+
+    const jobs = await context.cron.list({ includeDisabled: true });
+    const job = jobs.find((entry) => entry.id === jobId);
+    if (!job) {
+      respond(
+        true,
+        buildNotAcceptedCronRunPayload({
+          jobId,
+          mode,
+          queuedAt: now,
+          errorMessage: `job not found: ${jobId}`,
+        }),
+        undefined,
+      );
+      return;
+    }
+
+    const dedupeKey = `cron.run:force:${jobId}`;
+    if (mode === "force") {
+      const cached = context.dedupe.get(dedupeKey);
+      const cachedPayload =
+        cached && typeof cached.payload === "object" && cached.payload !== null
+          ? (cached.payload as Partial<CronRunAcceptedPayload>)
+          : null;
+      if (
+        cached &&
+        cached.ok &&
+        cachedPayload?.requestId &&
+        cachedPayload?.runId &&
+        now - cached.ts <= CRON_FORCE_RUN_DEDUPE_WINDOW_MS
+      ) {
+        respond(
+          true,
+          buildAcceptedCronRunPayload({
+            requestId: cachedPayload.requestId,
+            runId: cachedPayload.runId,
+            jobId,
+            mode,
+            queuedAt:
+              typeof cachedPayload.queuedAt === "number" && Number.isFinite(cachedPayload.queuedAt)
+                ? cachedPayload.queuedAt
+                : cached.ts,
+            deduped: true,
+            note: `Duplicate manual force run suppressed for ${CRON_FORCE_RUN_DEDUPE_WINDOW_MS}ms window.`,
+          }),
+          undefined,
+        );
+        return;
+      }
+    }
+
+    if (mode === "force" && typeof job.state.runningAtMs === "number") {
+      respond(
+        true,
+        buildNotAcceptedCronRunPayload({
+          jobId,
+          mode,
+          queuedAt: now,
+          errorMessage: `job already running: ${jobId}`,
+        }),
+        undefined,
+      );
+      return;
+    }
+
+    if (
+      mode === "due" &&
+      typeof job.state.nextRunAtMs === "number" &&
+      Number.isFinite(job.state.nextRunAtMs) &&
+      job.state.nextRunAtMs > now
+    ) {
+      respond(
+        true,
+        buildNotAcceptedCronRunPayload({
+          jobId,
+          mode,
+          queuedAt: now,
+          errorMessage: `job not due yet (nextRunAtMs=${job.state.nextRunAtMs})`,
+        }),
+        undefined,
+      );
+      return;
+    }
+
+    const requestId = randomUUID();
+    const runId = requestId;
+    const acceptedPayload = buildAcceptedCronRunPayload({
+      requestId,
+      runId,
+      jobId,
+      mode,
+      queuedAt: now,
+      deduped: false,
+    });
+    if (mode === "force") {
+      context.dedupe.set(dedupeKey, { ts: now, ok: true, payload: acceptedPayload });
+    }
+
+    respond(true, acceptedPayload, undefined);
+
+    void context.cron
+      .run(jobId, mode, { runId })
+      .then((result) => {
+        if (!result.ok || !result.ran) {
+          if (mode === "force") {
+            context.dedupe.delete(dedupeKey);
+          }
+          const reason = "reason" in result ? result.reason : "unknown";
+          context.logGateway.warn(
+            `cron.run accepted but not executed (requestId=${requestId}, jobId=${jobId}, reason=${String(reason)})`,
+          );
+        }
+      })
+      .catch((err) => {
+        if (mode === "force") {
+          context.dedupe.delete(dedupeKey);
+        }
+        context.logGateway.error(
+          `cron.run accepted execution failed (requestId=${requestId}, jobId=${jobId}): ${String(err)}`,
+        );
+      });
   },
   "cron.runs": async ({ params, respond, context }) => {
     if (!validateCronRunsParams(params)) {
@@ -226,6 +461,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       scope?: "job" | "all";
       id?: string;
       jobId?: string;
+      runId?: string;
       limit?: number;
       offset?: number;
       statuses?: Array<"ok" | "error" | "skipped">;
@@ -261,6 +497,7 @@ export const cronHandlers: GatewayRequestHandlers = {
         status: p.status,
         deliveryStatuses: p.deliveryStatuses,
         deliveryStatus: p.deliveryStatus,
+        runId: p.runId,
         query: p.query,
         sortDir: p.sortDir,
         jobNameById,
@@ -290,6 +527,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       status: p.status,
       deliveryStatuses: p.deliveryStatuses,
       deliveryStatus: p.deliveryStatus,
+      runId: p.runId,
       query: p.query,
       sortDir: p.sortDir,
     });

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -314,7 +314,6 @@ export const cronHandlers: GatewayRequestHandlers = {
     const p = params as { id?: string; jobId?: string; mode?: "due" | "force" };
     const jobId = p.id ?? p.jobId;
     const mode = p.mode ?? "force";
-    const now = Date.now();
     if (!jobId) {
       respond(
         false,
@@ -326,6 +325,7 @@ export const cronHandlers: GatewayRequestHandlers = {
 
     const jobs = await context.cron.list({ includeDisabled: true });
     const job = jobs.find((entry) => entry.id === jobId);
+    const now = Date.now();
     if (!job) {
       respond(
         true,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -41,6 +41,16 @@ async function yieldToEventLoop() {
   await setImmediatePromise();
 }
 
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (err: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 async function rmTempDir(dir: string) {
   for (let i = 0; i < 100; i += 1) {
     try {
@@ -498,6 +508,101 @@ describe("gateway server cron", () => {
       await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
     }
   }, 45_000);
+
+  test("returns immediate accepted ticket, dedupes duplicate force runs, and supports runId filtering", async () => {
+    const { prevSkipCron, dir } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-run-ticket-",
+      cronEnabled: false,
+    });
+    const deferred = createDeferred<{ status: "ok"; summary: string }>();
+    cronIsolatedRun.mockImplementationOnce(async () => await deferred.promise);
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "ticketed run",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "run me" },
+      });
+      expect(addRes.ok).toBe(true);
+      const jobIdValue = (addRes.payload as { id?: unknown } | null)?.id;
+      const jobId = typeof jobIdValue === "string" ? jobIdValue : "";
+      expect(jobId.length > 0).toBe(true);
+
+      const firstRunRes = await rpcReq(ws, "cron.run", { id: jobId, mode: "force" }, 20_000);
+      expect(firstRunRes.ok).toBe(true);
+      const firstPayload = firstRunRes.payload as
+        | { accepted?: unknown; runId?: unknown; requestId?: unknown; deduped?: unknown }
+        | undefined;
+      expect(firstPayload?.accepted).toBe(true);
+      expect(typeof firstPayload?.runId).toBe("string");
+      expect(typeof firstPayload?.requestId).toBe("string");
+      expect(firstPayload?.deduped).toBe(false);
+
+      const secondRunRes = await rpcReq(ws, "cron.run", { id: jobId, mode: "force" }, 20_000);
+      expect(secondRunRes.ok).toBe(true);
+      const secondPayload = secondRunRes.payload as
+        | { accepted?: unknown; runId?: unknown; requestId?: unknown; deduped?: unknown }
+        | undefined;
+      expect(secondPayload?.accepted).toBe(true);
+      expect(secondPayload?.deduped).toBe(true);
+      expect(secondPayload?.runId).toBe(firstPayload?.runId);
+      expect(secondPayload?.requestId).toBe(firstPayload?.requestId);
+
+      deferred.resolve({ status: "ok", summary: "ticketed done" });
+
+      const runId = typeof firstPayload?.runId === "string" ? firstPayload.runId : "";
+      expect(runId.length > 0).toBe(true);
+      await waitForCondition(async () => {
+        const filtered = await rpcReq(ws, "cron.runs", { id: jobId, runId, limit: 1 }, 20_000);
+        const entries = (filtered.payload as { entries?: unknown } | null)?.entries;
+        return (
+          Array.isArray(entries) &&
+          entries.length > 0 &&
+          (entries[0] as { runId?: unknown }).runId === runId
+        );
+      }, CRON_WAIT_TIMEOUT_MS);
+
+      const filteredRuns = await rpcReq(ws, "cron.runs", { id: jobId, runId, limit: 1 }, 20_000);
+      const filteredEntries = (filteredRuns.payload as { entries?: unknown } | null)?.entries as
+        | Array<{ runId?: unknown; status?: unknown; summary?: unknown }>
+        | undefined;
+      expect(Array.isArray(filteredEntries)).toBe(true);
+      expect(filteredEntries?.[0]?.runId).toBe(runId);
+      expect(filteredEntries?.[0]?.status).toBe("ok");
+      expect(filteredEntries?.[0]?.summary).toBe("ticketed done");
+    } finally {
+      await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("returns RUN_NOT_ACCEPTED payload when cron.run target job does not exist", async () => {
+    const { prevSkipCron, dir } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-not-accepted-",
+      cronEnabled: false,
+    });
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const runRes = await rpcReq(ws, "cron.run", { id: "missing-job", mode: "force" }, 20_000);
+      expect(runRes.ok).toBe(true);
+      const payload = runRes.payload as
+        | { accepted?: unknown; errorType?: unknown; status?: unknown; runId?: unknown }
+        | undefined;
+      expect(payload?.accepted).toBe(false);
+      expect(payload?.status).toBe("not-accepted");
+      expect(payload?.errorType).toBe("RUN_NOT_ACCEPTED");
+      expect(payload?.runId).toBe(null);
+    } finally {
+      await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
+    }
+  });
 
   test("posts webhooks for delivery mode and legacy notify fallback only when summary exists", async () => {
     const legacyNotifyJob = {

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -604,6 +604,49 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("returns RUN_NOT_ACCEPTED for due-mode runs when job is disabled", async () => {
+    const { prevSkipCron, dir } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-due-disabled-",
+      cronEnabled: false,
+    });
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "due disabled",
+        enabled: false,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "run me" },
+      });
+      expect(addRes.ok).toBe(true);
+      const jobId = (addRes.payload as { id?: string } | null)?.id ?? "";
+      expect(jobId.length > 0).toBe(true);
+
+      const runRes = await rpcReq(ws, "cron.run", { id: jobId, mode: "due" }, 20_000);
+      expect(runRes.ok).toBe(true);
+      const payload = runRes.payload as
+        | {
+            accepted?: unknown;
+            status?: unknown;
+            errorType?: unknown;
+            errorMessage?: unknown;
+            runId?: unknown;
+          }
+        | undefined;
+      expect(payload?.accepted).toBe(false);
+      expect(payload?.status).toBe("not-accepted");
+      expect(payload?.errorType).toBe("RUN_NOT_ACCEPTED");
+      expect(payload?.runId).toBe(null);
+      expect(typeof payload?.errorMessage).toBe("string");
+      expect(String(payload?.errorMessage)).toContain("disabled");
+    } finally {
+      await cleanupCronTestRun({ ws, server, dir, prevSkipCron });
+    }
+  });
+
   test("posts webhooks for delivery mode and legacy notify fallback only when summary exists", async () => {
     const legacyNotifyJob = {
       id: "legacy-notify-job",


### PR DESCRIPTION
## Summary

- Problem: `cron run` can time out at transport level while the job still executes later, causing clients/users to misclassify runs as failed and retrigger duplicates.
- Why it matters: false failure signaling can cause duplicate force-runs and duplicate notifications.
- What changed:
- `cron.run` now returns an immediate accepted payload (`accepted`, `requestId`/`runId`, `queuedAt`, reconcile hint) and executes asynchronously.
- Added force-run dedupe window (60s) for identical manual runs.
- Added explicit not-accepted payload (`RUN_NOT_ACCEPTED`) for missing/running/not-due cases.
- Added transport-timeout taxonomy in gateway call path (`GatewayTransportTimeoutError`) and CLI reconciliation (single `cron.runs` check on timeout-like responses).
- Added `runId` propagation/filtering across cron events, run logs, schema, validators, and `cron.runs`.
- What did NOT change (scope boundary):
- No scheduler timing semantics rewrite.
- No job payload execution model changes.
- No auth/token/capability expansion.
- AI assistance/testing note: AI-assisted. Testing degree: lightly tested (`pnpm build`, `pnpm check`, and scoped tests), with known unrelated baseline failures in full local `pnpm test`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `cron.run` now returns an immediate accepted ticket-style payload including `requestId`, `runId`, `queuedAt`, and reconciliation hint.
- Duplicate manual force-run requests within 60s are deduped.
- `cron.runs` supports `runId` filtering for reconciliation.
- CLI `cron run` performs one reconciliation call on timeout-like transport errors instead of immediately presenting a hard failure.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway cron + CLI
- Relevant config (redacted): local dev defaults

### Steps

1. Add a cron job and call `cron.run` in force mode.
2. Simulate/observe transport-timeout path.
3. Query `cron.runs` with returned `runId`.

### Expected

- Immediate accepted response with `requestId`/`runId`/`queuedAt`.
- Timeout-like path is reconciled once via `cron.runs`.
- Duplicate force-run request within dedupe window returns deduped accepted payload.

### Actual

- Matches expected behavior in scoped tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Accepted response contract for `cron.run`
- Deduped duplicate force runs
- `RUN_NOT_ACCEPTED` payload shape
- Timeout reconciliation in CLI
- `runId` filtering in `cron.runs`
- Edge cases checked:
- Missing job id target
- Job already running
- Not-due run in due mode
- What you did **not** verify:
- Full local `pnpm test` green run (current local suite has unrelated baseline failures outside this PR scope)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert commits:
- `8b3026708` (cron reliability changes)
- `fb5fae88f` (type-check cast fix for test)
- Files/config to restore:
- `src/gateway/server-methods/cron.ts`
- `src/cli/cron-cli/register.cron-simple.ts`
- `src/gateway/call.ts`
- `src/cron/*` touched files
- Known bad symptoms reviewers should watch for:
- `cron.run` returns synchronous execution result instead of accepted payload
- Missing `runId` in run-log filtering or reconciliation paths

## Risks and Mitigations

- Risk: force-run dedupe window may suppress intentionally repeated manual runs within 60s.
- Mitigation: dedupe is force-only, per-job, short-window, and response includes `deduped: true`.
- Risk: clients expecting old `cron.run` immediate execution semantics may need adjustment.
- Mitigation: accepted payload includes explicit reconcile contract and stable fields (`requestId`, `runId`, `queuedAt`).
