### PR TITLE
fix: deduplicate repeated invalid-config warning logs

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -82,6 +82,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
+const loggedConfigWarnings = new Set<string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -729,7 +730,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        const warningKey = `${configPath}:${details}`;
+        if (!loggedConfigWarnings.has(warningKey)) {
+          loggedConfigWarnings.add(warningKey);
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(
@@ -1075,7 +1080,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const details = validated.warnings
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
-      deps.logger.warn(`Config warnings:\n${details}`);
+      const warningKey = `write:${details}`;
+      if (!loggedConfigWarnings.has(warningKey)) {
+        loggedConfigWarnings.add(warningKey);
+        deps.logger.warn(`Config warnings:\n${details}`);
+      }
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -314,7 +314,7 @@ describe("startGatewayConfigReloader", () => {
     expect(onRestart).not.toHaveBeenCalled();
     // The warning should have been logged exactly once
     const warnCalls = log.warn.mock.calls.filter(
-      ([msg]: [string]) => typeof msg === "string" && msg.includes("invalid config"),
+      ([msg]: unknown[]) => typeof msg === "string" && msg.includes("invalid config"),
     );
     expect(warnCalls).toHaveLength(1);
     expect(warnCalls[0][0]).toContain("gateway.port: must be a number");
@@ -356,7 +356,7 @@ describe("startGatewayConfigReloader", () => {
 
     expect(readSnapshot).toHaveBeenCalledTimes(3);
     const warnCalls = log.warn.mock.calls.filter(
-      ([msg]: [string]) => typeof msg === "string" && msg.includes("invalid config"),
+      ([msg]: unknown[]) => typeof msg === "string" && msg.includes("invalid config"),
     );
     expect(warnCalls).toHaveLength(2);
     expect(onHotReload).toHaveBeenCalledTimes(1); // the valid snapshot triggers hot reload

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -286,6 +286,84 @@ describe("startGatewayConfigReloader", () => {
     await reloader.stop();
   });
 
+  it("deduplicates repeated invalid config warnings", async () => {
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      issues: [{ path: "gateway.port", message: "must be a number" }],
+      hash: "invalid-1",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(invalidSnapshot);
+    const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
+
+    // First file change → should log the warning
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // Second file change with identical issues → should NOT log again
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // Third file change → still no duplicate
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledTimes(3);
+    expect(onHotReload).not.toHaveBeenCalled();
+    expect(onRestart).not.toHaveBeenCalled();
+    // The warning should have been logged exactly once
+    const warnCalls = log.warn.mock.calls.filter(
+      ([msg]: [string]) => typeof msg === "string" && msg.includes("invalid config"),
+    );
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0][0]).toContain("gateway.port: must be a number");
+
+    await reloader.stop();
+  });
+
+  it("re-logs invalid config warning after config becomes valid then invalid again", async () => {
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      issues: [{ path: "gateway.port", message: "must be a number" }],
+      hash: "invalid-1",
+    });
+    const validSnapshot = makeSnapshot({
+      config: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      hash: "valid-1",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(invalidSnapshot)
+      .mockResolvedValueOnce(validSnapshot)
+      .mockResolvedValueOnce(invalidSnapshot);
+    const { watcher, onHotReload, log, reloader } = createReloaderHarness(readSnapshot);
+
+    // First: invalid → logs warning
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // Second: valid → clears dedup state
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // Third: invalid again with same issues → should log again
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledTimes(3);
+    const warnCalls = log.warn.mock.calls.filter(
+      ([msg]: [string]) => typeof msg === "string" && msg.includes("invalid config"),
+    );
+    expect(warnCalls).toHaveLength(2);
+    expect(onHotReload).toHaveBeenCalledTimes(1); // the valid snapshot triggers hot reload
+
+    await reloader.stop();
+  });
+
   it("contains restart callback failures and retries on subsequent changes", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -272,6 +272,7 @@ export function startGatewayConfigReloader(opts: {
   let stopped = false;
   let restartQueued = false;
   let missingConfigRetries = 0;
+  let lastInvalidIssues: string | null = null;
 
   const scheduleAfter = (wait: number) => {
     if (stopped) {
@@ -323,10 +324,14 @@ export function startGatewayConfigReloader(opts: {
 
   const handleInvalidSnapshot = (snapshot: ConfigFileSnapshot): boolean => {
     if (snapshot.valid) {
+      lastInvalidIssues = null;
       return false;
     }
     const issues = snapshot.issues.map((issue) => `${issue.path}: ${issue.message}`).join(", ");
-    opts.log.warn(`config reload skipped (invalid config): ${issues}`);
+    if (issues !== lastInvalidIssues) {
+      lastInvalidIssues = issues;
+      opts.log.warn(`config reload skipped (invalid config): ${issues}`);
+    }
     return true;
   };
 


### PR DESCRIPTION
## Summary

Closes #29745

When a config file stays invalid across multiple file-watch events (e.g. user is mid-edit), the gateway config reloader logs the same warning on **every** event. In busy environments with editors that trigger rapid saves, this can produce hundreds of duplicate lines per minute and inflate error logs by ~1 GB/day.

This PR adds deduplication at two levels:

- **`config-reload.ts`** — `handleInvalidSnapshot()` now tracks the last set of validation issues and only logs `config reload skipped (invalid config): …` when the issues text actually changes. The dedup state resets when the config becomes valid again.

- **`io.ts`** — Config warning logs in `readConfigFileSnapshot()` and the config-write path are now deduplicated via a module-level `Set<string>`, keyed by `configPath + details`.

## Changes

| File | Change |
|------|--------|
| `src/gateway/config-reload.ts` | Add `lastInvalidIssues` state + dedup check in `handleInvalidSnapshot()` |
| `src/config/io.ts` | Add `loggedConfigWarnings` Set + dedup guards on 2 warning log sites |
| `src/gateway/config-reload.test.ts` | 2 new tests: dedup across repeated invalids, re-log after valid→invalid cycle |

## Test plan

- [x] `vitest run src/gateway/config-reload.test.ts` — 16 tests pass (14 existing + 2 new)
- [ ] Manual: edit `openclaw.json` to introduce a validation error, save repeatedly, verify only one warning in logs
- [ ] Manual: fix the error, re-introduce it → verify warning appears again

🤖 Generated with [Claude Code](https://claude.com/claude-code)