### PR TITLE
fix(gateway): add exponential backoff for invalid config reload loop

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -292,6 +292,138 @@ describe("startGatewayConfigReloader", () => {
     await reloader.stop();
   });
 
+  it("logs invalid config once and suppresses duplicate warnings", async () => {
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      issues: [{ path: "channels.whatsapp.groups.*", message: 'Unrecognized key: "groupPolicy"' }],
+      hash: "invalid-1",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(invalidSnapshot);
+    const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
+
+    // First change event triggers the warning log.
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      'config reload skipped (invalid config): channels.whatsapp.groups.*: Unrecognized key: "groupPolicy"',
+    );
+
+    // Backoff timer fires — same issues, so warning is NOT re-logged.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+
+    await reloader.stop();
+  });
+
+  it("applies exponential backoff on repeated invalid configs", async () => {
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      issues: [{ path: "bad.key", message: "Unrecognized key" }],
+      hash: "invalid-exp",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValue(invalidSnapshot);
+    const { watcher, reloader } = createReloaderHarness(readSnapshot);
+
+    watcher.emit("change");
+    // Initial reload (debounce 0ms).
+    await vi.runOnlyPendingTimersAsync();
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+
+    // First backoff: 1s.
+    await vi.advanceTimersByTimeAsync(999);
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+
+    // Second backoff: 2s (doubles).
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(3);
+
+    // Third backoff: 4s (doubles again).
+    await vi.advanceTimersByTimeAsync(3_999);
+    expect(readSnapshot).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(4);
+
+    await reloader.stop();
+  });
+
+  it("resets backoff when config becomes valid", async () => {
+    const invalidSnapshot = makeSnapshot({
+      valid: false,
+      issues: [{ path: "bad.key", message: "Unrecognized key" }],
+      hash: "invalid-reset",
+    });
+    const validSnapshot = makeSnapshot({
+      config: { gateway: { reload: { debounceMs: 0 } }, hooks: { enabled: true } },
+      hash: "valid-reset",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(invalidSnapshot)
+      .mockResolvedValueOnce(validSnapshot)
+      .mockResolvedValueOnce(invalidSnapshot);
+    const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
+
+    // First: invalid config, triggers warning.
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+
+    // Backoff fires, config is now valid — backoff resets.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+
+    // Another file change — invalid again; should log again (backoff was reset).
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(log.warn).toHaveBeenCalledTimes(2);
+
+    await reloader.stop();
+  });
+
+  it("re-logs when invalid config issues change", async () => {
+    const snapshot1 = makeSnapshot({
+      valid: false,
+      issues: [{ path: "bad.key", message: "Unrecognized key" }],
+      hash: "invalid-a",
+    });
+    const snapshot2 = makeSnapshot({
+      valid: false,
+      issues: [{ path: "other.key", message: "Invalid type" }],
+      hash: "invalid-b",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(snapshot1)
+      .mockResolvedValueOnce(snapshot2);
+    const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
+
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "config reload skipped (invalid config): bad.key: Unrecognized key",
+    );
+
+    // Backoff fires, different issues — should log again and reset backoff to initial.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(log.warn).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      "config reload skipped (invalid config): other.key: Invalid type",
+    );
+
+    await reloader.stop();
+  });
+
   it("contains restart callback failures and retries on subsequent changes", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -46,6 +46,8 @@ const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
 };
 const MISSING_CONFIG_RETRY_DELAY_MS = 150;
 const MISSING_CONFIG_MAX_RETRIES = 2;
+const INVALID_CONFIG_INITIAL_BACKOFF_MS = 1_000;
+const INVALID_CONFIG_MAX_BACKOFF_MS = 5 * 60 * 1_000;
 
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
@@ -274,6 +276,8 @@ export function startGatewayConfigReloader(opts: {
   let stopped = false;
   let restartQueued = false;
   let missingConfigRetries = 0;
+  let invalidConfigBackoffMs = 0;
+  let lastInvalidIssues = "";
 
   const scheduleAfter = (wait: number) => {
     if (stopped) {
@@ -325,10 +329,21 @@ export function startGatewayConfigReloader(opts: {
 
   const handleInvalidSnapshot = (snapshot: ConfigFileSnapshot): boolean => {
     if (snapshot.valid) {
+      // Config became valid again — reset backoff state.
+      invalidConfigBackoffMs = 0;
+      lastInvalidIssues = "";
       return false;
     }
     const issues = snapshot.issues.map((issue) => `${issue.path}: ${issue.message}`).join(", ");
-    opts.log.warn(`config reload skipped (invalid config): ${issues}`);
+    // Only log when the issues change to avoid log spam.
+    if (issues !== lastInvalidIssues) {
+      opts.log.warn(`config reload skipped (invalid config): ${issues}`);
+      lastInvalidIssues = issues;
+      invalidConfigBackoffMs = INVALID_CONFIG_INITIAL_BACKOFF_MS;
+    } else {
+      invalidConfigBackoffMs = Math.min(invalidConfigBackoffMs * 2, INVALID_CONFIG_MAX_BACKOFF_MS);
+    }
+    scheduleAfter(invalidConfigBackoffMs);
     return true;
   };
 


### PR DESCRIPTION
## Summary

- Add exponential backoff (1s → 2s → 4s → … → 5min cap) when config validation fails during the reload loop, preventing the tight retry cycle that generated ~1GB logs
- Deduplicate log warnings: only log when the set of validation issues changes, suppressing repeated identical messages
- Reset backoff state when config becomes valid again, so the reloader recovers immediately on fix

Closes #29745

## Test plan

- [x] New test: logs invalid config warning once and suppresses duplicates on same issues
- [x] New test: verifies exponential backoff timing (1s → 2s → 4s)
- [x] New test: backoff resets when config becomes valid, re-logs on next invalid
- [x] New test: re-logs when invalid config issues change (different error)
- [x] All existing `config-reload.test.ts` tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)