### PR TITLE
fix(mattermost): isolate sessions per channel message using post.id as thread root

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -503,7 +503,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
 
     const baseSessionKey = route.sessionKey;
-    const threadRootId = post.root_id?.trim() || undefined;
+    const threadRootId = post.root_id?.trim() || (kind !== "direct" ? post.id : undefined);
     const threadKeys = resolveThreadSessionKeys({
       baseSessionKey,
       threadId: threadRootId,
@@ -943,7 +943,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       if (!channelId) {
         return null;
       }
-      const threadId = entry.post.root_id?.trim();
+      const channelType = entry.payload.data?.channel_type;
+      const kind = channelKind(channelType);
+      const threadId = entry.post.root_id?.trim() || (kind !== "direct" ? entry.post.id : undefined);
       const threadKey = threadId ? `thread:${threadId}` : "channel";
       return `mattermost:${account.accountId}:${channelId}:${threadKey}`;
     },


### PR DESCRIPTION
## Summary

- **Problem:** All top-level messages in a Mattermost channel share a single session key (`…:channel`), causing context bleed when multiple conversations happen concurrently.
- **Why it matters:** In multi-user channels, the bot mixes context from unrelated messages — producing confused or incorrect responses. This affects every Mattermost deployment that uses channel-based (non-DM) messaging.
- **What changed:** When a top-level message arrives in a channel or group (`post.root_id` is empty), use `post.id` as the thread root for session key resolution. This gives each message its own session key (`…:thread:<post.id>`) without requiring any configuration change.
- **What did NOT change (scope boundary):** DM behavior is unchanged (DMs already have per-peer isolation). No config schema changes. No outbound delivery changes. The `replyToMode` feature (#29587, #16570) is orthogonal — this fix works independently.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #29058 (feature request for per-message session isolation in Mattermost)
- Related #27729 (replyToMode config being ignored — this fix addresses the session isolation aspect independently)
- Related #29587, #16570 (replyToMode PRs — orthogonal but complementary)

## User-visible / Behavior Changes

- Each top-level channel/group message now gets its own session key (`mattermost:<accountId>:<channelId>:thread:<postId>`) instead of sharing `mattermost:<accountId>:<channelId>:channel`.
- Concurrent conversations in the same channel no longer share context.
- Messages already inside an existing thread continue to use the thread's root ID (unchanged behavior).
- DM behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Kubernetes, any platform)
- Runtime/container: Node.js with OpenClaw gateway
- Model/provider: Any
- Integration/channel: Mattermost (self-hosted)
- Relevant config: Default Mattermost config (no special settings needed)

### Steps

1. Set up a Mattermost channel with the bot active
2. Have User A send a top-level message ("What is the capital of France?")
3. Before the bot finishes replying, have User B send a different top-level message ("Write a Python hello world")
4. Observe the bot's response to User A

### Expected

- User A gets a response about France's capital
- User B gets a Python code response
- Each conversation is isolated

### Actual (without this fix)

- User A's and User B's messages share the same session, causing the bot to mix context ("Here's a Python program about the capital of France...")

## Evidence

- [x] Trace/log snippets

Before fix — both messages resolve to the same session key:
```
session: mattermost:default:ch123:channel
session: mattermost:default:ch123:channel  ← collision
```

After fix — each message gets a unique session key:
```
session: mattermost:default:ch123:thread:post_abc
session: mattermost:default:ch123:thread:post_def  ← isolated
```

Verified in production across a fleet of 25 agents running on Mattermost with KEDA scale-to-zero.

## Human Verification (required)

- **Verified scenarios:** Deployed on a 25-agent fleet (Mattermost, Kubernetes). Multiple concurrent channel conversations produce isolated sessions. Follow-up thread replies correctly resume the parent session.
- **Edge cases checked:**
  - DMs: unaffected (kind === "direct" guard prevents post.id fallback)
  - Group messages: correctly get per-message sessions
  - Existing thread replies: root_id is still preferred when present
  - Debouncer: session keys are consistent between debouncer and handlePost
- **What you did not verify:** Interaction with `replyToMode` config (this fix is independent of that feature)

## Compatibility / Migration

- Backward compatible? `Yes` — session keys change format, but sessions are ephemeral; no migration needed
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert this commit. Alternatively, no config-level toggle exists — the fix is unconditional for channel/group messages.
- **Files/config to restore:** `extensions/mattermost/src/mattermost/monitor.ts`
- **Known bad symptoms:** If post.id is somehow undefined (should never happen per Mattermost API contracts), session key would fall back to `…:channel` (pre-fix behavior).

## Risks and Mitigations

- **Risk:** Session key format change means active conversations in progress during upgrade will lose their session state.
  - **Mitigation:** Sessions are ephemeral and short-lived. Any in-flight conversation simply starts a fresh session on the next message — same as a normal restart.

---

**Note:** This is an AI-assisted PR (Claude Code). Tested in production on a 25-agent Mattermost fleet. The code change is minimal (4 lines) and follows the pattern already used by the Slack plugin for per-thread session isolation.