### PR TITLE
fix(plugins): prioritize bundled plugin over auto-discovered global duplicates

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -609,16 +609,6 @@ export function discoverOpenClawPlugins(params: {
     }
   }
 
-  const globalDir = path.join(resolveConfigDir(), "extensions");
-  discoverInDirectory({
-    dir: globalDir,
-    origin: "global",
-    ownershipUid: params.ownershipUid,
-    candidates,
-    diagnostics,
-    seen,
-  });
-
   const bundledDir = resolveBundledPluginsDir();
   if (bundledDir) {
     discoverInDirectory({
@@ -630,6 +620,18 @@ export function discoverOpenClawPlugins(params: {
       seen,
     });
   }
+
+  // Keep auto-discovered global extensions behind bundled plugins.
+  // Users can still intentionally override via plugins.load.paths (origin=config).
+  const globalDir = path.join(resolveConfigDir(), "extensions");
+  discoverInDirectory({
+    dir: globalDir,
+    origin: "global",
+    ownershipUid: params.ownershipUid,
+    candidates,
+    diagnostics,
+    seen,
+  });
 
   return { candidates, diagnostics };
 }


### PR DESCRIPTION
## Summary

- **Problem:** Auto-discovered global extensions could override bundled plugins with the same manifest id, causing duplicate `feishu` plugin resolution and unstable pairing behavior after upgrade.
- **Why it matters:** Users hit repeated pairing / `access not configured` loops because the wrong plugin copy won precedence.
- **What changed:** Plugin discovery order now loads bundled roots before global auto-discovery so bundled entries are authoritative by default.
- **What did NOT change:** Explicit `plugins.load.paths` (config origin) still has highest precedence and can intentionally override bundled plugins.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29632
- Closes #29622

## User-visible / Behavior Changes

- When both bundled and global plugins share the same id, bundled plugin is now selected by default for auto-discovered roots.
- Duplicate Feishu plugin override behavior is prevented in the default discovery path.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node + pnpm
- Integration/channel: plugin discovery + loader

### Steps

1. Have bundled `feishu` plugin present.
2. Also place a global auto-discovered plugin with id `feishu` under state extensions.
3. Start plugin loader with `plugins.entries.feishu.enabled=true`.

### Expected

- Bundled plugin remains loaded; global duplicate is marked overridden.

### Actual

- Before fix: global duplicate could win due discovery order.
- After fix: bundled wins by default in auto-discovery.

## Evidence

- `pnpm test -- --run src/plugins/loader.test.ts`

## Human Verification (required)

- Verified scenarios: bundled-vs-global duplicate id precedence and explicit config override behavior.
- Edge cases checked: duplicate id status/error metadata for overridden global entry.
- What I did **not** verify: full live Feishu pairing flow in a running gateway instance.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/plugins/discovery.ts`.
- Known bad symptoms: global duplicate plugins may shadow bundled plugins again.

## Risks and Mitigations

- Risk: installations relying on implicit global-over-bundled precedence may observe changed load choice.
- Mitigation: explicit config load paths continue to override intentionally; test coverage added for bundled/global duplicate behavior.

Made with [Cursor](https://cursor.com)