### PR TITLE
docs(plugins): add TokenRanger to community plugins page

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -47,7 +47,7 @@ Use this format when adding entries:
 
 - **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs, reducing input token costs by 50–80%. GPU-aware (full/light/passthrough strategies). Includes FastAPI sidecar, CLI setup, and `/tokenranger` command.
   npm: `openclaw-plugin-tokenranger`
-  repo: `https://github.com/synchronic1/openclaw-plugin-tokenranger`
+  repo: `https://github.com/peterjohannmedina/openclaw-plugin-tokenranger`
   install: `openclaw plugins install openclaw-plugin-tokenranger`
 
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,7 +45,7 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs, reducing input token costs by 50–80%. GPU-aware (full/light/passthrough strategies). Includes FastAPI sidecar, CLI setup, and `/tokenranger` command.
+- **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs, reducing token costs by 50–80%.
   npm: `openclaw-plugin-tokenranger`
   repo: `https://github.com/peterjohannmedina/openclaw-plugin-tokenranger`
   install: `openclaw plugins install openclaw-plugin-tokenranger`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,7 +45,7 @@ Use this format when adding entries:
 
 ## Listed plugins
 
-- **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs, reducing token costs by 50–80%.
+- **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs to reduce input token costs.
   npm: `openclaw-plugin-tokenranger`
   repo: `https://github.com/peterjohannmedina/openclaw-plugin-tokenranger`
   install: `openclaw plugins install openclaw-plugin-tokenranger`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **TokenRanger** — Compresses session context via a local Ollama SLM before sending to cloud LLMs, reducing input token costs by 50–80%. GPU-aware (full/light/passthrough strategies). Includes FastAPI sidecar, CLI setup, and `/tokenranger` command.
+  npm: `openclaw-plugin-tokenranger`
+  repo: `https://github.com/synchronic1/openclaw-plugin-tokenranger`
+  install: `openclaw plugins install openclaw-plugin-tokenranger`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
Adds **TokenRanger** to the community plugins listing per the [community plugins guidelines](https://docs.openclaw.ai/plugins/community).

- **npm:** `openclaw-plugin-tokenranger`
- **repo:** https://github.com/peterjohannmedina/openclaw-plugin-tokenranger
- **install:** `openclaw plugins install openclaw-plugin-tokenranger`

TokenRanger compresses session context through a local Ollama SLM before sending to cloud LLMs — 50–80% token reduction with graceful fallback if the sidecar is unreachable. GPU-aware routing (full/light/passthrough). Includes FastAPI sidecar, CLI setup command, and `/tokenranger` slash command.

Originally proposed as core extension in #27918; repackaged as standalone plugin per maintainer feedback. Maintained by [@peterjohannmedina](https://github.com/peterjohannmedina).