### PR TITLE
fix(minimax): parse remaining_percent as quota left

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -113,6 +113,47 @@ describe("fetchMinimaxUsage", () => {
     ]);
   });
 
+  it("prefers explicit used percent over derived remaining percent", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        data: {
+          usage_percent: 70,
+          remaining_percent: 30,
+          window_hours: 5,
+        },
+      }),
+    );
+
+    const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+    expect(result.windows).toEqual([
+      {
+        label: "5h",
+        usedPercent: 70,
+        resetAt: undefined,
+      },
+    ]);
+  });
+
+  it("finds nested remaining-percent-only records during candidate scan", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        data: {
+          metadata: { note: "ok" },
+          nested: [{ remaining_percent: 95, window_hours: 5 }],
+        },
+      }),
+    );
+
+    const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+    expect(result.windows).toEqual([
+      {
+        label: "5h",
+        usedPercent: 5,
+        resetAt: undefined,
+      },
+    ]);
+  });
+
   it("derives used from total and remaining counts", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -91,6 +91,28 @@ describe("fetchMinimaxUsage", () => {
     ]);
   });
 
+  it("derives used percent from remaining percent fields", async () => {
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        data: {
+          remaining_percent: 95,
+          window_hours: 5,
+          plan_name: "M2.5",
+        },
+      }),
+    );
+
+    const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+    expect(result.plan).toBe("M2.5");
+    expect(result.windows).toEqual([
+      {
+        label: "5h",
+        usedPercent: 5,
+        resetAt: undefined,
+      },
+    ]);
+  });
+
   it("derives used from total and remaining counts", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(200, {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -215,7 +215,7 @@ function hasAny(record: Record<string, unknown>, keys: readonly string[]): boole
 
 function scoreUsageRecord(record: Record<string, unknown>): number {
   let score = 0;
-  if (hasAny(record, PERCENT_KEYS)) {
+  if (hasAny(record, PERCENT_KEYS) || hasAny(record, REMAINING_PERCENT_KEYS)) {
     score += 4;
   }
   if (hasAny(record, TOTAL_KEYS)) {
@@ -320,12 +320,13 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
     return fromCounts;
   }
 
-  // Some MiniMax remains payloads report remaining%, not used%.
-  if (fromRemainingPercent !== null) {
-    return fromRemainingPercent;
+  // Explicit used-percent fields are more direct than inverted remaining-percent fields.
+  if (fromPercent !== null) {
+    return fromPercent;
   }
 
-  return fromPercent;
+  // Some MiniMax remains payloads report remaining%, not used%.
+  return fromRemainingPercent;
 }
 
 export async function fetchMinimaxUsage(

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -50,6 +50,26 @@ const PERCENT_KEYS = [
   "usageRatio",
 ] as const;
 
+const REMAINING_PERCENT_KEYS = [
+  "remain_percent",
+  "remainPercent",
+  "remaining_percent",
+  "remainingPercent",
+  "left_percent",
+  "leftPercent",
+  "percent_left",
+  "percentLeft",
+  "remain_rate",
+  "remaining_rate",
+  "left_rate",
+  "remain_ratio",
+  "remaining_ratio",
+  "left_ratio",
+  "remainRatio",
+  "remainingRatio",
+  "leftRatio",
+] as const;
+
 const USED_KEYS = [
   "used",
   "usage",
@@ -283,17 +303,29 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
       ? clampPercent((used / total) * 100)
       : null;
 
+  const remainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
+  const fromRemainingPercent =
+    remainingPercentRaw !== undefined
+      ? clampPercent(
+          100 - (remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw),
+        )
+      : null;
+
   const percentRaw = pickNumber(payload, PERCENT_KEYS);
-  if (percentRaw !== undefined) {
-    const normalized = clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
-    if (fromCounts !== null) {
-      // Count-derived usage is more stable across provider percent field variations.
-      return fromCounts;
-    }
-    return normalized;
+  const fromPercent =
+    percentRaw !== undefined ? clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw) : null;
+
+  // Count-derived usage is most reliable when present.
+  if (fromCounts !== null) {
+    return fromCounts;
   }
 
-  return fromCounts;
+  // Some MiniMax remains payloads report remaining%, not used%.
+  if (fromRemainingPercent !== null) {
+    return fromRemainingPercent;
+  }
+
+  return fromPercent;
 }
 
 export async function fetchMinimaxUsage(


### PR DESCRIPTION
## Summary
Fixes inverted MiniMax quota display in macOS menubar usage rows when MiniMax returns remaining percent fields (e.g. `remaining_percent`).

The parser previously treated percent-like fields as used% only, so a payload like `remaining_percent: 95` was interpreted as `95% used`, and UI showed `5% left` instead of `95% left`.

## What changed
- Added MiniMax remaining-percent key support (`remaining_percent`, `left_percent`, `remain_ratio`, etc.).
- Convert remaining% -> used% (`used = 100 - remaining`).
- Preserve existing precedence: count-derived usage still wins when both counts and percent exist.
- Added unit test covering `remaining_percent: 95` => `usedPercent: 5`.

## Tests
- `pnpm test src/infra/provider-usage.fetch.minimax.test.ts src/infra/provider-usage.test.ts`

Closes #29561
