### PR TITLE
chore(tts): rename TELEGRAM_OUTPUT to VOICE_BUBBLE_OUTPUT

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -66,7 +66,7 @@ const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   speed: 1.0,
 };
 
-const TELEGRAM_OUTPUT = {
+const VOICE_BUBBLE_OUTPUT = {
   openai: "opus" as const,
   // ElevenLabs output formats use codec_sample_rate_bitrate naming.
   // Opus @ 48kHz/64kbps is a good voice-note tradeoff for Telegram.
@@ -500,7 +500,7 @@ const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {
-    return TELEGRAM_OUTPUT;
+    return VOICE_BUBBLE_OUTPUT;
   }
   return DEFAULT_OUTPUT;
 }


### PR DESCRIPTION
## Summary

- Problem: `TELEGRAM_OUTPUT` constant name implies Telegram-only, but it's used for all channels that support voice-bubble playback (`telegram`, `feishu`, `whatsapp`).
- Why it matters: Misleading name makes `resolveOutputFormat` harder to read and maintain.
- What changed: Renamed `TELEGRAM_OUTPUT` → `VOICE_BUBBLE_OUTPUT` in `src/tts/tts.ts` (definition + reference).
- What did NOT change: Behavior, format values, and channel set are untouched.