### PR TITLE
feat(adapters): add sendPayload to remaining extensions and core adapters

### DIFF
--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -302,6 +302,21 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount> = {
     chunker: chunkTextForOutbound,
     chunkerMode: "text",
     textChunkLimit: 2000,
+    sendPayload: async ({ to, payload, accountId, cfg }) => {
+      const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+      const text = payload.text ?? "";
+      const result = await sendMessageZalo(to, text, {
+        accountId: accountId ?? undefined,
+        ...(media ? { mediaUrl: media } : {}),
+        cfg: cfg,
+      });
+      return {
+        channel: "zalo",
+        ok: result.ok,
+        messageId: result.messageId ?? "",
+        error: result.error ? new Error(result.error) : undefined,
+      };
+    },
     sendText: async ({ to, text, accountId, cfg }) => {
       const result = await sendMessageZalo(to, text, {
         accountId: accountId ?? undefined,

--- a/extensions/zalouser/src/channel.ts
+++ b/extensions/zalouser/src/channel.ts
@@ -518,6 +518,21 @@ export const zalouserPlugin: ChannelPlugin<ResolvedZalouserAccount> = {
     chunker: chunkTextForOutbound,
     chunkerMode: "text",
     textChunkLimit: 2000,
+    sendPayload: async ({ to, payload, accountId, cfg }) => {
+      const account = resolveZalouserAccountSync({ cfg: cfg, accountId });
+      const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+      const text = payload.text ?? "";
+      const result = await sendMessageZalouser(to, text, {
+        profile: account.profile,
+        ...(media ? { mediaUrl: media } : {}),
+      });
+      return {
+        channel: "zalouser",
+        ok: result.ok,
+        messageId: result.messageId ?? "",
+        error: result.error ? new Error(result.error) : undefined,
+      };
+    },
     sendText: async ({ to, text, accountId, cfg }) => {
       const account = resolveZalouserAccountSync({ cfg: cfg, accountId });
       const result = await sendMessageZalouser(to, text, { profile: account.profile });

--- a/src/channels/plugins/outbound/direct-text-media.ts
+++ b/src/channels/plugins/outbound/direct-text-media.ts
@@ -91,6 +91,30 @@ export function createDirectTextMediaOutbound<
     chunker: chunkText,
     chunkerMode: "text",
     textChunkLimit: 4000,
+    sendPayload: async ({ cfg, to, payload, accountId, deps, replyToId }) => {
+      const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+      if (media) {
+        return await sendDirect({
+          cfg,
+          to,
+          text: payload.text ?? "",
+          accountId,
+          deps,
+          replyToId,
+          mediaUrl: media,
+          buildOptions: params.buildMediaOptions,
+        });
+      }
+      return await sendDirect({
+        cfg,
+        to,
+        text: payload.text ?? "",
+        accountId,
+        deps,
+        replyToId,
+        buildOptions: params.buildTextOptions,
+      });
+    },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       return await sendDirect({
         cfg,

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -93,6 +93,28 @@ export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 4000,
+  sendPayload: async ({
+    to,
+    payload,
+    mediaLocalRoots,
+    accountId,
+    deps,
+    replyToId,
+    threadId,
+    identity,
+  }) => {
+    const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+    return await sendSlackOutboundMessage({
+      to,
+      text: payload.text ?? "",
+      ...(media ? { mediaUrl: media, mediaLocalRoots } : {}),
+      accountId,
+      deps,
+      replyToId,
+      threadId,
+      identity,
+    });
+  },
   sendText: async ({ to, text, accountId, deps, replyToId, threadId, identity }) => {
     return await sendSlackOutboundMessage({
       to,

--- a/src/channels/plugins/outbound/whatsapp.ts
+++ b/src/channels/plugins/outbound/whatsapp.ts
@@ -12,6 +12,18 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   pollMaxOptions: 12,
   resolveTarget: ({ to, allowFrom, mode }) =>
     resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  sendPayload: async ({ to, payload, mediaLocalRoots, accountId, deps, gifPlayback }) => {
+    const send =
+      deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;
+    const media = payload.mediaUrl ?? payload.mediaUrls?.[0];
+    const result = await send(to, payload.text ?? "", {
+      verbose: false,
+      ...(media ? { mediaUrl: media, mediaLocalRoots } : {}),
+      accountId: accountId ?? undefined,
+      gifPlayback,
+    });
+    return { channel: "whatsapp", ...result };
+  },
   sendText: async ({ to, text, accountId, deps, gifPlayback }) => {
     const send =
       deps?.sendWhatsApp ?? (await import("../../../web/outbound.js")).sendMessageWhatsApp;


### PR DESCRIPTION
## Summary

- Add `sendPayload` to remaining extension adapters: Zalo, Zalouser
- Add `sendPayload` to core adapters: Discord, Slack, WhatsApp, and the `createDirectTextMediaOutbound` helper (covering iMessage + Signal core)
- Core Telegram already has `sendPayload` on main

## Motivation

Same as #29993 — prepares adapters for the universal `sendPayload` delivery path. After this + the other adapter PRs, every channel adapter supports `sendPayload`.

## Test plan

- [ ] `pnpm build` passes
- [ ] Existing adapter tests still pass

Part of the lifecycle PR stack. Independent — can be merged without any other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)