### PR TITLE
fix(discord): add token-based fallback for application ID resolution

### DIFF
--- a/src/discord/probe.parse-token.test.ts
+++ b/src/discord/probe.parse-token.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseApplicationIdFromToken } from "./probe.js";
+
+describe("parseApplicationIdFromToken", () => {
+  it("extracts application ID from a valid token", () => {
+    // "1234567890" base64-encoded is "MTIzNDU2Nzg5MA=="
+    const token = `${Buffer.from("1234567890").toString("base64")}.timestamp.hmac`;
+    expect(parseApplicationIdFromToken(token)).toBe("1234567890");
+  });
+
+  it("extracts large snowflake IDs without precision loss", () => {
+    // ID that exceeds Number.MAX_SAFE_INTEGER (2^53 - 1 = 9007199254740991)
+    const largeId = "1477179610322964541";
+    const token = `${Buffer.from(largeId).toString("base64")}.GhIiP9.vU1xEpJ6NjFm`;
+    expect(parseApplicationIdFromToken(token)).toBe(largeId);
+  });
+
+  it("handles tokens with Bot prefix", () => {
+    const token = `Bot ${Buffer.from("9876543210").toString("base64")}.ts.hmac`;
+    expect(parseApplicationIdFromToken(token)).toBe("9876543210");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parseApplicationIdFromToken("")).toBeUndefined();
+  });
+
+  it("returns undefined for token without dots", () => {
+    expect(parseApplicationIdFromToken("nodots")).toBeUndefined();
+  });
+
+  it("returns undefined when decoded segment is not numeric", () => {
+    const token = `${Buffer.from("not-a-number").toString("base64")}.ts.hmac`;
+    expect(parseApplicationIdFromToken(token)).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only input", () => {
+    expect(parseApplicationIdFromToken("   ")).toBeUndefined();
+  });
+
+  it("returns undefined when first segment is empty (starts with dot)", () => {
+    expect(parseApplicationIdFromToken(".ts.hmac")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #29608 — Discord Application ID precision loss causing "Failed to resolve Discord application id" errors
- Adds `parseApplicationIdFromToken()` that base64-decodes the first segment of the bot token and keeps the snowflake ID as a string (avoiding `Number` precision loss for IDs > 2^53 - 1)
- Uses this as a fallback in `fetchDiscordApplicationId()` when the API call to `/oauth2/applications/@me` fails (timeout, network error, etc.)

## AI-Assisted PR 🤖

- [x] This PR was AI-assisted (built with Claude Code)
- [x] **Testing:** Lightly tested — `pnpm check` passes (format, lint, type-check all clean); `pnpm test` passes 958/959 tests (1 pre-existing failure in `server.canvas-auth.test.ts`, unrelated to this change)
- [x] I understand what the code does: adds a fallback to extract the Discord application ID directly from the bot token's base64-encoded first segment (kept as a string to avoid JS number precision loss) when the `/oauth2/applications/@me` API call fails

## Test plan

- [x] `pnpm check` — format, lint, type-check all pass
- [x] `pnpm test` — 958/959 pass (1 pre-existing failure unrelated to this change)
- [x] Existing `provider.test.ts` tests pass (3/3)
- [ ] Manual test: configure a Discord bot with an application ID exceeding `Number.MAX_SAFE_INTEGER` and verify the bot connects successfully even if the API probe times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)