### PR TITLE
feishu: make proxy env precedence test windows-safe

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -85,9 +85,11 @@ describe("createFeishuWSClient proxy handling", () => {
     createFeishuWSClient(baseAccount);
 
     expect(httpsProxyAgentCtorMock).toHaveBeenCalledTimes(1);
-    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://lower-https:8001");
+    const expectedProxy =
+      process.platform === "win32" ? "http://upper-https:8002" : "http://lower-https:8001";
+    expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith(expectedProxy);
     const options = firstWsClientOptions();
-    expect(options.agent).toEqual({ proxyUrl: "http://lower-https:8001" });
+    expect(options.agent).toEqual({ proxyUrl: expectedProxy });
   });
 
   it("passes HTTP_PROXY to ws client when https vars are unset", () => {


### PR DESCRIPTION
Windows env vars are case-insensitive, so setting both https_proxy and HTTPS_PROXY results in a single value and the precedence assertion becomes invalid on win32.

This updates the test expectation to account for win32 behavior while keeping the precedence check on case-sensitive platforms.