### PR TITLE
fix(minimax): split OAuth into separate Global and CN providers

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -46,13 +46,13 @@ Enable the bundled OAuth plugin and authenticate:
 ```bash
 openclaw plugins enable minimax-portal-auth  # skip if already loaded.
 openclaw gateway restart  # restart if gateway is already running
+
+# For international users (api.minimax.io)
 openclaw onboard --auth-choice minimax-portal
+
+# For users in China (api.minimaxi.com)
+openclaw onboard --auth-choice minimax-portal-cn
 ```
-
-You will be prompted to select an endpoint:
-
-- **Global** - International users (`api.minimax.io`)
-- **CN** - Users in China (`api.minimaxi.com`)
 
 See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 

--- a/docs/zh-CN/providers/minimax.md
+++ b/docs/zh-CN/providers/minimax.md
@@ -47,13 +47,13 @@ MiniMax 强调 M2.1 的以下改进：
 ```bash
 openclaw plugins enable minimax-portal-auth  # 如果已加载则跳过
 openclaw gateway restart  # 如果 Gateway 网关已在运行则重启
+
+# 国际用户（api.minimax.io）
 openclaw onboard --auth-choice minimax-portal
+
+# 中国用户（api.minimaxi.com）
+openclaw onboard --auth-choice minimax-portal-cn
 ```
-
-系统会提示你选择端点：
-
-- **Global** - 国际用户（`api.minimax.io`）
-- **CN** - 中国用户（`api.minimaxi.com`）
 
 详情参见 [MiniMax OAuth 插件 README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth)。
 

--- a/extensions/minimax-portal-auth/README.md
+++ b/extensions/minimax-portal-auth/README.md
@@ -18,16 +18,26 @@ openclaw gateway restart
 
 ## Authenticate
 
+This plugin provides two separate providers for different regions:
+
+### Global (International users)
+
 ```bash
 openclaw models auth login --provider minimax-portal --set-default
 ```
 
-You will be prompted to select an endpoint:
+Uses endpoint: `api.minimax.io`
 
-- **Global** - International users, optimized for overseas access (`api.minimax.io`)
-- **China** - Optimized for users in China (`api.minimaxi.com`)
+### China (CN users)
+
+```bash
+openclaw models auth login --provider minimax-portal-cn --set-default
+```
+
+Uses endpoint: `api.minimaxi.com`
 
 ## Notes
 
 - MiniMax OAuth uses a user-code login flow.
 - Currently, OAuth login is supported only for the Coding plan
+- Global and CN are now separate providers to avoid configuration conflicts when switching between regions

--- a/extensions/minimax-portal-auth/index.ts
+++ b/extensions/minimax-portal-auth/index.ts
@@ -6,8 +6,10 @@ import {
 } from "openclaw/plugin-sdk";
 import { loginMiniMaxPortalOAuth, type MiniMaxRegion } from "./oauth.js";
 
-const PROVIDER_ID = "minimax-portal";
-const PROVIDER_LABEL = "MiniMax";
+const PROVIDER_ID_GLOBAL = "minimax-portal";
+const PROVIDER_ID_CN = "minimax-portal-cn";
+const PROVIDER_LABEL_GLOBAL = "MiniMax (Global)";
+const PROVIDER_LABEL_CN = "MiniMax (CN)";
 const DEFAULT_MODEL = "MiniMax-M2.5";
 const DEFAULT_BASE_URL_CN = "https://api.minimaxi.com/anthropic";
 const DEFAULT_BASE_URL_GLOBAL = "https://api.minimax.io/anthropic";
@@ -15,12 +17,14 @@ const DEFAULT_CONTEXT_WINDOW = 200000;
 const DEFAULT_MAX_TOKENS = 8192;
 const OAUTH_PLACEHOLDER = "minimax-oauth";
 
-function getDefaultBaseUrl(region: MiniMaxRegion): string {
-  return region === "cn" ? DEFAULT_BASE_URL_CN : DEFAULT_BASE_URL_GLOBAL;
+function getProviderConfig(region: MiniMaxRegion) {
+  return region === "cn"
+    ? { id: PROVIDER_ID_CN, label: PROVIDER_LABEL_CN, baseUrl: DEFAULT_BASE_URL_CN }
+    : { id: PROVIDER_ID_GLOBAL, label: PROVIDER_LABEL_GLOBAL, baseUrl: DEFAULT_BASE_URL_GLOBAL };
 }
 
-function modelRef(modelId: string): string {
-  return `${PROVIDER_ID}/${modelId}`;
+function modelRef(providerId: string, modelId: string): string {
+  return `${providerId}/${modelId}`;
 }
 
 function buildModelDefinition(params: {
@@ -41,7 +45,7 @@ function buildModelDefinition(params: {
 }
 
 function createOAuthHandler(region: MiniMaxRegion) {
-  const defaultBaseUrl = getDefaultBaseUrl(region);
+  const providerConfig = getProviderConfig(region);
   const regionLabel = region === "cn" ? "CN" : "Global";
 
   return async (ctx: ProviderAuthContext): Promise<ProviderAuthResult> => {
@@ -60,8 +64,8 @@ function createOAuthHandler(region: MiniMaxRegion) {
         await ctx.prompter.note(result.notification_message, "MiniMax OAuth");
       }
 
-      const profileId = `${PROVIDER_ID}:default`;
-      const baseUrl = result.resourceUrl || defaultBaseUrl;
+      const profileId = `${providerConfig.id}:default`;
+      const baseUrl = result.resourceUrl || providerConfig.baseUrl;
 
       return {
         profiles: [
@@ -69,7 +73,7 @@ function createOAuthHandler(region: MiniMaxRegion) {
             profileId,
             credential: {
               type: "oauth" as const,
-              provider: PROVIDER_ID,
+              provider: providerConfig.id,
               access: result.access,
               refresh: result.refresh,
               expires: result.expires,
@@ -79,7 +83,7 @@ function createOAuthHandler(region: MiniMaxRegion) {
         configPatch: {
           models: {
             providers: {
-              [PROVIDER_ID]: {
+              [providerConfig.id]: {
                 baseUrl,
                 apiKey: OAUTH_PLACEHOLDER,
                 api: "anthropic-messages",
@@ -102,16 +106,20 @@ function createOAuthHandler(region: MiniMaxRegion) {
           agents: {
             defaults: {
               models: {
-                [modelRef("MiniMax-M2.1")]: { alias: "minimax-m2.1" },
-                [modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
+                [modelRef(providerConfig.id, "MiniMax-M2.1")]: {
+                  alias: `minimax-m2.1${region === "cn" ? "-cn" : ""}`,
+                },
+                [modelRef(providerConfig.id, "MiniMax-M2.5")]: {
+                  alias: `minimax-m2.5${region === "cn" ? "-cn" : ""}`,
+                },
               },
             },
           },
         },
-        defaultModel: modelRef(DEFAULT_MODEL),
+        defaultModel: modelRef(providerConfig.id, DEFAULT_MODEL),
         notes: [
           "MiniMax OAuth tokens auto-refresh. Re-run login if refresh fails or access is revoked.",
-          `Base URL defaults to ${defaultBaseUrl}. Override models.providers.${PROVIDER_ID}.baseUrl if needed.`,
+          `Base URL defaults to ${providerConfig.baseUrl}. Override models.providers.${providerConfig.id}.baseUrl if needed.`,
           ...(result.notification_message ? [result.notification_message] : []),
         ],
       };
@@ -133,11 +141,12 @@ const minimaxPortalPlugin = {
   description: "OAuth flow for MiniMax models",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
+    // Global provider (api.minimax.io)
     api.registerProvider({
-      id: PROVIDER_ID,
-      label: PROVIDER_LABEL,
+      id: PROVIDER_ID_GLOBAL,
+      label: PROVIDER_LABEL_GLOBAL,
       docsPath: "/providers/minimax",
-      aliases: ["minimax"],
+      aliases: ["minimax", "minimax-global"],
       auth: [
         {
           id: "oauth",
@@ -146,8 +155,18 @@ const minimaxPortalPlugin = {
           kind: "device_code",
           run: createOAuthHandler("global"),
         },
+      ],
+    });
+
+    // CN provider (api.minimaxi.com)
+    api.registerProvider({
+      id: PROVIDER_ID_CN,
+      label: PROVIDER_LABEL_CN,
+      docsPath: "/providers/minimax",
+      aliases: ["minimax-cn"],
+      auth: [
         {
-          id: "oauth-cn",
+          id: "oauth",
           label: "MiniMax OAuth (CN)",
           hint: "CN endpoint - api.minimaxi.com",
           kind: "device_code",

--- a/extensions/minimax-portal-auth/openclaw.plugin.json
+++ b/extensions/minimax-portal-auth/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "minimax-portal-auth",
-  "providers": ["minimax-portal"],
+  "providers": ["minimax-portal", "minimax-portal-cn"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -37,7 +37,11 @@ function isExternalProfileFresh(cred: AuthProfileCredential | undefined, now: nu
   if (cred.type !== "oauth" && cred.type !== "token") {
     return false;
   }
-  if (cred.provider !== "qwen-portal" && cred.provider !== "minimax-portal") {
+  if (
+    cred.provider !== "qwen-portal" &&
+    cred.provider !== "minimax-portal" &&
+    cred.provider !== "minimax-portal-cn"
+  ) {
     return false;
   }
   if (typeof cred.expires !== "number") {

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -69,7 +69,7 @@ export type QwenCliCredential = {
 
 export type MiniMaxCliCredential = {
   type: "oauth";
-  provider: "minimax-portal";
+  provider: "minimax-portal" | "minimax-portal-cn";
   access: string;
   refresh: string;
   expires: number;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -286,7 +286,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   if (normalized === "byteplus" || normalized === "byteplus-plan") {
     return pick("BYTEPLUS_API_KEY");
   }
-  if (normalized === "minimax-portal") {
+  if (normalized === "minimax-portal" || normalized === "minimax-portal-cn") {
     return pick("MINIMAX_OAUTH_TOKEN") ?? pick("MINIMAX_API_KEY");
   }
 

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -58,6 +58,7 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
+const MINIMAX_PORTAL_CN_BASE_URL = "https://api.minimaxi.com/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;
@@ -616,6 +617,26 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
+function buildMinimaxPortalCnProvider(): ProviderConfig {
+  return {
+    baseUrl: MINIMAX_PORTAL_CN_BASE_URL,
+    api: "anthropic-messages",
+    authHeader: true,
+    models: [
+      buildMinimaxTextModel({
+        id: MINIMAX_DEFAULT_MODEL_ID,
+        name: "MiniMax M2.1",
+        reasoning: false,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.5",
+        name: "MiniMax M2.5",
+        reasoning: true,
+      }),
+    ],
+  };
+}
+
 function buildMoonshotProvider(): ProviderConfig {
   return {
     baseUrl: MOONSHOT_BASE_URL,
@@ -921,6 +942,14 @@ export async function resolveImplicitProviders(params: {
   if (minimaxOauthProfile.length > 0) {
     providers["minimax-portal"] = {
       ...buildMinimaxPortalProvider(),
+      apiKey: MINIMAX_OAUTH_PLACEHOLDER,
+    };
+  }
+
+  const minimaxOauthCnProfile = listProfilesForProvider(authStore, "minimax-portal-cn");
+  if (minimaxOauthCnProfile.length > 0) {
+    providers["minimax-portal-cn"] = {
+      ...buildMinimaxPortalCnProvider(),
       apiKey: MINIMAX_OAUTH_PLACEHOLDER,
     };
   }

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -51,7 +51,13 @@ const AUTH_CHOICE_GROUP_DEFS: {
     value: "minimax",
     label: "MiniMax",
     hint: "M2.5 (recommended)",
-    choices: ["minimax-portal", "minimax-api", "minimax-api-key-cn", "minimax-api-lightning"],
+    choices: [
+      "minimax-portal",
+      "minimax-portal-cn",
+      "minimax-api",
+      "minimax-api-key-cn",
+      "minimax-api-lightning",
+    ],
   },
   {
     value: "moonshot",
@@ -271,8 +277,13 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   },
   {
     value: "minimax-portal",
-    label: "MiniMax OAuth",
-    hint: "Oauth plugin for MiniMax",
+    label: "MiniMax OAuth (Global)",
+    hint: "OAuth plugin for MiniMax (api.minimax.io)",
+  },
+  {
+    value: "minimax-portal-cn",
+    label: "MiniMax OAuth (CN)",
+    hint: "OAuth plugin for MiniMax China (api.minimaxi.com)",
   },
   { value: "qwen-portal", label: "Qwen OAuth" },
   {

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -86,21 +86,22 @@ export async function applyAuthChoiceMiniMax(
     return { config: nextConfig, agentModelOverride };
   };
   if (params.authChoice === "minimax-portal") {
-    // Let user choose between Global/CN endpoints
-    const endpoint = await params.prompter.select({
-      message: "Select MiniMax endpoint",
-      options: [
-        { value: "oauth", label: "Global", hint: "OAuth for international users" },
-        { value: "oauth-cn", label: "CN", hint: "OAuth for users in China" },
-      ],
-    });
-
     return await applyAuthChoicePluginProvider(params, {
       authChoice: "minimax-portal",
       pluginId: "minimax-portal-auth",
       providerId: "minimax-portal",
-      methodId: endpoint,
-      label: "MiniMax",
+      methodId: "oauth",
+      label: "MiniMax (Global)",
+    });
+  }
+
+  if (params.authChoice === "minimax-portal-cn") {
+    return await applyAuthChoicePluginProvider(params, {
+      authChoice: "minimax-portal-cn",
+      pluginId: "minimax-portal-auth",
+      providerId: "minimax-portal-cn",
+      methodId: "oauth",
+      label: "MiniMax (CN)",
     });
   }
 

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -45,6 +45,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "volcengine-api-key": "volcengine",
   "byteplus-api-key": "byteplus",
   "minimax-portal": "minimax-portal",
+  "minimax-portal-cn": "minimax-portal-cn",
   "qianfan-api-key": "qianfan",
   "custom-api-key": "custom",
 };

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1223,7 +1223,7 @@ describe("applyAuthChoice", () => {
       },
       {
         authChoice: "minimax-portal",
-        label: "MiniMax",
+        label: "MiniMax (Global)",
         authId: "oauth",
         authLabel: "MiniMax OAuth (Global)",
         providerId: "minimax-portal",
@@ -1232,7 +1232,6 @@ describe("applyAuthChoice", () => {
         api: "anthropic-messages",
         defaultModel: "minimax-portal/MiniMax-M2.1",
         apiKey: "minimax-oauth",
-        selectValue: "oauth",
       },
     ];
     for (const scenario of scenarios) {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -998,7 +998,8 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "chutes" ||
     authChoice === "openai-codex" ||
     authChoice === "qwen-portal" ||
-    authChoice === "minimax-portal"
+    authChoice === "minimax-portal" ||
+    authChoice === "minimax-portal-cn"
   ) {
     runtime.error("OAuth requires interactive mode.");
     runtime.exit(1);

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -40,6 +40,7 @@ export type AuthChoice =
   | "minimax-api-key-cn"
   | "minimax-api-lightning"
   | "minimax-portal"
+  | "minimax-portal-cn"
   | "opencode-zen"
   | "github-copilot"
   | "copilot-proxy"

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -39,6 +39,7 @@ const PROVIDER_PLUGIN_IDS: Array<{ pluginId: string; providerId: string }> = [
   { pluginId: "qwen-portal-auth", providerId: "qwen-portal" },
   { pluginId: "copilot-proxy", providerId: "copilot-proxy" },
   { pluginId: "minimax-portal-auth", providerId: "minimax-portal" },
+  { pluginId: "minimax-portal-auth", providerId: "minimax-portal-cn" },
 ];
 
 function hasNonEmptyString(value: unknown): boolean {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
 
<img width="973" height="235" alt="Clipboard_Screenshot_1772277201" src="https://github.com/user-attachments/assets/afc119e3-9295-47a3-80e9-c5e7cf6aeaa8" />

