### PR TITLE
Security: stop writing plaintext openclaw.json.bak on config save

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -25,20 +25,20 @@ const screenMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./gateway.js", () => ({
-  callGatewayTool: (...args: unknown[]) => gatewayMocks.callGatewayTool(...args),
-  readGatewayCallOptions: (...args: unknown[]) => gatewayMocks.readGatewayCallOptions(...args),
+  callGatewayTool: gatewayMocks.callGatewayTool,
+  readGatewayCallOptions: gatewayMocks.readGatewayCallOptions,
 }));
 
 vi.mock("./nodes-utils.js", () => ({
-  resolveNodeId: (...args: unknown[]) => nodeUtilsMocks.resolveNodeId(...args),
-  listNodes: (...args: unknown[]) => nodeUtilsMocks.listNodes(...args),
-  resolveNodeIdFromList: (...args: unknown[]) => nodeUtilsMocks.resolveNodeIdFromList(...args),
+  resolveNodeId: nodeUtilsMocks.resolveNodeId,
+  listNodes: nodeUtilsMocks.listNodes,
+  resolveNodeIdFromList: nodeUtilsMocks.resolveNodeIdFromList,
 }));
 
 vi.mock("../../cli/nodes-screen.js", () => ({
-  parseScreenRecordPayload: (...args: unknown[]) => screenMocks.parseScreenRecordPayload(...args),
-  screenRecordTempPath: (...args: unknown[]) => screenMocks.screenRecordTempPath(...args),
-  writeScreenRecordToFile: (...args: unknown[]) => screenMocks.writeScreenRecordToFile(...args),
+  parseScreenRecordPayload: screenMocks.parseScreenRecordPayload,
+  screenRecordTempPath: screenMocks.screenRecordTempPath,
+  writeScreenRecordToFile: screenMocks.writeScreenRecordToFile,
 }));
 
 import { createNodesTool } from "./nodes-tool.js";

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -20,7 +20,6 @@ import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
-import { shortenHomePath } from "../utils.js";
 import {
   maybeRemoveDeprecatedCliAuthProfiles,
   maybeRepairAnthropicOAuthProfileId,
@@ -299,10 +298,6 @@ export async function doctorCommand(
     cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
     await writeConfigFile(cfg);
     logConfigUpdated(runtime);
-    const backupPath = `${CONFIG_PATH}.bak`;
-    if (fs.existsSync(backupPath)) {
-      runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
-    }
   } else if (!prompter.shouldRepair) {
     runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -15,7 +15,6 @@ import {
 } from "../infra/shell-env.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
-import { rotateConfigBackups } from "./backup-rotation.js";
 import {
   applyCompactionDefaults,
   applyContextPruningDefaults,
@@ -1160,7 +1159,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const changeSummary =
         typeof changedPathCount === "number" ? `, changedPaths=${changedPathCount}` : "";
       deps.logger.warn(
-        `Config overwrite: ${configPath} (sha256 ${previousHash ?? "unknown"} -> ${nextHash}, backup=${configPath}.bak${changeSummary})`,
+        `Config overwrite: ${configPath} (sha256 ${previousHash ?? "unknown"} -> ${nextHash}${changeSummary})`,
       );
     };
     const logConfigWriteAnomalies = () => {
@@ -1237,13 +1236,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         encoding: "utf-8",
         mode: 0o600,
       });
-
-      if (deps.fs.existsSync(configPath)) {
-        await rotateConfigBackups(configPath, deps.fs.promises);
-        await deps.fs.promises.copyFile(configPath, `${configPath}.bak`).catch(() => {
-          // best-effort
-        });
-      }
 
       try {
         await deps.fs.promises.rename(tmp, configPath);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -445,8 +445,8 @@ describe("config io write", () => {
         .find((entry) => typeof entry === "string" && entry.startsWith("Config overwrite:"));
       expect(typeof overwriteLog).toBe("string");
       expect(overwriteLog).toContain(configPath);
-      expect(overwriteLog).toContain(`${configPath}.bak`);
       expect(overwriteLog).toContain("sha256");
+      await expect(fs.stat(`${configPath}.bak`)).rejects.toThrow();
     });
   });
 

--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -84,8 +84,11 @@ function resolveAccountConfig(
 }
 
 function mergeTelegramAccountConfig(cfg: OpenClawConfig, accountId: string): TelegramAccountConfig {
-  const { accounts: _ignored, groups: channelGroups, ...base } = (cfg.channels?.telegram ??
-    {}) as TelegramAccountConfig & { accounts?: unknown };
+  const {
+    accounts: _ignored,
+    groups: channelGroups,
+    ...base
+  } = (cfg.channels?.telegram ?? {}) as TelegramAccountConfig & { accounts?: unknown };
   const account = resolveAccountConfig(cfg, accountId) ?? {};
 
   // In multi-account setups, channel-level `groups` must NOT be inherited by


### PR DESCRIPTION
## Summary

- Problem: config writes could leave a plaintext rollback backup (`openclaw.json.bak`) on disk.
- Why it matters: rollback backups can contain sensitive material and conflict with the one-way secret-handling posture.
- What changed:
  - Stopped writing plaintext `openclaw.json.bak` on config save.
  - Removed stale doctor backup-log dead code tied to the old backup behavior.
- What did NOT change (scope boundary): no config schema changes, no gateway protocol changes, no new auth or network behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #29784

## User-visible / Behavior Changes

- `openclaw.json.bak` is no longer written during config saves.
- `doctor` no longer reports stale backup-log behavior tied to that removed path.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Mitigation: removing plaintext backup writes reduces accidental secret-at-rest exposure.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): standard `~/.openclaw/openclaw.json`

### Steps

1. Run a config write operation that previously emitted `.bak`.
2. Inspect state dir for `openclaw.json.bak`.
3. Run doctor and verify stale backup-log path is gone.

### Expected

- No plaintext `.bak` file written.
- Doctor output no longer references removed backup-log behavior.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Config save no longer creates `openclaw.json.bak`.
  - Doctor path cleanup behaves as expected.
- Edge cases checked:
  - Existing config write flow remains functional.
- What you did **not** verify:
  - Full platform matrix beyond local environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert PR commits.
- Files/config to restore:
  - Restore `~/.openclaw/openclaw.json` from your own backup if needed.
- Known bad symptoms reviewers should watch for:
  - Workflows expecting auto-generated plaintext `.bak` files.

## Risks and Mitigations

- Risk: operators relying on `.bak` may lose that fallback expectation.
  - Mitigation: use explicit backup workflows (doctor guidance/docs), not plaintext auto-backups.

AI-assisted: yes.
Testing level: lightly tested.
