### PR TITLE
feat(session): add announceDeliver option to suppress auto-delivery of subagent results

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -577,6 +577,7 @@ async function resolveSubagentCompletionOrigin(params: {
 async function sendAnnounce(item: AnnounceQueueItem) {
   const cfg = loadConfig();
   const announceTimeoutMs = resolveSubagentAnnounceTimeoutMs(cfg);
+  const announceDeliver = cfg.session?.announceDeliver !== false;
   const requesterDepth = getSubagentDepthFromSessionStore(item.sessionKey);
   const requesterIsSubagent = requesterDepth >= 1;
   const origin = item.origin;
@@ -600,7 +601,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       accountId: requesterIsSubagent ? undefined : origin?.accountId,
       to: requesterIsSubagent ? undefined : origin?.to,
       threadId: requesterIsSubagent ? undefined : threadId,
-      deliver: !requesterIsSubagent,
+      deliver: !requesterIsSubagent && announceDeliver,
       idempotencyKey,
     },
     timeoutMs: announceTimeoutMs,
@@ -832,6 +833,7 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "none",
       };
     }
+    const announceDeliver = loadConfig().session?.announceDeliver !== false;
     await runAnnounceDeliveryWithRetry({
       operation: "direct announce agent call",
       signal: params.signal,
@@ -841,7 +843,7 @@ async function sendSubagentAnnounceDirectly(params: {
           params: {
             sessionKey: canonicalRequesterSessionKey,
             message: params.triggerMessage,
-            deliver: shouldDeliverExternally,
+            deliver: shouldDeliverExternally && announceDeliver,
             bestEffortDeliver: params.bestEffortDeliver,
             channel: shouldDeliverExternally ? directChannel : undefined,
             accountId: shouldDeliverExternally ? directOrigin?.accountId : undefined,
@@ -1041,6 +1043,7 @@ function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
   announceType: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  announceDeliver?: boolean;
 }): string {
   if (params.remainingActiveSubagentRuns > 0) {
     const activeRunsLabel = params.remainingActiveSubagentRuns === 1 ? "run" : "runs";
@@ -1048,6 +1051,9 @@ function buildAnnounceReplyInstruction(params: {
   }
   if (params.requesterIsSubagent) {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
+  }
+  if (params.announceDeliver === false) {
+    return `A completed ${params.announceType} result is above. Auto-delivery is disabled for this session — use your own tools to deliver a user-facing update if needed. After handling, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
   }
   if (params.expectsCompletionMessage) {
     return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
@@ -1267,11 +1273,13 @@ export async function runSubagentAnnounceFlow(params: {
     } catch {
       // Best-effort only; fall back to default announce instructions when unavailable.
     }
+    const announceDeliver = loadConfig().session?.announceDeliver;
     const replyInstruction = buildAnnounceReplyInstruction({
       remainingActiveSubagentRuns,
       requesterIsSubagent,
       announceType,
       expectsCompletionMessage,
+      announceDeliver,
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -131,6 +131,14 @@ export type SessionConfig = {
   };
   /** Shared defaults for thread-bound session routing across channels/providers. */
   threadBindings?: SessionThreadBindingsConfig;
+  /**
+   * Whether subagent announce results are auto-delivered to the chat channel.
+   * When `false`, the announce trigger is still injected into the requester
+   * session but the agent's reply is **not** automatically sent — the agent
+   * must use its own tools (e.g. a card API) to deliver user-facing output.
+   * Default: `true` (auto-deliver).
+   */
+  announceDeliver?: boolean;
   /** Automatic session store maintenance (pruning, capping, file rotation). */
   maintenance?: SessionMaintenanceConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -69,6 +69,7 @@ export const SessionSchema = z
       })
       .strict()
       .optional(),
+    announceDeliver: z.boolean().optional(),
     maintenance: z
       .object({
         mode: z.enum(["enforce", "warn"]).optional(),


### PR DESCRIPTION
## Summary

Adds `session.announceDeliver` (boolean, default `true`) to let users opt out of automatic delivery of subagent announce replies to the chat channel.

**Motivation**: When agents use structured message formats (Feishu interactive cards, Slack Block Kit, Telegram InlineKeyboard, etc.), the hardcoded `deliver: true` in the announce flow causes raw text to leak into the channel *before* the agent can send a properly formatted message via its own tools.

With `announceDeliver: false`:
- The announce trigger is still injected into the requester session
- But the agent's reply is NOT automatically sent to the channel
- The agent must use its own tools (e.g. a card API) to deliver user-facing output
- A dedicated instruction tells the agent to handle delivery itself

## Files changed

- `src/agents/subagent-announce.ts` — `announceDeliver` config reads + conditional delivery in both queued and direct paths + instruction variant
- `src/config/types.base.ts` — `announceDeliver?: boolean` on `SessionConfig`
- `src/config/zod-schema.session.ts` — Zod validation for new field

## Test plan

- [ ] Verify default behavior unchanged (`announceDeliver` defaults to `true`)
- [ ] Verify `announceDeliver: false` suppresses channel delivery
- [ ] Verify announce trigger message is still injected into requester session
- [ ] Verify agent receives instruction to handle delivery via own tools
- [ ] Existing test suite passes

Rebased from closed PR #23048 onto latest main with conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)