### PR TITLE
fix(telegram): use EnvHttpProxyAgent to preserve proxy settings in global dispatcher

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -5,8 +5,8 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
-const AgentCtor = vi.hoisted(() =>
-  vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
+const EnvHttpProxyAgentCtor = vi.hoisted(() =>
+  vi.fn(function MockEnvHttpProxyAgent(this: { options: unknown }, options: unknown) {
     this.options = options;
   }),
 );
@@ -28,7 +28,7 @@ vi.mock("node:dns", async () => {
 });
 
 vi.mock("undici", () => ({
-  Agent: AgentCtor,
+  EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
   setGlobalDispatcher,
 }));
 
@@ -39,7 +39,7 @@ afterEach(() => {
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
   setGlobalDispatcher.mockReset();
-  AgentCtor.mockClear();
+  EnvHttpProxyAgentCtor.mockClear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   if (originalFetch) {
@@ -147,12 +147,12 @@ describe("resolveTelegramFetch", () => {
     expect(setDefaultResultOrder).toHaveBeenCalledTimes(2);
   });
 
-  it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
+  it("replaces global undici dispatcher with proxy-aware autoSelectFamily-enabled agent", async () => {
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    expect(AgentCtor).toHaveBeenCalledWith({
+    expect(EnvHttpProxyAgentCtor).toHaveBeenCalledWith({
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
@@ -174,13 +174,13 @@ describe("resolveTelegramFetch", () => {
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
-    expect(AgentCtor).toHaveBeenNthCalledWith(1, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(1, {
       connect: {
         autoSelectFamily: true,
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
-    expect(AgentCtor).toHaveBeenNthCalledWith(2, {
+    expect(EnvHttpProxyAgentCtor).toHaveBeenNthCalledWith(2, {
       connect: {
         autoSelectFamily: false,
         autoSelectFamilyAttemptTimeout: 300,

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,6 +1,6 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -45,8 +45,14 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
     try {
+      // Use EnvHttpProxyAgent instead of bare Agent so that HTTP_PROXY / HTTPS_PROXY
+      // environment variables are respected. A bare Agent here would silently
+      // discard any proxy dispatcher set earlier (e.g. by pi-ai's http-proxy.ts),
+      // breaking model API calls in regions that require a proxy for providers
+      // like OpenRouter. EnvHttpProxyAgent is a superset: it honours proxy env
+      // vars when present and behaves identically to Agent when they are absent.
       setGlobalDispatcher(
-        new Agent({
+        new EnvHttpProxyAgent({
           connect: {
             autoSelectFamily: autoSelectDecision.value,
             autoSelectFamilyAttemptTimeout: 300,


### PR DESCRIPTION
## Summary

- Problem: The Telegram IPv6/autoSelectFamily workaround in `src/telegram/fetch.ts` replaces the global undici dispatcher with a bare `Agent`, silently discarding any previously configured proxy dispatcher (e.g. the `EnvHttpProxyAgent` set by pi-ai's `http-proxy.ts`).
- Why it matters: In regions where providers like OpenRouter require a proxy, model API calls fail with `403 This model is not available in your region` because the bare `Agent` bypasses `HTTP_PROXY`/`HTTPS_PROXY` environment variables.
- What changed: Replaced `new Agent(...)` with `new EnvHttpProxyAgent(...)` when setting the global dispatcher. `EnvHttpProxyAgent` is a superset — it honours proxy env vars when present and behaves identically to `Agent` when they are absent.
- What did NOT change (scope boundary): Telegram's own proxy fetch (`makeProxyFetch` via `channels.telegram.proxy`) is unaffected. The `autoSelectFamily` and `dnsResultOrder` workarounds remain intact.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #25676

## User-visible / Behavior Changes

Users behind an HTTP proxy (`HTTPS_PROXY` / `HTTP_PROXY`) with a Telegram channel enabled will no longer see model API calls bypass the proxy. Previously, enabling Telegram would silently override the proxy dispatcher, causing 403 errors from providers that enforce region restrictions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same network calls, but they now correctly route through the user's configured proxy instead of going direct.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64, Apple Silicon)
- Runtime/container: Node 23.10.0 (native, non-container)
- Model/provider: OpenRouter (anthropic/claude-haiku-4.5, google/gemini-2.5-flash)
- Integration/channel: Telegram
- Relevant config: `HTTPS_PROXY=http://127.0.0.1:1088` via `NODE_OPTIONS=--require set-proxy.js`

### Steps

1. Configure `HTTPS_PROXY` environment variable (e.g. via `NODE_OPTIONS=--require set-proxy.js`)
2. Enable Telegram channel in `openclaw.json`
3. Start gateway and send a message via Telegram

### Expected

- Model API calls route through the proxy, model responds normally

### Actual (before fix)

- Model API calls bypass proxy, OpenRouter returns `403 This model is not available in your region`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Before: `embedded run agent end: isError=true error=403 This model is not available in your region.`
After: `embedded run agent end: isError=false` (9.2s, successful response via Telegram)

## Human Verification (required)

- Verified scenarios: Telegram bot on MBP behind Shadowsocks proxy — model calls succeed after fix
- Edge cases checked: Local/loopback requests unaffected; Telegram's own proxy fetch path unaffected; no-proxy environments unaffected (EnvHttpProxyAgent degrades to Agent behavior)
- What you did **not** verify: Bun runtime; Windows/Linux

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `EnvHttpProxyAgent` back to `Agent` in `src/telegram/fetch.ts`
- Files/config to restore: `src/telegram/fetch.ts`
- Known bad symptoms reviewers should watch for: Telegram connection failures on IPv6-broken networks (unlikely since EnvHttpProxyAgent supports the same connect options)

## Risks and Mitigations

- Risk: `EnvHttpProxyAgent` may behave differently than `Agent` in edge cases
  - Mitigation: `EnvHttpProxyAgent` extends Agent behavior; without proxy env vars it is functionally identical. All 43 existing Telegram tests pass.
