### PR TITLE
fix(config): accept agents.list[].params in schema

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -37,6 +37,7 @@ type ResolvedAgentConfig = {
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
+  params?: AgentEntry["params"];
   tools?: AgentEntry["tools"];
 };
 
@@ -139,6 +140,7 @@ export function resolveAgentConfig(
     groupChat: entry.groupChat,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
+    params: entry.params,
     tools: entry.tools,
   };
 }

--- a/src/config/zod-schema.agent-runtime.test.ts
+++ b/src/config/zod-schema.agent-runtime.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { AgentEntrySchema } from "./zod-schema.agent-runtime.js";
+
+describe("AgentEntrySchema params", () => {
+  it("accepts per-agent params overrides", () => {
+    expect(() =>
+      AgentEntrySchema.parse({
+        id: "main",
+        params: {
+          cacheRetention: "short",
+          temperature: 0.2,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects non-object params values", () => {
+    expect(() => AgentEntrySchema.parse({ id: "main", params: "invalid" })).toThrow();
+  });
+});

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -703,6 +703,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary

- Problem: `agents.list[].params` was documented and runtime-consumed, but schema validation rejected it as unknown.
- Why it matters: `openclaw doctor` blocked valid per-agent parameter overrides.
- What changed: `AgentEntrySchema` now accepts `params`; resolved agent scope includes `params`; regression test added.
- What did NOT change (scope boundary): no change to provider-specific stream param semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29771
- Related #

## User-visible / Behavior Changes

- `agents.list[].params` is accepted by config schema/doctor instead of rejected as unrecognized.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/macOS dev env
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): config validation / doctor
- Relevant config (redacted): `agents.list[].params` object (e.g. `cacheRetention`)

### Steps

1. Add `params` object under an agent entry in config.
2. Run schema validation / doctor.
3. Verify configuration is accepted.

### Expected

- Valid object under `agents.list[].params` passes validation.

### Actual

- Before fix, schema rejected `params` as unrecognized key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- --run src/config/zod-schema.agent-runtime.test.ts src/agents/agent-scope.test.ts`.
- Edge cases checked: valid object accepted; invalid non-object `params` rejected.
- What you did **not** verify: full end-to-end provider behavior for all possible custom param keys.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/config/zod-schema.agent-runtime.ts`, `src/agents/agent-scope.ts`, `src/config/zod-schema.agent-runtime.test.ts`.
- Known bad symptoms reviewers should watch for: doctor rejecting `agents.list[].params` again.

## Risks and Mitigations

- Risk: accepting generic `params` objects can allow typoed keys that providers ignore silently.
  - Mitigation: this matches existing runtime behavior/documentation; provider-level validation remains unchanged.
