### PR TITLE
fix(gateway): retry with local auth fallback on gateway token mismatch (#29552)

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -278,11 +278,7 @@ function resolveGatewayCredentialsFallback(
 
 function isGatewayTokenMismatchError(error: unknown): boolean {
   const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === "string"
-        ? error
-        : String(error);
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
   return message.toLowerCase().includes("gateway token mismatch");
 }
 
@@ -451,7 +447,10 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
       throw error;
     }
     const fallback = resolveGatewayCredentialsFallback(context, resolved);
-    if (!fallback || (fallback.token === resolved.token && fallback.password === resolved.password)) {
+    if (
+      !fallback ||
+      (fallback.token === resolved.token && fallback.password === resolved.password)
+    ) {
       throw error;
     }
     return await attempt(fallback);

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -254,6 +254,38 @@ function resolveGatewayCredentials(context: ResolvedGatewayCallContext): {
   });
 }
 
+function resolveGatewayCredentialsFallback(
+  context: ResolvedGatewayCallContext,
+  used: { token?: string; password?: string },
+): { token?: string; password?: string } | undefined {
+  if (context.isRemoteMode || context.urlOverride) {
+    return undefined;
+  }
+  if (context.explicitAuth.token || context.explicitAuth.password) {
+    return undefined;
+  }
+
+  const fallbackToken = trimToUndefined(context.config.gateway?.auth?.token);
+  const fallbackPassword = trimToUndefined(context.config.gateway?.auth?.password);
+  if (!fallbackToken && !fallbackPassword) {
+    return undefined;
+  }
+  if (used.token === fallbackToken && used.password === fallbackPassword) {
+    return undefined;
+  }
+  return { token: fallbackToken, password: fallbackPassword };
+}
+
+function isGatewayTokenMismatchError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : String(error);
+  return message.toLowerCase().includes("gateway token mismatch");
+}
+
 async function resolveGatewayTlsFingerprint(params: {
   opts: CallGatewayBaseOptions;
   context: ResolvedGatewayCallContext;
@@ -398,18 +430,32 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   });
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
-  const { token, password } = resolveGatewayCredentials(context);
-  return await executeGatewayRequestWithScopes<T>({
-    opts,
-    scopes,
-    url,
-    token,
-    password,
-    tlsFingerprint,
-    timeoutMs,
-    safeTimerTimeoutMs,
-    connectionDetails,
-  });
+  const resolved = resolveGatewayCredentials(context);
+  const attempt = (credentials: { token?: string; password?: string }) =>
+    executeGatewayRequestWithScopes<T>({
+      opts,
+      scopes,
+      url,
+      token: credentials.token,
+      password: credentials.password,
+      tlsFingerprint,
+      timeoutMs,
+      safeTimerTimeoutMs,
+      connectionDetails,
+    });
+
+  try {
+    return await attempt(resolved);
+  } catch (error) {
+    if (!isGatewayTokenMismatchError(error)) {
+      throw error;
+    }
+    const fallback = resolveGatewayCredentialsFallback(context, resolved);
+    if (!fallback || (fallback.token === resolved.token && fallback.password === resolved.password)) {
+      throw error;
+    }
+    return await attempt(fallback);
+  }
 }
 
 export async function callGatewayScoped<T = Record<string, unknown>>(


### PR DESCRIPTION
## Issue
Fix https://github.com/openclaw/openclaw/issues/29552
## Summary
Handle a real-world local gateway auth edge case where the first connection attempt fails with `gateway token mismatch`, and transparently recover by retrying with `gateway.auth` credentials from config.

## Changes
- Added token-mismatch detection in gateway call path to identify retry-worthy auth failures.
- Added a local fallback resolver to build a retry credential set from:
  - `gateway.auth.token`
  - `gateway.auth.password`
- Wrapped the scoped gateway request in a retry flow:
  - First attempt: keep current credential resolution behavior unchanged.
  - On mismatch error (local only), retry once with fallback credentials.
  - Skip fallback in these cases:
    - Remote mode
    - URL override mode
    - Explicit `token`/`password` was provided by caller
- Kept existing behavior and error flow intact for non-token-mismatch failures.

## Why
Users can hit startup/connection failures when env vars or runtime state supply a stale/incorrect token while the local config still contains the correct `gateway.auth` values. The fallback retry improves resilience and reduces manual recovery steps without altering normal auth precedence outside the mismatch path.

## Testing
- `corepack pnpm exec vitest run src/gateway/call.test.ts`
  - Result: **1 file passed, 29 tests passed**

## Notes
- This change does not change remote-mode auth semantics.
- No user-facing behavior changes are introduced except improved recovery from local token mismatch.