### PR TITLE
fix(voice-call): prevent duplicate media streams from Twilio double webhook

### DIFF
--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -87,6 +87,8 @@ export class TwilioProvider implements VoiceCallProvider {
   private callStreamMap = new Map<string, string>();
   /** Per-call tokens for media stream authentication */
   private streamAuthTokens = new Map<string, string>();
+  /** Tracks callSids that already have an active media stream to prevent duplicate streams */
+  private activeStreamCallSids = new Set<string>();
 
   /** Storage for TwiML content (for notify mode with URL-based TwiML) */
   private readonly twimlStorage = new Map<string, string>();
@@ -335,12 +337,14 @@ export class TwilioProvider implements VoiceCallProvider {
       case "no-answer":
       case "failed":
         this.streamAuthTokens.delete(callSid);
+        if (callSid) this.activeStreamCallSids.delete(callSid);
         if (callIdOverride) {
           this.deleteStoredTwiml(callIdOverride);
         }
         return { ...baseEvent, type: "call.ended", reason: callStatus };
       case "canceled":
         this.streamAuthTokens.delete(callSid);
+        if (callSid) this.activeStreamCallSids.delete(callSid);
         if (callIdOverride) {
           this.deleteStoredTwiml(callIdOverride);
         }
@@ -396,7 +400,16 @@ export class TwilioProvider implements VoiceCallProvider {
 
       // Conversation mode: return streaming TwiML immediately for outbound calls.
       if (isOutbound) {
+        // Guard against duplicate webhook POSTs from Twilio (issue #5732):
+        // Twilio may send the webhook twice; only the first should get <Connect><Stream>.
+        if (callSid && this.activeStreamCallSids.has(callSid)) {
+          console.log(`[voice-call] Duplicate webhook for ${callSid} — returning empty TwiML`);
+          return TwilioProvider.EMPTY_TWIML;
+        }
         const streamUrl = callSid ? this.getStreamUrlForCall(callSid) : null;
+        if (streamUrl && callSid) {
+          this.activeStreamCallSids.add(callSid);
+        }
         return streamUrl ? this.getStreamConnectXml(streamUrl) : TwilioProvider.PAUSE_TWIML;
       }
     }


### PR DESCRIPTION
## Problem

Twilio sends two webhook POST requests per call in some configurations. Both requests return `<Connect><Stream>` TwiML, which opens two concurrent media streams. The second stream kills the first, causing the call to disconnect immediately after connecting.

This is the root cause reported in #5732.

## Root Cause

In `generateTwimlResponse()`, outbound calls return `<Connect><Stream>` for any webhook where `isOutbound` is true and a `callId` query param is present. Since Twilio fires this webhook twice, both responses include `<Connect><Stream>`.

## Fix

Track active stream callSids in a `Set<string>` (`activeStreamCallSids`):
- On first webhook: add callSid to Set, return `<Connect><Stream>`
- On subsequent webhooks: callSid already in Set → return empty TwiML
- On call end (`completed`, `busy`, `no-answer`, `failed`, `canceled`): remove callSid from Set

## Testing

Tested with Twilio + Tailscale Funnel on macOS arm64. Calls now stay connected reliably. Previously every outbound call would disconnect within 1-2 seconds due to the duplicate stream.

Related: #5732, PR #25465