### PR TITLE
Feishu: harden message pipeline, metadata propagation, and plugin group dispatch

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,27 +162,29 @@
         "line_number": 19
       }
     ],
+    "Dockerfile": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "Dockerfile",
+        "hashed_secret": "5da5edbb9591bed4d6dddf20bd4df9a0fa813e9c",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
     "appcast.xml": [
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "2bc43713edb8f775582c6314953b7c020d691aba",
+        "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "2fcd83b35235522978c19dbbab2884a09aa64f35",
+        "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 209
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "appcast.xml",
-        "hashed_secret": "78b65f0952ed8a557e0f67b2364ff67cb6863bc8",
-        "is_verified": false,
-        "line_number": 310
+        "line_number": 360
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
@@ -194,13 +196,22 @@
         "line_number": 58
       }
     ],
+    "apps/android/app/src/test/java/ai/openclaw/android/voice/TalkModeConfigParsingTest.kt": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/android/app/src/test/java/ai/openclaw/android/voice/TalkModeConfigParsingTest.kt",
+        "hashed_secret": "fa3f8556220674269a6130b0eedd21dec9c033fb",
+        "is_verified": false,
+        "line_number": 46
+      }
+    ],
     "apps/ios/Sources/Gateway/GatewaySettingsStore.swift": [
       {
         "type": "Secret Keyword",
         "filename": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
-        "hashed_secret": "5f7c0c35e552780b67fe1c0ee186764354793be3",
+        "hashed_secret": "6e6d41276590ff54831ec6f800dfa32d5efdf351",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
       }
     ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
@@ -209,7 +220,16 @@
         "filename": "apps/ios/Tests/DeepLinkParserTests.swift",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 105
+      }
+    ],
+    "apps/ios/Tests/TalkModeConfigParsingTests.swift": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/ios/Tests/TalkModeConfigParsingTests.swift",
+        "hashed_secret": "fa3f8556220674269a6130b0eedd21dec9c033fb",
+        "is_verified": false,
+        "line_number": 26
       }
     ],
     "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift": [
@@ -218,23 +238,7 @@
         "filename": "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1492
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
+        "line_number": 1745
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -243,7 +247,7 @@
         "filename": "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift",
         "hashed_secret": "19dad5cecb110281417d1db56b60e1b006d55bb4",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 66
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift": [
@@ -270,7 +274,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 115
       }
     ],
     "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift": [
@@ -279,7 +283,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1492
+        "line_number": 1745
       }
     ],
     "docs/.i18n/zh-CN.tm.jsonl": [
@@ -9611,14 +9615,14 @@
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 187
+        "line_number": 189
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 501
       }
     ],
     "docs/channels/irc.md": [
@@ -9627,7 +9631,7 @@
         "filename": "docs/channels/irc.md",
         "hashed_secret": "d54831b8e4b461d85e32ea82156d2fb5ce5cb624",
         "is_verified": false,
-        "line_number": 191
+        "line_number": 198
       }
     ],
     "docs/channels/line.md": [
@@ -9636,7 +9640,7 @@
         "filename": "docs/channels/line.md",
         "hashed_secret": "83661b43df128631f891767fbfc5b049af3dce86",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 65
       }
     ],
     "docs/channels/matrix.md": [
@@ -9675,6 +9679,15 @@
         "line_number": 104
       }
     ],
+    "docs/channels/telegram.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/channels/telegram.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 807
+      }
+    ],
     "docs/channels/twitch.md": [
       {
         "type": "Secret Keyword",
@@ -9697,21 +9710,21 @@
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "39d711243bfcee9fec8299b204e1aa9c3430fa12",
         "is_verified": false,
-        "line_number": 281
+        "line_number": 301
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "1a8abbf465c52363ab4c9c6ad945b8e857cbea55",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 325
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "b9f640d6095b9f6b5a65983f7b76dbbb254e0044",
         "is_verified": false,
-        "line_number": 706
+        "line_number": 726
       }
     ],
     "docs/concepts/model-providers.md": [
@@ -9720,21 +9733,30 @@
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 226
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "6a4a6c8f2406f4f0843a0a1aae6a320f92f9d6ae",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 386
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "ef83ad68b9b66e008727b7c417c6a8f618b5177e",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 417
+      }
+    ],
+    "docs/design/kilo-gateway-integration.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/design/kilo-gateway-integration.md",
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_verified": false,
+        "line_number": 458
       }
     ],
     "docs/gateway/configuration-examples.md": [
@@ -9757,21 +9779,21 @@
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 336
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 431
+        "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 596
+        "line_number": 613
       }
     ],
     "docs/gateway/configuration-reference.md": [
@@ -9780,70 +9802,70 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 199
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1267
+        "line_number": 1609
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1283
+        "line_number": 1625
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1461
+        "line_number": 1810
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1603
+        "line_number": 1983
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 1631
+        "line_number": 2037
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 1862
+        "line_number": 2269
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 1966
+        "line_number": 2396
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2202
+        "line_number": 2649
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2204
+        "line_number": 2651
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9852,14 +9874,14 @@
         "filename": "docs/gateway/configuration.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 434
+        "line_number": 461
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 462
       }
     ],
     "docs/gateway/local-models.md": [
@@ -9878,13 +9900,38 @@
         "line_number": 124
       }
     ],
+    "docs/gateway/remote.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/gateway/remote.md",
+        "hashed_secret": "7d852a6979e11c7a40c35c63a2ee96edb2dc2c69",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/gateway/remote.md",
+        "hashed_secret": "e1ce9e0c459c8ef30dcadf6fc4e2d50f63a7aa8a",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "docs/gateway/secrets.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/gateway/secrets.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 183
+      }
+    ],
     "docs/gateway/tailscale.md": [
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/tailscale.md",
         "hashed_secret": "9cb0dc5383312aa15b9dc6745645bde18ff5ade9",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 86
       }
     ],
     "docs/help/environment.md": [
@@ -9909,35 +9956,44 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 1412
+        "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 1689
+        "line_number": 1780
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 1690
+        "line_number": 1781
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2118
+        "line_number": 2209
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2398
+        "line_number": 2489
+      }
+    ],
+    "docs/help/testing.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/help/testing.md",
+        "hashed_secret": "e008bed242a21b8279c220f84ba16019a67a9dd4",
+        "is_verified": false,
+        "line_number": 94
       }
     ],
     "docs/install/macos-vm.md": [
@@ -9964,7 +10020,16 @@
         "filename": "docs/perplexity.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 29
+      }
+    ],
+    "docs/platforms/raspberry-pi.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/platforms/raspberry-pi.md",
+        "hashed_secret": "66eba27d45030064a428078cf4d510002a445f27",
+        "is_verified": false,
+        "line_number": 200
       }
     ],
     "docs/plugins/voice-call.md": [
@@ -9973,7 +10038,7 @@
         "filename": "docs/plugins/voice-call.md",
         "hashed_secret": "cb46980ce5532f18440dff4bbbe097896a8c08c8",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 254
       }
     ],
     "docs/providers/anthropic.md": [
@@ -9991,7 +10056,7 @@
         "filename": "docs/providers/claude-max-api-proxy.md",
         "hashed_secret": "b5c2827eb65bf13b87130e7e3c424ba9ff07cd67",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 86
       }
     ],
     "docs/providers/glm.md": [
@@ -10001,6 +10066,22 @@
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
         "line_number": 24
+      }
+    ],
+    "docs/providers/kilocode.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/providers/kilocode.md",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/providers/kilocode.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 35
       }
     ],
     "docs/providers/litellm.md": [
@@ -10025,14 +10106,23 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 149
+      }
+    ],
+    "docs/providers/mistral.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/providers/mistral.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "docs/providers/moonshot.md": [
@@ -10041,7 +10131,7 @@
         "filename": "docs/providers/moonshot.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 49
       }
     ],
     "docs/providers/nvidia.md": [
@@ -10059,7 +10149,7 @@
         "filename": "docs/providers/ollama.md",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 37
       }
     ],
     "docs/providers/openai.md": [
@@ -10068,7 +10158,7 @@
         "filename": "docs/providers/openai.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       }
     ],
     "docs/providers/opencode.md": [
@@ -10148,13 +10238,38 @@
         "line_number": 27
       }
     ],
+    "docs/reference/secretref-user-supplied-credentials-matrix.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/secretref-user-supplied-credentials-matrix.json",
+        "hashed_secret": "d6c8cbcbe34bf0e02cf1a52e27afcf18b59b3f79",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/secretref-user-supplied-credentials-matrix.json",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "docs/start/wizard-cli-automation.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/start/wizard-cli-automation.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 155
+      }
+    ],
     "docs/tools/browser.md": [
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/tools/browser.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 149
       }
     ],
     "docs/tools/firecrawl.md": [
@@ -10172,7 +10287,7 @@
         "filename": "docs/tools/skills-config.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       }
     ],
     "docs/tools/skills.md": [
@@ -10181,7 +10296,7 @@
         "filename": "docs/tools/skills.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 200
       }
     ],
     "docs/tools/web.md": [
@@ -10190,28 +10305,35 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
-        "hashed_secret": "96c682c88ed551f22fe76d206c2dfb7df9221ad9",
+        "hashed_secret": "4a9fd550cf205ab06ee932f41a132ff53cb83d83",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/tools/web.md",
+        "hashed_secret": "1ccebc9638f47c80fc388173e346b2fa51178cca",
+        "is_verified": false,
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 179
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 235
+        "line_number": 277
       }
     ],
     "docs/tts.md": [
@@ -10227,7 +10349,16 @@
         "filename": "docs/tts.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 101
+      }
+    ],
+    "docs/vps.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/vps.md",
+        "hashed_secret": "66eba27d45030064a428078cf4d510002a445f27",
+        "is_verified": false,
+        "line_number": 60
       }
     ],
     "docs/zh-CN/brave-search.md": [
@@ -10261,7 +10392,7 @@
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 445
+        "line_number": 509
       }
     ],
     "docs/zh-CN/channels/line.md": [
@@ -10806,37 +10937,37 @@
         "filename": "extensions/bluebubbles/src/actions.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 54
       }
     ],
     "extensions/bluebubbles/src/attachments.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "db1530e1ea43af094d3d75b8dbaf19a4a182a318",
         "is_verified": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "extensions/bluebubbles/src/attachments.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 103
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 260
       }
     ],
     "extensions/bluebubbles/src/chat.test.ts": [
@@ -10845,42 +10976,51 @@
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 115
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "faacad0ce4ea1c19b46e128fd79679d37d3d331d",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "4dcc26a1d99532846fedf1265df4f40f4e0005b8",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 239
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "fd2a721f7be1ee3d691a011affcdb11d0ca365a8",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 302
+      }
+    ],
+    "extensions/bluebubbles/src/config-schema.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/config-schema.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 8
       }
     ],
     "extensions/bluebubbles/src/monitor.test.ts": [
@@ -10889,14 +11029,37 @@
         "filename": "extensions/bluebubbles/src/monitor.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 169
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/monitor.test.ts",
+        "hashed_secret": "891f33ddd2af62f77eab3b7aac8d4874acc093e4",
+        "is_verified": false,
+        "line_number": 2394
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.test.ts",
+        "hashed_secret": "01ee85f364fd0a345244d10a59d73b9f28b2e8da",
+        "is_verified": false,
+        "line_number": 2398
+      }
+    ],
+    "extensions/bluebubbles/src/monitor.webhook-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.webhook-auth.test.ts",
+        "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.webhook-auth.test.ts",
         "hashed_secret": "1ae0af3fe72b3ba394f9fa95a6cffc090d726c23",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 514
       }
     ],
     "extensions/bluebubbles/src/reactions.test.ts": [
@@ -10905,28 +11068,28 @@
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 192
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a4a05c9a6449eb9d6cdac81dd7edc49230e327e6",
         "is_verified": false,
-        "line_number": 209
+        "line_number": 223
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a2833da9f0a16f09994754d0a31749cecf8c8c77",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 295
       }
     ],
     "extensions/bluebubbles/src/send.test.ts": [
@@ -10935,14 +11098,14 @@
         "filename": "extensions/bluebubbles/src/send.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/send.test.ts",
         "hashed_secret": "faacad0ce4ea1c19b46e128fd79679d37d3d331d",
         "is_verified": false,
-        "line_number": 692
+        "line_number": 757
       }
     ],
     "extensions/bluebubbles/src/targets.test.ts": [
@@ -10951,16 +11114,7 @@
         "filename": "extensions/bluebubbles/src/targets.test.ts",
         "hashed_secret": "a3af2fb0c1e2a30bb038049e1e4b401593af6225",
         "is_verified": false,
-        "line_number": 61
-      }
-    ],
-    "extensions/bluebubbles/src/targets.ts": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "extensions/bluebubbles/src/targets.ts",
-        "hashed_secret": "a3af2fb0c1e2a30bb038049e1e4b401593af6225",
-        "is_verified": false,
-        "line_number": 265
+        "line_number": 62
       }
     ],
     "extensions/copilot-proxy/index.ts": [
@@ -10970,6 +11124,22 @@
         "hashed_secret": "50f013532a9770a2c2cfdc38b7581dd01df69b70",
         "is_verified": false,
         "line_number": 9
+      }
+    ],
+    "extensions/diagnostics-otel/src/service.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/diagnostics-otel/src/service.test.ts",
+        "hashed_secret": "e6aa9dc072fcb9dbe42761f25c976143c39d3deb",
+        "is_verified": false,
+        "line_number": 332
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/diagnostics-otel/src/service.test.ts",
+        "hashed_secret": "7e634f2e8cbddf340740ee856bf272aaa6d6d770",
+        "is_verified": false,
+        "line_number": 352
       }
     ],
     "extensions/feishu/skills/feishu-doc/SKILL.md": [
@@ -10990,6 +11160,80 @@
         "line_number": 40
       }
     ],
+    "extensions/feishu/src/accounts.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "e066a1720c6745f87bad43d4dc1206a6beaf4298",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "32db07403e892e96ab02693d38bffb2777e82c94",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "b72c7c889dbb48caa14157494693a442309d9f08",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "d15b430d272b72b4149afe9098236dd161888d76",
+        "is_verified": false,
+        "line_number": 167
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "ea45a4958bbb18451e1d48aa90745cb35a508b29",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "3017efcbcc4d30831b27c2793bac8e7ea61c905a",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "d71458b8c536cd76e92e54286dcd2185ed011c55",
+        "is_verified": false,
+        "line_number": 356
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "125c847c4eb45e28be988a135af24751c880f68a",
+        "is_verified": false,
+        "line_number": 361
+      }
+    ],
+    "extensions/feishu/src/bot.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/bot.test.ts",
+        "hashed_secret": "6ccf7c8dbcc240973f7793b6bbc8f1d5e6efd4b1",
+        "is_verified": false,
+        "line_number": 1229
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/bot.test.ts",
+        "hashed_secret": "1962fc9032fed7c415a657282d617ba80e82f884",
+        "is_verified": false,
+        "line_number": 1292
+      }
+    ],
     "extensions/feishu/src/channel.test.ts": [
       {
         "type": "Secret Keyword",
@@ -10999,13 +11243,140 @@
         "line_number": 21
       }
     ],
+    "extensions/feishu/src/chat.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/chat.test.ts",
+        "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
+        "is_verified": false,
+        "line_number": 32
+      }
+    ],
+    "extensions/feishu/src/client.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "2e8a3d5cbfeb3818c59b66a9f0bf3b80990489f3",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "cfc5057763ea7dabd5c6f7325c0d39c9b8d1baf1",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "8636f9964c42d12b2d698204e426276c41df66d1",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "2e59eff806170ad50c34e3372faef694874fae93",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "f4e4e5f8d09c24c2863cceca031e94154a63e138",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "e55783e61a4f2ae1efd1d1ccb142c902c473ef86",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "67db48d9a41265dfca56d8b198f3e28ee9b6bbcb",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "f546848b2bf72fec2651db6b80e5592fda678e2f",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "c7c5ddbf5e808a49ef38791caf8563c0bc0da434",
+        "is_verified": false,
+        "line_number": 241
+      }
+    ],
+    "extensions/feishu/src/config-schema.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "d25db33e5c07ac669f08da0adc2bde73b15ee929",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "8437d84cae482d10a2b9fd3f555d45006979e4be",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "32db07403e892e96ab02693d38bffb2777e82c94",
+        "is_verified": false,
+        "line_number": 174
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "2bd27e71d7e14bbd5ac1576290ed6074dc450b5a",
+        "is_verified": false,
+        "line_number": 185
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 205
+      }
+    ],
+    "extensions/feishu/src/docx.account-selection.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/docx.account-selection.test.ts",
+        "hashed_secret": "db2b80fd220b75be76e698a9164f989baf731caf",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/docx.account-selection.test.ts",
+        "hashed_secret": "57cb5f8d57e1a3c1bcf90d73e103af6a775591a6",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     "extensions/feishu/src/docx.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/feishu/src/docx.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 124
       }
     ],
     "extensions/feishu/src/media.test.ts": [
@@ -11014,7 +11385,101 @@
         "filename": "extensions/feishu/src/media.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 66
+      }
+    ],
+    "extensions/feishu/src/monitor.reaction.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/monitor.reaction.test.ts",
+        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
+        "is_verified": false,
+        "line_number": 80
+      }
+    ],
+    "extensions/feishu/src/monitor.startup.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/monitor.startup.test.ts",
+        "hashed_secret": "d7a9ded2b0088bfe63414c6a8e4696ddf8e8a00d",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    "extensions/feishu/src/monitor.webhook-security.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/monitor.webhook-security.test.ts",
+        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
+        "is_verified": false,
+        "line_number": 91
+      }
+    ],
+    "extensions/feishu/src/onboarding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "2e8a3d5cbfeb3818c59b66a9f0bf3b80990489f3",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "d5fc216f56ec5ef58691c854104ba78667d9efad",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "d819cf9769641b789fc8f539e0cd8cbe5606e057",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "72b6d12b3e7034420015375375466c37ec68be51",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "extensions/feishu/src/probe.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
+        "is_verified": false,
+        "line_number": 195
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "4205714cdfe14ed9e3d030ddf7887781b964f510",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "5a718c07b29bb4cd5fafb4a3ad377efc2dad9a59",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "5da0807f9682b03d10b7906c5d2312d46368500c",
+        "is_verified": false,
+        "line_number": 219
       }
     ],
     "extensions/feishu/src/reply-dispatcher.test.ts": [
@@ -11023,16 +11488,23 @@
         "filename": "extensions/feishu/src/reply-dispatcher.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
+    "extensions/feishu/src/tool-account-routing.test.ts": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/tool-account-routing.test.ts",
+        "hashed_secret": "db2b80fd220b75be76e698a9164f989baf731caf",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/tool-account-routing.test.ts",
+        "hashed_secret": "57cb5f8d57e1a3c1bcf90d73e103af6a775591a6",
+        "is_verified": false,
+        "line_number": 43
       }
     ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
@@ -11041,7 +11513,32 @@
         "filename": "extensions/google-gemini-cli-auth/oauth.test.ts",
         "hashed_secret": "021343c1f561d7bcbc3b513df45cc3a6baf67b43",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/google-gemini-cli-auth/oauth.test.ts",
+        "hashed_secret": "07d1db7c4a73c573d6d038b3d26194a7957c513c",
+        "is_verified": false,
+        "line_number": 311
+      }
+    ],
+    "extensions/googlechat/src/api.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/googlechat/src/api.test.ts",
+        "hashed_secret": "bc7bd07bb0114ca5928ca561817efc6cd7083966",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "extensions/googlechat/src/channel.outbound.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/googlechat/src/channel.outbound.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 50
       }
     ],
     "extensions/irc/src/accounts.ts": [
@@ -11050,7 +11547,7 @@
         "filename": "extensions/irc/src/accounts.ts",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 24
       }
     ],
     "extensions/irc/src/client.test.ts": [
@@ -11075,7 +11572,7 @@
         "filename": "extensions/line/src/channel.startup.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 94
       }
     ],
     "extensions/matrix/src/matrix/accounts.test.ts": [
@@ -11112,13 +11609,36 @@
         "line_number": 8
       }
     ],
+    "extensions/mattermost/src/normalize.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "713ecccd228f49a6068bedd7a64510b50b4284e5",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "a8e2493e7579ba630d56b2552d5fd2a7198ad943",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "9a33401dd4f9784482d2db77bbe93d99cea1a571",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
     "extensions/memory-lancedb/config.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/memory-lancedb/config.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 105
       }
     ],
     "extensions/memory-lancedb/index.test.ts": [
@@ -11130,6 +11650,15 @@
         "line_number": 71
       }
     ],
+    "extensions/msteams/src/monitor.lifecycle.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/msteams/src/monitor.lifecycle.test.ts",
+        "hashed_secret": "5a21585c3dfc2797afe4634fa150d996f4ef5b5e",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
     "extensions/msteams/src/probe.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11139,20 +11668,45 @@
         "line_number": 35
       }
     ],
+    "extensions/msteams/src/token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/msteams/src/token.test.ts",
+        "hashed_secret": "5a21585c3dfc2797afe4634fa150d996f4ef5b5e",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
     "extensions/nextcloud-talk/src/accounts.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/nextcloud-talk/src/accounts.ts",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/nextcloud-talk/src/accounts.ts",
         "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 169
+      }
+    ],
+    "extensions/nextcloud-talk/src/channel.startup.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/channel.startup.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/channel.startup.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 25
       }
     ],
     "extensions/nextcloud-talk/src/channel.ts": [
@@ -11161,7 +11715,34 @@
         "filename": "extensions/nextcloud-talk/src/channel.ts",
         "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 408
+      }
+    ],
+    "extensions/nextcloud-talk/src/inbound.authz.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/inbound.authz.test.ts",
+        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "extensions/nextcloud-talk/src/monitor.test-fixtures.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/monitor.test-fixtures.ts",
+        "hashed_secret": "ade798b3f263721ee0f791976a535c8c970644e1",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "extensions/nextcloud-talk/src/send.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/send.test.ts",
+        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
+        "is_verified": false,
+        "line_number": 11
       }
     ],
     "extensions/nostr/README.md": [
@@ -11171,6 +11752,36 @@
         "hashed_secret": "edeb23e25a619c434d22bb7f1c3ca4841166b4e8",
         "is_verified": false,
         "line_number": 46
+      }
+    ],
+    "extensions/nostr/src/channel.outbound.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "ce4303f6b22257d9c9cf314ef1dee4707c6e1c13",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "ce4303f6b22257d9c9cf314ef1dee4707c6e1c13",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "e8b2cccf31904f5d9c62838922648cfeaa4c07e0",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "44682b9fe21c229330c1e5cf9c414d4267d97719",
+        "is_verified": false,
+        "line_number": 66
       }
     ],
     "extensions/nostr/src/channel.test.ts": [
@@ -11287,7 +11898,7 @@
         "filename": "extensions/nostr/src/types.test.ts",
         "hashed_secret": "3bee216ebc256d692260fc3adc765050508fef5e",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 141
       }
     ],
     "extensions/open-prose/skills/prose/SKILL.md": [
@@ -11313,6 +11924,38 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 200
+      }
+    ],
+    "extensions/slack/src/channel.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "514f52b114ae97e309055b6f419798569dc48a2b",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 219
+      }
+    ],
+    "extensions/telegram/src/channel.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/telegram/src/channel.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 136
       }
     ],
     "extensions/twitch/src/onboarding.test.ts": [
@@ -11355,7 +11998,7 @@
         "filename": "extensions/voice-call/src/config.test.ts",
         "hashed_secret": "62207a469ec2fdcfc7d66b04c2980ac1501acbf0",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 79
       }
     ],
     "extensions/voice-call/src/providers/telnyx.test.ts": [
@@ -11374,15 +12017,6 @@
         "hashed_secret": "f51aaee16a4a756d287f126b99c081b73cba7f15",
         "is_verified": false,
         "line_number": 41
-      }
-    ],
-    "extensions/zalo/src/monitor.webhook.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "extensions/zalo/src/monitor.webhook.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 40
       }
     ],
     "skills/1password/references/cli-examples.md": [
@@ -11412,82 +12046,231 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
+    "src/acp/server.startup.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
+        "filename": "src/acp/server.startup.test.ts",
+        "hashed_secret": "60fe331dc434ac211c53f33da22a384aa0e3fec5",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "src/agents/auth-profiles.ensureauthprofilestore.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles.ensureauthprofilestore.test.ts",
+        "hashed_secret": "8ddd0305a1eb20fe22788ed63039576ffacf7d71",
+        "is_verified": false,
+        "line_number": 133
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles.ensureauthprofilestore.test.ts",
+        "hashed_secret": "f5063c3b092a24f182994723b16c4099a729da57",
+        "is_verified": false,
+        "line_number": 213
+      }
+    ],
+    "src/agents/auth-profiles.runtime-snapshot-save.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles.runtime-snapshot-save.test.ts",
+        "hashed_secret": "d26d39b8e2fd0e94133676613ac2b991d6323ec9",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "0775624b6a8da2aaf29e334372656c1b657c21b7",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "src/agents/auth-profiles/oauth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "eb1b3cd7ed5e769be25068fb6710cbbc19114d44",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "be8183812dd703839c1cbe55e6f9dc70b39dd14c",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "451dcebaa3609554e8042c6086376c4e1a8acc5f",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "ae6d23da3631e931bb3dc6ce23102be1b63b5de6",
+        "is_verified": false,
+        "line_number": 285
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "dd49f08a7746d9d6801e25ff98d71fcba99396f8",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.test.ts",
+        "hashed_secret": "a169e848e41c57e4793ce20019bf0f69a3072808",
+        "is_verified": false,
+        "line_number": 384
+      }
+    ],
+    "src/agents/compaction.identifier-preservation.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/compaction.identifier-preservation.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "src/agents/compaction.tool-result-details.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/compaction.tool-result-details.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 67
       }
     ],
-    "src/agents/memory-search.e2e.test.ts": [
+    "src/agents/memory-search.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
+        "filename": "src/agents/memory-search.test.ts",
         "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 191
       }
     ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
+    "src/agents/minimax-vlm.normalizes-api-key.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
+        "filename": "src/agents/minimax-vlm.normalizes-api-key.test.ts",
         "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/minimax-vlm.normalizes-api-key.test.ts",
+        "hashed_secret": "bcdec29c5e1ade0fc995c3a18862f0111e51a998",
+        "is_verified": false,
+        "line_number": 56
       }
     ],
-    "src/agents/model-auth.e2e.test.ts": [
+    "src/agents/model-auth-label.test.ts": [
+      {
+        "type": "GitHub Token",
+        "filename": "src/agents/model-auth-label.test.ts",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 35
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth-label.test.ts",
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "src/agents/model-auth.profiles.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 194
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 208
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 219
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
+        "hashed_secret": "b17453920671d0cb8a415b649a066b3df3d36fb0",
+        "is_verified": false,
+        "line_number": 253
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 286
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_verified": false,
-        "line_number": 319
+        "line_number": 301
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 333
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 344
+      }
+    ],
+    "src/agents/model-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 10
       }
     ],
     "src/agents/model-auth.ts": [
@@ -11497,6 +12280,13 @@
         "hashed_secret": "8956265d216d474a080edaa97880d37fc1386f33",
         "is_verified": false,
         "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 93
       }
     ],
     "src/agents/models-config.e2e-harness.ts": [
@@ -11505,32 +12295,96 @@
         "filename": "src/agents/models-config.e2e-harness.ts",
         "hashed_secret": "7cf31e8b6cda49f70c31f1f25af05d46f924142d",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 130
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
+    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "2a9da819718779deba96d5aee1d1f4948047c2bd",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 46
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "fa9144b340ea7886885669e2e7a808c86ee14a07",
         "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
+        "line_number": 117
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "565a8d87240aae631d7a901c1f697d46ee141a7b",
+        "is_verified": false,
+        "line_number": 214
+      }
+    ],
+    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts",
         "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 17
+      }
+    ],
+    "src/agents/models-config.providers.google-antigravity.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.google-antigravity.test.ts",
+        "hashed_secret": "65ef0bf81fc443b3e15a494151196f38c8273c96",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "src/agents/models-config.providers.kilocode.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.kilocode.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "src/agents/models-config.providers.kimi-coding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.kimi-coding.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "src/agents/models-config.providers.normalize-keys.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "ba4d38e2a7e8c718913887136d2526351d05cd69",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "b9cdfe69a75e4f2491bcbaf1934ab5e4fd69eb6b",
+        "is_verified": false,
+        "line_number": 52
       }
     ],
     "src/agents/models-config.providers.nvidia.test.ts": [
@@ -11546,38 +12400,54 @@
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 22
       }
     ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
+    "src/agents/models-config.providers.ollama.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.ollama.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
+        "line_number": 54
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.ollama.test.ts",
+        "hashed_secret": "3148ad4aafbeefee82355e1cde29b6d77ba4cf21",
+        "is_verified": false,
+        "line_number": 248
+      }
+    ],
+    "src/agents/models-config.providers.qianfan.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.qianfan.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 11
       }
     ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
+    "src/agents/models-config.providers.volcengine-byteplus.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.volcengine-byteplus.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts",
         "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
         "is_verified": false,
         "line_number": 100
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts",
         "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
         "is_verified": false,
         "line_number": 113
@@ -11589,7 +12459,39 @@
         "filename": "src/agents/openai-responses.reasoning-replay.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 92
+      }
+    ],
+    "src/agents/owner-display.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/owner-display.test.ts",
+        "hashed_secret": "e9dc4e431a9043d0d7d2750af1189e77e2834877",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/owner-display.test.ts",
+        "hashed_secret": "d9d2f263c630f79c8eb176dbccfef7c3ade3ddcc",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
+    "src/agents/pi-embedded-runner-extraparams.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-embedded-runner-extraparams.test.ts",
+        "hashed_secret": "4604122d2d19b953716499c7fade74e3db0ad17f",
+        "is_verified": false,
+        "line_number": 1075
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-embedded-runner-extraparams.test.ts",
+        "hashed_secret": "81181bf462a0965325a629cff91f511e285d59d4",
+        "is_verified": false,
+        "line_number": 1133
       }
     ],
     "src/agents/pi-embedded-runner.e2e.test.ts": [
@@ -11598,14 +12500,16 @@
         "filename": "src/agents/pi-embedded-runner.e2e.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 127
-      },
+        "line_number": 122
+      }
+    ],
+    "src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/pi-embedded-runner.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 140
       }
     ],
     "src/agents/pi-embedded-runner/model.ts": [
@@ -11614,7 +12518,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 232
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [
@@ -11623,16 +12527,73 @@
         "filename": "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
+    "src/agents/pi-extensions/compaction-safeguard.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
+        "is_verified": false,
+        "line_number": 665
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
+        "is_verified": false,
+        "line_number": 811
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 1490
+      }
+    ],
+    "src/agents/pi-model-discovery.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-model-discovery.ts",
+        "hashed_secret": "c218e39efa2e1aae69f39d2054528369ce1e1f46",
+        "is_verified": false,
+        "line_number": 124
+      }
+    ],
+    "src/agents/sandbox/browser.novnc-url.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/browser.novnc-url.test.ts",
+        "hashed_secret": "16c002d49d19805aa1bfba58e9c90b5476054b07",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/browser.novnc-url.test.ts",
+        "hashed_secret": "7ce0359f12857f2a90c7de465f40a95f01cb5da9",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "src/agents/sandbox/novnc-auth.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/novnc-auth.ts",
+        "hashed_secret": "928411b79ff1a026960bc787f1442a6720a21ca3",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "src/agents/sandbox/sanitize-env-vars.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/sanitize-env-vars.test.ts",
+        "hashed_secret": "c747c6b0a7bb9c6337b81875af1a9f9568c740ad",
+        "is_verified": false,
+        "line_number": 8
       }
     ],
     "src/agents/sanitize-for-prompt.test.ts": [
@@ -11644,65 +12605,141 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
+    "src/agents/session-transcript-repair.attachments.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "filename": "src/agents/session-transcript-repair.attachments.test.ts",
+        "hashed_secret": "d25df4833026f016b73dcfa20f33bf753daf7593",
         "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
+        "filename": "src/agents/session-transcript-repair.attachments.test.ts",
+        "hashed_secret": "30b1e9e71b6de9c2d579657e551b95f7eaae406d",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "src/agents/skills-install.download.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/agents/skills-install.download.test.ts",
+        "hashed_secret": "459acf71d00174faf13cfeee88513702c82d3cb3",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts",
+        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "is_verified": false,
+        "line_number": 118
+      }
+    ],
+    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
+    "src/agents/skills.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.test.ts",
         "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
         "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
+        "line_number": 278
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
+        "line_number": 317
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "895900e6b5d30fa84fbff6e4e4c10eb5a63c5f8f",
+        "is_verified": false,
+        "line_number": 392
+      }
+    ],
+    "src/agents/system-prompt.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/system-prompt.test.ts",
+        "hashed_secret": "0a111adae31992afa2873148fdfcaf39e70ec7d8",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/system-prompt.test.ts",
+        "hashed_secret": "2b3140fdd098f7cb2af72632ac2c0df772b8e90a",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
+    "src/agents/tools/pdf-tool.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/pdf-tool.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "src/agents/tools/web-fetch.ssrf.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-fetch.ssrf.test.ts",
         "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 84
       }
     ],
-    "src/agents/tools/web-search.e2e.test.ts": [
+    "src/agents/tools/web-search.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
+        "filename": "src/agents/tools/web-search.test.ts",
         "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "1561970702b4bf5bb10266b292e545ec14fc602e",
+        "is_verified": false,
+        "line_number": 224
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "c930e4d402a279c3feea98578f716d5665c8cc5d",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "5c1a5088b7790a73e236f21d65a5e4384a742af0",
+        "is_verified": false,
+        "line_number": 231
       }
     ],
     "src/agents/tools/web-search.ts": [
@@ -11711,85 +12748,85 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 97
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
-        "is_verified": false,
-        "line_number": 285
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "c4865ff9250aca23b0d98eb079dad70ebec1cced",
-        "is_verified": false,
-        "line_number": 295
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "527ee41f36386e85fa932ef09471ca017f3c95c8",
-        "is_verified": false,
-        "line_number": 298
+        "line_number": 254
       }
     ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
+    "src/agents/tools/web-tools.enabled-defaults.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "f6558c30641dd2d38c6e8e7389dd724327c9627e",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 53
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "59fa0cc80b21eb4ea49590dc887b95f5ae7e0bf5",
         "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
+        "line_number": 55
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "354a920b3d519d11b737695308dab1bfcf77dbb3",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "7ec282d2630c12bf9241ef44db50f1f780cdaa79",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "8ba65d9239fd59ffc16e202cb480d15e35bce964",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "fb724421f6f4a53c0a73101ea88e4090cabb7b1a",
+        "is_verified": false,
+        "line_number": 461
+      }
+    ],
+    "src/agents/tools/web-tools.fetch.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.fetch.test.ts",
         "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
         "is_verified": false,
-        "line_number": 246
+        "line_number": 133
       }
     ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
+    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 60
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 142
       }
     ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
+    "src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "type": "Hex High Entropy String",
+        "filename": "src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts",
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
+        "line_number": 216
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11807,7 +12844,14 @@
         "filename": "src/browser/bridge-server.auth.test.ts",
         "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 72
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/browser/bridge-server.auth.test.ts",
+        "hashed_secret": "26aaf463d1d85670b71c6a84a2f644ad5995efc8",
+        "is_verified": false,
+        "line_number": 93
       }
     ],
     "src/browser/browser-utils.test.ts": [
@@ -11816,14 +12860,14 @@
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "4e126c049580d66ca1549fa534d95a7263f27f46",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 43
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 164
       }
     ],
     "src/browser/cdp.test.ts": [
@@ -11832,7 +12876,23 @@
         "filename": "src/browser/cdp.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 243
+      }
+    ],
+    "src/channels/account-snapshot-fields.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/channels/account-snapshot-fields.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/channels/account-snapshot-fields.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 11
       }
     ],
     "src/channels/plugins/plugins-channel.test.ts": [
@@ -11841,16 +12901,107 @@
         "filename": "src/channels/plugins/plugins-channel.test.ts",
         "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
+    "src/cli/acp-cli.option-collisions.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
+        "filename": "src/cli/acp-cli.option-collisions.test.ts",
+        "hashed_secret": "e5d0d3f3697f96d69545f36ab2eaf1f9d4e2a8f8",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/acp-cli.option-collisions.test.ts",
+        "hashed_secret": "8eac0f7ffe62469bf88ebdb208115f1ce3567d07",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
+    "src/cli/command-secret-gateway.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/command-secret-gateway.test.ts",
+        "hashed_secret": "68c46e84d76d2e7e686e5158bf598909abd4e45b",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/command-secret-gateway.test.ts",
+        "hashed_secret": "3a20a67d6535d75cf0852a72a37e9c5a8fdb9976",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "src/cli/command-secret-gateway.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/command-secret-gateway.ts",
+        "hashed_secret": "41eaab877ca3a0e3aa14f5a4b7981f590e3c2bd6",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "src/cli/config-cli.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/config-cli.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 200
+      }
+    ],
+    "src/cli/daemon-cli/register-service-commands.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/daemon-cli/register-service-commands.test.ts",
+        "hashed_secret": "d717176567cedb0012b6b5f4653f688bbb9ccb8b",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "src/cli/daemon-cli/status.gather.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/daemon-cli/status.gather.test.ts",
+        "hashed_secret": "c09520299bf32111c9f2ebafaf5a9981ec51a91d",
+        "is_verified": false,
+        "line_number": 208
+      }
+    ],
+    "src/cli/program/register.onboard.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/program/register.onboard.test.ts",
+        "hashed_secret": "5da1c2e689ee66cf379bc74d3eafd0460db70ca0",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "src/cli/qr-cli.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "8fc5be300f480d027174b514b563e77548b636f2",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 235
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "4316c1b21634c0e3f4d53bfb3ca2f48dde69bc4e",
+        "is_verified": false,
+        "line_number": 290
       }
     ],
     "src/cli/update-cli.test.ts": [
@@ -11859,51 +13010,73 @@
         "filename": "src/cli/update-cli.test.ts",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 277
       }
     ],
-    "src/commands/auth-choice.e2e.test.ts": [
+    "src/commands/auth-choice.apply-helpers.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 454
+        "line_number": 105
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "bea2f7b64fab8d1d414d0449530b1e088d36d5b1",
         "is_verified": false,
-        "line_number": 487
+        "line_number": 111
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "d23a3625f8598b9cd747e74c1f1676f5ba7be530",
         "is_verified": false,
-        "line_number": 549
+        "line_number": 330
+      }
+    ],
+    "src/commands/auth-choice.apply-helpers.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.apply-helpers.ts",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "src/commands/auth-choice.apply.minimax.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.apply.minimax.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 162
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
+        "filename": "src/commands/auth-choice.apply.minimax.test.ts",
+        "hashed_secret": "c090713b544ae4cabb48f2153079955947c6e013",
         "is_verified": false,
-        "line_number": 584
-      },
+        "line_number": 175
+      }
+    ],
+    "src/commands/auth-choice.apply.openai.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
+        "filename": "src/commands/auth-choice.apply.openai.test.ts",
+        "hashed_secret": "c5831e54ef6edcf968300daf4a9a84580bc2ed37",
         "is_verified": false,
-        "line_number": 726
-      },
+        "line_number": 31
+      }
+    ],
+    "src/commands/auth-choice.apply.volcengine-byteplus.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
+        "filename": "src/commands/auth-choice.apply.volcengine-byteplus.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 798
+        "line_number": 55
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11915,29 +13088,105 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
+    "src/commands/auth-choice.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 679
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "c5831e54ef6edcf968300daf4a9a84580bc2ed37",
         "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
+        "line_number": 745
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
+        "is_verified": false,
+        "line_number": 955
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "1c62e8a666fb3e1b8c9b0c1cab8e1d6bbb136580",
+        "is_verified": false,
+        "line_number": 1065
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
+        "is_verified": false,
+        "line_number": 1222
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
+        "is_verified": false,
+        "line_number": 1234
+      }
+    ],
+    "src/commands/channels.config-only-status-output.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/channels.config-only-status-output.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/channels.config-only-status-output.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 150
+      }
+    ],
+    "src/commands/configure.gateway-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.test.ts",
+        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
+    "src/commands/daemon-install-helpers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/daemon-install-helpers.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 128
+      }
+    ],
+    "src/commands/doctor-gateway-auth-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-gateway-auth-token.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-gateway-auth-token.test.ts",
+        "hashed_secret": "0b75f28abf6b39a10d1398ce5a95e93a5cebbbda",
+        "is_verified": false,
+        "line_number": 206
       }
     ],
     "src/commands/doctor-memory-search.test.ts": [
@@ -11946,53 +13195,119 @@
         "filename": "src/commands/doctor-memory-search.test.ts",
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
-        "line_number": 38
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
+        "line_number": 43
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
+        "filename": "src/commands/doctor-memory-search.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 278
       }
     ],
-    "src/commands/models/list.status.e2e.test.ts": [
+    "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts",
+        "hashed_secret": "f3c7399f056377fc3dae16a9854fe636b720d3d0",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "src/commands/gateway-install-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/gateway-install-token.test.ts",
+        "hashed_secret": "f3c7399f056377fc3dae16a9854fe636b720d3d0",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
+    "src/commands/gateway-status/helpers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/gateway-status/helpers.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 183
+      }
+    ],
+    "src/commands/message.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/message.test.ts",
+        "hashed_secret": "3bb1ec510d35ab2af7d05d8bbd5f0820333f1a0d",
+        "is_verified": false,
+        "line_number": 194
+      }
+    ],
+    "src/commands/model-picker.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/model-picker.test.ts",
+        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
+        "is_verified": false,
+        "line_number": 105
+      }
+    ],
+    "src/commands/models/list.status.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "filename": "src/commands/models/list.status.test.ts",
         "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
         "is_verified": false,
         "line_number": 12
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "filename": "src/commands/models/list.status.test.ts",
         "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
         "is_verified": false,
         "line_number": 19
       },
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "filename": "src/commands/models/list.status.test.ts",
         "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 52
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "filename": "src/commands/models/list.status.test.ts",
         "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 52
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
+        "filename": "src/commands/models/list.status.test.ts",
         "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
         "is_verified": false,
-        "line_number": 57
+        "line_number": 58
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/models/list.status.test.ts",
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_verified": false,
+        "line_number": 234
+      }
+    ],
+    "src/commands/onboard-auth.config-core.kilocode.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
+        "hashed_secret": "01800a0712a2a1aa928b95c4745e9ee06673925b",
+        "is_verified": false,
+        "line_number": 163
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
+        "hashed_secret": "8d2ce71c6723bf46f6c166984b4ddb597f92322a",
+        "is_verified": false,
+        "line_number": 190
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -12001,104 +13316,185 @@
         "filename": "src/commands/onboard-auth.config-minimax.ts",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 37
       },
       {
         "type": "Secret Keyword",
         "filename": "src/commands/onboard-auth.config-minimax.ts",
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 79
       }
     ],
-    "src/commands/onboard-auth.e2e.test.ts": [
+    "src/commands/onboard-auth.credentials.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
+        "line_number": 97
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "3fabe94b84be76552a40fab6d3284697b136ea23",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "aec738f7a0d1056bee31567d522e7191a13ce31a",
+        "is_verified": false,
+        "line_number": 190
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "9705dbfd5f922106b199746632af2b66b02c3f0a",
         "is_verified": false,
         "line_number": 191
-      },
+      }
+    ],
+    "src/commands/onboard-auth.credentials.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "filename": "src/commands/onboard-auth.credentials.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 234
-      },
+        "line_number": 66
+      }
+    ],
+    "src/commands/onboard-auth.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
+        "filename": "src/commands/onboard-auth.test.ts",
+        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
         "is_verified": false,
-        "line_number": 282
-      },
+        "line_number": 423
+      }
+    ],
+    "src/commands/onboard-custom.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "filename": "src/commands/onboard-custom.test.ts",
         "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 432
+      }
+    ],
+    "src/commands/onboard-non-interactive.provider-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "is_verified": false,
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "b30fe42027936932dac6fdf4a501e8c3bdfa7af6",
+        "is_verified": false,
+        "line_number": 267
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "541f41c02803b448ab4fb539e7c36762f3c89904",
+        "is_verified": false,
+        "line_number": 285
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "a49c2cb9e519e7f303a49d3d22f6529d47c1cac0",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "is_verified": false,
+        "line_number": 306
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
+        "is_verified": false,
+        "line_number": 353
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 416
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "860b9fde8d17bab19f1327c80f0e000e14902423",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
+        "is_verified": false,
+        "line_number": 490
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
+        "is_verified": false,
+        "line_number": 522
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
+        "is_verified": false,
+        "line_number": 546
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
+        "is_verified": false,
+        "line_number": 563
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
+        "is_verified": false,
+        "line_number": 582
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
         "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
         "is_verified": false,
-        "line_number": 447
+        "line_number": 627
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive.provider-auth.test.ts",
+        "hashed_secret": "a31f4bfd65dd1a0a26d665ed7bf08ccd8f20a38c",
+        "is_verified": false,
+        "line_number": 653
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12107,7 +13503,82 @@
         "filename": "src/commands/onboard-non-interactive/api-keys.ts",
         "hashed_secret": "112f3a99b283a4e1788dedd8e0e5d35375c33747",
         "is_verified": false,
-        "line_number": 11
+        "line_number": 12
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive/api-keys.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "src/commands/onboard-non-interactive/local/auth-choice.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-non-interactive/local/auth-choice.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "src/commands/onboard-types.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-types.ts",
+        "hashed_secret": "d8bb04dddbecd3eb0eaa36481f878a4a60caeabc",
+        "is_verified": false,
+        "line_number": 90
+      }
+    ],
+    "src/commands/onboard.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard.test.ts",
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "src/commands/onboard.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard.ts",
+        "hashed_secret": "d8bb04dddbecd3eb0eaa36481f878a4a60caeabc",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 43
+      }
+    ],
+    "src/commands/status-all/channels.mattermost-token-summary.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/status-all/channels.mattermost-token-summary.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/status-all/channels.mattermost-token-summary.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 241
+      }
+    ],
+    "src/commands/status-all/channels.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/status-all/channels.ts",
+        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
+        "is_verified": false,
+        "line_number": 180
       }
     ],
     "src/commands/status.update.test.ts": [
@@ -12128,13 +13599,13 @@
         "line_number": 60
       }
     ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
+    "src/commands/zai-endpoint-detect.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
+        "filename": "src/commands/zai-endpoint-detect.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 61
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12143,7 +13614,7 @@
         "filename": "src/config/config-misc.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 89
       }
     ],
     "src/config/config.env-vars.test.ts": [
@@ -12187,20 +13658,71 @@
         "line_number": 33
       }
     ],
+    "src/config/config.web-search-provider.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "a704b0feaf024ae73cda6859104dd323bc36b451",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "6984b2d1edb45c9ba5de8d29e9cd9a2613c6a170",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "bfe8fe037d4fe1aa6c0aeecf94efe2ebc265c6f8",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "4ee210c6480582752ad7f74c74bd63a3d4531e51",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "6d166fccc1c1a5193f7f7397705c84a184d68c0e",
+        "is_verified": false,
+        "line_number": 98
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "0f7f0fad47a1470a44be65dac2b848a99e28302c",
+        "is_verified": false,
+        "line_number": 108
+      }
+    ],
     "src/config/env-preserve-io.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-preserve-io.test.ts",
         "hashed_secret": "85639f0560fd9bf8704f52e01c5e764c9ed5a6aa",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-preserve-io.test.ts",
         "hashed_secret": "996650087ab48bdb1ca80f0842c97d4fbb6f1c71",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 75
       }
     ],
     "src/config/env-preserve.test.ts": [
@@ -12239,28 +13761,37 @@
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 80
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "ec417f567082612f8fd6afafe1abcab831fca840",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "520bd69c3eb1646d9a78181ecb4c90c51fdf428d",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 101
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "f136444bf9b3d01a9f9b772b80ac6bf7b6a43ef0",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 282
+      }
+    ],
+    "src/config/io.runtime-snapshot-write.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/io.runtime-snapshot-write.test.ts",
+        "hashed_secret": "c7106700045d8a274b6702325ecf9bcb60d42318",
+        "is_verified": false,
+        "line_number": 34
       }
     ],
     "src/config/io.write-config.test.ts": [
@@ -12269,7 +13800,7 @@
         "filename": "src/config/io.write-config.test.ts",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 289
       }
     ],
     "src/config/model-alias-defaults.test.ts": [
@@ -12278,130 +13809,193 @@
         "filename": "src/config/model-alias-defaults.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 66
-      }
-    ],
-    "src/config/redact-snapshot.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
-        "is_verified": false,
-        "line_number": 77
+        "line_number": 13
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "filename": "src/config/model-alias-defaults.test.ts",
+        "hashed_secret": "fa9144b340ea7886885669e2e7a808c86ee14a07",
         "is_verified": false,
-        "line_number": 77
-      },
+        "line_number": 114
+      }
+    ],
+    "src/config/redact-snapshot.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "7f413afd37447cd321d79286be0f58d7a9875d9b",
         "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
-        "is_verified": false,
-        "line_number": 99
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
-        "is_verified": false,
-        "line_number": 110
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
-        "is_verified": false,
-        "line_number": 198
+        "line_number": 78
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "abb1aabcd0e49019c2873944a40671a80ccd64c7",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Private Key",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 123
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
+        "is_verified": false,
+        "line_number": 262
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "7505d64a54e061b7acd54ccd58b49dc43500b635",
+        "is_verified": false,
+        "line_number": 302
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 321
+        "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 321
+        "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a9c732e05044a08c760cce7f6d142cd0d35a19e5",
         "is_verified": false,
-        "line_number": 375
+        "line_number": 455
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "50843dd5651cfafbe7c5611c1eed195c63e6e3fd",
         "is_verified": false,
-        "line_number": 691
+        "line_number": 771
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "22edfa62d61f01fead87e40562f8c8a51caa2806",
+        "is_verified": false,
+        "line_number": 783
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "33e65bb7ffff7e05b434318409b212f8724bc961",
+        "is_verified": false,
+        "line_number": 806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "dc2e131fd7ef4cf84345ad7f6c92c3d656051ede",
+        "is_verified": false,
+        "line_number": 831
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "0834708d0ed84f1d023353afc867fb0a4e5ebfea",
+        "is_verified": false,
+        "line_number": 838
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "927e7cdedcb8f71af399a49fb90a381df8b8df28",
         "is_verified": false,
-        "line_number": 808
+        "line_number": 1007
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "1996cc327bd39dad69cd8feb24250dafd51e7c08",
         "is_verified": false,
-        "line_number": 814
+        "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a5c0a65a4fa8874a486aa5072671927ceba82a90",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 1037
       }
     ],
     "src/config/schema.help.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
+        "hashed_secret": "0e5d3640571f2efbf18795e839e3ce63e48db217",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 647
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.help.ts",
+        "hashed_secret": "327af8350d09e3c34503a060d6e48239d2b76193",
+        "is_verified": false,
+        "line_number": 654
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 130
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/schema.help.ts",
-        "hashed_secret": "bb7dfd9746e660e4a4374951ec5938ef0e343255",
-        "is_verified": false,
-        "line_number": 187
+        "line_number": 678
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12440,20 +14034,108 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "e73c9fcad85cd4eecc74181ec4bdb31064d68439",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 216
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "74beae44ed0636f88b34069cd1a470d72138cc1a",
+        "is_verified": false,
+        "line_number": 220
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "a62021f580899aeb00e34c89bfc424f7f2a4e0a2",
+        "is_verified": false,
+        "line_number": 223
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "b29c7b6c34904ec11011239b80e6c4d7d91e19c4",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "8a27e6b77ed38143fe79dcc29278d36af18952a9",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "4466ac06ccad45868be0a57782fd6fb9a7fd0dd5",
+        "is_verified": false,
+        "line_number": 239
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 323
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "8186f7a791a1941fe8c51e10afbfeae296c29b2d",
+        "is_verified": false,
+        "line_number": 414
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "110a17b4d0c0655d88f3cfa537af8d764b0cd5b3",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "003bf1c7238ce36b2757cb8bb526a656539b27f5",
+        "is_verified": false,
+        "line_number": 681
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/schema.labels.ts",
+        "hashed_secret": "fd8dfda8e6830a2e800cd89b146dc9c5c8c45a51",
+        "is_verified": false,
+        "line_number": 824
       }
     ],
     "src/config/slack-http-config.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/slack-http-config.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "src/config/talk.normalize.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/talk.normalize.test.ts",
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/talk.normalize.test.ts",
+        "hashed_secret": "653d2545f6d16efa76ad7740bab466e175c4efd3",
+        "is_verified": false,
+        "line_number": 101
+      }
+    ],
+    "src/config/telegram-webhook-port.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/telegram-webhook-port.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 10
@@ -12468,13 +14150,52 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
+    "src/config/types.secrets.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/types.secrets.ts",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
+        "is_verified": false,
+        "line_number": 1
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/types.secrets.ts",
+        "hashed_secret": "7505d64a54e061b7acd54ccd58b49dc43500b635",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/types.secrets.ts",
+        "hashed_secret": "54bcb6507d063252d24c07eed533526b4c6bd99d",
+        "is_verified": false,
+        "line_number": 182
+      }
+    ],
+    "src/docker-setup.e2e.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
+        "filename": "src/docker-setup.e2e.test.ts",
         "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/docker-setup.e2e.test.ts",
+        "hashed_secret": "299e5b3d10d301eb479c0b84b16d750cb799e274",
+        "is_verified": false,
+        "line_number": 250
+      }
+    ],
+    "src/gateway/auth-mode-policy.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/auth-mode-policy.test.ts",
+        "hashed_secret": "f3c7399f056377fc3dae16a9854fe636b720d3d0",
+        "is_verified": false,
+        "line_number": 16
       }
     ],
     "src/gateway/auth-rate-limit.ts": [
@@ -12483,7 +14204,7 @@
         "filename": "src/gateway/auth-rate-limit.ts",
         "hashed_secret": "76ed0a056aa77060de25754586440cff390791d0",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 39
       }
     ],
     "src/gateway/auth.test.ts": [
@@ -12492,88 +14213,289 @@
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 95
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 112
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/auth.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 254
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 262
+      }
+    ],
+    "src/gateway/auth.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/auth.ts",
+        "hashed_secret": "60acdb59369429ffd0729487ec638eb0f7f12976",
+        "is_verified": false,
+        "line_number": 255
       }
     ],
     "src/gateway/call.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
         "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
         "is_verified": false,
-        "line_number": 357
+        "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
         "is_verified": false,
-        "line_number": 361
+        "line_number": 611
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 638
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_verified": false,
+        "line_number": 646
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e493f561d90c6638c1f51c5a8a069c3b129b79ed",
         "is_verified": false,
-        "line_number": 408
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/call.test.ts",
-        "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
-        "is_verified": false,
-        "line_number": 413
+        "line_number": 690
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "bddc29032de580fb53b3a9a0357dd409086db800",
         "is_verified": false,
-        "line_number": 426
+        "line_number": 704
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
-        "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
+        "hashed_secret": "2e7d14ce1d0b584f112cca09f638557e42a2617b",
         "is_verified": false,
-        "line_number": 463
+        "line_number": 724
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "802c9dbd2953f682a244abc0ec00ad564ac0eb7d",
+        "is_verified": false,
+        "line_number": 869
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 901
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
+    "src/gateway/call.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.ts",
+        "hashed_secret": "e951da0670d747fb42c25e584913ced2a22df456",
+        "is_verified": false,
+        "line_number": 361
+      }
+    ],
+    "src/gateway/client.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/client.test.ts",
+        "hashed_secret": "2c35baf5aa803a12df64c64b97df0445c46aeb03",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "src/gateway/client.watchdog.test.ts": [
       {
         "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
+        "filename": "src/gateway/client.watchdog.test.ts",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 89
+      }
+    ],
+    "src/gateway/credential-precedence.parity.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 99
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
+        "is_verified": false,
+        "line_number": 132
+      }
+    ],
+    "src/gateway/credentials.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "e951da0670d747fb42c25e584913ced2a22df456",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "c4268595e9bc82fd8385d7f5c31cff96d677e31d",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "bc5f9ea9a906cf0641cf9e227b6b9ae3cdc9df59",
+        "is_verified": false,
+        "line_number": 298
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "60acdb59369429ffd0729487ec638eb0f7f12976",
+        "is_verified": false,
+        "line_number": 487
+      }
+    ],
+    "src/gateway/credentials.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.ts",
+        "hashed_secret": "44b291b1e7dffdf5f83d0330e1bf299ded0c5047",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.ts",
+        "hashed_secret": "60acdb59369429ffd0729487ec638eb0f7f12976",
+        "is_verified": false,
+        "line_number": 122
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.ts",
+        "hashed_secret": "e951da0670d747fb42c25e584913ced2a22df456",
+        "is_verified": false,
+        "line_number": 161
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.ts",
+        "hashed_secret": "bc5f9ea9a906cf0641cf9e227b6b9ae3cdc9df59",
+        "is_verified": false,
+        "line_number": 246
       }
     ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
@@ -12582,7 +14504,7 @@
         "filename": "src/gateway/gateway-cli-backend.live.test.ts",
         "hashed_secret": "3e2fd4a90d5afbd27974730c4d6a9592fe300825",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 45
       }
     ],
     "src/gateway/gateway-models.profiles.live.test.ts": [
@@ -12591,7 +14513,57 @@
         "filename": "src/gateway/gateway-models.profiles.live.test.ts",
         "hashed_secret": "3e2fd4a90d5afbd27974730c4d6a9592fe300825",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 384
+      }
+    ],
+    "src/gateway/protocol/connect-error-details.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/protocol/connect-error-details.ts",
+        "hashed_secret": "cddf015a69bab8333e7a150f443a5c5876afe36f",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/protocol/connect-error-details.ts",
+        "hashed_secret": "72f4b2b45f434ba3f40eb799a943095686bbf93d",
+        "is_verified": false,
+        "line_number": 8
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/protocol/connect-error-details.ts",
+        "hashed_secret": "1e9a3d9cdc4504e4a02e822bf5712a2bdc5a4b25",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "src/gateway/resolve-configured-secret-input-string.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/resolve-configured-secret-input-string.ts",
+        "hashed_secret": "46a808cfd5beafa5e60aefee867bf92025dc2849",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "src/gateway/server-methods/nodes.invoke-wake.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/gateway/server-methods/nodes.invoke-wake.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 118
+      }
+    ],
+    "src/gateway/server-methods/push.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/gateway/server-methods/push.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 81
       }
     ],
     "src/gateway/server-methods/skills.update.normalizes-api-key.test.ts": [
@@ -12609,41 +14581,73 @@
         "filename": "src/gateway/server-methods/talk.ts",
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
-    "src/gateway/server.auth.e2e.test.ts": [
+    "src/gateway/server.auth.control-ui.suite.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
+        "filename": "src/gateway/server.auth.control-ui.suite.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 460
+        "line_number": 239
+      }
+    ],
+    "src/gateway/server.auth.modes.suite.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.auth.modes.suite.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 23
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
+        "filename": "src/gateway/server.auth.modes.suite.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 478
+        "line_number": 41
       }
     ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
+    "src/gateway/server.reload.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
+        "filename": "src/gateway/server.reload.test.ts",
+        "hashed_secret": "49065744bf4bd652a16552fe7eb5ec2b85e04279",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.reload.test.ts",
+        "hashed_secret": "9f84a968f7170f7e95154d8d37169f7069d67874",
+        "is_verified": false,
+        "line_number": 489
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.reload.test.ts",
+        "hashed_secret": "f403198d1c2c8c90bdc96e487c0bf4df1abff1e1",
+        "is_verified": false,
+        "line_number": 534
+      }
+    ],
+    "src/gateway/server.skills-status.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/server.skills-status.test.ts",
         "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
+    "src/gateway/server.talk-config.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
+        "filename": "src/gateway/server.talk-config.test.ts",
         "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 70
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12652,7 +14656,37 @@
         "filename": "src/gateway/session-utils.test.ts",
         "hashed_secret": "bb9a5d9483409d2c60b28268a0efcb93324d4cda",
         "is_verified": false,
-        "line_number": 280
+        "line_number": 563
+      }
+    ],
+    "src/gateway/startup-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "1951c80555441588e8707fa68a6084a91c8a114a",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "0b75f28abf6b39a10d1398ce5a95e93a5cebbbda",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 448
       }
     ],
     "src/gateway/test-openai-responses-model.ts": [
@@ -12673,20 +14707,45 @@
         "line_number": 22
       }
     ],
+    "src/infra/channel-summary.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/channel-summary.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/channel-summary.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "src/infra/channel-summary.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/channel-summary.ts",
+        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
     "src/infra/env.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/infra/env.test.ts",
         "hashed_secret": "df98a117ddabf85991b9fe0e268214dc0e1254dc",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 7
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/env.test.ts",
         "hashed_secret": "6d811dc1f59a55ca1a3d38b5042a062b9f79e8ec",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 14
       }
     ],
     "src/infra/outbound/message-action-runner.test.ts": [
@@ -12695,14 +14754,14 @@
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 180
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 529
       }
     ],
     "src/infra/outbound/outbound.test.ts": [
@@ -12711,7 +14770,7 @@
         "filename": "src/infra/outbound/outbound.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 851
       }
     ],
     "src/infra/provider-usage.auth.normalizes-keys.test.ts": [
@@ -12720,21 +14779,51 @@
         "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
         "hashed_secret": "45c7365e3b542cdb4fae6ec10c2ff149224d7656",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 123
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
         "hashed_secret": "b67074884ab7ef7c7a8cd6a3da9565d96c792248",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
         "hashed_secret": "d4d8027e64f9cf4180d3aecfe31ea409368022ee",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
+        "hashed_secret": "8b743a178b5077d48494d391398fe6f4921ba0db",
+        "is_verified": false,
+        "line_number": 251
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
+        "hashed_secret": "07ff8d41dbd6fbd0f5570387116cf3424606c285",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/infra/provider-usage.auth.normalizes-keys.test.ts",
+        "hashed_secret": "2a27ce08b18c9dacf920d22f9795a62b883611e7",
+        "is_verified": false,
+        "line_number": 261
+      }
+    ],
+    "src/infra/push-apns.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/infra/push-apns.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 80
       }
     ],
     "src/infra/shell-env.test.ts": [
@@ -12743,21 +14832,21 @@
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "65c10dc3549fe07424148a8a4790a3341ecbc253",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "e013ffda590d2178607c16d11b1ea42f75ceb0e7",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 165
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "be6ee9a6bf9f2dad84a5a67d6c0576a5bacc391e",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 167
       }
     ],
     "src/line/accounts.test.ts": [
@@ -12789,7 +14878,14 @@
         "filename": "src/line/bot-handlers.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/line/bot-handlers.test.ts",
+        "hashed_secret": "d76baddf1b9e3d8e31216f22c73d65d2e91ada7b",
+        "is_verified": false,
+        "line_number": 358
       }
     ],
     "src/line/bot-message-context.test.ts": [
@@ -12799,6 +14895,13 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/line/bot-message-context.test.ts",
+        "hashed_secret": "d369d8c413645b43df8ac26be7295cd15a64f9bf",
+        "is_verified": false,
+        "line_number": 179
       }
     ],
     "src/line/monitor.fail-closed.test.ts": [
@@ -12808,6 +14911,15 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 22
+      }
+    ],
+    "src/line/monitor.lifecycle.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/line/monitor.lifecycle.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 91
       }
     ],
     "src/line/webhook-node.test.ts": [
@@ -12825,7 +14937,7 @@
         "filename": "src/line/webhook.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 21
       }
     ],
     "src/logging/redact.test.ts": [
@@ -12858,13 +14970,22 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
+    "src/media-understanding/apply.echo-transcript.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
+        "filename": "src/media-understanding/apply.echo-transcript.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 15
+      }
+    ],
+    "src/media-understanding/apply.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/apply.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -12873,7 +14994,7 @@
         "filename": "src/media-understanding/providers/deepgram/audio.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 20
       }
     ],
     "src/media-understanding/providers/google/video.test.ts": [
@@ -12882,7 +15003,32 @@
         "filename": "src/media-understanding/providers/google/video.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 56
+      }
+    ],
+    "src/media-understanding/providers/mistral/index.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/providers/mistral/index.test.ts",
+        "hashed_secret": "5b29ef735a0cc9246f2024fe148fa051ddcd9c7b",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/providers/mistral/index.test.ts",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "src/media-understanding/providers/moonshot/video.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/providers/moonshot/video.test.ts",
+        "hashed_secret": "4bbcb0d85f250c947d6a8311ef9d437467e0adcb",
+        "is_verified": false,
+        "line_number": 19
       }
     ],
     "src/media-understanding/providers/openai/audio.test.ts": [
@@ -12891,7 +15037,7 @@
         "filename": "src/media-understanding/providers/openai/audio.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 18
       }
     ],
     "src/media-understanding/runner.auto-audio.test.ts": [
@@ -12900,7 +15046,14 @@
         "filename": "src/media-understanding/runner.auto-audio.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.auto-audio.test.ts",
+        "hashed_secret": "b30fe42027936932dac6fdf4a501e8c3bdfa7af6",
+        "is_verified": false,
+        "line_number": 123
       }
     ],
     "src/media-understanding/runner.deepgram.test.ts": [
@@ -12909,7 +15062,50 @@
         "filename": "src/media-understanding/runner.deepgram.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 31
+      }
+    ],
+    "src/media-understanding/runner.proxy.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.proxy.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "src/media-understanding/runner.skip-tiny-audio.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.skip-tiny-audio.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "src/media-understanding/runner.video.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.video.test.ts",
+        "hashed_secret": "a47110e348a3063541fb1f1f640d635d457181a0",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.video.test.ts",
+        "hashed_secret": "2568d97e538e07521431c9ea738e5c2df14df7a2",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "src/memory/embeddings-ollama.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/memory/embeddings-ollama.test.ts",
+        "hashed_secret": "24ff85e3f39fdc772fc759b161935393b6df7071",
+        "is_verified": false,
+        "line_number": 47
       }
     ],
     "src/memory/embeddings-voyage.test.ts": [
@@ -12918,14 +15114,14 @@
         "filename": "src/memory/embeddings-voyage.test.ts",
         "hashed_secret": "7c2020578bbe5e2e3f78d7f954eb2ad8ab5b0403",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 24
       },
       {
         "type": "Secret Keyword",
         "filename": "src/memory/embeddings-voyage.test.ts",
         "hashed_secret": "8afdb3da9b79c8957ae35978ea8f33fbc3bfdf60",
         "is_verified": false,
-        "line_number": 77
+        "line_number": 88
       }
     ],
     "src/memory/embeddings.test.ts": [
@@ -12934,21 +15130,35 @@
         "filename": "src/memory/embeddings.test.ts",
         "hashed_secret": "a47110e348a3063541fb1f1f640d635d457181a0",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 47
       },
       {
         "type": "Secret Keyword",
         "filename": "src/memory/embeddings.test.ts",
         "hashed_secret": "c734e47630dda71619c696d88381f06f7511bd78",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 195
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/memory/embeddings.test.ts",
+        "hashed_secret": "3e10d010e7dfb478858d30459fa03f3824340d47",
+        "is_verified": false,
+        "line_number": 236
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/memory/embeddings.test.ts",
+        "hashed_secret": "758b085bf0f1a4a298ea42289e7141a67c6bd3bf",
+        "is_verified": false,
+        "line_number": 269
       },
       {
         "type": "Secret Keyword",
         "filename": "src/memory/embeddings.test.ts",
         "hashed_secret": "56e1d57b8db262b08bc73c60ed08d8c92e59503f",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 291
       }
     ],
     "src/pairing/pairing-store.ts": [
@@ -12957,7 +15167,7 @@
         "filename": "src/pairing/pairing-store.ts",
         "hashed_secret": "f8c6f1ff98c5ee78c27d34a3ca68f35ad79847af",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
     "src/pairing/setup-code.test.ts": [
@@ -12966,30 +15176,511 @@
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "4914c103484773b5a8e18448b11919bb349cbff8",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/pairing/setup-code.test.ts",
+        "hashed_secret": "1951c80555441588e8707fa68a6084a91c8a114a",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/pairing/setup-code.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 370
+      }
+    ],
+    "src/secrets/apply.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "b933c37f090368dee5ab803d71af8f5551729a9a",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "b99aa0d13685d4177199dcdb170d90032408b634",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "bb0a04dd3612988998c812bc3ad580ba0fb9d905",
+        "is_verified": false,
+        "line_number": 360
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "942c7142a36b069509b957db07321a1cb9b2123a",
+        "is_verified": false,
+        "line_number": 397
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "9c0faa509a7c3079f58421307ecbcaceb7cbd545",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "c9a4d024f4386d3a4b044de8cb52226383591481",
+        "is_verified": false,
+        "line_number": 483
+      }
+    ],
+    "src/secrets/apply.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 301
+      }
+    ],
+    "src/secrets/audit.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/audit.test.ts",
+        "hashed_secret": "acaaadd3c6826bd059f3a374d4e443119450c3d1",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/audit.test.ts",
+        "hashed_secret": "e474eaea44a76a69199fea5a7dbeb5b16a7300e5",
+        "is_verified": false,
+        "line_number": 149
+      }
+    ],
+    "src/secrets/audit.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/audit.ts",
+        "hashed_secret": "59bd0a3ff43b32849b319e645d4798d8a5d1e889",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/audit.ts",
+        "hashed_secret": "6a1cec45eaf37b34e1b1d89130d7746fe4006346",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "src/secrets/command-config.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/command-config.test.ts",
+        "hashed_secret": "e3801068cd8f45226d71fb7ccd94069d0fbba56d",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "src/secrets/command-config.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/command-config.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "src/secrets/configure-plan.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/configure-plan.test.ts",
+        "hashed_secret": "68c46e84d76d2e7e686e5158bf598909abd4e45b",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/configure-plan.test.ts",
+        "hashed_secret": "b340b5722fdf4bae59f23b1b829bad0a50b98c2a",
+        "is_verified": false,
+        "line_number": 142
+      }
+    ],
+    "src/secrets/credential-matrix.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/credential-matrix.ts",
+        "hashed_secret": "d6c8cbcbe34bf0e02cf1a52e27afcf18b59b3f79",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "src/secrets/path-utils.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/path-utils.test.ts",
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/path-utils.test.ts",
+        "hashed_secret": "ff3390557335ba88d37755e41514beb03bc499ec",
+        "is_verified": false,
+        "line_number": 68
+      }
+    ],
+    "src/secrets/resolve.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/resolve.test.ts",
+        "hashed_secret": "d5c682b893a50123f4ea5f5e6abec050140bf0d7",
+        "is_verified": false,
+        "line_number": 156
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/resolve.test.ts",
+        "hashed_secret": "16f3b7e5d8b028776a23183046ed8d7e2a6f83fd",
+        "is_verified": false,
+        "line_number": 170
+      }
+    ],
+    "src/secrets/runtime.coverage.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.coverage.test.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    "src/secrets/runtime.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "9c90ee4dffb05e756736e1c7053d58123fe10cd5",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "1fd9d21cd11c8693eeec9a7cbf715b3ae2d326a3",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "43b056d050e1ae71c4f4c2299a9ef1b013c61f4c",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "39a5fe6ff8439ab43fad9ef91f1ca904100b061f",
+        "is_verified": false,
+        "line_number": 129
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "91fe0371ebcd1ad6155f99def1a2141304f6ae92",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "1f94badc04cb188c75836443cba2aa7779f61fe0",
+        "is_verified": false,
+        "line_number": 132
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "5238105957f6328ec11257a883a6c1cfc65001cb",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "6121b5dc9796ceb63d4f1ace5659e79071868f8c",
+        "is_verified": false,
+        "line_number": 136
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "1e525b578bee91781afdcd6d433eb7131ef6aeea",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "0762c735468f5b820e28aac395c45c6f5fa3eaae",
+        "is_verified": false,
+        "line_number": 347
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "d94f69ee39f6dffd32670c5fba12fb9e3d53b8bb",
+        "is_verified": false,
+        "line_number": 402
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "3a967527e33b499e91ad068d3f1f9629d48b7b4b",
+        "is_verified": false,
+        "line_number": 497
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "5fa6902fc5cf953be91cab0bf71f529fcd659705",
+        "is_verified": false,
+        "line_number": 645
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "24f304df8c18c85f32628fe9b97a5dc586e43c1a",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "7d9cff01e1e63dbd63734c50281467072cf6d62b",
+        "is_verified": false,
+        "line_number": 825
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "f99fcac1041fa2167820b03b35e5aae2269ee93f",
+        "is_verified": false,
+        "line_number": 983
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "2bf0aeb6b84ed8ad339dd50e6a39727ca7a10c52",
+        "is_verified": false,
+        "line_number": 984
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "a9f4cca5e7d4317399993700c429da36953fe93a",
+        "is_verified": false,
+        "line_number": 1025
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "ea5382c98246f085585a7b30fb2169eef0c36487",
+        "is_verified": false,
+        "line_number": 1026
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "82a931de6fe3dfcc3fbac30f47d1c6946698349c",
+        "is_verified": false,
+        "line_number": 1061
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.test.ts",
+        "hashed_secret": "2b5562f74105fee1d5fb666d5c93412df68b0f09",
+        "is_verified": false,
+        "line_number": 1934
+      }
+    ],
+    "src/secrets/secret-value.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/secret-value.ts",
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "src/secrets/target-registry-data.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-data.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-data.ts",
+        "hashed_secret": "d6c8cbcbe34bf0e02cf1a52e27afcf18b59b3f79",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "src/secrets/target-registry-pattern.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-pattern.test.ts",
+        "hashed_secret": "8ea49ee60a850e4625efcff087156d314b8f3789",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-pattern.test.ts",
+        "hashed_secret": "de73eac0c305038f0437bc6a1f994a5a4379ed28",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "src/secrets/target-registry-pattern.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-pattern.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "src/secrets/target-registry-types.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-types.ts",
+        "hashed_secret": "ab10c0233a5b277d9e5a603b243a153266c80888",
+        "is_verified": false,
+        "line_number": 1
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-types.ts",
+        "hashed_secret": "d6c8cbcbe34bf0e02cf1a52e27afcf18b59b3f79",
+        "is_verified": false,
+        "line_number": 2
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/target-registry-types.ts",
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "is_verified": false,
+        "line_number": 3
       }
     ],
     "src/security/audit.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
+        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
+        "is_verified": false,
+        "line_number": 1493
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 1969
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 1970
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "7b231a50a498ef151e291795f46f56bee569eae5",
+        "is_verified": false,
+        "line_number": 1982
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "5a013c49508291c6816ac388f93a2c11973086ed",
+        "is_verified": false,
+        "line_number": 2058
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
         "hashed_secret": "21f688ab56f76a99e5c6ed342291422f4e57e47f",
         "is_verified": false,
-        "line_number": 2063
+        "line_number": 3473
       },
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
         "hashed_secret": "3dc927d80543dc0f643940b70d066bd4b4c4b78e",
         "is_verified": false,
-        "line_number": 2094
+        "line_number": 3486
+      }
+    ],
+    "src/security/external-content.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/security/external-content.test.ts",
+        "hashed_secret": "e8e6c2284ab5bee4de2ee53880c8fc2a4728d3e8",
+        "is_verified": false,
+        "line_number": 148
+      }
+    ],
+    "src/signal/identity.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/signal/identity.test.ts",
+        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "src/slack/monitor/monitor.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/slack/monitor/monitor.test.ts",
+        "hashed_secret": "431ef2b335d72ec03c3a5d6393c8ab87012bba48",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/slack/monitor/monitor.test.ts",
+        "hashed_secret": "6c8fd4b55b7a940cf3d484634cb4f2b9e1a8fe7a",
+        "is_verified": false,
+        "line_number": 78
       }
     ],
     "src/telegram/monitor.test.ts": [
@@ -12998,14 +15689,14 @@
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 432
       },
       {
         "type": "Secret Keyword",
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "5934c4d4a4fa5d66ddb3d3fc0bba84996c17a5b7",
         "is_verified": false,
-        "line_number": 233
+        "line_number": 479
       }
     ],
     "src/telegram/webhook.test.ts": [
@@ -13014,7 +15705,7 @@
         "filename": "src/telegram/webhook.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 24
       }
     ],
     "src/tts/tts.test.ts": [
@@ -13030,28 +15721,28 @@
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "b214f706bb602c1cc2adc5c6165e73622305f4bb",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 434
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "e29af93630aa18cc3457cb5b13937b7ab7c99c9b",
         "is_verified": false,
-        "line_number": 413
+        "line_number": 444
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 447
+        "line_number": 530
       }
     ],
     "src/tui/gateway-chat.test.ts": [
@@ -13060,7 +15751,60 @@
         "filename": "src/tui/gateway-chat.test.ts",
         "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tui/gateway-chat.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tui/gateway-chat.test.ts",
+        "hashed_secret": "21f688ab56f76a99e5c6ed342291422f4e57e47f",
+        "is_verified": false,
+        "line_number": 183
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tui/gateway-chat.test.ts",
+        "hashed_secret": "3dc927d80543dc0f643940b70d066bd4b4c4b78e",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tui/gateway-chat.test.ts",
+        "hashed_secret": "85f4320a77e4f8d305838b71eaeead29e708b1c9",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/tui/gateway-chat.test.ts",
+        "hashed_secret": "16e227bc459f3b9c200aaaff07c5c56cf4130f08",
+        "is_verified": false,
+        "line_number": 271
+      }
+    ],
+    "src/tui/tui-formatters.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/tui/tui-formatters.test.ts",
+        "hashed_secret": "9e0de74e24df61d8afd9dab34b470e2faf54b296",
+        "is_verified": false,
+        "line_number": 253
+      }
+    ],
+    "src/utils/mask-api-key.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/utils/mask-api-key.test.ts",
+        "hashed_secret": "389c3ec21b7325359051e97ff569b078843d2d37",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "src/web/login.test.ts": [
@@ -13072,13 +15816,90 @@
         "line_number": 60
       }
     ],
+    "src/wizard/onboarding.finalize.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.finalize.test.ts",
+        "hashed_secret": "5fa6902fc5cf953be91cab0bf71f529fcd659705",
+        "is_verified": false,
+        "line_number": 116
+      }
+    ],
+    "src/wizard/onboarding.gateway-config.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.gateway-config.test.ts",
+        "hashed_secret": "358fffeb5cef5e34ae867e1d9edf2ba420ca2bf6",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.gateway-config.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 162
+      }
+    ],
+    "src/wizard/onboarding.gateway-config.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.gateway-config.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 168
+      }
+    ],
+    "src/wizard/onboarding.secret-input.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.secret-input.test.ts",
+        "hashed_secret": "358fffeb5cef5e34ae867e1d9edf2ba420ca2bf6",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "src/wizard/onboarding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.test.ts",
+        "hashed_secret": "9c8c592cc7a339f158262ebc87ee5a0cce39ce83",
+        "is_verified": false,
+        "line_number": 399
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 481
+      }
+    ],
+    "ui/src/i18n/locales/de.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ui/src/i18n/locales/de.ts",
+        "hashed_secret": "e751faf13e70e4c0618a714cff7af8a5a14ddf32",
+        "is_verified": false,
+        "line_number": 61
+      }
+    ],
     "ui/src/i18n/locales/en.ts": [
       {
         "type": "Secret Keyword",
         "filename": "ui/src/i18n/locales/en.ts",
         "hashed_secret": "de0ff6b974d6910aca8d6b830e1b761f076d8fe6",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 61
+      }
+    ],
+    "ui/src/i18n/locales/es.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ui/src/i18n/locales/es.ts",
+        "hashed_secret": "ca74676aab0bf32f0775ec0a7aa7ed5b9d48b038",
+        "is_verified": false,
+        "line_number": 61
       }
     ],
     "ui/src/i18n/locales/pt-BR.ts": [
@@ -13087,7 +15908,16 @@
         "filename": "ui/src/i18n/locales/pt-BR.ts",
         "hashed_secret": "ef7b6f95faca2d7d3a5aa5a6434c89530c6dd243",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 61
+      }
+    ],
+    "ui/src/ui/config-form.browser.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ui/src/ui/config-form.browser.test.ts",
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_verified": false,
+        "line_number": 368
       }
     ],
     "vendor/a2ui/README.md": [
@@ -13100,5 +15930,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-17T13:34:38Z"
+  "generated_at": "2026-03-07T03:08:48Z"
 }

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -344,6 +344,8 @@ describe("resolveFeishuAccount", () => {
         accountId: "main",
       }),
     ).not.toThrow();
+  });
+});
 
 describe("resolveFeishuAccount renderMode fallback", () => {
   it("falls back to top-level renderMode when account override is missing", () => {

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -344,5 +344,48 @@ describe("resolveFeishuAccount", () => {
         accountId: "main",
       }),
     ).not.toThrow();
+
+describe("resolveFeishuAccount renderMode fallback", () => {
+  it("falls back to top-level renderMode when account override is missing", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          appId: "cli_xxx",
+          appSecret: "secret_xxx",
+          renderMode: "card",
+          accounts: {
+            pm: {
+              appId: "cli_pm",
+              appSecret: "secret_pm",
+            },
+          },
+        },
+      },
+    } as any;
+
+    const resolved = resolveFeishuAccount({ cfg, accountId: "architect" });
+    expect(resolved.config.renderMode).toBe("card");
+  });
+
+  it("prefers account-level renderMode when present", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          appId: "cli_xxx",
+          appSecret: "secret_xxx",
+          renderMode: "card",
+          accounts: {
+            pm: {
+              appId: "cli_pm",
+              appSecret: "secret_pm",
+              renderMode: "raw",
+            },
+          },
+        },
+      },
+    } as any;
+
+    const resolved = resolveFeishuAccount({ cfg, accountId: "pm" });
+    expect(resolved.config.renderMode).toBe("raw");
   });
 });

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -128,6 +128,19 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.content).toBe("hello world");
   });
 
+  it("strips only bot mention and preserves human mention text", () => {
+    const event = makeEvent(
+      "group",
+      [
+        { key: "@_bot_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+        { key: "@_user_1", name: "Luke", id: { open_id: "ou_luke" } },
+      ],
+      "@Bot @_bot_1 请 @Luke @_user_1 review",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.content).toBe("请 @Luke @_user_1 review");
+  });
+
   it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {
     const BOT_OPEN_ID = "ou_bot_123";
     const event = makePostEvent({

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -130,5 +130,38 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       BOT_OPEN_ID,
     );
     expect(ctx.content).toBe('<at user_id="ou_x">&lt;script&gt;</at> test');
+  it("returns original text when botOpenId is missing", () => {
+    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
+    expect(stripBotMention("@Bot hello @_bot_1", mentions)).toBe("@Bot hello @_bot_1");
+  });
+
+  it("strips mention name and key for normal mentions", () => {
+    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
+    expect(stripBotMention("@Bot hello @_bot_1", mentions, "ou_bot")).toBe("hello");
+  });
+
+  it("treats mention.name regex metacharacters as literal text", () => {
+    const mentions: Mentions = [{ key: "@_bot_1", name: ".*", id: { open_id: "ou_bot" } }];
+    expect(stripBotMention("@NotBot hello", mentions, "ou_bot")).toBe("@NotBot hello");
+  });
+
+  it("treats mention.key regex metacharacters as literal text", () => {
+    const mentions: Mentions = [{ key: ".*", name: "Bot", id: { open_id: "ou_bot" } }];
+    expect(stripBotMention("hello world", mentions, "ou_bot")).toBe("hello world");
+  });
+
+  it("trims once after all mention replacements", () => {
+    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
+    expect(stripBotMention("  @_bot_1 hello   ", mentions, "ou_bot")).toBe("hello");
+  });
+
+  it("strips only the current bot mention and preserves other user mentions", () => {
+    const mentions: Mentions = [
+      { key: "@_bot_1", name: "Bot One", id: { open_id: "ou_bot_1" } },
+      { key: "@_bot_2", name: "Bot Two", id: { open_id: "ou_bot_2" } },
+    ];
+    expect(stripBotMention("@Bot One @_bot_1 hi @Bot Two @_bot_2", mentions, "ou_bot_1")).toBe(
+      "hi @Bot Two @_bot_2",
+    );
   });
 });

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -130,38 +130,5 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       BOT_OPEN_ID,
     );
     expect(ctx.content).toBe('<at user_id="ou_x">&lt;script&gt;</at> test');
-  it("returns original text when botOpenId is missing", () => {
-    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
-    expect(stripBotMention("@Bot hello @_bot_1", mentions)).toBe("@Bot hello @_bot_1");
-  });
-
-  it("strips mention name and key for normal mentions", () => {
-    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
-    expect(stripBotMention("@Bot hello @_bot_1", mentions, "ou_bot")).toBe("hello");
-  });
-
-  it("treats mention.name regex metacharacters as literal text", () => {
-    const mentions: Mentions = [{ key: "@_bot_1", name: ".*", id: { open_id: "ou_bot" } }];
-    expect(stripBotMention("@NotBot hello", mentions, "ou_bot")).toBe("@NotBot hello");
-  });
-
-  it("treats mention.key regex metacharacters as literal text", () => {
-    const mentions: Mentions = [{ key: ".*", name: "Bot", id: { open_id: "ou_bot" } }];
-    expect(stripBotMention("hello world", mentions, "ou_bot")).toBe("hello world");
-  });
-
-  it("trims once after all mention replacements", () => {
-    const mentions: Mentions = [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }];
-    expect(stripBotMention("  @_bot_1 hello   ", mentions, "ou_bot")).toBe("hello");
-  });
-
-  it("strips only the current bot mention and preserves other user mentions", () => {
-    const mentions: Mentions = [
-      { key: "@_bot_1", name: "Bot One", id: { open_id: "ou_bot_1" } },
-      { key: "@_bot_2", name: "Bot Two", id: { open_id: "ou_bot_2" } },
-    ];
-    expect(stripBotMention("@Bot One @_bot_1 hi @Bot Two @_bot_2", mentions, "ou_bot_1")).toBe(
-      "hi @Bot Two @_bot_2",
-    );
   });
 });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -18,8 +18,14 @@ const {
   mockDownloadMessageResourceFeishu,
   mockCreateFeishuClient,
   mockResolveAgentRoute,
+  mockCreateReplyDispatcherWithTyping,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
+    dispatcher: vi.fn(),
+    replyOptions: {},
+    markDispatchIdle: vi.fn(),
+  })),
+  mockCreateReplyDispatcherWithTyping: vi.fn(() => ({
     dispatcher: vi.fn(),
     replyOptions: {},
     markDispatchIdle: vi.fn(),
@@ -125,6 +131,7 @@ describe("handleFeishuMessage command authorization", () => {
     },
   );
   const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
+  const mockIsControlCommandMessage = vi.fn(() => false);
   const mockShouldComputeCommandAuthorized = vi.fn(() => true);
   const mockReadAllowFromStore = vi.fn().mockResolvedValue([]);
   const mockUpsertPairingRequest = vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false });
@@ -140,6 +147,7 @@ describe("handleFeishuMessage command authorization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
+    mockIsControlCommandMessage.mockReturnValue(false);
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
       channel: "feishu",
@@ -190,6 +198,18 @@ describe("handleFeishuMessage command authorization", () => {
             upsertPairingRequest: mockUpsertPairingRequest,
             buildPairingReply: mockBuildPairingReply,
           },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn(() => ({ template: "channel+name+time" })),
+          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+          finalizeInboundContext: mockFinalizeInboundContext,
+          dispatchReplyFromConfig: mockDispatchReplyFromConfig,
+          withReplyDispatcher: mockWithReplyDispatcher,
+          createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
+        },
+        commands: {
+          shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
+          isControlCommandMessage: mockIsControlCommandMessage,
+          resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
         },
         media: {
           detectMime: vi.fn(async () => "application/octet-stream"),
@@ -757,6 +777,139 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("plugin dispatch mode runs dispatch pipeline with reply generation disabled", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dispatchMode: "plugin",
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-plugin",
+        },
+      },
+      message: {
+        message_id: "msg-plugin-dispatch-only",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello from plugin mode" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        replyResolver: expect.any(Function),
+        ctx: expect.objectContaining({
+          ChatType: "group",
+          MessageSid: "msg-plugin-dispatch-only",
+          SessionKey: expect.any(String),
+        }),
+      }),
+    );
+    const call = mockDispatchReplyFromConfig.mock.calls[0]?.[0] as
+      | {
+          replyResolver?: (() => Promise<unknown>) | undefined;
+        }
+      | undefined;
+    await expect(call?.replyResolver?.()).resolves.toBeUndefined();
+    expect(mockWithReplyDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("plugin dispatch mode still forwards control commands by default", async () => {
+    mockIsControlCommandMessage.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dispatchMode: "plugin",
+          groupPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-plugin",
+        },
+      },
+      message: {
+        message_id: "msg-plugin-control-default",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "/stop" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockIsControlCommandMessage).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockWithReplyDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("plugin dispatch mode can skip forwarding control commands", async () => {
+    mockIsControlCommandMessage.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dispatchMode: "plugin",
+          groupPolicy: "open",
+          pluginMode: {
+            forwardControlCommands: false,
+          },
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-plugin",
+        },
+      },
+      message: {
+        message_id: "msg-plugin-control-skip",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "/stop" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockIsControlCommandMessage).toHaveBeenCalledWith("/stop", cfg);
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+    expect(mockWithReplyDispatcher).not.toHaveBeenCalled();
+  });
   it("uses video file_key (not thumbnail image_key) for inbound video download", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -827,7 +827,7 @@ describe("handleFeishuMessage command authorization", () => {
         }
       | undefined;
     await expect(call?.replyResolver?.()).resolves.toBeUndefined();
-    expect(mockWithReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockWithReplyDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("plugin dispatch mode still forwards control commands by default", async () => {
@@ -866,7 +866,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockIsControlCommandMessage).not.toHaveBeenCalled();
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
-    expect(mockWithReplyDispatcher).not.toHaveBeenCalled();
+    expect(mockWithReplyDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("plugin dispatch mode can skip forwarding control commands", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -175,14 +175,14 @@ describe("handleFeishuMessage command authorization", () => {
               mockResolveAgentRoute as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
           },
           reply: {
-            resolveEnvelopeFormatOptions: vi.fn(() => ({ template: "channel+name+time" })),
+            resolveEnvelopeFormatOptions: vi.fn(() => ({ template: "channel+name+time" })) as any,
             formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
             finalizeInboundContext:
               mockFinalizeInboundContext as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
             dispatchReplyFromConfig: mockDispatchReplyFromConfig,
             withReplyDispatcher:
               mockWithReplyDispatcher as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
-            createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
+            createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping as any,
           },
           commands: {
             shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
@@ -192,7 +192,6 @@ describe("handleFeishuMessage command authorization", () => {
           media: {
             saveMediaBuffer:
               mockSaveMediaBuffer as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
-            detectMime: vi.fn(async () => "application/octet-stream"),
           },
           pairing: {
             readAllowFromStore: mockReadAllowFromStore,

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -175,44 +175,30 @@ describe("handleFeishuMessage command authorization", () => {
               mockResolveAgentRoute as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
           },
           reply: {
-            resolveEnvelopeFormatOptions: vi.fn(
-              () => ({}),
-            ) as unknown as PluginRuntime["channel"]["reply"]["resolveEnvelopeFormatOptions"],
+            resolveEnvelopeFormatOptions: vi.fn(() => ({ template: "channel+name+time" })),
             formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
             finalizeInboundContext:
               mockFinalizeInboundContext as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
             dispatchReplyFromConfig: mockDispatchReplyFromConfig,
             withReplyDispatcher:
               mockWithReplyDispatcher as unknown as PluginRuntime["channel"]["reply"]["withReplyDispatcher"],
+            createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
           },
           commands: {
             shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
+            isControlCommandMessage: mockIsControlCommandMessage,
             resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
           },
           media: {
             saveMediaBuffer:
               mockSaveMediaBuffer as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
+            detectMime: vi.fn(async () => "application/octet-stream"),
           },
           pairing: {
             readAllowFromStore: mockReadAllowFromStore,
             upsertPairingRequest: mockUpsertPairingRequest,
             buildPairingReply: mockBuildPairingReply,
           },
-        reply: {
-          resolveEnvelopeFormatOptions: vi.fn(() => ({ template: "channel+name+time" })),
-          formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
-          finalizeInboundContext: mockFinalizeInboundContext,
-          dispatchReplyFromConfig: mockDispatchReplyFromConfig,
-          withReplyDispatcher: mockWithReplyDispatcher,
-          createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
-        },
-        commands: {
-          shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
-          isControlCommandMessage: mockIsControlCommandMessage,
-          resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
-        },
-        media: {
-          detectMime: vi.fn(async () => "application/octet-stream"),
         },
       }),
     );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -481,14 +481,13 @@ function normalizeMentions(
 
   for (const mention of mentions) {
     const mentionId = mention.id.open_id;
-    const replacement =
-      botStripId && mentionId === botStripId
-        ? ""
-        : mentionId
-          ? `<at user_id="${mentionId}">${escapeName(mention.name)}</at>`
-          : `@${mention.name}`;
 
-    result = result.replace(new RegExp(escaped(mention.key), "g"), () => replacement).trim();
+    if (botStripId && mentionId === botStripId) {
+      // Strip the full bot mention: optional "@Name " prefix + key
+      const pattern = new RegExp(`(?:@${escaped(mention.name)}\\s+)?${escaped(mention.key)}`, "g");
+      result = result.replace(pattern, "").trim();
+    }
+    // Non-bot mentions: leave text as-is
   }
 
   return result;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1056,7 +1056,7 @@ export async function handleFeishuMessage(params: {
       );
       // Broadcast groups deliver the same event to every account; skip recording here
       // to avoid duplicate history entries inflating the context.
-      if (chatHistories && !broadcastAgents) {
+      if (chatHistories && !broadcastAgents && groupHistoryKey) {
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
           historyKey: groupHistoryKey,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1054,7 +1054,9 @@ export async function handleFeishuMessage(params: {
       log(
         `feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot, recording to history`,
       );
-      if (chatHistories) {
+      // Broadcast groups deliver the same event to every account; skip recording here
+      // to avoid duplicate history entries inflating the context.
+      if (chatHistories && !broadcastAgents) {
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
           historyKey: groupHistoryKey,
@@ -1497,35 +1499,77 @@ export async function handleFeishuMessage(params: {
         ctx.mentionedBot,
       );
 
-      const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
-        cfg,
-        agentId: route.agentId,
-        runtime: runtime as RuntimeEnv,
-        chatId: ctx.chatId,
-        replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
-        replyInThread,
-        rootId: ctx.rootId,
-        threadReply,
-        mentionTargets: ctx.mentionTargets,
-        accountId: account.accountId,
-        messageCreateTimeMs,
-      });
+      if (dispatchMode === "plugin") {
+        // When forwardControlCommands is explicitly false, skip control commands entirely.
+        const skipControlCommands = feishuCfg?.pluginMode?.forwardControlCommands === false;
+        if (
+          skipControlCommands &&
+          core.channel.commands.isControlCommandMessage(ctx.content, cfg)
+        ) {
+          log(`feishu[${account.accountId}]: plugin dispatch mode, skipping control command`);
+          return;
+        }
 
-      log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
-        dispatcher,
-        onSettled: () => {
-          markDispatchIdle();
-        },
-        run: () =>
-          core.channel.reply.dispatchReplyFromConfig({
-            ctx: ctxPayload,
-            cfg,
-            dispatcher,
-            replyOptions,
-          }),
-      });
+        // Plugin mode: run inference + hooks but suppress all Feishu replies.
+        // Use a no-op dispatcher so withReplyDispatcher can properly track and
+        // settle the pending-reply slot (avoids a permanently non-zero pending count).
+        // Pass replyResolver: async () => undefined to suppress reply generation.
+        log(
+          `feishu[${account.accountId}]: plugin dispatch mode, hooks-only for session=${route.sessionKey}`,
+        );
+        const noopDispatcher = {
+          sendToolResult: () => false,
+          sendBlockReply: () => false,
+          sendFinalReply: () => false,
+          waitForIdle: async () => {},
+          getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+          markComplete: () => {},
+        };
+        await core.channel.reply.withReplyDispatcher({
+          dispatcher: noopDispatcher,
+          run: () =>
+            core.channel.reply.dispatchReplyFromConfig({
+              ctx: ctxPayload,
+              cfg,
+              dispatcher: noopDispatcher,
+              replyResolver: async () => undefined,
+            }),
+        });
+      } else {
+        const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
+          cfg,
+          agentId: route.agentId,
+          runtime: runtime as RuntimeEnv,
+          chatId: ctx.chatId,
+          replyToMessageId: replyTargetMessageId,
+          skipReplyToInMessages: !isGroup,
+          replyInThread,
+          rootId: ctx.rootId,
+          threadReply,
+          mentionTargets: ctx.mentionTargets,
+          accountId: account.accountId,
+          messageCreateTimeMs,
+        });
+
+        log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
+        const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
+          dispatcher,
+          onSettled: () => {
+            markDispatchIdle();
+          },
+          run: () =>
+            core.channel.reply.dispatchReplyFromConfig({
+              ctx: ctxPayload,
+              cfg,
+              dispatcher,
+              replyOptions,
+            }),
+        });
+
+        log(
+          `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
+        );
+      }
 
       if (isGroup && historyKey && chatHistories) {
         clearHistoryEntriesIfEnabled({
@@ -1534,10 +1578,6 @@ export async function handleFeishuMessage(params: {
           limit: historyLimit,
         });
       }
-
-      log(
-        `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
-      );
     }
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -472,6 +472,7 @@ function normalizeMentions(
   text: string,
   mentions?: FeishuMessageEvent["message"]["mentions"],
   botStripId?: string,
+  chatType?: string,
 ): string {
   if (!mentions || mentions.length === 0) return text;
 
@@ -486,8 +487,19 @@ function normalizeMentions(
       // Strip the full bot mention: optional "@Name " prefix + key
       const pattern = new RegExp(`(?:@${escaped(mention.name)}\\s+)?${escaped(mention.key)}`, "g");
       result = result.replace(pattern, "").trim();
+    } else if (chatType !== "group" && chatType !== "private") {
+      // P2P / unspecified: normalize non-bot mentions to <at> tags or @Name fallback
+      const keyPattern = new RegExp(escaped(mention.key), "g");
+      if (mentionId) {
+        result = result.replace(
+          keyPattern,
+          () => `<at user_id="${mentionId}">${escapeName(mention.name)}</at>`,
+        );
+      } else {
+        result = result.replace(keyPattern, () => `@${mention.name}`);
+      }
     }
-    // Non-bot mentions: leave text as-is
+    // group/private: non-bot mentions left as-is
   }
 
   return result;
@@ -779,7 +791,12 @@ export function parseFeishuMessageEvent(
   // mentionedBot flag already captures whether the bot was addressed, so
   // keeping the mention tag in content only breaks command detection (#35994).
   // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
+  const content = normalizeMentions(
+    rawContent,
+    event.message.mentions,
+    botOpenId,
+    event.message.chat_type,
+  );
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -965,6 +965,7 @@ export async function handleFeishuMessage(params: {
     0,
     feishuCfg?.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
+  const dispatchMode = feishuCfg?.dispatchMode ?? "auto";
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
@@ -1049,13 +1050,11 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
-    if (requireMention && !ctx.mentionedBot) {
-      log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
-      // Record to pending history for non-broadcast groups only. For broadcast groups,
-      // the mentioned handler's broadcast dispatch writes the turn directly into all
-      // agent sessions — buffering here would cause duplicate replay when this account
-      // later becomes active via buildPendingHistoryContextFromMap.
-      if (!broadcastAgents && chatHistories && groupHistoryKey) {
+    if (dispatchMode !== "plugin" && requireMention && !ctx.mentionedBot) {
+      log(
+        `feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot, recording to history`,
+      );
+      if (chatHistories) {
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
           historyKey: groupHistoryKey,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -46,3 +46,50 @@ describe("feishuPlugin.status.probeAccount", () => {
     expect(result).toMatchObject({ ok: true, appId: "cli_main" });
   });
 });
+
+describe("feishuPlugin.configSchema", () => {
+  it("exposes account-level dispatchMode in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: {
+            accounts?: {
+              additionalProperties?: {
+                properties?: Record<string, unknown>;
+              };
+            };
+          };
+        }
+      | undefined;
+
+    const dispatchMode = schema?.properties?.accounts?.additionalProperties?.properties
+      ?.dispatchMode as { enum?: string[] } | undefined;
+
+    expect(dispatchMode?.enum).toEqual(["auto", "plugin"]);
+  });
+
+  it("exposes account-level pluginMode.forwardControlCommands in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: {
+            accounts?: {
+              additionalProperties?: {
+                properties?: Record<string, unknown>;
+              };
+            };
+          };
+        }
+      | undefined;
+
+    const pluginMode = schema?.properties?.accounts?.additionalProperties?.properties?.pluginMode as
+      | {
+          properties?: Record<string, unknown>;
+        }
+      | undefined;
+
+    const forwardControlCommands = pluginMode?.properties?.forwardControlCommands as
+      | { type?: string }
+      | undefined;
+
+    expect(forwardControlCommands?.type).toBe("boolean");
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -110,6 +110,14 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
           ],
         },
         connectionMode: { type: "string", enum: ["websocket", "webhook"] },
+        dispatchMode: { type: "string", enum: ["auto", "plugin"] },
+        pluginMode: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            forwardControlCommands: { type: "boolean" },
+          },
+        },
         webhookPath: { type: "string" },
         webhookHost: { type: "string" },
         webhookPort: { type: "integer", minimum: 1 },
@@ -149,6 +157,14 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookHost: { type: "string" },
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
+              dispatchMode: { type: "string", enum: ["auto", "plugin"] },
+              pluginMode: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  forwardControlCommands: { type: "boolean" },
+                },
+              },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -192,6 +192,9 @@ describe("FeishuConfigSchema defaultAccount", () => {
         true,
       );
     }
+  });
+});
+
 describe("FeishuConfigSchema dispatchMode", () => {
   it("accepts dispatchMode at account level", () => {
     const parsed = FeishuConfigSchema.parse({

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -192,5 +192,62 @@ describe("FeishuConfigSchema defaultAccount", () => {
         true,
       );
     }
+describe("FeishuConfigSchema dispatchMode", () => {
+  it("accepts dispatchMode at account level", () => {
+    const parsed = FeishuConfigSchema.parse({
+      enabled: true,
+      accounts: {
+        alpha: {
+          appId: "app",
+          appSecret: "secret",
+          dispatchMode: "plugin",
+        },
+      },
+    });
+
+    expect(parsed.accounts?.alpha?.dispatchMode).toBe("plugin");
+  });
+
+  it("rejects invalid dispatchMode values", () => {
+    expect(() =>
+      FeishuConfigSchema.parse({
+        accounts: {
+          alpha: {
+            appId: "app",
+            appSecret: "secret",
+            // oxlint-disable-next-line typescript/no-explicit-any
+            dispatchMode: "invalid" as any,
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("FeishuConfigSchema pluginMode", () => {
+  it("accepts pluginMode.forwardControlCommands at top level", () => {
+    const parsed = FeishuConfigSchema.parse({
+      pluginMode: {
+        forwardControlCommands: false,
+      },
+    });
+
+    expect(parsed.pluginMode?.forwardControlCommands).toBe(false);
+  });
+
+  it("accepts pluginMode.forwardControlCommands at account level", () => {
+    const parsed = FeishuConfigSchema.parse({
+      accounts: {
+        alpha: {
+          appId: "app",
+          appSecret: "secret",
+          pluginMode: {
+            forwardControlCommands: false,
+          },
+        },
+      },
+    });
+
+    expect(parsed.accounts?.alpha?.pluginMode?.forwardControlCommands).toBe(false);
   });
 });

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -13,6 +13,7 @@ const FeishuDomainSchema = z.union([
   z.string().url().startsWith("https://"),
 ]);
 const FeishuConnectionModeSchema = z.enum(["websocket", "webhook"]);
+const DispatchModeSchema = z.enum(["auto", "plugin"]);
 
 const ToolPolicySchema = z
   .object({
@@ -58,6 +59,13 @@ const ChannelHeartbeatVisibilitySchema = z
   .object({
     visibility: z.enum(["visible", "hidden"]).optional(),
     intervalMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+const PluginModeConfigSchema = z
+  .object({
+    forwardControlCommands: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -167,6 +175,7 @@ const FeishuSharedConfigShape = {
   mediaMaxMb: z.number().positive().optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
+  pluginMode: PluginModeConfigSchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
@@ -190,6 +199,7 @@ export const FeishuAccountConfigSchema = z
     verificationToken: buildSecretInputSchema().optional(),
     domain: FeishuDomainSchema.optional(),
     connectionMode: FeishuConnectionModeSchema.optional(),
+    dispatchMode: DispatchModeSchema.optional(),
     webhookPath: z.string().optional(),
     ...FeishuSharedConfigShape,
     groupSessionScope: GroupSessionScopeSchema,
@@ -208,6 +218,7 @@ export const FeishuConfigSchema = z
     verificationToken: buildSecretInputSchema().optional(),
     domain: FeishuDomainSchema.optional().default("feishu"),
     connectionMode: FeishuConnectionModeSchema.optional().default("websocket"),
+    dispatchMode: DispatchModeSchema.optional().default("auto"),
     webhookPath: z.string().optional().default("/feishu/events"),
     ...FeishuSharedConfigShape,
     dmPolicy: DmPolicySchema.optional().default("pairing"),

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,8 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-  });
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+  } as any);
 
   const buffer = await readFeishuResponseBuffer({
     response,
@@ -145,7 +146,8 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-  });
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+  } as any);
 
   const buffer = await readFeishuResponseBuffer({
     response,
@@ -200,7 +202,8 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-  });
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+  } as any);
 
   // SDK v1.30+ returns data directly without code wrapper on success
   // On error, it throws or returns { code, msg }

--- a/extensions/feishu/src/mention.test.ts
+++ b/extensions/feishu/src/mention.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMentionTagsForCard, normalizeMentionTagsForText } from "./mention.js";
+
+describe("mention tag normalization", () => {
+  it("converts text-style mentions to card-style mentions", () => {
+    const input = `<at user_id="ou_123">Emma</at> hello <at user_id='all'>Everyone</at>`;
+    const output = normalizeMentionTagsForCard(input);
+    expect(output).toBe("<at id=ou_123></at> hello <at id=all></at>");
+  });
+
+  it("converts card-style mentions to text-style mentions with display names", () => {
+    const input = "<at id=ou_123></at> hi";
+    const output = normalizeMentionTagsForText(input, { ou_123: "Emma" });
+    expect(output).toBe('<at user_id="ou_123">Emma</at> hi');
+  });
+
+  it("falls back to id when card mention has no mapped display name", () => {
+    const input = "<at id=ou_999></at>";
+    const output = normalizeMentionTagsForText(input);
+    expect(output).toBe('<at user_id="ou_999">ou_999</at>');
+  });
+
+  it("keeps non-mention text unchanged", () => {
+    const input = "plain text";
+    expect(normalizeMentionTagsForCard(input)).toBe(input);
+    expect(normalizeMentionTagsForText(input)).toBe(input);
+  });
+});

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -1,19 +1,24 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
+const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./media.js", () => ({
-  sendMediaFeishu: sendMediaFeishuMock,
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: resolveFeishuAccountMock,
 }));
 
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
+}));
+
+vi.mock("./media.js", () => ({
+  sendMediaFeishu: sendMediaFeishuMock,
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -27,11 +32,20 @@ vi.mock("./runtime.js", () => ({
 }));
 
 import { feishuOutbound } from "./outbound.js";
+
 const sendText = feishuOutbound.sendText!;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("feishuOutbound.sendText local-image auto-convert", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    resolveFeishuAccountMock.mockReturnValue({
+      config: { renderMode: "auto" },
+    });
     sendMessageFeishuMock.mockResolvedValue({ messageId: "text_msg" });
     sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
     sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
@@ -48,7 +62,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     const { dir, file } = await createTmpImage();
     try {
       const result = await sendText({
-        cfg: {} as any,
+        cfg: {} as never,
         to: "chat_1",
         text: file,
         accountId: "main",
@@ -62,6 +76,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         }),
       );
       expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+      expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
       expect(result).toEqual(
         expect.objectContaining({ channel: "feishu", messageId: "media_msg" }),
       );
@@ -72,7 +87,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
 
   it("keeps non-path text on the text-send path", async () => {
     await sendText({
-      cfg: {} as any,
+      cfg: {} as never,
       to: "chat_1",
       text: "please upload /tmp/example.png",
       accountId: "main",
@@ -93,7 +108,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
     try {
       await sendText({
-        cfg: {} as any,
+        cfg: {} as never,
         to: "chat_1",
         text: file,
         accountId: "main",
@@ -107,6 +122,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
           accountId: "main",
         }),
       );
+      expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
@@ -355,5 +371,112 @@ describe("feishuOutbound.sendMedia renderMode", () => {
         accountId: "main",
       }),
     );
+  });
+});
+
+describe("feishuOutbound renderMode routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    resolveFeishuAccountMock.mockReturnValue({
+      config: { renderMode: "auto" },
+    });
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "msg_text", chatId: "chat_1" });
+    sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "msg_card", chatId: "chat_1" });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "msg_media", chatId: "chat_1" });
+  });
+
+  it("uses markdown card when renderMode=card", async () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      config: { renderMode: "card" },
+    });
+
+    const sendText = feishuOutbound.sendText;
+    if (!sendText) {
+      throw new Error("feishuOutbound.sendText is not configured");
+    }
+    await sendText({
+      cfg: {} as never,
+      to: "chat:oc_xxx",
+      text: "plain text",
+      accountId: "pm",
+    });
+
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_xxx",
+        text: "plain text",
+        accountId: "pm",
+      }),
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("uses text send when renderMode=raw", async () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      config: { renderMode: "raw" },
+    });
+
+    const sendText = feishuOutbound.sendText;
+    if (!sendText) {
+      throw new Error("feishuOutbound.sendText is not configured");
+    }
+    await sendText({
+      cfg: {} as never,
+      to: "chat:oc_xxx",
+      text: "plain text",
+      accountId: "pm",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("uses markdown card in auto mode when message contains markdown block", async () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      config: { renderMode: "auto" },
+    });
+
+    const sendText = feishuOutbound.sendText;
+    if (!sendText) {
+      throw new Error("feishuOutbound.sendText is not configured");
+    }
+    await sendText({
+      cfg: {} as never,
+      to: "chat:oc_xxx",
+      text: "```ts\nconst x = 1\n```",
+      accountId: "pm",
+    });
+
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps media fallback aligned with renderMode=card", async () => {
+    resolveFeishuAccountMock
+      .mockReturnValueOnce({ config: { renderMode: "card" } })
+      .mockReturnValueOnce({ config: { renderMode: "card" } });
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    const sendMedia = feishuOutbound.sendMedia;
+    if (!sendMedia) {
+      throw new Error("feishuOutbound.sendMedia is not configured");
+    }
+    await sendMedia({
+      cfg: {} as never,
+      to: "chat:oc_xxx",
+      text: "",
+      mediaUrl: "https://example.com/a.png",
+      accountId: "pm",
+    });
+
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "📎 https://example.com/a.png",
+      }),
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -15,6 +15,14 @@ export function assertFeishuMessageApiSuccess(
   }
 }
 
+export function rethrowWithFeishuErrorDetail(err: unknown, prefix: string): never {
+  const data = (err as any)?.response?.data;
+  if (data && typeof data.msg === "string") {
+    throw new Error(`${prefix}: ${data.msg}`, { cause: err });
+  }
+  throw err;
+}
+
 export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -8,6 +8,7 @@ import {
   normalizeMentionTagsForCard,
   normalizeMentionTagsForText,
 } from "./mention.js";
+import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   assertFeishuMessageApiSuccess,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -2,8 +2,12 @@ import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
-import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
-import { parsePostContent } from "./post.js";
+import {
+  buildMentionedMessage,
+  buildMentionedCardContent,
+  normalizeMentionTagsForCard,
+  normalizeMentionTagsForText,
+} from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -253,6 +257,57 @@ export type SendFeishuMessageParams = {
   accountId?: string;
 };
 
+function buildMentionMeta(
+  mentions?: MentionTarget[],
+): { mentions: Array<{ id: string; name?: string }> } | undefined {
+  if (!mentions || mentions.length === 0) {
+    return undefined;
+  }
+  return {
+    mentions: mentions.map((mention) => ({
+      id: mention.openId,
+      name: mention.name,
+    })),
+  };
+}
+
+function buildMentionDisplayNameMap(
+  mentions?: MentionTarget[],
+): Record<string, string> | undefined {
+  if (!mentions || mentions.length === 0) {
+    return undefined;
+  }
+  const map: Record<string, string> = {};
+  for (const mention of mentions) {
+    const openId = mention.openId?.trim();
+    if (!openId) {
+      continue;
+    }
+    const name = mention.name?.trim();
+    if (name) {
+      map[openId] = name;
+    }
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+function normalizeCardMentionTags(value: unknown): unknown {
+  if (typeof value === "string") {
+    return normalizeMentionTagsForCard(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeCardMentionTags(item));
+  }
+  if (value && typeof value === "object") {
+    const normalized: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      normalized[key] = normalizeCardMentionTags(item);
+    }
+    return normalized;
+  }
+  return value;
+}
+
 function buildFeishuPostMessagePayload(params: { messageText: string }): {
   content: string;
   msgType: string;
@@ -279,6 +334,7 @@ export async function sendMessageFeishu(
   params: SendFeishuMessageParams,
 ): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const mentionMeta = buildMentionMeta(mentions);
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = getFeishuRuntime().channel.text.resolveMarkdownTableMode({
     cfg,
@@ -290,6 +346,7 @@ export async function sendMessageFeishu(
   if (mentions && mentions.length > 0) {
     rawText = buildMentionedMessage(mentions, rawText);
   }
+  rawText = normalizeMentionTagsForText(rawText, buildMentionDisplayNameMap(mentions));
   const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode);
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
@@ -317,10 +374,25 @@ export async function sendMessageFeishu(
       return sendFallbackDirect(client, directParams, "Feishu send failed");
     }
     assertFeishuMessageApiSuccess(response, "Feishu reply failed");
-    return toFeishuSendResult(response, receiveId);
+    return {
+      ...toFeishuSendResult(response, receiveId),
+      ...(mentionMeta ? { meta: mentionMeta } : {}),
+    };
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu send failed");
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      content,
+      msg_type: msgType,
+    },
+  });
+  assertFeishuMessageApiSuccess(response, "Feishu send failed");
+  return {
+    ...toFeishuSendResult(response, receiveId),
+    ...(mentionMeta ? { meta: mentionMeta } : {}),
+  };
 }
 
 export type SendFeishuCardParams = {
@@ -330,11 +402,13 @@ export type SendFeishuCardParams = {
   replyToMessageId?: string;
   /** When true, reply creates a Feishu topic thread instead of an inline reply */
   replyInThread?: boolean;
+  mentions?: MentionTarget[];
   accountId?: string;
 };
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, card, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const mentionMeta = buildMentionMeta(mentions);
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
@@ -361,10 +435,25 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       return sendFallbackDirect(client, directParams, "Feishu card send failed");
     }
     assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
-    return toFeishuSendResult(response, receiveId);
+    return {
+      ...toFeishuSendResult(response, receiveId),
+      ...(mentionMeta ? { meta: mentionMeta } : {}),
+    };
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu card send failed");
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      content,
+      msg_type: "interactive",
+    },
+  });
+  assertFeishuMessageApiSuccess(response, "Feishu card send failed");
+  return {
+    ...toFeishuSendResult(response, receiveId),
+    ...(mentionMeta ? { meta: mentionMeta } : {}),
+  };
 }
 
 export async function updateCardFeishu(params: {
@@ -380,7 +469,7 @@ export async function updateCardFeishu(params: {
   }
 
   const client = createFeishuClient(account);
-  const content = JSON.stringify(card);
+  const content = JSON.stringify(normalizeCardMentionTags(card));
 
   const response = await client.im.message.patch({
     path: { message_id: messageId },
@@ -434,8 +523,9 @@ export async function sendMarkdownCardFeishu(params: {
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
+  cardText = normalizeMentionTagsForCard(cardText);
   const card = buildMarkdownCard(cardText);
-  return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, accountId });
+  return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, mentions, accountId });
 }
 
 /**
@@ -459,7 +549,11 @@ export async function editMessageFeishu(params: {
     cfg,
     channel: "feishu",
   });
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode);
+  const normalizedText = normalizeMentionTagsForText(text ?? "");
+  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(
+    normalizedText,
+    tableMode,
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -9,7 +9,11 @@ import {
   normalizeMentionTagsForText,
 } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
+import {
+  assertFeishuMessageApiSuccess,
+  rethrowWithFeishuErrorDetail,
+  toFeishuSendResult,
+} from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
@@ -380,14 +384,19 @@ export async function sendMessageFeishu(
     };
   }
 
-  const response = await client.im.message.create({
-    params: { receive_id_type: receiveIdType },
-    data: {
-      receive_id: receiveId,
-      content,
-      msg_type: msgType,
-    },
-  });
+  let response;
+  try {
+    response = await client.im.message.create({
+      params: { receive_id_type: receiveIdType },
+      data: {
+        receive_id: receiveId,
+        content,
+        msg_type: msgType,
+      },
+    });
+  } catch (err) {
+    rethrowWithFeishuErrorDetail(err, "Feishu send failed");
+  }
   assertFeishuMessageApiSuccess(response, "Feishu send failed");
   return {
     ...toFeishuSendResult(response, receiveId),
@@ -441,14 +450,19 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     };
   }
 
-  const response = await client.im.message.create({
-    params: { receive_id_type: receiveIdType },
-    data: {
-      receive_id: receiveId,
-      content,
-      msg_type: "interactive",
-    },
-  });
+  let response;
+  try {
+    response = await client.im.message.create({
+      params: { receive_id_type: receiveIdType },
+      data: {
+        receive_id: receiveId,
+        content,
+        msg_type: "interactive",
+      },
+    });
+  } catch (err) {
+    rethrowWithFeishuErrorDetail(err, "Feishu card send failed");
+  }
   assertFeishuMessageApiSuccess(response, "Feishu card send failed");
   return {
     ...toFeishuSendResult(response, receiveId),
@@ -471,10 +485,15 @@ export async function updateCardFeishu(params: {
   const client = createFeishuClient(account);
   const content = JSON.stringify(normalizeCardMentionTags(card));
 
-  const response = await client.im.message.patch({
-    path: { message_id: messageId },
-    data: { content },
-  });
+  let response;
+  try {
+    response = await client.im.message.patch({
+      path: { message_id: messageId },
+      data: { content },
+    });
+  } catch (err) {
+    rethrowWithFeishuErrorDetail(err, "Feishu card update failed");
+  }
 
   if (response.code !== 0) {
     throw new Error(`Feishu card update failed: ${response.msg || `code ${response.code}`}`);
@@ -557,13 +576,18 @@ export async function editMessageFeishu(params: {
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
-  const response = await client.im.message.update({
-    path: { message_id: messageId },
-    data: {
-      msg_type: msgType,
-      content,
-    },
-  });
+  let response;
+  try {
+    response = await client.im.message.update({
+      path: { message_id: messageId },
+      data: {
+        msg_type: msgType,
+        content,
+      },
+    });
+  } catch (err) {
+    rethrowWithFeishuErrorDetail(err, "Feishu message edit failed");
+  }
 
   if (response.code !== 0) {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -58,6 +58,7 @@ export type FeishuMessageContext = {
 export type FeishuSendResult = {
   messageId: string;
   chatId: string;
+  meta?: Record<string, unknown>;
 };
 
 export type FeishuProbeResult = BaseProbeResult<string> & {

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -13,6 +13,7 @@ export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
 
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
+export type FeishuDispatchMode = "auto" | "plugin";
 
 export type FeishuDefaultAccountSelectionSource =
   | "explicit-default"

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -16,6 +16,7 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -25,7 +26,6 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
-import { emitMessageReceivedHooks } from "./message-received-hooks.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -16,7 +16,6 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -26,6 +25,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
+import { emitMessageReceivedHooks } from "./message-received-hooks.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";

--- a/src/auto-reply/reply/message-received-hooks.ts
+++ b/src/auto-reply/reply/message-received-hooks.ts
@@ -1,0 +1,94 @@
+import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { FinalizedMsgContext } from "../templating.js";
+
+function resolveInboundContent(ctx: FinalizedMsgContext): string {
+  if (typeof ctx.BodyForCommands === "string") {
+    return ctx.BodyForCommands;
+  }
+  if (typeof ctx.RawBody === "string") {
+    return ctx.RawBody;
+  }
+  if (typeof ctx.Body === "string") {
+    return ctx.Body;
+  }
+  return "";
+}
+
+export function emitMessageReceivedHooks(params: { ctx: FinalizedMsgContext }): void {
+  const { ctx } = params;
+
+  const timestamp =
+    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
+  const messageIdForHook =
+    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  const content = resolveInboundContent(ctx);
+  const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_received")) {
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: ctx.From ?? "",
+          content,
+          timestamp,
+          metadata: {
+            to: ctx.To,
+            provider: ctx.Provider,
+            surface: ctx.Surface,
+            threadId: ctx.MessageThreadId,
+            originatingChannel: ctx.OriginatingChannel,
+            originatingTo: ctx.OriginatingTo,
+            messageId: messageIdForHook,
+            channelData: ctx.ChannelData,
+            senderId: ctx.SenderId,
+            senderName: ctx.SenderName,
+            senderUsername: ctx.SenderUsername,
+            senderE164: ctx.SenderE164,
+            guildId: ctx.GroupSpace,
+            channelName: ctx.GroupChannel,
+          },
+        },
+        {
+          channelId,
+          accountId: ctx.AccountId,
+          conversationId,
+        },
+      )
+      .catch((err) => {
+        logVerbose(`dispatch-from-config: message_received plugin hook failed: ${String(err)}`);
+      });
+  }
+
+  const sessionKey = ctx.SessionKey;
+  if (sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        from: ctx.From ?? "",
+        content,
+        timestamp,
+        channelId,
+        accountId: ctx.AccountId,
+        conversationId,
+        messageId: messageIdForHook,
+        metadata: {
+          to: ctx.To,
+          provider: ctx.Provider,
+          surface: ctx.Surface,
+          threadId: ctx.MessageThreadId,
+          senderId: ctx.SenderId,
+          senderName: ctx.SenderName,
+          senderUsername: ctx.SenderUsername,
+          senderE164: ctx.SenderE164,
+          guildId: ctx.GroupSpace,
+          channelName: ctx.GroupChannel,
+        },
+      }),
+    ).catch((err) => {
+      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
+    });
+  }
+}

--- a/src/auto-reply/reply/message-received-hooks.ts
+++ b/src/auto-reply/reply/message-received-hooks.ts
@@ -43,7 +43,6 @@ export function emitMessageReceivedHooks(params: { ctx: FinalizedMsgContext }): 
             originatingChannel: ctx.OriginatingChannel,
             originatingTo: ctx.OriginatingTo,
             messageId: messageIdForHook,
-            channelData: ctx.ChannelData,
             senderId: ctx.SenderId,
             senderName: ctx.SenderName,
             senderUsername: ctx.SenderUsername,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -260,6 +260,7 @@ type MessageSentEvent = {
   content: string;
   error?: string;
   messageId?: string;
+  result?: OutboundDeliveryResult;
 };
 
 function hasMediaPayload(payload: ReplyPayload): boolean {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /invalid receive_id/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,7 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "Feishu send failed: invalid receive_id",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -691,3 +691,7 @@ export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
+// Plugin hooks
+export type { HookRunner } from "../plugins/hooks.js";
+export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+export { emitMessageReceivedHooks } from "../auto-reply/reply/message-received-hooks.js";


### PR DESCRIPTION
## Problem

The Feishu message pipeline has multiple gaps that affect message quality, plugin integration, and error recovery:

### 1. Mentions lost in outbound messages

When the model generates `<at user_id="ou_xxx">Name</at>` tags, they are passed to Feishu's API as-is. But Feishu's text message API and card API expect **different mention tag formats**:
- Text API: `<at user_id="ou_xxx">Name</at>` ✓
- Card API: `<at id=ou_xxx></at>` (no quotes, no inner text)

Cards with wrong mention format render as broken text instead of clickable @-mentions.

### 2. No plugin dispatch mode

Some integrations need to run the inference pipeline + hooks but **suppress all replies** to the Feishu chat (e.g., when a separate system handles the response). There's no way to do this — every dispatched message produces a Feishu reply.

```
Before:
  Feishu message → dispatch → inference → reply to Feishu (always)

After (dispatchMode="plugin"):
  Feishu message → dispatch → inference + hooks → no reply to Feishu
                                                  └→ plugins handle output
```

### 3. Delivery errors lose context

When a Feishu API call fails, the error message from the API response is not parsed or included in the error. Operators see generic "send failed" without knowing whether it was a rate limit, permission issue, or invalid parameter.

### 4. Mention metadata not in hook events

The `message_sent` hook event has no mention data. Plugins tracking sent messages can't know who was @-mentioned.

### 5. Missing `ChannelData` propagation

Inbound Feishu context (chatId, messageType, mentions, media paths, sender details) is not passed through to the dispatch pipeline. Plugins and hooks that need this data must re-fetch from the Feishu API.

## Fix

- **Mention normalization** (`mention.ts`):
  - `normalizeMentionTagsForCard()`: converts `<at user_id="...">Name</at>` → `<at id=...></at>`
  - `normalizeMentionTagsForText()`: converts `<at id=...></at>` → `<at user_id="...">Name</at>` with display name lookup
  - Applied in `sendMessageFeishu` based on message type (card vs text)

- **Plugin dispatch mode** (`bot.ts`):
  - New `dispatchMode` config option: `"auto"` (default, current behavior) or `"plugin"` (hooks-only, no reply)
  - Plugin mode uses a no-op dispatcher to properly track pending-reply slots
  - `requireMention` check is bypassed in plugin mode (all messages dispatched)

- **Error detail extraction** (`send-result.ts`):
  - `rethrowWithFeishuErrorDetail()`: parses Feishu API error responses and includes the error code + message in the thrown error

- **Mention metadata** (`send.ts`):
  - `buildMentionMeta()`: extracts mention targets into a `{ mentions: [{id, name}] }` structure
  - Passed as `meta` on `sendPayload` results → flows through to `message_sent` hooks

- **ChannelData propagation** (`bot.ts`):
  - Populates `ChannelData` with full Feishu event context (messageId, chatId, chatType, accountId, mentions, sender info, media paths)

- Tests for mention normalization, plugin dispatch flow, mention metadata, and ChannelData propagation

## Why merge

Without mention normalization, @-mentions in Feishu cards render as broken plain text — a visible UX bug for all card-mode deployments. Without plugin dispatch mode, integrations that need hooks-only processing cannot suppress Feishu replies, causing duplicate messages. The delivery error detail gap makes debugging Feishu API failures significantly harder. These are production-impacting issues for any Feishu-based deployment.