### PR TITLE
fix(nostr): supports NIP-4, auto-reconnect and DM policy enforcement

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -45,25 +45,31 @@ describe("nostr outbound cfg threading", () => {
     };
     mocks.startNostrBus.mockResolvedValueOnce(bus as any);
 
-    const cleanup = (await nostrPlugin.gateway!.startAccount!(
+    const ac = new AbortController();
+
+    // startAccount blocks until the abort signal fires, so don't await it.
+    const startPromise = nostrPlugin.gateway!.startAccount!(
       createStartAccountContext({
         account: {
           accountId: "default",
           enabled: true,
           configured: true,
-          privateKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-          publicKey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+          privateKey: "dead".repeat(16), // pragma: allowlist secret
+          publicKey: "face".repeat(16),
           relays: ["wss://relay.example.com"],
           config: {},
         },
-        abortSignal: new AbortController().signal,
+        abortSignal: ac.signal,
       }),
-    )) as { stop: () => void };
+    );
+
+    // Let startAccount set up the bus before testing outbound.
+    await vi.waitFor(() => expect(mocks.startNostrBus).toHaveBeenCalled());
 
     const cfg = {
       channels: {
         nostr: {
-          privateKey: "resolved-nostr-private-key",
+          nsec: "resolved-nostr-test-placeholder",
         },
       },
     };
@@ -83,6 +89,7 @@ describe("nostr outbound cfg threading", () => {
     expect(mocks.normalizePubkey).toHaveBeenCalledWith("NPUB123");
     expect(sendDm).toHaveBeenCalledWith("normalized-npub123", "converted:|a|b|");
 
-    cleanup.stop();
+    ac.abort();
+    await startPromise;
   });
 });

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -2,6 +2,7 @@ import {
   buildChannelConfigSchema,
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
+  createReplyPrefixOptions,
   DEFAULT_ACCOUNT_ID,
   formatPairingApproveHint,
   type ChannelPlugin,
@@ -214,18 +215,93 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
             `[${account.accountId}] DM from ${senderPubkey}: ${text.slice(0, 50)}...`,
           );
 
-          // Forward to OpenClaw's message pipeline
-          await (
-            runtime.channel.reply as { handleInboundMessage?: (params: unknown) => Promise<void> }
-          ).handleInboundMessage?.({
+          const cfg = runtime.config.loadConfig();
+          const route = runtime.channel.routing.resolveAgentRoute({
+            cfg,
             channel: "nostr",
             accountId: account.accountId,
-            senderId: senderPubkey,
-            chatType: "direct",
-            chatId: senderPubkey, // For DMs, chatId is the sender's pubkey
-            text,
-            reply: async (responseText: string) => {
-              await reply(responseText);
+            peer: { kind: "direct", id: senderPubkey },
+          });
+
+          const storePath = runtime.channel.session.resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          });
+          const envelopeOptions = runtime.channel.reply.resolveEnvelopeFormatOptions(cfg);
+          const previousTimestamp = runtime.channel.session.readSessionUpdatedAt({
+            storePath,
+            sessionKey: route.sessionKey,
+          });
+          const body = runtime.channel.reply.formatAgentEnvelope({
+            channel: "Nostr",
+            from: senderPubkey.slice(0, 12),
+            timestamp: Date.now(),
+            previousTimestamp,
+            envelope: envelopeOptions,
+            body: text,
+          });
+
+          const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+            Body: body,
+            BodyForAgent: text,
+            RawBody: text,
+            CommandBody: text,
+            From: `nostr:${senderPubkey}`,
+            To: `nostr:${account.publicKey}`,
+            SessionKey: route.sessionKey,
+            AccountId: route.accountId,
+            ChatType: "direct",
+            ConversationLabel: senderPubkey.slice(0, 12),
+            SenderId: senderPubkey,
+            Provider: "nostr",
+            Surface: "nostr",
+            MessageSid: `nostr-${Date.now()}`,
+            Timestamp: Date.now(),
+            WasMentioned: true, // DMs are always "mentioned"
+            CommandAuthorized: true,
+            OriginatingChannel: "nostr",
+            OriginatingTo: `nostr:${account.publicKey}`,
+          });
+
+          await runtime.channel.session.recordInboundSession({
+            storePath,
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            ctx: ctxPayload,
+            onRecordError: (err) => {
+              ctx.log?.error?.(`[${account.accountId}] failed updating session meta: ${String(err)}`);
+            },
+          });
+
+          const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+            cfg,
+            agentId: route.agentId,
+            channel: "nostr",
+            accountId: account.accountId,
+          });
+
+          const tableMode = runtime.channel.text.resolveMarkdownTableMode({
+            cfg,
+            channel: "nostr",
+            accountId: account.accountId,
+          });
+
+          await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+            ctx: ctxPayload,
+            cfg,
+            dispatcherOptions: {
+              ...prefixOptions,
+              deliver: async (payload) => {
+                const replyText = (payload as { text?: string }).text;
+                if (replyText) {
+                  const formatted = runtime.channel.text.convertMarkdownTables(replyText, tableMode);
+                  await reply(formatted);
+                }
+              },
+              onError: (err, info) => {
+                ctx.log?.error?.(`[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`);
+              },
+            },
+            replyOptions: {
+              onModelSelected,
             },
           });
         },
@@ -274,15 +350,20 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
         `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
       );
 
-      // Return cleanup function
-      return {
-        stop: () => {
-          bus.close();
-          activeBuses.delete(account.accountId);
-          metricsSnapshots.delete(account.accountId);
-          ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
-        },
-      };
+      // Keep the channel alive until the abort signal fires
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal?.aborted) {
+          resolve();
+          return;
+        }
+        ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+
+      // Cleanup on abort
+      bus.close();
+      activeBuses.delete(account.accountId);
+      metricsSnapshots.delete(account.accountId);
+      ctx.log?.info(`[${account.accountId}] Nostr provider stopped`);
     },
   },
 };

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -267,7 +267,9 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
             sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
             ctx: ctxPayload,
             onRecordError: (err) => {
-              ctx.log?.error?.(`[${account.accountId}] failed updating session meta: ${String(err)}`);
+              ctx.log?.error?.(
+                `[${account.accountId}] failed updating session meta: ${String(err)}`,
+              );
             },
           });
 
@@ -292,12 +294,17 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
               deliver: async (payload) => {
                 const replyText = (payload as { text?: string }).text;
                 if (replyText) {
-                  const formatted = runtime.channel.text.convertMarkdownTables(replyText, tableMode);
+                  const formatted = runtime.channel.text.convertMarkdownTables(
+                    replyText,
+                    tableMode,
+                  );
                   await reply(formatted);
                 }
               },
               onError: (err, info) => {
-                ctx.log?.error?.(`[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`);
+                ctx.log?.error?.(
+                  `[${account.accountId}] Nostr ${info.kind} reply failed: ${String(err)}`,
+                );
               },
             },
             replyOptions: {

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -3,8 +3,11 @@ import {
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
   createReplyPrefixOptions,
+  createScopedPairingAccess,
   DEFAULT_ACCOUNT_ID,
   formatPairingApproveHint,
+  readStoreAllowFromForDmPolicy,
+  resolveEffectiveAllowFromLists,
   type ChannelPlugin,
 } from "openclaw/plugin-sdk/nostr";
 import type { NostrProfile } from "./config-schema.js";
@@ -216,6 +219,89 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
           );
 
           const cfg = runtime.config.loadConfig();
+
+          // Enforce DM access policy before dispatching
+          const resolvedAccount = resolveNostrAccount({
+            cfg,
+            accountId: account.accountId,
+          });
+          const dmPolicy = resolvedAccount.config.dmPolicy ?? "pairing";
+
+          if (dmPolicy === "disabled") {
+            ctx.log?.debug?.(
+              `[${account.accountId}] drop DM from ${senderPubkey} (dmPolicy=disabled)`,
+            );
+            return;
+          }
+
+          const pairing = createScopedPairingAccess({
+            core: runtime,
+            channel: "nostr",
+            accountId: account.accountId,
+          });
+
+          const configAllowFrom = (resolvedAccount.config.allowFrom ?? []).map((e) => {
+            try {
+              return normalizePubkey(String(e));
+            } catch {
+              return String(e);
+            }
+          });
+
+          const storeAllowFrom = await readStoreAllowFromForDmPolicy({
+            provider: "nostr",
+            accountId: account.accountId,
+            dmPolicy,
+            readStore: pairing.readStoreForDmPolicy,
+          });
+          const storeAllowList = storeAllowFrom.map((e) => {
+            try {
+              return normalizePubkey(e);
+            } catch {
+              return e;
+            }
+          });
+
+          const { effectiveAllowFrom } = resolveEffectiveAllowFromLists({
+            allowFrom: configAllowFrom,
+            groupAllowFrom: [],
+            storeAllowFrom: storeAllowList,
+            dmPolicy,
+          });
+
+          if (dmPolicy !== "open") {
+            const normalizedSender = normalizePubkey(senderPubkey);
+            const isAllowed =
+              effectiveAllowFrom.includes("*") || effectiveAllowFrom.includes(normalizedSender);
+
+            if (!isAllowed) {
+              if (dmPolicy === "pairing") {
+                const { code, created } = await pairing.upsertPairingRequest({
+                  id: normalizedSender,
+                  meta: {},
+                });
+                if (created) {
+                  try {
+                    const pairingReply = runtime.channel.pairing.buildPairingReply({
+                      channel: "nostr",
+                      idLine: `Your Nostr pubkey: ${senderPubkey}`,
+                      code,
+                    });
+                    await reply(pairingReply);
+                  } catch (err) {
+                    ctx.log?.error?.(
+                      `[${account.accountId}] pairing reply failed for ${senderPubkey}: ${String(err)}`,
+                    );
+                  }
+                }
+              }
+              ctx.log?.debug?.(
+                `[${account.accountId}] drop DM from ${senderPubkey} (dmPolicy=${dmPolicy})`,
+              );
+              return;
+            }
+          }
+
           const route = runtime.channel.routing.resolveAgentRoute({
             cfg,
             channel: "nostr",
@@ -240,6 +326,10 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
             body: text,
           });
 
+          // Sender passed DM policy check — resolve command authorization
+          const isInConfigAllowFrom = configAllowFrom.includes(normalizePubkey(senderPubkey));
+          const commandAuthorized = isInConfigAllowFrom;
+
           const ctxPayload = runtime.channel.reply.finalizeInboundContext({
             Body: body,
             BodyForAgent: text,
@@ -257,7 +347,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
             MessageSid: `nostr-${Date.now()}`,
             Timestamp: Date.now(),
             WasMentioned: true, // DMs are always "mentioned"
-            CommandAuthorized: true,
+            CommandAuthorized: commandAuthorized,
             OriginatingChannel: "nostr",
             OriginatingTo: `nostr:${account.publicKey}`,
           });

--- a/extensions/nostr/src/metrics.ts
+++ b/extensions/nostr/src/metrics.ts
@@ -33,6 +33,7 @@ export type RelayMetricName =
   | "relay.message.notice"
   | "relay.message.ok"
   | "relay.message.auth"
+  | "relay.reconnect.scheduled"
   | "relay.circuit_breaker.open"
   | "relay.circuit_breaker.close"
   | "relay.circuit_breaker.half_open";
@@ -292,6 +293,12 @@ export function createMetrics(onMetric?: OnMetricCallback): NostrMetrics {
       case "relay.reconnect":
         if (relayUrl) {
           getOrCreateRelay(relayUrl).reconnects += value;
+        }
+        break;
+      case "relay.reconnect.scheduled":
+        // Tracked via relay.reconnect counter; value carries delay_ms for the callback
+        if (relayUrl) {
+          getOrCreateRelay(relayUrl).reconnects += 1;
         }
         break;
       case "relay.error":

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -35,6 +35,11 @@ const STARTUP_LOOKBACK_SEC = 120; // tolerate relay lag / clock skew
 const MAX_PERSISTED_EVENT_IDS = 5000;
 const STATE_PERSIST_DEBOUNCE_MS = 5000; // Debounce state writes
 
+// Subscription reconnect configuration
+const RECONNECT_BASE_MS = 2000; // initial backoff
+const RECONNECT_MAX_MS = 60000; // max backoff cap
+const RECONNECT_JITTER_MS = 1000; // random jitter added to backoff
+
 // Circuit breaker configuration
 const CIRCUIT_BREAKER_THRESHOLD = 5; // failures before opening
 const CIRCUIT_BREAKER_RESET_MS = 30000; // 30 seconds before half-open
@@ -488,28 +493,70 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     }
   }
 
-  const sub = pool.subscribeMany(
-    relays,
-    [{ kinds: [4], "#p": [pk], since }] as unknown as Parameters<typeof pool.subscribeMany>[1],
-    {
-      onevent: handleEvent,
-      oneose: () => {
-        // EOSE handler - called when all stored events have been received
-        for (const relay of relays) {
-          metrics.emit("relay.message.eose", 1, { relay });
-        }
-        onEose?.(relays.join(", "));
+  // Auto-reconnect state
+  let closed = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  let reconnectAttempts = 0;
+  let currentSub: ReturnType<typeof pool.subscribeMany> | undefined;
+
+  function subscribe(): void {
+    // On reconnect, use lastProcessedAt with lookback so we catch recent messages
+    // but still dedup via the seen tracker
+    const reconnectSince =
+      reconnectAttempts === 0
+        ? since
+        : Math.max(0, lastProcessedAt - STARTUP_LOOKBACK_SEC);
+
+    currentSub = pool.subscribeMany(
+      relays,
+      { kinds: [4], "#p": [pk], since: reconnectSince } as unknown as Parameters<
+        typeof pool.subscribeMany
+      >[1],
+      {
+        onevent: handleEvent,
+        oneose: () => {
+          // EOSE = subscription is healthy; reset backoff
+          reconnectAttempts = 0;
+          for (const relay of relays) {
+            metrics.emit("relay.message.eose", 1, { relay });
+          }
+          onEose?.(relays.join(", "));
+        },
+        onclose: (reason) => {
+          for (const relay of relays) {
+            metrics.emit("relay.message.closed", 1, { relay });
+            options.onDisconnect?.(relay);
+          }
+          const reasonStr = Array.isArray(reason) ? reason.join(", ") : String(reason ?? "unknown");
+          onError?.(new Error(`Subscription closed: ${reasonStr}`), "subscription");
+
+          // Auto-reconnect unless intentionally closed
+          if (!closed) {
+            const backoff = Math.min(
+              RECONNECT_BASE_MS * 2 ** reconnectAttempts,
+              RECONNECT_MAX_MS,
+            );
+            const jitter = Math.floor(Math.random() * RECONNECT_JITTER_MS);
+            const delay = backoff + jitter;
+            reconnectAttempts++;
+            onError?.(
+              new Error(`Reconnecting in ${delay}ms (attempt ${reconnectAttempts})`),
+              "subscription.reconnect",
+            );
+            metrics.emit("relay.reconnect.scheduled", delay);
+            reconnectTimer = setTimeout(() => {
+              if (!closed) {
+                subscribe();
+              }
+            }, delay);
+          }
+        },
       },
-      onclose: (reason) => {
-        // Handle subscription close
-        for (const relay of relays) {
-          metrics.emit("relay.message.closed", 1, { relay });
-          options.onDisconnect?.(relay);
-        }
-        onError?.(new Error(`Subscription closed: ${reason.join(", ")}`), "subscription");
-      },
-    },
-  );
+    );
+  }
+
+  // Start initial subscription
+  subscribe();
 
   // Public sendDm function
   const sendDm = async (toPubkey: string, text: string): Promise<void> => {
@@ -567,7 +614,11 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
 
   return {
     close: () => {
-      sub.close();
+      closed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      currentSub?.close();
       seen.stop();
       // Flush pending state write synchronously on close
       if (pendingWrite) {

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -503,9 +503,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
     // On reconnect, use lastProcessedAt with lookback so we catch recent messages
     // but still dedup via the seen tracker
     const reconnectSince =
-      reconnectAttempts === 0
-        ? since
-        : Math.max(0, lastProcessedAt - STARTUP_LOOKBACK_SEC);
+      reconnectAttempts === 0 ? since : Math.max(0, lastProcessedAt - STARTUP_LOOKBACK_SEC);
 
     currentSub = pool.subscribeMany(
       relays,
@@ -532,10 +530,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
 
           // Auto-reconnect unless intentionally closed
           if (!closed) {
-            const backoff = Math.min(
-              RECONNECT_BASE_MS * 2 ** reconnectAttempts,
-              RECONNECT_MAX_MS,
-            );
+            const backoff = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
             const jitter = Math.floor(Math.random() * RECONNECT_JITTER_MS);
             const delay = backoff + jitter;
             reconnectAttempts++;

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -124,13 +124,11 @@ export async function importProfileFromRelays(
 
         const sub = pool.subscribeMany(
           [relay],
-          [
-            {
-              kinds: [0],
-              authors: [pubkey],
-              limit: 1,
-            },
-          ] as unknown as Parameters<typeof pool.subscribeMany>[1],
+          {
+            kinds: [0],
+            authors: [pubkey],
+            limit: 1,
+          } as unknown as Parameters<typeof pool.subscribeMany>[1],
           {
             onevent(event) {
               events.push({ event, relay });

--- a/src/plugin-sdk/nostr.ts
+++ b/src/plugin-sdk/nostr.ts
@@ -3,6 +3,7 @@
 
 export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
 export { formatPairingApproveHint } from "../channels/plugins/helpers.js";
+export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export type { OpenClawConfig } from "../config/config.js";
 export { MarkdownConfigSchema } from "../config/zod-schema.core.js";
@@ -16,4 +17,9 @@ export {
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
+export { createScopedPairingAccess } from "./pairing-access.js";
 export { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
+export {
+  readStoreAllowFromForDmPolicy,
+  resolveEffectiveAllowFromLists,
+} from "../security/dm-policy-shared.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
DMs over NIP-4 doesn't work
once disconnected from relay server, it never re-connect.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: 
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

- Nostr should work. I'm using the Damus client with relay `wss://relay.damus.io`

### Actual

- Nostr doesn't work. 

## Evidence

NIP-4 Failure

  The original code was using a shortcut approach to handle inbound DMs — it called a generic handleInboundMessage method on runtime.channel.reply, passing a simple object with channel,
  senderId, text, and a reply callback. This bypassed the standard OpenClaw message pipeline that all other channels use.

  Why it failed: The plugin SDK doesn't expose a `handleInboundMessage` method on the reply interface (it was cast with as to access it). The proper pipeline requires:

  1. Route resolution — `resolveAgentRoute()` to determine which agent handles the message
  2. Session management — `resolveStorePath()`, `readSessionUpdatedAt()`, `recordInboundSession()` to track conversation state
  3. Envelope formatting — `formatAgentEnvelope()` and `finalizeInboundContext()` to build the full context payload (Body, From, To, SessionKey, ChatType, etc.)
  4. Buffered reply dispatch — `dispatchReplyWithBufferedBlockDispatcher()` with proper deliver callback, prefix options, and markdown table conversion

  The fix replaces the 7-line shortcut with the ~70-line canonical pipeline (matching how Telegram, Discord, etc. work), so NIP-4 encrypted DMs actually flow through the agent and get a
  reply.

  Reconnect to Relay

  The original `nostr-bus.ts` created a single `pool.subscribeMany()` call with no reconnect logic. When a relay closed the subscription (network blip, relay restart, idle timeout), the onclose
  handler just logged an error and emitted metrics — the subscription was dead permanently.

  The fix adds auto-reconnect with exponential backoff:

  - Wraps subscription creation in a `subscribe()` function that can be called again
  - On `onclose`, if not intentionally closed (closed flag), schedules a reconnect with exponential backoff (2s base, 60s cap, +random jitter)
  - On successful `oneose` (end-of-stored-events = subscription is healthy), resets the backoff counter to 0
  - Uses `lastProcessedAt` - `STARTUP_LOOKBACK_SEC` as the since filter on reconnect so recent messages aren't missed (dedup via the existing seen-event tracker)
  - The `close()` method sets closed = true and clears any pending reconnect timer

  Additionally, the `subscribeMany` filter argument was incorrectly wrapped in an array (`[{kinds:[4],...}]`) when the nostr-tools API expects a single filter object. The profile import in
  `nostr-profile-import.ts` had the same wrapping bug. Both were fixed.

  Channel lifecycle fix

  The `start()` function originally returned a `{ stop }` object immediately. The fix changes it to `await` on the abort signal (`ctx.abortSignal`), keeping the channel alive for the gateway's
  lifetime, and only cleans up when the signal fires. This prevents the channel from being garbage-collected prematurely.



## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Yes, I could use DMs to reach out to openclaw now over Nostr NIP-4.
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
