### PR TITLE
fix(configure): auto-add Tailscale origin to allowedOrigins

### DIFF
--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -5,8 +5,9 @@ import {
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
-import { findTailscaleBinary } from "../infra/tailscale.js";
+import { findTailscaleBinary, getTailnetHostname } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { defaultRuntime } from "../runtime.js";
 import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 import { note } from "../terminal/note.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
@@ -267,6 +268,26 @@ export async function promptGatewayConfig(
     trustedProxy: trustedProxyConfig,
   });
 
+  // When Tailscale is enabled, automatically add the Tailscale origin to allowedOrigins
+  // so users can access the Control UI via the Tailscale URL
+  let allowedOrigins = next.gateway?.controlUi?.allowedOrigins ?? [];
+  if (tailscaleMode !== "off") {
+    try {
+      const tailnetHostname = await getTailnetHostname();
+      const tailscaleOrigin = `https://${tailnetHostname}`;
+      if (!allowedOrigins.includes(tailscaleOrigin)) {
+        allowedOrigins = [...allowedOrigins, tailscaleOrigin];
+        defaultRuntime.log(`Added Tailscale origin to allowedOrigins: ${tailscaleOrigin}`);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      defaultRuntime.warn(
+        `Could not detect Tailscale hostname: ${errorMsg}. ` +
+        "You may need to manually add your Tailscale origin to gateway.controlUi.allowedOrigins"
+      );
+    }
+  }
+
   next = {
     ...next,
     gateway: {
@@ -277,6 +298,10 @@ export async function promptGatewayConfig(
       auth: authConfig,
       ...(customBindHost && { customBindHost }),
       ...(trustedProxies && { trustedProxies }),
+      controlUi: {
+        ...next.gateway?.controlUi,
+        allowedOrigins,
+      },
       tailscale: {
         ...next.gateway?.tailscale,
         mode: tailscaleMode,

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -7,7 +7,6 @@ import {
 } from "../gateway/gateway-config-prompts.shared.js";
 import { findTailscaleBinary, getTailnetHostname } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { defaultRuntime } from "../runtime.js";
 import { validateIPv4AddressInput } from "../shared/net/ipv4.js";
 import { note } from "../terminal/note.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
@@ -277,11 +276,11 @@ export async function promptGatewayConfig(
       const tailscaleOrigin = `https://${tailnetHostname}`;
       if (!allowedOrigins.includes(tailscaleOrigin)) {
         allowedOrigins = [...allowedOrigins, tailscaleOrigin];
-        defaultRuntime.log(`Added Tailscale origin to allowedOrigins: ${tailscaleOrigin}`);
+        runtime.log(`Added Tailscale origin to allowedOrigins: ${tailscaleOrigin}`);
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      defaultRuntime.warn(
+      runtime.error(
         `Could not detect Tailscale hostname: ${errorMsg}. ` +
         "You may need to manually add your Tailscale origin to gateway.controlUi.allowedOrigins"
       );


### PR DESCRIPTION
## Summary

Fixes #27877

When running `openclaw configure` with Tailscale serve/funnel mode, the wizard now automatically detects the Tailscale hostname and adds it to `gateway.controlUi.allowedOrigins`. This prevents the "origin not allowed" error when accessing the Control UI via the Tailscale URL.

## Problem

Users configuring Tailscale serve mode had to manually add the Tailscale origin to `allowedOrigins` after running the configure wizard, or they would see:

```
origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)
```

## Solution

The configure wizard now:

1. Detects when Tailscale mode is enabled (serve or funnel)
2. Calls `getTailnetHostname()` to get the Tailscale hostname
3. Automatically adds `https://<hostname>` to `gateway.controlUi.allowedOrigins`
4. Logs a success message when the origin is added
5. Shows a helpful warning if hostname detection fails

## Changes

- Import `getTailnetHostname` and `defaultRuntime` from tailscale module
- When `tailscaleMode !== "off"`, fetch the Tailscale hostname
- Add `https://<hostname>` to `allowedOrigins` if not already present
- Log success message when origin is added
- Show warning if hostname detection fails (e.g., Tailscale not running)

## Testing

- Lint passes ✅
- TypeScript compilation passes ✅

## Example

After running `openclaw configure` with Tailscale serve mode:

```json
{
  "gateway": {
    "controlUi": {
      "allowedOrigins": ["https://myhost.ts.net"]
    },
    "tailscale": {
      "mode": "serve"
    }
  }
}
```

The Control UI will now work immediately via `https://myhost.ts.net/overview` without manual configuration.

Fixes #27877