### PR TITLE
fix(onboard): raise custom endpoint verification timeout for slow cold starts

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -259,7 +259,7 @@ describe("promptCustomApiConfig", () => {
 
     const promise = runPromptCustomApi(prompter);
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     await promise;
 
     expect(prompter.text).toHaveBeenCalledTimes(6);

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -18,7 +18,7 @@ import type { SecretInputMode } from "./onboard-types.js";
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 4096;
 const DEFAULT_MAX_TOKENS = 4096;
-const VERIFY_TIMEOUT_MS = 30_000;
+const VERIFY_TIMEOUT_MS = 120_000;
 
 /**
  * Detects if a URL is from Azure AI Foundry or Azure OpenAI.


### PR DESCRIPTION
## Summary
- increase custom provider verification timeout from 30s to 120s
- keep probe payload minimal (`max_tokens: 1`) but allow slower first-token latency (e.g. large Ollama models)
- update timeout test to match new default

## Root cause
Custom OpenAI-compatible endpoint verification in `onboard-custom` used a hard timeout (`VERIFY_TIMEOUT_MS`) that was too short for cold-start latency on large local models. When the upstream needed longer before first token, undici aborted the request and surfaced `This operation was aborted`, causing false-negative verification failures.

Fixes #29754
