### PR TITLE
fix(feishu): use msg_type=file for video files instead of unsupported media

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -108,7 +108,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("uses msg_type=media for mp4", async () => {
+  it("uses msg_type=file for mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -124,7 +124,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
   });
@@ -171,7 +171,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media when replying with mp4", async () => {
+  it("uses msg_type=file when replying with mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -183,7 +183,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
 
@@ -203,7 +203,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media", reply_in_thread: true }),
+        data: expect.objectContaining({ msg_type: "file", reply_in_thread: true }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -308,8 +308,8 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for video, "audio" for audio, "file" for documents */
-  msgType?: "file" | "media" | "audio";
+  /** Use "audio" for audio files, "file" for documents and video */
+  msgType?: "file" | "audio";
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
@@ -447,8 +447,8 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu API: opus -> "audio", mp4 -> "media", everything else -> "file"
-    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    // Feishu API: opus -> "audio", everything else (including video) -> "file"
+    const msgType = fileType === "opus" ? "audio" : "file";
     return sendFileFeishu({
       cfg,
       to,


### PR DESCRIPTION
## Summary

Feishu API only supports these `msg_type` values: `text`, `image`, `file`, `audio`, `interactive`, `sticker`, `share_chat`, `share_user`.

The previous code sent mp4/mov/avi files with `msg_type="media"` which is **not a valid Feishu message type**, causing video sends to fail.

## Changes

- `extensions/feishu/src/media.ts`: Changed `sendFileFeishu` type signature from `"file" | "media" | "audio"` to `"file" | "audio"`. Changed `sendMediaFeishu` routing to use `"file"` for all non-audio file types (was `"media"` for mp4).
- `extensions/feishu/src/media.test.ts`: Updated 3 test cases to expect `msg_type="file"` for mp4 instead of `"media"`.

## Test plan

- [x] All 14 existing tests pass (`npx vitest run extensions/feishu/src/media.test.ts`)
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`, 0 warnings/errors)

Fixes #29560

lobster-biscuit