### PR TITLE
fix: log error when followup messages are silently dropped

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -6,7 +6,6 @@ import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
-import { logVerbose } from "../../globals.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
@@ -74,7 +73,9 @@ export function createFollowupRunner(params: {
     const shouldRouteToOriginating = isRoutableChannel(originatingChannel) && originatingTo;
 
     if (!shouldRouteToOriginating && !opts?.onBlockReply) {
-      logVerbose("followup queue: no onBlockReply handler; dropping payloads");
+      defaultRuntime.error?.(
+        `followup queue: no reply handler available; ${payloads.length} payload(s) dropped`,
+      );
       return;
     }
 
@@ -104,7 +105,7 @@ export function createFollowupRunner(params: {
         });
         if (!result.ok) {
           const errorMsg = result.error ?? "unknown error";
-          logVerbose(`followup queue: route-reply failed: ${errorMsg}`);
+          defaultRuntime.error?.(`followup queue: route-reply failed: ${errorMsg}`);
           // Fall back to the caller-provided dispatcher only when the
           // originating channel matches the session's message provider.
           // In that case onBlockReply was created by the same channel's

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -1,5 +1,6 @@
 import { resolveEmbeddedSessionLane } from "../../../agents/pi-embedded.js";
 import { clearCommandLane } from "../../../process/command-queue.js";
+import { defaultRuntime } from "../../../runtime.js";
 import { clearFollowupQueue } from "./state.js";
 
 export type ClearSessionQueueResult = {
@@ -23,6 +24,12 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     clearedKeys.push(cleaned);
     followupCleared += clearFollowupQueue(cleaned);
     laneCleared += clearCommandLane(resolveEmbeddedSessionLane(cleaned));
+  }
+
+  if (followupCleared > 0) {
+    defaultRuntime.error?.(
+      `followup queue: ${followupCleared} queued message(s) discarded on abort (keys=${clearedKeys.join(",")})`,
+    );
   }
 
   return { followupCleared, laneCleared, keys: clearedKeys };


### PR DESCRIPTION
## Summary

Fixes #29497

Queued followup messages were silently discarded on timeout/abort with only `logVerbose`-level logging that users never see. This made it impossible to diagnose why messages disappeared.

**Changes:**
- Upgrade the two silent-drop paths in `followup-runner.ts` from `logVerbose` to `defaultRuntime.error`:
  - When no reply handler is available (no `onBlockReply` and no routable originating channel)
  - When `routeReply` fails for a cross-channel message with no fallback
- Add an error log in `clearSessionQueues` (used by the abort path) when queued followup messages are discarded, including the count and affected queue keys
- Remove unused `logVerbose` import from `followup-runner.ts`

## Test plan

- [x] `pnpm test src/auto-reply/reply/followup-runner.test` — 17 tests pass
- [x] `pnpm test src/auto-reply/reply/agent-runner-helpers.test` — 6 tests pass
- [ ] Verify error logs appear when a followup message is dropped (manual: trigger timeout with a queued message, check gateway logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)