### PR TITLE
gateway: log channel auto-restart failures

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -246,7 +246,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 preserveRestartAttempts: true,
                 preserveManualStop: true,
               });
-            } catch {
+            } catch (err) {
+              if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+                log.debug?.(
+                  `[${id}] auto-restart aborted (attempt ${attempt}/${MAX_RESTART_ATTEMPTS}): ${formatErrorMessage(err)}`,
+                );
+                return;
+              }
+              log.warn?.(
+                `[${id}] auto-restart failed (attempt ${attempt}/${MAX_RESTART_ATTEMPTS}): ${formatErrorMessage(err)}`,
+              );
               // abort or startup failure — next crash will retry
             }
           })


### PR DESCRIPTION
When a channel task crashes, the gateway schedules auto-restart attempts. If the restart attempt is aborted or the startup fails, the current code silently ignores the error.

This keeps the same retry behavior but adds:
- debug log when restart is aborted
- warn log when restart fails unexpectedly

This should make channel stability issues diagnosable in the field without changing behavior.