### PR TITLE
Feishu: honor outbound renderMode for outbound messages

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,9 +1,10 @@
 import fs from "fs";
 import path from "path";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
+import { resolveFeishuAccount } from "./accounts.js";
 import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu } from "./send.js";
+import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -38,6 +39,27 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   return raw;
 }
 
+function shouldUseCard(text: string): boolean {
+  return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
+}
+
+async function sendOutboundText(params: {
+  cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
+  to: string;
+  text: string;
+  accountId?: string;
+}) {
+  const { cfg, to, text, accountId } = params;
+  const account = resolveFeishuAccount({ cfg, accountId });
+  const renderMode = account.config?.renderMode ?? "auto";
+
+  if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
+    return await sendMarkdownCardFeishu({ cfg, to, text, accountId });
+  }
+
+  return await sendMessageFeishu({ cfg, to, text, accountId });
+}
+
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
@@ -63,13 +85,23 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       }
     }
 
-    const result = await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
+    const result = await sendOutboundText({
+      cfg,
+      to,
+      text,
+      accountId: accountId ?? undefined,
+    });
     return { channel: "feishu", ...result };
   },
   sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots }) => {
     // Send text first if provided
     if (text?.trim()) {
-      await sendMessageFeishu({ cfg, to, text, accountId: accountId ?? undefined });
+      await sendOutboundText({
+        cfg,
+        to,
+        text,
+        accountId: accountId ?? undefined,
+      });
     }
 
     // Upload and send media if URL or local path provided
@@ -88,7 +120,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         // Fallback to URL link if upload fails
         const fallbackText = `📎 ${mediaUrl}`;
-        const result = await sendMessageFeishu({
+        const result = await sendOutboundText({
           cfg,
           to,
           text: fallbackText,
@@ -99,7 +131,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     }
 
     // No media URL, just return text result
-    const result = await sendMessageFeishu({
+    const result = await sendOutboundText({
       cfg,
       to,
       text: text ?? "",


### PR DESCRIPTION
## Summary

- Problem: Feishu outbound sends ignored `channels.feishu.renderMode`, so direct `message` sends and outbound captions always used `post` messages.
- Why it matters: users who configure `renderMode: "card"` lose markdown-table rendering outside the reply dispatcher.
- What changed: outbound text/caption sends now reuse the same card-vs-post decision used by Feishu replies.
- What did NOT change (scope boundary): media upload behavior, reply dispatcher behavior, and non-Feishu channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28616
- Related #28616

## User-visible / Behavior Changes

- Feishu outbound text sends now honor `renderMode: "card"`.
- Feishu outbound media captions now honor `renderMode: "card"` before the attachment is uploaded.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6.1
- Runtime/container: Node 24 / pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu outbound adapter
- Relevant config (redacted): `channels.feishu.renderMode = "card"`

### Steps

1. Configure Feishu with `renderMode: "card"`.
2. Send an outbound Feishu message or media caption containing a markdown table.
3. Inspect which Feishu send path the outbound adapter uses.

### Expected

- Outbound sends use the markdown-card path so tables render correctly.

### Actual

- Outbound sends always used `sendMessageFeishu()` / `post`, which drops table rendering.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bug locally with a Vitest harness against `upstream/main`; after the fix, `extensions/feishu/src/outbound.test.ts` confirms card sends for direct outbound text and captions when `renderMode=card`.
- Edge cases checked: existing local-image auto-upload path still prefers media sends; plain text still stays on the post-message path when card mode is not requested.
- What you did **not** verify: live Feishu delivery against a real tenant. `pnpm check` currently fails on `upstream/main` because of unrelated repo-wide missing-module/type errors in `extensions/diagnostics-otel/src/service.ts`, `src/discord/voice/manager.ts`, `src/gateway/server-cron.ts`, and `src/shared/net/ip.ts`.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or set `channels.feishu.renderMode` back to `"auto"`/`"raw"`.
- Files/config to restore: `extensions/feishu/src/outbound.ts`
- Known bad symptoms reviewers should watch for: outbound Feishu text unexpectedly switching to cards when `renderMode` is not `card` and the text is plain.

## Risks and Mitigations

- Risk: outbound auto-mode card detection drifts from the reply dispatcher heuristic over time.
- Mitigation: this PR matches the current reply-dispatcher heuristic and adds direct adapter coverage for both text and caption flows.
