### PR TITLE
Feishu: fix locale-wrapper post parser test

### DIFF
--- a/extensions/feishu/src/post.test.ts
+++ b/extensions/feishu/src/post.test.ts
@@ -92,11 +92,13 @@ describe("parsePostContent", () => {
     expect(parsePostContent(wrappedByPost)).toEqual({
       textContent: "标题\n\n内容A",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
     expect(parsePostContent(wrappedByLocale)).toEqual({
       textContent: "标题\n\n内容B",
       imageKeys: [],
+      mediaKeys: [],
       mentionedOpenIds: [],
     });
   });


### PR DESCRIPTION
## Summary

- Problem: `extensions/feishu/src/post.test.ts` expected objects without `mediaKeys` in locale-wrapper test cases.
- Why it matters: `parsePostContent` now always returns `mediaKeys`, causing CI test failure.
- What changed: Added `mediaKeys: []` to both locale-wrapper expectations.
- What did NOT change (scope boundary): No parser/runtime behavior changes; test-only update.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu extension tests
- Relevant config (redacted): default local test config

### Steps

1. Run `pnpm vitest extensions/feishu/src/post.test.ts` before fix.
2. Observe locale-wrapper test failure due to unexpected `mediaKeys` field.
3. Apply expectation update and rerun the same command.

### Expected

- Test suite passes with parser output shape including `mediaKeys`.

### Actual

- After fix, all tests in `extensions/feishu/src/post.test.ts` pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: locale-wrapper expectations and full `post.test.ts` file run.
- Edge cases checked: both wrapper styles (`post.zh_cn` and top-level `zh_cn`).
- What you did **not** verify: full repository test suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `extensions/feishu/src/post.test.ts`.
- Known bad symptoms reviewers should watch for: none beyond this test regression.

## Risks and Mitigations

- Risk: Minimal; test expectation could hide an unintended API shape change.
  - Mitigation: Change matches current parser contract used in other assertions.
