### PR TITLE
fix(line): detect M4A voice messages as audio/mp4 instead of video/mp4

### DIFF
--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -67,3 +67,49 @@ describe("downloadLineMedia", () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("detectContentType via downloadLineMedia", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("detects M4A voice messages as audio/mp4", async () => {
+    // Real M4A magic bytes: 00 00 00 1c 66 74 79 70 4d 34 41 20
+    const m4a = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20, 0x00, 0x00, 0x00,
+      0x00,
+    ]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([m4a]));
+    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("mid", "token");
+    expect(result.contentType).toBe("audio/mp4");
+    expect(result.path).toMatch(/\.m4a$/);
+  });
+
+  it("detects M4B audiobook as audio/mp4", async () => {
+    const m4b = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x42, 0x20, 0x00, 0x00, 0x00,
+      0x00,
+    ]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([m4b]));
+    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("mid", "token");
+    expect(result.contentType).toBe("audio/mp4");
+  });
+
+  it("detects regular MP4 video as video/mp4", async () => {
+    // MP4 with 'mp42' brand
+    const mp4 = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32, 0x00, 0x00, 0x00,
+      0x00,
+    ]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([mp4]));
+    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("mid", "token");
+    expect(result.contentType).toBe("video/mp4");
+    expect(result.path).toMatch(/\.mp4$/);
+  });
+});

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,20 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    // MPEG-4 container (ftyp box) — check sub-brand to distinguish audio from video
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      const brand = String.fromCharCode(buffer[8], buffer[9], buffer[10], buffer[11]);
+      // M4A and M4B are audio-only MPEG-4 containers
+      if (brand === "M4A " || brand === "M4B ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Problem

`detectContentType()` in `src/line/download.ts` checks for the MPEG-4 `ftyp` magic bytes (positions 4-7) before the M4A-specific check. Since M4A files also have `ftyp` at positions 4-7, the MP4 rule fires first, making the M4A check dead code. This causes LINE voice messages (M4A/AAC-LC) to be classified as `video/mp4` instead of `audio/mp4`, which breaks the entire audio transcription pipeline.

## Fix

Read the ftyp sub-brand at bytes 8-11 to distinguish audio containers (`M4A `, `M4B `) from video containers before falling back to `video/mp4`.

## Tests

Added 3 tests covering:
- M4A voice messages → `audio/mp4` with `.m4a` extension
- M4B audiobooks → `audio/mp4`  
- Regular MP4 video → `video/mp4` with `.mp4` extension

All 5 tests in `download.test.ts` pass.

Closes #29751