### PR TITLE
fix(line): detect M4A audio files correctly (Issue #29751)

### DIFF
--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,15 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
+    // MP4/M4A - check ftyp sub-brand to distinguish audio from video
     if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-        return "audio/mp4";
+      if (buffer.length >= 12) {
+        const subBrand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
+        if (subBrand === "M4A " || subBrand === "M4B ") {
+          return "audio/mp4";
+        }
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes Issue #29751: LINE voice messages (M4A) were incorrectly detected as video/mp4, causing the audio transcription pipeline to be skipped.

## Root Cause

The  function in `src/line/download.ts` checked for the MP4 ftyp magic bytes (bytes 4-7) before checking for M4A-specific markers. Since both MP4 video and M4A audio files share the same ftyp header, the function always returned `video/mp4` for any ftyp-based file, making the M4A-specific check dead code.

## Fix

Check the ftyp sub-brand at bytes 8-11 to distinguish M4A/M4B audio from MP4 video:
- `M4A ` → audio/mp4 (Apple AAC-LC audio)
- `M4B ` → audio/mp4 (Apple audiobook)
- Other → video/mp4

This ensures:
- LINE voice messages are correctly detected as audio/mp4
- Files are saved with .m4a extension
- Audio transcription pipeline is triggered correctly
- Agent receives transcript in ctx.Transcript

## Testing

The fix has been verified against the magic bytes from the issue:
```
00 00 00 1c 66 74 79 70 4d 34 41 20
                ftyp M4A
```

The subBrand at bytes 8-11 is 'M4A ' which now correctly returns 'audio/mp4'.

## Files Changed

- `src/line/download.ts`: Modified `detectContentType()` function