### PR TITLE
fix(auth): handle Gemini CLI loadCodeAssist 400 during OAuth

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -422,6 +422,61 @@ describe("loginGeminiCliOAuth", () => {
     expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
   });
 
+  it("throws when loadCodeAssist has mixed failures (400 plus transport/non-400)", async () => {
+    const requests: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = getRequestUrl(input);
+      requests.push(url);
+
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      if (url === LOAD_PROD) {
+        return responseJson({ error: { message: "bad request" } }, 400);
+      }
+      if (url === LOAD_DAILY) {
+        throw new Error("network down");
+      }
+      if (url === LOAD_AUTOPUSH) {
+        return responseJson({ error: { message: "unavailable" } }, 503);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let authUrl = "";
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+
+    await expect(
+      loginGeminiCliOAuth({
+        isRemote: true,
+        openUrl: async () => {},
+        log: (msg) => {
+          const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
+          if (found?.[0]) {
+            authUrl = found[0];
+          }
+        },
+        note: async () => {},
+        prompt: async () => {
+          const state = new URL(authUrl).searchParams.get("state");
+          return `${"http://localhost:8085/oauth2callback"}?code=oauth-code&state=${state}`;
+        },
+        progress: { update: () => {}, stop: () => {} },
+      }),
+    ).rejects.toThrow("loadCodeAssist failed: 503");
+
+    expect(requests.filter((url) => url.includes("v1internal:loadCodeAssist"))).toHaveLength(3);
+    expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
+  });
+
   it("continues OAuth flow when loadCodeAssist returns 400 from every endpoint", async () => {
     const requests: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -494,8 +494,11 @@ async function discoverProject(accessToken: string): Promise<string> {
   let activeEndpoint = CODE_ASSIST_ENDPOINT_PROD;
   let loadError: Error | undefined;
   let loadStatus: number | undefined;
+  let sawLoadAttempt = false;
+  let sawOnlyHttp400Failures = true;
   for (const endpoint of LOAD_CODE_ASSIST_ENDPOINTS) {
     try {
+      sawLoadAttempt = true;
       const response = await fetchWithTimeout(`${endpoint}/v1internal:loadCodeAssist`, {
         method: "POST",
         headers,
@@ -504,6 +507,7 @@ async function discoverProject(accessToken: string): Promise<string> {
 
       if (!response.ok) {
         loadStatus = response.status;
+        sawOnlyHttp400Failures &&= response.status === 400;
         const errorPayload = await response.json().catch(() => null);
         if (isVpcScAffected(errorPayload)) {
           data = { currentTier: { id: TIER_STANDARD } };
@@ -519,8 +523,10 @@ async function discoverProject(accessToken: string): Promise<string> {
       activeEndpoint = endpoint;
       loadError = undefined;
       loadStatus = undefined;
+      sawOnlyHttp400Failures = false;
       break;
     } catch (err) {
+      sawOnlyHttp400Failures = false;
       loadError = err instanceof Error ? err : new Error("loadCodeAssist failed", { cause: err });
     }
   }
@@ -533,7 +539,7 @@ async function discoverProject(accessToken: string): Promise<string> {
     if (envProject) {
       return envProject;
     }
-    if (loadStatus === 400) {
+    if (sawLoadAttempt && sawOnlyHttp400Failures && loadStatus === 400) {
       data = {
         allowedTiers: [{ id: TIER_FREE, isDefault: true }],
       };


### PR DESCRIPTION
Fixes #29539

## Summary
- treat repeated `loadCodeAssist` HTTP 400 responses as a recoverable path during Gemini CLI OAuth project discovery
- continue onboarding using a free-tier default instead of aborting OAuth immediately
- add regression coverage for the all-endpoints-400 scenario

## Validation
- `pnpm -C /home/openclaw/.openclaw/workspace/agents/charlie/repos/openclaw-29298 exec vitest run extensions/google-gemini-cli-auth/oauth.test.ts`
- `pnpm -C /home/openclaw/.openclaw/workspace/agents/charlie/repos/openclaw-29298 check`
- `pnpm -C /home/openclaw/.openclaw/workspace/agents/charlie/repos/openclaw-29298 check:docs`
- `pnpm -C /home/openclaw/.openclaw/workspace/agents/charlie/repos/openclaw-29298 protocol:check`
