### PR TITLE
Media: accept whitespace around MEDIA directive colon

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -206,6 +206,13 @@ describe("extractToolResultMediaPaths", () => {
     expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/indented.png"]);
   });
 
+  it("extracts MEDIA line with whitespace around colon", () => {
+    const result = {
+      content: [{ type: "text", text: "  MEDIA :  /tmp/indented.png" }],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/indented.png"]);
+  });
+
   it("extracts valid MEDIA: line while ignoring <media:audio> on another line", () => {
     const result = {
       content: [

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -11,12 +11,14 @@ describe("splitMediaFromOutput", () => {
   it("accepts supported media path variants", () => {
     const pathCases = [
       ["/Users/pete/My File.png", "MEDIA:/Users/pete/My File.png"],
+      ["/Users/pete/My File.png", "MEDIA : /Users/pete/My File.png"],
       ["/Users/pete/My File.png", 'MEDIA:"/Users/pete/My File.png"'],
       ["~/Pictures/My File.png", "MEDIA:~/Pictures/My File.png"],
       ["../../etc/passwd", "MEDIA:../../etc/passwd"],
       ["./screenshots/image.png", "MEDIA:./screenshots/image.png"],
       ["media/inbound/image.png", "MEDIA:media/inbound/image.png"],
       ["./screenshot.png", "  MEDIA:./screenshot.png"],
+      ["./screenshot.png", "  MEDIA :  ./screenshot.png"],
       ["C:\\Users\\pete\\Pictures\\snap.png", "MEDIA:C:\\Users\\pete\\Pictures\\snap.png"],
       [
         "/tmp/tts-fAJy8C/voice-1770246885083.opus",
@@ -49,5 +51,12 @@ describe("splitMediaFromOutput", () => {
   it("rejects bare words without file extensions", () => {
     const result = splitMediaFromOutput("MEDIA:screenshot");
     expect(result.mediaUrls).toBeUndefined();
+  });
+
+  it("keeps MEDIA with lenient whitespace in prose when it is not a valid token", () => {
+    const input = "The format is MEDIA : not-a-path";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe(input);
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -3,8 +3,8 @@
 import { parseFenceSpans } from "../markdown/fences.js";
 import { parseAudioTag } from "./audio-tags.js";
 
-// Allow optional wrapping backticks and punctuation after the token; capture the core token.
-export const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^\n]+)`?/gi;
+// Allow optional wrapping backticks and lenient whitespace around the colon.
+export const MEDIA_TOKEN_RE = /\bMEDIA\s*:\s*`?([^\n]+)`?/gi;
 
 export function normalizeMediaSource(src: string) {
   return src.startsWith("file://") ? src.replace("file://", "") : src;
@@ -117,7 +117,7 @@ export function splitMediaFromOutput(raw: string): {
     }
 
     const trimmedStart = line.trimStart();
-    if (!trimmedStart.startsWith("MEDIA:")) {
+    if (!/^MEDIA\s*:/i.test(trimmedStart)) {
       keptLines.push(line);
       lineOffset += line.length + 1; // +1 for newline
       continue;


### PR DESCRIPTION
## Summary

- Problem: the shared `MEDIA:` parser only accepted `MEDIA:` with no whitespace before the colon, so `MEDIA : /tmp/file.png` was treated as plain text.
- Why it matters: reply guidance and the downstream media loader already accept lenient whitespace, so the parser behavior was inconsistent and dropped valid media directives.
- What changed: widened the shared parser regex and line-start gate to accept `MEDIA\s*:` and added regression tests for parser and tool-result extraction paths.
- What did NOT change (scope boundary): no changes to media security rules, file loading behavior, or `file://` normalization logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29617
- Related #29617

## User-visible / Behavior Changes

- `MEDIA : /path/to/file.png` is now parsed the same way as `MEDIA:/path/to/file.png`.
- Tool-result media extraction now recognizes whitespace variants of `MEDIA:` lines.
- Prose like `MEDIA : not-a-path` still remains visible text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest in repo workspace
- Model/provider: N/A
- Integration/channel (if any): shared media parsing path used by reply/tool media extraction
- Relevant config (redacted): default test config

### Steps

1. Call `splitMediaFromOutput('MEDIA : /tmp/file.png')`.
2. Observe parser output before the fix.
3. Run the focused test suites after the fix.

### Expected

- The parser returns `mediaUrls: ['/tmp/file.png']`.
- Tool-result extraction also returns the local media path.
- Non-path prose using `MEDIA :` remains text.

### Actual

- Before the fix, the parser returned plain text for `MEDIA : /tmp/file.png` because only `MEDIA:` was matched.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct parser handling of `MEDIA :`, indented whitespace variants, and downstream tool-result extraction.
- Edge cases checked: prose containing `MEDIA : not-a-path` still stays as text; existing `MEDIA:` and `loadWebMedia` whitespace handling still pass.
- What you did **not** verify: full end-to-end channel delivery on a live integration.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e67f67386cdc2d58ccf0be8ad86901ca5a32f2da`.
- Files/config to restore: `src/media/parse.ts`, `src/media/parse.test.ts`, `src/agents/pi-embedded-subscribe.tools.media.test.ts`
- Known bad symptoms reviewers should watch for: over-eager parsing of prose lines that include `MEDIA :` without a valid path.

## Risks and Mitigations

- Risk: widening the parser could accidentally capture prose that was previously left untouched.
- Mitigation: added regression coverage for `MEDIA : not-a-path`, and kept the existing media validity checks unchanged.
