### PR TITLE
fix(agents): skip thinking/redacted_thinking blocks in stripThoughtSignatures

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -156,7 +156,8 @@ describe("stripThoughtSignatures", () => {
     expect(result).toEqual([
       { type: "text", text: "hello" },
       { type: "toolCall", id: "call_1", name: "read", arguments: {} },
-      { type: "thinking", thinking: "hmm" },
+      // thinking blocks are preserved verbatim — signature must not be stripped
+      { type: "thinking", thinking: "hmm", thought_signature: "msg_xyz" },
     ]);
   });
   it("handles empty array", () => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -160,6 +160,21 @@ describe("stripThoughtSignatures", () => {
       { type: "thinking", thinking: "hmm", thought_signature: "msg_xyz" },
     ]);
   });
+  it("strips msg_* signatures from thinking blocks when allowBase64Only=true (cross-provider)", () => {
+    const input = [
+      { type: "text", text: "hello", thought_signature: "msg_abc" },
+      { type: "thinking", thinking: "hmm", thought_signature: "msg_xyz" },
+      { type: "redacted_thinking", data: "...", thought_signature: "msg_zzz" },
+    ];
+    const result = stripThoughtSignatures(input, { allowBase64Only: true });
+
+    expect(result).toEqual([
+      { type: "text", text: "hello" },
+      // allowBase64Only=true — thinking blocks must also have non-base64 signatures stripped
+      { type: "thinking", thinking: "hmm" },
+      { type: "redacted_thinking", data: "..." },
+    ]);
+  });
   it("handles empty array", () => {
     expect(stripThoughtSignatures([])).toEqual([]);
   });

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -65,6 +65,12 @@ export function stripThoughtSignatures<T>(
     if (!block || typeof block !== "object") {
       return block;
     }
+    // Anthropic requires thinking/redacted_thinking blocks in the latest assistant
+    // message to be identical to the original response. Never modify these blocks.
+    const blockType = (block as { type?: unknown }).type;
+    if (blockType === "thinking" || blockType === "redacted_thinking") {
+      return block;
+    }
     const rec = block as ContentBlockWithSignature;
     const stripSnake = shouldStripSignature(rec.thought_signature);
     const stripCamel = includeCamelCase ? shouldStripSignature(rec.thoughtSignature) : false;

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -66,9 +66,15 @@ export function stripThoughtSignatures<T>(
       return block;
     }
     // Anthropic requires thinking/redacted_thinking blocks in the latest assistant
-    // message to be identical to the original response. Never modify these blocks.
+    // message to be identical to the original response. Only skip sanitization when
+    // targeting Anthropic (allowBase64Only=false). For cross-provider replay
+    // (allowBase64Only=true, e.g. Google/OpenRouter), signatures inside thinking
+    // blocks must still be stripped to avoid rejection by those providers.
     const blockType = (block as { type?: unknown }).type;
-    if (blockType === "thinking" || blockType === "redacted_thinking") {
+    if (
+      (blockType === "thinking" || blockType === "redacted_thinking") &&
+      !allowBase64Only
+    ) {
       return block;
     }
     const rec = block as ContentBlockWithSignature;


### PR DESCRIPTION
Fixes #29618.

## Problem

`stripThoughtSignatures` in `bootstrap.ts` iterates over all content blocks to strip `msg_*` thought signatures for cross-provider (Gemini) compatibility. When it encounters a thinking block whose signature matches, it spreads it into a new object and deletes the field.

Anthropic requires `thinking` and `redacted_thinking` blocks in the **latest assistant message** to be byte-identical to the original response. Any structural modification causes the API to reject with:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant message
cannot be modified. These blocks must remain as they were in the original response.
```

This surfaces in multi-turn sessions with extended thinking enabled, where stored thinking blocks are replayed through `sanitizeSessionHistory` → `stripThoughtSignatures`.

## Fix

Add an early-return guard for `type: "thinking"` and `type: "redacted_thinking"` blocks at the top of the `.map()` callback, before any processing occurs. Signature stripping is only needed for cross-provider compatibility — these block types are Anthropic-specific and must always be returned verbatim.