### PR TITLE
fix(message): add channels.defaults.defaultChannel to resolve ambiguity when multiple channels configured

### DIFF
--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -248,7 +248,6 @@ describe("messageCommand", () => {
     );
     testConfig = { channels: { defaults: { defaultChannel: "discord" } } };
     const deps = makeDeps();
-    const { messageCommand } = await loadMessageCommand();
     // Should not throw — defaultChannel resolves the ambiguity
     await expect(
       messageCommand(
@@ -260,6 +259,9 @@ describe("messageCommand", () => {
         runtime,
       ),
     ).resolves.not.toThrow();
+    // Verify discord was routed to, not telegram
+    expect(handleDiscordAction).toHaveBeenCalledOnce();
+    expect(handleTelegramAction).not.toHaveBeenCalled();
   });
 
   it("sends via gateway for WhatsApp", async () => {

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -22,6 +22,12 @@ export type ChannelDefaultsConfig = {
   groupPolicy?: GroupPolicy;
   /** Default heartbeat visibility for all channels. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /**
+   * Default channel to use when the message tool is called without an explicit
+   * `channel` parameter and multiple channels are configured.
+   * Example: "discord" or "telegram"
+   */
+  defaultChannel?: string;
 };
 
 export type ChannelModelByChannelConfig = Record<string, Record<string, string>>;

--- a/src/config/zod-schema.providers.ts
+++ b/src/config/zod-schema.providers.ts
@@ -28,6 +28,7 @@ export const ChannelsSchema = z
       .object({
         groupPolicy: GroupPolicySchema.optional(),
         heartbeat: ChannelHeartbeatVisibilitySchema,
+        defaultChannel: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -89,9 +89,19 @@ export async function resolveMessageChannelSelection(params: {
   const defaultChannel = params.cfg.channels?.defaults?.defaultChannel;
   if (defaultChannel) {
     const normalizedDefault = normalizeMessageChannel(defaultChannel);
-    if (normalizedDefault && isKnownChannel(normalizedDefault) && configured.includes(normalizedDefault as MessageChannelId)) {
+    if (
+      normalizedDefault &&
+      isKnownChannel(normalizedDefault) &&
+      configured.includes(normalizedDefault as MessageChannelId)
+    ) {
       return { channel: normalizedDefault as MessageChannelId, configured };
     }
+    // defaultChannel is set but doesn't match any active channel — warn so misconfiguration is diagnosable
+    const reason =
+      !normalizedDefault || !isKnownChannel(normalizedDefault)
+        ? `"${defaultChannel}" is not a recognised channel id`
+        : `"${defaultChannel}" is not currently configured (active: ${configured.join(", ")})`;
+    console.warn(`[channel-selection] channels.defaults.defaultChannel ignored: ${reason}.`);
   }
   throw new Error(
     `Channel is required when multiple channels are configured: ${configured.join(", ")}. Set delivery.channel explicitly or use a matching-channel session.`,

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -104,6 +104,6 @@ export async function resolveMessageChannelSelection(params: {
     console.warn(`[channel-selection] channels.defaults.defaultChannel ignored: ${reason}.`);
   }
   throw new Error(
-    `Channel is required when multiple channels are configured: ${configured.join(", ")}. Set delivery.channel explicitly or use a matching-channel session.`,
+    `Channel is required when multiple channels are configured: ${configured.join(", ")}. Set the channel parameter explicitly, or set channels.defaults.defaultChannel in config.`,
   );
 }

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -86,7 +86,14 @@ export async function resolveMessageChannelSelection(params: {
   if (configured.length === 0) {
     throw new Error("Channel is required (no configured channels detected).");
   }
+  const defaultChannel = params.cfg.channels?.defaults?.defaultChannel;
+  if (defaultChannel) {
+    const normalizedDefault = normalizeMessageChannel(defaultChannel);
+    if (normalizedDefault && isKnownChannel(normalizedDefault) && configured.includes(normalizedDefault as MessageChannelId)) {
+      return { channel: normalizedDefault as MessageChannelId, configured };
+    }
+  }
   throw new Error(
-    `Channel is required when multiple channels are configured: ${configured.join(", ")}`,
+    `Channel is required when multiple channels are configured: ${configured.join(", ")}. Set delivery.channel explicitly or use a matching-channel session.`,
   );
 }


### PR DESCRIPTION
## Problem

When two or more messaging channels are configured (e.g. Telegram + Discord), any call to the `message` tool that omits the `channel` parameter fails with:

```
Channel is required when multiple channels are configured: telegram, discord
```

This is a papercut for users who add a second channel after the fact — all their existing cron jobs that send to a single intended channel start failing.

Fixes #29766

## Solution

Add an optional `channels.defaults.defaultChannel` config field. When set, it is used as the fallback channel when no explicit `channel` parameter is provided.

```json
{
  "channels": {
    "defaults": {
      "defaultChannel": "discord"
    }
  }
}
```

Explicit `channel` parameters still take full precedence. The fallback is only applied when no channel is specified **and** multiple channels are configured.

## Changes (4 files, ~70 lines)

- `src/config/types.channels.ts` — add `defaultChannel?: string` to `ChannelDefaultsConfig`
- `src/config/zod-schema.providers.ts` — add `defaultChannel` to `ChannelsSchema.defaults`
- `src/infra/outbound/channel-selection.ts` — use `defaultChannel` as fallback before throwing
- `src/commands/message.test.ts` — add test for the new behavior

## Testing

Existing test `requires channel when multiple configured` still passes (no defaultChannel set → still throws).
New test `uses defaultChannel from config when multiple channels configured` verifies the fallback.