### PR TITLE
fix(line): classify LINE M4A voice payloads as audio

### DIFF
--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -66,4 +66,19 @@ describe("downloadLineMedia", () => {
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
     expect(writeSpy).not.toHaveBeenCalled();
   });
+
+  it("classifies M4A ftyp major brand as audio/mp4", async () => {
+    const m4aHeader = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+    ]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([m4aHeader]));
+    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("mid-audio", "token");
+    const writtenPath = writeSpy.mock.calls[0]?.[0];
+
+    expect(result.contentType).toBe("audio/mp4");
+    expect(result.path).toMatch(/\.m4a$/);
+    expect(writtenPath).toBe(result.path);
+  });
 });

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -53,6 +53,13 @@ export async function downloadLineMedia(
 }
 
 function detectContentType(buffer: Buffer): string {
+  const hasFtypBox =
+    buffer.length >= 12 &&
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70;
+
   // Check magic bytes
   if (buffer.length >= 2) {
     // JPEG
@@ -80,15 +87,15 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    if (hasFtypBox) {
+      // ISO BMFF containers share `ftyp`; use major brand to separate common
+      // M4A audio payloads from video mp4 containers.
+      const majorBrand = buffer.toString("ascii", 8, 12).toLowerCase();
+      const audioBrands = new Set(["m4a ", "m4b ", "m4p ", "m4r ", "f4a ", "f4b "]);
+      if (audioBrands.has(majorBrand)) {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Summary

- Problem: LINE voice clips in M4A containers were detected as `video/mp4`, so audio transcription did not run.
- Why it matters: users sending LINE voice messages got no transcript-driven response.
- What changed: MIME sniffing now checks `ftyp` major brand and classifies known audio brands (for example `M4A `) as `audio/mp4`; regression test added.
- What did NOT change (scope boundary): no change to non-LINE channels or downstream transcription model behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29751
- Related #

## User-visible / Behavior Changes

- LINE M4A voice messages are now treated as audio and continue through audio transcription paths.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/macOS dev env
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): LINE
- Relevant config (redacted): `channels.line.*` enabled, inbound voice message payload

### Steps

1. Configure LINE channel with media/audio understanding enabled.
2. Send a LINE voice message encoded as M4A (`ftypM4A `).
3. Observe detected MIME and extension handling in LINE media download path.

### Expected

- Voice payload is detected as audio (`audio/mp4`) and treated as transcript-eligible media.

### Actual

- Before fix it was detected as `video/mp4`, bypassing audio transcription selection.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- --run src/line/download.test.ts` (includes new M4A regression case).
- Edge cases checked: non-audio `ftyp` still maps to `video/mp4`; existing image detections unaffected.
- What you did **not** verify: live LINE webhook run against production bot.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/line/download.ts`, `src/line/download.test.ts`.
- Known bad symptoms reviewers should watch for: LINE voice messages classified as video again.

## Risks and Mitigations

- Risk: some uncommon ISO BMFF audio brand not in whitelist may still fall back to `video/mp4`.
  - Mitigation: current whitelist covers common M4A families; easy follow-up to extend brand list with real samples.
