### PR TITLE
feat(adapters): add sendPayload to team chat channel extensions

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -302,6 +302,28 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
+    sendPayload: async (ctx) => {
+      const send = ctx.deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
+      const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+      if (media) {
+        const result = await send(ctx.to, ctx.text, {
+          verbose: false,
+          mediaUrl: media,
+          mediaLocalRoots: ctx.mediaLocalRoots,
+          replyTo: ctx.replyToId ?? undefined,
+          accountId: ctx.accountId ?? undefined,
+          silent: ctx.silent ?? undefined,
+        });
+        return { channel: "discord", ...result };
+      }
+      const result = await send(ctx.to, ctx.text, {
+        verbose: false,
+        replyTo: ctx.replyToId ?? undefined,
+        accountId: ctx.accountId ?? undefined,
+        silent: ctx.silent ?? undefined,
+      });
+      return { channel: "discord", ...result };
+    },
     sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
       const result = await send(to, text, {

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -402,6 +402,57 @@ export const googlechatPlugin: ChannelPlugin<ResolvedGoogleChatAccount> = {
         error: missingTargetError("Google Chat", "<spaces/{space}|users/{user}>"),
       };
     },
+    sendPayload: async (ctx) => {
+      const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+      if (media) {
+        const account = resolveGoogleChatAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
+        const space = await resolveGoogleChatOutboundSpace({ account, target: ctx.to });
+        const thread = (ctx.threadId ?? ctx.replyToId ?? undefined) as string | undefined;
+        const runtime = getGoogleChatRuntime();
+        const maxBytes = resolveChannelMediaMaxBytes({
+          cfg: ctx.cfg,
+          resolveChannelLimitMb: ({ cfg, accountId }) =>
+            (
+              cfg.channels?.["googlechat"] as
+                | { accounts?: Record<string, { mediaMaxMb?: number }>; mediaMaxMb?: number }
+                | undefined
+            )?.accounts?.[accountId]?.mediaMaxMb ??
+            (cfg.channels?.["googlechat"] as { mediaMaxMb?: number } | undefined)?.mediaMaxMb,
+          accountId: ctx.accountId,
+        });
+        const loaded = await runtime.channel.media.fetchRemoteMedia({
+          url: media,
+          maxBytes: maxBytes ?? (account.config.mediaMaxMb ?? 20) * 1024 * 1024,
+        });
+        const upload = await uploadGoogleChatAttachment({
+          account,
+          space,
+          filename: loaded.fileName ?? "attachment",
+          buffer: loaded.buffer,
+          contentType: loaded.contentType,
+        });
+        const result = await sendGoogleChatMessage({
+          account,
+          space,
+          text: ctx.text,
+          thread,
+          attachments: upload.attachmentUploadToken
+            ? [
+                {
+                  attachmentUploadToken: upload.attachmentUploadToken,
+                  contentName: loaded.fileName,
+                },
+              ]
+            : undefined,
+        });
+        return { channel: "googlechat", messageId: result?.messageName ?? "", chatId: space };
+      }
+      const account = resolveGoogleChatAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
+      const space = await resolveGoogleChatOutboundSpace({ account, target: ctx.to });
+      const thread = (ctx.threadId ?? ctx.replyToId ?? undefined) as string | undefined;
+      const result = await sendGoogleChatMessage({ account, space, text: ctx.text, thread });
+      return { channel: "googlechat", messageId: result?.messageName ?? "", chatId: space };
+    },
     sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
       const account = resolveGoogleChatAccount({
         cfg: cfg,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -272,6 +272,15 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
       }
       return { ok: true, to: trimmed };
     },
+    sendPayload: async (ctx) => {
+      const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+      const result = await sendMessageMattermost(ctx.to, ctx.text, {
+        accountId: ctx.accountId ?? undefined,
+        replyToId: ctx.replyToId ?? undefined,
+        ...(media ? { mediaUrl: media } : {}),
+      });
+      return { channel: "mattermost", ...result };
+    },
     sendText: async ({ to, text, accountId, replyToId }) => {
       const result = await sendMessageMattermost(to, text, {
         accountId: accountId ?? undefined,

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -9,6 +9,22 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
+  sendPayload: async (ctx) => {
+    const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+    if (media) {
+      const send =
+        ctx.deps?.sendMSTeams ??
+        ((to: string, text: string, opts?: { mediaUrl?: string }) =>
+          sendMessageMSTeams({ cfg: ctx.cfg, to, text, mediaUrl: opts?.mediaUrl }));
+      const result = await send(ctx.to, ctx.text, { mediaUrl: media });
+      return { channel: "msteams", ...result };
+    }
+    const send =
+      ctx.deps?.sendMSTeams ??
+      ((to: string, text: string) => sendMessageMSTeams({ cfg: ctx.cfg, to, text }));
+    const result = await send(ctx.to, ctx.text);
+    return { channel: "msteams", ...result };
+  },
   sendText: async ({ cfg, to, text, deps }) => {
     const send = deps?.sendMSTeams ?? ((to, text) => sendMessageMSTeams({ cfg, to, text }));
     const result = await send(to, text);


### PR DESCRIPTION
## Summary

- Add `sendPayload` to team chat channel extension adapters: Discord, Slack, MS Teams, Mattermost, Google Chat, Synology Chat
- Each adapter's `sendPayload` extracts media from the payload and delegates to the existing channel-specific send functions

## Motivation

Same as #29993 — prepares adapters for the universal `sendPayload` delivery path.

## Test plan

- [ ] `pnpm build` passes
- [ ] Existing adapter tests still pass

Part of the lifecycle PR stack. Independent — can be merged without any other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)