### PR TITLE
Fixed google-gemini-cli oauth

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -422,6 +422,103 @@ describe("loginGeminiCliOAuth", () => {
     expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
   });
 
+  it("does not throw when onboardUser returns 400 (proceeds without projectId)", async () => {
+    const requests: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = getRequestUrl(input);
+      requests.push(url);
+
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      if ([LOAD_PROD, LOAD_DAILY, LOAD_AUTOPUSH].includes(url)) {
+        return responseJson({ error: { message: "bad request" } }, 400);
+      }
+      if (url === "https://cloudcode-pa.googleapis.com/v1internal:onboardUser") {
+        return responseJson({ error: { message: "bad request" } }, 400);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let authUrl = "";
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const result = await loginGeminiCliOAuth({
+      isRemote: true,
+      openUrl: async () => {},
+      log: (msg) => {
+        const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
+        if (found?.[0]) {
+          authUrl = found[0];
+        }
+      },
+      note: async () => {},
+      prompt: async () => {
+        const state = new URL(authUrl).searchParams.get("state");
+        return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
+      },
+      progress: { update: () => {}, stop: () => {} },
+    });
+
+    expect(result.projectId).toBe("");
+    expect(requests.filter((url) => url.includes("v1internal:onboardUser"))).toHaveLength(1);
+  });
+
+  it("uses GOOGLE_CLOUD_PROJECT when onboardUser returns 400 and env is set", async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = "my-env-project";
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = getRequestUrl(input);
+
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      if ([LOAD_PROD, LOAD_DAILY, LOAD_AUTOPUSH].includes(url)) {
+        return responseJson({ error: { message: "bad request" } }, 400);
+      }
+      if (url === "https://cloudcode-pa.googleapis.com/v1internal:onboardUser") {
+        return responseJson({ error: { message: "bad request" } }, 400);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let authUrl = "";
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const result = await loginGeminiCliOAuth({
+      isRemote: true,
+      openUrl: async () => {},
+      log: (msg) => {
+        const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
+        if (found?.[0]) {
+          authUrl = found[0];
+        }
+      },
+      note: async () => {},
+      prompt: async () => {
+        const state = new URL(authUrl).searchParams.get("state");
+        return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
+      },
+      progress: { update: () => {}, stop: () => {} },
+    });
+
+    expect(result.projectId).toBe("my-env-project");
+  });
+
   it("continues OAuth flow when loadCodeAssist returns 400 from every endpoint", async () => {
     const requests: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {

--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -239,14 +239,28 @@ describe("loginGeminiCliOAuth", () => {
     "GOOGLE_CLOUD_PROJECT_ID",
   ] as const;
 
-  function getExpectedPlatform(): "WINDOWS" | "MACOS" | "LINUX" {
-    if (process.platform === "win32") {
-      return "WINDOWS";
+  function getExpectedPlatform():
+    | "PLATFORM_UNSPECIFIED"
+    | "DARWIN_AMD64"
+    | "DARWIN_ARM64"
+    | "LINUX_AMD64"
+    | "LINUX_ARM64"
+    | "WINDOWS_AMD64" {
+    const { platform, arch } = process;
+    if (platform === "darwin") {
+      if (arch === "arm64") return "DARWIN_ARM64";
+      if (arch === "x64") return "DARWIN_AMD64";
+      return "PLATFORM_UNSPECIFIED";
     }
-    if (process.platform === "linux") {
-      return "LINUX";
+    if (platform === "linux") {
+      if (arch === "arm64") return "LINUX_ARM64";
+      if (arch === "x64") return "LINUX_AMD64";
+      return "PLATFORM_UNSPECIFIED";
     }
-    return "MACOS";
+    if (platform === "win32" && arch === "x64") {
+      return "WINDOWS_AMD64";
+    }
+    return "PLATFORM_UNSPECIFIED";
   }
 
   function getRequestUrl(input: string | URL | Request): string {
@@ -358,7 +372,7 @@ describe("loginGeminiCliOAuth", () => {
     const clientMetadata = getHeaderValue(firstHeaders, "Client-Metadata");
     expect(clientMetadata).toBeDefined();
     expect(JSON.parse(clientMetadata as string)).toEqual({
-      ideType: "ANTIGRAVITY",
+      ideType: "GEMINI_CLI",
       platform: getExpectedPlatform(),
       pluginType: "GEMINI",
     });
@@ -366,7 +380,7 @@ describe("loginGeminiCliOAuth", () => {
     const body = JSON.parse(String(loadRequests[0]?.init?.body));
     expect(body).toEqual({
       metadata: {
-        ideType: "ANTIGRAVITY",
+        ideType: "GEMINI_CLI",
         platform: getExpectedPlatform(),
         pluginType: "GEMINI",
       },
@@ -422,7 +436,7 @@ describe("loginGeminiCliOAuth", () => {
     expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
   });
 
-  it("does not throw when onboardUser returns 400 (proceeds without projectId)", async () => {
+  it("throws when onboardUser returns 400 without a recoverable project", async () => {
     const requests: string[] = [];
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = getRequestUrl(input);
@@ -450,24 +464,24 @@ describe("loginGeminiCliOAuth", () => {
 
     let authUrl = "";
     const { loginGeminiCliOAuth } = await import("./oauth.js");
-    const result = await loginGeminiCliOAuth({
-      isRemote: true,
-      openUrl: async () => {},
-      log: (msg) => {
-        const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
-        if (found?.[0]) {
-          authUrl = found[0];
-        }
-      },
-      note: async () => {},
-      prompt: async () => {
-        const state = new URL(authUrl).searchParams.get("state");
-        return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
-      },
-      progress: { update: () => {}, stop: () => {} },
-    });
-
-    expect(result.projectId).toBe("");
+    await expect(
+      loginGeminiCliOAuth({
+        isRemote: true,
+        openUrl: async () => {},
+        log: (msg) => {
+          const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
+          if (found?.[0]) {
+            authUrl = found[0];
+          }
+        },
+        note: async () => {},
+        prompt: async () => {
+          const state = new URL(authUrl).searchParams.get("state");
+          return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
+        },
+        progress: { update: () => {}, stop: () => {} },
+      }),
+    ).rejects.toThrow("Could not provision a Google Cloud project");
     expect(requests.filter((url) => url.includes("v1internal:onboardUser"))).toHaveLength(1);
   });
 

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -584,6 +584,25 @@ async function discoverProject(accessToken: string): Promise<string> {
   });
 
   if (!onboardResponse.ok) {
+    // 400 may mean the account is already provisioned or not eligible for onboarding.
+    // Try to extract a project from the body before giving up.
+    if (onboardResponse.status === 400) {
+      const errorBody = await onboardResponse.json().catch(() => null);
+      const projectFromBody =
+        errorBody?.cloudaicompanionProject?.id ??
+        errorBody?.response?.cloudaicompanionProject?.id ??
+        (typeof errorBody?.cloudaicompanionProject === "string"
+          ? errorBody.cloudaicompanionProject
+          : undefined);
+      if (projectFromBody) {
+        return projectFromBody;
+      }
+      if (envProject) {
+        return envProject;
+      }
+      // Proceed without a project; user can set GOOGLE_CLOUD_PROJECT manually.
+      return "";
+    }
     throw new Error(`onboardUser failed: ${onboardResponse.status} ${onboardResponse.statusText}`);
   }
 

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -233,14 +233,18 @@ type ClientMetadataPlatform =
   | "WINDOWS_AMD64";
 
 function resolvePlatform(): ClientMetadataPlatform {
-  const arch = process.arch === "arm64" ? "ARM64" : "AMD64";
-  if (process.platform === "darwin") {
-    return arch === "ARM64" ? "DARWIN_ARM64" : "DARWIN_AMD64";
+  const { platform, arch } = process;
+  if (platform === "darwin") {
+    if (arch === "arm64") return "DARWIN_ARM64";
+    if (arch === "x64") return "DARWIN_AMD64";
+    return "PLATFORM_UNSPECIFIED";
   }
-  if (process.platform === "linux") {
-    return arch === "ARM64" ? "LINUX_ARM64" : "LINUX_AMD64";
+  if (platform === "linux") {
+    if (arch === "arm64") return "LINUX_ARM64";
+    if (arch === "x64") return "LINUX_AMD64";
+    return "PLATFORM_UNSPECIFIED";
   }
-  if (process.platform === "win32") {
+  if (platform === "win32" && arch === "x64") {
     return "WINDOWS_AMD64";
   }
   return "PLATFORM_UNSPECIFIED";

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -521,6 +521,9 @@ async function discoverProject(accessToken: string): Promise<string> {
       loadStatus = undefined;
       break;
     } catch (err) {
+      // A transport error (timeout, network failure, etc.) is not a 400 response.
+      // Clear loadStatus so we don't misfire the 400→free-tier fallback below.
+      loadStatus = undefined;
       loadError = err instanceof Error ? err : new Error("loadCodeAssist failed", { cause: err });
     }
   }

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -224,14 +224,26 @@ function generatePkce(): { verifier: string; challenge: string } {
   return { verifier, challenge };
 }
 
-function resolvePlatform(): "WINDOWS" | "MACOS" | "LINUX" {
-  if (process.platform === "win32") {
-    return "WINDOWS";
+type ClientMetadataPlatform =
+  | "PLATFORM_UNSPECIFIED"
+  | "DARWIN_AMD64"
+  | "DARWIN_ARM64"
+  | "LINUX_AMD64"
+  | "LINUX_ARM64"
+  | "WINDOWS_AMD64";
+
+function resolvePlatform(): ClientMetadataPlatform {
+  const arch = process.arch === "arm64" ? "ARM64" : "AMD64";
+  if (process.platform === "darwin") {
+    return arch === "ARM64" ? "DARWIN_ARM64" : "DARWIN_AMD64";
   }
   if (process.platform === "linux") {
-    return "LINUX";
+    return arch === "ARM64" ? "LINUX_ARM64" : "LINUX_AMD64";
   }
-  return "MACOS";
+  if (process.platform === "win32") {
+    return "WINDOWS_AMD64";
+  }
+  return "PLATFORM_UNSPECIFIED";
 }
 
 async function fetchWithTimeout(
@@ -466,7 +478,7 @@ async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
   const platform = resolvePlatform();
   const metadata = {
-    ideType: "ANTIGRAVITY",
+    ideType: "GEMINI_CLI",
     platform,
     pluginType: "GEMINI",
   };
@@ -509,6 +521,24 @@ async function discoverProject(accessToken: string): Promise<string> {
           data = { currentTier: { id: TIER_STANDARD } };
           activeEndpoint = endpoint;
           loadError = undefined;
+          break;
+        }
+        // The 400 body may still carry project/tier data for already-provisioned accounts.
+        const projectFromError =
+          errorPayload?.cloudaicompanionProject?.id ??
+          errorPayload?.response?.cloudaicompanionProject?.id ??
+          (typeof errorPayload?.cloudaicompanionProject === "string"
+            ? errorPayload.cloudaicompanionProject
+            : undefined);
+        if (projectFromError || errorPayload?.currentTier || errorPayload?.allowedTiers) {
+          data = {
+            cloudaicompanionProject: projectFromError ?? errorPayload.cloudaicompanionProject,
+            currentTier: errorPayload.currentTier,
+            allowedTiers: errorPayload.allowedTiers,
+          };
+          activeEndpoint = endpoint;
+          loadError = undefined;
+          loadStatus = undefined;
           break;
         }
         loadError = new Error(`loadCodeAssist failed: ${response.status} ${response.statusText}`);
@@ -603,8 +633,12 @@ async function discoverProject(accessToken: string): Promise<string> {
       if (envProject) {
         return envProject;
       }
-      // Proceed without a project; user can set GOOGLE_CLOUD_PROJECT manually.
-      return "";
+      // Include the raw body so users/maintainers can diagnose the missing project.
+      throw new Error(
+        "Could not provision a Google Cloud project for this account. " +
+          "Set GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID and try again. " +
+          `(onboardUser 400 body: ${JSON.stringify(errorBody)})`,
+      );
     }
     throw new Error(`onboardUser failed: ${onboardResponse.status} ${onboardResponse.statusText}`);
   }

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -579,20 +579,26 @@ async function discoverProject(accessToken: string): Promise<string> {
     }
   }
 
+  // Helper used in both the currentTier and standalone-project paths below.
+  const resolvedProject = (() => {
+    const p = data.cloudaicompanionProject;
+    if (typeof p === "string" && p) return p;
+    if (typeof p === "object" && p?.id) return p.id;
+    return undefined;
+  })();
+
   if (data.currentTier) {
-    const project = data.cloudaicompanionProject;
-    if (typeof project === "string" && project) {
-      return project;
-    }
-    if (typeof project === "object" && project?.id) {
-      return project.id;
-    }
-    if (envProject) {
-      return envProject;
-    }
+    if (resolvedProject) return resolvedProject;
+    if (envProject) return envProject;
     throw new Error(
       "This account requires GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID to be set.",
     );
+  }
+
+  // If loadCodeAssist returned a project ID without tier info (e.g. 400 body
+  // for an already-provisioned account), return it directly — no onboarding needed.
+  if (resolvedProject) {
+    return resolvedProject;
   }
 
   const tier = getDefaultTier(data.allowedTiers);


### PR DESCRIPTION
## Summary

- **Root cause**: `loadCodeAssist` and `onboardUser` were receiving invalid enum values in `metadata`:
  - `platform: "MACOS"` — not a valid value; the API enum is `DARWIN_AMD64 | DARWIN_ARM64 | LINUX_AMD64 | LINUX_ARM64 | WINDOWS_AMD64`
  - `ideType: "ANTIGRAVITY"` — not a valid value; the API enum is `GEMINI_CLI | IDE_UNSPECIFIED | VSCODE | ...`
  - The API returned `400 INVALID_ARGUMENT` on every login attempt.
- **Why it matters**: Any user trying to sign in with Gemini CLI OAuth on macOS (or any platform) would get a 400 error and could never complete login.
- **What changed**:
  - Added `ClientMetadataPlatform` type with the correct enum values (sourced from `@google/gemini-cli-core/dist/src/code_assist/types.d.ts`).
  - Replaced `resolvePlatform()` to return the correct arch-aware value (`DARWIN_ARM64`, `DARWIN_AMD64`, `LINUX_AMD64`, `LINUX_ARM64`, `WINDOWS_AMD64`).
  - Changed `ideType` from `"ANTIGRAVITY"` to `"GEMINI_CLI"`.
  - Added extraction of project/tier data from `loadCodeAssist` 400 response bodies (some already-provisioned accounts return 400 but include the project in the error body).
  - Replaced `return ""` (which stored a broken credential with empty `projectId`) with a descriptive error that includes the raw 400 body for future debugging.
  - Fixed `loadStatus` being retained across loop iterations: transport errors (timeout/network) now reset `loadStatus = undefined` so they don't misfire the 400→free-tier fallback.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29539
- Related #29598

## User-visible / Behavior Changes

Users on macOS (and all other platforms) can now complete Gemini CLI OAuth login. Previously every login attempt failed with `400 INVALID_ARGUMENT` due to invalid enum values in the metadata sent to the Google Cloud Code Assist API.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime: Node 22
- Model/provider: google-gemini-cli
- Integration/channel: google-gemini-cli-auth plugin

### Steps

1. Install the plugin without `GOOGLE_CLOUD_PROJECT` set.
2. Run `openclaw configure` and complete Google OAuth.
3. Observe `onboardUser` returned `400 INVALID_ARGUMENT: Invalid value at 'metadata.platform', "MACOS"`.

### Expected

- Login completes and projectId is stored correctly.

### Actual (before fix)

```
Error: Could not provision a Google Cloud project for this account.
(onboardUser 400 body: {"error":{"code":400,"message":"Invalid value at 'metadata.platform'
(type.googleapis.com/google.internal.cloud.code.v1internal.ClientMetadata.Platform), \"MACOS\"",
...,"status":"INVALID_ARGUMENT"}})
```

### After fix

- Login completes successfully. `projectId` stored correctly. Gemini CLI models work via Telegram/gateway.

## Human Verification (required)

- Verified on a real macOS Apple Silicon machine with a real Google account.
- Login completed end-to-end: OAuth callback → `loadCodeAssist` → `onboardUser` → projectId stored → models respond correctly via Telegram.
- Confirmed enum values match `@google/gemini-cli-core/dist/src/code_assist/types.d.ts` installed at `/usr/local/lib/node_modules/@google/gemini-cli`.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? Users with a previously broken login (empty `projectId` stored) must delete and redo `/login`.

## Failure Recovery

- Revert: restore `resolvePlatform()` to the old string literals and `ideType` to `"ANTIGRAVITY"` — but this will break login again.
- Known bad symptom if regressed: `400 INVALID_ARGUMENT` on every login attempt, no valid credential stored.

## Risks and Mitigations

- Low risk: only the enum string values change. No logic, flow, or network call structure changed.
- The correct enum values are sourced directly from the installed `@google/gemini-cli-core` types, not guessed.
