### PR TITLE
fix(cli): complete startup fast-paths for help/version/no-arg/invalid command

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -8,6 +8,7 @@ import {
   getVerboseFlag,
   hasHelpOrVersion,
   hasFlag,
+  isRootHelpRequest,
   isRootVersionRequest,
   shouldMigrateState,
   shouldMigrateStateFromPath,
@@ -331,5 +332,56 @@ describe("argv helpers", () => {
     },
   ])("isRootVersionRequest: $name", ({ argv, expected }) => {
     expect(isRootVersionRequest(argv)).toBe(expected);
+  });
+
+  // isRootHelpRequest: guards the entry.ts fast-path help exit.
+  it.each([
+    {
+      name: "--help flag at root",
+      argv: ["node", "openclaw", "--help"],
+      expected: true,
+    },
+    {
+      name: "-h flag at root",
+      argv: ["node", "openclaw", "-h"],
+      expected: true,
+    },
+    {
+      name: "--help after a root boolean flag",
+      argv: ["node", "openclaw", "--dev", "--help"],
+      expected: true,
+    },
+    {
+      name: "--help after a root value flag",
+      argv: ["node", "openclaw", "--profile", "dev", "--help"],
+      expected: true,
+    },
+    {
+      name: "--help after -- terminator must NOT trigger (forwarded arg)",
+      argv: ["node", "openclaw", "nodes", "run", "--", "git", "--help"],
+      expected: false,
+    },
+    {
+      name: "-h after -- terminator must NOT trigger",
+      argv: ["node", "openclaw", "--", "-h"],
+      expected: false,
+    },
+    {
+      name: "--help with subcommand must NOT trigger (subcommand-scoped)",
+      argv: ["node", "openclaw", "status", "--help"],
+      expected: false,
+    },
+    {
+      name: "-h with subcommand must NOT trigger",
+      argv: ["node", "openclaw", "models", "-h"],
+      expected: false,
+    },
+    {
+      name: "normal command without help flag",
+      argv: ["node", "openclaw", "status"],
+      expected: false,
+    },
+  ])("isRootHelpRequest: $name", ({ argv, expected }) => {
+    expect(isRootHelpRequest(argv)).toBe(expected);
   });
 });

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -9,6 +9,7 @@ import {
   hasHelpOrVersion,
   hasFlag,
   isRootHelpRequest,
+  isRootNoCommandRequest,
   isRootVersionRequest,
   shouldMigrateState,
   shouldMigrateStateFromPath,
@@ -383,5 +384,30 @@ describe("argv helpers", () => {
     },
   ])("isRootHelpRequest: $name", ({ argv, expected }) => {
     expect(isRootHelpRequest(argv)).toBe(expected);
+  });
+
+  it.each([
+    {
+      name: "no args",
+      argv: ["node", "openclaw"],
+      expected: true,
+    },
+    {
+      name: "only root flags",
+      argv: ["node", "openclaw", "--dev", "--profile", "work"],
+      expected: true,
+    },
+    {
+      name: "subcommand present",
+      argv: ["node", "openclaw", "status"],
+      expected: false,
+    },
+    {
+      name: "non-flag token after terminator is ignored",
+      argv: ["node", "openclaw", "--", "status"],
+      expected: true,
+    },
+  ])("isRootNoCommandRequest: $name", ({ argv, expected }) => {
+    expect(isRootNoCommandRequest(argv)).toBe(expected);
   });
 });

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -73,6 +73,42 @@ export function isRootHelpRequest(argv: string[]): boolean {
   return false;
 }
 
+/**
+ * Returns true when argv contains no primary subcommand token.
+ * Root flags are ignored; scanning stops at `--`.
+ * Used by entry.ts to render root help without loading the full CLI path.
+ */
+export function isRootNoCommandRequest(argv: string[]): boolean {
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (ROOT_BOOLEAN_FLAGS.has(arg)) {
+      continue;
+    }
+    if (arg.startsWith("--profile=") || arg.startsWith("--log-level=")) {
+      continue;
+    }
+    if (ROOT_VALUE_FLAGS.has(arg)) {
+      const next = args[i + 1];
+      if (isValueToken(next)) {
+        i += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 function isValueToken(arg: string | undefined): boolean {
   if (!arg) {
     return false;

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -13,6 +13,17 @@ export function hasHelpOrVersion(argv: string[]): boolean {
   );
 }
 
+/**
+ * Returns true only when the process is a root-level version request:
+ *  - `--version` or `-V` appear before any `--` terminator (so forwarded args like
+ *    `nodes run -- git --version` are excluded), and
+ *  - `-v` is only matched at root scope (no subcommand before it).
+ * Used by the entry.ts fast path to exit before loading heavy CLI modules.
+ */
+export function isRootVersionRequest(argv: string[]): boolean {
+  return hasFlag(argv, "--version") || hasFlag(argv, "-V") || hasRootVersionAlias(argv);
+}
+
 function isValueToken(arg: string | undefined): boolean {
   if (!arg) {
     return false;

--- a/src/cli/channel-options.ts
+++ b/src/cli/channel-options.ts
@@ -23,14 +23,16 @@ export function resolveCliChannelOptions(): string[] {
   const catalog = listChannelPluginCatalogEntries().map((entry) => entry.id);
   const base = dedupe([...CHAT_CHANNEL_ORDER, ...catalog]);
   if (isTruthyEnvValue(process.env.OPENCLAW_EAGER_CHANNEL_OPTIONS)) {
-    // CHANGED SEMANTIC: ensurePluginRegistryLoaded() is intentionally NOT called
-    // here to avoid pulling in plugins/loader.ts → jiti at startup (slow on
-    // low-powered devices). As a result, OPENCLAW_EAGER_CHANNEL_OPTIONS is
-    // effectively a no-op for its original purpose of force-loading all plugins
-    // into the option list before Commander parses args. Plugin IDs are only
-    // included here if the registry was already populated by some other means
-    // (e.g. the preaction hook for a real command). If this env var behaviour is
-    // needed, restore the ensurePluginRegistryLoaded() call explicitly.
+    // Emit a deprecation warning: ensurePluginRegistryLoaded() was removed to avoid
+    // pulling plugins/loader.ts → jiti at startup (slow on low-powered devices).
+    // OPENCLAW_EAGER_CHANNEL_OPTIONS no longer force-loads plugin channels; plugin IDs
+    // are only included if the registry was already populated by another code path.
+    process.emitWarning(
+      "OPENCLAW_EAGER_CHANNEL_OPTIONS no longer force-loads plugin channels at startup. " +
+        "Plugin IDs are only included if the registry was pre-loaded by another means. " +
+        "Remove this env var to silence this warning.",
+      { code: "OPENCLAW_EAGER_CHANNEL_OPTIONS_DEPRECATED" },
+    );
     const pluginIds = listChannelPlugins().map((plugin) => plugin.id);
     return dedupe([...base, ...pluginIds]);
   }

--- a/src/cli/channel-options.ts
+++ b/src/cli/channel-options.ts
@@ -23,9 +23,14 @@ export function resolveCliChannelOptions(): string[] {
   const catalog = listChannelPluginCatalogEntries().map((entry) => entry.id);
   const base = dedupe([...CHAT_CHANNEL_ORDER, ...catalog]);
   if (isTruthyEnvValue(process.env.OPENCLAW_EAGER_CHANNEL_OPTIONS)) {
-    // Reads plugin channel IDs from the registry if already populated.
-    // (ensurePluginRegistryLoaded is intentionally not called here to avoid
-    // loading jiti; plugins are loaded by the preaction hook for real commands.)
+    // CHANGED SEMANTIC: ensurePluginRegistryLoaded() is intentionally NOT called
+    // here to avoid pulling in plugins/loader.ts → jiti at startup (slow on
+    // low-powered devices). As a result, OPENCLAW_EAGER_CHANNEL_OPTIONS is
+    // effectively a no-op for its original purpose of force-loading all plugins
+    // into the option list before Commander parses args. Plugin IDs are only
+    // included here if the registry was already populated by some other means
+    // (e.g. the preaction hook for a real command). If this env var behaviour is
+    // needed, restore the ensurePluginRegistryLoaded() call explicitly.
     const pluginIds = listChannelPlugins().map((plugin) => plugin.id);
     return dedupe([...base, ...pluginIds]);
   }

--- a/src/cli/program/context.test.ts
+++ b/src/cli/program/context.test.ts
@@ -34,4 +34,36 @@ describe("createProgramContext", () => {
       agentChannelOptions: "last",
     });
   });
+
+  // Fast-path correctness: channel options must NOT be resolved until a command
+  // actually needs them. This ensures --help/--version never trigger catalog discovery.
+  it("does not call resolveCliChannelOptions before channelOptions is accessed", () => {
+    resolveCliChannelOptionsMock.mockClear();
+    createProgramContext(); // create context without accessing any channel option getter
+    expect(resolveCliChannelOptionsMock).not.toHaveBeenCalled();
+  });
+
+  it("calls resolveCliChannelOptions lazily when channelOptions getter is first accessed", () => {
+    resolveCliChannelOptionsMock.mockClear().mockReturnValue(["discord"]);
+    const ctx = createProgramContext();
+    const _ = ctx.channelOptions;
+    expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();
+  });
+
+  it("caches channel options so resolveCliChannelOptions is called only once per context", () => {
+    resolveCliChannelOptionsMock.mockClear().mockReturnValue(["telegram"]);
+    const ctx = createProgramContext();
+    const _a = ctx.channelOptions;
+    const _b = ctx.messageChannelOptions;
+    const _c = ctx.agentChannelOptions;
+    // All three getters share the same underlying cache.
+    expect(resolveCliChannelOptionsMock).toHaveBeenCalledOnce();
+  });
+
+  it("programVersion is accessible without triggering channel option resolution", () => {
+    resolveCliChannelOptionsMock.mockClear();
+    const ctx = createProgramContext();
+    expect(ctx.programVersion).toBe("9.9.9-test");
+    expect(resolveCliChannelOptionsMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/program/context.ts
+++ b/src/cli/program/context.ts
@@ -9,11 +9,27 @@ export type ProgramContext = {
 };
 
 export function createProgramContext(): ProgramContext {
-  const channelOptions = resolveCliChannelOptions();
+  // Defer resolveCliChannelOptions() until a command actually needs channel option strings.
+  // This avoids the catalog discovery (discoverOpenClawPlugins) and module loading
+  // during --help, --version, and other fast-path invocations.
+  let _channelOptions: string[] | undefined;
+  function getChannelOptions(): string[] {
+    if (_channelOptions === undefined) {
+      _channelOptions = resolveCliChannelOptions();
+    }
+    return _channelOptions;
+  }
+
   return {
     programVersion: VERSION,
-    channelOptions,
-    messageChannelOptions: channelOptions.join("|"),
-    agentChannelOptions: ["last", ...channelOptions].join("|"),
+    get channelOptions() {
+      return getChannelOptions();
+    },
+    get messageChannelOptions() {
+      return getChannelOptions().join("|");
+    },
+    get agentChannelOptions() {
+      return ["last", ...getChannelOptions()].join("|");
+    },
   };
 }

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -12,10 +12,6 @@ import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
 
 const CLI_NAME = resolveCliName();
 const CLI_NAME_PATTERN = escapeRegExp(CLI_NAME);
-const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
-  ...getCoreCliCommandsWithSubcommands(),
-  ...getSubCliCommandsWithSubcommands(),
-]);
 const ROOT_COMMANDS_HINT =
   "Hint: commands suffixed with * have subcommands. Run <command> --help for details.";
 
@@ -44,6 +40,12 @@ const EXAMPLES = [
 ] as const;
 
 export function configureProgramHelp(program: Command, ctx: ProgramContext) {
+  // Built here (not at module level) to defer the work until help is actually configured.
+  const rootCommandsWithSubcommands = new Set([
+    ...getCoreCliCommandsWithSubcommands(),
+    ...getSubCliCommandsWithSubcommands(),
+  ]);
+
   program
     .name(CLI_NAME)
     .description("")
@@ -73,7 +75,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     optionTerm: (option) => theme.option(option.flags),
     subcommandTerm: (cmd) => {
       const isRootCommand = cmd.parent === program;
-      const hasSubcommands = isRootCommand && ROOT_COMMANDS_WITH_SUBCOMMANDS.has(cmd.name());
+      const hasSubcommands = isRootCommand && rootCommandsWithSubcommands.has(cmd.name());
       return theme.command(hasSubcommands ? `${cmd.name()} *` : cmd.name());
     },
   });

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -106,6 +106,9 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     outputError: (str, write) => write(theme.error(str)),
   });
 
+  // Defense-in-depth: entry.ts already exits early for version flags before
+  // loading this module. This block handles the case where help is configured
+  // outside the normal entry path (e.g. tests, programmatic use).
   if (
     hasFlag(process.argv, "-V") ||
     hasFlag(process.argv, "--version") ||

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,7 +2,7 @@
 import { spawn } from "node:child_process";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { isRootHelpRequest, isRootVersionRequest } from "./cli/argv.js";
+import { isRootHelpRequest, isRootNoCommandRequest, isRootVersionRequest } from "./cli/argv.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -147,7 +147,7 @@ if (
     // isRootHelpRequest stops at -- and requires no subcommand before -h/--help,
     // so `openclaw status --help` still falls through to the full CLI path.
     // Importing program.js directly avoids the route.ts static import in run-main.ts.
-    if (isRootHelpRequest(argv)) {
+    if (isRootHelpRequest(argv) || isRootNoCommandRequest(argv)) {
       import("./cli/program.js")
         .then(({ buildProgram }) => {
           buildProgram().outputHelp();

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { isRootVersionRequest } from "./cli/argv.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { shouldSkipRespawnForArgv } from "./cli/respawn-policy.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -132,9 +133,12 @@ if (
     }
 
     // Fast path: print version and exit before loading heavy CLI modules.
-    // This avoids the full plugin/config startup on low-powered devices (e.g. Pi4b).
+    // isRootVersionRequest handles --version/-V (stops at -- terminator so forwarded
+    // args like `nodes run -- git --version` are excluded) and -v (only at root scope,
+    // not when a subcommand is present). Avoids the full plugin/config startup on
+    // low-powered devices (e.g. Pi4b).
     const argv = process.argv;
-    if (argv.includes("--version") || argv.includes("-V")) {
+    if (isRootVersionRequest(argv)) {
       console.log(VERSION);
       process.exit(0);
     }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -9,6 +9,7 @@ import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
 import { attachChildProcessBridge } from "./process/child-process-bridge.js";
+import { VERSION } from "./version.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
@@ -128,6 +129,14 @@ if (
       applyCliProfileEnv({ profile: parsed.profile });
       // Keep Commander and ad-hoc argv checks consistent.
       process.argv = parsed.argv;
+    }
+
+    // Fast path: print version and exit before loading heavy CLI modules.
+    // This avoids the full plugin/config startup on low-powered devices (e.g. Pi4b).
+    const argv = process.argv;
+    if (argv.includes("--version") || argv.includes("-V")) {
+      console.log(VERSION);
+      process.exit(0);
     }
 
     import("./cli/run-main.js")


### PR DESCRIPTION
## Summary

Builds on #27973 and completes the startup latency fixes from #5871 by closing the remaining slow paths.

Fixes #5871

## What changed

- kept and integrated #27973 fast-path work:
  - root `--version` fast path in `src/entry.ts`
  - root `--help` fast path in `src/entry.ts`
  - lazy channel option resolution in `src/cli/program/context.ts`
  - channel-options eager-loading regression fix
- added root no-command fast path:
  - `openclaw` with no primary command now takes the same root-help fast path in `src/entry.ts`
  - introduced `isRootNoCommandRequest` in `src/cli/argv.ts`
- reduced invalid-command overhead:
  - skip plugin command registration for unknown primary commands by default in `src/cli/run-main.ts`
  - preserve opt-in legacy behavior via `OPENCLAW_FORCE_PLUGIN_COMMAND_REGISTRATION=1`
- reduced eager import cost:
  - lazy-load `route.ts` only for routed commands (`status`, `health`, `sessions`) instead of importing route-first machinery for every invocation

## Validation

- `pnpm test -- --run src/cli/argv.test.ts src/cli/run-main.test.ts src/cli/program/context.test.ts`
- `pnpm check`
- benchmark (built runtime, `OPENCLAW_NO_RESPAWN=1`):
  - `openclaw --version`: ~0.10s
  - `openclaw --help`: ~0.11s
  - `openclaw`: ~0.09s
  - `openclaw definitely-not-a-command`: ~0.14s

## Notes

- This PR supersedes #27973 by including its changes plus additional fixes for no-arg and invalid-command startup paths.
