### PR TITLE
Feishu: relay chat member events to plugin hooks and export monitor helpers

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -10,6 +10,8 @@ import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
+export { getBotOpenId } from "./src/monitor.js";
+export { createFeishuReplyDispatcher } from "./src/reply-dispatcher.js";
 export {
   sendMessageFeishu,
   sendCardFeishu,

--- a/extensions/feishu/src/exports.test.ts
+++ b/extensions/feishu/src/exports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("feishu extension exports", () => {
+  it("exports createFeishuReplyDispatcher and getBotOpenId", async () => {
+    const mod = await import("../index.js");
+
+    expect(typeof mod.createFeishuReplyDispatcher).toBe("function");
+    expect(typeof mod.getBotOpenId).toBe("function");
+  });
+});

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
@@ -36,6 +37,11 @@ export type FeishuReactionCreatedEvent = {
   operator_type?: string;
   user_id?: { open_id?: string };
   action_time?: string;
+};
+
+type FeishuChatMemberUserEvent = {
+  chat_id?: string;
+  users?: Array<{ name?: string; user_id?: { open_id?: string; union_id?: string } }>;
 };
 
 type ResolveReactionSyntheticEventParams = {
@@ -400,6 +406,13 @@ function registerEventHandlers(
       try {
         const event = data as unknown as FeishuBotAddedEvent;
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_added") && event.chat_id) {
+          void hookRunner.runChatMemberBotAdded(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
       }
@@ -408,8 +421,81 @@ function registerEventHandlers(
       try {
         const event = data as unknown as { chat_id: string };
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_deleted") && event.chat_id) {
+          void hookRunner.runChatMemberBotDeleted(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.added_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuChatMemberUserEvent;
+        const hookRunner = getGlobalHookRunner();
+        if (!hookRunner?.hasHooks("chat_member_user_added") || !event.chat_id) {
+          return;
+        }
+        const users = (event.users ?? [])
+          .filter((u) => u.user_id?.open_id)
+          .map((u) => ({
+            openId: u.user_id!.open_id!,
+            unionId: u.user_id?.union_id,
+            name: u.name,
+          }));
+        void hookRunner.runChatMemberUserAdded(
+          { chatId: event.chat_id, users },
+          { channelId: "feishu", accountId },
+        );
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuChatMemberUserEvent;
+        const hookRunner = getGlobalHookRunner();
+        if (!hookRunner?.hasHooks("chat_member_user_deleted") || !event.chat_id) {
+          return;
+        }
+        const users = (event.users ?? [])
+          .filter((u) => u.user_id?.open_id)
+          .map((u) => ({
+            openId: u.user_id!.open_id!,
+            unionId: u.user_id?.union_id,
+            name: u.name,
+          }));
+        void hookRunner.runChatMemberUserDeleted(
+          { chatId: event.chat_id, users },
+          { channelId: "feishu", accountId },
+        );
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user deleted event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.withdrawn_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuChatMemberUserEvent;
+        const hookRunner = getGlobalHookRunner();
+        if (!hookRunner?.hasHooks("chat_member_user_withdrawn") || !event.chat_id) {
+          return;
+        }
+        const users = (event.users ?? [])
+          .filter((u) => u.user_id?.open_id)
+          .map((u) => ({
+            openId: u.user_id!.open_id!,
+            unionId: u.user_id?.union_id,
+            name: u.name,
+          }));
+        void hookRunner.runChatMemberUserWithdrawn(
+          { chatId: event.chat_id, users },
+          { channelId: "feishu", accountId },
+        );
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user withdrawn event: ${String(err)}`);
       }
     },
     "im.message.reaction.created_v1": async (data) => {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
-import { getGlobalHookRunner } from "openclaw/plugin-sdk";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/compat";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";

--- a/extensions/feishu/src/monitor.events.test.ts
+++ b/extensions/feishu/src/monitor.events.test.ts
@@ -1,0 +1,209 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+const createFeishuWSClientMock = vi.hoisted(() => vi.fn());
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn(() => true),
+  runChatMemberBotAdded: vi.fn(),
+  runChatMemberBotDeleted: vi.fn(),
+  runChatMemberUserAdded: vi.fn(),
+  runChatMemberUserDeleted: vi.fn(),
+  runChatMemberUserWithdrawn: vi.fn(),
+}));
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuWSClient: createFeishuWSClientMock,
+  createEventDispatcher: createEventDispatcherMock,
+}));
+
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => hookRunnerMocks,
+  };
+});
+
+import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
+
+type RegisteredHandlers = Record<string, (data: unknown) => Promise<void>>;
+
+function buildWebSocketConfig(accountId = "default"): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          [accountId]: {
+            enabled: true,
+            appId: "cli_test",
+            appSecret: "secret_test",
+            connectionMode: "websocket",
+          },
+        },
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+async function waitForRegisterCall(registerMock: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    if (registerMock.mock.calls.length > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("event dispatcher handlers were not registered");
+}
+
+async function startMonitorAndGetHandlers(): Promise<{
+  handlers: RegisteredHandlers;
+  stop: () => Promise<void>;
+}> {
+  const registerMock = vi.fn();
+  createEventDispatcherMock.mockReturnValue({ register: registerMock });
+  createFeishuWSClientMock.mockReturnValue({ start: vi.fn() });
+  probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "ou_bot_default" });
+
+  const abortController = new AbortController();
+  const monitorPromise = monitorFeishuProvider({
+    config: buildWebSocketConfig(),
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
+    abortSignal: abortController.signal,
+  });
+
+  await waitForRegisterCall(registerMock);
+  const handlers = registerMock.mock.calls[0]?.[0] as RegisteredHandlers;
+  if (!handlers) {
+    throw new Error("missing registered handlers");
+  }
+
+  return {
+    handlers,
+    stop: async () => {
+      abortController.abort();
+      await monitorPromise;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hookRunnerMocks.hasHooks.mockReturnValue(true);
+});
+
+afterEach(() => {
+  stopFeishuMonitor();
+});
+
+describe("monitorFeishuProvider chat member relay", () => {
+  it("forwards Feishu member events to hook runner with normalized payload", async () => {
+    const { handlers, stop } = await startMonitorAndGetHandlers();
+    try {
+      await handlers["im.chat.member.bot.added_v1"]({
+        chat_id: "oc_group_1",
+        operator_id: { open_id: "ou_operator" },
+        external: false,
+      });
+      await handlers["im.chat.member.bot.deleted_v1"]({
+        chat_id: "oc_group_1",
+      });
+      await handlers["im.chat.member.user.added_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Alice", user_id: { open_id: "ou_alice", union_id: "on_alice" } },
+          { name: "Ghost", user_id: { union_id: "on_ghost" } },
+          { name: "Bob", user_id: { open_id: "ou_bob" } },
+        ],
+      });
+      await handlers["im.chat.member.user.deleted_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Alice", user_id: { open_id: "ou_alice", union_id: "on_alice" } },
+          { name: "NoOpen", user_id: { union_id: "on_none" } },
+        ],
+      });
+      await handlers["im.chat.member.user.withdrawn_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Bob", user_id: { open_id: "ou_bob", union_id: "on_bob" } },
+          { name: "NoOpen", user_id: {} },
+        ],
+      });
+
+      expect(hookRunnerMocks.runChatMemberBotAdded).toHaveBeenCalledWith(
+        { chatId: "oc_group_1" },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberBotDeleted).toHaveBeenCalledWith(
+        { chatId: "oc_group_1" },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserAdded).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [
+            { openId: "ou_alice", unionId: "on_alice", name: "Alice" },
+            { openId: "ou_bob", unionId: undefined, name: "Bob" },
+          ],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserDeleted).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [{ openId: "ou_alice", unionId: "on_alice", name: "Alice" }],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserWithdrawn).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [{ openId: "ou_bob", unionId: "on_bob", name: "Bob" }],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+    } finally {
+      await stop();
+    }
+  });
+
+  it("skips member relay when hook is not registered or chat_id is empty", async () => {
+    const { handlers, stop } = await startMonitorAndGetHandlers();
+    try {
+      hookRunnerMocks.hasHooks.mockReturnValue(false);
+      await handlers["im.chat.member.bot.added_v1"]({ chat_id: "oc_group_1" });
+      await handlers["im.chat.member.user.added_v1"]({
+        chat_id: "oc_group_1",
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      expect(hookRunnerMocks.runChatMemberBotAdded).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserAdded).not.toHaveBeenCalled();
+
+      hookRunnerMocks.hasHooks.mockReturnValue(true);
+      await handlers["im.chat.member.bot.deleted_v1"]({ chat_id: "" });
+      await handlers["im.chat.member.user.deleted_v1"]({
+        chat_id: "",
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      await handlers["im.chat.member.user.withdrawn_v1"]({
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      expect(hookRunnerMocks.runChatMemberBotDeleted).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserDeleted).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserWithdrawn).not.toHaveBeenCalled();
+    } finally {
+      await stop();
+    }
+  });
+});

--- a/extensions/feishu/src/monitor.events.test.ts
+++ b/extensions/feishu/src/monitor.events.test.ts
@@ -22,6 +22,23 @@ vi.mock("./client.js", () => ({
   createEventDispatcher: createEventDispatcherMock,
 }));
 
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  }),
+}));
+
 vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk")>();
   return {

--- a/extensions/feishu/src/monitor.events.test.ts
+++ b/extensions/feishu/src/monitor.events.test.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk/compat";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
@@ -39,8 +39,8 @@ vi.mock("./runtime.js", () => ({
   }),
 }));
 
-vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk")>();
+vi.mock("openclaw/plugin-sdk/compat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/compat")>();
   return {
     ...actual,
     getGlobalHookRunner: () => hookRunnerMocks,

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -150,3 +150,8 @@ export function stopFeishuMonitorState(accountId?: string): void {
   httpServers.clear();
   botOpenIds.clear();
 }
+
+export function getBotOpenId(accountId: string): string | undefined {
+  const value = botOpenIds.get(accountId)?.trim();
+  return value ? value : undefined;
+}

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -8,6 +8,7 @@ import {
 import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
 import {
   clearFeishuWebhookRateLimitStateForTest,
+  getBotOpenId,
   getFeishuWebhookRateLimitStateSizeForTest,
   isWebhookRateLimitedForTest,
   stopFeishuMonitorState,
@@ -22,6 +23,7 @@ export type MonitorFeishuOpts = {
 
 export {
   clearFeishuWebhookRateLimitStateForTest,
+  getBotOpenId,
   getFeishuWebhookRateLimitStateSizeForTest,
   isWebhookRateLimitedForTest,
   resolveReactionSyntheticEvent,

--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/compat";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,7 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/compat";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/compat";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -691,3 +691,7 @@ export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
+
+// Plugin hooks
+export type { HookRunner } from "../plugins/hooks.js";
+export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -18,6 +18,8 @@ import type {
   PluginHookBeforePromptBuildEvent,
   PluginHookBeforePromptBuildResult,
   PluginHookBeforeCompactionEvent,
+  PluginHookChatMemberBotEvent,
+  PluginHookChatMemberUserEvent,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
   PluginHookBeforeResetEvent,
@@ -66,6 +68,8 @@ export type {
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeResetEvent,
   PluginHookAfterCompactionEvent,
+  PluginHookChatMemberBotEvent,
+  PluginHookChatMemberUserEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -418,6 +422,65 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // Chat Member Hooks
+  // =========================================================================
+
+  /**
+   * Run chat_member_user_added hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runChatMemberUserAdded(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_added", event, ctx);
+  }
+
+  /**
+   * Run chat_member_user_deleted hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runChatMemberUserDeleted(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_deleted", event, ctx);
+  }
+
+  /**
+   * Run chat_member_user_withdrawn hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runChatMemberUserWithdrawn(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_withdrawn", event, ctx);
+  }
+
+  /**
+   * Run chat_member_bot_added hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runChatMemberBotAdded(
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_bot_added", event, ctx);
+  }
+
+  /**
+   * Run chat_member_bot_deleted hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runChatMemberBotDeleted(
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_bot_deleted", event, ctx);
+  }
+
+  // =========================================================================
   // Tool Hooks
   // =========================================================================
 
@@ -728,6 +791,12 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runMessageReceived,
     runMessageSending,
     runMessageSent,
+    // Chat member hooks
+    runChatMemberUserAdded,
+    runChatMemberUserDeleted,
+    runChatMemberUserWithdrawn,
+    runChatMemberBotAdded,
+    runChatMemberBotDeleted,
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -320,6 +320,11 @@ export type PluginHookName =
   | "message_received"
   | "message_sending"
   | "message_sent"
+  | "chat_member_user_added"
+  | "chat_member_user_deleted"
+  | "chat_member_user_withdrawn"
+  | "chat_member_bot_added"
+  | "chat_member_bot_deleted"
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
@@ -482,6 +487,17 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+};
+
+// chat_member_user_added / chat_member_user_deleted / chat_member_user_withdrawn hook
+export type PluginHookChatMemberUserEvent = {
+  chatId: string;
+  users: Array<{ openId: string; unionId?: string; name?: string }>;
+};
+
+// chat_member_bot_added / chat_member_bot_deleted hook
+export type PluginHookChatMemberBotEvent = {
+  chatId: string;
 };
 
 // Tool context
@@ -722,6 +738,26 @@ export type PluginHookHandlerMap = {
   ) => Promise<PluginHookMessageSendingResult | void> | PluginHookMessageSendingResult | void;
   message_sent: (
     event: PluginHookMessageSentEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_added: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_deleted: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_withdrawn: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_bot_added: (
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_bot_deleted: (
+    event: PluginHookChatMemberBotEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
   before_tool_call: (


### PR DESCRIPTION
## Summary
This PR adds first-class Feishu member event relay support in the extension monitor and exposes Feishu helper exports needed by plugin integrations.

### What changed
- Added plugin hook dispatch for Feishu membership lifecycle events:
  - `chat_member_user_added`
  - `chat_member_user_deleted`
  - `chat_member_user_withdrawn`
  - `chat_member_bot_added`
  - `chat_member_bot_deleted`
- Added coverage in `extensions/feishu/src/monitor.events.test.ts` for member-event relay behavior.
- Exported Feishu helper APIs from the extension entry:
  - `createFeishuReplyDispatcher`
  - `getBotOpenId`
- Included a small import cleanup in `extensions/feishu/src/monitor.ts` to remove a duplicated hook-runner import.

## Why this should be merged
OpenClaw’s plugin ecosystem depends on stable lifecycle hooks to automate onboarding, moderation, and access control flows. Without these member events, Feishu integrations cannot react when users or bots are added/removed from chats, which limits operational automation and creates behavioral gaps versus other channels.

This PR closes that gap with explicit, tested event wiring and makes helper APIs available for downstream extension/plugin use.

## Why this is important for OpenClaw
- Improves channel parity and consistency of hook semantics across providers.
- Enables real production workflows in Feishu tenants (auto-welcome, membership sync, policy enforcement).
- Reduces custom patching burden for plugin authors by exposing reusable Feishu primitives.

## Validation
- `pnpm vitest run extensions/feishu/src/monitor.events.test.ts extensions/feishu/src/exports.test.ts`
