### PR TITLE
fix(logging): invalidate cached subsystem logger on date change

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -264,7 +264,8 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
   let fileLoggerDate = "";
   const getFileLogger = () => {
-    const today = new Date().toISOString().slice(0, 10);
+    const d = new Date();
+    const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
     if (!fileLogger || fileLoggerDate !== today) {
       fileLogger = getChildLogger({ subsystem });
       fileLoggerDate = today;

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -262,9 +262,12 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerDate = "";
   const getFileLogger = () => {
-    if (!fileLogger) {
+    const today = new Date().toISOString().slice(0, 10);
+    if (!fileLogger || fileLoggerDate !== today) {
       fileLogger = getChildLogger({ subsystem });
+      fileLoggerDate = today;
     }
     return fileLogger;
   };


### PR DESCRIPTION
## Summary

Fixes #29594 — `createSubsystemLogger` caches the file logger in a closure and never invalidates it. After midnight, the cached logger continues writing to yesterday's log file (`openclaw-YYYY-MM-DD.log`), so all log levels except ERROR (which uses a separate code path) go to the stale file.

### Root Cause

`getFileLogger()` closure in `subsystem.ts` creates the logger once on first call and returns the cached instance forever. The underlying logger binds to a date-based file path at creation time.

### Fix

Add a date check: track the ISO date string when the logger was created. On each call, compare against `new Date().toISOString().slice(0, 10)`. When the date changes (midnight crossing), recreate the logger to bind to today's file.

### Changes

| File | Change |
|------|--------|
| `src/logging/subsystem.ts` | +4/-1: date guard on cached file logger |

### Validation

- Build: PASS
- Lint: 0 warnings, 0 errors
- Existing tests: 5/5 pass
- Performance: `toISOString().slice(0, 10)` is a single string operation per log call — negligible overhead vs file I/O

lobster-biscuit