### PR TITLE
feat(feishu): support image insertion into table cells and fix empty content edge cases

### DIFF
--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -28,9 +28,7 @@ Returns: title, plain text content, block statistics. Check `hint` field - if pr
 { "action": "write", "doc_token": "ABC123def", "content": "# Title\n\nMarkdown content..." }
 ```
 
-Replaces entire document with markdown content. Supports: headings, lists, code blocks, quotes, links, images (`![](url)` auto-uploaded), bold/italic/strikethrough.
-
-**Limitation:** Markdown tables are NOT supported.
+Replaces entire document with markdown content. Supports: headings, lists, code blocks, quotes, links, images (`![](url)` auto-uploaded), bold/italic/strikethrough, and GFM tables (`| col |` syntax — automatically converted to native Feishu table blocks).
 
 ### Append Content
 
@@ -38,7 +36,7 @@ Replaces entire document with markdown content. Supports: headings, lists, code 
 { "action": "append", "doc_token": "ABC123def", "content": "Additional content" }
 ```
 
-Appends markdown to end of document.
+Appends markdown to end of document. Supports the same content types as `write`, including GFM tables.
 
 ### Create Document
 
@@ -138,15 +136,26 @@ Optional: `parent_block_id` to insert under a specific block.
 
 ### Upload Image to Docx (from URL or local file)
 
+Two ways to control where the image is inserted:
+
+1. `after_block_id` — preferred for mid-document insertion
+
+Insert the image immediately after a known block. Get block IDs from `list_blocks` or `read`.
+
 ```json
 {
   "action": "upload_image",
   "doc_token": "ABC123def",
-  "url": "https://example.com/image.png"
+  "url": "https://example.com/image.png",
+  "after_block_id": "doxcnXxxBlockId"
 }
 ```
 
-Or local path with position control:
+The parent block and insertion index are resolved automatically. Use this whenever you know which block the image should follow.
+
+2. `parent_block_id` + `index` — for inserting as the first child
+
+Use when you need to insert at position 0 (before all existing children of a block), or when you want to append to a specific parent.
 
 ```json
 {
@@ -154,11 +163,11 @@ Or local path with position control:
   "doc_token": "ABC123def",
   "file_path": "/tmp/image.png",
   "parent_block_id": "doxcnParent",
-  "index": 5
+  "index": 0
 }
 ```
 
-Optional `index` (0-based) inserts the image at a specific position among sibling blocks. Omit to append at end.
+`index` is 0-based. Omit to append at the end of the parent. If both `after_block_id` and `parent_block_id` are supplied, `after_block_id` takes priority.
 
 **Note:** Image display size is determined by the uploaded image's pixel dimensions. For small images (e.g. 480x270 GIFs), scale to 800px+ width before uploading to ensure proper display.
 

--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -88,6 +88,21 @@ Returns full block data including tables, images. Use this to read structured co
 { "action": "delete_block", "doc_token": "ABC123def", "block_id": "doxcnXXX" }
 ```
 
+### Insert Content After a Block
+
+```json
+{
+  "action": "insert",
+  "doc_token": "ABC123def",
+  "after_block_id": "doxcnXxxBlockId",
+  "content": "## New Section\n\nMarkdown content..."
+}
+```
+
+Inserts markdown immediately after the specified block. Supports the same content types as `write`, including GFM tables and `![](url)` images.
+
+**Image note:** `![](url)` in `insert`/`write`/`append` only accepts HTTP URLs — local paths and file tokens are not supported. To insert a local image, use `upload_image` instead.
+
 ### Create Table (Docx Table Block)
 
 ```json

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -154,14 +154,28 @@ export const FeishuDocSchema = Type.Union([
           "Image as data URI (data:image/png;base64,...) or plain base64 string. Use instead of url/file_path for DALL-E outputs, canvas screenshots, etc.",
       }),
     ),
+    after_block_id: Type.Optional(
+      Type.String({
+        description:
+          "Insert the image immediately after this block (preferred for mid-document insertion). " +
+          "The parent and index are resolved automatically. Takes priority over parent_block_id/index if both are supplied. " +
+          "Get block IDs from list_blocks or read.",
+      }),
+    ),
     parent_block_id: Type.Optional(
-      Type.String({ description: "Parent block ID (default: document root)" }),
+      Type.String({
+        description:
+          "Parent block ID. Use with index=0 to insert at the start of a block (e.g. first child), " +
+          "or omit index to append. Use after_block_id instead for most mid-document insertions.",
+      }),
     ),
     filename: Type.Optional(Type.String({ description: "Optional filename override" })),
     index: Type.Optional(
       Type.Integer({
         minimum: 0,
-        description: "Insert position (0-based index among siblings). Omit to append.",
+        description:
+          "Insert position (0-based index among siblings, used with parent_block_id). " +
+          "Required when inserting as the first child (index=0). Omit to append.",
       }),
     ),
   }),

--- a/extensions/feishu/src/docx-color-text.ts
+++ b/extensions/feishu/src/docx-color-text.ts
@@ -120,17 +120,25 @@ export async function updateColorText(
 ) {
   const segments = parseColorMarkup(content);
 
+  // Feishu rejects elements with empty content — filter before building the
+  // elements array so edge-case inputs (adjacent tags, lone brackets, etc.)
+  // never reach the API with an empty text_run.content field.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK type
-  const elements: any[] = segments.map((seg) => ({
-    text_run: {
-      content: seg.text,
-      text_element_style: {
-        ...(seg.textColor && { text_color: seg.textColor }),
-        ...(seg.bgColor && { background_color: seg.bgColor }),
-        ...(seg.bold && { bold: true }),
+  const elements: any[] = segments
+    .filter((seg) => seg.text.length > 0)
+    .map((seg) => ({
+      text_run: {
+        content: seg.text,
+        text_element_style: {
+          ...(seg.textColor && { text_color: seg.textColor }),
+          ...(seg.bgColor && { background_color: seg.bgColor }),
+          ...(seg.bold && { bold: true }),
+        },
       },
-    },
-  }));
+    }));
+  if (elements.length === 0) {
+    throw new Error("color_text: content produced no non-empty text segments.");
+  }
 
   const res = await client.docx.documentBlock.patch({
     path: { document_id: docToken, block_id: blockId },

--- a/extensions/feishu/src/docx-picture-ops.ts
+++ b/extensions/feishu/src/docx-picture-ops.ts
@@ -1,0 +1,71 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH } from "./docx-table-ops.js";
+
+/**
+ * Read image pixel width from a PNG or JPEG buffer without external
+ * dependencies. Returns null for unsupported or malformed inputs.
+ *
+ * PNG: width is a big-endian uint32 at byte offset 16 (inside the IHDR chunk).
+ * JPEG: scan for the first SOF0–SOF3 marker (0xFF 0xC0–0xC3) and read the
+ *       width field at marker_offset + 7 (big-endian uint16).
+ *
+ * Known limitation: WebP and GIF are not parsed. Images in those formats will
+ * still be inserted correctly, but the table column width will not be adjusted
+ * to match the image's pixel dimensions.
+ */
+// ── PNG header offsets ────────────────────────────────────────────────────────
+// Byte layout: [0–7] signature | [8–11] IHDR length | [12–15] "IHDR" | [16–19] width
+const PNG_SIG_0 = 0x89; // first byte of PNG signature
+const PNG_SIG_1 = 0x50; // 'P'
+const PNG_SIG_2 = 0x4e; // 'N'
+const PNG_SIG_3 = 0x47; // 'G'
+const PNG_MIN_HEADER_BYTES = 24; // need at least 24 bytes to read IHDR width
+const PNG_WIDTH_OFFSET = 16; // big-endian uint32 at byte 16
+
+// ── JPEG header offsets ───────────────────────────────────────────────────────
+// SOI marker: 0xFF 0xD8.  Each subsequent segment: [0xFF][marker][length(2)][data...]
+// SOF0–SOF3 layout: 0xFF marker(1) length(2) precision(1) height(2) width(2)
+const JPEG_MARKER_PREFIX = 0xff;
+const JPEG_SOI_BYTE = 0xd8; // second byte of SOI marker
+const JPEG_MIN_SOI_BYTES = 4; // need ≥4 bytes to detect SOI + first segment marker
+const JPEG_SCAN_START = 2; // skip the 2-byte SOI marker
+const JPEG_SEGMENT_LOOKAHEAD = 8; // need i+8 bytes readable to safely decode SOF width
+const JPEG_SOF_FIRST = 0xc0; // SOF0 — baseline DCT
+const JPEG_SOF_LAST = 0xc3; // SOF3 — lossless sequential
+// SOF field layout: marker[2] + length[2] + precision[1] + height[2] → width at +7
+const JPEG_SOF_WIDTH_OFFSET = 7;
+const JPEG_MARKER_BYTES = 2; // 0xFF + marker_id
+const JPEG_SEG_LENGTH_OFFSET = 2; // length field starts 2 bytes into the segment
+
+export function getImageWidth(buf: Buffer): number | null {
+  // PNG: identify by 4-byte signature, read width from IHDR chunk at offset 16
+  if (
+    buf.length >= PNG_MIN_HEADER_BYTES &&
+    buf[0] === PNG_SIG_0 &&
+    buf[1] === PNG_SIG_1 &&
+    buf[2] === PNG_SIG_2 &&
+    buf[3] === PNG_SIG_3
+  ) {
+    return buf.readUInt32BE(PNG_WIDTH_OFFSET);
+  }
+  // JPEG: starts with 0xFF 0xD8; scan segments for SOF0–SOF3
+  if (
+    buf.length >= JPEG_MIN_SOI_BYTES &&
+    buf[0] === JPEG_MARKER_PREFIX &&
+    buf[1] === JPEG_SOI_BYTE
+  ) {
+    let i = JPEG_SCAN_START;
+    while (i + JPEG_SEGMENT_LOOKAHEAD < buf.length) {
+      if (buf[i] !== JPEG_MARKER_PREFIX) break;
+      const marker = buf[i + 1];
+      if (marker >= JPEG_SOF_FIRST && marker <= JPEG_SOF_LAST) {
+        // SOF layout: 0xFF marker(1) marker_id(1) length(2) precision(1) height(2) width(2)
+        return buf.readUInt16BE(i + JPEG_SOF_WIDTH_OFFSET);
+      }
+      // Advance past this segment: marker bytes + length field value
+      const segLen = buf.readUInt16BE(i + JPEG_SEG_LENGTH_OFFSET);
+      i += JPEG_MARKER_BYTES + segLen;
+    }
+  }
+  return null;
+}

--- a/extensions/feishu/src/docx-table-ops.ts
+++ b/extensions/feishu/src/docx-table-ops.ts
@@ -11,9 +11,10 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 
 // ============ Table Utilities ============
 
-// Feishu table constraints
-const MIN_COLUMN_WIDTH = 50; // Feishu API minimum
-const MAX_COLUMN_WIDTH = 400; // Reasonable maximum for readability
+// Feishu table column-width constraints (pixels).
+// Also imported by docx-picture-ops for image-aware column patching.
+export const MIN_COLUMN_WIDTH = 50; // Feishu API minimum
+export const MAX_COLUMN_WIDTH = 400; // Reasonable maximum for readability
 const DEFAULT_TABLE_WIDTH = 730; // Approximate Feishu page content width
 
 /**

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -35,6 +35,8 @@ describe("feishu_doc image fetch hardening", () => {
   const blockPatchMock = vi.hoisted(() => vi.fn());
   const scopeListMock = vi.hoisted(() => vi.fn());
 
+  let feishuDocTool: any;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -112,6 +114,22 @@ describe("feishu_doc image fetch hardening", () => {
     permissionMemberCreateMock.mockResolvedValue({ code: 0 });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: { appId: "app_id", appSecret: "app_secret" },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
+      .find((tool) => tool.name === "feishu_doc");
   });
 
   it("inserts blocks sequentially to preserve document order", async () => {
@@ -135,21 +153,6 @@ describe("feishu_doc image fetch hardening", () => {
       data: { children: [{ block_type: 3, block_id: "h1" }] },
     });
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: { appId: "app_id", appSecret: "app_secret" },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -194,21 +197,6 @@ describe("feishu_doc image fetch hardening", () => {
       },
     }));
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: { appId: "app_id", appSecret: "app_secret" },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const longMarkdown = Array.from(
@@ -254,21 +242,6 @@ describe("feishu_doc image fetch hardening", () => {
       data: { children: data.children },
     }));
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: { appId: "app_id", appSecret: "app_secret" },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const fencedMarkdown = [
@@ -306,24 +279,6 @@ describe("feishu_doc image fetch hardening", () => {
       new Error("Blocked: resolves to private/internal IP address"),
     );
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -341,24 +296,6 @@ describe("feishu_doc image fetch hardening", () => {
   });
 
   it("reports owner permission details when grant succeeds", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -378,24 +315,6 @@ describe("feishu_doc image fetch hardening", () => {
     const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     permissionMemberCreateMock.mockRejectedValueOnce(new Error("permission denied"));
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -414,24 +333,6 @@ describe("feishu_doc image fetch hardening", () => {
   });
 
   it("skips permission grant when owner_open_id is omitted", async () => {
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -449,24 +350,6 @@ describe("feishu_doc image fetch hardening", () => {
       data: { document: { title: "Created Doc" } },
     });
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -488,24 +371,6 @@ describe("feishu_doc image fetch hardening", () => {
     const localPath = join(tmpdir(), `feishu-docx-upload-${Date.now()}.txt`);
     await fs.writeFile(localPath, "hello from local file", "utf8");
 
-    const registerTool = vi.fn();
-    registerFeishuDocTools({
-      config: {
-        channels: {
-          feishu: {
-            appId: "app_id",
-            appSecret: "app_secret",
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-      .find((tool) => tool.name === "feishu_doc");
     expect(feishuDocTool).toBeDefined();
 
     const result = await feishuDocTool.execute("tool-call", {
@@ -549,24 +414,6 @@ describe("feishu_doc image fetch hardening", () => {
     await fs.writeFile(localPath, "hello from local file", "utf8");
 
     try {
-      const registerTool = vi.fn();
-      registerFeishuDocTools({
-        config: {
-          channels: {
-            feishu: {
-              appId: "app_id",
-              appSecret: "app_secret",
-            },
-          },
-        } as any,
-        logger: { debug: vi.fn(), info: vi.fn() } as any,
-        registerTool,
-      } as any);
-
-      const feishuDocTool = registerTool.mock.calls
-        .map((call) => call[0])
-        .map((tool) => (typeof tool === "function" ? tool({}) : tool))
-        .find((tool) => tool.name === "feishu_doc");
       expect(feishuDocTool).toBeDefined();
 
       const result = await feishuDocTool.execute("tool-call", {
@@ -581,5 +428,21 @@ describe("feishu_doc image fetch hardening", () => {
     } finally {
       await fs.unlink(localPath);
     }
+  });
+
+  it("rejects update_block with empty content before hitting the API", async () => {
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "update_block",
+      doc_token: "doc_1",
+      block_id: "block_1",
+      content: "",
+    });
+
+    expect(result.details.error).toMatch(/content must be a non-empty string/);
+    expect(result.details.error).toMatch(/upload_image/);
+    // Guard must fire before any network call
+    expect(blockPatchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -591,10 +591,17 @@ async function uploadImageBlock(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block type
     const items: any[] = [];
     let pageToken: string | undefined;
+    let pages = 0;
+    const MAX_PAGES = 20; // 20 × 200 = 4000 siblings; enough for any real document
     do {
+      if (pages++ >= MAX_PAGES) {
+        throw new Error(
+          `after_block_id resolution exceeded ${MAX_PAGES} pages; parent block has too many children`,
+        );
+      }
       const res = await client.docx.documentBlockChildren.get({
         path: { document_id: docToken, block_id: parentBlockId },
-        params: pageToken ? { page_token: pageToken } : {},
+        params: { ...(pageToken ? { page_token: pageToken } : {}), page_size: 200 },
       });
       if (res.code !== 0) throw new Error(res.msg);
       items.push(...(res.data?.items ?? []));

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -9,6 +9,7 @@ import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
 import { updateColorText } from "./docx-color-text.js";
+import { getImageWidth } from "./docx-picture-ops.js";
 import {
   cleanBlocksForDescendant,
   insertTableRow,
@@ -540,7 +541,8 @@ async function processImages(
     return 0;
   }
 
-  const imageBlocks = insertedBlocks.filter((b) => b.block_type === 27);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block types
+  const imageBlocks = insertedBlocks.filter((b: any) => b.block_type === 27);
 
   let processed = 0;
   for (let i = 0; i < Math.min(imageUrls.length, imageBlocks.length); i++) {
@@ -555,9 +557,7 @@ async function processImages(
 
       await client.docx.documentBlock.patch({
         path: { document_id: docToken, block_id: blockId },
-        data: {
-          replace_image: { token: fileToken },
-        },
+        data: { replace_image: { token: fileToken } },
       });
 
       processed++;
@@ -579,20 +579,54 @@ async function uploadImageBlock(
   filename?: string,
   index?: number,
   imageInput?: string, // data URI, plain base64, or local path
+  afterBlockId?: string, // takes priority over parentBlockId/index if provided
 ) {
+  // Resolve after_block_id → (parentBlockId, index) when provided.
+  if (afterBlockId) {
+    const blockInfo = await client.docx.documentBlock.get({
+      path: { document_id: docToken, block_id: afterBlockId },
+    });
+    if (blockInfo.code !== 0) throw new Error(blockInfo.msg);
+    parentBlockId = blockInfo.data?.block?.parent_id ?? docToken;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block type
+    const items: any[] = [];
+    let pageToken: string | undefined;
+    do {
+      const res = await client.docx.documentBlockChildren.get({
+        path: { document_id: docToken, block_id: parentBlockId },
+        params: pageToken ? { page_token: pageToken } : {},
+      });
+      if (res.code !== 0) throw new Error(res.msg);
+      items.push(...(res.data?.items ?? []));
+      pageToken = res.data?.page_token ?? undefined;
+    } while (pageToken);
+    const idx = items.findIndex((item: any) => item.block_id === afterBlockId);
+    if (idx === -1) throw new Error(`after_block_id "${afterBlockId}" not found`);
+    index = idx + 1;
+  }
+
   // Step 1: Create an empty image block (block_type 27).
   // Per Feishu FAQ: image token cannot be set at block creation time.
-  const insertRes = await client.docx.documentBlockChildren.create({
-    path: { document_id: docToken, block_id: parentBlockId ?? docToken },
-    params: { document_revision_id: -1 },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK type
-    data: { children: [{ block_type: 27, image: {} as any }], index: index ?? -1 },
+  // Use the Descendant API for all parents — it works for document root,
+  // regular blocks, and TableCell alike, while the Children API silently
+  // misroutes image blocks into TableCell parents.
+  const effectiveParentId = parentBlockId ?? docToken;
+  const tempId = `img_${Math.random().toString(36).slice(2, 10)}`;
+  /* eslint-disable @typescript-eslint/no-explicit-any -- SDK types */
+  const descRes = await (client.docx.documentBlockDescendant as any).create({
+    path: { document_id: docToken, block_id: effectiveParentId },
+    data: {
+      children_id: [tempId],
+      descendants: [{ block_id: tempId, block_type: 27, image: {} as any }],
+      index: index ?? -1,
+    },
   });
-  if (insertRes.code !== 0) {
-    throw new Error(`Failed to create image block: ${insertRes.msg}`);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  if (descRes.code !== 0) {
+    throw new Error(`Failed to create image block: ${descRes.msg}`);
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK return shape
-  const imageBlockId = insertRes.data?.children?.find((b: any) => b.block_type === 27)?.block_id;
+  const imageBlockId = descRes.data?.children?.find((b: any) => b.block_type === 27)?.block_id;
   if (!imageBlockId) {
     throw new Error("Failed to create image block");
   }
@@ -636,18 +670,19 @@ async function uploadFileBlock(
 ) {
   const blockId = parentBlockId ?? docToken;
 
-  // Feishu API does not allow creating empty file blocks (block_type 23).
-  // Workaround: create a placeholder text block, then replace it with file content.
-  // Actually, file blocks need a different approach: use markdown link as placeholder.
+  // Feishu does not support creating file blocks (block_type 23) directly via the
+  // block API. Workaround: insert a markdown-link placeholder block to reserve a
+  // document position, immediately delete it, then upload the file to Feishu Drive
+  // and return the file_token for the caller to reference.
   const upload = await resolveUploadInput(url, filePath, maxBytes, filename);
 
-  // Create a placeholder text block first
+  // Insert a temporary markdown-link placeholder, then immediately delete it.
   const placeholderMd = `[${upload.fileName}](https://example.com/placeholder)`;
   const converted = await convertMarkdown(client, placeholderMd);
   const sorted = sortBlocksByFirstLevel(converted.blocks, converted.firstLevelBlockIds);
   const { children: inserted } = await insertBlocks(client, docToken, sorted, blockId);
 
-  // Get the first inserted block - we'll delete it and create the file in its place
+  // Locate the placeholder so it can be deleted; no file block is inserted in the document.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK return shape
   const placeholderBlock = inserted[0];
   if (!placeholderBlock?.block_id) {
@@ -875,9 +910,6 @@ async function insertDoc(
 
   const parentId = blockInfo.data?.block?.parent_id ?? docToken;
 
-  // Paginate through all children to reliably locate after_block_id.
-  // documentBlockChildren.get returns up to 200 children per page; large
-  // parents require multiple requests.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block type
   const items: any[] = [];
   let pageToken: string | undefined;
@@ -943,6 +975,7 @@ async function createTable(
   columnSize: number,
   parentBlockId?: string,
   columnWidth?: number[],
+  index?: number,
 ) {
   if (columnWidth && columnWidth.length !== columnSize) {
     throw new Error("column_width length must equal column_size");
@@ -964,6 +997,7 @@ async function createTable(
           },
         },
       ],
+      ...(index !== undefined ? { index } : {}),
     },
   });
 
@@ -1035,28 +1069,37 @@ async function writeTableCells(
       const cellId = cellIds[r * cols + c];
       if (!cellId) continue;
 
-      // table cell is a container block: clear existing children, then create text child blocks
+      // Clear existing children before writing new content.
       const childrenRes = await client.docx.documentBlockChildren.get({
         path: { document_id: docToken, block_id: cellId },
       });
-      if (childrenRes.code !== 0) {
-        throw new Error(childrenRes.msg);
-      }
-
+      if (childrenRes.code !== 0) throw new Error(childrenRes.msg);
       const existingChildren = childrenRes.data?.items ?? [];
       if (existingChildren.length > 0) {
         const delRes = await client.docx.documentBlockChildren.batchDelete({
           path: { document_id: docToken, block_id: cellId },
           data: { start_index: 0, end_index: existingChildren.length },
         });
-        if (delRes.code !== 0) {
-          throw new Error(delRes.msg);
-        }
+        if (delRes.code !== 0) throw new Error(delRes.msg);
       }
 
       const text = rowValues[c] ?? "";
+      // Skip empty cells — convertMarkdown("") returns 400 from the Feishu API.
+      if (text.trim() === "") {
+        written++;
+        continue;
+      }
+
       const converted = await convertMarkdown(client, text);
-      const sorted = sortBlocksByFirstLevel(converted.blocks, converted.firstLevelBlockIds);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block types
+      const sorted = sortBlocksByFirstLevel(converted.blocks, converted.firstLevelBlockIds)
+        // Strip trailing empty paragraph that the convert API always appends.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK block types
+        .filter((b: any) => {
+          if (b.block_type !== 2) return true;
+          const elems = b.text?.elements ?? [];
+          return elems.length > 0 && elems.some((e: any) => e.text_run?.content?.trim());
+        });
 
       if (sorted.length > 0) {
         await insertBlocks(client, docToken, sorted, cellId);
@@ -1082,6 +1125,7 @@ async function createTableWithValues(
   values: string[][],
   parentBlockId?: string,
   columnWidth?: number[],
+  index?: number,
 ) {
   const created = await createTable(
     client,
@@ -1090,6 +1134,7 @@ async function createTableWithValues(
     columnSize,
     parentBlockId,
     columnWidth,
+    index,
   );
 
   const tableBlockId = created.table_block_id;
@@ -1113,6 +1158,15 @@ async function updateBlock(
   blockId: string,
   content: string,
 ) {
+  // Feishu rejects update_text_elements when content is empty (code 99992402).
+  // Throw early so the caller gets a clear message instead of an opaque API error.
+  if (!content) {
+    throw new Error(
+      "update_block: content must be a non-empty string. " +
+        "To insert an image into a document, use the upload_image action instead.",
+    );
+  }
+
   const blockInfo = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: blockId },
   });
@@ -1352,6 +1406,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       p.filename,
                       p.index,
                       p.image, // data URI or plain base64
+                      p.after_block_id,
                     ),
                   );
                 case "upload_file":


### PR DESCRIPTION
Addresses edge cases and fragilities in the feishu doc extension.

## Changes

**Feat**
- `upload_image`: support inserting images into table cells (TableCell parent); add optional `after_block_id` for mid-document insertion, resolves parent + index automatically
- `upload_image`: `documentBlockDescendant.create` is now used for all parents (document root, regular blocks, TableCell) — the Children API silently misroutes image blocks to the document root when the parent is a TableCell

**Fix**
- Empty content edge case fixes: `write_table_cells` skips `convertMarkdown` for empty cells and filters the trailing empty paragraph it always appends; `color_text` filters zero-length segments before calling `update_text_elements`; `update_block` guards against empty `content` before hitting the API

**Test**
- Align `docx.test.ts` with community style (shared `feishuDocTool` in `beforeEach`); add test for empty-content guard in `update_block`

**Docs**
- Update `SKILL.md` to document both insertion strategies (`after_block_id` vs `parent_block_id + index`)