### PR TITLE
fix(logging): respect file log level setting - Fixes #29448

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -54,3 +54,22 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(log.isEnabled("info")).toBe(true);
   });
 });
+
+describe("file logging respects level setting", () => {
+  it("does not write to file when level is set to info and message is debug", () => {
+    // This tests the fix for issue #29448
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const log = createSubsystemLogger("test/subsystem");
+
+    // isEnabled should return false for debug to file
+    expect(log.isEnabled("debug", "file")).toBe(false);
+  });
+
+  it("writes to file when level is set to debug", () => {
+    setLoggerOverride({ level: "debug", consoleLevel: "silent" });
+    const log = createSubsystemLogger("test/subsystem");
+
+    // isEnabled should return true for debug to file
+    expect(log.isEnabled("debug", "file")).toBe(true);
+  });
+});

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -281,7 +281,9 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       }
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
-    logToFile(getFileLogger(), level, message, fileMeta);
+    if (isFileLogLevelEnabled(level)) {
+      logToFile(getFileLogger(), level, message, fileMeta);
+    }
     if (!shouldLogToConsole(level, { level: consoleSettings.level })) {
       return;
     }


### PR DESCRIPTION
## Summary

This PR fixes issue #29448 - logging level config not working.

## Problem

The `emit()` function in `src/logging/subsystem.ts` was calling `logToFile()` without checking if file logging was enabled for the given log level. This caused DEBUG logs to be written to file even when `logging.level` was set to `info`.

## Solution

Added a check for `isFileLogLevelEnabled(level)` before writing to file.

## Changes

- `src/logging/subsystem.ts`: Added file log level check before calling `logToFile()`
- `src/logging/subsystem.test.ts`: Added tests to verify the fix

## Testing

All 49 logging tests pass.

## Related Issue

Fixes #29448

---

AI-assisted contribution (built with assistance)