### PR TITLE
feat: expand ~ (tilde) to home directory in file tools (read/write/edit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .
+- File tools/tilde paths: expand `~/...` against the user home directory before workspace-root checks in host file read/write/edit paths, while preserving root-boundary enforcement so outside-root targets remain blocked. (#29779) Thanks @Glucksberg.
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -173,3 +173,67 @@ describe("fs-safe", () => {
     });
   });
 });
+
+describe("tilde expansion in file tools", () => {
+  it("expandHomePrefix respects process.env.HOME changes", async () => {
+    const { expandHomePrefix } = await import("./home-dir.js");
+    const originalHome = process.env.HOME;
+    const fakeHome = "/tmp/fake-home-test";
+    process.env.HOME = fakeHome;
+    try {
+      const result = expandHomePrefix("~/file.txt");
+      expect(result).toBe(`${fakeHome}/file.txt`);
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("reads a file via ~/path after HOME override", async () => {
+    const root = await tempDirs.make("openclaw-tilde-test-");
+    const originalHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      await fs.writeFile(path.join(root, "hello.txt"), "tilde-works");
+      const result = await openFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/hello.txt",
+      });
+      const buf = Buffer.alloc(result.stat.size);
+      await result.handle.read(buf, 0, buf.length, 0);
+      await result.handle.close();
+      expect(buf.toString("utf8")).toBe("tilde-works");
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("writes a file via ~/path after HOME override", async () => {
+    const root = await tempDirs.make("openclaw-tilde-test-");
+    const originalHome = process.env.HOME;
+    process.env.HOME = root;
+    try {
+      await writeFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/output.txt",
+        data: "tilde-write-works",
+      });
+      const content = await fs.readFile(path.join(root, "output.txt"), "utf8");
+      expect(content).toBe("tilde-write-works");
+    } finally {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it("rejects ~/path that resolves outside root", async () => {
+    const root = await tempDirs.make("openclaw-tilde-outside-");
+    // HOME points to real home, ~/file goes to /home/dev/file which is outside root
+    await expect(
+      openFileWithinRoot({
+        rootDir: root,
+        relativePath: "~/escape.txt",
+      }),
+    ).rejects.toMatchObject({
+      code: expect.stringMatching(/outside-workspace|not-found|invalid-path/),
+    });
+  });
+});

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
 import { assertNoPathAliasEscape } from "./path-alias-guards.js";
+import { expandHomePrefix } from "./home-dir.js";
 import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-guards.js";
 
 export type SafeOpenErrorCode =
@@ -119,7 +120,8 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const resolved = path.resolve(rootWithSep, params.relativePath);
+  const expanded = expandHomePrefix(params.relativePath);
+  const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
   }
@@ -188,7 +190,8 @@ export async function writeFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const resolved = path.resolve(rootWithSep, params.relativePath);
+  const expanded = expandHomePrefix(params.relativePath);
+  const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
   }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -5,8 +5,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
-import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import { expandHomePrefix } from "./home-dir.js";
+import { assertNoPathAliasEscape } from "./path-alias-guards.js";
 import { isNotFoundPathError, isPathInside, isSymlinkOpenError } from "./path-guards.js";
 
 export type SafeOpenErrorCode =
@@ -49,6 +49,16 @@ const OPEN_WRITE_FLAGS =
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
+
+async function expandRelativePathWithHome(relativePath: string): Promise<string> {
+  let home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  try {
+    home = await fs.realpath(home);
+  } catch {
+    // If the home dir cannot be canonicalized, keep lexical expansion behavior.
+  }
+  return expandHomePrefix(relativePath, { home });
+}
 
 async function openVerifiedLocalFile(
   filePath: string,
@@ -121,7 +131,7 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const expanded = expandHomePrefix(params.relativePath, { home: os.homedir() });
+  const expanded = await expandRelativePathWithHome(params.relativePath);
   const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
@@ -191,7 +201,7 @@ export async function writeFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const expanded = expandHomePrefix(params.relativePath, { home: os.homedir() });
+  const expanded = await expandRelativePathWithHome(params.relativePath);
   const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -2,6 +2,7 @@ import type { Stats } from "node:fs";
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
 import { assertNoPathAliasEscape } from "./path-alias-guards.js";
@@ -120,7 +121,7 @@ export async function openFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const expanded = expandHomePrefix(params.relativePath);
+  const expanded = expandHomePrefix(params.relativePath, { home: os.homedir() });
   const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");
@@ -190,7 +191,7 @@ export async function writeFileWithinRoot(params: {
     throw err;
   }
   const rootWithSep = ensureTrailingSep(rootReal);
-  const expanded = expandHomePrefix(params.relativePath);
+  const expanded = expandHomePrefix(params.relativePath, { home: os.homedir() });
   const resolved = path.resolve(rootWithSep, expanded);
   if (!isPathInside(rootWithSep, resolved)) {
     throw new SafeOpenError("outside-workspace", "file is outside workspace root");


### PR DESCRIPTION
## Summary

LLMs frequently use `~/path` in tool calls (read/write/edit) because tilde notation dominates their training data (docs, READMEs, Stack Overflow, tutorials). Since these tools receive paths as raw JSON strings — without shell expansion — the `~` arrives as a literal character, causing `File not found` errors.

## Root cause

This became a user-visible issue after [`e3385a65`](https://github.com/openclaw/openclaw/commit/e3385a65789b0fdb59d5a4a659715142f99fd85c) (`fix(security): harden root file guards and host writes`, Feb 26 2026). That commit introduced `createHostWorkspaceWriteTool` and `createHostWorkspaceEditTool`, which route **all** host file operations through `openFileWithinRoot` / `writeFileWithinRoot` — the same guards previously used only for sandboxed tools.

**Before `e3385a65`:** file tools used `pi-coding-agent`'s direct operations, which resolved paths without strict root validation. A literal `~` would be handled by Node's `path.resolve()`, which treated it as a relative segment — sometimes working by accident.

**After `e3385a65`:** every file operation goes through `fs-safe.ts` root guards. A literal `~` is resolved as a relative path inside the workspace root (e.g., `/workspace/~/file.txt`), which doesn't exist → `File not found`.

This is not a security regression — the hardening is correct. But it exposed a missing piece: tilde expansion was never applied to these paths.

## Changes

- **`src/infra/fs-safe.ts`**: Call `expandHomePrefix()` on the relative path before `path.resolve()` in both `openFileWithinRoot` and `writeFileWithinRoot`
- **`src/infra/fs-safe.test.ts`**: 4 new tests covering tilde read, write, unit expansion, and security rejection

## Why this is safe

1. `expandHomePrefix()` is an **existing utility** already used in `cron/store.ts` and `infra/exec-approvals.ts` — no new code, just reuse
2. Expansion happens **before** `isPathInside()` guard — sandbox checks still reject paths outside workspace root
3. `~/path` that resolves outside the allowed root is rejected with `invalid-path` error
4. Zero API changes — absolute paths continue to work identically

## Motivation

Observed in production: after updating to a version containing `e3385a65`, file tool errors started appearing whenever LLM agents used `~/path` notation. This affects all models — they default to tilde because it is the overwhelmingly common format in Unix documentation. Rather than fighting this with prompt guardrails on every agent, the fix aligns tool behavior with LLM expectations and completes the security hardening that `e3385a65` started.

## Test results

```
15 passed (15) — all existing + 4 new tilde expansion tests
```