### PR TITLE
fix(control-ui): skip device pairing when authenticated via Tailscale identity

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -186,6 +186,9 @@ describe("ws connect policy", () => {
     expect(shouldSkipControlUiPairing(bypass, false, false)).toBe(false);
     expect(shouldSkipControlUiPairing(strict, true, false)).toBe(false);
     expect(shouldSkipControlUiPairing(strict, false, true)).toBe(true);
+    // Tailscale identity auth skips pairing regardless of policy/sharedAuthOk
+    expect(shouldSkipControlUiPairing(strict, false, false, true)).toBe(true);
+    expect(shouldSkipControlUiPairing(bypass, false, false, true)).toBe(true);
   });
 
   test("trusted-proxy control-ui bypass only applies to operator + trusted-proxy auth", () => {

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -36,8 +36,16 @@ export function shouldSkipControlUiPairing(
   policy: ControlUiAuthPolicy,
   sharedAuthOk: boolean,
   trustedProxyAuthOk = false,
+  tailscaleAuthOk = false,
 ): boolean {
   if (trustedProxyAuthOk) {
+    return true;
+  }
+  // When the connection was authenticated via Tailscale identity, the Tailscale
+  // network has already vouched for the user.  Requiring a separate device
+  // pairing round-trip adds no security benefit and is confusing to operators
+  // who set allowTailscale: true expecting seamless Control UI access.
+  if (tailscaleAuthOk) {
     return true;
   }
   return policy.allowBypass && sharedAuthOk;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -712,10 +712,12 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
+        const tailscaleAuthOk = authOk && authMethod === "tailscale";
         const skipPairing = shouldSkipControlUiPairing(
           controlUiAuthPolicy,
           sharedAuthOk,
           trustedProxyAuthOk,
+          tailscaleAuthOk,
         );
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {


### PR DESCRIPTION
## Summary

Fixes #29670

When `gateway.auth.allowTailscale: true` is set and a Control UI WebSocket connection authenticates successfully via Tailscale identity headers (`authMethod = "tailscale"`), the device pairing round-trip is unnecessary. The Tailscale network has already verified the connecting user's identity.

## Root Cause

`shouldSkipControlUiPairing` only bypassed device pairing for:
- `trustedProxyAuthOk` — trusted-proxy auth mode
- `policy.allowBypass && sharedAuthOk` — `dangerouslyDisableDeviceAuth` + shared-secret auth

Tailscale auth set `authOk = true` (via `authorizeWsControlUiGatewayConnect`) but `sharedAuthOk` remained `false` — the shared-secret probe in `resolveConnectAuthState` intentionally passes `allowTailscale: false` to avoid conflating identity auth with credential auth.

Result: the Control UI always demanded device pairing even with `allowTailscale: true`, because pairing-skip was conditioned on `sharedAuthOk`.

## Fix

**`connect-policy.ts`** — add optional `tailscaleAuthOk` parameter to `shouldSkipControlUiPairing`; when true, return `true` (skip pairing), analogous to the existing `trustedProxyAuthOk` bypass.

**`message-handler.ts`** — compute `tailscaleAuthOk = authOk && authMethod === "tailscale"` and forward it to `shouldSkipControlUiPairing`.

**`connect-policy.test.ts`** — two new assertions confirming Tailscale auth skips pairing regardless of policy / sharedAuthOk.