### PR TITLE
fix: evict stale in-memory index cache after external DB rebuild

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -119,6 +119,7 @@ export abstract class MemoryManagerSyncOps {
   } = { enabled: false, available: false };
   protected vectorReady: Promise<boolean> | null = null;
   protected watcher: FSWatcher | null = null;
+  protected dbInode: number | null = null;
   protected watchTimer: NodeJS.Timeout | null = null;
   protected sessionWatchTimer: NodeJS.Timeout | null = null;
   protected sessionUnsubscribe: (() => void) | null = null;
@@ -247,7 +248,35 @@ export abstract class MemoryManagerSyncOps {
 
   protected openDatabase(): DatabaseSync {
     const dbPath = resolveUserPath(this.settings.store.path);
-    return this.openDatabaseAtPath(dbPath);
+    const db = this.openDatabaseAtPath(dbPath);
+    try {
+      this.dbInode = fsSync.statSync(dbPath).ino;
+    } catch {
+      this.dbInode = null;
+    }
+    return db;
+  }
+
+  /**
+   * Check if the SQLite database file has been replaced externally
+   * (e.g., by `openclaw memory index --force` in a separate CLI process).
+   * If the inode has changed, re-open the database connection.
+   */
+  protected reopenDatabaseIfReplaced(): boolean {
+    const dbPath = resolveUserPath(this.settings.store.path);
+    try {
+      const currentInode = fsSync.statSync(dbPath).ino;
+      if (this.dbInode !== null && currentInode !== this.dbInode) {
+        log.info("memory: database file replaced externally, re-opening connection");
+        try { this.db.close(); } catch { /* ignore */ }
+        this.db = this.openDatabase();
+        this.ensureSchema();
+        return true;
+      }
+    } catch {
+      // DB file missing — will be recreated on next sync
+    }
+    return false;
   }
 
   private openDatabaseAtPath(dbPath: string): DatabaseSync {
@@ -635,6 +664,13 @@ export abstract class MemoryManagerSyncOps {
     if (!this.provider) {
       log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
       return;
+    }
+
+    // If the DB file was replaced externally (e.g., `openclaw memory index --force`),
+    // re-open the connection so we read fresh data instead of the deleted inode.
+    const dbReplaced = this.reopenDatabaseIfReplaced();
+    if (dbReplaced) {
+      params.needsFullReindex = true;
     }
 
     const files = await listMemoryFiles(this.workspaceDir, this.settings.extraPaths);

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -40,6 +40,28 @@ const log = createSubsystemLogger("memory");
 
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 
+/**
+ * Evict all cached managers, closing their SQLite connections and file watchers.
+ * The next call to `MemoryIndexManager.get()` will create fresh instances that
+ * re-open the (possibly rebuilt) SQLite database.
+ *
+ * This should be called when the underlying index files may have been rebuilt
+ * externally (e.g., by `openclaw memory index --force` in a separate CLI process).
+ */
+export async function evictAllMemoryManagers(): Promise<number> {
+  const count = INDEX_CACHE.size;
+  const managers = Array.from(INDEX_CACHE.values());
+  for (const manager of managers) {
+    try {
+      await manager.close();
+    } catch {
+      // close() already deletes from INDEX_CACHE; ignore errors
+    }
+  }
+  INDEX_CACHE.clear();
+  return count;
+}
+
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   protected readonly cfg: OpenClawConfig;


### PR DESCRIPTION
## Problem

When `openclaw memory index --force` runs as a CLI process, it deletes and recreates the SQLite database file. The gateway process keeps an open file descriptor to the old (deleted) inode via the `INDEX_CACHE` singleton Map. Subsequent `memory_search` tool calls return **stale chunks with wrong line numbers** — the only workaround is a full gateway restart.

This is particularly painful after nightly memory compression: a 1452-line daily log gets compressed to 479 lines, but search still returns chunks referencing lines >479 from the old version.

## Root Cause

`MemoryIndexManager.get()` caches instances in a module-level `Map`. The cached instance holds a `DatabaseSync` connection opened at gateway startup. When the CLI deletes `main.sqlite` and creates a new one, the gateway's fd still points to the old (unlinked) inode on Linux. The watcher-triggered `sync()` skips re-indexing because the CLI already wrote matching hashes to the new DB — but the gateway never reads the new DB.

## Fix

**1. Inode change detection** (`manager-sync-ops.ts`):
- Track the DB file's inode when opening the connection
- Before each `syncMemoryFiles()`, check if the inode has changed
- If changed: close old connection, re-open, force full re-read

**2. `evictAllMemoryManagers()`** (`manager.ts`):
- Export a function that closes all cached managers and clears `INDEX_CACHE`
- Can be called from config-reload handlers or future IPC mechanisms

## Testing

Reproduced on Linux (Ubuntu, ext4):
1. `openclaw memory index --force --agent main` (CLI rebuilds DB)
2. `memory_search` in gateway returns stale chunks (line refs from pre-compression file)
3. Gateway restart fixes it (confirms in-memory cache is the issue)
4. With this fix: watcher sync detects inode change → re-opens DB → fresh chunks returned