### PR TITLE
fix: fall back to first configured channel when channel:last is ambiguous in isolated sessions

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -11,6 +11,7 @@ vi.mock("../../infra/outbound/channel-selection.js", () => ({
   resolveMessageChannelSelection: vi
     .fn()
     .mockResolvedValue({ channel: "telegram", configured: ["telegram"] }),
+  listConfiguredMessageChannels: vi.fn().mockResolvedValue(["telegram"]),
 }));
 
 vi.mock("../../pairing/pairing-store.js", () => ({
@@ -22,7 +23,10 @@ vi.mock("../../web/accounts.js", () => ({
 }));
 
 import { loadSessionStore } from "../../config/sessions.js";
-import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "../../infra/outbound/channel-selection.js";
 import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
 import { resolveDeliveryTarget } from "./delivery-target.js";
@@ -237,17 +241,21 @@ describe("resolveDeliveryTarget", () => {
     expect(result.error.message).toContain('No delivery target resolved for channel "telegram"');
   });
 
-  it("returns an error when channel selection is ambiguous", async () => {
+  it("returns an error with first configured channel when selection is ambiguous", async () => {
     setMainSessionEntry(undefined);
     vi.mocked(resolveMessageChannelSelection).mockRejectedValueOnce(
-      new Error("Channel is required when multiple channels are configured: telegram, slack"),
+      new Error("Channel is required when multiple channels are configured: telegram, discord"),
     );
+    vi.mocked(listConfiguredMessageChannels).mockResolvedValueOnce(["telegram", "discord"]);
 
     const result = await resolveForAgent({
       cfg: makeCfg({ bindings: [] }),
       target: { channel: "last", to: undefined },
     });
-    expect(result.channel).toBeUndefined();
+    // channel is now set to the first configured channel so that explicit
+    // message tool calls within the agent still work, even though delivery
+    // fails (no `to` can be resolved).
+    expect(result.channel).toBe("telegram");
     expect(result.to).toBeUndefined();
     expect(result.ok).toBe(false);
     if (result.ok) {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -5,7 +5,10 @@ import {
   resolveAgentMainSessionKey,
   resolveStorePath,
 } from "../../config/sessions.js";
-import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "../../infra/outbound/channel-selection.js";
 import type { OutboundChannel } from "../../infra/outbound/targets.js";
 import {
   resolveOutboundTarget,
@@ -82,6 +85,15 @@ export async function resolveDeliveryTarget(
         channelResolutionError = new Error(
           `${detail} Set delivery.channel explicitly or use a main session with a previous channel.`,
         );
+        // Even though auto-delivery will fail, provide a fallback messageChannel
+        // so that explicit message tool calls within the agent still work.
+        // Without this, agents running in isolated cron sessions inherit
+        // messageChannel=undefined and every message tool call fails with
+        // "Unknown Channel" or similar downstream errors.
+        const configured = await listConfiguredMessageChannels(cfg).catch(() => []);
+        if (configured.length > 0) {
+          fallbackChannel = configured[0];
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #29769

## Problem

When a cron job uses `delivery.channel = "last"` with no prior session context, and multiple channels (e.g. `telegram` + `discord`) are configured, `resolveDeliveryTarget` catches the ambiguous-channel error but leaves `fallbackChannel = undefined`. This causes `messageChannel = undefined` to propagate into the agent runner, making every subsequent `message` tool call fail with `Unknown Channel` or `guildId required` — even calls that provide an explicit target.

## Fix

In the catch block of `delivery-target.ts`, call `listConfiguredMessageChannels` and use the first result as `fallbackChannel`. Auto-delivery still fails with the existing helpful error (no `to` can be resolved), but the agent runs with a valid `messageChannel` so its explicit message tool calls work.

## Changes

- `src/cron/isolated-agent/delivery-target.ts` — add `listConfiguredMessageChannels` to catch block (+12 lines)
- `src/cron/isolated-agent/delivery-target.test.ts` — mock `listConfiguredMessageChannels`, update test expectation to match new behavior

## Tests

```
✓ src/cron/isolated-agent/delivery-target.test.ts (15 tests) 16ms
```

All 15 existing tests pass. The previously-failing test case was updated to assert the new correct behavior (`result.channel` is now the first configured channel instead of `undefined`).