### PR TITLE
fix(config): add missing extraArgs to browser zod schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -130,4 +130,24 @@ describe("config schema regressions", () => {
       expect(res.issues[0]?.path).toBe("channels.imessage.attachmentRoots.0");
     }
   });
+
+  it("accepts browser.extraArgs for proxy and custom flags", () => {
+    const res = validateConfigObject({
+      browser: {
+        extraArgs: ["--proxy-server=http://127.0.0.1:7890"],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects browser.extraArgs with non-array value", () => {
+    const res = validateConfigObject({
+      browser: {
+        extraArgs: "--proxy-server=http://127.0.0.1:7890" as unknown,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -278,6 +278,7 @@ export const OpenClawSchema = z
               }),
           )
           .optional(),
+        extraArgs: z.array(z.string()).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem**: `browser.extraArgs` field is already supported in `browser.config.ts` and used in `chrome.ts` to pass extra CLI arguments to Chromium (e.g. `--proxy-server`), but the Zod validation schema in `zod-schema.ts` was never updated.
- **Why it matters**: Because the browser schema uses `.strict()`, any config containing `extraArgs` is rejected with an "Unrecognized key" error, making the feature unusable.
- **What changed**: Added `extraArgs: z.array(z.string()).optional()` to the browser Zod schema to match the existing TypeScript type definition, and added schema regression tests.
- **What did NOT change (scope boundary)**: No logic, runtime behavior changes. Only schema validation alignment + tests.

## Discovery Context

I was configuring OpenClaw behind a corporate proxy and needed to pass `--proxy-server=http://127.0.0.1:7890` to the browser via `browser.extraArgs`. The config was rejected immediately with:

```
Unrecognized key(s) in object: 'extraArgs'
```

After tracing the error, I found that the Zod schema in `zod-schema.ts` uses `.strict()` mode but never declared the `extraArgs` field, even though:
1. The TypeScript type `BrowserConfig` in `types.browser.ts` already defines `extraArgs?: string[]`
2. `resolveBrowserConfig()` in `browser/config.ts` already processes it
3. `chrome.ts` already passes it to Chromium launch args
4. `browser/config.test.ts` already has 5 test cases covering it

So the feature was fully implemented but completely blocked by a missing schema field.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #18443 (original extraArgs implementation)

## User-visible / Behavior Changes

Users can now set `browser.extraArgs` in their config without getting a Zod validation error. Common use cases:
- `--proxy-server=...` for proxy environments
- `--disable-gpu` for headless servers
- `--user-agent=...` for custom user agents

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: `browser.extraArgs: ["--proxy-server=..."]`

### Steps

1. Add `browser.extraArgs: ["--proxy-server=http://127.0.0.1:7890"]` to config
2. Run any command that loads config
3. Before fix: Zod throws "Unrecognized key(s) in object: 'extraArgs'"
4. After fix: Config loads successfully

### Expected

- Config with `extraArgs` is accepted

### Actual (before fix)

- Config rejected with Zod strict mode error

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added 2 regression tests in `config.schema-regressions.test.ts`:
- `accepts browser.extraArgs for proxy and custom flags` — verifies array of strings is accepted
- `rejects browser.extraArgs with non-array value` — verifies type safety

Existing tests in `browser/config.test.ts` (5 test cases) also cover runtime behavior of `extraArgs`.

## Human Verification (required)

- Verified scenarios: Confirmed `extraArgs` field is accepted by Zod schema after adding the line; all existing + new tests pass.
- Edge cases checked: Empty array, multiple args, undefined (optional), non-array value (rejected).
- What you did **not** verify: Live Chromium launch with extra args (covered by existing tests in chrome.ts).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single line addition in `zod-schema.ts`
- Files/config to restore: `src/config/zod-schema.ts`
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None
