### PR TITLE
fix(models): label codex weekly usage window as Week

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -35,7 +35,7 @@ describe("fetchCodexUsage", () => {
             reset_at: 1_700_000_000,
           },
           secondary_window: {
-            limit_window_seconds: 86_400,
+            limit_window_seconds: 604_800,
             used_percent: 75,
             reset_at: 1_700_050_000,
           },
@@ -51,7 +51,7 @@ describe("fetchCodexUsage", () => {
     expect(result.plan).toBe("Plus ($12.50)");
     expect(result.windows).toEqual([
       { label: "3h", usedPercent: 35.5, resetAt: 1_700_000_000_000 },
-      { label: "Day", usedPercent: 75, resetAt: 1_700_050_000_000 },
+      { label: "Week", usedPercent: 75, resetAt: 1_700_050_000_000 },
     ]);
   });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,7 +65,7 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),


### PR DESCRIPTION
### Summary
- `openclaw models status` could label Codex secondary usage as `Day` even when the backend window is weekly.
- The Codex usage parser now maps secondary windows by duration so weekly windows are labeled `Week`.
- Added regression coverage to assert a `604800s` (7-day) secondary window renders as `Week`.
- This keeps CLI usage wording aligned with the actual reset window shown by backend data.

### Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

### Linked Issue/PR
- #29783

### User-visible / Behavior Changes
- Before: Codex secondary window could display as `Day` for a weekly limit.
- After: Codex secondary window displays `Week` when `limit_window_seconds >= 604800` (168h).
- Daily windows remain `Day` for `>=24h && <168h`.

### Security Impact (required)
- None. This change only adjusts display labeling logic and tests.

### Repro + Verification

### Environment
- OpenClaw baseline discussed in issue: `2026.2.26`
- Reported OS: Ubuntu (issue report)
- Local verification: macOS (dev workspace)

### steps
1. Run `openclaw models status` with `openai-codex` configured.
2. Return a Codex secondary usage window of `limit_window_seconds=604800`.
3. Inspect the usage label in CLI output.

### Expected
- Secondary window label should be `Week` for 7-day windows.

### Actual
- Previously label could appear as `Day`.

### Evidence
- Failing behavior context captured in issue #29783.
- Passing after patch:
  - `pnpm test src/infra/provider-usage.fetch.codex.test.ts`
  - Assertion now expects `{ label: "Week", usedPercent: 75, ... }` for `604800s` secondary window.

Attach at least one:
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Human Verification (required)
- What I personally verified:
  - Ran `pnpm test src/infra/provider-usage.fetch.codex.test.ts` locally and confirmed all tests pass.
  - Confirmed parser logic now maps secondary windows with `>=168h` to `Week`. via patch
- Edge cases checked:
  - `604800s` => `Week`
  - `86400s` remains `Day`
  Shows as week now when you run the openclaw models status

### Compatibility / Migration
- Backward compatible? Yes.
- Config/env changes? None.
- Migration needed? No.
- If yes, exact upgrade steps:
  - Not applicable.

### Failure Recovery (if this breaks)
- How to disable/revert this change quickly:
  - Revert this PR.
- Files/config to restore:
  - `src/infra/provider-usage.fetch.codex.ts`
  - `src/infra/provider-usage.fetch.codex.test.ts`
- Known bad symptoms reviewers should watch for:
  - 7-day Codex windows still labeled as `Day`.
  - Non-weekly windows incorrectly relabeled to `Week`.

### Risks and Mitigations
- Risk:
  - Window-duration assumptions from backend could change.
  - Mitigation:
    - Keep mapping duration-based and guarded by unit tests for known durations.

Closes #29783
Co-Authored with Codex 5.3