### PR TITLE
fix(restart): add Windows schtasks support to triggerOpenClawRestart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Restart: add Windows `schtasks` support to `triggerOpenClawRestart()` so the `/restart` chat command works on Windows instead of returning "unsupported platform restart". (#29949)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)


### PR DESCRIPTION
## Summary

Add Windows `schtasks` support to `triggerOpenClawRestart()` so the `/restart` chat command works on Windows.

## Problem

`triggerOpenClawRestart()` only handled macOS (launchctl) and Linux (systemd) restarts. On Windows, it fell through to a generic `{ ok: false, method: 'supervisor', detail: 'unsupported platform restart' }` error, making the `/restart` command non-functional on Windows.

Meanwhile, `restartScheduledTask()` in `src/daemon/schtasks.ts` already had the correct async Windows implementation using `schtasks /End` + `schtasks /Run`.

## Changes

- Added a `win32` branch in `triggerOpenClawRestart()` that calls `schtasks /End` (tolerating failure if task isn't running) followed by `schtasks /Run`, using the same task name resolution as the existing daemon code (`OPENCLAW_WINDOWS_TASK_NAME` env override or `resolveGatewayWindowsTaskName()`).
- Added `"schtasks"` to the `RestartAttempt.method` type union.
- Added `resolveGatewayWindowsTaskName` import from `../daemon/constants.js`.

## Test plan

- Added 3 regression tests in `src/infra/restart.test.ts`:
  - Verifies successful `schtasks /End` + `/Run` returns `{ ok: true, method: "schtasks" }`
  - Verifies `/Run` failure returns `{ ok: false, method: "schtasks" }` with error detail
  - Verifies `OPENCLAW_WINDOWS_TASK_NAME` env override is respected
- All 7 tests pass: `pnpm vitest run src/infra/restart.test.ts`

## Effect on User Experience

Before: `/restart` command in Telegram/Discord/etc fails on Windows with "unsupported platform restart".
After: `/restart` correctly restarts the gateway via Windows Task Scheduler, matching the behavior of `openclaw gateway restart` CLI.

Closes #29949
