### PR TITLE
feat: auto-save old model as fallback when user changes model

### DIFF
--- a/src/commands/models/set.test.ts
+++ b/src/commands/models/set.test.ts
@@ -43,13 +43,7 @@ describe("models/set", () => {
   } as unknown as import("../../runtime.js").RuntimeEnv;
 
   beforeEach(() => {
-    mocks.readConfigFileSnapshot.mockClear();
-    mocks.writeConfigFile.mockClear();
-    mocks.logConfigUpdated.mockClear();
-    mockRuntime.log.mockClear();
-    mocks.resolveAgentModelPrimaryValue.mockClear();
-    mocks.applyDefaultModelPrimaryUpdate.mockClear();
-    mocks.resolveModelTarget.mockClear();
+    vi.clearAllMocks();
   });
 
   describe("auto-save old model as fallback", () => {

--- a/src/commands/models/set.test.ts
+++ b/src/commands/models/set.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  writeConfigFile: vi.fn(),
+  logConfigUpdated: vi.fn(),
+  resolveAgentModelPrimaryValue: vi.fn(),
+  applyDefaultModelPrimaryUpdate: vi.fn(),
+  resolveModelTarget: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: (...args: unknown[]) => mocks.readConfigFileSnapshot(...args),
+  writeConfigFile: (...args: unknown[]) => mocks.writeConfigFile(...args),
+}));
+
+vi.mock("../../config/logging.js", () => ({
+  logConfigUpdated: (...args: unknown[]) => mocks.logConfigUpdated(...args),
+}));
+
+vi.mock("../../config/model-input.js", () => ({
+  resolveAgentModelPrimaryValue: (...args: unknown[]) =>
+    mocks.resolveAgentModelPrimaryValue(...args),
+  toAgentModelListLike: vi.fn((x) => x),
+}));
+
+vi.mock("./shared.js", () => ({
+  applyDefaultModelPrimaryUpdate: (...args: unknown[]) =>
+    mocks.applyDefaultModelPrimaryUpdate(...args),
+  resolveModelTarget: (...args: unknown[]) => mocks.resolveModelTarget(...args),
+  updateConfig: async (fn: (cfg: unknown) => unknown) => {
+    const cfg = await mocks.readConfigFileSnapshot();
+    return fn(cfg.config);
+  },
+}));
+
+import { modelsSetCommand } from "./set.js";
+
+describe("models/set", () => {
+  const mockRuntime = {
+    log: vi.fn(),
+  } as unknown as import("../../runtime.js").RuntimeEnv;
+
+  beforeEach(() => {
+    mocks.readConfigFileSnapshot.mockClear();
+    mocks.writeConfigFile.mockClear();
+    mocks.logConfigUpdated.mockClear();
+    mockRuntime.log.mockClear();
+    mocks.resolveAgentModelPrimaryValue.mockClear();
+    mocks.applyDefaultModelPrimaryUpdate.mockClear();
+    mocks.resolveModelTarget.mockClear();
+  });
+
+  describe("auto-save old model as fallback", () => {
+    it("adds old model as fallback when switching models", async () => {
+      const oldConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-4o",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const updatedConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      mocks.resolveAgentModelPrimaryValue.mockReturnValueOnce("openai/gpt-4o");
+      mocks.applyDefaultModelPrimaryUpdate.mockReturnValueOnce(updatedConfig);
+      mocks.resolveModelTarget.mockReturnValueOnce({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+
+      mocks.readConfigFileSnapshot
+        .mockResolvedValueOnce({ valid: true, config: oldConfig })
+        .mockResolvedValueOnce({ valid: true, config: oldConfig })
+        .mockResolvedValueOnce({ valid: true, config: updatedConfig });
+
+      mocks.writeConfigFile.mockResolvedValue(undefined);
+
+      await modelsSetCommand("claude-opus-4-6", mockRuntime);
+
+      // Should have called writeConfigFile 3 times (read old, update, add fallback)
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not add duplicate fallback if already in fallbacks", async () => {
+      const oldConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-4o",
+              fallbacks: ["anthropic/claude-sonnet-4-5"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const updatedConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["anthropic/claude-sonnet-4-5"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      mocks.resolveAgentModelPrimaryValue.mockReturnValueOnce("openai/gpt-4o");
+      mocks.applyDefaultModelPrimaryUpdate.mockReturnValueOnce(updatedConfig);
+      mocks.resolveModelTarget.mockReturnValueOnce({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+
+      mocks.readConfigFileSnapshot
+        .mockResolvedValueOnce({ valid: true, config: oldConfig })
+        .mockResolvedValueOnce({ valid: true, config: oldConfig })
+        .mockResolvedValueOnce({ valid: true, config: updatedConfig });
+
+      mocks.writeConfigFile.mockResolvedValue(undefined);
+
+      await modelsSetCommand("claude-opus-4-6", mockRuntime);
+
+      // Should only write twice (read + update), not add duplicate fallback
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not add fallback if old model equals new model", async () => {
+      const config = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      mocks.resolveAgentModelPrimaryValue.mockReturnValueOnce("anthropic/claude-opus-4-6");
+      mocks.applyDefaultModelPrimaryUpdate.mockReturnValueOnce(config);
+      mocks.resolveModelTarget.mockReturnValueOnce({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+
+      mocks.readConfigFileSnapshot
+        .mockResolvedValueOnce({ valid: true, config })
+        .mockResolvedValueOnce({ valid: true, config });
+
+      mocks.writeConfigFile.mockResolvedValue(undefined);
+
+      await modelsSetCommand("claude-opus-4-6", mockRuntime);
+
+      // Should only write twice (read + update), no fallback added
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not add fallback if no old model exists", async () => {
+      const oldConfig = {
+        agents: {},
+      } as unknown as OpenClawConfig;
+
+      const newConfig = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      mocks.resolveAgentModelPrimaryValue.mockReturnValueOnce(null);
+      mocks.applyDefaultModelPrimaryUpdate.mockReturnValueOnce(newConfig);
+
+      mocks.readConfigFileSnapshot
+        .mockResolvedValueOnce({ valid: true, config: oldConfig })
+        .mockResolvedValueOnce({ valid: true, config: newConfig });
+
+      mocks.writeConfigFile.mockResolvedValue(undefined);
+
+      await modelsSetCommand("claude-opus-4-6", mockRuntime);
+
+      // Should only write once (update only), no fallback
+      expect(mocks.writeConfigFile).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,11 +1,7 @@
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import {
-  applyDefaultModelPrimaryUpdate,
-  resolveModelTarget,
-  updateConfig,
-} from "./shared.js";
+import { applyDefaultModelPrimaryUpdate, resolveModelTarget, updateConfig } from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
   // Read current model before updating
@@ -23,7 +19,8 @@ export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
     const newModelKey = `${resolved.provider}/${resolved.model}`;
 
     // Only add old model as fallback if it's not already the primary or in fallbacks
-    const currentFallbacks = updated.agents?.defaults?.model?.fallbacks ?? [];
+    const modelConfig = updated.agents?.defaults?.model;
+    const currentFallbacks = (modelConfig as { fallbacks?: string[] })?.fallbacks ?? [];
     if (oldModel !== newModelKey && !currentFallbacks.includes(oldModel)) {
       await updateConfig((cfg) => ({
         ...cfg,
@@ -32,7 +29,7 @@ export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
           defaults: {
             ...cfg.agents?.defaults,
             model: {
-              ...cfg.agents?.defaults?.model,
+              ...(typeof modelConfig === "object" ? modelConfig : {}),
               fallbacks: [...currentFallbacks, oldModel],
             },
           },

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,12 +1,46 @@
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import {
+  applyDefaultModelPrimaryUpdate,
+  resolveModelTarget,
+  updateConfig,
+} from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
+  // Read current model before updating
+  const currentCfg = await updateConfig((cfg) => cfg);
+  const oldModel = resolveAgentModelPrimaryValue(currentCfg.agents?.defaults?.model);
+
+  // Update to new model
   const updated = await updateConfig((cfg) => {
     return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
   });
+
+  // If old model exists and is different from new model, add it as fallback
+  if (oldModel && oldModel !== modelRaw) {
+    const resolved = resolveModelTarget({ raw: modelRaw, cfg: updated });
+    const newModelKey = `${resolved.provider}/${resolved.model}`;
+
+    // Only add old model as fallback if it's not already the primary or in fallbacks
+    const currentFallbacks = updated.agents?.defaults?.model?.fallbacks ?? [];
+    if (oldModel !== newModelKey && !currentFallbacks.includes(oldModel)) {
+      await updateConfig((cfg) => ({
+        ...cfg,
+        agents: {
+          ...cfg.agents,
+          defaults: {
+            ...cfg.agents?.defaults,
+            model: {
+              ...cfg.agents?.defaults?.model,
+              fallbacks: [...currentFallbacks, oldModel],
+            },
+          },
+        },
+      }));
+      runtime.log(`Old model "${oldModel}" set as fallback.`);
+    }
+  }
 
   logConfigUpdated(runtime);
   runtime.log(


### PR DESCRIPTION
When user runs 'openclaw model set <new-model>', the old model is automatically saved as the last fallback. This ensures the system remains usable even if the new model is misconfigured.