### PR TITLE
Gateway: harden node override policy and security audit checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,15 +203,6 @@
         "line_number": 723
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -228,22 +219,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1763
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -11012,15 +10987,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11389,84 +11355,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11485,31 +11373,6 @@
         "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11524,40 +11387,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11596,15 +11425,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11614,67 +11434,6 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
-        "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
     "src/agents/tools/web-search.ts": [
       {
         "type": "Secret Keyword",
@@ -11682,63 +11441,6 @@
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
         "line_number": 292
-      }
-    ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11793,15 +11495,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11809,50 +11502,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11864,31 +11513,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11896,52 +11520,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11958,96 +11536,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12075,15 +11563,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12336,14 +11815,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 653
+        "line_number": 657
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 686
+        "line_number": 690
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12389,7 +11868,7 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 326
+        "line_number": 327
       }
     ],
     "src/config/slack-http-config.test.ts": [
@@ -12408,15 +11887,6 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 10
-      }
-    ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
       }
     ],
     "src/gateway/auth-rate-limit.ts": [
@@ -12502,15 +11972,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12545,40 +12006,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12793,15 +12220,6 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12917,14 +12335,14 @@
         "filename": "src/security/audit.test.ts",
         "hashed_secret": "21f688ab56f76a99e5c6ed342291422f4e57e47f",
         "is_verified": false,
-        "line_number": 3473
+        "line_number": 3563
       },
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
         "hashed_secret": "3dc927d80543dc0f643940b70d066bd4b4c4b78e",
         "is_verified": false,
-        "line_number": 3486
+        "line_number": 3576
       }
     ],
     "src/telegram/monitor.test.ts": [
@@ -13035,5 +12453,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-09T01:11:58Z"
+  "generated_at": "2026-03-09T07:09:25Z"
 }

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -179,9 +179,22 @@ describe("config schema regressions", () => {
     const res = validateConfigObject({
       browser: {
         extraArgs: "--proxy-server=http://127.0.0.1:7890" as unknown,
+  it("rejects displayName-like gateway.nodes.overrides keys", () => {
+    const res = validateConfigObject({
+      gateway: {
+        nodes: {
+          overrides: {
+            "My MacBook": {
+              denyCommands: ["system.run"],
+            },
+          },
+        },
       },
     });
 
     expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.nodes.overrides.My MacBook");
+    }
   });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -179,6 +179,12 @@ describe("config schema regressions", () => {
     const res = validateConfigObject({
       browser: {
         extraArgs: "--proxy-server=http://127.0.0.1:7890" as unknown,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
   it("rejects displayName-like gateway.nodes.overrides keys", () => {
     const res = validateConfigObject({
       gateway: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -418,6 +418,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings). Enabling dangerous commands here is a security-sensitive override and is flagged by `openclaw security audit`.",
   "gateway.nodes.denyCommands":
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
+  "gateway.nodes.overrides":
+    "Per-node command policy overrides, keyed by node displayName, nodeId, or nodeId prefix. " +
+    "Each entry may specify allowCommands and denyCommands that merge with the global lists. " +
+    "Match precedence is nodeId exact, then displayName exact, then longest nodeId prefix.",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -419,9 +419,9 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.nodes.denyCommands":
     "Node command names to block even if present in node claims or default allowlist (exact command-name matching only, e.g. `system.run`; does not inspect shell text inside that command).",
   "gateway.nodes.overrides":
-    "Per-node command policy overrides, keyed by node displayName, nodeId, or nodeId prefix. " +
+    "Per-node command policy overrides, keyed by nodeId or nodeId prefix. " +
     "Each entry may specify allowCommands and denyCommands that merge with the global lists. " +
-    "Match precedence is nodeId exact, then displayName exact, then longest nodeId prefix.",
+    "Match precedence is nodeId exact, then longest nodeId prefix.",
   nodeHost:
     "Node host controls for features exposed from this gateway node to other nodes or clients. Keep defaults unless you intentionally proxy local capabilities across your node network.",
   "nodeHost.browserProxy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -274,6 +274,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.nodes.browser.node": "Gateway Node Browser Pin",
   "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
   "gateway.nodes.denyCommands": "Gateway Node Denylist",
+  "gateway.nodes.overrides": "Per-Node Command Overrides",
   nodeHost: "Node Host",
   "nodeHost.browserProxy": "Node Browser Proxy",
   "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -365,8 +365,9 @@ export type GatewayNodesConfig = {
   /** Commands to deny even if they appear in the defaults or node claims. */
   denyCommands?: string[];
   /**
-   * Per-node overrides keyed by node displayName, nodeId, or nodeId prefix.
-   * Match precedence: nodeId exact, then displayName exact, then longest nodeId prefix.
+   * Per-node overrides keyed by nodeId or nodeId prefix.
+   * Match precedence: nodeId exact, then longest nodeId prefix.
+   * displayName-based matching is intentionally unsupported.
    */
   overrides?: Record<string, GatewayNodeOverrideConfig>;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -345,6 +345,13 @@ export type GatewayHttpConfig = {
   securityHeaders?: GatewayHttpSecurityHeadersConfig;
 };
 
+export type GatewayNodeOverrideConfig = {
+  /** Additional node.invoke commands to allow for this specific node. */
+  allowCommands?: string[];
+  /** Commands to deny for this specific node (merged with global denyCommands). */
+  denyCommands?: string[];
+};
+
 export type GatewayNodesConfig = {
   /** Browser routing policy for node-hosted browser proxies. */
   browser?: {
@@ -357,6 +364,11 @@ export type GatewayNodesConfig = {
   allowCommands?: string[];
   /** Commands to deny even if they appear in the defaults or node claims. */
   denyCommands?: string[];
+  /**
+   * Per-node overrides keyed by node displayName, nodeId, or nodeId prefix.
+   * Match precedence: nodeId exact, then displayName exact, then longest nodeId prefix.
+   */
+  overrides?: Record<string, GatewayNodeOverrideConfig>;
 };
 
 export type GatewayToolsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -804,7 +804,10 @@ export const OpenClawSchema = z
             denyCommands: z.array(z.string()).optional(),
             overrides: z
               .record(
-                z.string(),
+                z.string().regex(/^[A-Za-z0-9._:-]+$/, {
+                  message:
+                    "gateway.nodes.overrides keys must be nodeId or nodeId prefix tokens (letters, numbers, ., _, :, -)",
+                }),
                 z
                   .object({
                     allowCommands: z.array(z.string()).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -802,6 +802,17 @@ export const OpenClawSchema = z
               .optional(),
             allowCommands: z.array(z.string()).optional(),
             denyCommands: z.array(z.string()).optional(),
+            overrides: z
+              .record(
+                z.string(),
+                z
+                  .object({
+                    allowCommands: z.array(z.string()).optional(),
+                    denyCommands: z.array(z.string()).optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -401,7 +401,7 @@ describe("resolveNodeCommandAllowlist", () => {
           nodes: {
             denyCommands: ["camera.snap"],
             overrides: {
-              "lukin-dev": {
+              "node-123": {
                 denyCommands: ["browser.proxy"],
               },
             },
@@ -422,7 +422,7 @@ describe("resolveNodeCommandAllowlist", () => {
           nodes: {
             allowCommands: ["camera.snap"],
             overrides: {
-              "my-node": {
+              n1: {
                 allowCommands: ["screen.record"],
               },
             },
@@ -435,22 +435,19 @@ describe("resolveNodeCommandAllowlist", () => {
     expect(allow.has("screen.record")).toBe(true);
   });
 
-  it("nodeId match takes priority over displayName", () => {
+  it("ignores displayName-only overrides", () => {
     const allow = resolveNodeCommandAllowlist(
       {
         gateway: {
           nodes: {
             overrides: {
               "my-display": { denyCommands: ["system.run"] },
-              "node-abc": { denyCommands: ["system.notify"] },
             },
           },
         },
       },
       { platform: "linux", deviceFamily: "", nodeId: "node-abc", displayName: "my-display" },
     );
-    // nodeId override wins: system.notify denied, system.run allowed
-    expect(allow.has("system.notify")).toBe(false);
     expect(allow.has("system.run")).toBe(true);
   });
 
@@ -504,7 +501,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "n1", displayName: "my-node" },
+      { platform: "linux", deviceFamily: "", nodeId: "my-node", displayName: "my-node" },
     );
     // camera.snap added by allow but removed by deny
     expect(allow.has("camera.snap")).toBe(false);

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -543,7 +543,6 @@ describe("resolveNodeCommandAllowlist", () => {
     // "node-lukin-" is the longest prefix → only browser.proxy denied
     expect(allow.has("browser.proxy")).toBe(false);
     expect(allow.has("system.run")).toBe(true);
-
   });
 });
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -393,6 +393,161 @@ describe("resolveNodeCommandAllowlist", () => {
     expect(allow.has("system.which")).toBe(false);
     expect(allow.has("device.info")).toBe(true);
   });
+
+  it("per-node denyCommands merges with global deny", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            denyCommands: ["camera.snap"],
+            overrides: {
+              "lukin-dev": {
+                denyCommands: ["browser.proxy"],
+              },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "node-123", displayName: "lukin-dev" },
+    );
+    expect(allow.has("camera.snap")).toBe(false);
+    expect(allow.has("browser.proxy")).toBe(false);
+    expect(allow.has("system.run")).toBe(true);
+  });
+
+  it("per-node allowCommands merges with global allow", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            allowCommands: ["camera.snap"],
+            overrides: {
+              "my-node": {
+                allowCommands: ["screen.record"],
+              },
+            },
+          },
+        },
+      },
+      { platform: "ios", deviceFamily: "iPhone", nodeId: "n1", displayName: "my-node" },
+    );
+    expect(allow.has("camera.snap")).toBe(true);
+    expect(allow.has("screen.record")).toBe(true);
+  });
+
+  it("nodeId match takes priority over displayName", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            overrides: {
+              "my-display": { denyCommands: ["system.run"] },
+              "node-abc": { denyCommands: ["system.notify"] },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "node-abc", displayName: "my-display" },
+    );
+    // nodeId override wins: system.notify denied, system.run allowed
+    expect(allow.has("system.notify")).toBe(false);
+    expect(allow.has("system.run")).toBe(true);
+  });
+
+  it("matches by nodeId prefix", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            overrides: {
+              "node-": { denyCommands: ["browser.proxy"] },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20", displayName: "" },
+    );
+    expect(allow.has("browser.proxy")).toBe(false);
+    expect(allow.has("system.run")).toBe(true);
+  });
+
+  it("falls back to global config when no override matches", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            denyCommands: ["camera.snap"],
+            overrides: {
+              "other-node": { denyCommands: ["browser.proxy"] },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "my-node", displayName: "my-node" },
+    );
+    // Global deny applies, per-node deny for "other-node" does not
+    expect(allow.has("camera.snap")).toBe(false);
+    expect(allow.has("browser.proxy")).toBe(true);
+  });
+
+  it("per-node allow and deny coexist; deny wins over allow", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            overrides: {
+              "my-node": {
+                allowCommands: ["camera.snap", "screen.record"],
+                denyCommands: ["camera.snap"],
+              },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "n1", displayName: "my-node" },
+    );
+    // camera.snap added by allow but removed by deny
+    expect(allow.has("camera.snap")).toBe(false);
+    // screen.record only in allow, not denied
+    expect(allow.has("screen.record")).toBe(true);
+  });
+
+  it("ignores empty-string override key", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            overrides: {
+              "": { denyCommands: ["system.run"] },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "any-node", displayName: "" },
+    );
+    // Empty key should not match — system.run stays allowed
+    expect(allow.has("system.run")).toBe(true);
+  });
+
+  it("prefix match picks longest matching key", () => {
+    const allow = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            overrides: {
+              "node-": { denyCommands: ["system.run", "browser.proxy"] },
+              "node-lukin-": { denyCommands: ["browser.proxy"] },
+            },
+          },
+        },
+      },
+      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20", displayName: "" },
+    );
+    // "node-lukin-" is the longest prefix → only browser.proxy denied
+    expect(allow.has("browser.proxy")).toBe(false);
+    expect(allow.has("system.run")).toBe(true);
+
+  });
 });
 
 describe("normalizeVoiceWakeTriggers", () => {

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -408,7 +408,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "node-123", displayName: "lukin-dev" },
+      { platform: "linux", deviceFamily: "", nodeId: "node-123" },
     );
     expect(allow.has("camera.snap")).toBe(false);
     expect(allow.has("browser.proxy")).toBe(false);
@@ -429,7 +429,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "ios", deviceFamily: "iPhone", nodeId: "n1", displayName: "my-node" },
+      { platform: "ios", deviceFamily: "iPhone", nodeId: "n1" },
     );
     expect(allow.has("camera.snap")).toBe(true);
     expect(allow.has("screen.record")).toBe(true);
@@ -446,7 +446,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "node-abc", displayName: "my-display" },
+      { platform: "linux", deviceFamily: "", nodeId: "node-abc" },
     );
     expect(allow.has("system.run")).toBe(true);
   });
@@ -462,7 +462,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20", displayName: "" },
+      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20" },
     );
     expect(allow.has("browser.proxy")).toBe(false);
     expect(allow.has("system.run")).toBe(true);
@@ -480,7 +480,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "my-node", displayName: "my-node" },
+      { platform: "linux", deviceFamily: "", nodeId: "my-node" },
     );
     // Global deny applies, per-node deny for "other-node" does not
     expect(allow.has("camera.snap")).toBe(false);
@@ -501,7 +501,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "my-node", displayName: "my-node" },
+      { platform: "linux", deviceFamily: "", nodeId: "my-node" },
     );
     // camera.snap added by allow but removed by deny
     expect(allow.has("camera.snap")).toBe(false);
@@ -520,7 +520,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "any-node", displayName: "" },
+      { platform: "linux", deviceFamily: "", nodeId: "any-node" },
     );
     // Empty key should not match — system.run stays allowed
     expect(allow.has("system.run")).toBe(true);
@@ -538,7 +538,7 @@ describe("resolveNodeCommandAllowlist", () => {
           },
         },
       },
-      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20", displayName: "" },
+      { platform: "linux", deviceFamily: "", nodeId: "node-lukin-20" },
     );
     // "node-lukin-" is the longest prefix → only browser.proxy denied
     expect(allow.has("browser.proxy")).toBe(false);

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -202,7 +202,7 @@ export function resolveNodeCommandAllowlist(
 
 function resolveNodeOverride(
   cfg: OpenClawConfig,
-  node?: Partial<Pick<NodeSession, "nodeId" | "displayName">>,
+  node?: Partial<Pick<NodeSession, "nodeId">>,
 ): GatewayNodeOverrideConfig | undefined {
   const overrides = cfg.gateway?.nodes?.overrides;
   if (!overrides || !node) {
@@ -212,11 +212,7 @@ function resolveNodeOverride(
   if (node.nodeId && overrides[node.nodeId]) {
     return overrides[node.nodeId];
   }
-  // 2. displayName exact match
-  if (node.displayName && overrides[node.displayName]) {
-    return overrides[node.displayName];
-  }
-  // 3. nodeId prefix match (longest prefix wins; skip empty keys)
+  // 2. nodeId prefix match (longest prefix wins; skip empty keys)
   if (node.nodeId) {
     let bestKey: string | undefined;
     for (const key of Object.keys(overrides)) {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { GatewayNodeOverrideConfig } from "../config/types.gateway.js";
 import {
   NODE_BROWSER_PROXY_COMMAND,
   NODE_SYSTEM_NOTIFY_COMMAND,
@@ -172,20 +173,64 @@ function normalizePlatformId(platform?: string, deviceFamily?: string): Platform
 
 export function resolveNodeCommandAllowlist(
   cfg: OpenClawConfig,
-  node?: Pick<NodeSession, "platform" | "deviceFamily">,
+  node?: Pick<NodeSession, "platform" | "deviceFamily"> &
+    Partial<Pick<NodeSession, "nodeId" | "displayName">>,
 ): Set<string> {
   const platformId = normalizePlatformId(node?.platform, node?.deviceFamily);
   const base = PLATFORM_DEFAULTS[platformId] ?? PLATFORM_DEFAULTS.unknown;
-  const extra = cfg.gateway?.nodes?.allowCommands ?? [];
-  const deny = new Set(cfg.gateway?.nodes?.denyCommands ?? []);
-  const allow = new Set([...base, ...extra].map((cmd) => cmd.trim()).filter(Boolean));
-  for (const blocked of deny) {
-    const trimmed = blocked.trim();
-    if (trimmed) {
-      allow.delete(trimmed);
-    }
+
+  // Global config
+  const extraGlobal = cfg.gateway?.nodes?.allowCommands ?? [];
+  const denyGlobal = cfg.gateway?.nodes?.denyCommands ?? [];
+
+  // Per-node override lookup
+  const override = resolveNodeOverride(cfg, node);
+  const extraNode = override?.allowCommands ?? [];
+  const denyNode = override?.denyCommands ?? [];
+
+  // Merge: base + global allow + per-node allow
+  const allow = new Set(
+    [...base, ...extraGlobal, ...extraNode].map((cmd) => cmd.trim()).filter(Boolean),
+  );
+
+  // Remove: global deny + per-node deny
+  for (const cmd of [...denyGlobal, ...denyNode].map((c) => c.trim()).filter(Boolean)) {
+    allow.delete(cmd);
   }
   return allow;
+}
+
+function resolveNodeOverride(
+  cfg: OpenClawConfig,
+  node?: Partial<Pick<NodeSession, "nodeId" | "displayName">>,
+): GatewayNodeOverrideConfig | undefined {
+  const overrides = cfg.gateway?.nodes?.overrides;
+  if (!overrides || !node) {
+    return undefined;
+  }
+  // 1. nodeId exact match
+  if (node.nodeId && overrides[node.nodeId]) {
+    return overrides[node.nodeId];
+  }
+  // 2. displayName exact match
+  if (node.displayName && overrides[node.displayName]) {
+    return overrides[node.displayName];
+  }
+  // 3. nodeId prefix match (longest prefix wins; skip empty keys)
+  if (node.nodeId) {
+    let bestKey: string | undefined;
+    for (const key of Object.keys(overrides)) {
+      if (key && node.nodeId.startsWith(key)) {
+        if (!bestKey || key.length > bestKey.length) {
+          bestKey = key;
+        }
+      }
+    }
+    if (bestKey) {
+      return overrides[bestKey];
+    }
+  }
+  return undefined;
 }
 
 export function isNodeCommandAllowed(params: {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -173,8 +173,7 @@ function normalizePlatformId(platform?: string, deviceFamily?: string): Platform
 
 export function resolveNodeCommandAllowlist(
   cfg: OpenClawConfig,
-  node?: Pick<NodeSession, "platform" | "deviceFamily"> &
-    Partial<Pick<NodeSession, "nodeId" | "displayName">>,
+  node?: Pick<NodeSession, "platform" | "deviceFamily"> & Partial<Pick<NodeSession, "nodeId">>,
 ): Set<string> {
   const platformId = normalizePlatformId(node?.platform, node?.deviceFamily);
   const base = PLATFORM_DEFAULTS[platformId] ?? PLATFORM_DEFAULTS.unknown;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -965,6 +965,8 @@ export function attachGatewayWsMessageHandler(params: {
           const allowlist = resolveNodeCommandAllowlist(cfg, {
             platform: connectParams.client.platform,
             deviceFamily: connectParams.client.deviceFamily,
+            nodeId: device?.id ?? connectParams.client.id,
+            displayName: connectParams.client.displayName,
           });
           const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
           const filtered = declared

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -966,7 +966,6 @@ export function attachGatewayWsMessageHandler(params: {
             platform: connectParams.client.platform,
             deviceFamily: connectParams.client.deviceFamily,
             nodeId: device?.id ?? connectParams.client.id,
-            displayName: connectParams.client.displayName,
           });
           const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
           const filtered = declared

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -567,7 +567,7 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: { source: "file", path: secretFile, mode: "json", allowInsecurePath: true },
             },
           },
           models: {
@@ -658,7 +658,7 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: { source: "file", path: secretFile, mode: "json", allowInsecurePath: true },
             },
           },
           models: {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1085,6 +1085,12 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
       for (const value of overrideAllowCommands.get(entry.overrideKey) ?? []) {
         knownCommands.add(value);
       }
+    } else {
+      for (const values of overrideAllowCommands.values()) {
+        for (const value of values) {
+          knownCommands.add(value);
+        }
+      }
     }
 
     for (const value of entry.values) {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1057,16 +1057,36 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
     return findings;
   }
 
-  const knownCommands = listKnownNodeCommands(cfg);
-  for (const entry of listConfiguredNodeAllowCommandEntries(cfg)) {
-    for (const value of entry.values) {
-      knownCommands.add(value);
+  const baseKnownCommands = listKnownNodeCommands(cfg);
+  const allowEntries = listConfiguredNodeAllowCommandEntries(cfg);
+  const globalAllowCommands = new Set(
+    allowEntries.filter((entry) => !entry.overrideKey).flatMap((entry) => entry.values),
+  );
+  const overrideAllowCommands = new Map<string, Set<string>>();
+  for (const entry of allowEntries) {
+    if (!entry.overrideKey) {
+      continue;
     }
+    const values = overrideAllowCommands.get(entry.overrideKey) ?? new Set<string>();
+    for (const value of entry.values) {
+      values.add(value);
+    }
+    overrideAllowCommands.set(entry.overrideKey, values);
   }
 
   const patternLike: string[] = [];
   const unknownExact: string[] = [];
   for (const entry of denyEntries) {
+    const knownCommands = new Set(baseKnownCommands);
+    for (const value of globalAllowCommands) {
+      knownCommands.add(value);
+    }
+    if (entry.overrideKey) {
+      for (const value of overrideAllowCommands.get(entry.overrideKey) ?? []) {
+        knownCommands.add(value);
+      }
+    }
+
     for (const value of entry.values) {
       if (looksLikeNodeCommandPattern(value)) {
         patternLike.push(`${entry.path}: ${value}`);
@@ -1100,7 +1120,11 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
 
     detailParts.push(`Unknown command names (not in defaults/allowCommands): ${unknownDetails}`);
   }
-  const examples = Array.from(knownCommands).slice(0, 8);
+  const exampleCommands = new Set(baseKnownCommands);
+  for (const value of globalAllowCommands) {
+    exampleCommands.add(value);
+  }
+  const examples = Array.from(exampleCommands).slice(0, 8);
 
   findings.push({
     checkId: "gateway.nodes.deny_commands_ineffective",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -198,6 +198,89 @@ function normalizeNodeCommand(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+type NodeCommandConfigEntry = {
+  path: string;
+  values: string[];
+  overrideKey?: string;
+};
+
+function formatNodeOverrideConfigPath(
+  key: string,
+  field: "allowCommands" | "denyCommands",
+): string {
+  return `gateway.nodes.overrides[${JSON.stringify(key)}].${field}`;
+}
+
+function listConfiguredNodeAllowCommandEntries(cfg: OpenClawConfig): NodeCommandConfigEntry[] {
+  const out: NodeCommandConfigEntry[] = [];
+  const globalAllow = cfg.gateway?.nodes?.allowCommands;
+  if (Array.isArray(globalAllow)) {
+    const values = globalAllow.map(normalizeNodeCommand).filter(Boolean);
+    if (values.length > 0) {
+      out.push({ path: "gateway.nodes.allowCommands", values });
+    }
+  }
+
+  const overrides = cfg.gateway?.nodes?.overrides;
+  if (!overrides) {
+    return out;
+  }
+  for (const [key, override] of Object.entries(overrides)) {
+    if (!override) {
+      continue;
+    }
+    const allow = override.allowCommands;
+    if (!Array.isArray(allow)) {
+      continue;
+    }
+    const values = allow.map(normalizeNodeCommand).filter(Boolean);
+    if (values.length === 0) {
+      continue;
+    }
+    out.push({
+      path: formatNodeOverrideConfigPath(key, "allowCommands"),
+      values,
+      overrideKey: key,
+    });
+  }
+  return out;
+}
+
+function listConfiguredNodeDenyCommandEntries(cfg: OpenClawConfig): NodeCommandConfigEntry[] {
+  const out: NodeCommandConfigEntry[] = [];
+  const globalDeny = cfg.gateway?.nodes?.denyCommands;
+  if (Array.isArray(globalDeny)) {
+    const values = globalDeny.map(normalizeNodeCommand).filter(Boolean);
+    if (values.length > 0) {
+      out.push({ path: "gateway.nodes.denyCommands", values });
+    }
+  }
+
+  const overrides = cfg.gateway?.nodes?.overrides;
+  if (!overrides) {
+    return out;
+  }
+  for (const [key, override] of Object.entries(overrides)) {
+    if (!override) {
+      continue;
+    }
+    const deny = override.denyCommands;
+    if (!Array.isArray(deny)) {
+      continue;
+    }
+    const values = deny.map(normalizeNodeCommand).filter(Boolean);
+    if (values.length === 0) {
+      continue;
+    }
+    out.push({
+      path: formatNodeOverrideConfigPath(key, "denyCommands"),
+      values,
+      overrideKey: key,
+    });
+  }
+  return out;
+}
+
 function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
   const baseCfg: OpenClawConfig = {
     ...cfg,
@@ -969,21 +1052,31 @@ export function collectSandboxDangerousConfigFindings(cfg: OpenClawConfig): Secu
 
 export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const denyListRaw = cfg.gateway?.nodes?.denyCommands;
-  if (!Array.isArray(denyListRaw) || denyListRaw.length === 0) {
-    return findings;
-  }
-
-  const denyList = denyListRaw.map(normalizeNodeCommand).filter(Boolean);
-  if (denyList.length === 0) {
+  const denyEntries = listConfiguredNodeDenyCommandEntries(cfg);
+  if (denyEntries.length === 0) {
     return findings;
   }
 
   const knownCommands = listKnownNodeCommands(cfg);
-  const patternLike = denyList.filter((entry) => looksLikeNodeCommandPattern(entry));
-  const unknownExact = denyList.filter(
-    (entry) => !looksLikeNodeCommandPattern(entry) && !knownCommands.has(entry),
-  );
+  for (const entry of listConfiguredNodeAllowCommandEntries(cfg)) {
+    for (const value of entry.values) {
+      knownCommands.add(value);
+    }
+  }
+
+  const patternLike: string[] = [];
+  const unknownExact: string[] = [];
+  for (const entry of denyEntries) {
+    for (const value of entry.values) {
+      if (looksLikeNodeCommandPattern(value)) {
+        patternLike.push(`${entry.path}: ${value}`);
+        continue;
+      }
+      if (!knownCommands.has(value)) {
+        unknownExact.push(`${entry.path}: ${value}`);
+      }
+    }
+  }
   if (patternLike.length === 0 && unknownExact.length === 0) {
     return findings;
   }
@@ -1012,9 +1105,9 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   findings.push({
     checkId: "gateway.nodes.deny_commands_ineffective",
     severity: "warn",
-    title: "Some gateway.nodes.denyCommands entries are ineffective",
+    title: "Some node denyCommands entries are ineffective",
     detail:
-      "gateway.nodes.denyCommands uses exact node command-name matching only (for example `system.run`), not shell-text filtering inside a command payload.\n" +
+      "gateway.nodes.denyCommands uses exact node command-name matching only (global and per-node overrides, for example `system.run`), not shell-text filtering inside a command payload.\n" +
       detailParts.map((entry) => `- ${entry}`).join("\n"),
     remediation:
       `Use exact command names (for example: ${examples.join(", ")}). ` +
@@ -1028,21 +1121,33 @@ export function collectNodeDangerousAllowCommandFindings(
   cfg: OpenClawConfig,
 ): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const allowRaw = cfg.gateway?.nodes?.allowCommands;
-  if (!Array.isArray(allowRaw) || allowRaw.length === 0) {
+  const allowEntries = listConfiguredNodeAllowCommandEntries(cfg);
+  if (allowEntries.length === 0) {
     return findings;
   }
 
-  const allow = new Set(allowRaw.map(normalizeNodeCommand).filter(Boolean));
-  if (allow.size === 0) {
-    return findings;
+  const globalDeny = new Set((cfg.gateway?.nodes?.denyCommands ?? []).map(normalizeNodeCommand));
+  const dangerousEntries: string[] = [];
+  for (const entry of allowEntries) {
+    const allowSet = new Set(entry.values);
+    const denySet = new Set(globalDeny);
+    if (entry.overrideKey) {
+      const overrideDeny = cfg.gateway?.nodes?.overrides?.[entry.overrideKey]?.denyCommands;
+      if (Array.isArray(overrideDeny)) {
+        for (const cmd of overrideDeny.map(normalizeNodeCommand).filter(Boolean)) {
+          denySet.add(cmd);
+        }
+      }
+    }
+    const dangerousAllowed = DEFAULT_DANGEROUS_NODE_COMMANDS.filter(
+      (cmd) => allowSet.has(cmd) && !denySet.has(cmd),
+    );
+    if (dangerousAllowed.length === 0) {
+      continue;
+    }
+    dangerousEntries.push(`${entry.path}: ${dangerousAllowed.join(", ")}`);
   }
-
-  const deny = new Set((cfg.gateway?.nodes?.denyCommands ?? []).map(normalizeNodeCommand));
-  const dangerousAllowed = DEFAULT_DANGEROUS_NODE_COMMANDS.filter(
-    (cmd) => allow.has(cmd) && !deny.has(cmd),
-  );
-  if (dangerousAllowed.length === 0) {
+  if (dangerousEntries.length === 0) {
     return findings;
   }
 
@@ -1051,10 +1156,11 @@ export function collectNodeDangerousAllowCommandFindings(
     severity: isGatewayRemotelyExposed(cfg) ? "critical" : "warn",
     title: "Dangerous node commands explicitly enabled",
     detail:
-      `gateway.nodes.allowCommands includes: ${dangerousAllowed.join(", ")}. ` +
-      "These commands can trigger high-impact device actions (camera/screen/contacts/calendar/reminders/SMS).",
+      "Dangerous node commands are enabled by these settings:\n" +
+      dangerousEntries.map((entry) => `- ${entry}`).join("\n") +
+      "\nThese commands can trigger high-impact device actions (camera/screen/contacts/calendar/reminders/SMS).",
     remediation:
-      "Remove these entries from gateway.nodes.allowCommands (recommended). " +
+      "Remove these entries from gateway.nodes.allowCommands / gateway.nodes.overrides.*.allowCommands (recommended). " +
       "If you keep them, treat gateway auth as full operator access and keep gateway exposure local/tailnet-only.",
   });
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1116,7 +1116,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   if (unknownExact.length > 0) {
     const unknownDetails = unknownExact
       .map((entry) => {
-        const suggestions = suggestKnownNodeCommands(entry, knownCommands);
+        const suggestions = suggestKnownNodeCommands(entry, baseKnownCommands);
         if (suggestions.length === 0) {
           return entry;
         }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1075,7 +1075,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   }
 
   const patternLike: string[] = [];
-  const unknownExact: string[] = [];
+  const unknownExact: { label: string; command: string }[] = [];
   for (const entry of denyEntries) {
     const knownCommands = new Set(baseKnownCommands);
     for (const value of globalAllowCommands) {
@@ -1099,7 +1099,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
         continue;
       }
       if (!knownCommands.has(value)) {
-        unknownExact.push(`${entry.path}: ${value}`);
+        unknownExact.push({ label: `${entry.path}: ${value}`, command: value });
       }
     }
   }
@@ -1116,11 +1116,11 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   if (unknownExact.length > 0) {
     const unknownDetails = unknownExact
       .map((entry) => {
-        const suggestions = suggestKnownNodeCommands(entry, baseKnownCommands);
+        const suggestions = suggestKnownNodeCommands(entry.command, baseKnownCommands);
         if (suggestions.length === 0) {
-          return entry;
+          return entry.label;
         }
-        return `${entry} (did you mean: ${suggestions.join(", ")})`;
+        return `${entry.label} (did you mean: ${suggestions.join(", ")})`;
       })
       .join(", ");
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1201,6 +1201,31 @@ description: test skill
     expect(finding?.detail).not.toContain("did you mean");
   });
 
+  it("flags ineffective gateway.nodes.overrides.*.denyCommands entries", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          overrides: {
+            "node-a": {
+              denyCommands: ["camera.*", "camera.snapx"],
+            },
+          },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+
+    const finding = res.findings.find(
+      (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
+    );
+    expect(finding?.severity).toBe("warn");
+    expect(finding?.detail).toContain('gateway.nodes.overrides["node-a"].denyCommands: camera.*');
+    expect(finding?.detail).toContain(
+      'gateway.nodes.overrides["node-a"].denyCommands: camera.snapx',
+    );
+  });
+
   it("scores dangerous gateway.nodes.allowCommands by exposure", async () => {
     const cases: Array<{
       name: string;
@@ -1242,12 +1267,55 @@ description: test skill
     );
   });
 
+  it("flags dangerous gateway.nodes.overrides.*.allowCommands entries", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "loopback",
+        nodes: {
+          overrides: {
+            "node-a": {
+              allowCommands: ["camera.snap", "screen.record"],
+            },
+          },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    const finding = res.findings.find(
+      (f) => f.checkId === "gateway.nodes.allow_commands_dangerous",
+    );
+    expect(finding?.severity).toBe("warn");
+    expect(finding?.detail).toContain('gateway.nodes.overrides["node-a"].allowCommands');
+    expect(finding?.detail).toContain("camera.snap");
+    expect(finding?.detail).toContain("screen.record");
+  });
+
   it("does not flag dangerous allowCommands entries when denied again", async () => {
     const cfg: OpenClawConfig = {
       gateway: {
         nodes: {
           allowCommands: ["camera.snap", "screen.record"],
           denyCommands: ["camera.snap", "screen.record"],
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+    expectNoFinding(res, "gateway.nodes.allow_commands_dangerous");
+  });
+
+  it("does not flag dangerous overrides allowCommands entries when denied again", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: ["camera.snap"],
+          overrides: {
+            "node-a": {
+              allowCommands: ["camera.snap", "screen.record"],
+              denyCommands: ["screen.record"],
+            },
+          },
         },
       },
     };

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1226,6 +1226,28 @@ description: test skill
     );
   });
 
+  it("treats override-only allowCommands as known for global denyCommands audit", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: ["foo.bar"],
+          overrides: {
+            "node-a": {
+              allowCommands: ["foo.bar"],
+            },
+          },
+        },
+      },
+    };
+
+    const res = await audit(cfg);
+
+    const finding = res.findings.find(
+      (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("scores dangerous gateway.nodes.allowCommands by exposure", async () => {
     const cases: Array<{
       name: string;


### PR DESCRIPTION
## Problem

The gateway's node command policy system has security and correctness gaps:

### 1. Per-node overrides not supported

The config supports `gateway.nodes.allowCommands` and `gateway.nodes.denyCommands` globally, but there is no way to configure **per-node** command policies. A home lab Raspberry Pi and a production server get the same command allowlist.

```
Before (flat config):
  gateway.nodes.allowCommands = ["camera_snap", "screen_record", "run"]
  → ALL nodes get camera_snap, screen_record, AND run (too permissive for some)

After (per-node overrides):
  gateway.nodes.allowCommands = ["camera_snap"]          ← global baseline
  gateway.nodes.overrides:
    "node-rpi-":                                          ← prefix match
      allowCommands: ["screen_record"]                    ← adds to baseline
    "node-prod-server":                                   ← exact match
      denyCommands: ["run"]                               ← removes from baseline
```

### 2. Security audit doesn't check per-node overrides

The `collectNodeDenyCommandPatternFindings` function only checks global deny commands. Dangerous commands added via per-node overrides are invisible to the security audit.

### 3. `displayName` used in override matching (security risk)

The original `resolveNodeCommandAllowlist` accepted `displayName` for matching, which is user-controllable and could be spoofed to escalate permissions.

## Fix

- **Per-node override config**: New `gateway.nodes.overrides` config section with `allowCommands`/`denyCommands` per nodeId. Match precedence: exact nodeId → longest nodeId prefix.
- **Merged resolution**: `resolveNodeCommandAllowlist` now merges: `platformDefaults + globalAllow + nodeAllow - globalDeny - nodeDeny`
- **Security audit extended**: `collectNodeDenyCommandPatternFindings` and `collectNodeAllowCommandFindings` now iterate all override entries, checking each against known commands
- **`displayName` removed**: Override matching uses only `nodeId` (system-assigned, not spoofable)
- Schema, help text, labels, and Zod validation added for the new config section
- Comprehensive tests for override resolution, prefix matching, deny merging, and audit findings

## Why merge

Without per-node overrides, operators must choose between over-permissive (all nodes get all commands) or under-permissive (no node gets specialized commands) configurations. The `displayName` matching is a privilege escalation vector — a compromised node could set its display name to match a trusted node's override key. The audit gap means dangerous per-node configurations go undetected. All three are security-relevant issues for any multi-node deployment.