### PR TITLE
fix: distinguish outside-workspace errors from not-found in fs-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- FS/Sandbox workspace boundaries: add a dedicated `outside-workspace` safe-open error code for root-escape checks, and propagate specific outside-workspace messages across edit/browser/media consumers instead of generic not-found/invalid-path fallbacks. (#29715) Thanks @YuzuruS.
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 

--- a/src/agents/pi-tools.read.host-edit-access.test.ts
+++ b/src/agents/pi-tools.read.host-edit-access.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type CapturedEditOperations = {
+  access: (absolutePath: string) => Promise<void>;
+};
+
+const mocks = vi.hoisted(() => ({
+  operations: undefined as CapturedEditOperations | undefined,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createEditTool: (_cwd: string, options?: { operations?: CapturedEditOperations }) => {
+      mocks.operations = options?.operations;
+      return {
+        name: "edit",
+        description: "test edit tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      };
+    },
+  };
+});
+
+const { createHostWorkspaceEditTool } = await import("./pi-tools.read.js");
+
+describe("createHostWorkspaceEditTool host access mapping", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    mocks.operations = undefined;
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "maps outside-workspace safe-open failures to EACCES",
+    async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-access-test-"));
+      const workspaceDir = path.join(tmpDir, "workspace");
+      const outsideDir = path.join(tmpDir, "outside");
+      const linkDir = path.join(workspaceDir, "escape");
+      const outsideFile = path.join(outsideDir, "secret.txt");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(outsideFile, "secret", "utf8");
+      await fs.symlink(outsideDir, linkDir);
+
+      createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+      expect(mocks.operations).toBeDefined();
+
+      await expect(
+        mocks.operations!.access(path.join(workspaceDir, "escape", "secret.txt")),
+      ).rejects.toMatchObject({ code: "EACCES" });
+    },
+  );
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -854,6 +854,9 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
         if (error instanceof SafeOpenError && error.code === "not-found") {
           throw createFsAccessError("ENOENT", absolutePath);
         }
+        if (error instanceof SafeOpenError && error.code === "outside-workspace") {
+          throw createFsAccessError("EACCES", absolutePath);
+        }
         throw error;
       }
     },

--- a/src/browser/paths.ts
+++ b/src/browser/paths.ts
@@ -235,6 +235,12 @@ async function resolveCheckedPathsWithinRoot(params: {
         resolvedPaths.push(pathResult.fallbackPath);
         continue;
       }
+      if (err instanceof SafeOpenError && err.code === "outside-workspace") {
+        return {
+          ok: false,
+          error: `File is outside ${params.scopeLabel}`,
+        };
+      }
       return {
         ok: false,
         error: `Invalid path: must stay within ${params.scopeLabel} and be a regular non-symlink file`,

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -67,7 +67,7 @@ describe("fs-safe", () => {
         rootDir: root,
         relativePath: path.join("..", path.basename(outside), "outside.txt"),
       }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    ).rejects.toMatchObject({ code: "outside-workspace" });
   });
 
   it.runIf(process.platform !== "win32")("blocks symlink escapes under root", async () => {
@@ -131,7 +131,7 @@ describe("fs-safe", () => {
         relativePath: "../escape.txt",
         data: "x",
       }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    ).rejects.toMatchObject({ code: "outside-workspace" });
   });
 
   it.runIf(process.platform !== "win32")("rejects writing through hardlink aliases", async () => {

--- a/src/media/server.outside-workspace.test.ts
+++ b/src/media/server.outside-workspace.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openFileWithinRoot: vi.fn(),
+  cleanOldMedia: vi.fn().mockResolvedValue(undefined),
+}));
+
+let mediaDir = "";
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    openFileWithinRoot: mocks.openFileWithinRoot,
+  };
+});
+
+vi.mock("./store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./store.js")>();
+  return {
+    ...actual,
+    getMediaDir: () => mediaDir,
+    cleanOldMedia: mocks.cleanOldMedia,
+  };
+});
+
+const { SafeOpenError } = await import("../infra/fs-safe.js");
+const { startMediaServer } = await import("./server.js");
+
+describe("media server outside-workspace mapping", () => {
+  let server: Awaited<ReturnType<typeof startMediaServer>>;
+  let port = 0;
+
+  beforeAll(async () => {
+    mediaDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-outside-workspace-"));
+    server = await startMediaServer(0, 1_000);
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(mediaDir, { recursive: true, force: true });
+    mediaDir = "";
+  });
+
+  it("returns 400 with a specific outside-workspace message", async () => {
+    mocks.openFileWithinRoot.mockRejectedValueOnce(
+      new SafeOpenError("outside-workspace", "file is outside workspace root"),
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/media/ok-id`);
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("file is outside workspace root");
+  });
+});

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -75,6 +75,10 @@ export function attachMediaRoutes(
       });
     } catch (err) {
       if (err instanceof SafeOpenError) {
+        if (err.code === "outside-workspace") {
+          res.status(400).send("file is outside workspace root");
+          return;
+        }
         if (err.code === "invalid-path") {
           res.status(400).send("invalid path");
           return;

--- a/src/media/store.outside-workspace.test.ts
+++ b/src/media/store.outside-workspace.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+
+const mocks = vi.hoisted(() => ({
+  readLocalFileSafely: vi.fn(),
+}));
+
+vi.mock("../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    readLocalFileSafely: mocks.readLocalFileSafely,
+  };
+});
+
+const { saveMediaSource } = await import("./store.js");
+const { SafeOpenError } = await import("../infra/fs-safe.js");
+
+describe("media store outside-workspace mapping", () => {
+  let tempHome: TempHomeEnv;
+  let home = "";
+
+  beforeAll(async () => {
+    tempHome = await createTempHomeEnv("openclaw-media-store-test-home-");
+    home = tempHome.home;
+  });
+
+  afterAll(async () => {
+    await tempHome.restore();
+  });
+
+  it("maps outside-workspace reads to a descriptive invalid-path error", async () => {
+    const sourcePath = path.join(home, "outside-media.txt");
+    await fs.writeFile(sourcePath, "hello");
+    mocks.readLocalFileSafely.mockRejectedValueOnce(
+      new SafeOpenError("outside-workspace", "file is outside workspace root"),
+    );
+
+    await expect(saveMediaSource(sourcePath)).rejects.toMatchObject({
+      code: "invalid-path",
+      message: "Media path is outside workspace root",
+    });
+  });
+});

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -241,6 +241,10 @@ function toSaveMediaSourceError(err: SafeOpenError): SaveMediaSourceError {
       return new SaveMediaSourceError("too-large", "Media exceeds 5MB limit", { cause: err });
     case "not-found":
       return new SaveMediaSourceError("not-found", "Media path does not exist", { cause: err });
+    case "outside-workspace":
+      return new SaveMediaSourceError("invalid-path", "Media path is outside workspace root", {
+        cause: err,
+      });
     case "invalid-path":
     default:
       return new SaveMediaSourceError("invalid-path", "Media path is not safe to read", {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When the Edit tool tries to open a file outside the workspace root, `SafeOpenError` throws with code `"invalid-path"` and message `"path escapes root"`. Consumers cannot distinguish this from other invalid-path cases (hardlinks, symlinks, non-files) and often fall back to a misleading `"File not found"` message.
- Why it matters: Users see "File not found" when the real cause is "file is outside workspace", making debugging confusing.
- What changed: Added a new `"outside-workspace"` error code to `SafeOpenErrorCode`. All path-escapes-root checks in `openFileWithinRoot` / `writeFileWithinRoot` now use this code. Consumers (`pi-tools.read.ts`, `browser/paths.ts`, `media/server.ts`) handle it with specific, accurate messages.
- What did NOT change (scope boundary): Other `"invalid-path"` uses (hardlinks, symlinks, non-files) remain unchanged. `readLocalFileSafely` is unaffected (no root boundary check).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28427, #28763, #29612

## User-visible / Behavior Changes

- Edit/Write tools now report `"file is outside workspace root"` or `"File is outside {scopeLabel}"` instead of `"File not found"` or `"Invalid path"` when targeting a file outside the workspace.
- Media server returns `400 "file is outside workspace root"` instead of `400 "invalid path"` for outside-workspace requests.
- Sandbox FS errors for outside-workspace paths report `EACCES` instead of rethrowing a raw `SafeOpenError`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 24.0.0
- Runtime/container: Node.js via pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create a workspace directory and a file outside it
2. Call `openFileWithinRoot` with a relative path that escapes the root (e.g. `../outside/file.txt`)
3. Observe the error code and message

### Expected

- `SafeOpenError` with code `"outside-workspace"` and message `"file is outside workspace root"`

### Actual

- Previously: `SafeOpenError` with code `"invalid-path"` and message `"path escapes root"`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/infra/fs-safe.test.ts` — all 11 tests pass, including updated traversal expectations (`"outside-workspace"`).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm tsgo`, `pnpm lint`, `pnpm vitest run src/infra/fs-safe.test.ts` all pass
- Edge cases checked: read traversal, write traversal, symlink escape (via existing tests)
- What you did **not** verify: Windows CI (no Windows environment available locally), end-to-end Edit tool UX in the CLI

## Compatibility / Migration

- Backward compatible? `No` — code that matches `err.code === "invalid-path"` for path-escapes-root will no longer trigger; they need to also check `"outside-workspace"`.
- Config/env changes? `No`
- Migration needed? `No` — consumers in this repo are updated in this PR. External consumers of the plugin-sdk `SafeOpenErrorCode` type will get a compile error if they have exhaustive switches, which is the desired behavior.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; change `"outside-workspace"` back to `"invalid-path"` with `"path escapes root"` message
- Files/config to restore: `src/infra/fs-safe.ts`, `src/agents/pi-tools.read.ts`, `src/browser/paths.ts`, `src/media/server.ts`, `src/infra/fs-safe.test.ts`
- Known bad symptoms reviewers should watch for: Any consumer that matches only `"invalid-path"` for workspace boundary errors would silently miss the new code and fall through to a generic handler

## Risks and Mitigations

- Risk: External plugin-sdk consumers with exhaustive `SafeOpenErrorCode` switches get a compile error
  - Mitigation: This is intentional — the new type variant forces them to handle the case explicitly. The `.d.ts` is auto-generated from source.