### PR TITLE
fix(agents): preserve thinking/redacted_thinking blocks in stripThoughtSignatures

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -65,6 +65,12 @@ export function stripThoughtSignatures<T>(
     if (!block || typeof block !== "object") {
       return block;
     }
+    // Never modify thinking/redacted_thinking blocks — Anthropic requires these
+    // to be identical to the original API response.
+    const blockType = (block as { type?: unknown }).type;
+    if (blockType === "thinking" || blockType === "redacted_thinking") {
+      return block;
+    }
     const rec = block as ContentBlockWithSignature;
     const stripSnake = shouldStripSignature(rec.thought_signature);
     const stripCamel = includeCamelCase ? shouldStripSignature(rec.thoughtSignature) : false;


### PR DESCRIPTION
## Summary

- `stripThoughtSignatures` removes `thought_signature` fields from content blocks for cross-provider compatibility (e.g. Gemini)
- However, it also modifies `thinking` and `redacted_thinking` blocks via object spread + delete
- Anthropic's API requires these blocks to be **identical** to the original response in the latest assistant message
- On multi-turn conversations, the modified thinking blocks cause the API to reject with: `"thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."`

## Fix

Skip `type: "thinking"` and `type: "redacted_thinking"` blocks in `stripThoughtSignatures` — these blocks should never have their signatures stripped since they must be preserved verbatim for Anthropic.

Fixes #29618

## Reproduction

1. Use Anthropic provider with extended thinking enabled
2. Have a multi-turn conversation in a Discord thread where thinking blocks are stored in session
3. On a subsequent turn, the session history replay modifies the thinking blocks via `sanitizeSessionHistory` → `sanitizeSessionMessagesImages` → `stripThoughtSignatures`
4. API rejects with the error above

## Test plan

- [ ] Verify multi-turn conversations with extended thinking no longer produce "cannot be modified" errors
- [ ] Verify cross-provider signature stripping still works for non-thinking blocks (e.g. text blocks with `thought_signature`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)