### PR TITLE
fix(skills): handle unquoted colons in SKILL.md frontmatter description

### DIFF
--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -102,4 +102,3 @@ category: openclaw: command
     expect(result.category).toBe("openclaw: command");
   });
 });
-

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -85,4 +85,21 @@ description: Generate images IMPORTANT: Must use anime style
     expect(result.name).toBe("my-skill");
     expect(result.description).toBe("Generate images IMPORTANT: Must use anime style");
   });
+
+  it("preserves intentional single-line YAML nested maps (bot concern)", () => {
+    // "key: nested: val" is a YAML parse error ("Nested mappings are not allowed").
+    // parseYamlFrontmatter returns null and parseFrontmatterBlock falls back to
+    // the line-parser entirely — it reads `openclaw: command` as a plain string.
+    // This confirms the bot's edge case cannot reach the merge step at all.
+    const content = `---
+name: my-skill
+category: openclaw: command
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("my-skill");
+    // YAML throws → line-parser wins for the entire doc; value is the raw string
+    expect(result.category).toBe("openclaw: command");
+  });
 });
+

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -72,4 +72,17 @@ metadata:
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});
   });
+
+  it("parses description containing an inline colon without corruption (issue #29981)", () => {
+    // YAML mis-parses "description: Foo IMPORTANT: bar" as a nested object.
+    // The line-parser reads it correctly as a plain string – we should prefer that.
+    const content = `---
+name: my-skill
+description: Generate images IMPORTANT: Must use anime style
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("my-skill");
+    expect(result.description).toBe("Generate images IMPORTANT: Must use anime style");
+  });
 });

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -150,16 +150,19 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   const merged: ParsedFrontmatter = { ...yamlParsed };
   for (const [key, value] of Object.entries(lineParsed)) {
     const yamlValue = yamlParsed[key];
-    // Prefer the line-parser value in these two cases:
-    // 1. The line-parser found a JSON-like value (starts with { or [) for a
-    //    field where YAML produced a plain string — keep the raw JSON form.
-    // 2. YAML parsed a single-line field as a nested object (JSON string
-    //    starting with "{") because of an unquoted colon inside the value
-    //    (e.g. "description: Foo IMPORTANT: bar"), but the line-parser
-    //    correctly read it as a plain, single-line string.  In this case we
-    //    trust the line-parser.  We guard against multi-line YAML objects
-    //    (indented blocks) by requiring the line-parser value to be a
-    //    single-line, non-JSON string.
+    // Prefer the line-parser value in two cases:
+    // 1. Line-parser found a JSON-like value (starts with { or [) — keep it
+    //    verbatim so downstream consumers can parse the raw JSON/JSON5.
+    // 2. YAML parsed a single-line field as a nested object because an
+    //    unquoted colon inside the value confused the parser
+    //    (e.g. "description: Foo IMPORTANT: bar" → {"IMPORTANT":"bar"}).
+    //    Note: bare double-colon YAML ("key: nested: val") is a YAML error
+    //    and throws before reaching this merge step, so that edge case cannot
+    //    occur.  The only way to get a legitimate single-line YAML object is
+    //    flow syntax ({...}) — which the line-parser also preserves as a
+    //    JSON-like value handled by case 1 above.
+    //    We guard against multi-line YAML objects (indented blocks) by
+    //    requiring the line-parser value to be a single-line, non-JSON string.
     const lineParsedIsPlainSingleLine =
       !value.includes("\n") &&
       !value.startsWith("{") &&

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -164,9 +164,7 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
     //    We guard against multi-line YAML objects (indented blocks) by
     //    requiring the line-parser value to be a single-line, non-JSON string.
     const lineParsedIsPlainSingleLine =
-      !value.includes("\n") &&
-      !value.startsWith("{") &&
-      !value.startsWith("[");
+      !value.includes("\n") && !value.startsWith("{") && !value.startsWith("[");
     const yamlWasMisparsedAsObject =
       typeof yamlValue === "string" &&
       (yamlValue.startsWith("{") || yamlValue.startsWith("[")) &&

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -149,7 +149,26 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
 
   const merged: ParsedFrontmatter = { ...yamlParsed };
   for (const [key, value] of Object.entries(lineParsed)) {
-    if (value.startsWith("{") || value.startsWith("[")) {
+    const yamlValue = yamlParsed[key];
+    // Prefer the line-parser value in these two cases:
+    // 1. The line-parser found a JSON-like value (starts with { or [) for a
+    //    field where YAML produced a plain string — keep the raw JSON form.
+    // 2. YAML parsed a single-line field as a nested object (JSON string
+    //    starting with "{") because of an unquoted colon inside the value
+    //    (e.g. "description: Foo IMPORTANT: bar"), but the line-parser
+    //    correctly read it as a plain, single-line string.  In this case we
+    //    trust the line-parser.  We guard against multi-line YAML objects
+    //    (indented blocks) by requiring the line-parser value to be a
+    //    single-line, non-JSON string.
+    const lineParsedIsPlainSingleLine =
+      !value.includes("\n") &&
+      !value.startsWith("{") &&
+      !value.startsWith("[");
+    const yamlWasMisparsedAsObject =
+      typeof yamlValue === "string" &&
+      (yamlValue.startsWith("{") || yamlValue.startsWith("[")) &&
+      lineParsedIsPlainSingleLine;
+    if (value.startsWith("{") || value.startsWith("[") || yamlWasMisparsedAsObject) {
       merged[key] = value;
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `SKILL.md` files with a colon inside the `description` field (e.g. `description: Step-by-step: do X`) failed to load because YAML mis-parsed the value as a nested object.

## Why is this needed?

When an unquoted colon is present in the frontmatter value, YAML's parser treats it as a key-value pair within a nested object. This causes the skill's description to be corrupted (JSON-stringified object) or missing. The existing merge logic didn't account for this specific mismatch between YAML and line-based parsing.

## How was it tested?

- Added a regression test case in `src/markdown/frontmatter.test.ts` covering unquoted colons in descriptions.
- - Verified that all 6 frontmatter tests pass.
- - Verified that legitimate multi-line YAML objects (like `metadata:`) are still correctly preserved.
## Changes

- Modified `src/markdown/frontmatter.ts` to detect when YAML produces an object for a field that the line-parser identifies as a single-line plain string, and favor the line-parser's result in that case.
## Related issue
Closes #29981