### PR TITLE
docs: add openclaw-guardian to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **Guardian** — Security layer for OpenClaw with regex blacklist + LLM intent verification to prevent dangerous tool execution.
+  npm: `openclaw-guardian`
+  repo: `https://github.com/fatcatMaoFei/openclaw-guardian`
+  install: `openclaw plugins install openclaw-guardian`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Add openclaw-guardian to community plugins

**openclaw-guardian** is a security layer plugin for OpenClaw that provides:
- Regex-based command blacklist for fast pre-screening
- LLM-powered intent verification for nuanced threat detection
- Configurable protection against dangerous tool execution

### Checklist

- [x] Published on npm: [`openclaw-guardian@0.1.0`](https://www.npmjs.com/package/openclaw-guardian)
- [x] Source code on GitHub: [fatcatMaoFei/openclaw-guardian](https://github.com/fatcatMaoFei/openclaw-guardian)
- [x] Repository includes setup/usage documentation (README)
- [x] Issue tracker enabled
- [x] Actively maintained

Install: `openclaw plugins install openclaw-guardian`