### PR TITLE
fix: fire before_reset plugin hook from gateway sessions.reset

### DIFF
--- a/src/gateway/server-methods/sessions.before-reset-hook.test.ts
+++ b/src/gateway/server-methods/sessions.before-reset-hook.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Flush fire-and-forget microtask chains. */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  loadSessionStore: vi.fn(() => ({})),
+  updateSessionStore: vi.fn(
+    async (_path: string, fn: (store: Record<string, unknown>) => unknown) => {
+      return fn({});
+    },
+  ),
+  snapshotSessionOrigin: vi.fn(),
+  resolveMainSessionKey: vi.fn(() => "main"),
+  loadSessionEntry: vi.fn(() => ({
+    cfg: {},
+    storePath: "/tmp/store",
+    store: {},
+    entry: { sessionId: "old-session-id", sessionFile: undefined as string | undefined },
+    canonicalKey: "main",
+    legacyKey: undefined as string | undefined,
+  })),
+  resolveGatewaySessionStoreTarget: vi.fn(() => ({
+    storePath: "/tmp/store",
+    canonicalKey: "main",
+    storeKeys: ["main"],
+    agentId: "main",
+  })),
+  triggerInternalHook: vi.fn(),
+  createInternalHookEvent: vi.fn(() => ({ messages: [] })),
+  getGlobalHookRunner: vi.fn(),
+  abortEmbeddedPiRun: vi.fn(),
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+  clearSessionQueues: vi.fn(),
+  clearBootstrapSnapshot: vi.fn(),
+  stopSubagentsForRequester: vi.fn(),
+  unbindThreadBindingsBySessionKey: vi.fn(),
+  archiveSessionTranscripts: vi.fn(() => []),
+  getAcpSessionManager: vi.fn(() => ({
+    cancelSession: vi.fn(),
+    closeSession: vi.fn(),
+  })),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  fsReadFile: vi.fn(),
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      promises: {
+        ...actual.promises,
+        readFile: mocks.fsReadFile,
+      },
+    },
+  };
+});
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: mocks.loadSessionStore,
+  updateSessionStore: mocks.updateSessionStore,
+  snapshotSessionOrigin: mocks.snapshotSessionOrigin,
+  resolveMainSessionKey: mocks.resolveMainSessionKey,
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  triggerInternalHook: mocks.triggerInternalHook,
+  createInternalHookEvent: mocks.createInternalHookEvent,
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: mocks.getGlobalHookRunner,
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: mocks.abortEmbeddedPiRun,
+  waitForEmbeddedPiRunEnd: mocks.waitForEmbeddedPiRunEnd,
+}));
+
+vi.mock("../../auto-reply/reply/queue.js", () => ({
+  clearSessionQueues: mocks.clearSessionQueues,
+}));
+
+vi.mock("../../auto-reply/reply/abort.js", () => ({
+  stopSubagentsForRequester: mocks.stopSubagentsForRequester,
+}));
+
+vi.mock("../../agents/bootstrap-cache.js", () => ({
+  clearBootstrapSnapshot: mocks.clearBootstrapSnapshot,
+}));
+
+vi.mock("../../discord/monitor/thread-bindings.js", () => ({
+  unbindThreadBindingsBySessionKey: mocks.unbindThreadBindingsBySessionKey,
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../session-utils.js", () => ({
+  loadSessionEntry: mocks.loadSessionEntry,
+  resolveGatewaySessionStoreTarget: mocks.resolveGatewaySessionStoreTarget,
+  archiveSessionTranscripts: mocks.archiveSessionTranscripts,
+  listSessionsFromStore: vi.fn(),
+  loadCombinedSessionStoreForGateway: vi.fn(),
+  pruneLegacyStoreKeys: vi.fn(),
+  readSessionPreviewItemsFromTranscript: vi.fn(),
+  resolveSessionModelRef: vi.fn(),
+  resolveSessionTranscriptCandidates: vi.fn(() => []),
+}));
+
+vi.mock("../sessions-patch.js", () => ({
+  applySessionsPatchToStore: vi.fn(),
+}));
+
+vi.mock("../sessions-resolve.js", () => ({
+  resolveSessionKeyFromResolveParams: vi.fn(),
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: mocks.getAcpSessionManager,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+  resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  isSubagentSessionKey: vi.fn(() => false),
+  normalizeAgentId: vi.fn((id: string) => id),
+  parseAgentSessionKey: vi.fn(() => ({ agentId: "main" })),
+}));
+
+function makeHookRunner(opts: { hasBeforeReset: boolean }) {
+  return {
+    hasHooks: vi.fn((name: string) => {
+      if (name === "before_reset") {
+        return opts.hasBeforeReset;
+      }
+      if (name === "subagent_ended") {
+        return false;
+      }
+      return false;
+    }),
+    runBeforeReset: vi.fn(),
+    runSubagentEnded: vi.fn(),
+  };
+}
+
+describe("sessions.reset before_reset plugin hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfig.mockReturnValue({});
+    // Session entry WITHOUT sessionFile — takes the "no session file" path
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/store",
+      store: {},
+      entry: { sessionId: "old-session-id", sessionFile: undefined },
+      canonicalKey: "main",
+      legacyKey: undefined,
+    });
+    mocks.resolveGatewaySessionStoreTarget.mockReturnValue({
+      storePath: "/tmp/store",
+      canonicalKey: "main",
+      storeKeys: ["main"],
+      agentId: "main",
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, fn) => fn({}));
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+  });
+
+  it("fires hookRunner.runBeforeReset when before_reset hooks are registered", async () => {
+    const hookRunner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(hookRunner);
+
+    const { sessionsHandlers } = await import("./sessions.js");
+
+    const respond = vi.fn();
+    await sessionsHandlers["sessions.reset"]({
+      req: { type: "req" as const, id: "1", method: "sessions.reset" },
+      params: { key: "main" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    await flushPromises();
+
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ ok: true }), undefined);
+    expect(hookRunner.runBeforeReset).toHaveBeenCalledTimes(1);
+    expect(hookRunner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "reset" }),
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "main",
+        sessionId: "old-session-id",
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+  });
+
+  it("does not fire hookRunner.runBeforeReset when no hooks are registered", async () => {
+    const hookRunner = makeHookRunner({ hasBeforeReset: false });
+    mocks.getGlobalHookRunner.mockReturnValue(hookRunner);
+
+    const { sessionsHandlers } = await import("./sessions.js");
+
+    const respond = vi.fn();
+    await sessionsHandlers["sessions.reset"]({
+      req: { type: "req" as const, id: "1", method: "sessions.reset" },
+      params: { key: "main" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    await flushPromises();
+
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ ok: true }), undefined);
+    expect(hookRunner.runBeforeReset).not.toHaveBeenCalled();
+  });
+
+  it("passes reason 'new' when p.reason is 'new'", async () => {
+    const hookRunner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(hookRunner);
+
+    const { sessionsHandlers } = await import("./sessions.js");
+
+    const respond = vi.fn();
+    await sessionsHandlers["sessions.reset"]({
+      req: { type: "req" as const, id: "1", method: "sessions.reset" },
+      params: { key: "main", reason: "new" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    await flushPromises();
+
+    expect(hookRunner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "new" }),
+      expect.any(Object),
+    );
+  });
+
+  it("reads session transcript and passes messages when sessionFile is set", async () => {
+    const hookRunner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(hookRunner);
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/store",
+      store: {},
+      entry: { sessionId: "old-session-id", sessionFile: "/tmp/transcript.jsonl" },
+      canonicalKey: "main",
+      legacyKey: undefined,
+    });
+    mocks.fsReadFile.mockResolvedValue(
+      '{"type":"message","message":{"role":"user","content":"hello"}}\n' +
+        '{"type":"message","message":{"role":"assistant","content":"hi"}}\n',
+    );
+
+    const { sessionsHandlers } = await import("./sessions.js");
+
+    const respond = vi.fn();
+    await sessionsHandlers["sessions.reset"]({
+      req: { type: "req" as const, id: "1", method: "sessions.reset" },
+      params: { key: "main" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    });
+    await flushPromises();
+
+    expect(mocks.fsReadFile).toHaveBeenCalledWith("/tmp/transcript.jsonl", "utf-8");
+    expect(hookRunner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/transcript.jsonl",
+        messages: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi" },
+        ],
+        reason: "reset",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/gateway/server-methods/sessions.before-reset-hook.test.ts
+++ b/src/gateway/server-methods/sessions.before-reset-hook.test.ts
@@ -139,6 +139,7 @@ vi.mock("../../routing/session-key.js", () => ({
   isSubagentSessionKey: vi.fn(() => false),
   normalizeAgentId: vi.fn((id: string) => id),
   parseAgentSessionKey: vi.fn(() => ({ agentId: "main" })),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
 }));
 
 function makeHookRunner(opts: { hasBeforeReset: boolean }) {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
@@ -441,6 +441,48 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
+
+    // Fire before_reset plugin hook — extract memories before session history is lost (#25074)
+    const hookRunner = getGlobalHookRunner();
+    if (hookRunner?.hasHooks("before_reset")) {
+      const sessionFile = entry?.sessionFile;
+      const agentId = (target.canonicalKey ?? key).split(":")[0] || "main";
+      void (async () => {
+        try {
+          const messages: unknown[] = [];
+          if (sessionFile) {
+            const content = await fs.promises.readFile(sessionFile, "utf-8");
+            for (const line of content.split("\n")) {
+              if (!line.trim()) {
+                continue;
+              }
+              try {
+                const parsed = JSON.parse(line);
+                if (parsed.type === "message" && parsed.message) {
+                  messages.push(parsed.message);
+                }
+              } catch {
+                // skip malformed lines
+              }
+            }
+          } else {
+            logVerbose("before_reset: no session file available, firing hook with empty messages");
+          }
+          await hookRunner.runBeforeReset(
+            { sessionFile, messages, reason: commandReason },
+            {
+              agentId,
+              sessionKey: target.canonicalKey ?? key,
+              sessionId: entry?.sessionId,
+              workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+            },
+          );
+        } catch (err: unknown) {
+          logVerbose(`before_reset hook failed: ${String(err)}`);
+        }
+      })();
+    }
+
     const sessionId = entry?.sessionId;
     const cleanupError = await ensureSessionRuntimeCleanup({ cfg, key, target, sessionId });
     if (cleanupError) {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -22,6 +22,7 @@ import {
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import {
   ErrorCodes,
@@ -446,7 +447,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const hookRunner = getGlobalHookRunner();
     if (hookRunner?.hasHooks("before_reset")) {
       const sessionFile = entry?.sessionFile;
-      const agentId = (target.canonicalKey ?? key).split(":")[0] || "main";
+      const agentId = resolveAgentIdFromSessionKey(target.canonicalKey ?? key);
       void (async () => {
         try {
           const messages: unknown[] = [];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Plugin `api.on('before_reset', ...)` handlers never fired when a session reset was triggered via the gateway `sessions.reset` RPC (e.g., from the TUI `/new` or `/reset` command). The gateway path only called `triggerInternalHook()` (internal hook bus) but never invoked `hookRunner.runBeforeReset()` (plugin hook runner). The auto-reply path in `commands-core.ts` correctly calls both.
- Why it matters: Plugins relying on `before_reset` to save state or flush buffers received no signal for gateway-originated resets — the dominant reset path in production (TUI, web UI, mobile).
- What changed: `sessions.reset` handler in `src/gateway/server-methods/sessions.ts` now checks `hookRunner.hasHooks("before_reset")` and calls `hookRunner.runBeforeReset()` fire-and-forget before the session is cleared, mirroring the pattern in `commands-core.ts:90-130`.
- What did NOT change (scope boundary): The auto-reply path's hook dispatch is untouched. `triggerInternalHook()` calls unchanged. Plugin SDK, hook runner interface, and all other RPC handlers are unmodified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25074
- Related #

## User-visible / Behavior Changes

Plugins registering `api.on('before_reset', ...)` will now receive hook events when a session is reset from any gateway-connected client (TUI, web UI, mobile apps). Previously this only fired on the auto-reply path. No config or API changes required.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Any gateway-connected client (TUI, web UI)
- Relevant config (redacted): Any config with a plugin registering `before_reset`

### Steps

1. Install a plugin that registers `api.on('before_reset', handler)`
2. Open the TUI or any gateway client and issue `/new` or `/reset`
3. Observe whether the plugin handler fires

### Expected

- Plugin `before_reset` handler fires with session messages and reason before the session is cleared

### Actual

- Plugin handler never fires; `hookRunner.runBeforeReset()` was never called from the gateway path

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/gateway/server-methods/sessions.before-reset-hook.test.ts` (299 lines, 4 tests) covers: hook fires when handlers registered, does not fire when no handlers, correct reason propagation, transcript JSONL read and messages extracted.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Traced both code paths (`commands-core.ts` auto-reply and `sessions.ts` gateway) side by side. Confirmed the gateway path previously lacked `hookRunner.runBeforeReset()`. Verified new code follows the same guard pattern used elsewhere.
- Edge cases checked: No session file present (fires hook with empty messages, logs verbose warning). `reason: "new"` propagates correctly. Hook errors caught and logged without blocking reset.
- What you did **not** verify: End-to-end test with a live plugin on a running gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/gateway/server-methods/sessions.ts` to remove the `before_reset` hook block
- Files/config to restore: `src/gateway/server-methods/sessions.ts`
- Known bad symptoms reviewers should watch for: A plugin's `before_reset` handler throwing an unhandled error that escapes the try/catch (should be swallowed by the catch + logVerbose)

## Risks and Mitigations

- Risk: A misbehaving plugin `before_reset` handler could hang or be slow
  - Mitigation: The hook fires fire-and-forget; the `respond()` call and session store update proceed immediately, so RPC response latency is unaffected.