### PR TITLE
fix(plugins): uninstall leaves directory on disk, add --force to install

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -190,6 +190,11 @@
       - any-glob-to-any-file:
           - "src/agents/**"
 
+"plugins":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/plugins/**"
+
 "security":
   - changed-files:
       - any-glob-to-any-file:

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -518,8 +518,9 @@ export function registerPluginsCli(program: Command) {
     .description("Install a plugin (path, archive, or npm spec)")
     .argument("<path-or-spec>", "Path (.ts/.js/.zip/.tgz/.tar.gz) or an npm package spec")
     .option("-l, --link", "Link a local path instead of copying", false)
+    .option("--force", "Overwrite existing plugin installation", false)
     .option("--pin", "Record npm installs as exact resolved <name>@<version>", false)
-    .action(async (raw: string, opts: { link?: boolean; pin?: boolean }) => {
+    .action(async (raw: string, opts: { link?: boolean; force?: boolean; pin?: boolean }) => {
       const fileSpec = resolveFileNpmSpecToLocalPath(raw);
       if (fileSpec && !fileSpec.ok) {
         defaultRuntime.error(fileSpec.error);
@@ -571,6 +572,7 @@ export function registerPluginsCli(program: Command) {
         const result = await installPluginFromPath({
           path: resolved,
           logger: createPluginInstallLogger(),
+          mode: opts.force ? "update" : "install",
         });
         if (!result.ok) {
           defaultRuntime.error(result.error);
@@ -623,6 +625,7 @@ export function registerPluginsCli(program: Command) {
       const result = await installPluginFromNpmSpec({
         spec: raw,
         logger: createPluginInstallLogger(),
+        mode: opts.force ? "update" : "install",
       });
       if (!result.ok) {
         const bundledFallback = isPackageNotFoundInstallError(result.error)

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -534,7 +534,11 @@ export function registerPluginsCli(program: Command) {
         if (opts.link) {
           const existing = cfg.plugins?.load?.paths ?? [];
           const merged = Array.from(new Set([...existing, resolved]));
-          const probe = await installPluginFromPath({ path: resolved, dryRun: true });
+          const probe = await installPluginFromPath({
+            path: resolved,
+            dryRun: true,
+            mode: opts.force ? "update" : "install",
+          });
           if (!probe.ok) {
             defaultRuntime.error(probe.error);
             process.exit(1);

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -30,10 +30,6 @@ export function resolveUninstallDirectoryTarget(params: {
   installRecord?: PluginInstallRecord;
   extensionsDir?: string;
 }): string | null {
-  if (!params.hasInstall) {
-    return null;
-  }
-
   if (params.installRecord?.source === "path") {
     return null;
   }
@@ -43,6 +39,12 @@ export function resolveUninstallDirectoryTarget(params: {
     defaultPath = resolvePluginInstallDir(params.pluginId, params.extensionsDir);
   } catch {
     return null;
+  }
+
+  // No install record — still return the default path so the caller can
+  // delete the directory if it exists on disk (entry-only uninstall case).
+  if (!params.hasInstall) {
+    return defaultPath;
   }
 
   const configuredPath = params.installRecord?.installPath;


### PR DESCRIPTION
## Summary

- **`plugins uninstall`** now deletes the plugin directory even when only a `plugins.entries` record exists (no `plugins.installs` record). Previously it returned early and left the directory on disk, forcing users to manually `rm -rf ~/.openclaw/extensions/<id>` before reinstalling.
- **`plugins install --force`** adds a `--force` flag that passes `mode: "update"` to the install pipeline, allowing overwrite of an existing plugin directory instead of erroring with "plugin already exists (delete it first)".
- The `--force` flag also works with `--link` for linked local plugins.

## Test plan

- [x] New unit tests for `resolveUninstallDirectoryTarget` returning default path when `hasInstall` is false
- [x] New unit test for `uninstallPlugin` deleting directory with entry-only config (no install record)
- [x] Existing install/uninstall tests pass (42/42)
- [x] Manual verification: `plugins install --force <path>` overwrites existing plugin
- [x] TypeScript typecheck passes
- [x] Lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)