### PR TITLE
fix: add global fallback for image model logging

### DIFF
--- a/src/commands/models/set-image.ts
+++ b/src/commands/models/set-image.ts
@@ -10,6 +10,10 @@ export async function modelsSetImageCommand(modelRaw: string, runtime: RuntimeEn
 
   logConfigUpdated(runtime);
   runtime.log(
-    `Image model: ${resolveAgentModelPrimaryValue(updated.agents?.defaults?.imageModel) ?? modelRaw}`,
+    `Image model: ${
+      resolveAgentModelPrimaryValue(updated.agents?.defaults?.imageModel) ??
+      resolveAgentModelPrimaryValue(updated.global?.imageModel) ??
+      modelRaw
+    }`,
   );
 }


### PR DESCRIPTION
## Bug
The logging logic attempted to resolve the image model value but failed to fall back to global defaults or the input value if the specific agent configuration was missing.

## Fix
Added explicit fallback logic: `agent defaults → global defaults → raw input`

## Impact
Ensures the log message displays the resolved image model correctly when users set a global image model without explicit agent-level overrides.