### PR TITLE
fix(config): reject path traversal sequences in exec secret IDs (#29829)

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -8,7 +8,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const ENV_SECRET_REF_ID_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
 const SECRET_PROVIDER_ALIAS_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-const EXEC_SECRET_REF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+const EXEC_SECRET_REF_ID_PATTERN = /^(?!.*\.\.)[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
 


### PR DESCRIPTION
## Problem

`EXEC_SECRET_REF_ID_PATTERN` in `src/config/zod-schema.core.ts` allows `.` and `/` characters, so values like `a/../../../etc/passwd` pass Zod validation:

```ts
// Before
const EXEC_SECRET_REF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
```

While exec secret callers already need operator-level config access, the permissive pattern gives a false sense of restriction and could enable unintended path references in UI-driven or multi-operator config scenarios.

## Fix

Added a negative lookahead to reject any ID containing a `..` path traversal sequence:

```ts
// After
const EXEC_SECRET_REF_ID_PATTERN = /^(?!.*\.\.)([A-Za-z0-9][A-Za-z0-9._:/-]{0,255})$/;
```

## Verification (step 6 — code-level, matching step 3)

| Input | Before | After |
|-------|--------|-------|
| `a/../../../etc/passwd` | ✅ accepted | ❌ rejected |
| `scripts/../../shadow` | ✅ accepted | ❌ rejected |
| `scripts/get-secret.sh` | ✅ accepted | ✅ accepted |
| `vault:secret/mykey` | ✅ accepted | ✅ accepted |

Note: absolute paths starting with `/` (e.g. `/usr/bin/gpg`) were already rejected by the first-character `[A-Za-z0-9]` requirement — this PR does not change that behavior.

Fixes #29829