### PR TITLE
feat(adapters): add sendPayload to alt channel extensions

### DIFF
--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -296,6 +296,22 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = {
     chunker: (text, limit) => getIrcRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 350,
+    sendPayload: async (ctx) => {
+      const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+      if (media) {
+        const combined = `${ctx.text}\n\nAttachment: ${media}`;
+        const result = await sendMessageIrc(ctx.to, combined, {
+          accountId: ctx.accountId ?? undefined,
+          replyTo: ctx.replyToId ?? undefined,
+        });
+        return { channel: "irc", ...result };
+      }
+      const result = await sendMessageIrc(ctx.to, ctx.text, {
+        accountId: ctx.accountId ?? undefined,
+        replyTo: ctx.replyToId ?? undefined,
+      });
+      return { channel: "irc", ...result };
+    },
     sendText: async ({ to, text, accountId, replyToId }) => {
       const result = await sendMessageIrc(to, text, {
         accountId: accountId ?? undefined,

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -7,6 +7,23 @@ export const matrixOutbound: ChannelOutboundAdapter = {
   chunker: (text, limit) => getMatrixRuntime().channel.text.chunkMarkdownText(text, limit),
   chunkerMode: "markdown",
   textChunkLimit: 4000,
+  sendPayload: async (ctx) => {
+    const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+    const send = ctx.deps?.sendMatrix ?? sendMessageMatrix;
+    const resolvedThreadId =
+      ctx.threadId !== undefined && ctx.threadId !== null ? String(ctx.threadId) : undefined;
+    const result = await send(ctx.to, ctx.text, {
+      mediaUrl: media ?? undefined,
+      replyToId: ctx.replyToId ?? undefined,
+      threadId: resolvedThreadId,
+      accountId: ctx.accountId ?? undefined,
+    });
+    return {
+      channel: "matrix",
+      messageId: result.messageId,
+      roomId: result.roomId,
+    };
+  },
   sendText: async ({ to, text, deps, replyToId, threadId, accountId }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -262,6 +262,22 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     chunker: (text, limit) => getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
     textChunkLimit: 4000,
+    sendPayload: async (ctx) => {
+      const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+      if (media) {
+        const messageWithMedia = `${ctx.text}\n\nAttachment: ${media}`;
+        const result = await sendMessageNextcloudTalk(ctx.to, messageWithMedia, {
+          accountId: ctx.accountId ?? undefined,
+          replyTo: ctx.replyToId ?? undefined,
+        });
+        return { channel: "nextcloud-talk", ...result };
+      }
+      const result = await sendMessageNextcloudTalk(ctx.to, ctx.text, {
+        accountId: ctx.accountId ?? undefined,
+        replyTo: ctx.replyToId ?? undefined,
+      });
+      return { channel: "nextcloud-talk", ...result };
+    },
     sendText: async ({ to, text, accountId, replyToId }) => {
       const result = await sendMessageNextcloudTalk(to, text, {
         accountId: accountId ?? undefined,

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -135,6 +135,28 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = {
   outbound: {
     deliveryMode: "direct",
     textChunkLimit: 4000,
+    // Nostr is text-only (no media support); sendPayload delegates to text path
+    sendPayload: async (ctx) => {
+      const core = getNostrRuntime();
+      const aid = ctx.accountId ?? DEFAULT_ACCOUNT_ID;
+      const bus = activeBuses.get(aid);
+      if (!bus) {
+        throw new Error(`Nostr bus not running for account ${aid}`);
+      }
+      const tableMode = core.channel.text.resolveMarkdownTableMode({
+        cfg: core.config.loadConfig(),
+        channel: "nostr",
+        accountId: aid,
+      });
+      const message = core.channel.text.convertMarkdownTables(ctx.text ?? "", tableMode);
+      const normalizedTo = normalizePubkey(ctx.to);
+      await bus.sendDm(normalizedTo, message);
+      return {
+        channel: "nostr" as const,
+        to: normalizedTo,
+        messageId: `nostr-${Date.now()}`,
+      };
+    },
     sendText: async ({ to, text, accountId }) => {
       const core = getNostrRuntime();
       const aid = accountId ?? DEFAULT_ACCOUNT_ID;

--- a/extensions/tlon/src/channel.ts
+++ b/extensions/tlon/src/channel.ts
@@ -156,6 +156,12 @@ const tlonOutbound: ChannelOutboundAdapter = {
   },
 };
 
+tlonOutbound.sendPayload = async (ctx) => {
+  const media = ctx.payload.mediaUrl ?? ctx.payload.mediaUrls?.[0];
+  if (media) return tlonOutbound.sendMedia!({ ...ctx, mediaUrl: media });
+  return tlonOutbound.sendText!({ ...ctx });
+};
+
 export const tlonPlugin: ChannelPlugin = {
   id: TLON_CHANNEL_ID,
   meta: {

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -185,3 +185,13 @@ export const twitchOutbound: ChannelOutboundAdapter = {
     });
   },
 };
+
+twitchOutbound.sendPayload = async (ctx) => {
+  const payload = (ctx as Record<string, unknown>).payload as {
+    mediaUrl?: string;
+    mediaUrls?: string[];
+  };
+  const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+  if (media) return twitchOutbound.sendMedia!({ ...ctx, mediaUrl: media });
+  return twitchOutbound.sendText!({ ...ctx });
+};


### PR DESCRIPTION
## Summary

- Add `sendPayload` to alt channel extension adapters: Matrix, Feishu, IRC, Nextcloud Talk, Nostr, Tlon, Twitch
- Each adapter's `sendPayload` extracts media from the payload and delegates to existing send functions
- Nostr (text-only channel) delegates directly to the text sending path

## Motivation

Same as #29993 — prepares adapters for the universal `sendPayload` delivery path.

## Test plan

- [ ] `pnpm build` passes
- [ ] Existing adapter tests still pass

Part of the lifecycle PR stack. Independent — can be merged without any other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)