### PR TITLE
fix(cron): avoid marking queued announce paths as delivered

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -1064,6 +1064,32 @@ describe("subagent announce formatting", () => {
     expect(params.accountId).toBe("kev");
   });
 
+  it("does not report cron announce as delivered when it was only queued", async () => {
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-cron-queued",
+        lastChannel: "telegram",
+        lastTo: "123",
+        queueMode: "collect",
+        queueDebounceMs: 0,
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-cron-queued",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      announceType: "cron job",
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps queued idempotency unique for same-ms distinct child runs", async () => {
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
     embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1340,7 +1340,17 @@ export async function runSubagentAnnounceFlow(params: {
       directIdempotencyKey,
       signal: params.signal,
     });
-    didAnnounce = delivery.delivered;
+    // Cron delivery state should only be marked as delivered when we have a
+    // direct path result. Queue/steer means "accepted for later processing",
+    // not a confirmed channel send, and can otherwise produce false positives.
+    if (
+      announceType === "cron job" &&
+      (delivery.path === "queued" || delivery.path === "steered")
+    ) {
+      didAnnounce = false;
+    } else {
+      didAnnounce = delivery.delivered;
+    }
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.error?.(
         `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,


### PR DESCRIPTION
## Summary

- **Problem:** Cron announce delivery could be recorded as `delivered=true` when subagent announce only queued/steered work and no direct outbound send was confirmed.
- **Why it matters:** Users see false-positive delivery status (`delivered`) even when destination channels never received the message.
- **What changed:** In subagent announce flow, cron announce now treats `queued` / `steered` paths as not-delivered for delivery-state reporting; only direct path counts as delivered.
- **What did NOT change:** Non-cron subagent announce behavior and queue mechanics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29660

## User-visible / Behavior Changes

- Cron run delivery status no longer reports `delivered` when announce output was merely queued/steered and not yet directly sent.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node + pnpm
- Integration/channel: cron isolated announce flow

### Steps

1. Run cron announce path where requester session is active and announcement is queued/steered.
2. Observe the boolean returned to cron delivery tracking.

### Expected

- Delivery state should remain false unless direct path succeeds.

### Actual

- Before fix: queued/steered outcomes could mark delivered=true.
- After fix: queued/steered outcomes do not mark delivered=true for cron reporting.

## Evidence

- `pnpm test -- --run src/agents/subagent-announce.format.test.ts`

## Human Verification (required)

- Verified scenarios: cron announce queued path now returns false; direct-path behavior remains unchanged.
- Edge cases checked: queue-mode collect with cron announce type.
- What I did **not** verify: full end-to-end live Telegram cron announce in production runtime.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit.
- Files/config to restore: `src/agents/subagent-announce.ts`.
- Known bad symptoms: cron delivery state may again over-report delivered in queued paths.

## Risks and Mitigations

- Risk: stricter delivered semantics may expose previously hidden delivery gaps.
- Mitigation: behavior is now truthful to actual direct-send confirmation; regression test added.

Made with [Cursor](https://cursor.com)