### PR TITLE
Control UI Chat: session picker + new session + rename

### DIFF
--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -54,6 +54,17 @@ Notes:
 - If the same person contacts you on multiple channels, use `session.identityLinks` to collapse their DM sessions into one canonical identity.
 - You can verify your DM settings with `openclaw security audit` (see [security](/cli/security)).
 
+## Session mutation permissions for browser clients
+
+`webchat` clients are intentionally restricted from mutating session metadata (`sessions.patch`, `sessions.delete`).
+
+Control UI uses `client.mode = "ui"` for management workflows (session label updates and session-focused chat UX), while preserving mutation restrictions for regular webchat clients.
+
+This keeps a clear separation between:
+
+- end-user webchat messaging surface (no session metadata mutation)
+- authenticated control/management surface (session metadata management allowed)
+
 ## Gateway is the source of truth
 
 All session state is **owned by the gateway** (the “master” OpenClaw). UI clients (macOS app, WebChat, etc.) must query the gateway for session lists and token counts instead of reading local files.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -91,6 +91,28 @@ Cron jobs panel notes:
 - Set `cron.webhookToken` to send a dedicated bearer token, if omitted the webhook is sent without an auth header.
 - Deprecated fallback: stored legacy jobs with `notify: true` can still use `cron.webhook` until migrated.
 
+## Session management in Chat
+
+The Chat tab supports explicit session management so you can isolate topics by session key.
+
+- **Session selector**: switch between recent sessions.
+- **New session**: create a new session key and switch to it immediately.
+- **Rename session**: update the current session label (display name).
+
+### Session key vs `/new`
+
+- `/new` (or reset) starts a new transcript under the **same** session key.
+- **New session** creates a **different** session key, which isolates context/history from other topics.
+
+### How the dropdown list is populated
+
+The Chat session dropdown reuses the existing Control UI sessions state from `sessions.list`.
+The number of entries depends on current sessions filters (`activeMinutes`, `limit`, `includeGlobal`, `includeUnknown`).
+
+### Deep links
+
+You can open a specific session directly with `/chat?session=<sessionKey>`.
+
 ## Chat behavior
 
 - `chat.send` is **non-blocking**: it acks immediately with `{ runId, status: "started" }` and the response streams via `chat` events.

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -150,7 +150,7 @@ export function connectGateway(host: GatewayHost) {
     token: host.settings.token.trim() ? host.settings.token : undefined,
     password: host.password.trim() ? host.password : undefined,
     clientName: "openclaw-control-ui",
-    mode: "webchat",
+    mode: "ui",
     instanceId: host.clientInstanceId,
     onHello: (hello) => {
       if (host.client !== client) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,16 +1,19 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
+import { patchSession } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
+import { generateUUID } from "./uuid.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -35,6 +38,11 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   state.sessionKey = sessionKey;
   state.chatMessage = "";
+  state.chatAttachments = [];
+  state.chatQueue = [];
+  state.sidebarOpen = false;
+  state.sidebarContent = null;
+  state.sidebarError = null;
   state.chatStream = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
@@ -45,6 +53,61 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
     sessionKey,
     lastActiveSessionKey: sessionKey,
   });
+}
+
+function slugifySessionTitle(input: string): string {
+  const raw = (input ?? "").trim().toLowerCase();
+  if (!raw) {
+    return "chat";
+  }
+  // Keep it conservative: [a-z0-9-]
+  const slug = raw
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40);
+  return slug || "chat";
+}
+
+function formatUiSessionTimestamp(d: Date): string {
+  const y = String(d.getFullYear());
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${y}${m}${day}-${hh}${mm}`;
+}
+
+type SessionDefaultsSnapshotExtra = {
+  defaultAgentId?: string;
+};
+
+function resolveAgentIdForNewUiSession(state: AppViewState): string {
+  const parsed = parseAgentSessionKey(state.sessionKey);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  const selected = state.agentsSelectedId?.trim();
+  if (selected) {
+    return selected;
+  }
+  const assistant = state.assistantAgentId?.trim();
+  if (assistant) {
+    return assistant;
+  }
+  const snapshot = state.hello?.snapshot as
+    | { sessionDefaults?: SessionDefaultsSnapshotExtra }
+    | undefined;
+  const fallback = snapshot?.sessionDefaults?.defaultAgentId?.trim();
+  return fallback || "main";
+}
+
+function generateNewUiSessionKey(state: AppViewState, title?: string): string {
+  const agentId = resolveAgentIdForNewUiSession(state);
+  const ts = formatUiSessionTimestamp(new Date());
+  const slug = slugifySessionTitle(title ?? "");
+  const rand = generateUUID().split("-")[0].slice(0, 4).toLowerCase();
+  return `agent:${agentId}:ui:${ts}-${slug}-${rand}`;
 }
 
 export function renderTab(state: AppViewState, tab: Tab) {
@@ -93,6 +156,50 @@ export function renderChatControls(state: AppViewState) {
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const focusActive = state.onboarding ? true : state.settings.chatFocusMode;
+
+  const switchToSession = (next: string) => {
+    resetChatStateForSessionSwitch(state, next);
+    void state.loadAssistantIdentity();
+    syncUrlWithSessionKey(
+      state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
+      next,
+      true,
+    );
+    void loadChatHistory(state as unknown as ChatState);
+  };
+
+  const handleNewSession = async () => {
+    if (!state.connected) {
+      return;
+    }
+    const titleRaw = window.prompt("New session name (optional)", "");
+    if (titleRaw === null) {
+      return;
+    }
+    const title = titleRaw.trim();
+    const key = generateNewUiSessionKey(state, title || undefined);
+    const label = title || `Chat ${formatUiSessionTimestamp(new Date())}`;
+    await patchSession(state as unknown as Parameters<typeof patchSession>[0], key, { label });
+    switchToSession(key);
+  };
+
+  const handleRenameSession = async () => {
+    if (!state.connected) {
+      return;
+    }
+    const currentRow = state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey);
+    const suggested =
+      currentRow?.label?.trim() || resolveSessionDisplayName(state.sessionKey, currentRow);
+    const nextRaw = window.prompt("Rename session", suggested);
+    if (nextRaw === null) {
+      return;
+    }
+    const nextLabel = nextRaw.trim();
+    await patchSession(state as unknown as Parameters<typeof patchSession>[0], state.sessionKey, {
+      label: nextLabel || null,
+    });
+  };
+
   // Refresh icon
   const refreshIcon = html`
     <svg
@@ -135,25 +242,7 @@ export function renderChatControls(state: AppViewState) {
           ?disabled=${!state.connected}
           @change=${(e: Event) => {
             const next = (e.target as HTMLSelectElement).value;
-            state.sessionKey = next;
-            state.chatMessage = "";
-            state.chatStream = null;
-            (state as unknown as OpenClawApp).chatStreamStartedAt = null;
-            state.chatRunId = null;
-            (state as unknown as OpenClawApp).resetToolStream();
-            (state as unknown as OpenClawApp).resetChatScroll();
-            state.applySettings({
-              ...state.settings,
-              sessionKey: next,
-              lastActiveSessionKey: next,
-            });
-            void state.loadAssistantIdentity();
-            syncUrlWithSessionKey(
-              state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
-              next,
-              true,
-            );
-            void loadChatHistory(state as unknown as ChatState);
+            switchToSession(next);
           }}
         >
           ${repeat(
@@ -166,6 +255,27 @@ export function renderChatControls(state: AppViewState) {
           )}
         </select>
       </label>
+
+      <button
+        class="btn btn--sm btn--icon"
+        ?disabled=${!state.connected}
+        @click=${handleNewSession}
+        aria-label="New session"
+        title="Create and switch to a new named session"
+      >
+        ${icons.plus}
+      </button>
+
+      <button
+        class="btn btn--sm btn--icon"
+        ?disabled=${!state.connected}
+        @click=${handleRenameSession}
+        aria-label="Rename session"
+        title="Rename current session"
+      >
+        ${icons.edit}
+      </button>
+
       <button
         class="btn btn--sm btn--icon"
         ?disabled=${state.chatLoading || !state.connected}

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -103,6 +103,12 @@ export const icons = {
       <path d="m6 6 12 12" />
     </svg>
   `,
+  plus: html`
+    <svg viewBox="0 0 24 24">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  `,
   check: html`
     <svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></svg>
   `,


### PR DESCRIPTION
## Summary

This PR improves session management in Control UI Chat by adding:

- session picker (recent sessions)
- new session creation (new session key + immediate switch)
- rename current session label

It also sets Control UI gateway connect mode to `ui` (instead of `webchat`) so session metadata updates (`sessions.patch`) are allowed for Control UI, while regular webchat restrictions remain unchanged.

## Why

Previously, Chat usage in Control UI often felt stuck on one session key (commonly `agent:main:main`), and `/new` only reset transcript under the same key.
Users needed explicit UI-level session key management to isolate topics cleanly.

## Behavior details

- Chat session picker reuses existing Control UI sessions state from `sessions.list`.
- Entry count is determined by existing sessions filters:
  - `activeMinutes`
  - `limit`
  - `includeGlobal`
  - `includeUnknown`
- Therefore, shorter dropdown lists are expected when filters are narrow.

## Security / permission model

- `webchat` clients remain restricted from `sessions.patch` / `sessions.delete`.
- Control UI uses `client.mode=ui` for management workflows (session label updates in UI).

This preserves separation between:
- end-user webchat messaging surface
- authenticated control/management surface

## User-facing changes

- In Chat header:
  - switch session from dropdown
  - create new session and switch
  - rename current session label
- Deep link remains supported:
  - `/chat?session=<sessionKey>`

## Notes

- `/new` semantics are unchanged:
  - still resets transcript under the same session key
- New session action creates a new key to isolate context/history across topics
