### PR TITLE
fix(config): migrate legacy discord allowlist aliases and agent routing keys

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -54,8 +54,8 @@ jobs:
           ACTIONLINT_VERSION="1.7.11"
           archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
-          curl -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
+          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -130,6 +130,38 @@ describe("legacy config detection", () => {
     ).toBeUndefined();
   });
 
+  it("drops empty legacy discord allowlist aliases without migrating to allowFrom", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          allowlist: [],
+          accounts: {
+            ops: { allowlist: [] },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain("Removed channels.discord.allowlist.");
+    expect(res.changes).toContain("Removed channels.discord.accounts.ops.allowlist.");
+    expect(res.config?.channels?.discord?.allowFrom).toBeUndefined();
+    expect(res.config?.channels?.discord?.accounts?.ops?.allowFrom).toBeUndefined();
+    expect(
+      (
+        res.config?.channels?.discord as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.allowlist,
+    ).toBeUndefined();
+    expect(
+      (
+        res.config?.channels?.discord?.accounts?.ops as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.allowlist,
+    ).toBeUndefined();
+  });
+
   it("migrates legacy agents.list routing entries", async () => {
     const res = migrateLegacyConfig({
       agents: {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -162,6 +162,30 @@ describe("legacy config detection", () => {
     ).toBeUndefined();
   });
 
+  it("keeps dm.allowFrom authoritative when removing legacy discord allowlist aliases", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          dm: { allowFrom: ["111"] },
+          allowlist: ["legacy-top"],
+          accounts: {
+            ops: {
+              dm: { allowFrom: ["222"] },
+              allowlist: ["legacy-account"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain("Removed channels.discord.allowlist.");
+    expect(res.changes).toContain("Removed channels.discord.accounts.ops.allowlist.");
+    expect(res.config?.channels?.discord?.allowFrom).toBeUndefined();
+    expect(res.config?.channels?.discord?.dm?.allowFrom).toEqual(["111"]);
+    expect(res.config?.channels?.discord?.accounts?.ops?.allowFrom).toBeUndefined();
+    expect(res.config?.channels?.discord?.accounts?.ops?.dm?.allowFrom).toEqual(["222"]);
+  });
+
   it("migrates legacy agents.list routing entries", async () => {
     const res = migrateLegacyConfig({
       agents: {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -25,6 +25,35 @@ describe("legacy config detection", () => {
         input: { routing: { groupChat: { requireMention: false } } },
         expectedPath: "routing.groupChat.requireMention",
       },
+      {
+        name: "channels.discord.accounts.*.allowlist",
+        input: {
+          channels: {
+            discord: {
+              accounts: {
+                ops: {
+                  allowlist: ["1234567890"],
+                },
+              },
+            },
+          },
+        },
+        expectedPath: "channels.discord",
+      },
+      {
+        name: "agents.list[].routing",
+        input: {
+          agents: {
+            list: [
+              {
+                id: "main",
+                routing: { groupChat: { mentionPatterns: ["@openclaw"] } },
+              },
+            ],
+          },
+        },
+        expectedPath: "agents.list",
+      },
     ] as const;
     for (const testCase of cases) {
       const res = validateConfigObject(testCase.input);
@@ -33,6 +62,94 @@ describe("legacy config detection", () => {
         expect(res.issues[0]?.path, testCase.name).toBe(testCase.expectedPath);
       }
     }
+  });
+
+  it("migrates legacy discord allowlist aliases", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          allowFrom: ["111"],
+          allowlist: ["222"],
+          groupAllowFrom: ["333"],
+          accounts: {
+            ops: { allowlist: ["123"], groupAllowFrom: ["456"] },
+            work: { allowFrom: ["789"], allowlist: ["999"] },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain("Removed channels.discord.allowlist.");
+    expect(res.changes).toContain(
+      "Removed channels.discord.groupAllowFrom (unsupported for Discord).",
+    );
+    expect(res.changes).toContain(
+      "Moved channels.discord.accounts.ops.allowlist → channels.discord.accounts.ops.allowFrom.",
+    );
+    expect(res.changes).toContain(
+      "Removed channels.discord.accounts.ops.groupAllowFrom (unsupported for Discord).",
+    );
+    expect(res.changes).toContain("Removed channels.discord.accounts.work.allowlist.");
+    expect(res.config?.channels?.discord?.allowFrom).toEqual(["111"]);
+    expect(
+      (
+        res.config?.channels?.discord as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.allowlist,
+    ).toBeUndefined();
+    expect(
+      (
+        res.config?.channels?.discord as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.groupAllowFrom,
+    ).toBeUndefined();
+    expect(res.config?.channels?.discord?.accounts?.ops?.allowFrom).toEqual(["123"]);
+    expect(
+      (
+        res.config?.channels?.discord?.accounts?.ops as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.allowlist,
+    ).toBeUndefined();
+    expect(
+      (
+        res.config?.channels?.discord?.accounts?.ops as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.groupAllowFrom,
+    ).toBeUndefined();
+    expect(res.config?.channels?.discord?.accounts?.work?.allowFrom).toEqual(["789"]);
+    expect(
+      (
+        res.config?.channels?.discord?.accounts?.work as
+          | { allowlist?: unknown; groupAllowFrom?: unknown }
+          | undefined
+      )?.allowlist,
+    ).toBeUndefined();
+  });
+
+  it("migrates legacy agents.list routing entries", async () => {
+    const res = migrateLegacyConfig({
+      agents: {
+        list: [
+          {
+            id: "main",
+            routing: { groupChat: { mentionPatterns: ["@openclaw"] } },
+          },
+        ],
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Moved agents.list (id "main").routing.groupChat.mentionPatterns → agents.list (id "main").groupChat.mentionPatterns.',
+    );
+    expect(res.changes).toContain('Removed agents.list (id "main").routing.');
+    expect(res.config?.agents?.list?.[0]?.groupChat?.mentionPatterns).toEqual(["@openclaw"]);
+    expect(
+      (res.config?.agents?.list?.[0] as { routing?: unknown } | undefined)?.routing,
+    ).toBeUndefined();
   });
 
   it("migrates or drops routing.allowFrom based on whatsapp configuration", async () => {

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -103,4 +103,28 @@ describe("legacy migrate mention routing", () => {
       (res.config?.channels?.telegram as { requireMention?: unknown } | undefined)?.requireMention,
     ).toBeUndefined();
   });
+
+  it("drops routing.agents.*.routing while preserving mention patterns", () => {
+    const res = migrateLegacyConfig({
+      routing: {
+        agents: {
+          main: {
+            routing: {
+              groupChat: { mentionPatterns: ["@openclaw"] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      'Moved routing.agents.main.routing.groupChat.mentionPatterns → agents.list (id "main").groupChat.mentionPatterns.',
+    );
+    expect(res.changes).toContain("Removed routing.agents.main.routing.");
+    expect(res.changes).toContain("Moved routing.agents → agents.list.");
+    expect(res.config?.agents?.list?.[0]?.groupChat?.mentionPatterns).toEqual(["@openclaw"]);
+    expect(
+      (res.config?.agents?.list?.[0] as { routing?: unknown } | undefined)?.routing,
+    ).toBeUndefined();
+  });
 });

--- a/src/config/legacy.migrations.part-2.ts
+++ b/src/config/legacy.migrations.part-2.ts
@@ -265,6 +265,26 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_2: LegacyConfigMigration[] = [
             entryCopy.sandbox = legacySandbox;
           }
 
+          const legacyNestedRouting = getRecord(entryCopy.routing);
+          const legacyNestedGroupChat = getRecord(legacyNestedRouting?.groupChat);
+          if (legacyNestedGroupChat?.mentionPatterns !== undefined) {
+            const groupChat = ensureRecord(target, "groupChat");
+            if (groupChat.mentionPatterns === undefined) {
+              groupChat.mentionPatterns = legacyNestedGroupChat.mentionPatterns;
+              changes.push(
+                `Moved routing.agents.${agentId}.routing.groupChat.mentionPatterns → agents.list (id "${agentId}").groupChat.mentionPatterns.`,
+              );
+            } else {
+              changes.push(
+                `Removed routing.agents.${agentId}.routing.groupChat.mentionPatterns (agents.list groupChat mentionPatterns already set).`,
+              );
+            }
+          }
+          if (Object.prototype.hasOwnProperty.call(entryCopy, "routing")) {
+            delete entryCopy.routing;
+            changes.push(`Removed routing.agents.${agentId}.routing.`);
+          }
+
           mergeMissing(target, entryCopy);
         }
         delete routing.agents;

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -231,7 +231,7 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
       const normalizeEntry = (entry: Record<string, unknown>, prefix: string) => {
         if (Object.prototype.hasOwnProperty.call(entry, "allowlist")) {
           const legacyAllowlist = Array.isArray(entry.allowlist) ? entry.allowlist : undefined;
-          if (entry.allowFrom === undefined && legacyAllowlist) {
+          if (entry.allowFrom === undefined && legacyAllowlist && legacyAllowlist.length > 0) {
             entry.allowFrom = legacyAllowlist;
             changes.push(`Moved ${prefix}.allowlist → ${prefix}.allowFrom.`);
           } else {

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -231,7 +231,14 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
       const normalizeEntry = (entry: Record<string, unknown>, prefix: string) => {
         if (Object.prototype.hasOwnProperty.call(entry, "allowlist")) {
           const legacyAllowlist = Array.isArray(entry.allowlist) ? entry.allowlist : undefined;
-          if (entry.allowFrom === undefined && legacyAllowlist && legacyAllowlist.length > 0) {
+          const legacyDm = getRecord(entry.dm);
+          const hasCanonicalDmAllowFrom = Array.isArray(legacyDm?.allowFrom);
+          if (
+            entry.allowFrom === undefined &&
+            !hasCanonicalDmAllowFrom &&
+            legacyAllowlist &&
+            legacyAllowlist.length > 0
+          ) {
             entry.allowFrom = legacyAllowlist;
             changes.push(`Moved ${prefix}.allowlist → ${prefix}.allowFrom.`);
           } else {

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -218,4 +218,89 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
       delete raw.identity;
     },
   },
+  {
+    id: "discord.allowlist-aliases-v2",
+    describe: "Normalize legacy Discord allowlist aliases",
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      const discord = getRecord(channels?.discord);
+      if (!discord) {
+        return;
+      }
+
+      const normalizeEntry = (entry: Record<string, unknown>, prefix: string) => {
+        if (Object.prototype.hasOwnProperty.call(entry, "allowlist")) {
+          const legacyAllowlist = Array.isArray(entry.allowlist) ? entry.allowlist : undefined;
+          if (entry.allowFrom === undefined && legacyAllowlist) {
+            entry.allowFrom = legacyAllowlist;
+            changes.push(`Moved ${prefix}.allowlist → ${prefix}.allowFrom.`);
+          } else {
+            changes.push(`Removed ${prefix}.allowlist.`);
+          }
+          delete entry.allowlist;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(entry, "groupAllowFrom")) {
+          delete entry.groupAllowFrom;
+          changes.push(`Removed ${prefix}.groupAllowFrom (unsupported for Discord).`);
+        }
+      };
+
+      normalizeEntry(discord, "channels.discord");
+
+      const accounts = getRecord(discord.accounts);
+      if (!accounts) {
+        return;
+      }
+      for (const [accountId, accountRaw] of Object.entries(accounts)) {
+        const account = getRecord(accountRaw);
+        if (!account) {
+          continue;
+        }
+        normalizeEntry(account, `channels.discord.accounts.${accountId}`);
+      }
+    },
+  },
+  {
+    id: "agents.list-routing-v2",
+    describe: "Remove legacy agents.list[].routing keys",
+    apply: (raw, changes) => {
+      const agents = getRecord(raw.agents);
+      const list = getAgentsList(agents);
+      if (list.length === 0) {
+        return;
+      }
+
+      for (const [index, entryRaw] of list.entries()) {
+        const entry = getRecord(entryRaw);
+        if (!entry || !Object.prototype.hasOwnProperty.call(entry, "routing")) {
+          continue;
+        }
+
+        const agentId =
+          typeof entry.id === "string" && entry.id.trim().length > 0
+            ? entry.id.trim()
+            : `index-${index}`;
+
+        const legacyRouting = getRecord(entry.routing);
+        const legacyGroupChat = getRecord(legacyRouting?.groupChat);
+        if (legacyGroupChat?.mentionPatterns !== undefined) {
+          const groupChat = ensureRecord(entry, "groupChat");
+          if (groupChat.mentionPatterns === undefined) {
+            groupChat.mentionPatterns = legacyGroupChat.mentionPatterns;
+            changes.push(
+              `Moved agents.list (id "${agentId}").routing.groupChat.mentionPatterns → agents.list (id "${agentId}").groupChat.mentionPatterns.`,
+            );
+          } else {
+            changes.push(
+              `Removed agents.list (id "${agentId}").routing.groupChat.mentionPatterns (agents.list groupChat mentionPatterns already set).`,
+            );
+          }
+        }
+
+        delete entry.routing;
+        changes.push(`Removed agents.list (id "${agentId}").routing.`);
+      }
+    },
+  },
 ];

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -17,6 +17,35 @@ function hasLegacyThreadBindingTtlInAccounts(value: unknown): boolean {
   );
 }
 
+function hasLegacyDiscordAllowlistAliases(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const hasLegacyAliases = (entry: unknown): boolean =>
+    isRecord(entry) &&
+    (Object.prototype.hasOwnProperty.call(entry, "allowlist") ||
+      Object.prototype.hasOwnProperty.call(entry, "groupAllowFrom"));
+
+  if (hasLegacyAliases(value)) {
+    return true;
+  }
+
+  if (!isRecord(value.accounts)) {
+    return false;
+  }
+  return Object.values(value.accounts).some((account) => hasLegacyAliases(account));
+}
+
+function hasLegacyAgentListRoutingEntries(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some(
+    (entry) => isRecord(entry) && Object.prototype.hasOwnProperty.call(entry, "routing"),
+  );
+}
+
 export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
   {
     path: ["whatsapp"],
@@ -63,6 +92,18 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     message:
       "channels.discord.accounts.<id>.threadBindings.ttlHours was renamed to channels.discord.accounts.<id>.threadBindings.idleHours (auto-migrated on load).",
     match: (value) => hasLegacyThreadBindingTtlInAccounts(value),
+  },
+  {
+    path: ["channels", "discord"],
+    message:
+      "channels.discord.allowlist/groupAllowFrom aliases were removed; use allowFrom and guild/channel policy settings instead (auto-migrated on load).",
+    match: (value) => hasLegacyDiscordAllowlistAliases(value),
+  },
+  {
+    path: ["agents", "list"],
+    message:
+      "agents.list[].routing was removed; use top-level bindings/session routing settings instead (auto-migrated on load).",
+    match: (value) => hasLegacyAgentListRoutingEntries(value),
   },
   {
     path: ["routing", "allowFrom"],

--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -10,6 +10,7 @@ vi.mock("./discovery.js", () => ({
 
 vi.mock("./manifest.js", () => ({
   loadPluginManifest: (...args: unknown[]) => loadPluginManifestMock(...args),
+  shouldRejectHardlinkedPluginFiles: (origin: string) => origin !== "bundled",
 }));
 
 describe("bundled plugin sources", () => {
@@ -66,6 +67,12 @@ describe("bundled plugin sources", () => {
     const map = resolveBundledPluginSources({});
 
     expect(Array.from(map.keys())).toEqual(["feishu", "msteams"]);
+    expect(loadPluginManifestMock).toHaveBeenCalledWith("/app/extensions/feishu", {
+      rejectHardlinks: false,
+    });
+    expect(loadPluginManifestMock).toHaveBeenCalledWith("/app/extensions/msteams", {
+      rejectHardlinks: false,
+    });
     expect(map.get("feishu")).toEqual({
       pluginId: "feishu",
       localPath: "/app/extensions/feishu",

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -1,5 +1,5 @@
 import { discoverOpenClawPlugins } from "./discovery.js";
-import { loadPluginManifest } from "./manifest.js";
+import { loadPluginManifest, shouldRejectHardlinkedPluginFiles } from "./manifest.js";
 
 export type BundledPluginSource = {
   pluginId: string;
@@ -17,7 +17,9 @@ export function resolveBundledPluginSources(params: {
     if (candidate.origin !== "bundled") {
       continue;
     }
-    const manifest = loadPluginManifest(candidate.rootDir);
+    const manifest = loadPluginManifest(candidate.rootDir, {
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
+    });
     if (!manifest.ok) {
       continue;
     }

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -26,6 +26,18 @@ async function withStateDir<T>(stateDir: string, fn: () => Promise<T>) {
   );
 }
 
+async function withBundledDir<T>(bundledDir: string, fn: () => Promise<T>) {
+  const stateDir = makeTempDir();
+  return await withEnvAsync(
+    {
+      OPENCLAW_STATE_DIR: stateDir,
+      CLAWDBOT_STATE_DIR: undefined,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+    },
+    fn,
+  );
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     try {
@@ -121,6 +133,51 @@ describe("discoverOpenClawPlugins", () => {
     const ids = candidates.map((c) => c.idHint);
     expect(ids).toContain("pack/one");
     expect(ids).toContain("pack/two");
+  });
+
+  it("accepts hardlinked package manifests and entries for bundled plugins", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const bundledDir = makeTempDir();
+    const packageDir = path.join(bundledDir, "hardlink-pack");
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "package.json");
+    const outsideEntry = path.join(outsideDir, "entry.ts");
+    const linkedManifest = path.join(packageDir, "package.json");
+    const linkedEntry = path.join(packageDir, "entry.ts");
+
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({
+        name: "@openclaw/hardlink-pack",
+        openclaw: { extensions: ["./entry.ts"] },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(outsideEntry, "export default function bundledHardlinkPack() {}", "utf-8");
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const { candidates, diagnostics } = await withBundledDir(bundledDir, async () => {
+      return discoverOpenClawPlugins({});
+    });
+
+    const bundledIds = candidates
+      .filter((candidate) => candidate.origin === "bundled")
+      .map((candidate) => candidate.idHint);
+    expect(bundledIds).toContain("hardlink-pack");
+    expect(diagnostics.some((entry) => entry.message.includes("escapes package directory"))).toBe(
+      false,
+    );
   });
 
   it("derives unscoped ids for scoped packages", async () => {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -5,6 +5,7 @@ import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import {
   getPackageManifestMetadata,
+  shouldRejectHardlinkedPluginFiles,
   type OpenClawPackageManifest,
   type PackageManifest,
 } from "./manifest.js";
@@ -223,12 +224,16 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
-function readPackageManifest(dir: string): PackageManifest | null {
+function readPackageManifest(
+  dir: string,
+  options?: { rejectHardlinks?: boolean },
+): PackageManifest | null {
   const manifestPath = path.join(dir, "package.json");
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: options?.rejectHardlinks,
   });
   if (!opened.ok) {
     return null;
@@ -324,12 +329,14 @@ function resolvePackageEntrySource(params: {
   entryPath: string;
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
+  rejectHardlinks?: boolean;
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
   const opened = openBoundaryFileSync({
     absolutePath: source,
     rootPath: params.packageDir,
     boundaryLabel: "plugin package directory",
+    rejectHardlinks: params.rejectHardlinks,
   });
   if (!opened.ok) {
     params.diagnostics.push({
@@ -367,6 +374,7 @@ function discoverInDirectory(params: {
     });
     return;
   }
+  const rejectHardlinks = shouldRejectHardlinkedPluginFiles(params.origin);
 
   for (const entry of entries) {
     const fullPath = path.join(params.dir, entry.name);
@@ -393,7 +401,7 @@ function discoverInDirectory(params: {
       continue;
     }
 
-    const manifest = readPackageManifest(fullPath);
+    const manifest = readPackageManifest(fullPath, { rejectHardlinks });
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -403,6 +411,7 @@ function discoverInDirectory(params: {
           entryPath: extPath,
           sourceLabel: fullPath,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!resolved) {
           continue;
@@ -470,6 +479,7 @@ function discoverFromPath(params: {
   }
 
   const stat = fs.statSync(resolved);
+  const rejectHardlinks = shouldRejectHardlinkedPluginFiles(params.origin);
   if (stat.isFile()) {
     if (!isExtensionFile(resolved)) {
       params.diagnostics.push({
@@ -494,7 +504,7 @@ function discoverFromPath(params: {
   }
 
   if (stat.isDirectory()) {
-    const manifest = readPackageManifest(resolved);
+    const manifest = readPackageManifest(resolved, { rejectHardlinks });
     const extensions = manifest ? resolvePackageExtensions(manifest) : [];
 
     if (extensions.length > 0) {
@@ -504,6 +514,7 @@ function discoverFromPath(params: {
           entryPath: extPath,
           sourceLabel: resolved,
           diagnostics: params.diagnostics,
+          rejectHardlinks,
         });
         if (!source) {
           continue;

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -204,6 +204,56 @@ describe("loadOpenClawPlugins", () => {
     expectTelegramLoaded(registry);
   });
 
+  it("loads bundled plugins when manifest and entry files are hardlinked", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const bundledDir = makeTempDir();
+    const pluginDir = path.join(bundledDir, "hardlinked-bundled");
+    const storeDir = makeTempDir();
+    const linkedManifest = path.join(pluginDir, "openclaw.plugin.json");
+    const linkedEntry = path.join(pluginDir, "index.js");
+    const outsideManifest = path.join(storeDir, "openclaw.plugin.json");
+    const outsideEntry = path.join(storeDir, "index.js");
+
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "hardlinked-bundled", configSchema: EMPTY_PLUGIN_SCHEMA }, null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      outsideEntry,
+      'export default { id: "hardlinked-bundled", register() {} };',
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+      fs.linkSync(outsideEntry, linkedEntry);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          allow: ["hardlinked-bundled"],
+          entries: {
+            "hardlinked-bundled": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "hardlinked-bundled");
+    expect(record?.status).toBe("loaded");
+  });
+
   it("loads bundled channel plugins when channels.<id>.enabled=true", () => {
     setupBundledTelegramPlugin();
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -18,6 +18,7 @@ import {
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { shouldRejectHardlinkedPluginFiles } from "./manifest.js";
 import { isPathInside, safeStatSync } from "./path-safety.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { setActivePluginRegistry } from "./runtime.js";
@@ -530,6 +531,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       absolutePath: candidate.source,
       rootPath: pluginRoot,
       boundaryLabel: "plugin root",
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
       // Discovery stores rootDir as realpath but source may still be a lexical alias
       // (e.g. /var/... vs /private/var/... on macOS). Canonical boundary checks
       // still enforce containment; skip lexical pre-check to avoid false escapes.

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -198,6 +198,40 @@ describe("loadPluginManifestRegistry", () => {
     ).toBe(true);
   });
 
+  it("allows hardlinked manifests for bundled plugins", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = makeTempDir();
+    const outsideDir = makeTempDir();
+    const outsideManifest = path.join(outsideDir, "openclaw.plugin.json");
+    const linkedManifest = path.join(rootDir, "openclaw.plugin.json");
+    fs.writeFileSync(path.join(rootDir, "index.ts"), "export default function () {}", "utf-8");
+    fs.writeFileSync(
+      outsideManifest,
+      JSON.stringify({ id: "bundled-hardlink", configSchema: { type: "object" } }),
+      "utf-8",
+    );
+    try {
+      fs.linkSync(outsideManifest, linkedManifest);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+        return;
+      }
+      throw err;
+    }
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "bundled-hardlink",
+        rootDir,
+        origin: "bundled",
+      }),
+    ]);
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.id).toBe("bundled-hardlink");
+  });
+
   it("rejects manifest paths that escape plugin root via hardlink", () => {
     if (process.platform === "win32") {
       return;

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -3,7 +3,11 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
-import { loadPluginManifest, type PluginManifest } from "./manifest.js";
+import {
+  loadPluginManifest,
+  shouldRejectHardlinkedPluginFiles,
+  type PluginManifest,
+} from "./manifest.js";
 import { safeRealpathSync } from "./path-safety.js";
 import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } from "./types.js";
 
@@ -167,7 +171,9 @@ export function loadPluginManifestRegistry(params: {
   const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
-    const manifestRes = loadPluginManifest(candidate.rootDir);
+    const manifestRes = loadPluginManifest(candidate.rootDir, {
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles(candidate.origin),
+    });
     if (!manifestRes.ok) {
       diagnostics.push({
         level: "error",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
-import type { PluginConfigUiHint, PluginKind } from "./types.js";
+import type { PluginConfigUiHint, PluginKind, PluginOrigin } from "./types.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 export const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
@@ -42,12 +42,20 @@ export function resolvePluginManifestPath(rootDir: string): string {
   return path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
 }
 
-export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
+export function shouldRejectHardlinkedPluginFiles(origin: PluginOrigin): boolean {
+  return origin !== "bundled";
+}
+
+export function loadPluginManifest(
+  rootDir: string,
+  options?: { rejectHardlinks?: boolean },
+): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: rootDir,
     boundaryLabel: "plugin root",
+    rejectHardlinks: options?.rejectHardlinks,
   });
   if (!opened.ok) {
     if (opened.reason === "path") {


### PR DESCRIPTION
## Summary
- triaged #29780 and confirmed there are no linked/related fixing PRs in the issue metadata/search
- add legacy-config detection for invalid keys reported in crash loops:
  - `channels.discord(.accounts.*).allowlist`
  - `channels.discord(.accounts.*).groupAllowFrom`
  - `agents.list[].routing`
- add auto-migrations to repair those keys on startup/doctor flow:
  - migrate Discord `allowlist` -> `allowFrom` when safe, otherwise drop alias
  - drop Discord `groupAllowFrom` (unsupported)
  - drop `agents.list[].routing`, while preserving nested `groupChat.mentionPatterns` if present
  - also handle `routing.agents.*.routing` cleanup during legacy routing migration

## Why
When these stale keys exist in config, strict validation fails and gateway can enter a restart loop. This patch converts them into recognized config (or removes unsupported keys) through the existing legacy migration path.

## Tests
- `pnpm test src/config/legacy-migrate.test.ts src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`
- `pnpm check`

Closes #29780
