### PR TITLE
docs(telegram): add DM no-reply pairing troubleshooting

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -679,6 +679,33 @@ openclaw message send --channel telegram --target @name --message "hi"
 
   </Accordion>
 
+  <Accordion title="DMing the bot but getting no reply">
+
+    If your bot token is valid and polling is healthy, the most common cause is DM pairing/allowlist access control.
+
+    1. DM the bot and send `/start`.
+    2. Check pending pairing requests:
+
+```bash
+openclaw pairing list telegram
+```
+
+    3. Approve with the exact code:
+
+```bash
+openclaw pairing approve telegram <CODE>
+```
+
+    4. Test again in Telegram (same DM chat).
+
+    Quick checks:
+
+    - confirm you're messaging the correct bot username from BotFather
+    - if using `dmPolicy: "allowlist"`, verify your numeric Telegram user ID is in `allowFrom`
+    - if no pairing requests appear, use `openclaw channels status --probe` and `openclaw logs --follow`
+
+  </Accordion>
+
   <Accordion title="Polling or network instability">
 
     - Node 22+ + custom fetch/proxy can trigger immediate abort behavior if AbortSignal types mismatch.

--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -30,3 +30,4 @@ openclaw pairing approve --channel telegram --account work <code> --notify
 - `pairing list` supports `--account <accountId>` for multi-account channels.
 - `pairing approve` supports `--account <accountId>` and `--notify`.
 - If only one pairing-capable channel is configured, `pairing approve <code>` is allowed.
+- If your pairing message shows the code in angle brackets (for example `<2E9RUPHW>`), pass only the code value: `2E9RUPHW`.


### PR DESCRIPTION
## Summary
- add a Telegram troubleshooting accordion for the common "DM sent but no reply" case
- document exact pairing verification/approval steps (`pairing list` + `pairing approve`)
- add quick checks for wrong bot, allowlist mode, and probe/log diagnostics
- clarify in CLI pairing docs that codes should be passed without angle brackets

## Why
Users often have healthy Telegram channel status but still see no response until sender pairing is approved. This adds a focused, actionable playbook in the Telegram docs and pairing CLI reference.

## Docs only
No runtime behavior changes.
