### PR TITLE
docs(agents): align memory guidance with runtime policy

### DIFF
--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -48,7 +48,9 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 
 ## Session start (required)
 
-- Read `SOUL.md`, `USER.md`, `memory.md`, and today+yesterday in `memory/`.
+- Read `SOUL.md` and `USER.md`.
+- For prior work/decisions/preferences/todos, run `memory_search` on `MEMORY.md` + `memory/*.md`, then use `memory_get` for only the needed lines.
+- If memory tools are unavailable, read `memory.md` and today+yesterday in `memory/`.
 - Do it before responding.
 
 ## Soul (required)
@@ -66,7 +68,7 @@ cp docs/reference/AGENTS.default.md ~/.openclaw/workspace/AGENTS.md
 
 - Daily log: `memory/YYYY-MM-DD.md` (create `memory/` if needed).
 - Long-term memory: `memory.md` for durable facts, preferences, and decisions.
-- On session start, read today + yesterday + `memory.md` if present.
+- On session start, prefer `memory_search` + `memory_get`; only fall back to direct file reads when tools are unavailable.
 - Capture: decisions, preferences, constraints, open loops.
 - Avoid secrets unless explicitly requested.
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -19,8 +19,9 @@ Before doing anything else:
 
 1. Read `SOUL.md` — this is who you are
 2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
+3. For prior work/decisions/preferences/todos, use `memory_search` on `MEMORY.md` + `memory/*.md`
+4. Use `memory_get` to pull only the lines you need from search hits
+5. If memory tools are unavailable, read `memory/YYYY-MM-DD.md` (today + yesterday); in **MAIN SESSION**, also read `MEMORY.md`
 
 Don't ask permission. Just do it.
 
@@ -205,7 +206,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 Periodically (every few days), use a heartbeat to:
 
-1. Read through recent `memory/YYYY-MM-DD.md` files
+1. Use `memory_search` across `MEMORY.md` + recent `memory/YYYY-MM-DD.md` files
 2. Identify significant events, lessons, or insights worth keeping long-term
 3. Update `MEMORY.md` with distilled learnings
 4. Remove outdated info from MEMORY.md that's no longer relevant


### PR DESCRIPTION
## Summary

- Problem: AGENTS templates instructed broad file reads, conflicting with runtime memory-tool-first guidance.
- Why it matters: inconsistent guidance causes agent behavior drift and reviewer confusion.
- What changed: templates now prioritize `memory_search` + `memory_get`, with direct file reads only as fallback when memory tools are unavailable.
- What did NOT change (scope boundary): no runtime code path changed; docs/template alignment only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29772
- Related #

## User-visible / Behavior Changes

- New workspaces created from these templates now guide agents to use memory tools before full memory file reads.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: N/A (docs-only)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): documentation templates
- Relevant config (redacted): N/A

### Steps

1. Open `docs/reference/templates/AGENTS.md` and `docs/reference/AGENTS.default.md`.
2. Compare session-start memory guidance against system prompt behavior.
3. Verify guidance now states memory tools first, file-read fallback second.

### Expected

- Template instructions are consistent with runtime memory usage guidance.

### Actual

- Before fix, template wording emphasized direct file reads and conflicted with memory tool flow.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manual review of both docs files and resulting instruction order.
- Edge cases checked: fallback path still documents behavior when memory tools are unavailable.
- What you did **not** verify: N/A (docs-only; no runtime execution changes).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `docs/reference/templates/AGENTS.md`, `docs/reference/AGENTS.default.md`.
- Known bad symptoms reviewers should watch for: templates drifting from runtime/system-prompt memory guidance.

## Risks and Mitigations

- Risk: docs wording may still be interpreted differently across locales.
  - Mitigation: this aligns canonical English templates; locale updates can mirror this phrasing.
