### PR TITLE
feat(typex): add TypeX channel extension

### DIFF
--- a/docs/channels/typex.md
+++ b/docs/channels/typex.md
@@ -1,0 +1,69 @@
+---
+summary: "TypeX channel setup and configuration"
+read_when:
+  - You want to connect OpenClaw to TypeX
+  - You are configuring TypeX QR login
+title: "TypeX"
+---
+
+# TypeX
+
+TypeX is available as a plugin channel.
+
+## Plugin required
+
+Install the plugin:
+
+```bash
+openclaw plugins install @openclaw/typex
+```
+
+Local checkout:
+
+```bash
+openclaw plugins install ./extensions/typex
+```
+
+## Quick setup
+
+1. Run channel setup:
+
+```bash
+openclaw channels add
+```
+
+2. Select **TypeX**.
+3. Scan the QR code shown in the terminal.
+4. After login succeeds, OpenClaw saves your `token` under `channels.typex.accounts.<userId>`.
+
+## Minimal config
+
+```json5
+{
+  channels: {
+    typex: {
+      enabled: true,
+      defaultAccount: "<user_id>",
+      accounts: {
+        "<user_id>": {
+          token: "sessionid=...",
+        },
+      },
+    },
+  },
+}
+```
+
+## Capabilities
+
+- Direct messages: supported
+- Media send: supported
+- Reactions: not supported
+- Threads: not supported
+- Polls: not supported
+
+## Notes
+
+- Inbound messages are polled from TypeX API.
+- Message offset (`pos`) is stored in `channels.typex.accounts.<accountId>.pos`.
+- Default target hint is `chat_id`.

--- a/docs/channels/typex.md
+++ b/docs/channels/typex.md
@@ -57,7 +57,7 @@ openclaw channels add
 ## Capabilities
 
 - Direct messages: supported
-- Media send: supported
+- Media send: not supported yet
 - Reactions: not supported
 - Threads: not supported
 - Polls: not supported
@@ -65,5 +65,5 @@ openclaw channels add
 ## Notes
 
 - Inbound messages are polled from TypeX API.
-- Message offset (`pos`) is stored in `channels.typex.accounts.<accountId>.pos`.
+- Message offset (`pos`) is stored in state files under `~/.openclaw/typex/`.
 - Default target hint is `chat_id`.

--- a/docs/channels/typex.md
+++ b/docs/channels/typex.md
@@ -65,5 +65,5 @@ openclaw channels add
 ## Notes
 
 - Inbound messages are polled from TypeX API.
-- Message offset (`pos`) is stored in state files under `~/.openclaw/typex/`.
+- Message offset (`pos`) is stored in state files under `~/.openclaw/state/typex/`.
 - Default target hint is `chat_id`.

--- a/docs/zh-CN/channels/typex.md
+++ b/docs/zh-CN/channels/typex.md
@@ -1,0 +1,67 @@
+---
+summary: "TypeX 渠道接入与配置"
+read_when:
+  - 你需要把 OpenClaw 连接到 TypeX
+  - 你要配置 TypeX 二维码登录
+title: "TypeX"
+---
+
+# TypeX
+
+TypeX 以插件渠道提供。
+
+## 需要先安装插件
+
+```bash
+openclaw plugins install @openclaw/typex
+```
+
+本地源码方式：
+
+```bash
+openclaw plugins install ./extensions/typex
+```
+
+## 快速配置
+
+1. 运行：
+
+```bash
+openclaw channels add
+```
+
+2. 选择 **TypeX**。
+3. 按提示扫码登录。
+4. 登录成功后会把 `token` 写入 `channels.typex.accounts.<userId>`。
+
+## 最小配置示例
+
+```json5
+{
+  channels: {
+    typex: {
+      enabled: true,
+      defaultAccount: "<user_id>",
+      accounts: {
+        "<user_id>": {
+          token: "sessionid=...",
+        },
+      },
+    },
+  },
+}
+```
+
+## 能力
+
+- 私聊：支持
+- 媒体发送：支持
+- Reactions：不支持
+- Threads：不支持
+- Polls：不支持
+
+## 说明
+
+- 入站消息通过 TypeX API 轮询获取。
+- 偏移量 `pos` 保存在 `channels.typex.accounts.<accountId>.pos`。
+- 默认目标提示为 `chat_id`。

--- a/docs/zh-CN/channels/typex.md
+++ b/docs/zh-CN/channels/typex.md
@@ -55,7 +55,7 @@ openclaw channels add
 ## 能力
 
 - 私聊：支持
-- 媒体发送：支持
+- 媒体发送：暂不支持
 - Reactions：不支持
 - Threads：不支持
 - Polls：不支持
@@ -63,5 +63,5 @@ openclaw channels add
 ## 说明
 
 - 入站消息通过 TypeX API 轮询获取。
-- 偏移量 `pos` 保存在 `channels.typex.accounts.<accountId>.pos`。
+- 偏移量 `pos` 保存在 state 文件（`~/.openclaw/typex/`）中。
 - 默认目标提示为 `chat_id`。

--- a/docs/zh-CN/channels/typex.md
+++ b/docs/zh-CN/channels/typex.md
@@ -63,5 +63,5 @@ openclaw channels add
 ## 说明
 
 - 入站消息通过 TypeX API 轮询获取。
-- 偏移量 `pos` 保存在 state 文件（`~/.openclaw/typex/`）中。
+- 偏移量 `pos` 保存在 state 文件（`~/.openclaw/state/typex/`）中。
 - 默认目标提示为 `chat_id`。

--- a/extensions/typex/index.ts
+++ b/extensions/typex/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { typexPlugin } from "./src/channel.js";
+import { setTypeXRuntime } from "./src/client/runtime.js";
+
+const plugin = {
+  id: "typex",
+  name: "TypeX",
+  description: "TypeX channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setTypeXRuntime(api.runtime);
+    api.registerChannel({ plugin: typexPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/typex/openclaw.plugin.json
+++ b/extensions/typex/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "typex",
+  "channels": ["typex"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/typex/package.json
+++ b/extensions/typex/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openclaw/typex",
+  "version": "2026.2.27",
+  "description": "OpenClaw TypeX channel plugin",
+  "type": "module",
+  "dependencies": {
+    "qrcode-terminal": "^0.12.0",
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "typex",
+      "label": "TypeX",
+      "selectionLabel": "TypeX (QR Code Login)",
+      "docsPath": "/channels/typex",
+      "docsLabel": "typex",
+      "blurb": "TypeX bot via QR code login.",
+      "order": 100,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/typex",
+      "localPath": "extensions/typex",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/typex/src/channel.ts
+++ b/extensions/typex/src/channel.ts
@@ -22,7 +22,7 @@ export const typexPlugin = {
   onboarding: typexOnboardingAdapter,
   capabilities: {
     chatTypes: ["direct"],
-    media: true,
+    media: false,
     reactions: false,
     threads: false,
     polls: false,
@@ -63,6 +63,10 @@ export const typexPlugin = {
       };
     },
     defaultAccountId: (cfg) => {
+      const configuredDefault = cfg.channels?.["typex"]?.defaultAccount?.trim();
+      if (configuredDefault) {
+        return configuredDefault;
+      }
       const accs = cfg.channels?.["typex"]?.accounts || {};
       const first = Object.keys(accs)[0];
       return first || DEFAULT_ACCOUNT_ID;

--- a/extensions/typex/src/channel.ts
+++ b/extensions/typex/src/channel.ts
@@ -78,10 +78,11 @@ export const typexPlugin = {
       const account =
         cfg.channels?.["typex"]?.accounts?.[id] ||
         (id === DEFAULT_ACCOUNT_ID ? globalCheck : undefined);
+      const channelEnabled = cfg.channels?.["typex"]?.enabled !== false;
       return {
         accountId: id,
         name: account?.name || "TypeX",
-        enabled: account?.enabled !== false,
+        enabled: channelEnabled && account?.enabled !== false,
         configured: Boolean(account?.token),
         tokenSource: "config",
         config: account || {},

--- a/extensions/typex/src/channel.ts
+++ b/extensions/typex/src/channel.ts
@@ -1,0 +1,175 @@
+import type { ChannelPlugin } from "openclaw/plugin-sdk";
+import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { monitorTypeXProvider } from "./client/monitor.js";
+import { typexOutbound } from "./client/outbound.js";
+import { TypeXConfigSchema } from "./config-schema.js";
+import { typexOnboardingAdapter } from "./onboarding.js";
+
+const meta = {
+  id: "typex",
+  label: "TypeX",
+  selectionLabel: "TypeX (QR Code Login)",
+  detailLabel: "TypeX Bot",
+  docsPath: "/channels/typex",
+  docsLabel: "typex",
+  blurb: "TypeX bot via QR Code login.",
+  order: 100,
+};
+
+export const typexPlugin = {
+  id: "typex",
+  meta,
+  onboarding: typexOnboardingAdapter,
+  capabilities: {
+    chatTypes: ["direct"],
+    media: true,
+    reactions: false,
+    threads: false,
+    polls: false,
+    nativeCommands: false,
+    blockStreaming: false,
+  },
+  reload: { configPrefixes: ["channels.typex"] },
+  outbound: typexOutbound as any,
+
+  messaging: {
+    normalizeTarget: (t) => t,
+    targetResolver: {
+      looksLikeId: () => true,
+      hint: "chat_id",
+    },
+  },
+
+  configSchema: buildChannelConfigSchema(TypeXConfigSchema as any),
+
+  config: {
+    listAccountIds: (cfg) => {
+      const accs = cfg.channels?.["typex"]?.accounts || {};
+      return Object.keys(accs);
+    },
+    resolveAccount: (cfg, accountId) => {
+      const id = accountId || DEFAULT_ACCOUNT_ID;
+      const globalCheck = cfg.channels?.["typex"];
+      const account =
+        cfg.channels?.["typex"]?.accounts?.[id] ||
+        (id === DEFAULT_ACCOUNT_ID ? globalCheck : undefined);
+      return {
+        accountId: id,
+        name: account?.name || "TypeX",
+        enabled: account?.enabled !== false,
+        configured: Boolean(account?.token),
+        tokenSource: "config",
+        config: account || {},
+      };
+    },
+    defaultAccountId: (cfg) => {
+      const accs = cfg.channels?.["typex"]?.accounts || {};
+      const first = Object.keys(accs)[0];
+      return first || DEFAULT_ACCOUNT_ID;
+    },
+    setAccountEnabled: ({ cfg }) => cfg,
+    deleteAccount: ({ cfg }) => cfg,
+    isConfigured: (acc) => acc.configured,
+    describeAccount: (acc) => ({
+      accountId: acc.accountId!,
+      name: acc.name,
+      enabled: acc.enabled,
+      configured: acc.configured,
+      tokenSource: acc.tokenSource,
+    }),
+    resolveAllowFrom: () => [],
+    formatAllowFrom: () => [],
+  },
+
+  gateway: {
+    startAccount: async (ctx) => {
+      const { account, log, setStatus, abortSignal, runtime, cfg } = ctx;
+      const typexCfg = (cfg.channels?.["typex"] ?? {}) as Record<string, any>;
+
+      log?.info(`[${account.accountId}] TypeX Provider starting...`);
+
+      setStatus({
+        accountId: account.accountId,
+        running: true,
+        lastStartAt: Date.now(),
+      });
+
+      try {
+        await monitorTypeXProvider({
+          account,
+          runtime,
+          abortSignal,
+          log,
+          typexCfg,
+          cfg,
+        });
+      } catch (err) {
+        log?.error(`TypeX Provider crashed: ${err}`);
+        setStatus({
+          accountId: account.accountId,
+          running: false,
+          lastError: err instanceof Error ? err.message : String(err),
+          lastStopAt: Date.now(),
+        });
+        throw err;
+      }
+    },
+  },
+  security: {
+    // Simplified security policy
+    resolveDmPolicy: () => ({
+      policy: "open",
+      allowFrom: [],
+      policyPath: "",
+      allowFromPath: "",
+      approveHint: "",
+      normalizeEntry: (s) => s,
+    }),
+  },
+
+  groups: {
+    resolveRequireMention: () => false,
+  },
+
+  directory: {
+    self: async () => null,
+    listPeers: async () => [],
+    listGroups: async () => [],
+  },
+
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: () => [],
+    buildChannelSummary: async ({ snapshot }) => ({
+      configured: snapshot.configured,
+      tokenSource: snapshot.tokenSource,
+      running: snapshot.running,
+      lastStartAt: snapshot.lastStartAt,
+      lastStopAt: snapshot.lastStopAt,
+      lastError: snapshot.lastError,
+      probe: snapshot.probe,
+      lastProbeAt: snapshot.lastProbeAt,
+    }),
+    probeAccount: async () => ({ ok: true, timestamp: Date.now() }),
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      tokenSource: account.tokenSource,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: null,
+      lastOutboundAt: null,
+    }),
+    logSelfId: () => {},
+  },
+} satisfies ChannelPlugin<any>;

--- a/extensions/typex/src/channel.ts
+++ b/extensions/typex/src/channel.ts
@@ -185,8 +185,20 @@ export const typexPlugin = {
       configured: acc.configured,
       tokenSource: acc.tokenSource,
     }),
-    resolveAllowFrom: () => [],
-    formatAllowFrom: () => [],
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const resolvedAccountId =
+        accountId ?? resolveConfiguredDefaultAccountId(cfg) ?? DEFAULT_ACCOUNT_ID;
+      const useAccountPath = Boolean(cfg.channels?.typex?.accounts?.[resolvedAccountId]);
+      const source = useAccountPath
+        ? cfg.channels?.typex?.accounts?.[resolvedAccountId]?.allowFrom
+        : cfg.channels?.typex?.allowFrom;
+      return Array.isArray(source) ? source.map((entry) => String(entry)) : [];
+    },
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim())
+        .filter(Boolean)
+        .map((entry) => entry.toLowerCase()),
   },
 
   gateway: {

--- a/extensions/typex/src/channel.ts
+++ b/extensions/typex/src/channel.ts
@@ -188,10 +188,9 @@ export const typexPlugin = {
     resolveAllowFrom: ({ cfg, accountId }) => {
       const resolvedAccountId =
         accountId ?? resolveConfiguredDefaultAccountId(cfg) ?? DEFAULT_ACCOUNT_ID;
-      const useAccountPath = Boolean(cfg.channels?.typex?.accounts?.[resolvedAccountId]);
-      const source = useAccountPath
-        ? cfg.channels?.typex?.accounts?.[resolvedAccountId]?.allowFrom
-        : cfg.channels?.typex?.allowFrom;
+      const accountAllowFrom = cfg.channels?.typex?.accounts?.[resolvedAccountId]?.allowFrom;
+      const source =
+        accountAllowFrom !== undefined ? accountAllowFrom : cfg.channels?.typex?.allowFrom;
       return Array.isArray(source) ? source.map((entry) => String(entry)) : [];
     },
     formatAllowFrom: ({ allowFrom }) =>

--- a/extensions/typex/src/client/accounts.ts
+++ b/extensions/typex/src/client/accounts.ts
@@ -89,6 +89,10 @@ export function listTypeXAccountIds(cfg: OpenClawConfig): string[] {
 }
 
 export function resolveDefaultTypeXAccountId(cfg: OpenClawConfig): string {
+  const configuredDefault = cfg.channels?.["typex"]?.defaultAccount?.trim();
+  if (configuredDefault) {
+    return normalizeAccountId(configuredDefault);
+  }
   const ids = listTypeXAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;

--- a/extensions/typex/src/client/accounts.ts
+++ b/extensions/typex/src/client/accounts.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import type { TypeXAccountConfig } from "../types.js";
+
+export type TypeXTokenSource = "config" | "file" | "env" | "none";
+
+export type ResolvedTypeXAccount = {
+  accountId: string;
+  config: TypeXAccountConfig;
+  tokenSource: TypeXTokenSource;
+  name?: string;
+  enabled: boolean;
+};
+
+function readFileIfExists(filePath?: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  try {
+    return fs.readFileSync(filePath, "utf-8").trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): TypeXAccountConfig | undefined {
+  const accounts = cfg.channels?.["typex"]?.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+  const direct = accounts[accountId] as TypeXAccountConfig | undefined;
+  if (direct) {
+    return direct;
+  }
+  const normalized = normalizeAccountId(accountId);
+  const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === normalized);
+  return matchKey ? (accounts[matchKey] as TypeXAccountConfig | undefined) : undefined;
+}
+
+function mergeTypeXAccountConfig(cfg: OpenClawConfig, accountId: string): TypeXAccountConfig {
+  const { accounts: _ignored, ...base } = (cfg.channels?.["typex"] ?? {}) as TypeXAccountConfig & {
+    accounts?: unknown;
+  };
+  const account = resolveAccountConfig(cfg, accountId) ?? {};
+  return { ...base, ...account };
+}
+
+function resolveAppSecret(config?: { appSecret?: string; appSecretFile?: string }): {
+  value?: string;
+  source?: Exclude<TypeXTokenSource, "env" | "none">;
+} {
+  const direct = config?.appSecret?.trim();
+  if (direct) {
+    return { value: direct, source: "config" };
+  }
+  const fromFile = readFileIfExists(config?.appSecretFile);
+  if (fromFile) {
+    return { value: fromFile, source: "file" };
+  }
+  return {};
+}
+
+export function listTypeXAccountIds(cfg: OpenClawConfig): string[] {
+  const typexCfg = cfg.channels?.["typex"];
+  const accounts = typexCfg?.accounts;
+  const ids = new Set<string>();
+
+  const baseConfigured = Boolean(
+    typexCfg?.appId?.trim() && (typexCfg?.appSecret?.trim() || Boolean(typexCfg?.appSecretFile)),
+  );
+  const envConfigured = Boolean(
+    process.env.TYPEX_APP_ID?.trim() && process.env.TYPEX_APP_SECRET?.trim(),
+  );
+  if (baseConfigured || envConfigured) {
+    ids.add(DEFAULT_ACCOUNT_ID);
+  }
+
+  if (accounts) {
+    for (const id of Object.keys(accounts)) {
+      ids.add(normalizeAccountId(id));
+    }
+  }
+
+  return Array.from(ids);
+}
+
+export function resolveDefaultTypeXAccountId(cfg: OpenClawConfig): string {
+  const ids = listTypeXAccountIds(cfg);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+export function resolveTypeXAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedTypeXAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const baseEnabled = params.cfg.channels?.["typex"]?.enabled !== false;
+  const merged = mergeTypeXAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+
+  const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
+  const envAppId = allowEnv ? process.env.TYPEX_APP_ID?.trim() : undefined;
+  const envAppSecret = allowEnv ? process.env.TYPEX_APP_SECRET?.trim() : undefined;
+
+  const appId = merged.appId?.trim() || envAppId || "";
+  const secretResolution = resolveAppSecret(merged);
+  const appSecret = secretResolution.value ?? envAppSecret ?? "";
+
+  let tokenSource: TypeXTokenSource = "none";
+  if (secretResolution.value) {
+    tokenSource = secretResolution.source ?? "config";
+  } else if (envAppSecret) {
+    tokenSource = "env";
+  }
+  if (!appId || !appSecret) {
+    tokenSource = "none";
+  }
+
+  const config: TypeXAccountConfig = {
+    ...merged,
+    appId,
+    appSecret,
+  };
+
+  const name = config.name?.trim() || config.botName?.trim() || undefined;
+
+  return {
+    accountId,
+    config,
+    tokenSource,
+    name,
+    enabled,
+  };
+}

--- a/extensions/typex/src/client/client.ts
+++ b/extensions/typex/src/client/client.ts
@@ -2,7 +2,6 @@ import { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
 import { TypeXMessageEnum, type TypeXClientOptions } from "./types.js";
 
 const TYPEX_DOMAIN = "https://api-coco.typex.im";
-// const TYPEX_DOMAIN = "https://api-tx.bossjob.net.cn";
 
 let prompter: WizardPrompter | undefined;
 
@@ -88,7 +87,7 @@ export class TypeXClient {
     }
   }
 
-  async sendMessage(content: string | object, msgType: TypeXMessageEnum = 0) {
+  async sendMessage(to: string, content: string | object, msgType: TypeXMessageEnum = 0) {
     const token = this.accessToken;
     if (!token) {
       throw new Error("TypeXClient: Not authenticated.");
@@ -109,11 +108,11 @@ export class TypeXClient {
 
     if (prompter)
       prompter.note(
-        `TypeXClient sending message: content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
+        `TypeXClient sending message: to=${to} content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
       );
     else
       console.log(
-        `TypeXClient sending message: content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
+        `TypeXClient sending message: to=${to} content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
       );
 
     try {

--- a/extensions/typex/src/client/client.ts
+++ b/extensions/typex/src/client/client.ts
@@ -1,0 +1,215 @@
+import { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
+import { TypeXMessageEnum, type TypeXClientOptions } from "./types.js";
+
+const TYPEX_DOMAIN = "https://api-coco.typex.im";
+// const TYPEX_DOMAIN = "https://api-tx.bossjob.net.cn";
+
+let prompter: WizardPrompter | undefined;
+
+export class TypeXClient {
+  private options: TypeXClientOptions;
+  private accessToken?: string;
+  private userId?: string;
+
+  constructor(options: TypeXClientOptions) {
+    this.options = options;
+    if (options.token) {
+      this.accessToken = options.token;
+    }
+  }
+
+  async getAccessToken() {
+    if (this.accessToken) {
+      return this.accessToken;
+    }
+    return "";
+  }
+
+  async getCurUserId() {
+    if (this.userId) {
+      return this.userId;
+    }
+    return "";
+  }
+
+  async fetchQrcodeUrl() {
+    try {
+      const qrResponse = await fetch(`${TYPEX_DOMAIN}/user/qrcode?login_type=open`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!qrResponse.ok) {
+        throw new Error(`Failed to get QR code: ${qrResponse.statusText}`);
+      }
+      const qrResult = await qrResponse.json();
+      if (qrResult.code !== 0 || !qrResult.data) {
+        throw new Error(`Failed to get QR code: ${qrResult.msg}`);
+      }
+
+      return qrResult.data;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async checkLoginStatus(qrcodeId: string) {
+    try {
+      const checkRes = await fetch(`${TYPEX_DOMAIN}/open/qrcode/check_auth`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          qr_code_id: qrcodeId,
+        }),
+      });
+      const setCookieHeader = checkRes.headers.get("set-cookie");
+
+      if (setCookieHeader) {
+        const match = setCookieHeader.match(/(sessionid=[^;]+)/);
+
+        if (match && match[1]) {
+          this.accessToken = match[1];
+        }
+      }
+      const checkData = await checkRes.json();
+      if (checkData.code === 0) {
+        const { user_id } = checkData.data;
+        this.userId = user_id;
+        return true;
+      } else if (checkData.code === 10001) {
+        return false;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async sendMessage(content: string | object, msgType: TypeXMessageEnum = 0) {
+    const token = this.accessToken;
+    if (!token) {
+      throw new Error("TypeXClient: Not authenticated.");
+    }
+
+    let finalContent = content;
+    if (typeof content === "object") {
+      try {
+        finalContent = JSON.stringify(content);
+      } catch (e) {
+        if (e instanceof Error) {
+          if (prompter) prompter.note("Failed to stringify message content");
+          else console.log("Failed to stringify message content");
+        }
+        finalContent = String(content as unknown);
+      }
+    }
+
+    if (prompter)
+      prompter.note(
+        `TypeXClient sending message: content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
+      );
+    else
+      console.log(
+        `TypeXClient sending message: content=${typeof finalContent === "string" ? finalContent : JSON.stringify(finalContent)}`,
+      );
+
+    try {
+      const url = `${TYPEX_DOMAIN}/open/claw/send_message`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: token,
+        },
+        body: JSON.stringify({
+          content: {
+            text: finalContent,
+          },
+          msg_type: msgType,
+        }),
+      });
+      const resJson = await response.json();
+
+      if (resJson.code !== 0) {
+        throw new Error(`Send message failed: [${resJson.code}] ${resJson.message}`);
+      }
+
+      if (prompter) prompter.note("Message sent successfully", resJson.data);
+      else console.log("Message sent successfully", JSON.stringify(resJson.data));
+
+      return (
+        resJson.data || {
+          message_id: `msg_${Date.now()}`,
+        }
+      );
+    } catch (error) {
+      if (prompter) prompter.note(`Error sending message to TypeX API: ${error}`);
+      else console.log(`Error sending message to TypeX API: ${error}`);
+      throw error;
+    }
+  }
+
+  async fetchMessages(pos: number) {
+    if (!this.accessToken) {
+      if (prompter) prompter.note("TypeXClient: No token, skipping fetch.");
+      else console.log("TypeXClient: No token, skipping fetch.");
+      return [];
+    }
+
+    try {
+      const url = `${TYPEX_DOMAIN}/open/claw/message`;
+      if (prompter) prompter.note(`Fetching messages from pos: ${pos}`);
+      // else console.log(`Fetching messages from pos: ${pos}`);
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          Cookie: this.accessToken,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ pos: pos }),
+      });
+
+      const resJson = await response.json();
+
+      if (resJson.code !== 0) {
+        if (prompter) prompter.note(`Fetch failed with code ${resJson.code}: ${resJson.message}`);
+        else console.log(`Fetch failed with code ${resJson.code}: ${resJson.message}`);
+        return [];
+      }
+      if (Array.isArray(resJson.data)) {
+        return resJson.data;
+      }
+
+      return [];
+    } catch (e) {
+      if (prompter) prompter.note(`Fetch messages network error: ${e}`);
+      else console.log(`Fetch messages network error: ${e}`);
+      return [];
+    }
+  }
+}
+
+export function getTypeXClient(accountId?: string, manualOptions?: TypeXClientOptions) {
+  const typexCfg = (manualOptions?.typexCfg ?? {}) as Record<string, any>;
+  const clawPrompter = manualOptions?.prompter;
+  if (clawPrompter) {
+    prompter = clawPrompter;
+  }
+
+  let token = manualOptions?.token;
+
+  if (accountId && typexCfg.accounts?.[accountId]) {
+    token = typexCfg.accounts[accountId].token;
+  }
+
+  if (!manualOptions?.skipConfigCheck) {
+    throw new Error("TypeX not configured yet.");
+  }
+
+  return new TypeXClient({
+    token: token,
+  });
+}

--- a/extensions/typex/src/client/client.ts
+++ b/extensions/typex/src/client/client.ts
@@ -147,6 +147,7 @@ export class TypeXClient {
             Cookie: token,
           },
           body: JSON.stringify({
+            ...(to ? { chat_id: to } : {}),
             content: {
               text: finalContent,
             },

--- a/extensions/typex/src/client/config.ts
+++ b/extensions/typex/src/client/config.ts
@@ -1,0 +1,54 @@
+import type { OpenClawConfig, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk";
+import type { TypeXGroupConfig } from "../types.js";
+
+const firstDefined = <T>(...values: Array<T | undefined>) => {
+  for (const value of values) {
+    if (typeof value !== "undefined") {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export type ResolvedTypeXConfig = {
+  enabled: boolean;
+  dmPolicy: DmPolicy;
+  groupPolicy: GroupPolicy;
+  allowFrom: string[];
+  groupAllowFrom: string[];
+  historyLimit: number;
+  dmHistoryLimit: number;
+  textChunkLimit: number;
+  chunkMode: "length" | "newline";
+  blockStreaming: boolean;
+  streaming: boolean;
+  mediaMaxMb: number;
+  groups: Record<string, TypeXGroupConfig>;
+};
+
+export function resolveTypeXConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+}): ResolvedTypeXConfig {
+  const { cfg, accountId } = params;
+  const typexCfg = cfg.channels?.typex;
+  const accountCfg = accountId ? typexCfg?.accounts?.[accountId] : undefined;
+  const defaults = cfg.channels?.defaults;
+
+  return {
+    enabled: firstDefined(accountCfg?.enabled, typexCfg?.enabled, true) ?? true,
+    dmPolicy: firstDefined(accountCfg?.dmPolicy, typexCfg?.dmPolicy) ?? "pairing",
+    groupPolicy:
+      firstDefined(accountCfg?.groupPolicy, typexCfg?.groupPolicy, defaults?.groupPolicy) ?? "open",
+    allowFrom: (accountCfg?.allowFrom ?? typexCfg?.allowFrom ?? []).map(String),
+    groupAllowFrom: (accountCfg?.groupAllowFrom ?? typexCfg?.groupAllowFrom ?? []).map(String),
+    historyLimit: firstDefined(accountCfg?.historyLimit, typexCfg?.historyLimit) ?? 10,
+    dmHistoryLimit: firstDefined(accountCfg?.dmHistoryLimit, typexCfg?.dmHistoryLimit) ?? 20,
+    textChunkLimit: firstDefined(accountCfg?.textChunkLimit, typexCfg?.textChunkLimit) ?? 2000,
+    chunkMode: firstDefined(accountCfg?.chunkMode, typexCfg?.chunkMode) ?? "length",
+    blockStreaming: firstDefined(accountCfg?.blockStreaming, typexCfg?.blockStreaming) ?? true,
+    streaming: firstDefined(accountCfg?.streaming, typexCfg?.streaming) ?? true,
+    mediaMaxMb: firstDefined(accountCfg?.mediaMaxMb, typexCfg?.mediaMaxMb) ?? 30,
+    groups: { ...typexCfg?.groups, ...accountCfg?.groups },
+  };
+}

--- a/extensions/typex/src/client/message.ts
+++ b/extensions/typex/src/client/message.ts
@@ -113,7 +113,7 @@ export async function processTypeXMessage(
         };
         // Handle text response
         if (responsePayload.text) {
-          await sendMessageTypeX(client, responsePayload.text, {
+          await sendMessageTypeX(client, chatId, responsePayload.text, {
             msgType: TypeXMessageEnum.richText,
           });
         }
@@ -126,7 +126,12 @@ export async function processTypeXMessage(
             : [];
 
         for (const mediaUrl of mediaUrls) {
-          await sendMessageTypeX(client, {}, { mediaUrl, msgType: TypeXMessageEnum.richText });
+          await sendMessageTypeX(
+            client,
+            chatId,
+            {},
+            { mediaUrl, msgType: TypeXMessageEnum.richText },
+          );
         }
       },
       onError: (err: Error) => {

--- a/extensions/typex/src/client/message.ts
+++ b/extensions/typex/src/client/message.ts
@@ -1,0 +1,142 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { TypeXClient } from "./client.js";
+import { getTypeXRuntime } from "./runtime.js";
+import { sendMessageTypeX } from "./send.js";
+import { TypeXMessageEnum, type TypeXMessageEntry } from "./types.js";
+
+export type ProcessTypeXMessageOptions = {
+  /** Full OpenClaw gateway config (needed for bindings/routing). */
+  cfg?: OpenClawConfig;
+  accountId?: string;
+  botName?: string;
+  typexCfg?: Record<string, any>;
+  logger?:
+    | { warn: (msg: string) => void; info: (msg: string) => void; error: (msg: string) => void }
+    | undefined;
+};
+
+export async function processTypeXMessage(
+  client: TypeXClient,
+  payload: TypeXMessageEntry,
+  appId: string,
+  options: ProcessTypeXMessageOptions = {},
+) {
+  // Use the full OpenClaw config for routing/bindings + dispatch.
+  // (typexCfg is only the channel-specific config.)
+  const cfg = options.cfg;
+  const accountId = options.accountId ?? appId;
+  const logger = options.logger;
+  const runtime = getTypeXRuntime();
+  const channel = (runtime as Record<string, unknown>).channel as
+    | {
+        reply?: {
+          dispatchReplyWithBufferedBlockDispatcher?: (opts: unknown) => Promise<unknown>;
+        };
+        routing?: {
+          resolveAgentRoute?: (input: unknown) => any;
+        };
+      }
+    | undefined;
+  if (!channel?.reply?.dispatchReplyWithBufferedBlockDispatcher) {
+    logger?.error(`[typex:${accountId}] dispatchReplyWithBufferedBlockDispatcher not available`);
+    return;
+  }
+
+  if (!payload || !payload.chat_id) {
+    logger?.warn("Received invalid event payload");
+    return;
+  }
+
+  const chatId = payload.chat_id;
+  const senderId = payload.sender_id;
+  // Use content as text for now. If content is JSON string, parse it.
+  let text = payload.content.text;
+  // Attempt simple parsing if it looks like JSON? For now assume plain text or handle in future.
+
+  // Basic logging
+  logger?.info(`Processing TypeX message from ${senderId} in ${chatId}`);
+
+  // Build Context for Agent
+  const ctx = {
+    Body: text,
+    RawBody: text,
+    From: senderId,
+    To: chatId,
+    SenderId: senderId,
+    SenderName: payload.sender_name || "User",
+    ChatType: "dm", // Simplified, TypeX mostly DM for now?
+    Provider: "typex",
+    Surface: "typex",
+    Timestamp: payload.create_time || Date.now(),
+    MessageSid: payload.message_id,
+    AccountId: accountId,
+    OriginatingChannel: "typex",
+    OriginatingTo: chatId,
+  };
+
+  if (!cfg) {
+    logger?.error(`[typex:${accountId}] missing full OpenClaw cfg; cannot route/bind.`);
+    return;
+  }
+
+  // Resolve agent route (bindings) and stamp SessionKey so the message runs in the right agent lane.
+  try {
+    const routing = channel.routing;
+    const route = routing?.resolveAgentRoute?.({
+      cfg,
+      channel: "typex",
+      accountId,
+      peer: { kind: "direct", id: String(chatId) },
+    });
+    if (route?.sessionKey) {
+      (ctx as any).SessionKey = route.sessionKey;
+      logger?.info(
+        `[typex:${accountId}] resolved route: agentId=${route.agentId} matchedBy=${route.matchedBy} sessionKey=${route.sessionKey}`,
+      );
+    }
+  } catch (e: any) {
+    logger?.error(`[typex:${accountId}] resolveAgentRoute failed: ${e?.message || String(e)}`);
+  }
+
+  // Dispatch to Agent
+  await channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx,
+    cfg,
+    dispatcherOptions: {
+      channel: "typex",
+      accountId,
+      deliver: async (payload: unknown) => {
+        const responsePayload = payload as {
+          text?: string;
+          mediaUrls?: string[];
+          mediaUrl?: string;
+        };
+        // Handle text response
+        if (responsePayload.text) {
+          await sendMessageTypeX(client, responsePayload.text, {
+            msgType: TypeXMessageEnum.richText,
+          });
+        }
+
+        // Handle media if present in response
+        const mediaUrls = responsePayload.mediaUrls?.length
+          ? responsePayload.mediaUrls
+          : responsePayload.mediaUrl
+            ? [responsePayload.mediaUrl]
+            : [];
+
+        for (const mediaUrl of mediaUrls) {
+          await sendMessageTypeX(client, {}, { mediaUrl, msgType: TypeXMessageEnum.richText });
+        }
+      },
+      onError: (err: Error) => {
+        logger?.error(`Reply dispatch error: ${err.message}`);
+      },
+    },
+    replyOptions: {
+      disableBlockStreaming: true,
+      // Do not use embedded agent; let gateway bindings decide the agent.
+      embedded: false,
+    },
+  });
+}

--- a/extensions/typex/src/client/monitor.ts
+++ b/extensions/typex/src/client/monitor.ts
@@ -1,0 +1,245 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import { writeJsonFileAtomically } from "openclaw/plugin-sdk";
+import { getTypeXClient } from "./client.js";
+import { processTypeXMessage } from "./message.js";
+import { getTypeXRuntime } from "./runtime.js";
+
+export type MonitorTypeXOpts = {
+  account: unknown; // ResolvedTypeXAccount + extras from gateway
+  runtime: RuntimeEnv;
+  abortSignal: AbortSignal;
+  log?: unknown;
+  typexCfg: Record<string, any>;
+  /** Full OpenClaw gateway config (needed for bindings/routing). */
+  cfg: OpenClawConfig;
+};
+
+type TypeXPosState = {
+  version: 1;
+  lastPos: number;
+  accountId: string;
+};
+
+const POS_STORE_VERSION = 1;
+
+const OPENCLAW_CONFIG_PATH =
+  process.env.OPENCLAW_CONFIG_PATH || path.join(os.homedir(), ".openclaw", "openclaw.json");
+
+function normalizeAccountIdForFile(accountId: string): string {
+  return (accountId || "default").replace(/[^a-z0-9._-]+/gi, "_");
+}
+
+function resolveTypeXPosStatePath(accountId: string): string {
+  const stateDir = getTypeXRuntime().state.resolveStateDir(process.env, os.homedir);
+  const normalized = normalizeAccountIdForFile(accountId);
+  return path.join(stateDir, "typex", `update-pos-${normalized}.json`);
+}
+
+function parseTypeXPosState(raw: string): TypeXPosState | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<TypeXPosState>;
+    if (parsed.version !== POS_STORE_VERSION) {
+      return null;
+    }
+    if (
+      typeof parsed.lastPos !== "number" ||
+      !Number.isFinite(parsed.lastPos) ||
+      parsed.lastPos < 0
+    ) {
+      return null;
+    }
+    if (typeof parsed.accountId !== "string" || !parsed.accountId.trim()) {
+      return null;
+    }
+    return {
+      version: POS_STORE_VERSION,
+      lastPos: parsed.lastPos,
+      accountId: parsed.accountId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readPosFromState(accountId: string): Promise<number | null> {
+  const filePath = resolveTypeXPosStatePath(accountId);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = parseTypeXPosState(raw);
+    if (!parsed) {
+      return null;
+    }
+    // Guard against accidental account file reuse.
+    if (parsed.accountId !== accountId) {
+      return null;
+    }
+    return parsed.lastPos;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    return null;
+  }
+}
+
+async function writePosToState(accountId: string, pos: number): Promise<void> {
+  const filePath = resolveTypeXPosStatePath(accountId);
+  const payload: TypeXPosState = {
+    version: POS_STORE_VERSION,
+    lastPos: pos,
+    accountId,
+  };
+  await writeJsonFileAtomically(filePath, payload);
+}
+
+async function readPosFromConfig(params: {
+  accountId: string;
+  channelKey: "typex" | "openclaw-extension-typex";
+}): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(OPENCLAW_CONFIG_PATH, "utf-8");
+    const cfg = JSON.parse(raw);
+    const pos = cfg?.channels?.[params.channelKey]?.accounts?.[params.accountId]?.pos;
+    if (typeof pos === "number" && Number.isFinite(pos) && pos >= 0) {
+      return pos;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+async function readLegacyPosFile(accountId: string): Promise<number | null> {
+  // Legacy state file locations (pre-state-dir storage):
+  //   v1 (oldest): /tmp/typex/.typex_pos_<safeId>.json
+  //   v2:          /tmp/typex/<accountId>/.typex_pos.json
+  const safeId = normalizeAccountIdForFile(accountId);
+  const legacyCandidates = [
+    path.join("/tmp", "typex", `.typex_pos_${safeId}.json`),
+    path.join("/tmp", "typex", accountId, ".typex_pos.json"),
+  ];
+
+  for (const candidate of legacyCandidates) {
+    try {
+      const data = await fs.readFile(candidate, "utf-8");
+      const json = JSON.parse(data) as { pos?: unknown };
+      if (typeof json.pos === "number" && Number.isFinite(json.pos) && json.pos >= 0) {
+        await fs.unlink(candidate).catch(() => {
+          // best effort cleanup
+        });
+        return json.pos;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Read TypeX stream position.
+ * Priority:
+ * 1) state dir (new)
+ * 2) channels.typex.accounts.<id>.pos (legacy in-config)
+ * 3) channels.openclaw-extension-typex.accounts.<id>.pos (old plugin id)
+ * 4) /tmp/typex legacy files
+ */
+async function readPos(accountId: string): Promise<number> {
+  const statePos = await readPosFromState(accountId);
+  if (typeof statePos === "number") {
+    return statePos;
+  }
+
+  const migrationCandidates: Array<() => Promise<number | null>> = [
+    () => readPosFromConfig({ accountId, channelKey: "typex" }),
+    () => readPosFromConfig({ accountId, channelKey: "openclaw-extension-typex" }),
+    () => readLegacyPosFile(accountId),
+  ];
+
+  for (const candidate of migrationCandidates) {
+    const pos = await candidate();
+    if (typeof pos === "number") {
+      await writePosToState(accountId, pos).catch(() => {
+        // non-fatal; fallback to using runtime pos only
+      });
+      return pos;
+    }
+  }
+
+  return 0;
+}
+
+async function savePos(accountId: string, pos: number): Promise<void> {
+  try {
+    await writePosToState(accountId, pos);
+  } catch {
+    // Non-fatal: losing pos means re-processing a few messages at worst.
+  }
+}
+
+export async function monitorTypeXProvider(opts: MonitorTypeXOpts) {
+  try {
+    const { account, runtime, abortSignal, log, typexCfg, cfg } = opts;
+    const accountObj = account as {
+      config: { token?: string; appId?: string };
+      accountId: string;
+      name?: string;
+    };
+    const { token, appId } = accountObj.config;
+    const logger = log as
+      | { warn: (msg: string) => void; info: (msg: string) => void; error: (msg: string) => void }
+      | undefined;
+
+    if (!token) {
+      logger?.warn(`[${accountObj.accountId}] No token found. Stopping monitor.`);
+      return;
+    }
+
+    const client = getTypeXClient(undefined, { token, skipConfigCheck: true });
+
+    logger?.info(`[${accountObj.accountId}] Starting TypeX monitor for ${accountObj.accountId}...`);
+
+    let currentPos = await readPos(accountObj.accountId);
+    logger?.info(`[${accountObj.accountId}] Loaded pos: ${currentPos}`);
+
+    while (!abortSignal.aborted) {
+      try {
+        const messages = await client.fetchMessages(currentPos);
+
+        if (messages && messages.length > 0) {
+          for (const msg of messages) {
+            await processTypeXMessage(client, msg, appId || accountObj.accountId, {
+              accountId: accountObj.accountId,
+              cfg,
+              typexCfg,
+              botName: accountObj.name,
+              logger,
+            });
+
+            if (typeof msg.position === "number") {
+              currentPos = msg.position;
+              await savePos(accountObj.accountId, currentPos);
+            }
+          }
+        }
+      } catch (err) {
+        logger?.error(
+          `Error in TypeX polling loop: ${err instanceof Error ? err.stack : String(err)}`,
+        );
+      }
+
+      if (abortSignal.aborted) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+    }
+    logger?.info("Stopping TypeX monitor...");
+  } catch (e) {
+    throw e;
+  }
+}

--- a/extensions/typex/src/client/outbound.ts
+++ b/extensions/typex/src/client/outbound.ts
@@ -24,7 +24,7 @@ export const typexOutbound: ChannelOutboundAdapter = {
   sendText: async ({ to, text, accountId, cfg }: any) => {
     const token = resolveToken(cfg, accountId);
     const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
-    const result = await sendMessageTypeX(client, text ?? "");
+    const result = await sendMessageTypeX(client, to, text ?? "");
     return {
       channel: "typex",
       messageId: result?.message_id || "unknown",
@@ -38,7 +38,7 @@ export const typexOutbound: ChannelOutboundAdapter = {
     }
     const token = resolveToken(cfg, accountId);
     const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
-    const result = await sendMessageTypeX(client, text ?? "");
+    const result = await sendMessageTypeX(client, to, text ?? "");
     return {
       channel: "typex",
       messageId: result?.message_id || "unknown",

--- a/extensions/typex/src/client/outbound.ts
+++ b/extensions/typex/src/client/outbound.ts
@@ -1,0 +1,45 @@
+import type { ChannelOutboundAdapter, OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { getTypeXClient } from "./client.js";
+import { sendMessageTypeX } from "./send.js";
+
+function resolveToken(cfg: OpenClawConfig, accountId?: string | null): string | undefined {
+  const id = accountId ?? DEFAULT_ACCOUNT_ID;
+  const account = cfg.channels?.typex?.accounts?.[id];
+  if (typeof account?.token === "string" && account.token.trim()) {
+    return account.token;
+  }
+  const rootToken = cfg.channels?.typex?.token;
+  if (typeof rootToken === "string" && rootToken.trim()) {
+    return rootToken;
+  }
+  return undefined;
+}
+
+export const typexOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "direct",
+  chunkerMode: "markdown",
+  textChunkLimit: 2000,
+
+  sendText: async ({ to, text, accountId, cfg }: any) => {
+    const token = resolveToken(cfg, accountId);
+    const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
+    const result = await sendMessageTypeX(client, { text });
+    return {
+      channel: "typex",
+      messageId: result?.message_id || "unknown",
+      chatId: to,
+    };
+  },
+
+  sendMedia: async ({ to, text, mediaUrl, accountId, cfg }: any) => {
+    const token = resolveToken(cfg, accountId);
+    const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
+    const result = await sendMessageTypeX(client, { text: text || "" }, { mediaUrl });
+    return {
+      channel: "typex",
+      messageId: result?.message_id || "unknown",
+      chatId: to,
+    };
+  },
+};

--- a/extensions/typex/src/client/outbound.ts
+++ b/extensions/typex/src/client/outbound.ts
@@ -24,7 +24,7 @@ export const typexOutbound: ChannelOutboundAdapter = {
   sendText: async ({ to, text, accountId, cfg }: any) => {
     const token = resolveToken(cfg, accountId);
     const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
-    const result = await sendMessageTypeX(client, { text });
+    const result = await sendMessageTypeX(client, text ?? "");
     return {
       channel: "typex",
       messageId: result?.message_id || "unknown",
@@ -33,9 +33,12 @@ export const typexOutbound: ChannelOutboundAdapter = {
   },
 
   sendMedia: async ({ to, text, mediaUrl, accountId, cfg }: any) => {
+    if (mediaUrl) {
+      throw new Error("TypeX media sending is not supported yet.");
+    }
     const token = resolveToken(cfg, accountId);
     const client = getTypeXClient(accountId ?? undefined, { token, skipConfigCheck: true });
-    const result = await sendMessageTypeX(client, { text: text || "" }, { mediaUrl });
+    const result = await sendMessageTypeX(client, text ?? "");
     return {
       channel: "typex",
       messageId: result?.message_id || "unknown",

--- a/extensions/typex/src/client/runtime.ts
+++ b/extensions/typex/src/client/runtime.ts
@@ -1,0 +1,18 @@
+/**
+ * Global runtime reference for the TypeX plugin.
+ */
+
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setTypeXRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function getTypeXRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("TypeX runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/typex/src/client/send.ts
+++ b/extensions/typex/src/client/send.ts
@@ -1,4 +1,3 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk";
 import type { TypeXClient } from "./client.js";
 // import { loadWebMedia } from "../web/media.js";
 import { TypeXMessageEnum } from "./types.js";
@@ -11,6 +10,7 @@ export type TypeXSendOpts = {
 
 export async function sendMessageTypeX(
   client: TypeXClient,
+  to: string,
   content: string | { text?: string },
   opts: TypeXSendOpts = {},
 ) {
@@ -21,5 +21,5 @@ export async function sendMessageTypeX(
     throw new Error("TypeX media sending is not supported yet.");
   }
 
-  return await client.sendMessage(finalContent, msgType);
+  return await client.sendMessage(to, finalContent, msgType);
 }

--- a/extensions/typex/src/client/send.ts
+++ b/extensions/typex/src/client/send.ts
@@ -1,0 +1,27 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk";
+import type { TypeXClient } from "./client.js";
+// import { loadWebMedia } from "../web/media.js";
+import { TypeXMessageEnum } from "./types.js";
+
+export type TypeXSendOpts = {
+  msgType?: TypeXMessageEnum;
+  mediaUrl?: string;
+  maxBytes?: number;
+};
+
+export async function sendMessageTypeX(
+  client: TypeXClient,
+  content: string | { text?: string },
+  opts: TypeXSendOpts = {},
+) {
+  let msgType = opts.msgType || TypeXMessageEnum.text;
+  let finalContent: string | object = content;
+
+  // Send the main message
+  try {
+    const res = await client.sendMessage(finalContent, msgType);
+    return res;
+  } catch (err) {
+    throw err;
+  }
+}

--- a/extensions/typex/src/client/send.ts
+++ b/extensions/typex/src/client/send.ts
@@ -14,14 +14,12 @@ export async function sendMessageTypeX(
   content: string | { text?: string },
   opts: TypeXSendOpts = {},
 ) {
-  let msgType = opts.msgType || TypeXMessageEnum.text;
+  const msgType = opts.msgType || TypeXMessageEnum.text;
   let finalContent: string | object = content;
 
-  // Send the main message
-  try {
-    const res = await client.sendMessage(finalContent, msgType);
-    return res;
-  } catch (err) {
-    throw err;
+  if (opts.mediaUrl) {
+    throw new Error("TypeX media sending is not supported yet.");
   }
+
+  return await client.sendMessage(finalContent, msgType);
 }

--- a/extensions/typex/src/client/types.ts
+++ b/extensions/typex/src/client/types.ts
@@ -1,0 +1,30 @@
+import { OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
+
+export enum TypeXMessageEnum {
+  text = 0,
+  richText = 8,
+}
+
+export type TypeXMessage = {
+  msg_type: TypeXMessageEnum;
+  content: string;
+};
+
+export interface TypeXClientOptions {
+  token?: string;
+  skipConfigCheck?: boolean;
+  typexCfg?: Record<string, unknown>;
+  prompter?: WizardPrompter;
+}
+
+export interface TypeXMessageEntry {
+  message_id: string;
+  chat_id: string;
+  sender_id: string;
+  sender_name?: string;
+  msg_type: TypeXMessageEnum;
+  content: {
+    text: string;
+  };
+  create_time: number;
+}

--- a/extensions/typex/src/config-schema.ts
+++ b/extensions/typex/src/config-schema.ts
@@ -1,0 +1,35 @@
+import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk";
+import { z } from "zod";
+
+const allowFromEntry = z.union([z.string(), z.number()]);
+const toolsBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
+
+const TypeXGroupSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    tools: ToolPolicySchema,
+    toolsBySender: toolsBySenderSchema,
+    systemPrompt: z.string().optional(),
+  })
+  .strict();
+
+const TypeXAccountSchema = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    token: z.string().optional(),
+    pos: z.number().int().nonnegative().optional(),
+    appId: z.string().optional(),
+    appSecret: z.string().optional(),
+    botName: z.string().optional(),
+    markdown: MarkdownConfigSchema.optional(),
+    allowFrom: z.array(allowFromEntry).optional(),
+    responsePrefix: z.string().optional(),
+    groups: z.record(z.string(), TypeXGroupSchema.optional()).optional(),
+  })
+  .strict();
+
+export const TypeXConfigSchema = TypeXAccountSchema.extend({
+  defaultAccount: z.string().optional(),
+  accounts: z.object({}).catchall(TypeXAccountSchema).optional(),
+});

--- a/extensions/typex/src/config-schema.ts
+++ b/extensions/typex/src/config-schema.ts
@@ -2,6 +2,8 @@ import { MarkdownConfigSchema, ToolPolicySchema } from "openclaw/plugin-sdk";
 import { z } from "zod";
 
 const allowFromEntry = z.union([z.string(), z.number()]);
+const dmPolicySchema = z.enum(["open", "pairing", "allowlist", "disabled"]);
+const groupPolicySchema = z.enum(["open", "allowlist", "disabled"]);
 const toolsBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
 const TypeXGroupSchema = z
@@ -23,7 +25,10 @@ const TypeXAccountSchema = z
     appSecret: z.string().optional(),
     botName: z.string().optional(),
     markdown: MarkdownConfigSchema.optional(),
+    dmPolicy: dmPolicySchema.optional(),
+    groupPolicy: groupPolicySchema.optional(),
     allowFrom: z.array(allowFromEntry).optional(),
+    groupAllowFrom: z.array(allowFromEntry).optional(),
     responsePrefix: z.string().optional(),
     groups: z.record(z.string(), TypeXGroupSchema.optional()).optional(),
   })

--- a/extensions/typex/src/normalize.ts
+++ b/extensions/typex/src/normalize.ts
@@ -1,0 +1,5 @@
+export function normalizeTypeXTarget(raw: string): string {
+  let normalized = raw.replace(/^typex:/i, "").trim();
+  normalized = normalized.replace(/^(group|chat|user|dm):/i, "").trim();
+  return normalized;
+}

--- a/extensions/typex/src/onboarding.ts
+++ b/extensions/typex/src/onboarding.ts
@@ -1,0 +1,81 @@
+import type { ChannelOnboardingAdapter } from "openclaw/plugin-sdk";
+import qrcode from "qrcode-terminal";
+import { resolveDefaultTypeXAccountId } from "./client/accounts.js";
+import { getTypeXClient } from "./client/client.js";
+
+export const typexOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel: "typex",
+  getStatus: async ({ cfg }) => {
+    const accountId = resolveDefaultTypeXAccountId(cfg);
+    const configured = Boolean(cfg.channels?.["typex"]?.accounts?.[accountId]?.token);
+
+    return {
+      channel: "typex",
+      configured,
+      statusLines: [`TypeX (${accountId}): ${configured ? "configured" : "not configured"}`],
+      selectionHint: configured ? "configured" : "setup needed",
+      quickstartScore: configured ? 5 : 0,
+    };
+  },
+  configure: async ({ cfg, prompter }) => {
+    const typexCfg = (cfg.channels?.["typex"] ?? {}) as Record<string, any>;
+    const client = getTypeXClient(undefined, { skipConfigCheck: true, typexCfg, prompter });
+    await prompter.note(`Initializing TypeX ...\nPlease scan the QR code shortly.`, "TypeX Setup");
+
+    try {
+      const qrcodeData = await client.fetchQrcodeUrl();
+      const parsedData = new URLSearchParams(qrcodeData);
+      const qrcodeId = parsedData.get("qr_code_id") || "";
+      console.log("\nScan this QR code with TypeX App:\n");
+      qrcode.generate(qrcodeData, { small: true });
+
+      // Polling
+      await prompter.note("Waiting for scan...", "Status");
+
+      let token: string | null = null;
+      let userId: string = "";
+      let attempts = 0;
+      const maxAttempts = 60;
+
+      while (!token && attempts < maxAttempts) {
+        // wait for about 2 min
+        await new Promise((r) => setTimeout(r, 2000));
+
+        const loginSuccessfully = await client.checkLoginStatus(qrcodeId);
+
+        if (loginSuccessfully) {
+          token = await client.getAccessToken();
+          userId = await client.getCurUserId();
+          break;
+        }
+
+        attempts++;
+        process.stdout.write(".");
+      }
+
+      console.log("\n");
+
+      if (!token) {
+        throw new Error("Login timed out. Please try again.");
+      }
+
+      if (!cfg.channels) cfg.channels = {};
+      if (!cfg.channels["typex"]) cfg.channels["typex"] = {};
+      if (!cfg.channels["typex"].accounts) cfg.channels["typex"].accounts = {};
+
+      // save config
+      cfg.channels["typex"].accounts[userId] = {
+        token: token,
+      };
+      cfg.channels["typex"].defaultAccount = userId;
+
+      await prompter.note("Success! TypeX linked.", "Done");
+      await client.sendMessage("openclaw linked");
+
+      return { cfg, accountId: userId };
+    } catch (error) {
+      await prompter.note(`Setup Failed: ${String(error)}`, "Error");
+      return { cfg };
+    }
+  },
+};

--- a/extensions/typex/src/onboarding.ts
+++ b/extensions/typex/src/onboarding.ts
@@ -70,7 +70,7 @@ export const typexOnboardingAdapter: ChannelOnboardingAdapter = {
       cfg.channels["typex"].defaultAccount = userId;
 
       await prompter.note("Success! TypeX linked.", "Done");
-      await client.sendMessage("openclaw linked");
+      await client.sendMessage(userId, "openclaw linked");
 
       return { cfg, accountId: userId };
     } catch (error) {

--- a/extensions/typex/src/onboarding.ts
+++ b/extensions/typex/src/onboarding.ts
@@ -82,8 +82,12 @@ export const typexOnboardingAdapter: ChannelOnboardingAdapter = {
       if (!cfg.channels["typex"].accounts) cfg.channels["typex"].accounts = {};
 
       // save config
+      const existingAccount = ((
+        cfg.channels["typex"].accounts as Record<string, Record<string, unknown>>
+      )[userId] ?? {}) as Record<string, unknown>;
       cfg.channels["typex"].accounts[userId] = {
-        token: token,
+        ...existingAccount,
+        token,
       };
       cfg.channels["typex"].defaultAccount = userId;
 

--- a/extensions/typex/src/types.ts
+++ b/extensions/typex/src/types.ts
@@ -1,0 +1,95 @@
+import type { DmPolicy, GroupPolicy, MarkdownConfig, DmConfig } from "openclaw/plugin-sdk";
+
+export type TypeXGroupConfig = {
+  requireMention?: boolean;
+  /** If specified, only load these skills for this group. Omit = all skills; empty = no skills. */
+  skills?: string[];
+  /** If false, disable the bot for this group. */
+  enabled?: boolean;
+  /** Optional allowlist for group senders. */
+  allowFrom?: Array<string | number>;
+  /** Optional system prompt snippet for this group. */
+  systemPrompt?: string;
+};
+
+export type TypeXAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** TypeX email (shape depends on your provider). */
+  email?: string;
+  /** TypeX token. */
+  token?: string;
+  /** Last message position. */
+  last_msg_pos?: number;
+  /** App ID. */
+  appId?: string;
+  /** App Secret. */
+  appSecret?: string;
+  /** Path to file containing app secret (for secret managers). */
+  appSecretFile?: string;
+  /** Optional API domain or base URL override. */
+  domain?: string;
+  /** Bot display name (used for UI surfaces). */
+  botName?: string;
+  /** If false, do not start this TypeX account. Default: true. */
+  enabled?: boolean;
+  /** Markdown formatting overrides (tables). */
+  markdown?: MarkdownConfig;
+  /** Allow channel-initiated config writes (default: true). */
+  configWrites?: boolean;
+  /**
+   * Controls how TypeX direct chats (DMs) are handled:
+   * - "pairing" (default): unknown senders get a pairing code; owner must approve
+   * - "allowlist": only allow senders in allowFrom (or paired allow store)
+   * - "open": allow all inbound DMs (requires allowFrom to include "*")
+   * - "disabled": ignore all inbound DMs
+   */
+  dmPolicy?: DmPolicy;
+  /**
+   * Controls how group messages are handled:
+   * - "open": groups bypass allowFrom, only mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
+   */
+  groupPolicy?: GroupPolicy;
+  /** Allowlist for DM senders (identifier format depends on your provider). */
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for group senders. */
+  groupAllowFrom?: Array<string | number>;
+  /** Max group messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by sender id. */
+  dms?: Record<string, DmConfig>;
+  /** Per-group config keyed by group/chat id. */
+  groups?: Record<string, TypeXGroupConfig>;
+  /** Outbound text chunk size (chars). Default: 2000. */
+  textChunkLimit?: number;
+  /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
+  chunkMode?: "length" | "newline";
+  /** Disable block streaming for this account. */
+  blockStreaming?: boolean;
+  /**
+   * Enable streaming mode for replies (shows typing indicator / live updates).
+   * Default: true.
+   */
+  streaming?: boolean;
+  /** Media max size in MB. */
+  mediaMaxMb?: number;
+  /** Outbound response prefix override for this channel/account. */
+  responsePrefix?: string;
+  /** default account. */
+  defaultAccount?: string;
+};
+
+export type TypeXConfig = {
+  /** Optional per-account TypeX configuration (multi-account). */
+  accounts?: Record<string, TypeXAccountConfig>;
+  /** Top-level app ID (alternative to accounts). */
+  appId?: string;
+  /** Top-level app secret (alternative to accounts). */
+  appSecret?: string;
+  /** Top-level app secret file (alternative to accounts). */
+  appSecretFile?: string;
+} & Omit<TypeXAccountConfig, "appId" | "appSecret" | "appSecretFile">;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.25.0
@@ -228,7 +232,7 @@ importers:
         version: 7.0.0-dev.20260301.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -255,11 +259,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   extensions/acpx:
     dependencies:
@@ -448,6 +448,15 @@ importers:
       '@twurple/chat':
         specifier: ^8.0.3
         version: 8.0.3(@twurple/auth@8.0.3)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
+  extensions/typex:
+    dependencies:
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5285,7 +5294,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: ^2.34
+      request: npm:@cypress/request@3.0.10
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -9416,8 +9425,8 @@ snapshots:
 
   '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -9427,7 +9436,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
@@ -9444,7 +9453,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9458,7 +9467,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/expect@4.0.18':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.25.0
@@ -228,7 +232,7 @@ importers:
         version: 7.0.0-dev.20260301.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -255,11 +259,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   extensions/acpx:
     dependencies:
@@ -5294,7 +5294,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: ^2.34
+      request: npm:@cypress/request@3.0.10
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -5658,7 +5658,6 @@ packages:
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -9425,8 +9424,8 @@ snapshots:
 
   '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -9436,7 +9435,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
@@ -9453,7 +9452,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9467,7 +9466,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/expect@4.0.18':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,10 +198,6 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.25.0
@@ -232,7 +228,7 @@ importers:
         version: 7.0.0-dev.20260301.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -260,6 +256,10 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
 
   extensions/acpx:
     dependencies:
@@ -5294,7 +5294,7 @@ packages:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: npm:@cypress/request@3.0.10
+      request: ^2.34
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -9425,7 +9425,7 @@ snapshots:
 
   '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
@@ -9436,7 +9436,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
@@ -9453,7 +9453,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9467,7 +9467,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@4.0.18':
     dependencies:


### PR DESCRIPTION
## Summary

- Problem: TypeX was not available as a built-in channel integration in OpenClaw.
- Why it matters: This blocked first-class maintenance and upstream channel inclusion.
- What changed:
  - Added built-in TypeX channel under `extensions/typex`.
  - Implemented onboarding, inbound polling, outbound delivery, account resolution, and status/docs wiring following existing channel patterns.
  - Added migration-safe cursor (`pos`) persistence to state files with legacy fallback paths.
  - Addressed review feedback around default account selection, allowlist/policy behavior, onboarding error handling, and lockfile consistency.
- What did NOT change (scope boundary):
  - No cross-channel framework refactor.
  - No TypeX media-send support (still unsupported).

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Docs
- [x] Chore/infra
- [ ] Refactor
- [ ] Security hardening

## Scope (select all touched areas)

- [x] Integrations
- [x] Docs
- [x] CI/CD / infra
- [x] Auth / tokens
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX

## Linked Issue/PR

- Related #29584

## User-visible / Behavior Changes

- New built-in **TypeX** channel integration is available.
- TypeX onboarding now fails fast on invalid/missing QR id and no longer returns success-shaped results on setup failure.
- TypeX account/default resolution now consistently respects `defaultAccount` and channel-level `enabled`.
- TypeX DM policy/allowlist behavior now follows configured values (including account/channel fallback handling).
- TypeX cursor (`pos`) persists in state and migrates from legacy locations automatically.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes**
- New/changed network calls? **Yes**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation:
  - TypeX network calls use guarded fetch wrappers.
  - DM policy/allowlist now honor configured controls.
  - Onboarding no longer masks setup failures as successful configuration.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway runtime + GitHub CI
- Model/provider: OpenAI Codex path during gateway tests
- Integration/channel: TypeX
- Relevant config (redacted): `channels.typex` with account token/defaultAccount and policy/allowlist variants

### Steps

1. Configure/link TypeX via onboarding QR flow.
2. Send inbound messages and verify route/session resolution.
3. Verify outbound replies.
4. Restart gateway and verify cursor continuity.
5. Re-test after account switching.

### Expected

- TypeX behaves according to config (account/default/policy/allowlist), and cursor continuity survives restart.

### Actual

- Matches expected after this PR’s fixes.

## Evidence

- [x] Failing logs before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording

## Human Verification (required)

- Verified scenarios:
  - Inbound polling → route resolution → agent response → outbound send
  - Account switching + restart cursor continuity
  - Onboarding success/failure behavior
  - DM policy/allowlist behavior
- Edge cases checked:
  - Legacy cursor migration fallback order
  - Missing `qr_code_id` handling
  - Account-level allowlist unset with channel-level fallback
- What I did **not** verify:
  - Media sending (currently unsupported for TypeX)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **Yes** (automatic)
- If yes, exact upgrade steps:
  - No manual action required.
  - Cursor migration fallback order:
    1. state file
    2. `channels.typex.accounts.<id>.pos`
    3. `channels.openclaw-extension-typex.accounts.<id>.pos`
    4. legacy `/tmp/typex/*`

## Failure Recovery (if this breaks)

- How to disable/revert quickly:
  - Set `channels.typex.enabled=false` or remove `channels.typex` config.
- Files/config to restore:
  - `channels.typex` section and TypeX state cursor files.
- Known bad symptoms:
  - QR onboarding cannot complete
  - Unexpected allowlist/policy behavior
  - Cursor not advancing across restarts

## Risks and Mitigations

- Risk: Config precedence confusion between account-level and channel-level fields.
  - Mitigation: Explicit fallback/precedence logic and schema alignment.
- Risk: Legacy cursor migration inconsistencies.
  - Mitigation: Ordered fallback migration + persisted state writes + restart validation.