### PR TITLE
fix(dashboard): stop emitting dead URL when control UI disabled

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -115,4 +115,27 @@ describe("dashboardCommand", () => {
       "Browser launch disabled (--no-open). Use the URL above.",
     );
   });
+
+  it("fails fast when control UI is disabled in config", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      valid: true,
+      config: { gateway: { controlUi: { enabled: false } } },
+      issues: [],
+      legacyIssues: [],
+    });
+
+    await dashboardCommand(runtime);
+
+    expect(resolveControlUiLinksMock).not.toHaveBeenCalled();
+    expect(copyToClipboardMock).not.toHaveBeenCalled();
+    expect(openUrlMock).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Dashboard is disabled because gateway.controlUi.enabled=false.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -113,4 +113,31 @@ describe("dashboardCommand bind selection", () => {
       basePath: undefined,
     });
   });
+
+  it("exits early when control UI is disabled", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      valid: true,
+      config: {
+        gateway: {
+          controlUi: { enabled: false },
+        },
+      },
+      issues: [],
+      legacyIssues: [],
+    });
+
+    await dashboardCommand(runtime, { noOpen: true });
+
+    expect(mocks.resolveGatewayPort).not.toHaveBeenCalled();
+    expect(mocks.resolveControlUiLinks).not.toHaveBeenCalled();
+    expect(mocks.copyToClipboard).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Dashboard is disabled because gateway.controlUi.enabled=false.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -19,6 +19,12 @@ export async function dashboardCommand(
 ) {
   const snapshot = await readConfigFileSnapshot();
   const cfg = snapshot.valid ? snapshot.config : {};
+  if (cfg.gateway?.controlUi?.enabled === false) {
+    runtime.error("Dashboard is disabled because gateway.controlUi.enabled=false.");
+    runtime.error("Enable it with: openclaw config set gateway.controlUi.enabled true");
+    runtime.exit(1);
+    return;
+  }
   const port = resolveGatewayPort(cfg);
   const bind = cfg.gateway?.bind ?? "loopback";
   const basePath = cfg.gateway?.controlUi?.basePath;


### PR DESCRIPTION
## Summary
- Add a dashboard preflight check for `gateway.controlUi.enabled=false`.
- Exit early with a clear remediation command instead of printing a dashboard URL that will 404.
- Add command-level tests to cover the disabled-control-ui path.

## Test plan
- [x] `pnpm test -- --run src/commands/dashboard.test.ts src/commands/dashboard.links.test.ts`

Made with [Cursor](https://cursor.com)