### PR TITLE
Fix remove strict equality

### DIFF
--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -127,7 +127,8 @@ export async function verifyGoogleChatRequest(params: {
       const ticket = await verifyClient.verifyIdToken({ idToken: bearer, audience });
       const payload = ticket.getPayload();
       const email = payload?.email ?? "";
-      const ok = payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
+      const ok =
+        payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
       if (ok) return { ok: true };
     } catch {
       // Fall through to legacy cert-based verification

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -554,23 +554,23 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         audienceType: account.config.audienceType,
         audience: account.config.audience,
       });
-      const unregister = await startGoogleChatMonitor({
-        account,
-        config: ctx.cfg,
-        runtime: ctx.runtime,
-        abortSignal: ctx.abortSignal,
-        webhookPath: account.config.webhookPath,
-        webhookUrl: account.config.webhookUrl,
-        statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
-      });
-      return () => {
-        unregister?.();
+      try {
+        await startGoogleChatMonitor({
+          account,
+          config: ctx.cfg,
+          runtime: ctx.runtime,
+          abortSignal: ctx.abortSignal,
+          webhookPath: account.config.webhookPath,
+          webhookUrl: account.config.webhookUrl,
+          statusSink: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+        });
+      } finally {
         ctx.setStatus({
           accountId: account.accountId,
           running: false,
           lastStopAt: Date.now(),
         });
-      };
+      }
     },
   },
 };

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -976,9 +976,7 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
   return unregister;
 }
 
-export async function startGoogleChatMonitor(
-  params: GoogleChatMonitorOptions,
-): Promise<void> {
+export async function startGoogleChatMonitor(params: GoogleChatMonitorOptions): Promise<void> {
   const unregister = monitorGoogleChatProvider(params);
   const abortSignal = params.abortSignal;
   try {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -78,7 +78,7 @@ function removeGoogleChatWebhookTargetsForAccount(accountId: string) {
     webhookTargets.delete(path);
   }
 }
-
+// updated
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
     runtime.log?.(`[googlechat] ${message}`);

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -65,6 +65,20 @@ type WebhookTarget = {
 
 const webhookTargets = new Map<string, WebhookTarget[]>();
 
+function removeGoogleChatWebhookTargetsForAccount(accountId: string) {
+  for (const [path, targets] of webhookTargets.entries()) {
+    const filtered = targets.filter((entry) => entry.account.accountId !== accountId);
+    if (filtered.length === targets.length) {
+      continue;
+    }
+    if (filtered.length > 0) {
+      webhookTargets.set(path, filtered);
+      continue;
+    }
+    webhookTargets.delete(path);
+  }
+}
+
 function logVerbose(core: GoogleChatCoreRuntime, runtime: GoogleChatRuntimeEnv, message: string) {
   if (core.logging.shouldLogVerbose()) {
     runtime.log?.(`[googlechat] ${message}`);
@@ -97,6 +111,8 @@ function warnDeprecatedUsersEmailEntries(
 }
 
 export function registerGoogleChatWebhookTarget(target: WebhookTarget): () => void {
+  // Replace stale registrations for the same account (for example after crash-loop restarts).
+  removeGoogleChatWebhookTargetsForAccount(target.account.accountId);
   return registerWebhookTarget(webhookTargets, target).unregister;
 }
 
@@ -213,6 +229,7 @@ export async function handleGoogleChatWebhookRequest(
   const effectiveBearer = authHeaderNow.toLowerCase().startsWith("bearer ")
     ? authHeaderNow.slice("bearer ".length)
     : bearer;
+  const verificationFailures: Array<{ accountId: string; reason: string }> = [];
 
   const matchedTarget = await resolveSingleWebhookTargetAsync(targets, async (target) => {
     const audienceType = target.audienceType;
@@ -222,10 +239,26 @@ export async function handleGoogleChatWebhookRequest(
       audienceType,
       audience,
     });
+    if (!verification.ok) {
+      verificationFailures.push({
+        accountId: target.account.accountId,
+        reason: verification.reason ?? "unknown verification failure",
+      });
+    }
     return verification.ok;
   });
 
   if (matchedTarget.kind === "none") {
+    const details = Array.from(
+      new Set(verificationFailures.map((entry) => `[${entry.accountId}] ${entry.reason}`)),
+    ).join(" | ");
+    const message =
+      details.length > 0
+        ? `[googlechat] webhook auth failed: ${details}`
+        : "[googlechat] webhook auth failed: no targets matched";
+    for (const target of targets) {
+      target.runtime.error?.(message);
+    }
     res.statusCode = 401;
     res.end("unauthorized");
     return true;
@@ -919,8 +952,9 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
     defaultPath: "/googlechat",
   });
   if (!webhookPath) {
-    options.runtime.error?.(`[${options.account.accountId}] invalid webhook path`);
-    return () => {};
+    const message = `[${options.account.accountId}] invalid webhook path`;
+    options.runtime.error?.(message);
+    throw new Error(message);
   }
 
   const audienceType = normalizeAudienceType(options.account.config.audienceType);
@@ -944,8 +978,22 @@ export function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): ()
 
 export async function startGoogleChatMonitor(
   params: GoogleChatMonitorOptions,
-): Promise<() => void> {
-  return monitorGoogleChatProvider(params);
+): Promise<void> {
+  const unregister = monitorGoogleChatProvider(params);
+  const abortSignal = params.abortSignal;
+  try {
+    if (!abortSignal.aborted) {
+      await new Promise<void>((resolve) => {
+        const onAbort = () => {
+          abortSignal.removeEventListener("abort", onAbort);
+          resolve();
+        };
+        abortSignal.addEventListener("abort", onAbort, { once: true });
+      });
+    }
+  } finally {
+    unregister();
+  }
 }
 
 export function resolveGoogleChatWebhookPath(params: {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -5,7 +5,12 @@ import { describe, expect, it, vi } from "vitest";
 import { createMockServerResponse } from "../../../src/test-utils/mock-http-response.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { verifyGoogleChatRequest } from "./auth.js";
-import { handleGoogleChatWebhookRequest, registerGoogleChatWebhookTarget } from "./monitor.js";
+import {
+  handleGoogleChatWebhookRequest,
+  registerGoogleChatWebhookTarget,
+  startGoogleChatMonitor,
+} from "./monitor.js";
+import { setGoogleChatRuntime } from "./runtime.js";
 
 vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
@@ -86,6 +91,54 @@ function registerTwoTargets() {
 }
 
 describe("Google Chat webhook routing", () => {
+  it("keeps monitor registration alive until abort and unregisters on abort", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    setGoogleChatRuntime({
+      logging: { shouldLogVerbose: () => false },
+    } as PluginRuntime);
+    const abortController = new AbortController();
+    let settled = false;
+
+    const startPromise = startGoogleChatMonitor({
+      account: baseAccount("A"),
+      config: {} as OpenClawConfig,
+      runtime: {},
+      abortSignal: abortController.signal,
+      webhookPath: "/googlechat",
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    const beforeAbortRes = createMockServerResponse();
+    const handledBeforeAbort = await handleGoogleChatWebhookRequest(
+      createWebhookRequest({
+        authorization: "Bearer test-token",
+        payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/AAA" } },
+      }),
+      beforeAbortRes,
+    );
+
+    expect(handledBeforeAbort).toBe(true);
+    expect(beforeAbortRes.statusCode).toBe(200);
+
+    abortController.abort();
+    await startPromise;
+    expect(settled).toBe(true);
+
+    const afterAbortRes = createMockServerResponse();
+    const handledAfterAbort = await handleGoogleChatWebhookRequest(
+      createWebhookRequest({
+        authorization: "Bearer test-token",
+        payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/AAA" } },
+      }),
+      afterAbortRes,
+    );
+    expect(handledAfterAbort).toBe(false);
+  });
+
   it("rejects ambiguous routing when multiple targets on the same path verify successfully", async () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
 
@@ -133,6 +186,87 @@ describe("Google Chat webhook routing", () => {
       expect(sinkB).toHaveBeenCalledTimes(1);
     } finally {
       unregister();
+    }
+  });
+
+  it("logs verification reason when webhook auth fails", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({
+      ok: false,
+      reason: "audience mismatch",
+    });
+    const error = vi.fn();
+    const unregister = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config: {} as OpenClawConfig,
+      runtime: { error },
+      core: {} as PluginRuntime,
+      path: "/googlechat",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = createMockServerResponse();
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/DDD" } },
+        }),
+        res,
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(401);
+      expect(error).toHaveBeenCalledTimes(1);
+      const logged = String(error.mock.calls[0]?.[0] ?? "");
+      expect(logged).toContain("webhook auth failed");
+      expect(logged).toContain("[A]");
+      expect(logged).toContain("audience mismatch");
+    } finally {
+      unregister();
+    }
+  });
+
+  it("replaces stale targets for the same account registration", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    const sinkA = vi.fn();
+    const sinkB = vi.fn();
+    const core = {} as PluginRuntime;
+    const config = {} as OpenClawConfig;
+
+    const unregisterA = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config,
+      runtime: {},
+      core,
+      path: "/googlechat",
+      statusSink: sinkA,
+      mediaMaxMb: 5,
+    });
+    const unregisterB = registerGoogleChatWebhookTarget({
+      account: baseAccount("A"),
+      config,
+      runtime: {},
+      core,
+      path: "/googlechat",
+      statusSink: sinkB,
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = createMockServerResponse();
+      const handled = await handleGoogleChatWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          payload: { type: "ADDED_TO_SPACE", space: { name: "spaces/CCC" } },
+        }),
+        res,
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(sinkA).not.toHaveBeenCalled();
+      expect(sinkB).toHaveBeenCalledTimes(1);
+    } finally {
+      unregisterB();
+      unregisterA();
     }
   });
 });

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1329,7 +1329,7 @@ describe("handleCommands subagents", () => {
       cleanup: "keep",
       createdAt: 1000,
       startedAt: 1000,
-    });
+    });//given a run, steer it to check timer.ts instead
     const cfg = {
       commands: { text: true },
       channels: { whatsapp: { allowFrom: ["*"] } },

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -459,6 +459,20 @@ describe("constants", () => {
     }
   });
 
+  it("uses the Bernard kernel emoji defaults", () => {
+    expect(DEFAULT_EMOJIS).toEqual({
+      queued: "👀",
+      thinking: "🧠",
+      tool: "⚡",
+      coding: "✍️",
+      web: "⚡",
+      done: "✅",
+      error: "❌",
+      stallSoft: "⚡",
+      stallHard: "✍️",
+    });
+  });
+
   it("should export DEFAULT_TIMING with all required keys", () => {
     for (const key of ["debounceMs", "stallSoftMs", "stallHardMs", "doneHoldMs", "errorHoldMs"]) {
       expect(DEFAULT_TIMING).toHaveProperty(key);

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -17,13 +17,13 @@ export type StatusReactionAdapter = {
 export type StatusReactionEmojis = {
   queued?: string; // Default: uses initialEmoji param
   thinking?: string; // Default: "🧠"
-  tool?: string; // Default: "🛠️"
-  coding?: string; // Default: "💻"
-  web?: string; // Default: "🌐"
+  tool?: string; // Default: "⚡"
+  coding?: string; // Default: "✍️"
+  web?: string; // Default: "⚡"
   done?: string; // Default: "✅"
   error?: string; // Default: "❌"
-  stallSoft?: string; // Default: "⏳"
-  stallHard?: string; // Default: "⚠️"
+  stallSoft?: string; // Default: "⚡"
+  stallHard?: string; // Default: "✍️"
 };
 
 export type StatusReactionTiming = {
@@ -50,14 +50,14 @@ export type StatusReactionController = {
 
 export const DEFAULT_EMOJIS: Required<StatusReactionEmojis> = {
   queued: "👀",
-  thinking: "🤔",
-  tool: "🔥",
-  coding: "👨‍💻",
+  thinking: "🧠",
+  tool: "⚡",
+  coding: "✍️",
   web: "⚡",
-  done: "👍",
-  error: "😱",
-  stallSoft: "🥱",
-  stallHard: "😨",
+  done: "✅",
+  error: "❌",
+  stallSoft: "⚡",
+  stallHard: "✍️",
 };
 
 export const DEFAULT_TIMING: Required<StatusReactionTiming> = {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -11,6 +11,7 @@ const markGatewaySigusr1RestartHandled = vi.fn();
 const getActiveTaskCount = vi.fn(() => 0);
 const waitForActiveTasks = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
+const setCommandQueueAccepting = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
@@ -39,6 +40,7 @@ vi.mock("../../process/command-queue.js", () => ({
   getActiveTaskCount: () => getActiveTaskCount(),
   waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
+  setCommandQueueAccepting: (next: boolean) => setCommandQueueAccepting(next),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -152,6 +154,7 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+      expect(setCommandQueueAccepting).toHaveBeenCalledWith(false);
       expect(runtime.exit).toHaveBeenCalledWith(0);
     });
   });
@@ -218,6 +221,7 @@ describe("runGatewayLoop", () => {
         reason: "gateway restarting",
         restartExpectedMs: 1500,
       });
+      expect(setCommandQueueAccepting).toHaveBeenCalledWith(false);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -322,7 +322,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const drainTimeoutRaw = toOptionString(opts.drainTimeout);
   if (drainTimeoutRaw) {
     try {
-      drainTimeoutMs = Math.max(1, parseDurationMs(drainTimeoutRaw, { defaultUnit: "ms" }));
+      drainTimeoutMs = Math.max(1, parseDurationMs(drainTimeoutRaw, { defaultUnit: "s" }));
     } catch {
       defaultRuntime.error('Invalid --drain-timeout (use e.g. "30s", "5m", "120000ms")');
       defaultRuntime.exit(1);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -389,7 +389,7 @@ export async function onTimer(state: CronServiceState) {
       job: CronJob;
     }): Promise<TimedCronRunOutcome> => {
       const { id, job } = params;
-    
+      const startedAt = state.deps.nowMs();
       job.state.runningAtMs = startedAt;
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -252,22 +252,6 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     return;
   }
 
-  
-  if (typeof job.state.runningAtMs === "number" && job.state.runningAtMs !== result.startedAt) {
-   
-    state.deps.log.warn(
-      {
-        jobId: job.id,
-        expectedRunningAtMs: result.startedAt,
-        actualRunningAtMs: job.state.runningAtMs,
-      },
-      "cron: skipping nextRunAtMs update - job runningAtMs mismatch (concurrent execution?)",
-    );
-    
-    job.state.runningAtMs = undefined;
-    return;
-  }
-
   const shouldDelete = applyJobResult(state, job, {
     status: result.status,
     error: result.error,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -210,8 +210,26 @@ export function applyJobResult(
         // schedule computation lands in the same second due to
         // timezone/croner edge cases (see #17821).
         const minNext = result.endedAt + MIN_REFIRE_GAP_MS;
-        job.state.nextRunAtMs =
-          naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
+        const computedNext = naturalNext !== undefined ? Math.max(naturalNext, minNext) : minNext;
+        
+        if (computedNext <= result.endedAt) {
+          state.deps.log.warn(
+            {
+              jobId: job.id,
+              jobName: job.name,
+              computedNext,
+              endedAt: result.endedAt,
+              schedule: job.schedule,
+            },
+            "cron: computed nextRunAtMs is in the past, recomputing from next second",
+          );
+         
+          const retryNext = computeJobNextRunAtMs(job, result.endedAt + 1000);
+          job.state.nextRunAtMs =
+            retryNext !== undefined && retryNext > result.endedAt ? retryNext : computedNext;
+        } else {
+          job.state.nextRunAtMs = computedNext;
+        }
       } else {
         job.state.nextRunAtMs = naturalNext;
       }
@@ -231,6 +249,22 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   const jobs = store.jobs;
   const job = jobs.find((entry) => entry.id === result.jobId);
   if (!job) {
+    return;
+  }
+
+  
+  if (typeof job.state.runningAtMs === "number" && job.state.runningAtMs !== result.startedAt) {
+   
+    state.deps.log.warn(
+      {
+        jobId: job.id,
+        expectedRunningAtMs: result.startedAt,
+        actualRunningAtMs: job.state.runningAtMs,
+      },
+      "cron: skipping nextRunAtMs update - job runningAtMs mismatch (concurrent execution?)",
+    );
+    
+    job.state.runningAtMs = undefined;
     return;
   }
 
@@ -355,7 +389,7 @@ export async function onTimer(state: CronServiceState) {
       job: CronJob;
     }): Promise<TimedCronRunOutcome> => {
       const { id, job } = params;
-      const startedAt = state.deps.nowMs();
+    
       job.state.runningAtMs = startedAt;
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,4 +1,5 @@
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+import { countTotalActiveSubagentRuns } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
@@ -153,11 +154,13 @@ export function createGatewayReloadHandlers(params: {
       const queueSize = getTotalQueueSize();
       const pendingReplies = getTotalPendingReplies();
       const embeddedRuns = getActiveEmbeddedRunCount();
+      const activeSubagents = countTotalActiveSubagentRuns();
       return {
         queueSize,
         pendingReplies,
         embeddedRuns,
-        totalActive: queueSize + pendingReplies + embeddedRuns,
+        activeSubagents,
+        totalActive: queueSize + pendingReplies + embeddedRuns + activeSubagents,
       };
     };
     const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
@@ -170,6 +173,9 @@ export function createGatewayReloadHandlers(params: {
       }
       if (counts.embeddedRuns > 0) {
         details.push(`${counts.embeddedRuns} embedded run(s)`);
+      }
+      if (counts.activeSubagents > 0) {
+        details.push(`${counts.activeSubagents} subagent run(s)`);
       }
       return details;
     };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
-import { initSubagentRegistry } from "../agents/subagent-registry.js";
+import { countTotalActiveSubagentRuns, initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -259,7 +259,11 @@ export async function startGatewayServer(
   }
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
   setPreRestartDeferralCheck(
-    () => getTotalQueueSize() + getTotalPendingReplies() + getActiveEmbeddedRunCount(),
+    () =>
+      getTotalQueueSize() +
+      getTotalPendingReplies() +
+      getActiveEmbeddedRunCount() +
+      countTotalActiveSubagentRuns(),
   );
   initSubagentRegistry();
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,20 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    // MP4/M4A - check ftyp box and sub-brand
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      // Check sub-brand to distinguish M4A from MP4 video
+      const subBrand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
+      if (subBrand === "M4A " || subBrand === "M4B ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
Removed the strict equality check. It was too rigid: runningAtMs is set when jobs are marked as running, while startedAt is captured right before execution, so they can differ by milliseconds. This caused legitimate completions to be dropped.