### PR TITLE
fix: resolve correct API transport for GitHub Copilot models

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -307,4 +307,102 @@ describe("models-config", () => {
       }
     });
   });
+
+  it("fills placeholder apiKey for authHeader:false provider with models", async () => {
+    await withTempHome(async () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "local-qwen": {
+              baseUrl: "http://localhost:8090/v1",
+              api: "openai-completions",
+              authHeader: false,
+              models: [
+                {
+                  id: "coding",
+                  name: "Qwen2.5-Coder-14B (local)",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 32768,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; models?: Array<{ id: string }> }>;
+      }>();
+      // A placeholder apiKey should be set so pi-coding-agent's ModelRegistry
+      // validation does not reject the entire models.json.
+      expect(parsed.providers["local-qwen"]?.apiKey).toBe("none");
+      expect(parsed.providers["local-qwen"]?.models?.map((m) => m.id)).toContain("coding");
+    });
+  });
+
+  it("authHeader:false provider does not break other providers in models.json", async () => {
+    await withTempHome(async () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "local-qwen": {
+              baseUrl: "http://localhost:8090/v1",
+              api: "openai-completions",
+              authHeader: false,
+              models: [
+                {
+                  id: "coding",
+                  name: "Local Qwen",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 32768,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+            "github-copilot": {
+              baseUrl: "https://api.enterprise.githubcopilot.com",
+              apiKey: "ghu_test123",
+              models: [
+                {
+                  id: "claude-opus-4.6",
+                  name: "Claude Opus 4.6 (Copilot)",
+                  api: "openai-completions",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 200000,
+                  maxTokens: 128000,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<
+          string,
+          { apiKey?: string; baseUrl?: string; models?: Array<{ id: string; api?: string }> }
+        >;
+      }>();
+      // local-qwen gets placeholder apiKey
+      expect(parsed.providers["local-qwen"]?.apiKey).toBe("none");
+      // github-copilot is preserved with its real apiKey and models
+      expect(parsed.providers["github-copilot"]?.apiKey).toBe("ghu_test123");
+      expect(parsed.providers["github-copilot"]?.baseUrl).toBe(
+        "https://api.enterprise.githubcopilot.com",
+      );
+      const copilotModelIds = parsed.providers["github-copilot"]?.models?.map((m) => m.id);
+      expect(copilotModelIds).toContain("claude-opus-4.6");
+    });
+  });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -468,6 +468,13 @@ export function normalizeProviders(params: {
         const apiKey = resolveAwsSdkApiKeyVarName();
         mutated = true;
         normalizedProvider = { ...normalizedProvider, apiKey };
+      } else if (normalizedProvider.authHeader === false) {
+        // Provider explicitly opted out of auth (e.g. local models like Ollama, LM Studio).
+        // pi-coding-agent's ModelRegistry validates that providers with custom models have an
+        // apiKey, but auth-less providers don't need one. Use a placeholder to satisfy
+        // validation and prevent the entire models.json from being rejected.
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: "none" };
       } else {
         const fromEnv = resolveEnvApiKeyVarName(normalizedKey);
         const fromProfiles = resolveApiKeyFromProfiles({

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -324,4 +324,67 @@ describe("resolveModel", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-antigravity/some-model");
   });
+
+  it("uses anthropic-messages api for github-copilot Claude model fallback (enterprise)", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://api.enterprise.githubcopilot.com",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("github-copilot", "claude-opus-4.7", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "claude-opus-4.7",
+      provider: "github-copilot",
+      api: "anthropic-messages",
+    });
+  });
+
+  it("uses openai-completions api for github-copilot GPT-4.x model fallback", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://api.individual.githubcopilot.com",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("github-copilot", "gpt-4.2", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gpt-4.2",
+      provider: "github-copilot",
+      api: "openai-completions",
+    });
+  });
+
+  it("uses openai-responses api for github-copilot GPT-5.x model fallback (enterprise)", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "github-copilot": {
+            baseUrl: "https://api.enterprise.githubcopilot.com",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("github-copilot", "gpt-5.3", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gpt-5.3",
+      provider: "github-copilot",
+      api: "openai-responses",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -2,6 +2,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ModelDefinitionConfig } from "../../config/types.js";
+import { resolveCopilotModelApi } from "../../providers/github-copilot-models.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
@@ -96,10 +97,18 @@ export function resolveModel(
     }
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
+      // For github-copilot, resolve the correct API transport per model rather than
+      // defaulting to openai-responses. Copilot proxies to different backends
+      // (Anthropic for Claude, OpenAI for GPT, etc.) and each needs its native API.
+      const fallbackApi =
+        providerCfg?.api ??
+        (normalizedProvider === "github-copilot"
+          ? resolveCopilotModelApi(modelId)
+          : "openai-responses");
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        api: fallbackApi,
         provider,
         baseUrl: providerCfg?.baseUrl,
         reasoning: false,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -445,6 +445,13 @@ export async function runEmbeddedPiAgent(
             githubToken: apiKeyInfo.apiKey,
           });
           authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+          // The Copilot token exchange returns the correct API base URL derived
+          // from the token's proxy-ep field (individual vs enterprise). Update the
+          // model so requests hit the right endpoint — the built-in catalog
+          // hardcodes the individual URL which fails for enterprise tokens (421).
+          if (copilotToken.baseUrl) {
+            model.baseUrl = copilotToken.baseUrl;
+          }
         } else {
           authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
         }

--- a/src/providers/github-copilot-models.test.ts
+++ b/src/providers/github-copilot-models.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildCopilotModelDefinition, getDefaultCopilotModelIds } from "./github-copilot-models.js";
+import {
+  buildCopilotModelDefinition,
+  getDefaultCopilotModelIds,
+  resolveCopilotModelApi,
+} from "./github-copilot-models.js";
 
 describe("github-copilot-models", () => {
   describe("getDefaultCopilotModelIds", () => {
@@ -19,10 +23,64 @@ describe("github-copilot-models", () => {
     });
   });
 
+  describe("resolveCopilotModelApi", () => {
+    it("resolves Claude models to anthropic-messages", () => {
+      expect(resolveCopilotModelApi("claude-sonnet-4.6")).toBe("anthropic-messages");
+      expect(resolveCopilotModelApi("claude-opus-4.6")).toBe("anthropic-messages");
+      expect(resolveCopilotModelApi("claude-haiku-4.5")).toBe("anthropic-messages");
+      expect(resolveCopilotModelApi("claude-sonnet-4.5")).toBe("anthropic-messages");
+      expect(resolveCopilotModelApi("Claude-Opus-4.5")).toBe("anthropic-messages");
+    });
+
+    it("resolves GPT-5.x models to openai-responses", () => {
+      expect(resolveCopilotModelApi("gpt-5")).toBe("openai-responses");
+      expect(resolveCopilotModelApi("gpt-5.1")).toBe("openai-responses");
+      expect(resolveCopilotModelApi("gpt-5.2")).toBe("openai-responses");
+      expect(resolveCopilotModelApi("gpt-5-mini")).toBe("openai-responses");
+    });
+
+    it("resolves codex models to openai-responses", () => {
+      expect(resolveCopilotModelApi("gpt-5.1-codex")).toBe("openai-responses");
+      expect(resolveCopilotModelApi("gpt-5.2-codex")).toBe("openai-responses");
+    });
+
+    it("resolves GPT-4.x models to openai-completions", () => {
+      expect(resolveCopilotModelApi("gpt-4o")).toBe("openai-completions");
+      expect(resolveCopilotModelApi("gpt-4.1")).toBe("openai-completions");
+      expect(resolveCopilotModelApi("gpt-4.1-mini")).toBe("openai-completions");
+    });
+
+    it("resolves Gemini models to openai-completions", () => {
+      expect(resolveCopilotModelApi("gemini-2.5-pro")).toBe("openai-completions");
+      expect(resolveCopilotModelApi("gemini-3-pro-preview")).toBe("openai-completions");
+    });
+
+    it("resolves Grok models to openai-completions", () => {
+      expect(resolveCopilotModelApi("grok-code-fast-1")).toBe("openai-completions");
+    });
+
+    it("resolves o-series models to openai-completions", () => {
+      expect(resolveCopilotModelApi("o1")).toBe("openai-completions");
+      expect(resolveCopilotModelApi("o3-mini")).toBe("openai-completions");
+    });
+  });
+
   describe("buildCopilotModelDefinition", () => {
-    it("builds a valid definition for claude-sonnet-4.6", () => {
+    it("builds a valid definition for claude-sonnet-4.6 with anthropic-messages api", () => {
       const def = buildCopilotModelDefinition("claude-sonnet-4.6");
       expect(def.id).toBe("claude-sonnet-4.6");
+      expect(def.api).toBe("anthropic-messages");
+    });
+
+    it("builds a valid definition for gpt-4o with openai-completions api", () => {
+      const def = buildCopilotModelDefinition("gpt-4o");
+      expect(def.id).toBe("gpt-4o");
+      expect(def.api).toBe("openai-completions");
+    });
+
+    it("builds a valid definition for gpt-5 with openai-responses api", () => {
+      const def = buildCopilotModelDefinition("gpt-5");
+      expect(def.id).toBe("gpt-5");
       expect(def.api).toBe("openai-responses");
     });
 

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -22,6 +22,31 @@ export function getDefaultCopilotModelIds(): string[] {
   return [...DEFAULT_MODEL_IDS];
 }
 
+/**
+ * Resolve the correct API transport for a Copilot model based on its model ID.
+ *
+ * GitHub Copilot proxies requests to different upstream providers:
+ * - Claude models → Anthropic Messages API (native Anthropic transport)
+ * - GPT-5.x / Codex models → OpenAI Responses API
+ * - GPT-4.x / Gemini / Grok / other models → OpenAI Chat Completions API
+ *
+ * pi-ai's built-in catalog already maps these correctly; this function mirrors
+ * that logic for fallback/inline model definitions that aren't in the catalog.
+ */
+export function resolveCopilotModelApi(modelId: string): ModelDefinitionConfig["api"] {
+  const lower = modelId.toLowerCase();
+  // Claude models use the native Anthropic Messages API through Copilot's proxy.
+  if (lower.startsWith("claude-")) {
+    return "anthropic-messages";
+  }
+  // GPT-5.x and Codex models support the OpenAI Responses API.
+  if (lower.startsWith("gpt-5") || lower.includes("codex")) {
+    return "openai-responses";
+  }
+  // All other models (GPT-4.x, Gemini, Grok, o1, o3, etc.) use Chat Completions.
+  return "openai-completions";
+}
+
 export function buildCopilotModelDefinition(modelId: string): ModelDefinitionConfig {
   const id = modelId.trim();
   if (!id) {
@@ -30,10 +55,7 @@ export function buildCopilotModelDefinition(modelId: string): ModelDefinitionCon
   return {
     id,
     name: id,
-    // pi-coding-agent's registry schema doesn't know about a "github-copilot" API.
-    // We use OpenAI-compatible responses API, while keeping the provider id as
-    // "github-copilot" (pi-ai uses that to attach Copilot-specific headers).
-    api: "openai-responses",
+    api: resolveCopilotModelApi(id),
     reasoning: false,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },


### PR DESCRIPTION
## Summary

- Fix GitHub Copilot provider model resolution to route each model to the correct API transport instead of hardcoding `openai-responses` for all models
- Fix `authHeader: false` providers (e.g. local models) breaking pi-coding-agent's ModelRegistry validation, which cascades to discard **all** custom models including Copilot enterprise overrides
- Fix Copilot model `baseUrl` not being updated at runtime from token exchange, causing enterprise tokens to be sent to the individual endpoint (421 Misdirected Request)

## Problem

Three compounding bugs cause GitHub Copilot enterprise users to get **421 Misdirected Request** errors:

### Bug 1: `authHeader: false` providers break all custom models
When a provider like `local-qwen` has `authHeader: false` (no auth needed) and custom models but no `apiKey`, pi-coding-agent's `validateConfig()` throws. Since validation iterates all providers in a single try block, this **discards every custom model from every provider** — including Copilot models with the enterprise `baseUrl` and correct `api` overrides. Only pi-ai's built-in catalog survives, with `baseUrl: "api.individual.githubcopilot.com"` hardcoded.

### Bug 2: Wrong API transport for Copilot models
`buildCopilotModelDefinition()` hardcoded `api: "openai-responses"` for all Copilot models. Claude models need `anthropic-messages`, GPT-4.x/Gemini/Grok need `openai-completions`, and only GPT-5.x/Codex use `openai-responses`.

### Bug 3: Runtime baseUrl not updated from token exchange  
`resolveCopilotApiToken()` returns both `token` and `baseUrl` (derived from the token's `proxy-ep` field — `api.enterprise.*` vs `api.individual.*`), but `run.ts` only used the `token` and discarded the `baseUrl`. Even when custom models loaded correctly, the model's `baseUrl` could be stale.

## Changes

### `src/agents/models-config.providers.ts`
When a provider has `authHeader: false` (explicitly opted out of auth) and custom models but no `apiKey`, set a `"none"` placeholder to satisfy pi-coding-agent's validation. This prevents one auth-less provider from breaking the entire `models.json`.

### `src/agents/pi-embedded-runner/run.ts`  
After Copilot token exchange, update `model.baseUrl` from `copilotToken.baseUrl` so requests hit the correct endpoint (enterprise vs individual) even if `models.json` has a stale URL.

### `src/providers/github-copilot-models.ts`
Added `resolveCopilotModelApi()` that maps model IDs to the correct API transport via prefix matching. Updated `buildCopilotModelDefinition()` to use it.

### `src/agents/pi-embedded-runner/model.ts`
Updated the generic provider fallback in `resolveModel()` to use `resolveCopilotModelApi()` for `github-copilot` provider.

### Tests
- 2 new tests for `authHeader: false` placeholder apiKey behavior (including cross-provider isolation)
- 7 test cases for `resolveCopilotModelApi()` 
- 3 new tests for `buildCopilotModelDefinition()` API transport
- 3 tests for `resolveModel()` github-copilot fallback (enterprise + individual URLs)

## Testing

```
✓ models-config.fills-missing-provider-apikey-from-env-var.test.ts (8 tests)
✓ src/providers/github-copilot-models.test.ts (15 tests)
✓ src/agents/pi-embedded-runner/model.test.ts (20 tests)
```