### PR TITLE
feat(bindings): support topic-level agent routing for Telegram forum groups

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -45,7 +45,7 @@ export type AgentBinding = {
   match: {
     channel: string;
     accountId?: string;
-    peer?: { kind: ChatType; id: string };
+    peer?: { kind: ChatType; id: string; topic?: string | number };
     guildId?: string;
     teamId?: string;
     /** Discord role IDs used for role-based routing. */

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -102,6 +102,44 @@ describe("resolveAgentRoute", () => {
     expect(route.matchedBy).toBe("binding.peer");
   });
 
+  test("telegram topic peer binding routes to correct agent (#1615)", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "topic-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-100123456789", topic: "42" },
+          },
+        },
+        {
+          agentId: "group-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group", id: "-100123456789" },
+          },
+        },
+      ],
+    };
+    // Message from topic 42 should route to topic-agent
+    const topicRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-100123456789:topic:42" },
+    });
+    expect(topicRoute.agentId).toBe("topic-agent");
+    expect(topicRoute.matchedBy).toBe("binding.peer");
+
+    // Message from the group root (no topic) should route to group-agent
+    const groupRoute = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-100123456789" },
+    });
+    expect(groupRoute.agentId).toBe("group-agent");
+    expect(groupRoute.matchedBy).toBe("binding.peer");
+  });
+
   test("discord channel peer binding wins over guild binding", () => {
     const cfg: OpenClawConfig = {
       bindings: [

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -216,13 +216,17 @@ function getEvaluatedBindingsForChannelAccount(
 }
 
 function normalizePeerConstraint(
-  peer: { kind?: string; id?: string } | undefined,
+  peer: { kind?: string; id?: string; topic?: string | number } | undefined,
 ): NormalizedPeerConstraint {
   if (!peer) {
     return { state: "none" };
   }
   const kind = normalizeChatType(peer.kind);
-  const id = normalizeId(peer.id);
+  const baseId = normalizeId(peer.id);
+  const topic = peer.topic != null ? String(peer.topic).trim() : "";
+  // Combine id and topic into the canonical peer ID used by Telegram forum groups
+  // (e.g. "-100123456789:topic:42"), matching buildTelegramGroupPeerId output.
+  const id = topic ? `${baseId}:topic:${topic}` : baseId;
   if (!kind || !id) {
     return { state: "invalid" };
   }
@@ -233,7 +237,7 @@ function normalizeBindingMatch(
   match:
     | {
         accountId?: string | undefined;
-        peer?: { kind?: string; id?: string } | undefined;
+        peer?: { kind?: string; id?: string; topic?: string | number } | undefined;
         guildId?: string | undefined;
         teamId?: string | undefined;
         roles?: string[] | undefined;


### PR DESCRIPTION
Closes #1615

## What

Adds an optional 	opic field to AgentBinding.match.peer, enabling clean per-topic agent routing in Telegram forum groups.

## Before

Users had to embed the topic in the peer id directly:
```json
{ "peer": { "kind": "group", "id": "-100123456789:topic:42" } }
```

## After

The 	opic field makes it explicit:
```json
{
  "bindings": [
    {
      "agentId": "main-agent",
      "match": { "channel": "telegram", "peer": { "kind": "group", "id": "-100123456789", "topic": "1" } }
    },
    {
      "agentId": "specialized-agent",
      "match": { "channel": "telegram", "peer": { "kind": "group", "id": "-100123456789", "topic": "42" } }
    }
  ]
}
```

## Implementation

- src/config/types.agents.ts: Added 	opic?: string | number to AgentBinding.match.peer
- src/routing/resolve-route.ts: 
ormalizePeerConstraint now combines id + 	opic into the canonical {id}:topic:{topic} format (matching uildTelegramGroupPeerId output), keeping the routing engine unchanged
- src/routing/resolve-route.test.ts: Added test case for Telegram topic routing