### PR TITLE
feat: include usage totals in lifecycle end/error events

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -31,6 +31,7 @@ function createContext(
       debug: vi.fn(),
       warn: vi.fn(),
     },
+    getUsageTotals: vi.fn(() => undefined),
     flushBlockReplyBuffer: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
@@ -56,13 +57,15 @@ describe("handleAgentEnd", () => {
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain("runId=run-1");
     expect(warn.mock.calls[0]?.[0]).toContain("error=connection refused");
-    expect(onAgentEvent).toHaveBeenCalledWith({
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        error: "connection refused",
-      },
-    });
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "lifecycle",
+        data: expect.objectContaining({
+          phase: "error",
+          error: "connection refused",
+        }),
+      }),
+    );
   });
 
   it("keeps non-error run-end logging on debug only", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -40,6 +40,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     ctx.log.warn(
       `embedded run agent end: runId=${ctx.params.runId} isError=true error=${errorText}`,
     );
+    const usage = ctx.getUsageTotals();
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
@@ -47,6 +48,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
         phase: "error",
         error: errorText,
         endedAt: Date.now(),
+        usage,
       },
     });
     void ctx.params.onAgentEvent?.({
@@ -54,21 +56,24 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       data: {
         phase: "error",
         error: errorText,
+        usage,
       },
     });
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
+    const usage = ctx.getUsageTotals();
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
       data: {
         phase: "end",
         endedAt: Date.now(),
+        usage,
       },
     });
     void ctx.params.onAgentEvent?.({
       stream: "lifecycle",
-      data: { phase: "end" },
+      data: { phase: "end", usage },
     });
   }
 

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -157,6 +157,18 @@ describe("agent event handler", () => {
     return payload;
   }
 
+  function expectSingleErrorChatPayload(broadcast: ReturnType<typeof vi.fn>) {
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      state?: string;
+      errorMessage?: string;
+      usage?: unknown;
+    };
+    expect(payload.state).toBe("error");
+    return payload;
+  }
+
   it("emits chat delta for assistant text-only events", () => {
     const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantText(
       createHarness({ now: 1_000 }),
@@ -216,6 +228,40 @@ describe("agent event handler", () => {
 
     const payload = expectSingleFinalChatPayload(broadcast) as { message?: unknown };
     expect(payload.message).toBeUndefined();
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  it("includes lifecycle usage in chat error payload", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 2_100,
+    });
+    chatRunState.registry.add("run-usage-error", {
+      sessionKey: "session-usage-error",
+      clientRunId: "client-usage-error",
+    });
+
+    handler({
+      runId: "run-usage-error",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: {
+        phase: "error",
+        error: "provider failed",
+        usage: { input: 12, output: 34, cacheRead: 2, cacheWrite: 1, total: 49 },
+      },
+    });
+
+    const payload = expectSingleErrorChatPayload(broadcast);
+    expect(payload.errorMessage).toContain("provider failed");
+    expect(payload.usage).toEqual({
+      input: 12,
+      output: 34,
+      cacheRead: 2,
+      cacheWrite: 1,
+      total: 49,
+    });
     expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
     nowSpy?.mockRestore();
   });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -323,6 +323,13 @@ export function createAgentEventHandler({
     seq: number,
     jobState: "done" | "error",
     error?: unknown,
+    usage?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      total?: number;
+    },
   ) => {
     const bufferedText = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
@@ -351,6 +358,7 @@ export function createAgentEventHandler({
                 timestamp: Date.now(),
               }
             : undefined,
+        usage: usage || undefined,
       };
       broadcast("chat", payload);
       nodeSendToSession(sessionKey, "chat", payload);
@@ -362,6 +370,7 @@ export function createAgentEventHandler({
       seq,
       state: "error" as const,
       errorMessage: error ? formatForLog(error) : undefined,
+      usage: usage || undefined,
     };
     broadcast("chat", payload);
     nodeSendToSession(sessionKey, "chat", payload);
@@ -456,6 +465,15 @@ export function createAgentEventHandler({
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text);
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
+        const lifecycleUsage = evt.data?.usage as
+          | {
+              input?: number;
+              output?: number;
+              cacheRead?: number;
+              cacheWrite?: number;
+              total?: number;
+            }
+          | undefined;
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
@@ -469,6 +487,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            lifecycleUsage,
           );
         } else {
           emitChatFinal(
@@ -478,6 +497,7 @@ export function createAgentEventHandler({
             evt.seq,
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
+            lifecycleUsage,
           );
         }
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {


### PR DESCRIPTION
## Summary

Propagate token usage (input, output, cacheRead, cacheWrite, total) from agent lifecycle events through to chat broadcast payloads.

This allows clients to display token consumption even when a run ends with an error, improving observability for operators and mobile clients.

## Changes

- **`pi-embedded-subscribe.handlers.lifecycle.ts`**: Call `getUsageTotals()` on agent end, attach usage to lifecycle event data for both error and normal end paths
- **`server-chat.ts`**: Accept optional `usage` param in `emitChatFinal`/`emitChatError`, extract lifecycle usage from event data and forward to chat payload
- **Tests**: Updated lifecycle test assertions for new field, added new test verifying usage flows through to chat error payload

## Testing

- `npx tsc --noEmit` — zero errors
- `npx vitest run` on both changed test files — 18/18 passing