### PR TITLE
fix: fire before_reset plugin hook from gateway sessions.reset

### DIFF
--- a/src/gateway/server-methods/sessions.before-reset-hook.test.ts
+++ b/src/gateway/server-methods/sessions.before-reset-hook.test.ts
@@ -1,0 +1,289 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+// ── Shared mock state ──────────────────────────────────────────────────────
+const mocks = {
+  triggerInternalHook: vi.fn(),
+  getGlobalHookRunner: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(() => "/workspace/main"),
+  loadConfig: vi.fn(() => ({})),
+  resolveGatewaySessionStoreTarget: vi.fn(() => ({
+    agentId: "main",
+    storePath: "/tmp/store.json",
+    canonicalKey: "agent:main:test-key",
+    storeKeys: ["agent:main:test-key"],
+  })),
+  loadSessionEntry: vi.fn(() => ({
+    entry: undefined,
+    legacyKey: undefined,
+    canonicalKey: undefined,
+  })),
+  updateSessionStore: vi.fn(
+    async (_path: string, fn: (store: Record<string, SessionEntry>) => SessionEntry) => {
+      const store: Record<string, SessionEntry> = {};
+      return fn(store);
+    },
+  ),
+  ensureSessionRuntimeCleanup: vi.fn(async () => null),
+  closeAcpRuntimeForSession: vi.fn(async () => null),
+  getAcpSessionManager: vi.fn(() => null),
+  emitSessionUnboundLifecycleEvent: vi.fn(),
+  archiveSessionTranscriptsForSession: vi.fn(),
+};
+
+// ── Module mocks ───────────────────────────────────────────────────────────
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: vi.fn(() => ({ messages: [] })),
+  triggerInternalHook: mocks.triggerInternalHook,
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: mocks.getGlobalHookRunner,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+  resolveDefaultAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  snapshotSessionOrigin: vi.fn(),
+  resolveMainSessionKey: vi.fn(() => "agent:main:main"),
+  updateSessionStore: mocks.updateSessionStore,
+}));
+
+vi.mock(import("../../routing/session-key.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isSubagentSessionKey: vi.fn(() => false),
+    normalizeAgentId: vi.fn((id: string) => id),
+    parseAgentSessionKey: vi.fn(() => ({ agentId: "main" })),
+  };
+});
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../discord/monitor/thread-bindings.js", () => ({
+  unbindThreadBindingsBySessionKey: vi.fn(),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn(),
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+}));
+
+vi.mock("../../auto-reply/reply/abort.js", () => ({
+  stopSubagentsForRequester: vi.fn(),
+}));
+
+vi.mock("../../auto-reply/reply/queue.js", () => ({
+  clearSessionQueues: vi.fn(),
+}));
+
+vi.mock("../../agents/bootstrap-cache.js", () => ({
+  clearBootstrapSnapshot: vi.fn(),
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: mocks.getAcpSessionManager,
+}));
+
+// Mock the session-utils barrel used by sessions.ts
+vi.mock("../session-utils.js", () => ({
+  archiveFileOnDisk: vi.fn(),
+  archiveSessionTranscripts: vi.fn(),
+  listSessionsFromStore: vi.fn(() => []),
+  loadCombinedSessionStoreForGateway: vi.fn(() => ({})),
+  loadSessionEntry: mocks.loadSessionEntry,
+  pruneLegacyStoreKeys: vi.fn(),
+  readSessionPreviewItemsFromTranscript: vi.fn(() => []),
+  resolveGatewaySessionStoreTarget: mocks.resolveGatewaySessionStoreTarget,
+  resolveSessionModelRef: vi.fn(() => ({ model: "test", provider: "test" })),
+  resolveSessionTranscriptCandidates: vi.fn(() => []),
+  migrateAndPruneSessionStoreKey: vi.fn(({ key }: { key: string }) => ({ primaryKey: key })),
+  archiveSessionTranscriptsForSession: mocks.archiveSessionTranscriptsForSession,
+  emitSessionUnboundLifecycleEvent: mocks.emitSessionUnboundLifecycleEvent,
+  ensureSessionRuntimeCleanup: mocks.ensureSessionRuntimeCleanup,
+  closeAcpRuntimeForSession: mocks.closeAcpRuntimeForSession,
+}));
+
+vi.mock("../protocol/index.js", () => ({
+  ErrorCodes: { INVALID_REQUEST: "INVALID_REQUEST" },
+  errorShape: vi.fn((_code: string, msg: string) => ({ error: msg })),
+  validateSessionsCompactParams: vi.fn(() => true),
+  validateSessionsDeleteParams: vi.fn(() => true),
+  validateSessionsListParams: vi.fn(() => true),
+  validateSessionsPatchParams: vi.fn(() => true),
+  validateSessionsPreviewParams: vi.fn(() => true),
+  validateSessionsResetParams: vi.fn(() => true),
+  validateSessionsResolveParams: vi.fn(() => true),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function makeHookRunner(opts: { hasBeforeReset: boolean }) {
+  return {
+    hasHooks: vi.fn((name: string) => name === "before_reset" && opts.hasBeforeReset),
+    runBeforeReset: vi.fn(async () => {}),
+    runSubagentEnded: vi.fn(),
+  };
+}
+
+type RespondFn = (success: boolean, data: unknown, error: unknown) => void;
+
+async function callSessionsReset(params: {
+  key: string;
+  reason?: string;
+  entry?: SessionEntry;
+  sessionFile?: string;
+}) {
+  // Dynamic import so mocks are applied
+  const mod = await import("./sessions.js");
+  const handlers = mod.sessionsHandlers;
+  const handler = handlers["sessions.reset"];
+  const respond = vi.fn() as unknown as RespondFn;
+
+  if (params.entry) {
+    mocks.loadSessionEntry.mockReturnValue({
+      entry: { ...params.entry, sessionFile: params.sessionFile },
+      legacyKey: undefined,
+      canonicalKey: "agent:main:test-key",
+    });
+  }
+
+  await handler({
+    params: { key: params.key, reason: params.reason ?? "reset" },
+    respond,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+
+  // Flush fire-and-forget microtasks
+  await new Promise((r) => setTimeout(r, 50));
+  return { respond };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe("sessions.reset before_reset plugin hook (#25074)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires hookRunner.runBeforeReset when before_reset hooks are registered", async () => {
+    const runner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(runner);
+
+    await callSessionsReset({ key: "agent:main:test-key" });
+
+    expect(runner.hasHooks).toHaveBeenCalledWith("before_reset");
+    expect(runner.runBeforeReset).toHaveBeenCalledOnce();
+    expect(runner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "reset", messages: [] }),
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:test-key",
+        workspaceDir: "/workspace/main",
+      }),
+    );
+  });
+
+  it("does NOT fire when no before_reset hooks are registered", async () => {
+    const runner = makeHookRunner({ hasBeforeReset: false });
+    mocks.getGlobalHookRunner.mockReturnValue(runner);
+
+    await callSessionsReset({ key: "agent:main:test-key" });
+
+    expect(runner.hasHooks).toHaveBeenCalledWith("before_reset");
+    expect(runner.runBeforeReset).not.toHaveBeenCalled();
+  });
+
+  it('passes reason "new" when p.reason is "new"', async () => {
+    const runner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(runner);
+
+    await callSessionsReset({ key: "agent:main:test-key", reason: "new" });
+
+    expect(runner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "new" }),
+      expect.anything(),
+    );
+  });
+
+  it("reads session transcript and passes parsed messages", async () => {
+    const runner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(runner);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sessions-test-"));
+    const transcriptPath = path.join(tmpDir, "session.jsonl");
+    const lines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      JSON.stringify({ type: "other", data: "ignored" }),
+      "",
+    ];
+    fs.writeFileSync(transcriptPath, lines.join("\n"));
+
+    const entry: SessionEntry = {
+      sessionId: "test-session",
+      updatedAt: Date.now(),
+      sessionFile: transcriptPath,
+    };
+
+    await callSessionsReset({ key: "agent:main:test-key", entry, sessionFile: transcriptPath });
+
+    expect(runner.runBeforeReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: transcriptPath,
+        messages: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi" },
+        ],
+      }),
+      expect.anything(),
+    );
+
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it("does NOT fire hook when session runtime cleanup fails", async () => {
+    const runner = makeHookRunner({ hasBeforeReset: true });
+    mocks.getGlobalHookRunner.mockReturnValue(runner);
+
+    // Provide a sessionId so ensureSessionRuntimeCleanup calls waitForEmbeddedPiRunEnd
+    const entry: SessionEntry = { sessionId: "active-session", updatedAt: Date.now() };
+    mocks.loadSessionEntry.mockReturnValue({
+      entry,
+      legacyKey: undefined,
+      canonicalKey: "agent:main:test-key",
+    });
+
+    // Simulate active run that won't end (waitForEmbeddedPiRunEnd returns false → error)
+    const { waitForEmbeddedPiRunEnd } = await import("../../agents/pi-embedded.js");
+    vi.mocked(waitForEmbeddedPiRunEnd).mockResolvedValue(false);
+
+    const { respond } = await callSessionsReset({ key: "agent:main:test-key" });
+
+    expect(runner.hasHooks).toHaveBeenCalledWith("before_reset");
+    expect(runner.runBeforeReset).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+});

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
@@ -471,6 +471,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     await triggerInternalHook(hookEvent);
+
+    const hookRunner = getGlobalHookRunner();
+    const wantsBeforeReset = hookRunner?.hasHooks("before_reset") ?? false;
+
     const mutationCleanupError = await cleanupSessionBeforeMutation({
       cfg,
       key,
@@ -483,6 +487,49 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     if (mutationCleanupError) {
       respond(false, undefined, mutationCleanupError);
       return;
+    }
+
+    // Fire before_reset plugin hook after cleanup succeeds (#25074).
+    // Read transcript eagerly (before archival can rename/delete the file),
+    // then fire-and-forget only the hook dispatch to avoid blocking the response.
+    if (wantsBeforeReset && hookRunner) {
+      const sessionFile = entry?.sessionFile;
+      const messages: unknown[] = [];
+      if (sessionFile) {
+        try {
+          const content = await fs.promises.readFile(sessionFile, "utf-8");
+          for (const line of content.split("\n")) {
+            if (!line.trim()) {
+              continue;
+            }
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.type === "message" && parsed.message) {
+                messages.push(parsed.message);
+              }
+            } catch {
+              // skip malformed lines
+            }
+          }
+        } catch {
+          logVerbose("before_reset: failed to read session file, firing hook with empty messages");
+        }
+      } else {
+        logVerbose("before_reset: no session file available, firing hook with empty messages");
+      }
+      void hookRunner
+        .runBeforeReset(
+          { sessionFile, messages, reason: commandReason },
+          {
+            agentId: target.agentId,
+            sessionKey: target.canonicalKey ?? key,
+            sessionId: entry?.sessionId,
+            workspaceDir: resolveAgentWorkspaceDir(cfg, target.agentId),
+          },
+        )
+        .catch((err: unknown) => {
+          logVerbose(`before_reset hook failed: ${String(err)}`);
+        });
     }
     let oldSessionId: string | undefined;
     let oldSessionFile: string | undefined;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Plugin `api.on('before_reset', ...)` handlers never fired when a session reset was triggered via the gateway `sessions.reset` RPC (e.g., from the TUI `/new` or `/reset` command). The gateway path only called `triggerInternalHook()` (internal hook bus) but never invoked `hookRunner.runBeforeReset()` (plugin hook runner). The auto-reply path in `commands-core.ts` correctly calls both.
- Why it matters: Plugins relying on `before_reset` to save state or flush buffers received no signal for gateway-originated resets — the dominant reset path in production (TUI, web UI, mobile).
- What changed: `sessions.reset` handler in `src/gateway/server-methods/sessions.ts` now checks `hookRunner.hasHooks("before_reset")` and calls `hookRunner.runBeforeReset()` fire-and-forget before the session is cleared, mirroring the pattern in `commands-core.ts:90-130`.
- What did NOT change (scope boundary): The auto-reply path's hook dispatch is untouched. `triggerInternalHook()` calls unchanged. Plugin SDK, hook runner interface, and all other RPC handlers are unmodified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25074
- Related #

## User-visible / Behavior Changes

Plugins registering `api.on('before_reset', ...)` now receive hook events when a session is reset from any gateway-connected client (TUI, web UI, mobile apps). Previously this only fired on the auto-reply path. No config or API changes required.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Any gateway-connected client (TUI, web UI)
- Relevant config (redacted): Any config with a plugin registering `before_reset`

### Steps

1. Install a plugin that registers `api.on('before_reset', handler)`
2. Open the TUI or any gateway client and issue `/new` or `/reset`
3. Observe whether the plugin handler fires

### Expected

- Plugin `before_reset` handler fires with session messages and reason before the session is cleared

### Actual

- Plugin handler never fires; `hookRunner.runBeforeReset()` was never called from the gateway path

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/gateway/server-methods/sessions.before-reset-hook.test.ts` (4 tests) covers: hook fires when handlers registered, does not fire when no handlers, correct reason propagation, transcript JSONL read and messages extracted.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Traced both code paths (`commands-core.ts` auto-reply and `sessions.ts` gateway) side by side. Confirmed the gateway path previously lacked `hookRunner.runBeforeReset()`. Verified new code follows the same guard pattern used elsewhere. Uses `target.agentId` (properly resolved by `resolveGatewaySessionStoreTarget`) instead of naive string splitting.
- Edge cases checked: No session file present (fires hook with empty messages, logs verbose warning). `reason: "new"` propagates correctly. Hook errors caught and logged without blocking reset.
- What you did **not** verify: End-to-end test with a live plugin on a running gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/gateway/server-methods/sessions.ts` to remove the `before_reset` hook block
- Files/config to restore: `src/gateway/server-methods/sessions.ts`
- Known bad symptoms reviewers should watch for: A plugin's `before_reset` handler throwing an unhandled error that escapes the try/catch (should be swallowed by the catch + logVerbose)

## Risks and Mitigations

- Risk: A misbehaving plugin `before_reset` handler could hang or be slow
  - Mitigation: The hook fires fire-and-forget; the `respond()` call and session store update proceed immediately, so RPC response latency is unaffected.