### PR TITLE
fix(memory): await sync in search() to prevent race condition after restart

### DIFF
--- a/src/memory/manager.async-search.test.ts
+++ b/src/memory/manager.async-search.test.ts
@@ -59,46 +59,66 @@ describe("memory search async sync", () => {
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 
-  it("does not await sync when searching", async () => {
+  it("awaits sync before returning search results", async () => {
     const cfg = buildConfig();
     manager = await createMemoryManagerOrThrow(cfg);
 
-    const pending = new Promise<void>(() => {});
-    const syncMock = vi.fn(async () => pending);
-    (manager as unknown as { sync: () => Promise<void> }).sync = syncMock;
+    // Track whether sync completed before search returned
+    const callOrder: string[] = [];
+    const originalSync = (
+      manager as unknown as { sync: (...args: unknown[]) => Promise<void> }
+    ).sync.bind(manager);
 
-    const activeManager = manager;
-    if (!activeManager) {
-      throw new Error("manager missing");
-    }
-    await activeManager.search("hello");
-    expect(syncMock).toHaveBeenCalledTimes(1);
+    (manager as unknown as { sync: (...args: unknown[]) => Promise<void> }).sync = vi.fn(
+      async (...args: unknown[]) => {
+        callOrder.push("sync-start");
+        await originalSync(...args);
+        callOrder.push("sync-end");
+      },
+    );
+
+    await manager.search("hello");
+    callOrder.push("search-done");
+
+    // Sync must have started AND completed before search resolved
+    expect(callOrder.indexOf("sync-start")).toBeLessThan(callOrder.indexOf("search-done"));
+    expect(callOrder.indexOf("sync-end")).toBeLessThan(callOrder.indexOf("search-done"));
   });
 
-  it("waits for in-flight search sync during close", async () => {
+  it("blocks search until sync completes (no race condition)", async () => {
     const cfg = buildConfig();
-    let releaseSync = () => {};
-    const syncGate = new Promise<void>((resolve) => {
-      releaseSync = () => resolve();
-    });
-    embedBatch.mockImplementation(async (input: string[]) => {
-      await syncGate;
-      return input.map(() => [0.3, 0.2, 0.1]);
-    });
-
     manager = await createMemoryManagerOrThrow(cfg);
-    await manager.search("hello");
 
-    let closed = false;
-    const closePromise = manager.close().then(() => {
-      closed = true;
+    let syncCompleted = false;
+    let resolveSync: () => void;
+    const syncGate = new Promise<void>((resolve) => {
+      resolveSync = resolve;
     });
 
-    await Promise.resolve();
-    expect(closed).toBe(false);
+    // Replace sync with a gated version
+    (manager as unknown as { sync: () => Promise<void> }).sync = vi.fn(async () => {
+      await syncGate;
+      syncCompleted = true;
+    });
 
-    releaseSync();
-    await closePromise;
-    manager = null;
+    // Start search (will block on sync)
+    let searchDone = false;
+    const searchPromise = manager.search("hello").then(() => {
+      searchDone = true;
+    });
+
+    // Give microtasks time to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Search should NOT have completed (sync is still blocked)
+    expect(searchDone).toBe(false);
+    expect(syncCompleted).toBe(false);
+
+    // Release sync
+    resolveSync!();
+    await searchPromise;
+
+    expect(syncCompleted).toBe(true);
+    expect(searchDone).toBe(true);
   });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -219,9 +219,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (key && this.sessionWarm.has(key)) {
       return;
     }
-    void this.sync({ reason: "session-start" }).catch((err) => {
+    try {
+      await this.sync({ reason: "session-start" });
+    } catch (err) {
       log.warn(`memory sync failed (session-start): ${String(err)}`);
-    });
+    }
     if (key) {
       this.sessionWarm.add(key);
     }
@@ -235,11 +237,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       sessionKey?: string;
     },
   ): Promise<MemorySearchResult[]> {
-    void this.warmSession(opts?.sessionKey);
+    await this.warmSession(opts?.sessionKey);
     if (this.settings.sync.onSearch && (this.dirty || this.sessionsDirty)) {
-      void this.sync({ reason: "search" }).catch((err) => {
+      try {
+        await this.sync({ reason: "search" });
+      } catch (err) {
         log.warn(`memory sync failed (search): ${String(err)}`);
-      });
+      }
     }
     const cleaned = query.trim();
     if (!cleaned) {


### PR DESCRIPTION
## Summary

After a gateway restart, the first `memory_search` call returns 0 results due to a race condition: `search()` fired `sync()` as fire-and-forget, proceeding to query before the vector index was rebuilt.

## Changes

- **`warmSession()`**: `await` the sync call instead of fire-and-forget (`void`)
- **`search()`**: `await this.warmSession()` and `await this.sync()` when dirty, ensuring the index is ready before querying
- Updated tests to verify the new blocking behavior

## Root Cause

```js
// Before (fire-and-forget — search races ahead of sync)
void this.warmSession(opts?.sessionKey);
void this.sync({ reason: 'search' }).catch(...);
// ... proceeds to query empty index → 0 results

// After (await — search waits for index)
await this.warmSession(opts?.sessionKey);
await this.sync({ reason: 'search' });
```

## Performance

The sync guard (`if (this.dirty || this.sessionsDirty)`) ensures `sync()` is only awaited on the first call after restart. Once sync completes and `dirty` is cleared, subsequent searches skip it entirely. The `sync()` method also deduplicates concurrent calls via `this.syncing`.

Fixes #29588

Signed-off-by: sxu75374 <imshuaixu@gmail.com>