### PR TITLE
fix(feishu): non-blocking WS ACK and preserve full streaming card content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Streaming card text fidelity: merge throttled/fragmented partial updates without dropping content and avoid newline injection when stitching chunk-style deltas so card-stream output matches final reply text. (#29616) Thanks @HaoHuaqing.
 - Security/Feishu webhook ingress: bound unauthenticated webhook rate-limit state with stale-window pruning and a hard key cap to prevent unbounded pre-auth memory growth from rotating source keys. (#26050) Thanks @bmendonca3.
 - Security/Compaction audit: remove the post-compaction audit injection message. (#28507) Thanks @fuller-stack-dev and @vincentkoc.
 - Web tools/RFC2544 fake-IP compatibility: allow RFC2544 benchmark range (`198.18.0.0/15`) for trusted web-tool fetch endpoints so proxy fake-IP networking modes do not trigger false SSRF blocks. Landed from contributor PR #31176 by @sunkinux. Thanks @sunkinux.

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { mergeStreamingText } from "./streaming-card.js";
+
+describe("mergeStreamingText", () => {
+  it("prefers the latest full text when it already includes prior text", () => {
+    expect(mergeStreamingText("hello", "hello world")).toBe("hello world");
+  });
+
+  it("keeps previous text when the next partial is empty or redundant", () => {
+    expect(mergeStreamingText("hello", "")).toBe("hello");
+    expect(mergeStreamingText("hello world", "hello")).toBe("hello world");
+  });
+
+  it("appends fragmented chunks without injecting newlines", () => {
+    expect(mergeStreamingText("hello wor", "ld")).toBe("hello world");
+    expect(mergeStreamingText("line1", "line2")).toBe("line1line2");
+  });
+});

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -85,6 +85,24 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+function mergeStreamingText(
+  previousText: string | undefined,
+  nextText: string | undefined,
+): string {
+  const previous = typeof previousText === "string" ? previousText : "";
+  const next = typeof nextText === "string" ? nextText : "";
+  if (!next) {
+    return previous;
+  }
+  if (!previous || next === previous || next.includes(previous)) {
+    return next;
+  }
+  if (previous.includes(next)) {
+    return previous;
+  }
+  return `${previous}${previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n"}${next}`;
+}
+
 /** Streaming card session manager */
 export class FeishuStreamingSession {
   private client: Client;
@@ -235,10 +253,15 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
+    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
+    if (!mergedInput || mergedInput === this.state.currentText) {
+      return;
+    }
+
     // Throttle: skip if updated recently, but remember pending text
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = text;
+      this.pendingText = mergedInput;
       return;
     }
     this.pendingText = null;
@@ -248,8 +271,12 @@ export class FeishuStreamingSession {
       if (!this.state || this.closed) {
         return;
       }
-      this.state.currentText = text;
-      await this.updateCardContent(text, (e) => this.log?.(`Update failed: ${String(e)}`));
+      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
+      if (!mergedText || mergedText === this.state.currentText) {
+        return;
+      }
+      this.state.currentText = mergedText;
+      await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
   }
@@ -261,8 +288,8 @@ export class FeishuStreamingSession {
     this.closed = true;
     await this.queue;
 
-    // Use finalText, or pending throttled text, or current text
-    const text = finalText ?? this.pendingText ?? this.state.currentText;
+    const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
+    const text = finalText ? mergeStreamingText(pendingMerged, finalText) : pendingMerged;
     const apiBase = resolveApiBase(this.creds.domain);
 
     // Only send final update if content differs from what's already displayed

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -85,7 +85,7 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
-function mergeStreamingText(
+export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
 ): string {
@@ -100,7 +100,8 @@ function mergeStreamingText(
   if (previous.includes(next)) {
     return previous;
   }
-  return `${previous}${previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n"}${next}`;
+  // Fallback for fragmented partial chunks: append as-is to avoid losing tokens.
+  return `${previous}${next}`;
 }
 
 /** Streaming card session manager */


### PR DESCRIPTION
## Summary
This PR fixes two Feishu channel reliability issues:

1. `im.message.receive_v1` callback in WS mode could block ACK while awaiting full message processing.
   - Feishu long-connection requires quick callback return.
   - Fix: make callback fire-and-forget and handle errors via `.catch(...)`.

2. Streaming card only showed tail chunks for long replies.
   - Root cause: block streaming delivers incremental chunks, but Feishu streaming card update path treated each chunk as full replacement.
   - Fix: merge incremental text into accumulated content before each update, and also merge on close.

## User-facing impact
- Long or complex Feishu messages no longer silently fail due delayed callback ACK.
- Streaming card keeps full generated content instead of only last lines.

## Root Cause Details
- OpenClaw block streaming pipeline emits chunk payloads (`onBlockReply`) incrementally.
- Feishu streaming session `update(text)` overwrote `currentText` with latest chunk and pushed that to card element content.
- Final visual result looked truncated to tail chunk.

## Changes
- `src/feishu/monitor.ts`
  - Switch WS event handler from `async/await` to synchronous callback with async background processing:
    - `void processFeishuMessage(...).catch(...)`

- `src/feishu/streaming-card.ts`
  - Add `mergeStreamingText(previous, next)` helper.
  - `update(text)` now merges chunk into accumulated content before updating card.
  - `close(finalText)` merges final text with accumulated content and updates once before closing streaming mode.

## Suggested test plan
1. Send a long/complex Feishu message that triggers multi-step tool calls.
2. Verify immediate callback handling (no missing response due ACK timing).
3. Observe streaming card during generation:
   - content should grow progressively,
   - final content should include all previous chunks.
4. Confirm logs contain:
   - `Received Feishu message event`
   - `embedded run done`
   - `Closed streaming session`
   - no `Error processing Feishu message` / `embedded run timeout`.

## Notes
- This patch is logic-only and backwards compatible with current card APIs.
- No config migration required.
