### PR TITLE
fix(models): fallback qwen-portal built-ins when registry missing

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -171,6 +171,38 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
+  it("resolves qwen-portal/coder-model via built-in provider fallback when registry is unavailable", () => {
+    const result = resolveModel("qwen-portal", "coder-model", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "qwen-portal",
+      id: "coder-model",
+      name: "Qwen Coder",
+      api: "openai-completions",
+      baseUrl: "https://portal.qwen.ai/v1",
+      input: ["text"],
+      contextWindow: 128000,
+      maxTokens: 8192,
+    });
+  });
+
+  it("resolves qwen-portal/vision-model via built-in provider fallback when registry is unavailable", () => {
+    const result = resolveModel("qwen-portal", "vision-model", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "qwen-portal",
+      id: "vision-model",
+      name: "Qwen Vision",
+      api: "openai-completions",
+      baseUrl: "https://portal.qwen.ai/v1",
+      input: ["text", "image"],
+      contextWindow: 128000,
+      maxTokens: 8192,
+    });
+  });
+
   it("prefers matching configured model metadata for fallback token limits", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -39,6 +39,66 @@ export function buildInlineProviderModels(
   });
 }
 
+type BuiltInFallbackModel = {
+  provider: string;
+  modelId: string;
+  name: string;
+  api: ModelDefinitionConfig["api"];
+  baseUrl: string;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  contextWindow: number;
+  maxTokens: number;
+};
+
+const BUILT_IN_PROVIDER_FALLBACK_MODELS: BuiltInFallbackModel[] = [
+  {
+    provider: "qwen-portal",
+    modelId: "coder-model",
+    name: "Qwen Coder",
+    api: "openai-completions",
+    baseUrl: "https://portal.qwen.ai/v1",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 8192,
+  },
+  {
+    provider: "qwen-portal",
+    modelId: "vision-model",
+    name: "Qwen Vision",
+    api: "openai-completions",
+    baseUrl: "https://portal.qwen.ai/v1",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 8192,
+  },
+];
+
+function resolveBuiltInProviderFallback(provider: string, modelId: string): Model<Api> | null {
+  const normalizedProvider = normalizeProviderId(provider);
+  const definition = BUILT_IN_PROVIDER_FALLBACK_MODELS.find(
+    (entry) =>
+      normalizeProviderId(entry.provider) === normalizedProvider && entry.modelId === modelId,
+  );
+  if (!definition) {
+    return null;
+  }
+  return normalizeModelCompat({
+    id: definition.modelId,
+    name: definition.name,
+    api: definition.api,
+    provider,
+    baseUrl: definition.baseUrl,
+    reasoning: definition.reasoning,
+    input: definition.input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: definition.contextWindow,
+    maxTokens: definition.maxTokens,
+  } as Model<Api>);
+}
+
 export function resolveModel(
   provider: string,
   modelId: string,
@@ -94,6 +154,16 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
+
+    const builtInProviderFallback = resolveBuiltInProviderFallback(provider, modelId);
+    if (builtInProviderFallback) {
+      return {
+        model: builtInProviderFallback,
+        authStorage,
+        modelRegistry,
+      };
+    }
+
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);


### PR DESCRIPTION
## Summary
- fix `resolveModel()` to return built-in Qwen portal model definitions when the runtime registry does not include `qwen-portal/coder-model` or `qwen-portal/vision-model`
- keep fallback ordering safe: apply this after forward-compat/openrouter handling and before generic provider fallback
- add regression tests covering both Qwen portal model ids

## Root cause
`models list` and runtime model resolution can hit a path where the discovered registry does not include qwen-portal catalog entries yet. In that state, `resolveModel("qwen-portal", "coder-model")` returned `Unknown model`, so the configured default got tagged as `missing` and could not run.

## Validation
- `pnpm test src/agents/pi-embedded-runner/model.test.ts`

Fixes #29679
