### PR TITLE
chore(nostr): fix oxlint disable rule typo

### DIFF
--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -632,7 +632,7 @@ async function sendEncryptedDm(
 
     const startTime = Date.now();
     try {
-      // oxlint-disable-next-line typescript/await-thenable typesciript/no-floating-promises
+      // oxlint-disable-next-line typescript/await-thenable typescript/no-floating-promises
       await pool.publish([relay], reply);
       const latency = Date.now() - startTime;
 


### PR DESCRIPTION
## Summary
- fix a typo in an oxlint-disable-next-line rule name in extensions/nostr/src/nostr-bus.ts
- no runtime behavior changes

## Testing
- not run (comment-only change)