### PR TITLE
fix: normalize OpenAI-compatible baseUrl ending in /chat/completions

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -100,6 +100,40 @@ describe("normalizeModelCompat — Anthropic baseUrl", () => {
   });
 });
 
+describe("normalizeModelCompat — OpenAI-compatible baseUrl", () => {
+  it("strips trailing /chat/completions from openai-completions baseUrl", () => {
+    const model = {
+      ...baseModel(),
+      provider: "n1n",
+      api: "openai-completions" as Api,
+      baseUrl: "https://api.n1n.ai/v1/chat/completions",
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.baseUrl).toBe("https://api.n1n.ai/v1");
+  });
+
+  it("strips trailing /chat/completions/ with slash", () => {
+    const model = {
+      ...baseModel(),
+      provider: "n1n",
+      api: "openai-completions" as Api,
+      baseUrl: "https://api.n1n.ai/v1/chat/completions/",
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.baseUrl).toBe("https://api.n1n.ai/v1");
+  });
+
+  it("does not strip /chat/completions for non-openai adapters", () => {
+    const model = {
+      ...baseModel(),
+      api: "openai-responses" as Api,
+      baseUrl: "https://api.example.com/v1/chat/completions",
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.baseUrl).toBe("https://api.example.com/v1/chat/completions");
+  });
+});
+
 describe("normalizeModelCompat", () => {
   it("forces supportsDeveloperRole off for z.ai models", () => {
     const model = baseModel();

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -112,6 +112,22 @@ describe("normalizeModelCompat — OpenAI-compatible baseUrl", () => {
     expect(normalized.baseUrl).toBe("https://api.n1n.ai/v1");
   });
 
+  it("preserves z.ai compat tweak when baseUrl is normalized", () => {
+    const model = {
+      ...baseModel(),
+      provider: "zai",
+      api: "openai-completions" as Api,
+      baseUrl: "https://api.z.ai/api/coding/paas/v4/chat/completions",
+    };
+    delete (model as { compat?: unknown }).compat;
+
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.baseUrl).toBe("https://api.z.ai/api/coding/paas/v4");
+    expect(
+      (normalized.compat as { supportsDeveloperRole?: boolean } | undefined)?.supportsDeveloperRole,
+    ).toBe(false);
+  });
+
   it("strips trailing /chat/completions/ with slash", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -28,6 +28,20 @@ function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-
 function normalizeAnthropicBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/v1\/?$/, "");
 }
+
+/**
+ * pi-ai constructs OpenAI-compatible chat-completions requests as
+ * `${baseUrl}/chat/completions`.
+ *
+ * If users configure `baseUrl` as a full endpoint (e.g. `.../v1/chat/completions`),
+ * requests become `.../v1/chat/completions/chat/completions` and fail with 404.
+ *
+ * Strip one trailing `/chat/completions` segment so both base styles work.
+ */
+function normalizeOpenAiCompletionsBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/chat\/completions\/?$/i, "");
+}
+
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";
 
@@ -37,6 +51,13 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     const normalised = normalizeAnthropicBaseUrl(baseUrl);
     if (normalised !== baseUrl) {
       return { ...model, baseUrl: normalised } as Model<"anthropic-messages">;
+    }
+  }
+
+  if (isOpenAiCompletionsModel(model) && baseUrl) {
+    const normalized = normalizeOpenAiCompletionsBaseUrl(baseUrl);
+    if (normalized !== baseUrl) {
+      return { ...model, baseUrl: normalized } as Model<"openai-completions">;
     }
   }
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -43,38 +43,43 @@ function normalizeOpenAiCompletionsBaseUrl(baseUrl: string): string {
 }
 
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
+  let nextModel = model;
+
   const baseUrl = model.baseUrl ?? "";
 
   // Normalise anthropic-messages baseUrl: strip trailing /v1 that users may
   // have included in their config. pi-ai appends /v1/messages itself.
-  if (isAnthropicMessagesModel(model) && baseUrl) {
+  if (isAnthropicMessagesModel(nextModel) && baseUrl) {
     const normalised = normalizeAnthropicBaseUrl(baseUrl);
     if (normalised !== baseUrl) {
-      return { ...model, baseUrl: normalised } as Model<"anthropic-messages">;
+      nextModel = { ...nextModel, baseUrl: normalised } as Model<"anthropic-messages">;
     }
   }
 
-  if (isOpenAiCompletionsModel(model) && baseUrl) {
-    const normalized = normalizeOpenAiCompletionsBaseUrl(baseUrl);
-    if (normalized !== baseUrl) {
-      return { ...model, baseUrl: normalized } as Model<"openai-completions">;
+  const normalizedBaseUrl = nextModel.baseUrl ?? "";
+  if (isOpenAiCompletionsModel(nextModel) && normalizedBaseUrl) {
+    const normalized = normalizeOpenAiCompletionsBaseUrl(normalizedBaseUrl);
+    if (normalized !== normalizedBaseUrl) {
+      nextModel = { ...nextModel, baseUrl: normalized } as Model<"openai-completions">;
     }
   }
 
-  const isZai = model.provider === "zai" || baseUrl.includes("api.z.ai");
+  const compatBaseUrl = nextModel.baseUrl ?? "";
+  const isZai = nextModel.provider === "zai" || compatBaseUrl.includes("api.z.ai");
   const isMoonshot =
-    model.provider === "moonshot" ||
-    baseUrl.includes("moonshot.ai") ||
-    baseUrl.includes("moonshot.cn");
-  const isDashScope = model.provider === "dashscope" || isDashScopeCompatibleEndpoint(baseUrl);
-  if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(model)) {
-    return model;
+    nextModel.provider === "moonshot" ||
+    compatBaseUrl.includes("moonshot.ai") ||
+    compatBaseUrl.includes("moonshot.cn");
+  const isDashScope =
+    nextModel.provider === "dashscope" || isDashScopeCompatibleEndpoint(compatBaseUrl);
+  if ((!isZai && !isMoonshot && !isDashScope) || !isOpenAiCompletionsModel(nextModel)) {
+    return nextModel;
   }
 
-  const openaiModel = model;
+  const openaiModel = nextModel;
   const compat = openaiModel.compat ?? undefined;
   if (compat?.supportsDeveloperRole === false) {
-    return model;
+    return nextModel;
   }
 
   openaiModel.compat = compat


### PR DESCRIPTION
## Summary
Fixes #29702.

Some OpenAI-compatible providers are configured with a full endpoint base URL (for example `.../v1/chat/completions`). The OpenAI adapter appends `/chat/completions`, which caused duplicate paths like `/chat/completions/chat/completions` and 404 failures.

## Root cause
`normalizeModelCompat` already normalizes Anthropic-style `.../v1` base URLs, but it did not normalize OpenAI-compatible `.../chat/completions` URLs.

## Fix
- Add `normalizeOpenAiCompletionsBaseUrl()` to strip one trailing `/chat/completions` segment for `openai-completions` models.
- Keep behavior scoped to `openai-completions` only.
- Add regression tests for:
  - `.../chat/completions`
  - `.../chat/completions/`
  - non-openai adapters remain unchanged

## Validation
- `pnpm test -- src/agents/model-compat.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`