### PR TITLE
Gateway: honor message-channel header for chat completions

### DIFF
--- a/src/gateway/openai-http.message-channel.test.ts
+++ b/src/gateway/openai-http.message-channel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { agentCommand, installGatewayTestHooks, withGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "test" });
+
+describe("OpenAI HTTP message channel", () => {
+  it("passes x-openclaw-message-channel through to agentCommand", async () => {
+    agentCommand.mockReset();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    await withGatewayServer(
+      async ({ port }) => {
+        const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer secret",
+            "x-openclaw-message-channel": "custom-client-channel",
+          },
+          body: JSON.stringify({
+            model: "openclaw",
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+
+        expect(res.status).toBe(200);
+        const firstCall = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+          | { messageChannel?: string }
+          | undefined;
+        expect(firstCall?.messageChannel).toBe("custom-client-channel");
+        await res.text();
+      },
+      {
+        serverOptions: {
+          host: "127.0.0.1",
+          auth: { mode: "token", token: "secret" },
+          controlUiEnabled: false,
+          openAiChatCompletionsEnabled: true,
+        },
+      },
+    );
+  });
+});

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -5,6 +5,7 @@ import { agentCommand } from "../commands/agent.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
@@ -14,7 +15,7 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
-import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
+import { getHeader, resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -45,6 +46,7 @@ function buildAgentCommandInput(params: {
   prompt: { message: string; extraSystemPrompt?: string };
   sessionKey: string;
   runId: string;
+  messageChannel: string;
 }) {
   return {
     message: params.prompt.message,
@@ -52,7 +54,7 @@ function buildAgentCommandInput(params: {
     sessionKey: params.sessionKey,
     runId: params.runId,
     deliver: false as const,
-    messageChannel: "webchat" as const,
+    messageChannel: params.messageChannel,
     bestEffortDeliver: false as const,
   };
 }
@@ -226,6 +228,8 @@ export async function handleOpenAiHttpRequest(
 
   const agentId = resolveAgentIdForRequest({ req, model });
   const sessionKey = resolveOpenAiSessionKey({ req, agentId, user });
+  const messageChannel =
+    normalizeMessageChannel(getHeader(req, "x-openclaw-message-channel") ?? "") ?? "webchat";
   const prompt = buildAgentPrompt(payload.messages);
   if (!prompt.message) {
     sendJson(res, 400, {
@@ -243,6 +247,7 @@ export async function handleOpenAiHttpRequest(
     prompt,
     sessionKey,
     runId,
+    messageChannel,
   });
 
   if (!stream) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `POST /v1/chat/completions` ignored `x-openclaw-message-channel` and always invoked `agentCommand` with `messageChannel: "webchat"`.
- Why it matters: clients using that endpoint cannot preserve their true origin channel, which breaks channel-aware behavior and delivery context.
- What changed: the OpenAI-compatible HTTP bridge now reads and normalizes `x-openclaw-message-channel`, then passes it through to `agentCommand` instead of hardcoding `webchat`.
- What did NOT change (scope boundary): this PR does not change session-key resolution, delivery behavior, `/v1/responses`, or any other HTTP endpoint.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29449
- Related #29449

## User-visible / Behavior Changes

`POST /v1/chat/completions` now preserves `x-openclaw-message-channel` when invoking the agent run instead of forcing the origin channel to `webchat`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.0, pnpm 10.23.0
- Model/provider: OpenAI-compatible gateway endpoint
- Integration/channel (if any): `POST /v1/chat/completions`
- Relevant config (redacted): token auth, `openAiChatCompletionsEnabled: true`

### Steps

1. On `upstream/main`, run `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29449-openai-message-channel.test.ts --reporter=verbose`.
2. Observe the failing assertion: the first `agentCommand` call receives `messageChannel: "webchat"` even when the request header sets `x-openclaw-message-channel: custom-client-channel`.
3. On this branch, run `pnpm exec vitest run src/gateway/openai-http.message-channel.test.ts --reporter=verbose`.

### Expected

- `/v1/chat/completions` should pass the normalized `x-openclaw-message-channel` header through to `agentCommand`.

### Actual

- Before this patch, the endpoint hardcoded `messageChannel: "webchat"`.
- After this patch, the endpoint forwards `custom-client-channel` into `agentCommand`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bad header handling with a focused gateway harness; added `src/gateway/openai-http.message-channel.test.ts`; confirmed both the throwaway repro and the in-repo gateway test now observe `messageChannel: "custom-client-channel"`.
- Edge cases checked: the new path still normalizes the header through the existing message-channel helper, so built-in and plugin channels follow the same normalization as other gateway surfaces.
- What you did **not** verify: downstream delivery behavior after the agent run, because this bug is limited to request-to-agent plumbing.

Verification commands:

- `pnpm exec vitest run src/gateway/openai-http.message-channel.test.ts --reporter=verbose`
- `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29449-openai-message-channel.test.ts --reporter=verbose`
- `pnpm check` currently stops on the existing unrelated `src/gateway/server-cron.ts(197)` type error present on current `upstream/main`; this PR does not touch that file.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4bc1b6ddd3`.
- Files/config to restore: `src/gateway/openai-http.ts` and `src/gateway/openai-http.message-channel.test.ts`.
- Known bad symptoms reviewers should watch for: custom channel headers unexpectedly being dropped or normalized incorrectly.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: callers can now pass arbitrary channel identifiers through this endpoint, which changes behavior for requests that previously always looked like `webchat`.
  - Mitigation: the value is still normalized by the shared `normalizeMessageChannel` helper, matching the behavior already used by other gateway HTTP entry points.
