### PR TITLE
LINE: classify M4A voice downloads as audio

### DIFF
--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -66,4 +66,23 @@ describe("downloadLineMedia", () => {
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
     expect(writeSpy).not.toHaveBeenCalled();
   });
+
+  it("classifies M4A voice messages as audio/mp4", async () => {
+    const m4a = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+    ]);
+    getMessageContentMock.mockResolvedValueOnce(chunks([m4a]));
+
+    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
+
+    const result = await downloadLineMedia("voice-message", "token");
+    const writtenPath = writeSpy.mock.calls[0]?.[0];
+
+    expect(result.contentType).toBe("audio/mp4");
+    expect(result.path).toMatch(/\.m4a$/);
+    expect(typeof writtenPath).toBe("string");
+    if (typeof writtenPath === "string") {
+      expect(writtenPath).toMatch(/\.m4a$/);
+    }
+  });
 });

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -80,15 +80,13 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
+    // MP4 family
     if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+      const majorBrand = buffer.subarray(8, 12).toString("ascii");
+      if (majorBrand === "M4A ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: LINE media downloads classified any `ftyp` MP4-family file as `video/mp4`, which mis-labeled M4A voice messages.
- Why it matters: LINE voice messages then land with the wrong MIME type and file extension, which breaks downstream audio handling.
- What changed: the LINE download sniffer now checks the MP4 major brand and returns `audio/mp4` for `ftypM4A ` before falling back to generic MP4 video.
- What did NOT change (scope boundary): this PR does not change LINE upload behavior, non-MP4 media detection, or broader media normalization outside `src/line/download.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29751
- Related #29751

## User-visible / Behavior Changes

LINE M4A voice downloads now return `audio/mp4` and use `.m4a` temp files instead of being mislabeled as `video/mp4`/`.mp4`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): LINE media download path
- Relevant config (redacted): none

### Steps

1. On `upstream/main`, run `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29751-line-m4a.test.ts --reporter=verbose` with a harness that feeds an `ftypM4A ` header into `downloadLineMedia`.
2. Observe the failure: `result.contentType` is `video/mp4` instead of `audio/mp4`.
3. On this branch, run `pnpm exec vitest run src/line/download.test.ts --reporter=verbose`.

### Expected

- LINE M4A voice downloads should be classified as `audio/mp4` and use a `.m4a` temp file.

### Actual

- Before this patch, the generic MP4 branch ran first and returned `video/mp4` for M4A voice content.
- After this patch, `ftypM4A ` is classified as `audio/mp4` and written to a `.m4a` temp path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bad MIME classification with a focused Vitest harness; added an in-repo regression test proving `downloadLineMedia` now reports `audio/mp4` and `.m4a` for `ftypM4A ` content.
- Edge cases checked: confirmed the generic MP4 path still exists for non-M4A brands by limiting the special case to the `M4A ` major brand.
- What you did **not** verify: a live LINE device round-trip, because the bug is in deterministic local MIME sniffing.

Verification commands:

- `pnpm exec vitest run src/line/download.test.ts --reporter=verbose`
- `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29751-line-m4a.test.ts --reporter=verbose`
- `pnpm check` currently stops on the existing unrelated `src/gateway/server-cron.ts(197)` type error present on current `upstream/main`; this PR does not touch that file.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `aaa5596637`.
- Files/config to restore: `src/line/download.ts` and `src/line/download.test.ts`.
- Known bad symptoms reviewers should watch for: non-M4A MP4 video unexpectedly being labeled as audio.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: other MP4-family audio brands besides `M4A ` still follow the generic MP4 path.
  - Mitigation: this PR intentionally fixes the confirmed LINE `ftypM4A ` repro without broadening the sniffing rules beyond the validated failing case.
