### PR TITLE
Feishu: recover from withdrawn reply targets

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -208,6 +208,24 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("falls back to a direct send when the reply target was withdrawn", async () => {
+    messageReplyMock.mockResolvedValueOnce({
+      code: 230011,
+      msg: "The message was withdrawn.",
+    });
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("video"),
+      fileName: "reply.mp4",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(messageReplyMock).toHaveBeenCalledTimes(1);
+    expect(messageCreateMock).toHaveBeenCalledTimes(1);
+  });
+
   it("omits reply_in_thread when replyInThread is false", async () => {
     await sendMediaFeishu({
       cfg: {} as any,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -55,6 +55,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   let typingState: TypingIndicatorState | null = null;
   const typingCallbacks = createTypingCallbacks({
+    // Deleted/withdrawn reply targets should stop Feishu typing immediately
+    // instead of spending another keepalive interval on the same dead message.
+    maxConsecutiveFailures: 1,
     start: async () => {
       // Check if typing indicator is enabled (default: true)
       if (!(account.config.typingIndicator ?? true)) {

--- a/extensions/feishu/src/send-reply-fallback.test.ts
+++ b/extensions/feishu/src/send-reply-fallback.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
+const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
+
+const replyMock = vi.hoisted(() => vi.fn());
+const createMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./send-target.js", () => ({
+  resolveFeishuSendTarget: resolveFeishuSendTargetMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: getFeishuRuntimeMock,
+}));
+
+import { sendCardFeishu, sendMessageFeishu } from "./send.js";
+
+describe("Feishu reply fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    replyMock.mockResolvedValue({ code: 230011, msg: "The message was withdrawn." });
+    createMock.mockResolvedValue({ code: 0, data: { message_id: "m_fallback" } });
+    resolveFeishuSendTargetMock.mockReturnValue({
+      client: {
+        im: {
+          message: {
+            reply: replyMock,
+            create: createMock,
+          },
+        },
+      },
+      receiveId: "ou_user",
+      receiveIdType: "open_id",
+    });
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+        },
+      },
+    });
+  });
+
+  it("falls back to a direct send when a text reply target was withdrawn", async () => {
+    await expect(
+      sendMessageFeishu({
+        cfg: {} as never,
+        to: "user:ou_user",
+        text: "hello",
+        replyToMessageId: "om_deleted",
+      }),
+    ).resolves.toEqual({ messageId: "m_fallback", chatId: "ou_user" });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a direct send when a card reply target was deleted", async () => {
+    await expect(
+      sendCardFeishu({
+        cfg: {} as never,
+        to: "user:ou_user",
+        card: { schema: "2.0", elements: [] },
+        replyToMessageId: "om_deleted",
+      }),
+    ).resolves.toEqual({ messageId: "m_fallback", chatId: "ou_user" });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -6,6 +6,30 @@ export type FeishuMessageApiResponse = {
   };
 };
 
+const FEISHU_REPLY_TARGET_GONE_CODES = new Set([230011, 231003]);
+
+export function getFeishuReplyTargetGoneCode(value: unknown): number | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  const directCode = (value as { code?: number }).code;
+  if (typeof directCode === "number" && FEISHU_REPLY_TARGET_GONE_CODES.has(directCode)) {
+    return directCode;
+  }
+
+  const responseCode = (value as { response?: { data?: { code?: number } } }).response?.data?.code;
+  if (typeof responseCode === "number" && FEISHU_REPLY_TARGET_GONE_CODES.has(responseCode)) {
+    return responseCode;
+  }
+
+  return undefined;
+}
+
+export function isFeishuReplyTargetGone(value: unknown): boolean {
+  return getFeishuReplyTargetGoneCode(value) !== undefined;
+}
+
 export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,

--- a/extensions/feishu/src/typing.behavior.test.ts
+++ b/extensions/feishu/src/typing.behavior.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
+const reactionCreateMock = vi.hoisted(() => vi.fn());
+const reactionDeleteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: resolveFeishuAccountMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: getFeishuRuntimeMock,
+}));
+
+import { addTypingIndicator, removeTypingIndicator } from "./typing.js";
+
+describe("Feishu typing target-gone handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeishuAccountMock.mockReturnValue({
+      configured: true,
+      accountId: "main",
+      config: {},
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+    });
+    createFeishuClientMock.mockReturnValue({
+      im: {
+        messageReaction: {
+          create: reactionCreateMock,
+          delete: reactionDeleteMock,
+        },
+      },
+    });
+    getFeishuRuntimeMock.mockReturnValue({
+      logging: {
+        shouldLogVerbose: () => true,
+      },
+    });
+  });
+
+  it("throws when add typing hits a deleted message so keepalive can stop", async () => {
+    reactionCreateMock.mockResolvedValue({ code: 231003, msg: "The message is not found" });
+
+    await expect(
+      addTypingIndicator({
+        cfg: {} as never,
+        messageId: "om_deleted",
+        runtime: { log: vi.fn() } as never,
+      }),
+    ).rejects.toMatchObject({ code: 231003 });
+  });
+
+  it("throws when removing typing hits a withdrawn message", async () => {
+    reactionDeleteMock.mockResolvedValue({ code: 230011, msg: "The message was withdrawn." });
+
+    await expect(
+      removeTypingIndicator({
+        cfg: {} as never,
+        state: { messageId: "om_deleted", reactionId: "reaction_1" },
+        runtime: { log: vi.fn() } as never,
+      }),
+    ).rejects.toMatchObject({ code: 230011 });
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu replies treat withdrawn/deleted reply targets as terminal failures, so the final message is dropped, and typing indicator calls keep targeting the same dead message.
- Why it matters: users can get no reply at all if they withdraw the triggering message while the agent is still processing, and the gateway keeps emitting avoidable typing-indicator failures.
- What changed: text/card/media reply sends now fall back to a normal direct send when Feishu returns 230011/231003, typing target-gone errors now surface instead of being swallowed, and Feishu reply typing now trips immediately on the first terminal target-gone error.
- What did NOT change (scope boundary): no routing changes, no Feishu payload format changes beyond removing reply metadata on fallback, and no non-Feishu typing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27103
- Related #27190

## User-visible / Behavior Changes

Feishu now falls back to a normal send when a reply target was withdrawn or deleted, and typing keepalive stops immediately for the same terminal target-gone errors.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.1
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): Feishu replies enabled with standard reply-to behavior

### Steps

1. Trigger a Feishu reply that targets an existing message and then make Feishu report the target as withdrawn/deleted (`230011` / `231003`).
2. Observe the reply send path and the typing indicator path while the agent is still processing.
3. Verify whether the final message falls back to a direct send and whether typing retries keep targeting the dead message.

### Expected

- The final reply should still be delivered as a normal send without reply metadata.
- Typing keepalive should stop immediately once Feishu says the target message is gone.

### Actual

- On `upstream/main`, the reply fails and is dropped, while typing-target errors are swallowed and the keepalive keeps retrying the same deleted message.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the withdrawn-target send failure locally with a focused temporary Vitest case, reproduced the swallowed typing-target error with a second temporary Vitest case, then confirmed both pass after the fix.
- Edge cases checked: text, cards, and media now all fall back to direct send; non-target-gone reply errors still propagate; typing still ignores other non-critical errors but now stops immediately on target-gone responses.
- What you did **not** verify: live Feishu traffic against a production tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous reply/typing behavior.
- Files/config to restore: `extensions/feishu/src/send.ts`, `extensions/feishu/src/media.ts`, `extensions/feishu/src/typing.ts`, `extensions/feishu/src/reply-dispatcher.ts`
- Known bad symptoms reviewers should watch for: replies unexpectedly losing reply threading when the target still exists, or typing stopping too early on non-terminal errors.

## Risks and Mitigations

- Risk: a Feishu reply target-gone response now converts the send into a non-reply message.
  - Mitigation: the fallback is limited to Feishu’s explicit withdrawn/deleted codes, which is strictly better than dropping the reply entirely.

## Verification Commands

```bash
pnpm exec vitest run /tmp/feishu-withdrawn-send-fallback-repro.test.ts /tmp/feishu-typing-target-gone-repro.test.ts --config /tmp/vitest.single-feishu-withdrawn.config.ts
pnpm exec vitest run extensions/feishu/src/send-reply-fallback.test.ts extensions/feishu/src/media.test.ts extensions/feishu/src/typing.behavior.test.ts extensions/feishu/src/typing.test.ts extensions/feishu/src/reply-dispatcher.test.ts --config /tmp/vitest.single-feishu-withdrawn.config.ts
pnpm check
```

`pnpm check` still fails on current `upstream/main` because of unrelated baseline typecheck errors in `extensions/diagnostics-otel/src/service.ts`, `src/discord/voice/manager.ts`, `src/gateway/server-cron.ts`, and `src/shared/net/ip.ts`.
