### PR TITLE
fix(ui-cron): include configured model suggestions for scheduled jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/Cron: include configured agent model defaults/fallbacks in cron model suggestions so scheduled-job model autocomplete reflects configured models. (#29709)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -65,6 +65,7 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { resolveConfiguredCronModelSuggestions } from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
 import { renderChat } from "./views/chat.ts";
@@ -178,6 +179,7 @@ export function renderApp(state: AppViewState) {
     new Set(
       [
         ...state.cronModelSuggestions,
+        ...resolveConfiguredCronModelSuggestions(configValue),
         ...state.cronJobs
           .map((job) => {
             if (job.payload.kind !== "agentTurn" || typeof job.payload.model !== "string") {

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveEffectiveModelFallbacks } from "./agents-utils.ts";
+import {
+  resolveConfiguredCronModelSuggestions,
+  resolveEffectiveModelFallbacks,
+} from "./agents-utils.ts";
 
 describe("resolveEffectiveModelFallbacks", () => {
   it("inherits defaults when no entry fallbacks are configured", () => {
@@ -38,5 +41,49 @@ describe("resolveEffectiveModelFallbacks", () => {
     };
 
     expect(resolveEffectiveModelFallbacks(entryModel, defaultModel)).toEqual([]);
+  });
+});
+
+describe("resolveConfiguredCronModelSuggestions", () => {
+  it("collects defaults primary/fallbacks, alias map keys, and per-agent model entries", () => {
+    const result = resolveConfiguredCronModelSuggestions({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.2",
+            fallbacks: ["google/gemini-2.5-pro", "openai/gpt-5.2-mini"],
+          },
+          models: {
+            "anthropic/claude-sonnet-4-5": { alias: "smart" },
+            "openai/gpt-5.2": { alias: "main" },
+          },
+        },
+        list: {
+          writer: {
+            model: { primary: "xai/grok-4", fallbacks: ["openai/gpt-5.2-mini"] },
+          },
+          planner: {
+            model: "google/gemini-2.5-flash",
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual([
+      "anthropic/claude-sonnet-4-5",
+      "google/gemini-2.5-flash",
+      "google/gemini-2.5-pro",
+      "openai/gpt-5.2",
+      "openai/gpt-5.2-mini",
+      "xai/grok-4",
+    ]);
+  });
+
+  it("returns empty array for invalid or missing config shape", () => {
+    expect(resolveConfiguredCronModelSuggestions(null)).toEqual([]);
+    expect(resolveConfiguredCronModelSuggestions({})).toEqual([]);
+    expect(resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } })).toEqual(
+      [],
+    );
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** Scheduled job Advanced model suggestions only reflected `models.list` + prior job history, so configured primary/fallback models could be missing.
- **Why it matters:** Operators cannot reliably select configured routing models when overriding cron job execution model.
- **What changed:** Merged configured model references from `agents.defaults.model`, `agents.defaults.models`, and `agents.list.*.model` into cron model suggestions in Control UI.
- **What did NOT change:** No backend model routing, no API contract, and no cron execution semantics were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29668

## User-visible / Behavior Changes

- Cron Advanced model suggestion list now includes configured defaults/fallbacks and per-agent model entries, even if not present in runtime catalog history.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node + pnpm
- Integration/channel: Control UI (Cron page)

### Steps

1. Configure `agents.defaults.model.primary/fallbacks` and/or `agents.list.<id>.model` with models not yet present in cron history.
2. Open Control UI → Cron → Advanced → Model suggestions.

### Expected

- Suggestion list includes configured models from defaults and agent entries.

### Actual

- Before fix: suggestion list could omit configured models.
- After fix: configured models are included.

## Evidence

- `pnpm test -- --run ui/src/ui/views/agents-utils.test.ts`

## Human Verification (required)

- Verified scenarios: defaults primary/fallbacks, model alias map keys, per-agent model object/string entries.
- Edge cases checked: missing/invalid config shapes return empty additions.
- What I did **not** verify: full browser manual click-through in live Control UI.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `ui/src/ui/app-render.ts`, `ui/src/ui/views/agents-utils.ts`.
- Known bad symptoms: Cron model suggestions revert to previous incomplete list behavior.

## Risks and Mitigations

- Risk: Suggestion list may include extra entries from broad config parsing.
- Mitigation: Strict string normalization + dedupe + targeted unit tests for expected merge behavior.

Made with [Cursor](https://cursor.com)