### PR TITLE
fix(sandbox): pass OPENCLAW_BROWSER_NO_SANDBOX=1 to browser container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Install/npm: fix npm global install deprecation warnings. (#28318) Thanks @vincentkoc.
 - fix(model): preserve reasoning in provider fallback resolution. (#29285) Fixes #25636. Thanks @vincentkoc.
 - Browser/Open & navigate: accept `url` as an alias parameter for `open` and `navigate`. (#29260) Thanks @vincentkoc.
+- Sandbox/Browser Docker: pass `OPENCLAW_BROWSER_NO_SANDBOX=1` to sandbox browser containers and bump sandbox browser security hash epoch so existing containers are recreated and pick up the env on upgrade. (#29879) Thanks @Lukavyi.
 - Codex/Usage window: label weekly usage window as `Week` instead of `Day`. (#26267) Thanks @Sid-Qin.
 - Slack/Native commands: register Slack native status as `/agentstatus` (Slack-reserved `/status`) so manifest slash command registration stays valid while text `/status` still works. Landed from contributor PR #29032 by @maloqab. Thanks @maloqab.
 - Android/Nodes reliability: reject `facing=both` when `deviceId` is set to avoid mislabeled duplicate captures, allow notification `open`/`reply` on non-clearable entries while still gating dismiss, trigger listener rebind before notification actions, and scale invoke-result ack timeout to invoke budget for large clip payloads. (#28260) Thanks @obviyus.

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -158,6 +158,7 @@ describe("ensureSandboxBrowser create args", () => {
     expect(createArgs).toBeDefined();
     expect(createArgs).toContain("127.0.0.1::6080");
     const envEntries = envEntriesFromDockerArgs(createArgs ?? []);
+    expect(envEntries).toContain("OPENCLAW_BROWSER_NO_SANDBOX=1");
     const passwordEntry = envEntries.find((entry) =>
       entry.startsWith("OPENCLAW_BROWSER_NOVNC_PASSWORD="),
     );

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -263,6 +263,10 @@ export async function ensureSandboxBrowser(params: {
     }
     args.push("-e", `OPENCLAW_BROWSER_VNC_PORT=${params.cfg.browser.vncPort}`);
     args.push("-e", `OPENCLAW_BROWSER_NOVNC_PORT=${params.cfg.browser.noVncPort}`);
+    // Chromium's setuid/namespace sandbox cannot work inside Docker containers
+    // (PID namespace creation requires privileges Docker does not grant by default).
+    // The container itself provides isolation, so --no-sandbox is safe here.
+    args.push("-e", "OPENCLAW_BROWSER_NO_SANDBOX=1");
     if (noVncEnabled && noVncPassword) {
       args.push("-e", `${NOVNC_PASSWORD_ENV_KEY}=${noVncPassword}`);
     }

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -38,7 +38,7 @@ export const DEFAULT_TOOL_DENY = [
 
 export const DEFAULT_SANDBOX_BROWSER_IMAGE = "openclaw-sandbox-browser:bookworm-slim";
 export const DEFAULT_SANDBOX_COMMON_IMAGE = "openclaw-sandbox-common:bookworm-slim";
-export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-02-21-novnc-auth-default";
+export const SANDBOX_BROWSER_SECURITY_HASH_EPOCH = "2026-02-28-no-sandbox-env";
 
 export const DEFAULT_SANDBOX_BROWSER_PREFIX = "openclaw-sbx-browser-";
 export const DEFAULT_SANDBOX_BROWSER_NETWORK = "openclaw-sandbox-browser";


### PR DESCRIPTION
## Summary

Sandbox browser Chromium fails to start in Docker because the setuid/namespace sandbox requires privileges that Docker containers do not grant by default (PID namespace creation fails with `EPERM`).

The entrypoint (`sandbox-browser-entrypoint.sh`) already supports the `OPENCLAW_BROWSER_NO_SANDBOX` env var to pass `--no-sandbox` to Chromium, but `ensureSandboxBrowser()` in `browser.ts` never passed it to the container.

## Changes

- Pass `OPENCLAW_BROWSER_NO_SANDBOX=1` env var when creating the sandbox browser Docker container

## Why `--no-sandbox` is safe here

The Docker container itself provides process isolation. This is standard practice for headless Chromium in Docker — Playwright, Puppeteer, and Selenium all use `--no-sandbox` in containerized environments.

## Testing

1. Build sandbox browser image: `bash scripts/sandbox-browser-setup.sh`
2. Remove old browser containers: `docker rm -f $(docker ps -aq --filter name=openclaw-sbx-browser)`
3. Use browser tool from a sandboxed agent — Chromium now starts successfully and CDP becomes reachable

**Before fix:** `No usable sandbox!` error, container exits with code 1, CDP never reachable
**After fix:** Chromium starts, CDP reachable, browser tool works

Fixes #28870