### PR TITLE
fix(cron): avoid 30s timeout for cron run --expect-final

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -674,4 +674,20 @@ describe("cron cli", () => {
     const patch = updateCall?.[2] as { patch?: { failureAlert?: boolean } };
     expect(patch?.patch?.failureAlert).toBe(false);
   });
+
+  it("uses a longer default timeout for cron run", async () => {
+    await runCronCommand(["cron", "run", "job-1", "--expect-final"]);
+
+    const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
+    const opts = (runCall?.[1] ?? {}) as { timeout?: string };
+    expect(opts.timeout).toBe("600000");
+  });
+
+  it("preserves explicit --timeout for cron run", async () => {
+    await runCronCommand(["cron", "run", "job-1", "--expect-final", "--timeout", "45000"]);
+
+    const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
+    const opts = (runCall?.[1] ?? {}) as { timeout?: string };
+    expect(opts.timeout).toBe("45000");
+  });
 });

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -156,7 +156,7 @@ async function expectCronEditWithScheduleLookupExit(
   ).rejects.toThrow("__exit__:1");
 }
 
-async function runCronRunAndCaptureExit(params: { ran: boolean }) {
+async function runCronRunAndCaptureExit(params: { ran: boolean; args?: string[] }) {
   resetGatewayMock();
   callGatewayFromCli.mockImplementation(
     async (method: string, _opts: unknown, callParams?: unknown) => {
@@ -177,11 +177,15 @@ async function runCronRunAndCaptureExit(params: { ran: boolean }) {
   runtime.exit = exitSpy;
   try {
     const program = buildProgram();
-    await program.parseAsync(["cron", "run", "job-1"], { from: "user" });
+    await program.parseAsync(params.args ?? ["cron", "run", "job-1"], { from: "user" });
   } finally {
     runtime.exit = originalExit;
   }
-  return exitSpy;
+  const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
+  return {
+    exitSpy,
+    runOpts: (runCall?.[1] ?? {}) as { timeout?: string },
+  };
 }
 
 describe("cron cli", () => {
@@ -197,7 +201,7 @@ describe("cron cli", () => {
       expectedExitCode: 1,
     },
   ])("$name", async ({ ran, expectedExitCode }) => {
-    const exitSpy = await runCronRunAndCaptureExit({ ran });
+    const { exitSpy } = await runCronRunAndCaptureExit({ ran });
     expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
   });
 
@@ -676,18 +680,18 @@ describe("cron cli", () => {
   });
 
   it("uses a longer default timeout for cron run", async () => {
-    await runCronCommand(["cron", "run", "job-1", "--expect-final"]);
-
-    const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
-    const opts = (runCall?.[1] ?? {}) as { timeout?: string };
-    expect(opts.timeout).toBe("600000");
+    const { runOpts } = await runCronRunAndCaptureExit({
+      ran: true,
+      args: ["cron", "run", "job-1", "--expect-final"],
+    });
+    expect(runOpts.timeout).toBe("600000");
   });
 
   it("preserves explicit --timeout for cron run", async () => {
-    await runCronCommand(["cron", "run", "job-1", "--expect-final", "--timeout", "45000"]);
-
-    const runCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.run");
-    const opts = (runCall?.[1] ?? {}) as { timeout?: string };
-    expect(opts.timeout).toBe("45000");
+    const { runOpts } = await runCronRunAndCaptureExit({
+      ran: true,
+      args: ["cron", "run", "job-1", "--expect-final", "--timeout", "45000"],
+    });
+    expect(runOpts.timeout).toBe("45000");
   });
 });

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -93,8 +93,11 @@ export function registerCronSimpleCommands(cron: Command) {
       .description("Run a cron job now (debug)")
       .argument("<id>", "Job id")
       .option("--due", "Run only when due (default behavior in older versions)", false)
-      .action(async (id, opts) => {
+      .action(async (id, opts, command) => {
         try {
+          if (command.getOptionValueSource("timeout") === "default") {
+            opts.timeout = "600000";
+          }
           const res = await callGatewayFromCli("cron.run", opts, {
             id,
             mode: opts.due ? "due" : "force",


### PR DESCRIPTION
## Summary
- set a longer default timeout for `cron run` when caller did not explicitly provide `--timeout`
- keep user-supplied `--timeout` unchanged
- add CLI tests for default and explicit timeout behavior

## Why
`openclaw cron run <id> --expect-final` can legitimately run much longer than 30s. With the current default timeout, CLI exits with `gateway timeout after 30000ms` while the cron run may still continue server-side.

## Behavior
- if timeout source is default: use `600000` ms for `cron run`
- if user passes `--timeout`, preserve that value

## Validation
- Added test: `uses a longer default timeout for cron run`
- Added test: `preserves explicit --timeout for cron run`

Related: #29601