### PR TITLE
feat: add reasoningDefault config option

### DIFF
--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -10,6 +10,7 @@ export async function resolveCurrentDirectiveLevels(params: {
   agentCfg?: {
     thinkingDefault?: unknown;
     verboseDefault?: unknown;
+    reasoningDefault?: unknown;
     elevatedDefault?: unknown;
   };
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
@@ -28,7 +29,9 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -350,6 +350,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -508,7 +508,7 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.agent?.reasoningDefault ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -174,6 +174,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning display level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -119,6 +119,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),


### PR DESCRIPTION
Add `reasoningDefault` to agent defaults config, matching the existing pattern of `verboseDefault` and `elevatedDefault`.

This allows users to set reasoning display visibility (`"off"` / `"on"` / `"stream"`) as a persistent default rather than toggling `/reasoning` per session.

## Problem

The reasoning display level resolution chain hardcodes `"off"` as the fallback, with no config lookup:

```ts
const resolvedReasoningLevel =
  directives.reasoningLevel ??
  sessionEntry?.reasoningLevel ??
  "off"; // no agentCfg lookup
```

Meanwhile `verboseDefault` and `elevatedDefault` both support config-level defaults.

## Changes

- **`src/config/zod-schema.agent-defaults.ts`** — add `reasoningDefault` schema (`"off" | "on" | "stream"`)
- **`src/config/types.agent-defaults.ts`** — add `reasoningDefault` type
- **`src/auto-reply/reply/get-reply-directives.ts`** — read `agentCfg?.reasoningDefault` in resolution chain
- **`src/auto-reply/reply/directive-handling.levels.ts`** — read `agentCfg?.reasoningDefault` in current level resolution
- **`src/auto-reply/status.ts`** — read `reasoningDefault` in `/status` display

## Usage

```json
{
  "agents": {
    "defaults": {
      "reasoningDefault": "on"
    }
  }
}
```

Closes #29708