### PR TITLE
fix(gemini-cli-auth): align loadCodeAssist metadata enums

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,16 +239,6 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "LINUX" {
-    if (process.platform === "win32") {
-      return "WINDOWS";
-    }
-    if (process.platform === "linux") {
-      return "LINUX";
-    }
-    return "MACOS";
-  }
-
   function getRequestUrl(input: string | URL | Request): string {
     return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
   }
@@ -358,16 +348,16 @@ describe("loginGeminiCliOAuth", () => {
     const clientMetadata = getHeaderValue(firstHeaders, "Client-Metadata");
     expect(clientMetadata).toBeDefined();
     expect(JSON.parse(clientMetadata as string)).toEqual({
-      ideType: "ANTIGRAVITY",
-      platform: getExpectedPlatform(),
+      ideType: "IDE_UNSPECIFIED",
+      platform: "PLATFORM_UNSPECIFIED",
       pluginType: "GEMINI",
     });
 
     const body = JSON.parse(String(loadRequests[0]?.init?.body));
     expect(body).toEqual({
       metadata: {
-        ideType: "ANTIGRAVITY",
-        platform: getExpectedPlatform(),
+        ideType: "IDE_UNSPECIFIED",
+        platform: "PLATFORM_UNSPECIFIED",
         pluginType: "GEMINI",
       },
     });

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -224,16 +224,6 @@ function generatePkce(): { verifier: string; challenge: string } {
   return { verifier, challenge };
 }
 
-function resolvePlatform(): "WINDOWS" | "MACOS" | "LINUX" {
-  if (process.platform === "win32") {
-    return "WINDOWS";
-  }
-  if (process.platform === "linux") {
-    return "LINUX";
-  }
-  return "MACOS";
-}
-
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
@@ -464,10 +454,9 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
 
 async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
-  const platform = resolvePlatform();
   const metadata = {
-    ideType: "ANTIGRAVITY",
-    platform,
+    ideType: "IDE_UNSPECIFIED",
+    platform: "PLATFORM_UNSPECIFIED",
     pluginType: "GEMINI",
   };
   const headers = {


### PR DESCRIPTION
## Summary
- Switch Gemini CLI OAuth loadCodeAssist metadata to stable enum values (`IDE_UNSPECIFIED` and `PLATFORM_UNSPECIFIED`).
- Keep plugin type and endpoint fallback behavior unchanged.
- Update OAuth tests to assert the new metadata contract.

## Test plan
- [x] `pnpm test -- --run extensions/google-gemini-cli-auth/oauth.test.ts`

Made with [Cursor](https://cursor.com)