### PR TITLE
test(feishu): stabilize proxy env precedence test on windows

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -77,8 +77,10 @@ describe("createFeishuWSClient proxy handling", () => {
   });
 
   it("prefers HTTPS proxy vars over HTTP proxy vars across runtimes", () => {
-    process.env.https_proxy = "http://lower-https:8001";
-    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    // Windows env keys are case-insensitive, so keep both https keys aligned.
+    const httpsProxy = "http://https-proxy:8001";
+    process.env.https_proxy = httpsProxy;
+    process.env.HTTPS_PROXY = httpsProxy;
     process.env.http_proxy = "http://lower-http:8003";
     process.env.HTTP_PROXY = "http://upper-http:8004";
 


### PR DESCRIPTION
## Summary

- Problem: extensions/feishu/src/client.test.ts asserted different values for https_proxy and HTTPS_PROXY.
- Why it matters: on Windows, env keys are case-insensitive, so this assertion is nondeterministic and fails CI.
- What changed: made the test assert stable precedence (https* over http*) without relying on case-sensitive env behavior.
- Scope boundary: no production/runtime logic changed.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

None.

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

- Ran: corepack pnpm exec vitest run extensions/feishu/src/client.test.ts
- Result: 3/3 passed on Windows.
- Ran: corepack pnpm exec oxfmt --check extensions/feishu/src/client.test.ts
- Result: formatting clean.

## Risks and Mitigations

- Risk: test intent could become less explicit about lowercase-vs-uppercase ordering.
- Mitigation: test now validates cross-platform stable behavior that matches runtime semantics in all environments.