### PR TITLE
fix: prevent silent drop of followup messages on timeout/abort

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -484,6 +484,82 @@ describe("createFollowupRunner typing cleanup", () => {
   });
 });
 
+describe("createFollowupRunner abort/timeout retry", () => {
+  it("throws when run is aborted with no payloads so drain keeps the item", async () => {
+    const typing = createMockTypingController();
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: { aborted: true, durationMs: 600_000 },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing,
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await expect(runner(baseQueuedRun())).rejects.toThrow("followup run aborted without payloads");
+    expect(onBlockReply).not.toHaveBeenCalled();
+    // Typing cleanup should still happen via the finally block.
+    expect(typing.markRunComplete).toHaveBeenCalled();
+    expect(typing.markDispatchIdle).toHaveBeenCalled();
+  });
+
+  it("throws when run is aborted with undefined payloads", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      meta: { aborted: true, durationMs: 600_000 },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: vi.fn(async () => {}) },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await expect(runner(baseQueuedRun())).rejects.toThrow("followup run aborted without payloads");
+  });
+
+  it("does not throw when aborted but payloads were produced", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "partial result" }],
+      meta: { aborted: true, durationMs: 600_000 },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await runner(baseQueuedRun());
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw on empty payloads when run was NOT aborted", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: { durationMs: 1_000 },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    // Should resolve normally (no throw), just no payloads delivered.
+    await runner(baseQueuedRun());
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+});
+
 describe("createFollowupRunner agentDir forwarding", () => {
   it("passes queued run agentDir to runEmbeddedPiAgent", async () => {
     runEmbeddedPiAgentMock.mockClear();

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -235,6 +235,17 @@ export function createFollowupRunner(params: {
       }
 
       const payloadArray = runResult.payloads ?? [];
+
+      // When the run was aborted/timed-out and produced no payloads, throw so
+      // drainNextQueueItem keeps the item in the queue for retry.
+      if (runResult.meta.aborted && payloadArray.length === 0) {
+        const sk = queued.run.sessionKey ?? "unknown";
+        defaultRuntime.error?.(
+          `Followup run aborted with no payloads (session=${sk}); keeping in queue for retry`,
+        );
+        throw new Error("followup run aborted without payloads");
+      }
+
       if (payloadArray.length === 0) {
         return;
       }


### PR DESCRIPTION
## Summary

- When a followup agent run aborts/times out and produces no payloads, the runner now throws instead of silently returning. This prevents `drainNextQueueItem` from removing the item from the queue, so it gets retried on the next drain cycle.
- Adds a warning log with session key context when this occurs.

Fixes #29497

## Test plan

- [x] Added test: aborted run with empty payloads throws (item stays in queue)
- [x] Added test: aborted run with undefined payloads throws
- [x] Added test: aborted run WITH payloads still delivers normally
- [x] Added test: non-aborted empty payloads still return silently (no regression)
- [x] All 21 followup-runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)