### PR TITLE
fix(config): add missing params field to AgentEntrySchema (#17470)

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -704,6 +704,7 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Adds the missing `params` field to `AgentEntrySchema` in `zod-schema.agent-runtime.ts`.

PR #17470 (commit `160bd61ff`) added per-agent `params` support to the TypeScript type (`types.agents.ts`) and the runtime (`extra-params.ts`), but did not update the Zod validation schema. Since `AgentEntrySchema` uses `.strict()`, configs with `agents.list[].params` are rejected at validation time with `Unrecognized key: "params"`.

## Changes

One-line addition to `AgentEntrySchema`:

```typescript
params: z.record(z.string(), z.unknown()).optional(),
```

This matches the existing pattern in `zod-schema.agent-defaults.ts` (line 27) for `agents.defaults.models[].params`.

## Testing

- [x] Verified config with `agents.list[].params` loads successfully after fix
- [x] Verified gateway starts and reloads without validation errors
- [x] Verified runtime correctly merges agent-level params with global model params
- [x] `pnpm build` passes

Closes #29902

---

- [x] AI-assisted (Claude, via OpenClaw agent session)
- [x] Fully tested on live instance
- [x] Reviewed and understood by human operator before submission