### PR TITLE
fix(security): recognize localized Windows SYSTEM account in ACL audit

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -111,9 +111,7 @@ Successfully processed 1 files`;
         "\u043d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c 0 \u0444\u0430\u0439\u043b\u043e\u0432";
       const entries = parseIcaclsOutput(output, "C:\\Users\\karte\\.openclaw");
       expect(entries).toHaveLength(1);
-      expect(entries[0].principal).toBe(
-        "NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410",
-      );
+      expect(entries[0].principal).toBe("NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410");
     });
 
     it("parses SID-format principals", () => {
@@ -123,9 +121,7 @@ Successfully processed 1 files`;
       const entries = parseIcaclsOutput(output, "C:\\test\\file.txt");
       expect(entries).toHaveLength(2);
       expect(entries[0].principal).toBe("S-1-5-18");
-      expect(entries[1].principal).toBe(
-        "S-1-5-21-1824257776-4070701511-781240313-1001",
-      );
+      expect(entries[1].principal).toBe("S-1-5-21-1824257776-4070701511-781240313-1001");
     });
 
     it("ignores malformed ACL lines that contain ':' but no rights tokens", () => {
@@ -138,10 +134,7 @@ Successfully processed 1 files`;
 
     it("handles quoted target paths", () => {
       const output = `"C:\\path with spaces\\file.txt" BUILTIN\\Administrators:(F)`;
-      const entries = parseIcaclsOutput(
-        output,
-        "C:\\path with spaces\\file.txt",
-      );
+      const entries = parseIcaclsOutput(output, "C:\\path with spaces\\file.txt");
       expect(entries).toHaveLength(1);
     });
 
@@ -203,9 +196,7 @@ Successfully processed 1 files`;
     });
 
     it("classifies current user as trusted", () => {
-      const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "WORKGROUP\\TestUser" }),
-      ];
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "WORKGROUP\\TestUser" })];
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
       const summary = summarizeWindowsAcl(entries, env);
       expect(summary.trusted).toHaveLength(1);
@@ -237,9 +228,7 @@ Successfully processed 1 files`;
     });
 
     it("classifies BUILTIN\\Administrators SID (S-1-5-32-544) as trusted", () => {
-      const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "S-1-5-32-544" }),
-      ];
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "S-1-5-32-544" })];
       const summary = summarizeWindowsAcl(entries);
       expect(summary.trusted).toHaveLength(1);
       expect(summary.untrustedGroup).toHaveLength(0);
@@ -486,27 +475,21 @@ Successfully processed 1 files`;
 
   describe("summarizeWindowsAcl — localized SYSTEM account names", () => {
     it("classifies French SYSTEM (AUTORITE NT\\Système) as trusted", () => {
-      const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "AUTORITE NT\\Système" }),
-      ];
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "AUTORITE NT\\Système" })];
       const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
       expect(trusted).toHaveLength(1);
       expect(untrustedGroup).toHaveLength(0);
     });
 
     it("classifies German SYSTEM (NT-AUTORITÄT\\SYSTEM) as trusted", () => {
-      const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "NT-AUTORITÄT\\SYSTEM" }),
-      ];
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "NT-AUTORITÄT\\SYSTEM" })];
       const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
       expect(trusted).toHaveLength(1);
       expect(untrustedGroup).toHaveLength(0);
     });
 
     it("classifies Spanish SYSTEM (AUTORIDAD NT\\SYSTEM) as trusted", () => {
-      const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" }),
-      ];
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" })];
       const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
       expect(trusted).toHaveLength(1);
       expect(untrustedGroup).toHaveLength(0);
@@ -518,10 +501,7 @@ Successfully processed 1 files`;
         aclEntry({ principal: "AUTORITE NT\\Système" }),
       ];
       const env = { USERNAME: "Pierre", USERDOMAIN: "MYPC" };
-      const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(
-        entries,
-        env,
-      );
+      const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, env);
       expect(trusted).toHaveLength(2);
       expect(untrustedWorld).toHaveLength(0);
       expect(untrustedGroup).toHaveLength(0);

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -111,7 +111,9 @@ Successfully processed 1 files`;
         "\u043d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c 0 \u0444\u0430\u0439\u043b\u043e\u0432";
       const entries = parseIcaclsOutput(output, "C:\\Users\\karte\\.openclaw");
       expect(entries).toHaveLength(1);
-      expect(entries[0].principal).toBe("NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410");
+      expect(entries[0].principal).toBe(
+        "NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410",
+      );
     });
 
     it("parses SID-format principals", () => {
@@ -121,7 +123,9 @@ Successfully processed 1 files`;
       const entries = parseIcaclsOutput(output, "C:\\test\\file.txt");
       expect(entries).toHaveLength(2);
       expect(entries[0].principal).toBe("S-1-5-18");
-      expect(entries[1].principal).toBe("S-1-5-21-1824257776-4070701511-781240313-1001");
+      expect(entries[1].principal).toBe(
+        "S-1-5-21-1824257776-4070701511-781240313-1001",
+      );
     });
 
     it("ignores malformed ACL lines that contain ':' but no rights tokens", () => {
@@ -134,7 +138,10 @@ Successfully processed 1 files`;
 
     it("handles quoted target paths", () => {
       const output = `"C:\\path with spaces\\file.txt" BUILTIN\\Administrators:(F)`;
-      const entries = parseIcaclsOutput(output, "C:\\path with spaces\\file.txt");
+      const entries = parseIcaclsOutput(
+        output,
+        "C:\\path with spaces\\file.txt",
+      );
       expect(entries).toHaveLength(1);
     });
 
@@ -176,8 +183,18 @@ Successfully processed 1 files`;
 
     it("classifies world principals", () => {
       const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "Everyone", rights: ["R"], rawRights: "(R)", canWrite: false }),
-        aclEntry({ principal: "BUILTIN\\Users", rights: ["R"], rawRights: "(R)", canWrite: false }),
+        aclEntry({
+          principal: "Everyone",
+          rights: ["R"],
+          rawRights: "(R)",
+          canWrite: false,
+        }),
+        aclEntry({
+          principal: "BUILTIN\\Users",
+          rights: ["R"],
+          rawRights: "(R)",
+          canWrite: false,
+        }),
       ];
       const summary = summarizeWindowsAcl(entries);
       expect(summary.trusted).toHaveLength(0);
@@ -186,7 +203,9 @@ Successfully processed 1 files`;
     });
 
     it("classifies current user as trusted", () => {
-      const entries: WindowsAclEntry[] = [aclEntry({ principal: "WORKGROUP\\TestUser" })];
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "WORKGROUP\\TestUser" }),
+      ];
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
       const summary = summarizeWindowsAcl(entries, env);
       expect(summary.trusted).toHaveLength(1);
@@ -218,7 +237,9 @@ Successfully processed 1 files`;
     });
 
     it("classifies BUILTIN\\Administrators SID (S-1-5-32-544) as trusted", () => {
-      const entries: WindowsAclEntry[] = [aclEntry({ principal: "S-1-5-32-544" })];
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "S-1-5-32-544" }),
+      ];
       const summary = summarizeWindowsAcl(entries);
       expect(summary.trusted).toHaveLength(1);
       expect(summary.untrustedGroup).toHaveLength(0);
@@ -235,9 +256,13 @@ Successfully processed 1 files`;
 
     it("matches SIDs case-insensitively and trims USERSID", () => {
       const entries: WindowsAclEntry[] = [
-        aclEntry({ principal: "s-1-5-21-1824257776-4070701511-781240313-1001" }),
+        aclEntry({
+          principal: "s-1-5-21-1824257776-4070701511-781240313-1001",
+        }),
       ];
-      const env = { USERSID: "  S-1-5-21-1824257776-4070701511-781240313-1001  " };
+      const env = {
+        USERSID: "  S-1-5-21-1824257776-4070701511-781240313-1001  ",
+      };
       const summary = summarizeWindowsAcl(entries, env);
       expect(summary.trusted).toHaveLength(1);
       expect(summary.untrustedGroup).toHaveLength(0);
@@ -293,7 +318,9 @@ Successfully processed 1 files`;
         stderr: "",
       });
 
-      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+      });
       expect(result.ok).toBe(true);
       expect(result.entries).toHaveLength(2);
       expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt"]);
@@ -302,7 +329,9 @@ Successfully processed 1 files`;
     it("returns error state on exec failure", async () => {
       const mockExec = vi.fn().mockRejectedValue(new Error("icacls not found"));
 
-      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+      });
       expect(result.ok).toBe(false);
       expect(result.error).toContain("icacls not found");
       expect(result.entries).toHaveLength(0);
@@ -314,7 +343,9 @@ Successfully processed 1 files`;
         stderr: "C:\\test\\file.txt NT AUTHORITY\\SYSTEM:(F)",
       });
 
-      const result = await inspectWindowsAcl("C:\\test\\file.txt", { exec: mockExec });
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+      });
       expect(result.ok).toBe(true);
       expect(result.entries).toHaveLength(2);
     });
@@ -384,21 +415,30 @@ Successfully processed 1 files`;
   describe("formatIcaclsResetCommand", () => {
     it("generates command for files", () => {
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
-      const result = formatIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env });
+      const result = formatIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env,
+      });
       expect(result).toBe(
-        'icacls "C:\\test\\file.txt" /inheritance:r /grant:r "WORKGROUP\\TestUser:F" /grant:r "SYSTEM:F"',
+        'icacls "C:\\test\\file.txt" /inheritance:r /grant:r "WORKGROUP\\TestUser:F" /grant:r "*S-1-5-18:F"',
       );
     });
 
     it("generates command for directories with inheritance flags", () => {
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
-      const result = formatIcaclsResetCommand("C:\\test\\dir", { isDir: true, env });
+      const result = formatIcaclsResetCommand("C:\\test\\dir", {
+        isDir: true,
+        env,
+      });
       expect(result).toContain("(OI)(CI)F");
     });
 
     it("uses system username when env is empty (falls back to os.userInfo)", () => {
       // When env is empty, resolveWindowsUserPrincipal falls back to os.userInfo().username
-      const result = formatIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env: {} });
+      const result = formatIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env: {},
+      });
       // Should contain the actual system username from os.userInfo
       expect(result).toContain(`"${MOCK_USERNAME}:F"`);
       expect(result).not.toContain("%USERNAME%");
@@ -408,7 +448,10 @@ Successfully processed 1 files`;
   describe("createIcaclsResetCommand", () => {
     it("returns structured command object", () => {
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
-      const result = createIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env });
+      const result = createIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env,
+      });
       expect(result).not.toBeNull();
       expect(result?.command).toBe("icacls");
       expect(result?.args).toContain("C:\\test\\file.txt");
@@ -417,7 +460,10 @@ Successfully processed 1 files`;
 
     it("returns command with system username when env is empty (falls back to os.userInfo)", () => {
       // When env is empty, resolveWindowsUserPrincipal falls back to os.userInfo().username
-      const result = createIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env: {} });
+      const result = createIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env: {},
+      });
       // Should return a valid command using the system username
       expect(result).not.toBeNull();
       expect(result?.command).toBe("icacls");
@@ -426,9 +472,70 @@ Successfully processed 1 files`;
 
     it("includes display string matching formatIcaclsResetCommand", () => {
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
-      const result = createIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env });
-      const expected = formatIcaclsResetCommand("C:\\test\\file.txt", { isDir: false, env });
+      const result = createIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env,
+      });
+      const expected = formatIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env,
+      });
       expect(result?.display).toBe(expected);
+    });
+  });
+
+  describe("summarizeWindowsAcl — localized SYSTEM account names", () => {
+    it("classifies French SYSTEM (AUTORITE NT\\Système) as trusted", () => {
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "AUTORITE NT\\Système" }),
+      ];
+      const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
+      expect(trusted).toHaveLength(1);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+
+    it("classifies German SYSTEM (NT-AUTORITÄT\\SYSTEM) as trusted", () => {
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "NT-AUTORITÄT\\SYSTEM" }),
+      ];
+      const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
+      expect(trusted).toHaveLength(1);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+
+    it("classifies Spanish SYSTEM (AUTORIDAD NT\\SYSTEM) as trusted", () => {
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" }),
+      ];
+      const { trusted, untrustedGroup } = summarizeWindowsAcl(entries);
+      expect(trusted).toHaveLength(1);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+
+    it("French Windows full scenario: user + Système only → no untrusted", () => {
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "MYPC\\Pierre" }),
+        aclEntry({ principal: "AUTORITE NT\\Système" }),
+      ];
+      const env = { USERNAME: "Pierre", USERDOMAIN: "MYPC" };
+      const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(
+        entries,
+        env,
+      );
+      expect(trusted).toHaveLength(2);
+      expect(untrustedWorld).toHaveLength(0);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+  });
+
+  describe("formatIcaclsResetCommand — uses SID for SYSTEM", () => {
+    it("uses *S-1-5-18 instead of SYSTEM in reset command", () => {
+      const cmd = formatIcaclsResetCommand("C:\\test.json", {
+        isDir: false,
+        env: { USERNAME: "TestUser", USERDOMAIN: "PC" },
+      });
+      expect(cmd).toContain("*S-1-5-18:F");
+      expect(cmd).not.toContain("SYSTEM:F");
     });
   });
 });

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -33,9 +33,14 @@ const TRUSTED_BASE = new Set([
   "system",
   "builtin\\administrators",
   "creator owner",
+  // Localized SYSTEM account names (French, German, Spanish, Portuguese)
+  "autorite nt\\système",
+  "nt-autorität\\system",
+  "autoridad nt\\system",
+  "autoridade nt\\system",
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
-const TRUSTED_SUFFIXES = ["\\administrators", "\\system"];
+const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([
@@ -52,7 +57,9 @@ const STATUS_PREFIXES = [
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
-export function resolveWindowsUserPrincipal(env?: NodeJS.ProcessEnv): string | null {
+export function resolveWindowsUserPrincipal(
+  env?: NodeJS.ProcessEnv,
+): string | null {
   const username = env?.USERNAME?.trim() || os.userInfo().username?.trim();
   if (!username) {
     return null;
@@ -86,7 +93,9 @@ function classifyPrincipal(
   const normalized = normalize(principal);
 
   if (SID_RE.test(normalized)) {
-    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";
+    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized)
+      ? "trusted"
+      : "group";
   }
 
   if (
@@ -101,14 +110,37 @@ function classifyPrincipal(
   ) {
     return "world";
   }
+
+  // Fallback: strip diacritics and re-check for localized SYSTEM variants
+  const stripped = normalized.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  if (
+    stripped !== normalized &&
+    (TRUSTED_BASE.has(stripped) ||
+      TRUSTED_SUFFIXES.some((suffix) => {
+        const strippedSuffix = suffix
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "");
+        return stripped.endsWith(strippedSuffix);
+      }))
+  ) {
+    return "trusted";
+  }
+
   return "group";
 }
 
-function rightsFromTokens(tokens: string[]): { canRead: boolean; canWrite: boolean } {
+function rightsFromTokens(tokens: string[]): {
+  canRead: boolean;
+  canWrite: boolean;
+} {
   const upper = tokens.join("").toUpperCase();
   const canWrite =
-    upper.includes("F") || upper.includes("M") || upper.includes("W") || upper.includes("D");
-  const canRead = upper.includes("F") || upper.includes("M") || upper.includes("R");
+    upper.includes("F") ||
+    upper.includes("M") ||
+    upper.includes("W") ||
+    upper.includes("D");
+  const canRead =
+    upper.includes("F") || upper.includes("M") || upper.includes("R");
   return { canRead, canWrite };
 }
 
@@ -155,7 +187,9 @@ function parseAceEntry(entry: string): WindowsAclEntry | null {
     return null;
   }
 
-  const rights = tokens.filter((token) => !INHERIT_FLAGS.has(token.toUpperCase()));
+  const rights = tokens.filter(
+    (token) => !INHERIT_FLAGS.has(token.toUpperCase()),
+  );
   if (rights.length === 0) {
     return null;
   }
@@ -164,7 +198,10 @@ function parseAceEntry(entry: string): WindowsAclEntry | null {
   return { principal, rights, rawRights, canRead, canWrite };
 }
 
-export function parseIcaclsOutput(output: string, targetPath: string): WindowsAclEntry[] {
+export function parseIcaclsOutput(
+  output: string,
+  targetPath: string,
+): WindowsAclEntry[] {
   const entries: WindowsAclEntry[] = [];
   const normalizedTarget = targetPath.trim();
   const lowerTarget = normalizedTarget.toLowerCase();
@@ -209,7 +246,10 @@ export function summarizeWindowsAcl(
   const untrustedWorld: WindowsAclEntry[] = [];
   const untrustedGroup: WindowsAclEntry[] = [];
   for (const entry of entries) {
-    const classification = classifyPrincipal(entry.principal, trustedPrincipals);
+    const classification = classifyPrincipal(
+      entry.principal,
+      trustedPrincipals,
+    );
     if (classification === "trusted") {
       trusted.push(entry);
     } else if (classification === "world") {
@@ -230,7 +270,10 @@ export async function inspectWindowsAcl(
     const { stdout, stderr } = await exec("icacls", [targetPath]);
     const output = `${stdout}\n${stderr}`.trim();
     const entries = parseIcaclsOutput(output, targetPath);
-    const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, opts?.env);
+    const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(
+      entries,
+      opts?.env,
+    );
     return { ok: true, entries, trusted, untrustedWorld, untrustedGroup };
   } catch (err) {
     return {
@@ -252,7 +295,9 @@ export function formatWindowsAclSummary(summary: WindowsAclSummary): string {
   if (untrusted.length === 0) {
     return "trusted-only";
   }
-  return untrusted.map((entry) => `${entry.principal}:${entry.rawRights}`).join(", ");
+  return untrusted
+    .map((entry) => `${entry.principal}:${entry.rawRights}`)
+    .join(", ");
 }
 
 export function formatIcaclsResetCommand(
@@ -261,7 +306,7 @@ export function formatIcaclsResetCommand(
 ): string {
   const user = resolveWindowsUserPrincipal(opts.env) ?? "%USERNAME%";
   const grant = opts.isDir ? "(OI)(CI)F" : "F";
-  return `icacls "${targetPath}" /inheritance:r /grant:r "${user}:${grant}" /grant:r "SYSTEM:${grant}"`;
+  return `icacls "${targetPath}" /inheritance:r /grant:r "${user}:${grant}" /grant:r "*S-1-5-18:${grant}"`;
 }
 
 export function createIcaclsResetCommand(
@@ -279,7 +324,11 @@ export function createIcaclsResetCommand(
     "/grant:r",
     `${user}:${grant}`,
     "/grant:r",
-    `SYSTEM:${grant}`,
+    `*S-1-5-18:${grant}`,
   ];
-  return { command: "icacls", args, display: formatIcaclsResetCommand(targetPath, opts) };
+  return {
+    command: "icacls",
+    args,
+    display: formatIcaclsResetCommand(targetPath, opts),
+  };
 }

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -57,9 +57,7 @@ const STATUS_PREFIXES = [
 
 const normalize = (value: string) => value.trim().toLowerCase();
 
-export function resolveWindowsUserPrincipal(
-  env?: NodeJS.ProcessEnv,
-): string | null {
+export function resolveWindowsUserPrincipal(env?: NodeJS.ProcessEnv): string | null {
   const username = env?.USERNAME?.trim() || os.userInfo().username?.trim();
   if (!username) {
     return null;
@@ -93,9 +91,7 @@ function classifyPrincipal(
   const normalized = normalize(principal);
 
   if (SID_RE.test(normalized)) {
-    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized)
-      ? "trusted"
-      : "group";
+    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";
   }
 
   if (
@@ -117,9 +113,7 @@ function classifyPrincipal(
     stripped !== normalized &&
     (TRUSTED_BASE.has(stripped) ||
       TRUSTED_SUFFIXES.some((suffix) => {
-        const strippedSuffix = suffix
-          .normalize("NFD")
-          .replace(/[\u0300-\u036f]/g, "");
+        const strippedSuffix = suffix.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
         return stripped.endsWith(strippedSuffix);
       }))
   ) {
@@ -135,12 +129,8 @@ function rightsFromTokens(tokens: string[]): {
 } {
   const upper = tokens.join("").toUpperCase();
   const canWrite =
-    upper.includes("F") ||
-    upper.includes("M") ||
-    upper.includes("W") ||
-    upper.includes("D");
-  const canRead =
-    upper.includes("F") || upper.includes("M") || upper.includes("R");
+    upper.includes("F") || upper.includes("M") || upper.includes("W") || upper.includes("D");
+  const canRead = upper.includes("F") || upper.includes("M") || upper.includes("R");
   return { canRead, canWrite };
 }
 
@@ -187,9 +177,7 @@ function parseAceEntry(entry: string): WindowsAclEntry | null {
     return null;
   }
 
-  const rights = tokens.filter(
-    (token) => !INHERIT_FLAGS.has(token.toUpperCase()),
-  );
+  const rights = tokens.filter((token) => !INHERIT_FLAGS.has(token.toUpperCase()));
   if (rights.length === 0) {
     return null;
   }
@@ -198,10 +186,7 @@ function parseAceEntry(entry: string): WindowsAclEntry | null {
   return { principal, rights, rawRights, canRead, canWrite };
 }
 
-export function parseIcaclsOutput(
-  output: string,
-  targetPath: string,
-): WindowsAclEntry[] {
+export function parseIcaclsOutput(output: string, targetPath: string): WindowsAclEntry[] {
   const entries: WindowsAclEntry[] = [];
   const normalizedTarget = targetPath.trim();
   const lowerTarget = normalizedTarget.toLowerCase();
@@ -246,10 +231,7 @@ export function summarizeWindowsAcl(
   const untrustedWorld: WindowsAclEntry[] = [];
   const untrustedGroup: WindowsAclEntry[] = [];
   for (const entry of entries) {
-    const classification = classifyPrincipal(
-      entry.principal,
-      trustedPrincipals,
-    );
+    const classification = classifyPrincipal(entry.principal, trustedPrincipals);
     if (classification === "trusted") {
       trusted.push(entry);
     } else if (classification === "world") {
@@ -270,10 +252,7 @@ export async function inspectWindowsAcl(
     const { stdout, stderr } = await exec("icacls", [targetPath]);
     const output = `${stdout}\n${stderr}`.trim();
     const entries = parseIcaclsOutput(output, targetPath);
-    const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(
-      entries,
-      opts?.env,
-    );
+    const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, opts?.env);
     return { ok: true, entries, trusted, untrustedWorld, untrustedGroup };
   } catch (err) {
     return {
@@ -295,9 +274,7 @@ export function formatWindowsAclSummary(summary: WindowsAclSummary): string {
   if (untrusted.length === 0) {
     return "trusted-only";
   }
-  return untrusted
-    .map((entry) => `${entry.principal}:${entry.rawRights}`)
-    .join(", ");
+  return untrusted.map((entry) => `${entry.principal}:${entry.rawRights}`).join(", ");
 }
 
 export function formatIcaclsResetCommand(


### PR DESCRIPTION
Fixes #29681

## Problem

On non-English Windows (e.g. French `fr-FR` locale), the security audit reports a false positive for `fs.config.perms_writable` because the SYSTEM account is named `AUTORITE NT\Système` instead of `NT AUTHORITY\SYSTEM`. The ACL checker fails to recognize it as a trusted principal.

## Changes

- **Add localized SYSTEM names** to `TRUSTED_BASE`: French (`AUTORITE NT\Système`), German (`NT-AUTORITÄT\SYSTEM`), Spanish (`AUTORIDAD NT\SYSTEM`), Portuguese (`AUTORIDADE NT\SYSTEM`)
- **Add `\système` suffix** to `TRUSTED_SUFFIXES` for French locale matching
- **Diacritics-stripping fallback** in `classifyPrincipal`: normalizes Unicode (NFD + strip combining marks) and re-checks against trusted sets, catching any locale not explicitly listed
- **Use SID `*S-1-5-18`** in `formatIcaclsResetCommand` and `createIcaclsResetCommand` instead of hardcoded `"SYSTEM"` string — SID references work on all Windows locales

## Tests

- Added tests for French, German, Spanish localized SYSTEM classification
- Added full-scenario test (French user + Système = all trusted)
- Added test verifying SID usage in reset commands
- All 40 tests pass