### PR TITLE
fix(nodes): cap screen_record duration to prevent long-running tool calls

### DIFF
--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -219,6 +219,71 @@ describe("nodes notifications_action", () => {
   });
 });
 
+describe("nodes screen_record", () => {
+  it("rejects durationMs values above the hard cap", async () => {
+    callGateway.mockImplementation(async ({ method }) => {
+      if (method === "node.list") {
+        return mockNodeList(["screen.record"]);
+      }
+      if (method === "node.invoke") {
+        throw new Error("screen.record should not be called when duration is out of range");
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    await expect(
+      executeNodes({
+        action: "screen_record",
+        node: NODE_ID,
+        durationMs: 360_000,
+      }),
+    ).rejects.toThrow(/durationMs must be between 1000 and 300000/i);
+  });
+
+  it("passes bounded durationMs to screen.record", async () => {
+    callGateway.mockImplementation(async ({ method, params }) => {
+      if (method === "node.list") {
+        return mockNodeList(["screen.record"]);
+      }
+      if (method === "node.invoke") {
+        expect(params).toMatchObject({
+          nodeId: NODE_ID,
+          command: "screen.record",
+          params: {
+            durationMs: 30_000,
+            screenIndex: 0,
+            fps: 10,
+            format: "mp4",
+            includeAudio: true,
+          },
+        });
+        return {
+          payload: {
+            format: "mp4",
+            base64: "aGVsbG8=",
+            durationMs: 30_000,
+            fps: 10,
+            screenIndex: 0,
+            hasAudio: true,
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    const result = await executeNodes({
+      action: "screen_record",
+      node: NODE_ID,
+      durationMs: 30_000,
+    });
+
+    expect(result.content?.[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/^FILE:/),
+    });
+  });
+});
+
 describe("nodes device_status and device_info", () => {
   it("invokes device.status and returns payload", async () => {
     callGateway.mockImplementation(async ({ method, params }) => {

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -56,6 +56,8 @@ const NOTIFY_DELIVERIES = ["system", "overlay", "auto"] as const;
 const NOTIFICATIONS_ACTIONS = ["open", "dismiss", "reply"] as const;
 const CAMERA_FACING = ["front", "back", "both"] as const;
 const LOCATION_ACCURACY = ["coarse", "balanced", "precise"] as const;
+const SCREEN_RECORD_DURATION_MIN_MS = 1_000;
+const SCREEN_RECORD_DURATION_MAX_MS = 300_000;
 const NODE_READ_ACTION_COMMANDS = {
   camera_list: "camera.list",
   notifications_list: "notifications.list",
@@ -420,12 +422,21 @@ export function createNodesTool(options?: {
           case "screen_record": {
             const node = readStringParam(params, "node", { required: true });
             const nodeId = await resolveNodeId(gatewayOpts, node);
-            const durationMs =
+            const durationMsRaw =
               typeof params.durationMs === "number" && Number.isFinite(params.durationMs)
                 ? params.durationMs
                 : typeof params.duration === "string"
                   ? parseDurationMs(params.duration)
                   : 10_000;
+            if (
+              durationMsRaw < SCREEN_RECORD_DURATION_MIN_MS ||
+              durationMsRaw > SCREEN_RECORD_DURATION_MAX_MS
+            ) {
+              throw new Error(
+                `durationMs must be between ${SCREEN_RECORD_DURATION_MIN_MS} and ${SCREEN_RECORD_DURATION_MAX_MS}`,
+              );
+            }
+            const durationMs = Math.trunc(durationMsRaw);
             const fps =
               typeof params.fps === "number" && Number.isFinite(params.fps) ? params.fps : 10;
             const screenIndex =


### PR DESCRIPTION
## Summary
- enforce a server-side duration guard for `nodes` tool `screen_record` action
- reject values outside 1s..5m before invoking `screen.record`
- add unit tests for out-of-range rejection and bounded forwarding

## Why
`screen_record` accepted unbounded `durationMs`, allowing accidental or malicious hour-long recordings that tie up gateway/node resources.

Fixes #29831

## Testing
- `pnpm exec vitest run src/agents/openclaw-tools.camera.test.ts`