### PR TITLE
fix: align system prompt memory instructions with AGENTS.md

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -38,17 +38,29 @@ function buildMemorySection(params: {
   isMinimal: boolean;
   availableTools: Set<string>;
   citationsMode?: MemoryCitationsMode;
+  readToolName: string;
 }) {
   if (params.isMinimal) {
     return [];
   }
-  if (!params.availableTools.has("memory_search") && !params.availableTools.has("memory_get")) {
-    return [];
-  }
   const lines = [
     "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
+    "Before doing anything else:",
+    `1. Read SOUL.md — this is who you are (use \`${params.readToolName}\`)`,
+    "2. Read USER.md — this is who you're helping",
+    "3. Read memory/YYYY-MM-DD.md (today + yesterday) for recent context",
+    "4. If in MAIN SESSION (direct chat with your human): Also read MEMORY.md",
+    "Don't ask permission. Just do it.",
+    "",
+    "For targeted memory searches about prior work, decisions, dates, people, preferences, or todos:",
   ];
+  if (params.availableTools.has("memory_search") || params.availableTools.has("memory_get")) {
+    lines.push(
+      "You can use memory_search on MEMORY.md + memory/*.md, then use memory_get to pull specific lines if needed.",
+    );
+  } else {
+    lines.push("Read the relevant memory files directly using the read tool.");
+  }
   if (params.citationsMode === "off") {
     lines.push(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
@@ -402,6 +414,7 @@ export function buildAgentSystemPrompt(params: {
     isMinimal,
     availableTools,
     citationsMode: params.memoryCitationsMode,
+    readToolName,
   });
   const docsSection = buildDocsSection({
     docsPath: params.docsPath,


### PR DESCRIPTION
Resolves #29772

The hardcoded system prompt previously instructed agents to use memory_search and memory_get tools to pull only needed lines, which conflicted with AGENTS.md instructions to read entire files directly.

## Changes
- Updated \uildMemorySection\ to match AGENTS.md template instructions
- Agents now read SOUL.md, USER.md, and memory files directly at session start
- Memory tools (memory_search/memory_get) are now optional for targeted searches
- Maintains backward compatibility with memory tool availability checks

## Testing
- [x] No linter errors
- [ ] Manual testing recommended to verify agent behavior matches AGENTS.md expectations