### PR TITLE
Feishu: honor defaultAccount for tool fallback

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -1,0 +1,27 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it } from "vitest";
+import { resolveDefaultFeishuAccountId } from "./accounts.js";
+
+describe("resolveDefaultFeishuAccountId", () => {
+  it("prefers channels.feishu.defaultAccount over alphabetical fallback", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "main",
+          accounts: {
+            alpha: {
+              appId: "cli_alpha",
+              appSecret: "secret_alpha",
+            },
+            main: {
+              appId: "cli_main",
+              appSecret: "secret_main",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveDefaultFeishuAccountId(cfg)).toBe("main");
+  });
+});

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -35,6 +35,11 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
  * Resolve the default account ID.
  */
 export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
+  const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
+  const configuredDefault = feishuCfg?.defaultAccount?.trim();
+  if (configuredDefault) {
+    return normalizeAccountId(configuredDefault);
+  }
   const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
@@ -64,7 +69,7 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
   // Extract base config (exclude accounts field to avoid recursion)
-  const { accounts: _ignored, ...base } = feishuCfg ?? {};
+  const { accounts: _ignored, defaultAccount: _ignoredDefaultAccount, ...base } = feishuCfg ?? {};
 
   // Get account-specific overrides
   const account = resolveAccountConfig(cfg, accountId) ?? {};

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -138,3 +138,19 @@ describe("FeishuConfigSchema optimization flags", () => {
     expect(result.accounts?.main?.resolveSenderNames).toBe(false);
   });
 });
+
+describe("FeishuConfigSchema defaultAccount", () => {
+  it("accepts a top-level defaultAccount", () => {
+    const result = FeishuConfigSchema.parse({
+      defaultAccount: "main",
+      accounts: {
+        main: {
+          appId: "cli_main",
+          appSecret: "secret_main",
+        },
+      },
+    });
+
+    expect(result.defaultAccount).toBe("main");
+  });
+});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -191,6 +191,7 @@ export const FeishuAccountConfigSchema = z
 export const FeishuConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    defaultAccount: z.string().optional(),
     // Top-level credentials (backward compatible for single-account mode)
     appId: z.string().optional(),
     appSecret: z.string().optional(),

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -108,4 +108,33 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
     expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");
   });
+
+  test("wiki tool falls back to channels.feishu.defaultAccount when agentAccountId is missing", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          defaultAccount: "b",
+          accounts: {
+            a: {
+              appId: "app-a",
+              appSecret: "sec-a",
+            },
+            b: {
+              appId: "app-b",
+              appSecret: "sec-b",
+            },
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"];
+
+    const { api, resolveTool } = createToolFactoryHarness(cfg);
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki");
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
 });

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveFeishuAccount } from "./accounts.js";
+import { resolveDefaultFeishuAccountId, resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
@@ -24,7 +24,8 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      normalizeOptionalAccountId(params.defaultAccountId),
+      normalizeOptionalAccountId(params.defaultAccountId) ??
+      resolveDefaultFeishuAccountId(params.api.config),
   });
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu tool execution still ignores `channels.feishu.defaultAccount` when no explicit tool account is provided.
- Why it matters: doc/wiki/drive/perm calls can resolve to the wrong account and fail with missing-scope or missing-credential errors even when the correct default account is configured.
- What changed: taught the Feishu config schema and account resolver about top-level `defaultAccount`, then reused that default in shared tool account resolution.
- What did NOT change (scope boundary): no Feishu API payload changes, no per-tool routing changes, and no non-Feishu account selection behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21900
- Related #28616

## User-visible / Behavior Changes

Feishu doc/wiki/drive/perm tool calls now honor `channels.feishu.defaultAccount` when no explicit tool account is supplied.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.1
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): `channels.feishu.defaultAccount: "main"` with multiple configured accounts

### Steps

1. Configure Feishu with `channels.feishu.defaultAccount: "main"` and two accounts, for example `alpha` and `main`.
2. Leave the tool call without an explicit `accountId` and invoke a Feishu tool that goes through shared tool account routing, for example `feishu_wiki`.
3. Observe which account config is passed to `createFeishuClient`.

### Expected

- The tool should use the configured `channels.feishu.defaultAccount` account.

### Actual

- On `upstream/main`, the shared fallback ignores `channels.feishu.defaultAccount` and resolves the synthetic `default` account path instead of the configured default account.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the pre-fix failure locally with a focused Vitest harness against `upstream/main`, then verified the added regression tests pass on this branch.
- Edge cases checked: top-level `defaultAccount` is accepted by schema parsing, and `resolveDefaultFeishuAccountId` still preserves existing fallback behavior when `defaultAccount` is unset.
- What you did **not** verify: live Feishu API calls against a production tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous tool-account fallback behavior.
- Files/config to restore: `extensions/feishu/src/accounts.ts`, `extensions/feishu/src/config-schema.ts`, `extensions/feishu/src/tool-account.ts`
- Known bad symptoms reviewers should watch for: Feishu tools selecting an unexpected account when both `defaultAccount` and explicit `accountId` are absent.

## Risks and Mitigations

- Risk: existing installs that accidentally relied on the broken fallback may now use a different Feishu app.
  - Mitigation: the new behavior matches the documented/configured `defaultAccount` contract and only applies when callers omit an explicit `accountId`.

## Verification Commands

```bash
pnpm exec vitest run extensions/feishu/src/accounts.test.ts extensions/feishu/src/config-schema.test.ts extensions/feishu/src/tool-account-routing.test.ts
pnpm check
```

`pnpm check` still fails on current `upstream/main` because of unrelated baseline typecheck errors in `extensions/diagnostics-otel/src/service.ts`, `src/discord/voice/manager.ts`, `src/gateway/server-cron.ts`, and `src/shared/net/ip.ts`.
