### PR TITLE
fix(android): stabilize onboarding and voice node flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Onboarding + voice reliability: request per-toggle onboarding permissions, update pairing guidance to `openclaw devices list/approve`, restore assistant speech playback in mic capture flow, cancel superseded in-flight speech (mute + per-reply token rotation), and keep `talk.config` loads retryable after transient failures. (#29796) Thanks @obviyus.
 - FS/Sandbox workspace boundaries: add a dedicated `outside-workspace` safe-open error code for root-escape checks, and propagate specific outside-workspace messages across edit/browser/media consumers instead of generic not-found/invalid-path fallbacks. (#29715) Thanks @YuzuruS.
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -54,6 +54,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val micConversation: StateFlow<List<VoiceConversationEntry>> = runtime.micConversation
   val micInputLevel: StateFlow<Float> = runtime.micInputLevel
   val micIsSending: StateFlow<Boolean> = runtime.micIsSending
+  val speakerEnabled: StateFlow<Boolean> = runtime.speakerEnabled
   val manualEnabled: StateFlow<Boolean> = runtime.manualEnabled
   val manualHost: StateFlow<String> = runtime.manualHost
   val manualPort: StateFlow<Int> = runtime.manualPort
@@ -131,6 +132,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setMicEnabled(enabled: Boolean) {
     runtime.setMicEnabled(enabled)
+  }
+
+  fun setSpeakerEnabled(enabled: Boolean) {
+    runtime.setSpeakerEnabled(enabled)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -349,7 +349,9 @@ class NodeRuntime(context: Context) {
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        voiceReplySpeaker.speakAssistantReply(text)
+        if (prefs.speakerEnabled.value) {
+          voiceReplySpeaker.speakAssistantReply(text)
+        }
       },
     )
   }
@@ -632,6 +634,13 @@ class NodeRuntime(context: Context) {
     prefs.setTalkEnabled(value)
     micCapture.setMicEnabled(value)
     externalAudioCaptureActive.value = value
+  }
+
+  val speakerEnabled: StateFlow<Boolean>
+    get() = prefs.speakerEnabled
+
+  fun setSpeakerEnabled(value: Boolean) {
+    prefs.setSpeakerEnabled(value)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -99,6 +99,9 @@ class SecurePrefs(context: Context) {
   private val _talkEnabled = MutableStateFlow(plainPrefs.getBoolean("talk.enabled", false))
   val talkEnabled: StateFlow<Boolean> = _talkEnabled
 
+  private val _speakerEnabled = MutableStateFlow(plainPrefs.getBoolean("voice.speakerEnabled", true))
+  val speakerEnabled: StateFlow<Boolean> = _speakerEnabled
+
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
     plainPrefs.edit { putString("gateway.lastDiscoveredStableID", trimmed) }
@@ -268,6 +271,11 @@ class SecurePrefs(context: Context) {
   fun setTalkEnabled(value: Boolean) {
     plainPrefs.edit { putBoolean("talk.enabled", value) }
     _talkEnabled.value = value
+  }
+
+  fun setSpeakerEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean("voice.speakerEnabled", value) }
+    _speakerEnabled.value = value
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
@@ -60,6 +60,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,6 +80,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
 import ai.openclaw.android.R
@@ -96,6 +100,24 @@ private enum class OnboardingStep(val index: Int, val label: String) {
 private enum class GatewayInputMode {
   SetupCode,
   Manual,
+}
+
+private enum class PermissionToggle {
+  Discovery,
+  Location,
+  Notifications,
+  Microphone,
+  Camera,
+  Photos,
+  Contacts,
+  Calendar,
+  Motion,
+  Sms,
+}
+
+private enum class SpecialAccessToggle {
+  NotificationListener,
+  AppUpdates,
 }
 
 private val onboardingBackgroundGradient =
@@ -210,18 +232,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
   var gatewayError by rememberSaveable { mutableStateOf<String?>(null) }
   var attemptedConnect by rememberSaveable { mutableStateOf(false) }
 
-  var enableDiscovery by rememberSaveable { mutableStateOf(true) }
-  var enableLocation by rememberSaveable { mutableStateOf(false) }
-  var enableNotifications by rememberSaveable { mutableStateOf(true) }
-  var enableNotificationListener by rememberSaveable { mutableStateOf(false) }
-  var enableAppUpdates by rememberSaveable { mutableStateOf(false) }
-  var enableMicrophone by rememberSaveable { mutableStateOf(false) }
-  var enableCamera by rememberSaveable { mutableStateOf(false) }
-  var enablePhotos by rememberSaveable { mutableStateOf(false) }
-  var enableContacts by rememberSaveable { mutableStateOf(false) }
-  var enableCalendar by rememberSaveable { mutableStateOf(false) }
-  var enableMotion by rememberSaveable { mutableStateOf(false) }
-  var enableSms by rememberSaveable { mutableStateOf(false) }
+  val lifecycleOwner = LocalLifecycleOwner.current
 
   val smsAvailable =
     remember(context) {
@@ -232,6 +243,13 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
       hasMotionCapabilities(context)
     }
   val motionPermissionRequired = Build.VERSION.SDK_INT >= 29
+  val notificationsPermissionRequired = Build.VERSION.SDK_INT >= 33
+  val discoveryPermission =
+    if (Build.VERSION.SDK_INT >= 33) {
+      Manifest.permission.NEARBY_WIFI_DEVICES
+    } else {
+      Manifest.permission.ACCESS_FINE_LOCATION
+    }
   val photosPermission =
     if (Build.VERSION.SDK_INT >= 33) {
       Manifest.permission.READ_MEDIA_IMAGES
@@ -239,52 +257,93 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
       Manifest.permission.READ_EXTERNAL_STORAGE
     }
 
-  val selectedPermissions =
-    remember(
-      context,
-      enableDiscovery,
-      enableLocation,
-      enableNotifications,
-      enableMicrophone,
-      enableCamera,
-      enablePhotos,
-      enableContacts,
-      enableCalendar,
-      enableMotion,
-      enableSms,
-      smsAvailable,
-      motionAvailable,
-      motionPermissionRequired,
-      photosPermission,
-    ) {
-      val requested = mutableListOf<String>()
-      if (enableDiscovery) {
-        requested += if (Build.VERSION.SDK_INT >= 33) Manifest.permission.NEARBY_WIFI_DEVICES else Manifest.permission.ACCESS_FINE_LOCATION
-      }
-      if (enableLocation) {
-        requested += Manifest.permission.ACCESS_FINE_LOCATION
-        requested += Manifest.permission.ACCESS_COARSE_LOCATION
-      }
-      if (enableNotifications && Build.VERSION.SDK_INT >= 33) requested += Manifest.permission.POST_NOTIFICATIONS
-      if (enableMicrophone) requested += Manifest.permission.RECORD_AUDIO
-      if (enableCamera) requested += Manifest.permission.CAMERA
-      if (enablePhotos) requested += photosPermission
-      if (enableContacts) {
-        requested += Manifest.permission.READ_CONTACTS
-        requested += Manifest.permission.WRITE_CONTACTS
-      }
-      if (enableCalendar) {
-        requested += Manifest.permission.READ_CALENDAR
-        requested += Manifest.permission.WRITE_CALENDAR
-      }
-      if (enableMotion && motionAvailable && motionPermissionRequired) {
-        requested += Manifest.permission.ACTIVITY_RECOGNITION
-      }
-      if (enableSms && smsAvailable) requested += Manifest.permission.SEND_SMS
-      requested
-        .distinct()
-        .filterNot { isPermissionGranted(context, it) }
+  var enableDiscovery by
+    rememberSaveable {
+      mutableStateOf(isPermissionGranted(context, discoveryPermission))
     }
+  var enableLocation by rememberSaveable { mutableStateOf(false) }
+  var enableNotifications by
+    rememberSaveable {
+      mutableStateOf(
+        !notificationsPermissionRequired ||
+          isPermissionGranted(context, Manifest.permission.POST_NOTIFICATIONS),
+      )
+    }
+  var enableNotificationListener by
+    rememberSaveable {
+      mutableStateOf(isNotificationListenerEnabled(context))
+    }
+  var enableAppUpdates by
+    rememberSaveable {
+      mutableStateOf(canInstallUnknownApps(context))
+    }
+  var enableMicrophone by rememberSaveable { mutableStateOf(false) }
+  var enableCamera by rememberSaveable { mutableStateOf(false) }
+  var enablePhotos by rememberSaveable { mutableStateOf(false) }
+  var enableContacts by rememberSaveable { mutableStateOf(false) }
+  var enableCalendar by rememberSaveable { mutableStateOf(false) }
+  var enableMotion by
+    rememberSaveable {
+      mutableStateOf(
+        motionAvailable &&
+          (!motionPermissionRequired || isPermissionGranted(context, Manifest.permission.ACTIVITY_RECOGNITION)),
+      )
+    }
+  var enableSms by
+    rememberSaveable {
+      mutableStateOf(smsAvailable && isPermissionGranted(context, Manifest.permission.SEND_SMS))
+    }
+
+  var pendingPermissionToggle by remember { mutableStateOf<PermissionToggle?>(null) }
+  var pendingSpecialAccessToggle by remember { mutableStateOf<SpecialAccessToggle?>(null) }
+
+  fun setPermissionToggleEnabled(toggle: PermissionToggle, enabled: Boolean) {
+    when (toggle) {
+      PermissionToggle.Discovery -> enableDiscovery = enabled
+      PermissionToggle.Location -> enableLocation = enabled
+      PermissionToggle.Notifications -> enableNotifications = enabled
+      PermissionToggle.Microphone -> enableMicrophone = enabled
+      PermissionToggle.Camera -> enableCamera = enabled
+      PermissionToggle.Photos -> enablePhotos = enabled
+      PermissionToggle.Contacts -> enableContacts = enabled
+      PermissionToggle.Calendar -> enableCalendar = enabled
+      PermissionToggle.Motion -> enableMotion = enabled && motionAvailable
+      PermissionToggle.Sms -> enableSms = enabled && smsAvailable
+    }
+  }
+
+  fun isPermissionToggleGranted(toggle: PermissionToggle): Boolean =
+    when (toggle) {
+      PermissionToggle.Discovery -> isPermissionGranted(context, discoveryPermission)
+      PermissionToggle.Location ->
+        isPermissionGranted(context, Manifest.permission.ACCESS_FINE_LOCATION) ||
+          isPermissionGranted(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+      PermissionToggle.Notifications ->
+        !notificationsPermissionRequired ||
+          isPermissionGranted(context, Manifest.permission.POST_NOTIFICATIONS)
+      PermissionToggle.Microphone -> isPermissionGranted(context, Manifest.permission.RECORD_AUDIO)
+      PermissionToggle.Camera -> isPermissionGranted(context, Manifest.permission.CAMERA)
+      PermissionToggle.Photos -> isPermissionGranted(context, photosPermission)
+      PermissionToggle.Contacts ->
+        isPermissionGranted(context, Manifest.permission.READ_CONTACTS) &&
+          isPermissionGranted(context, Manifest.permission.WRITE_CONTACTS)
+      PermissionToggle.Calendar ->
+        isPermissionGranted(context, Manifest.permission.READ_CALENDAR) &&
+          isPermissionGranted(context, Manifest.permission.WRITE_CALENDAR)
+      PermissionToggle.Motion ->
+        !motionAvailable ||
+          !motionPermissionRequired ||
+          isPermissionGranted(context, Manifest.permission.ACTIVITY_RECOGNITION)
+      PermissionToggle.Sms ->
+        !smsAvailable || isPermissionGranted(context, Manifest.permission.SEND_SMS)
+    }
+
+  fun setSpecialAccessToggleEnabled(toggle: SpecialAccessToggle, enabled: Boolean) {
+    when (toggle) {
+      SpecialAccessToggle.NotificationListener -> enableNotificationListener = enabled
+      SpecialAccessToggle.AppUpdates -> enableAppUpdates = enabled
+    }
+  }
 
   val enabledPermissionSummary =
     remember(
@@ -335,10 +394,83 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     step = OnboardingStep.FinalCheck
   }
 
-  val permissionLauncher =
+  val togglePermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-      proceedFromPermissions()
+      val pendingToggle = pendingPermissionToggle ?: return@rememberLauncherForActivityResult
+      setPermissionToggleEnabled(pendingToggle, isPermissionToggleGranted(pendingToggle))
+      pendingPermissionToggle = null
     }
+
+  val requestPermissionToggle: (PermissionToggle, Boolean, List<String>) -> Unit =
+    request@{ toggle, enabled, permissions ->
+      if (!enabled) {
+        setPermissionToggleEnabled(toggle, false)
+        return@request
+      }
+      if (isPermissionToggleGranted(toggle)) {
+        setPermissionToggleEnabled(toggle, true)
+        return@request
+      }
+      val missing = permissions.distinct().filterNot { isPermissionGranted(context, it) }
+      if (missing.isEmpty()) {
+        setPermissionToggleEnabled(toggle, isPermissionToggleGranted(toggle))
+        return@request
+      }
+      pendingPermissionToggle = toggle
+      togglePermissionLauncher.launch(missing.toTypedArray())
+    }
+
+  val requestSpecialAccessToggle: (SpecialAccessToggle, Boolean) -> Unit =
+    request@{ toggle, enabled ->
+      if (!enabled) {
+        setSpecialAccessToggleEnabled(toggle, false)
+        pendingSpecialAccessToggle = null
+        return@request
+      }
+      val grantedNow =
+        when (toggle) {
+          SpecialAccessToggle.NotificationListener -> isNotificationListenerEnabled(context)
+          SpecialAccessToggle.AppUpdates -> canInstallUnknownApps(context)
+        }
+      if (grantedNow) {
+        setSpecialAccessToggleEnabled(toggle, true)
+        pendingSpecialAccessToggle = null
+        return@request
+      }
+      pendingSpecialAccessToggle = toggle
+      when (toggle) {
+        SpecialAccessToggle.NotificationListener -> openNotificationListenerSettings(context)
+        SpecialAccessToggle.AppUpdates -> openUnknownAppSourcesSettings(context)
+      }
+    }
+
+  DisposableEffect(lifecycleOwner, context, pendingSpecialAccessToggle) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event != Lifecycle.Event.ON_RESUME) {
+          return@LifecycleEventObserver
+        }
+        when (pendingSpecialAccessToggle) {
+          SpecialAccessToggle.NotificationListener -> {
+            setSpecialAccessToggleEnabled(
+              SpecialAccessToggle.NotificationListener,
+              isNotificationListenerEnabled(context),
+            )
+            pendingSpecialAccessToggle = null
+          }
+          SpecialAccessToggle.AppUpdates -> {
+            setSpecialAccessToggleEnabled(
+              SpecialAccessToggle.AppUpdates,
+              canInstallUnknownApps(context),
+            )
+            pendingSpecialAccessToggle = null
+          }
+          null -> Unit
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
 
   val qrScanLauncher =
     rememberLauncherForActivityResult(ScanContract()) { result ->
@@ -485,18 +617,105 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               enableSms = enableSms,
               smsAvailable = smsAvailable,
               context = context,
-              onDiscoveryChange = { enableDiscovery = it },
-              onLocationChange = { enableLocation = it },
-              onNotificationsChange = { enableNotifications = it },
-              onNotificationListenerChange = { enableNotificationListener = it },
-              onAppUpdatesChange = { enableAppUpdates = it },
-              onMicrophoneChange = { enableMicrophone = it },
-              onCameraChange = { enableCamera = it },
-              onPhotosChange = { enablePhotos = it },
-              onContactsChange = { enableContacts = it },
-              onCalendarChange = { enableCalendar = it },
-              onMotionChange = { enableMotion = it },
-              onSmsChange = { enableSms = it },
+              onDiscoveryChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Discovery,
+                  checked,
+                  listOf(discoveryPermission),
+                )
+              },
+              onLocationChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Location,
+                  checked,
+                  listOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                  ),
+                )
+              },
+              onNotificationsChange = { checked ->
+                if (!notificationsPermissionRequired) {
+                  setPermissionToggleEnabled(PermissionToggle.Notifications, checked)
+                } else {
+                  requestPermissionToggle(
+                    PermissionToggle.Notifications,
+                    checked,
+                    listOf(Manifest.permission.POST_NOTIFICATIONS),
+                  )
+                }
+              },
+              onNotificationListenerChange = { checked ->
+                requestSpecialAccessToggle(SpecialAccessToggle.NotificationListener, checked)
+              },
+              onAppUpdatesChange = { checked ->
+                requestSpecialAccessToggle(SpecialAccessToggle.AppUpdates, checked)
+              },
+              onMicrophoneChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Microphone,
+                  checked,
+                  listOf(Manifest.permission.RECORD_AUDIO),
+                )
+              },
+              onCameraChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Camera,
+                  checked,
+                  listOf(Manifest.permission.CAMERA),
+                )
+              },
+              onPhotosChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Photos,
+                  checked,
+                  listOf(photosPermission),
+                )
+              },
+              onContactsChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Contacts,
+                  checked,
+                  listOf(
+                    Manifest.permission.READ_CONTACTS,
+                    Manifest.permission.WRITE_CONTACTS,
+                  ),
+                )
+              },
+              onCalendarChange = { checked ->
+                requestPermissionToggle(
+                  PermissionToggle.Calendar,
+                  checked,
+                  listOf(
+                    Manifest.permission.READ_CALENDAR,
+                    Manifest.permission.WRITE_CALENDAR,
+                  ),
+                )
+              },
+              onMotionChange = { checked ->
+                if (!motionAvailable) {
+                  setPermissionToggleEnabled(PermissionToggle.Motion, false)
+                } else if (!motionPermissionRequired) {
+                  setPermissionToggleEnabled(PermissionToggle.Motion, checked)
+                } else {
+                  requestPermissionToggle(
+                    PermissionToggle.Motion,
+                    checked,
+                    listOf(Manifest.permission.ACTIVITY_RECOGNITION),
+                  )
+                }
+              },
+              onSmsChange = { checked ->
+                if (!smsAvailable) {
+                  setPermissionToggleEnabled(PermissionToggle.Sms, false)
+                } else {
+                  requestPermissionToggle(
+                    PermissionToggle.Sms,
+                    checked,
+                    listOf(Manifest.permission.SEND_SMS),
+                  )
+                }
+              },
             )
           OnboardingStep.FinalCheck ->
             FinalStep(
@@ -609,11 +828,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               onClick = {
                 viewModel.setCameraEnabled(enableCamera)
                 viewModel.setLocationMode(if (enableLocation) LocationMode.WhileUsing else LocationMode.Off)
-                if (selectedPermissions.isEmpty()) {
-                  proceedFromPermissions()
-                } else {
-                  permissionLauncher.launch(selectedPermissions.toTypedArray())
-                }
+                proceedFromPermissions()
               },
               modifier = Modifier.weight(1f).height(52.dp),
               shape = RoundedCornerShape(14.dp),

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt
@@ -1563,8 +1563,8 @@ private fun FinalStep(
       } else {
         GuideBlock(title = "Pairing Required") {
           Text("Run these on the gateway host:", style = onboardingCalloutStyle, color = onboardingTextSecondary)
-          CommandBlock("openclaw nodes pending")
-          CommandBlock("openclaw nodes approve <requestId>")
+          CommandBlock("openclaw devices list")
+          CommandBlock("openclaw devices approve <requestId>")
           Text("Then tap Connect again.", style = onboardingCalloutStyle, color = onboardingTextSecondary)
         }
       }

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/VoiceTabScreen.kt
@@ -10,12 +10,6 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,14 +21,11 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -44,9 +35,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MicOff
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -74,9 +69,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.MainViewModel
 import ai.openclaw.android.voice.VoiceConversationEntry
 import ai.openclaw.android.voice.VoiceConversationRole
-import kotlin.math.PI
 import kotlin.math.max
-import kotlin.math.sin
 
 @Composable
 fun VoiceTabScreen(viewModel: MainViewModel) {
@@ -85,10 +78,9 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
   val activity = remember(context) { context.findActivity() }
   val listState = rememberLazyListState()
 
-  val isConnected by viewModel.isConnected.collectAsState()
   val gatewayStatus by viewModel.statusText.collectAsState()
   val micEnabled by viewModel.micEnabled.collectAsState()
-  val micStatusText by viewModel.micStatusText.collectAsState()
+  val speakerEnabled by viewModel.speakerEnabled.collectAsState()
   val micLiveTranscript by viewModel.micLiveTranscript.collectAsState()
   val micQueuedMessages by viewModel.micQueuedMessages.collectAsState()
   val micConversation by viewModel.micConversation.collectAsState()
@@ -138,33 +130,6 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         .padding(horizontal = 20.dp, vertical = 14.dp),
     verticalArrangement = Arrangement.spacedBy(10.dp),
   ) {
-    Row(
-      modifier = Modifier.fillMaxWidth(),
-      horizontalArrangement = Arrangement.SpaceBetween,
-      verticalAlignment = Alignment.CenterVertically,
-    ) {
-      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(
-          "VOICE",
-          style = mobileCaption1.copy(fontWeight = FontWeight.Bold, letterSpacing = 1.sp),
-          color = mobileAccent,
-        )
-        Text("Voice mode", style = mobileTitle2, color = mobileText)
-      }
-      Surface(
-        shape = RoundedCornerShape(999.dp),
-        color = if (isConnected) mobileAccentSoft else mobileSurfaceStrong,
-        border = BorderStroke(1.dp, if (isConnected) mobileAccent.copy(alpha = 0.25f) else mobileBorderStrong),
-      ) {
-        Text(
-          if (isConnected) "Connected" else "Offline",
-          modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-          style = mobileCaption1,
-          color = if (isConnected) mobileAccent else mobileTextSecondary,
-        )
-      }
-    }
-
     LazyColumn(
       state = listState,
       modifier = Modifier.fillMaxWidth().weight(1f),
@@ -173,15 +138,31 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
     ) {
       if (micConversation.isEmpty() && !showThinkingBubble) {
         item {
-          Column(
-            modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+          Box(
+            modifier = Modifier.fillParentMaxHeight().fillMaxWidth(),
+            contentAlignment = Alignment.Center,
           ) {
-            Text(
-              "Tap the mic and speak. Each pause sends a turn automatically.",
-              style = mobileCallout,
-              color = mobileTextSecondary,
-            )
+            Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+              Icon(
+                imageVector = Icons.Default.Mic,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = mobileTextTertiary,
+              )
+              Text(
+                "Tap the mic to start",
+                style = mobileHeadline,
+                color = mobileTextSecondary,
+              )
+              Text(
+                "Each pause sends a turn automatically.",
+                style = mobileCallout,
+                color = mobileTextTertiary,
+              )
+            }
           }
         }
       }
@@ -197,122 +178,139 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       }
     }
 
-    Surface(
+    Column(
       modifier = Modifier.fillMaxWidth(),
-      shape = RoundedCornerShape(20.dp),
-      color = Color.White,
-      border = BorderStroke(1.dp, mobileBorder),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-      Column(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-      ) {
+      if (!micLiveTranscript.isNullOrBlank()) {
         Surface(
-          shape = RoundedCornerShape(999.dp),
-          color = mobileSurface,
-          border = BorderStroke(1.dp, mobileBorder),
+          modifier = Modifier.fillMaxWidth(),
+          shape = RoundedCornerShape(14.dp),
+          color = mobileAccentSoft,
+          border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
         ) {
-          val queueCount = micQueuedMessages.size
-          val stateText =
-            when {
-              queueCount > 0 -> "$queueCount queued"
-              micIsSending -> "Sending"
-              micEnabled -> "Listening"
-              else -> "Mic off"
-            }
           Text(
-            "$gatewayStatus · $stateText",
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
-            style = mobileCaption1,
-            color = mobileTextSecondary,
+            micLiveTranscript!!.trim(),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            style = mobileCallout,
+            color = mobileText,
+          )
+        }
+      }
+
+      // Mic button with input-reactive ring + speaker toggle
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        // Speaker toggle
+        IconButton(
+          onClick = { viewModel.setSpeakerEnabled(!speakerEnabled) },
+          modifier = Modifier.size(48.dp),
+          colors =
+            IconButtonDefaults.iconButtonColors(
+              containerColor = if (speakerEnabled) mobileSurface else mobileDangerSoft,
+            ),
+        ) {
+          Icon(
+            imageVector = if (speakerEnabled) Icons.AutoMirrored.Filled.VolumeUp else Icons.AutoMirrored.Filled.VolumeOff,
+            contentDescription = if (speakerEnabled) "Mute speaker" else "Unmute speaker",
+            modifier = Modifier.size(22.dp),
+            tint = if (speakerEnabled) mobileTextSecondary else mobileDanger,
           )
         }
 
-        if (!micLiveTranscript.isNullOrBlank()) {
-          Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(14.dp),
-            color = mobileAccentSoft,
-            border = BorderStroke(1.dp, mobileAccent.copy(alpha = 0.2f)),
+        // Ring size = 68dp base + up to 22dp driven by mic input level.
+        // The outer Box is fixed at 90dp (max ring size) so the ring never shifts the button.
+        Box(
+          modifier = Modifier.padding(horizontal = 16.dp).size(90.dp),
+          contentAlignment = Alignment.Center,
+        ) {
+          if (micEnabled) {
+            val ringLevel = micInputLevel.coerceIn(0f, 1f)
+            val ringSize = 68.dp + (22.dp * max(ringLevel, 0.05f))
+            Box(
+              modifier =
+                Modifier
+                  .size(ringSize)
+                  .background(mobileAccent.copy(alpha = 0.12f + 0.14f * ringLevel), CircleShape),
+            )
+          }
+          Button(
+            onClick = {
+              if (micEnabled) {
+                viewModel.setMicEnabled(false)
+                return@Button
+              }
+              if (hasMicPermission) {
+                viewModel.setMicEnabled(true)
+              } else {
+                pendingMicEnable = true
+                requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
+              }
+            },
+            shape = CircleShape,
+            contentPadding = PaddingValues(0.dp),
+            modifier = Modifier.size(60.dp),
+            colors =
+              ButtonDefaults.buttonColors(
+                containerColor = if (micEnabled) mobileDanger else mobileAccent,
+                contentColor = Color.White,
+              ),
           ) {
-            Text(
-              micLiveTranscript!!.trim(),
-              modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-              style = mobileCallout,
-              color = mobileText,
+            Icon(
+              imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
+              contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
+              modifier = Modifier.size(24.dp),
             )
           }
         }
 
-        MicWaveform(level = micInputLevel, active = micEnabled)
+        // Invisible spacer to balance the row (same size as speaker button)
+        Box(modifier = Modifier.size(48.dp))
+      }
 
-        Button(
-          onClick = {
-            if (micEnabled) {
-              viewModel.setMicEnabled(false)
-              return@Button
-            }
-            if (hasMicPermission) {
-              viewModel.setMicEnabled(true)
-            } else {
-              pendingMicEnable = true
-              requestMicPermission.launch(Manifest.permission.RECORD_AUDIO)
-            }
-          },
-          shape = CircleShape,
-          contentPadding = PaddingValues(0.dp),
-          modifier = Modifier.size(86.dp),
-          colors =
-            ButtonDefaults.buttonColors(
-              containerColor = if (micEnabled) mobileDanger else mobileAccent,
-              contentColor = Color.White,
-            ),
-        ) {
-          Icon(
-            imageVector = if (micEnabled) Icons.Default.MicOff else Icons.Default.Mic,
-            contentDescription = if (micEnabled) "Turn microphone off" else "Turn microphone on",
-            modifier = Modifier.size(30.dp),
-          )
+      // Status + labels
+      val queueCount = micQueuedMessages.size
+      val stateText =
+        when {
+          queueCount > 0 -> "$queueCount queued"
+          micIsSending -> "Sending"
+          micEnabled -> "Listening"
+          else -> "Mic off"
         }
+      Text(
+        "$gatewayStatus · $stateText",
+        style = mobileCaption1,
+        color = mobileTextSecondary,
+      )
 
-        Text(
-          if (micEnabled) "Tap to stop" else "Tap to speak",
-          style = mobileCallout,
-          color = mobileTextSecondary,
-        )
-
-        if (!hasMicPermission) {
-          val showRationale =
-            if (activity == null) {
-              false
-            } else {
-              ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
-            }
-          Text(
-            if (showRationale) {
-              "Microphone permission is required for voice mode."
-            } else {
-              "Microphone blocked. Open app settings to enable it."
-            },
-            style = mobileCaption1,
-            color = mobileWarning,
-            textAlign = TextAlign.Center,
-          )
-          Button(
-            onClick = { openAppSettings(context) },
-            shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
-          ) {
-            Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+      if (!hasMicPermission) {
+        val showRationale =
+          if (activity == null) {
+            false
+          } else {
+            ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.RECORD_AUDIO)
           }
-        }
-
         Text(
-          micStatusText,
+          if (showRationale) {
+            "Microphone permission is required for voice mode."
+          } else {
+            "Microphone blocked. Open app settings to enable it."
+          },
           style = mobileCaption1,
-          color = mobileTextTertiary,
+          color = mobileWarning,
+          textAlign = TextAlign.Center,
         )
+        Button(
+          onClick = { openAppSettings(context) },
+          shape = RoundedCornerShape(12.dp),
+          colors = ButtonDefaults.buttonColors(containerColor = mobileSurfaceStrong, contentColor = mobileText),
+        ) {
+          Text("Open settings", style = mobileCallout.copy(fontWeight = FontWeight.SemiBold))
+        }
       }
     }
   }
@@ -327,18 +325,18 @@ private fun VoiceTurnBubble(entry: VoiceConversationEntry) {
   ) {
     Surface(
       modifier = Modifier.fillMaxWidth(0.90f),
-      shape = RoundedCornerShape(14.dp),
-      color = if (isUser) mobileAccentSoft else mobileSurface,
-      border = BorderStroke(1.dp, if (isUser) mobileAccent.copy(alpha = 0.2f) else mobileBorder),
+      shape = RoundedCornerShape(12.dp),
+      color = if (isUser) mobileAccentSoft else Color.White,
+      border = BorderStroke(1.dp, if (isUser) mobileAccent else mobileBorderStrong),
     ) {
       Column(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 11.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
       ) {
         Text(
           if (isUser) "You" else "OpenClaw",
-          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
-          color = mobileTextSecondary,
+          style = mobileCaption2.copy(fontWeight = FontWeight.SemiBold, letterSpacing = 0.6.sp),
+          color = if (isUser) mobileAccent else mobileTextSecondary,
         )
         Text(
           if (entry.isStreaming && entry.text.isBlank()) "Listening response…" else entry.text,
@@ -355,12 +353,12 @@ private fun VoiceThinkingBubble() {
   Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
     Surface(
       modifier = Modifier.fillMaxWidth(0.68f),
-      shape = RoundedCornerShape(14.dp),
-      color = mobileSurface,
-      border = BorderStroke(1.dp, mobileBorder),
+      shape = RoundedCornerShape(12.dp),
+      color = Color.White,
+      border = BorderStroke(1.dp, mobileBorderStrong),
     ) {
       Row(
-        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+        modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
       ) {
@@ -387,44 +385,6 @@ private fun ThinkingDot(alpha: Float, color: Color) {
     shape = CircleShape,
     color = color,
   ) {}
-}
-
-@Composable
-private fun MicWaveform(level: Float, active: Boolean) {
-  val transition = rememberInfiniteTransition(label = "voiceWave")
-  val phase by
-    transition.animateFloat(
-      initialValue = 0f,
-      targetValue = 1f,
-      animationSpec = infiniteRepeatable(animation = tween(1_000, easing = LinearEasing), repeatMode = RepeatMode.Restart),
-      label = "voiceWavePhase",
-    )
-
-  val effective = if (active) level.coerceIn(0f, 1f) else 0f
-  val base = max(effective, if (active) 0.05f else 0f)
-
-  Row(
-    modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
-    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
-    repeat(16) { index ->
-      val pulse =
-        if (!active) {
-          0f
-        } else {
-          ((sin(((phase * 2f * PI) + (index * 0.55f)).toDouble()) + 1.0) * 0.5).toFloat()
-        }
-      val barHeight = 6.dp + (24.dp * (base * pulse))
-      Box(
-        modifier =
-          Modifier
-            .width(5.dp)
-            .height(barHeight)
-            .background(if (active) mobileAccent else mobileBorderStrong, RoundedCornerShape(999.dp)),
-      )
-    }
-  }
 }
 
 private fun Context.hasRecordAudioPermission(): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -194,6 +194,11 @@ class TalkModeManager(
     }
   }
 
+  suspend fun speakAssistantReply(text: String) {
+    reloadConfig()
+    playAssistant(text)
+  }
+
   private fun start() {
     mainHandler.post {
       if (_isListening.value) return@post

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -997,7 +997,8 @@ class TalkModeManager(
       apiKey = envKey?.takeIf { it.isNotEmpty() }
       voiceAliases = emptyMap()
       defaultOutputFormat = defaultOutputFormatFallback
-      configLoaded = true
+      // Keep config load retryable after transient fetch failures.
+      configLoaded = false
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/voice/TalkModeManager.kt
@@ -27,6 +27,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.util.UUID
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -148,6 +149,7 @@ class TalkModeManager(
   private var chatSubscribedSessionKey: String? = null
   private var configLoaded = false
   @Volatile private var playbackEnabled = true
+  @Volatile private var playbackGeneration = 0L
 
   private var player: MediaPlayer? = null
   private var streamingSource: StreamingMediaDataSource? = null
@@ -197,8 +199,10 @@ class TalkModeManager(
   }
 
   fun setPlaybackEnabled(enabled: Boolean) {
+    if (playbackEnabled == enabled) return
     playbackEnabled = enabled
     if (!enabled) {
+      playbackGeneration += 1
       stopSpeaking()
     }
   }
@@ -209,9 +213,10 @@ class TalkModeManager(
 
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
+    val playbackToken = playbackGeneration
     ensureConfigLoaded()
-    if (!playbackEnabled) return
-    playAssistant(text)
+    ensurePlaybackActive(playbackToken)
+    playAssistant(text, playbackToken)
   }
 
   private fun start() {
@@ -389,8 +394,14 @@ class TalkModeManager(
         return
       }
       Log.d(tag, "assistant text ok chars=${assistant.length}")
-      playAssistant(assistant)
+      val playbackToken = playbackGeneration
+      ensurePlaybackActive(playbackToken)
+      playAssistant(assistant, playbackToken)
     } catch (err: Throwable) {
+      if (err is CancellationException) {
+        Log.d(tag, "finalize speech cancelled")
+        return
+      }
       _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
       Log.w(tag, "finalize failed: ${err.message ?: err::class.simpleName}")
     }
@@ -507,7 +518,7 @@ class TalkModeManager(
     return null
   }
 
-  private suspend fun playAssistant(text: String) {
+  private suspend fun playAssistant(text: String, playbackToken: Long) {
     val parsed = TalkDirectiveParser.parse(text)
     if (parsed.unknownKeys.isNotEmpty()) {
       Log.w(tag, "Unknown talk directive keys: ${parsed.unknownKeys}")
@@ -535,6 +546,7 @@ class TalkModeManager(
         modelOverrideActive = true
       }
     }
+    ensurePlaybackActive(playbackToken)
 
     val apiKey =
       apiKey?.trim()?.takeIf { it.isNotEmpty() }
@@ -561,9 +573,10 @@ class TalkModeManager(
         if (apiKey.isNullOrEmpty()) {
           Log.w(tag, "missing ELEVENLABS_API_KEY; falling back to system voice")
         }
+        ensurePlaybackActive(playbackToken)
         _usingFallbackTts.value = true
         _statusText.value = "Speaking (System)…"
-        speakWithSystemTts(cleaned)
+        speakWithSystemTts(cleaned, playbackToken)
       } else {
         _usingFallbackTts.value = false
         val ttsStarted = SystemClock.elapsedRealtime()
@@ -584,43 +597,71 @@ class TalkModeManager(
             language = TalkModeRuntime.validatedLanguage(directive?.language),
             latencyTier = TalkModeRuntime.validatedLatencyTier(directive?.latencyTier),
           )
-        streamAndPlay(voiceId = voiceId!!, apiKey = apiKey!!, request = request)
+        streamAndPlay(voiceId = voiceId!!, apiKey = apiKey!!, request = request, playbackToken = playbackToken)
         Log.d(tag, "elevenlabs stream ok durMs=${SystemClock.elapsedRealtime() - ttsStarted}")
       }
     } catch (err: Throwable) {
+      if (isPlaybackCancelled(err, playbackToken)) {
+        Log.d(tag, "assistant speech cancelled")
+        return
+      }
       Log.w(tag, "speak failed: ${err.message ?: err::class.simpleName}; falling back to system voice")
       try {
+        ensurePlaybackActive(playbackToken)
         _usingFallbackTts.value = true
         _statusText.value = "Speaking (System)…"
-        speakWithSystemTts(cleaned)
+        speakWithSystemTts(cleaned, playbackToken)
       } catch (fallbackErr: Throwable) {
+        if (isPlaybackCancelled(fallbackErr, playbackToken)) {
+          Log.d(tag, "assistant fallback speech cancelled")
+          return
+        }
         _statusText.value = "Speak failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}"
         Log.w(tag, "system voice failed: ${fallbackErr.message ?: fallbackErr::class.simpleName}")
       }
+    } finally {
+      _isSpeaking.value = false
     }
-
-    _isSpeaking.value = false
   }
 
-  private suspend fun streamAndPlay(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+  private suspend fun streamAndPlay(
+    voiceId: String,
+    apiKey: String,
+    request: ElevenLabsRequest,
+    playbackToken: Long,
+  ) {
+    ensurePlaybackActive(playbackToken)
     stopSpeaking(resetInterrupt = false)
+    ensurePlaybackActive(playbackToken)
 
     pcmStopRequested = false
     val pcmSampleRate = TalkModeRuntime.parsePcmSampleRate(request.outputFormat)
     if (pcmSampleRate != null) {
       try {
-        streamAndPlayPcm(voiceId = voiceId, apiKey = apiKey, request = request, sampleRate = pcmSampleRate)
+        streamAndPlayPcm(
+          voiceId = voiceId,
+          apiKey = apiKey,
+          request = request,
+          sampleRate = pcmSampleRate,
+          playbackToken = playbackToken,
+        )
         return
       } catch (err: Throwable) {
-        if (pcmStopRequested) return
+        if (isPlaybackCancelled(err, playbackToken) || pcmStopRequested) return
         Log.w(tag, "pcm playback failed; falling back to mp3: ${err.message ?: err::class.simpleName}")
       }
     }
 
-    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = request)
+    ensurePlaybackActive(playbackToken)
+    streamAndPlayMp3(voiceId = voiceId, apiKey = apiKey, request = request, playbackToken = playbackToken)
   }
 
-  private suspend fun streamAndPlayMp3(voiceId: String, apiKey: String, request: ElevenLabsRequest) {
+  private suspend fun streamAndPlayMp3(
+    voiceId: String,
+    apiKey: String,
+    request: ElevenLabsRequest,
+    playbackToken: Long,
+  ) {
     val dataSource = StreamingMediaDataSource()
     streamingSource = dataSource
 
@@ -657,7 +698,7 @@ class TalkModeManager(
     val fetchJob =
       scope.launch(Dispatchers.IO) {
         try {
-          streamTts(voiceId = voiceId, apiKey = apiKey, request = request, sink = dataSource)
+          streamTts(voiceId = voiceId, apiKey = apiKey, request = request, sink = dataSource, playbackToken = playbackToken)
           fetchError.complete(null)
         } catch (err: Throwable) {
           dataSource.fail()
@@ -667,8 +708,11 @@ class TalkModeManager(
 
     Log.d(tag, "play start")
     try {
+      ensurePlaybackActive(playbackToken)
       prepared.await()
+      ensurePlaybackActive(playbackToken)
       finished.await()
+      ensurePlaybackActive(playbackToken)
       fetchError.await()?.let { throw it }
     } finally {
       fetchJob.cancel()
@@ -682,7 +726,9 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     sampleRate: Int,
+    playbackToken: Long,
   ) {
+    ensurePlaybackActive(playbackToken)
     val minBuffer =
       AudioTrack.getMinBufferSize(
         sampleRate,
@@ -718,20 +764,22 @@ class TalkModeManager(
 
     Log.d(tag, "pcm play start sampleRate=$sampleRate bufferSize=$bufferSize")
     try {
-      streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track)
+      streamPcm(voiceId = voiceId, apiKey = apiKey, request = request, track = track, playbackToken = playbackToken)
     } finally {
       cleanupPcmTrack()
     }
     Log.d(tag, "pcm play done")
   }
 
-  private suspend fun speakWithSystemTts(text: String) {
+  private suspend fun speakWithSystemTts(text: String, playbackToken: Long) {
     val trimmed = text.trim()
     if (trimmed.isEmpty()) return
+    ensurePlaybackActive(playbackToken)
     val ok = ensureSystemTts()
     if (!ok) {
       throw IllegalStateException("system TTS unavailable")
     }
+    ensurePlaybackActive(playbackToken)
 
     val tts = systemTts ?: throw IllegalStateException("system TTS unavailable")
     val utteranceId = "talk-${UUID.randomUUID()}"
@@ -741,6 +789,7 @@ class TalkModeManager(
     systemTtsPendingId = utteranceId
 
     withContext(Dispatchers.Main) {
+      ensurePlaybackActive(playbackToken)
       val params = Bundle()
       tts.speak(trimmed, TextToSpeech.QUEUE_FLUSH, params, utteranceId)
     }
@@ -751,6 +800,7 @@ class TalkModeManager(
       } catch (err: Throwable) {
         throw err
       }
+      ensurePlaybackActive(playbackToken)
     }
   }
 
@@ -870,6 +920,17 @@ class TalkModeManager(
     return true
   }
 
+  private fun ensurePlaybackActive(playbackToken: Long) {
+    if (!playbackEnabled || playbackToken != playbackGeneration) {
+      throw CancellationException("assistant speech cancelled")
+    }
+  }
+
+  private fun isPlaybackCancelled(err: Throwable?, playbackToken: Long): Boolean {
+    if (err is CancellationException) return true
+    return !playbackEnabled || playbackToken != playbackGeneration
+  }
+
   private suspend fun ensureConfigLoaded() {
     if (!configLoaded) {
       reloadConfig()
@@ -950,8 +1011,10 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     sink: StreamingMediaDataSource,
+    playbackToken: Long,
   ) {
     withContext(Dispatchers.IO) {
+      ensurePlaybackActive(playbackToken)
       val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
       try {
         val payload = buildRequestPayload(request)
@@ -967,8 +1030,10 @@ class TalkModeManager(
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
+            ensurePlaybackActive(playbackToken)
             val read = input.read(buffer)
             if (read <= 0) break
+            ensurePlaybackActive(playbackToken)
             sink.append(buffer.copyOf(read))
           }
         }
@@ -984,8 +1049,10 @@ class TalkModeManager(
     apiKey: String,
     request: ElevenLabsRequest,
     track: AudioTrack,
+    playbackToken: Long,
   ) {
     withContext(Dispatchers.IO) {
+      ensurePlaybackActive(playbackToken)
       val conn = openTtsConnection(voiceId = voiceId, apiKey = apiKey, request = request)
       try {
         val payload = buildRequestPayload(request)
@@ -1000,21 +1067,21 @@ class TalkModeManager(
         val buffer = ByteArray(8 * 1024)
         conn.inputStream.use { input ->
           while (true) {
-            if (pcmStopRequested) return@withContext
+            if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
             val read = input.read(buffer)
             if (read <= 0) break
             var offset = 0
             while (offset < read) {
-              if (pcmStopRequested) return@withContext
+              if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
               val wrote =
                 try {
                   track.write(buffer, offset, read - offset)
                 } catch (err: Throwable) {
-                  if (pcmStopRequested) return@withContext
+                  if (pcmStopRequested || isPlaybackCancelled(err, playbackToken)) return@withContext
                   throw err
                 }
               if (wrote <= 0) {
-                if (pcmStopRequested) return@withContext
+                if (pcmStopRequested || isPlaybackCancelled(null, playbackToken)) return@withContext
                 throw IllegalStateException("AudioTrack write failed: $wrote")
               }
               offset += wrote


### PR DESCRIPTION
## Summary
- request permissions per onboarding toggle and keep disabled when denied
- fix Android pairing guidance to the actual `devices list/approve` commands
- restore assistant speech playback in voice mode with immediate speaker mute/unmute behavior
- refresh talk config on reconnect and cut conversation update churn in mic capture

## Testing
- `cd apps/android && ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "ai.openclaw.android.voice.*"`
