### PR TITLE
Transcript: keep delivery-mirror writes from changing active leaf

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as jsonFiles from "../../infra/json-files.js";
 import {
@@ -323,6 +324,78 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.content[0].type).toBe("text");
       expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
     }
+  });
+
+  it("keeps the existing leaf after appending a delivery-mirror message", async () => {
+    const sessionId = "test-session-leaf";
+    const sessionKey = "test-session-leaf-key";
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        sessionFile,
+        chatType: "direct",
+        channel: "discord",
+      },
+    };
+    fs.writeFileSync(fixture.storePath(), JSON.stringify(store), "utf-8");
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: "seed user" }],
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "seed assistant" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "mock-1",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+    const savedLeafId = sessionManager.getLeafId();
+    expect(savedLeafId).not.toBeNull();
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "delivery mirror entry",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const reopened = SessionManager.open(result.sessionFile);
+
+    const lines = fs.readFileSync(result.sessionFile, "utf-8").trim().split("\n");
+    const entries = lines.map((line) => JSON.parse(line));
+    const deliveryMirrorEntry = entries.find(
+      (entry) => entry.type === "message" && entry.message?.model === "delivery-mirror",
+    );
+    const branchSummaryEntries = entries.filter((entry) => entry.type === "branch_summary");
+
+    expect(deliveryMirrorEntry?.id).toBeTruthy();
+    expect(branchSummaryEntries.length).toBeGreaterThan(0);
+    expect(branchSummaryEntries.some((entry) => entry.parentId === savedLeafId)).toBe(true);
+    expect(reopened.getLeafId()).not.toBe(deliveryMirrorEntry?.id);
   });
 });
 


### PR DESCRIPTION
## Problem

When a delivery-mirror message (e.g., a message forwarded to another channel) is appended to a session transcript, it **overwrites the active leaf ID** of the conversation tree. The next time the session is loaded, `_buildIndex()` picks the delivery-mirror entry as the active leaf, causing the main conversation to "jump" to a dead-end branch.

```
Before this fix:
  User msg → Assistant msg (leafId=A) → delivery-mirror appended (leafId=B)
  Next session open: _buildIndex() → leafId=B → context walks from B → skips main chain

After this fix:
  User msg → Assistant msg (leafId=A) → delivery-mirror appended → branchWithSummary(A) persisted
  Next session open: _buildIndex() → leafId=A → context walks main chain correctly
```

## Fix

In `appendAssistantMessageToSessionTranscript`:
1. Save `leafId` before appending the delivery-mirror message
2. After appending, call `branchWithSummary(savedLeafId)` to persist a branch_summary entry
3. On next `SessionManager.open()`, `_buildIndex()` picks up the branch_summary and restores the correct leaf

Added a comprehensive test that verifies the leaf is preserved after delivery-mirror writes.

## Why merge

Without this fix, any session that receives delivery-mirror messages (cross-channel forwarding, webhook mirrors) will have its conversation context corrupted on next load. The model loses track of the main conversation thread and either produces confused responses or fails to continue the conversation. This is a data integrity issue that affects all users with delivery mirroring enabled.