### PR TITLE
fix: handle DashScope DataInspectionFailed with actionable recovery hint

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -44,6 +44,15 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("/think minimal");
     expect(result).not.toContain("Context overflow");
   });
+  it("returns a recovery hint for DashScope data inspection failures", () => {
+    const msg = makeAssistantError(
+      "<400> InternalError.Algo.DataInspectionFailed: Input text data may contain inappropriate content.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("content inspection rejected");
+    expect(result).toContain("/new");
+    expect(result).not.toContain("Context overflow");
+  });
   it("returns a friendly message for Anthropic role ordering", () => {
     const msg = makeAssistantError('messages: roles must alternate between "user" and "assistant"');
     expect(formatAssistantErrorText(msg)).toContain("Message ordering conflict");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -47,6 +47,18 @@ function isReasoningConstraintErrorMessage(raw: string): boolean {
   );
 }
 
+function isDataInspectionFailedErrorMessage(raw?: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  return (
+    lower.includes("internalerror.algo.datainspectionfailed") ||
+    (lower.includes("input text data") && lower.includes("inappropriate content")) ||
+    (lower.includes("input data") && lower.includes("inappropriate content"))
+  );
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -497,6 +509,13 @@ export function formatAssistantErrorText(
     return (
       "Reasoning is required for this model endpoint. " +
       "Use /think minimal (or any non-off level) and try again."
+    );
+  }
+
+  if (isDataInspectionFailedErrorMessage(raw)) {
+    return (
+      "Provider content inspection rejected this request. " +
+      "Run /new (or /reset) to start a fresh session and retry."
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes #26376 by handling DashScope/Alibaba content-inspection failures (`InternalError.Algo.DataInspectionFailed`) explicitly in user-facing error formatting.

## Root cause
- OpenClaw surfaces provider errors through `formatAssistantErrorText`.
- DashScope returns `InternalError.Algo.DataInspectionFailed: Input text data may contain inappropriate content.` for some requests when prior session context is flagged.
- This error was not recognized by existing classifiers (context overflow / role ordering / timeout / billing), so users only saw a raw provider error and no recovery path.
- Clearing `sessions.json` worked because it removed the flagged conversation history, confirming this is often session-history related rather than current single input text.

## Changes
- Added `isDataInspectionFailedErrorMessage()` matcher in `src/agents/pi-embedded-helpers/errors.ts`.
- Added dedicated rewrite in `formatAssistantErrorText()` to return:
  - `Provider content inspection rejected this request. Run /new (or /reset) to start a fresh session and retry.`
- Added regression test in `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts` ensuring:
  - DataInspectionFailed maps to the recovery hint
  - It does **not** misclassify as context overflow

## Validation
- `pnpm -s vitest src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
- All tests in target file pass (22/22).

## Notes
This fix improves UX/safety by guiding users to safe session reset instead of deleting session files manually.
