### PR TITLE
GitHub: add regression bug issue template and routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/regression_bug_report.yml
@@ -1,20 +1,45 @@
-name: Bug report
-description: Report a non-regression defect or unexpected behavior in OpenClaw.
-title: "[Bug]: "
+name: Regression bug report
+description: Report behavior that worked previously and now fails in OpenClaw.
+title: "[Regression Bug]: "
 labels:
   - bug
+  - regression
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for filing this report. Keep it concise, reproducible, and evidence-based.
-        If this behavior worked previously and now fails, use the "Regression bug report" template instead.
+        Use this form only for regressions: behavior that previously worked and now fails.
+        Keep reports concise, reproducible, and evidence-based.
   - type: textarea
     id: summary
     attributes:
       label: Summary
-      description: One-sentence statement of what is broken.
-      placeholder: After upgrading to <version>, <channel> behavior regressed from <prior version>.
+      description: One-sentence statement of what regressed.
+      placeholder: Replies in Slack threads worked in <prior version> but fail in <current version>.
+    validations:
+      required: true
+  - type: input
+    id: last_known_good_version
+    attributes:
+      label: Last known good version
+      description: Exact version/build where behavior still worked.
+      placeholder: <version such as 2026.2.10>
+    validations:
+      required: true
+  - type: input
+    id: first_bad_version
+    attributes:
+      label: First known bad version
+      description: Exact version/build where behavior first failed.
+      placeholder: <version such as 2026.2.17>
+    validations:
+      required: true
+  - type: textarea
+    id: regression_window
+    attributes:
+      label: Regression window and trigger
+      description: Describe when this started and what changed around that time.
+      placeholder: Started after upgrading from <last-good-version> to <first-bad-version>; no config changes.
     validations:
       required: true
   - type: textarea
@@ -32,7 +57,7 @@ body:
     id: expected
     attributes:
       label: Expected behavior
-      description: What should happen if the bug does not exist.
+      description: What should happen if the regression does not exist.
       placeholder: Agent posts a reply in the same thread.
     validations:
       required: true
@@ -40,16 +65,8 @@ body:
     id: actual
     attributes:
       label: Actual behavior
-      description: What happened instead, including user-visible errors.
+      description: What happens now, including user-visible errors.
       placeholder: No reply is posted; gateway logs "reply target not found".
-    validations:
-      required: true
-  - type: input
-    id: version
-    attributes:
-      label: OpenClaw version
-      description: Exact version/build tested.
-      placeholder: <version such as 2026.2.17>
     validations:
       required: true
   - type: input
@@ -70,7 +87,7 @@ body:
     id: logs
     attributes:
       label: Logs, screenshots, and evidence
-      description: Include redacted logs/screenshots/recordings that prove the behavior.
+      description: Include redacted logs/screenshots/recordings that prove the regression.
       render: shell
   - type: textarea
     id: impact
@@ -88,9 +105,11 @@ body:
         Severity: High (blocks replies)
         Frequency: 100% repro
         Consequence: Agents cannot respond in threads
+    validations:
+      required: true
   - type: textarea
     id: additional_information
     attributes:
       label: Additional information
       description: Add any context that helps triage but does not fit above.
-      placeholder: Regression started after upgrade from <previous-version>; temporary workaround is ...
+      placeholder: Temporary workaround is rolling back to <last-known-good-version>.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Regression reports were mixed into the generic bug template, making regressions less visible at intake.
- Why it matters: Regressions need immediate triage signal because they imply previously working behavior broke.
- What changed: Added a dedicated `Regression bug report` issue form with `[Regression Bug]: ` title prefix and required regression-window fields; updated the bug template to route regressions to the new form.
- What did NOT change (scope boundary): No runtime code, no CI behavior, and no issue automation workflow changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- GitHub issue intake now includes a dedicated `Regression bug report` template with `[Regression Bug]: ` title prefix and regression-specific required fields.
- The generic `Bug report` template now explicitly routes regression cases to the regression form.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev shell
- Model/provider: N/A
- Integration/channel (if any): GitHub Issue Forms
- Relevant config (redacted): N/A

### Steps

1. Open GitHub "New issue" for `openclaw/openclaw`.
2. Confirm `Regression bug report` appears in the template picker.
3. Select it and verify title prefix and required fields render.

### Expected

- Regression reports are clearly distinguished at intake by title and form structure.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Parsed issue template YAML locally and verified template content/diff.
- Edge cases checked: Regression template includes both last-known-good and first-known-bad required fields.
- What you did **not** verify: Live manual issue submission in GitHub UI.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit restoring previous issue templates.
- Files/config to restore: `.github/ISSUE_TEMPLATE/bug_report.yml`, remove `.github/ISSUE_TEMPLATE/regression_bug_report.yml`.
- Known bad symptoms reviewers should watch for: Missing template render or invalid issue form YAML.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Regression label auto-apply fails if label is missing in repo.
  - Mitigation: Created `regression` label in repository before opening this PR.
