### PR TITLE
feat(exec): add session-based trust windows for exec approvals

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,72 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
     }
 }
 
+public struct ExecApprovalsTrustStatusParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String?)
+    {
+        self.agentid = agentid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct ExecApprovalsTrustStatusResult: Codable, Sendable {
+    public let agentid: String
+    public let trustwindow: AnyCodable?
+
+    public init(
+        agentid: String,
+        trustwindow: AnyCodable?)
+    {
+        self.agentid = agentid
+        self.trustwindow = trustwindow
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case trustwindow = "trustWindow"
+    }
+}
+
+public struct TrustWindow: Codable, Sendable {
+    public let status: String
+    public let expiresat: Int
+    public let grantedat: Int
+    public let grantedby: String?
+    public let security: String
+    public let ask: String
+
+    public init(
+        status: String,
+        expiresat: Int,
+        grantedat: Int,
+        grantedby: String?,
+        security: String,
+        ask: String)
+    {
+        self.status = status
+        self.expiresat = expiresat
+        self.grantedat = grantedat
+        self.grantedby = grantedby
+        self.security = security
+        self.ask = ask
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case expiresat = "expiresAt"
+        case grantedat = "grantedAt"
+        case grantedby = "grantedBy"
+        case security
+        case ask
+    }
+}
+
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2818,6 +2818,72 @@ public struct ExecApprovalsSnapshot: Codable, Sendable {
     }
 }
 
+public struct ExecApprovalsTrustStatusParams: Codable, Sendable {
+    public let agentid: String?
+
+    public init(
+        agentid: String?)
+    {
+        self.agentid = agentid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+    }
+}
+
+public struct ExecApprovalsTrustStatusResult: Codable, Sendable {
+    public let agentid: String
+    public let trustwindow: AnyCodable?
+
+    public init(
+        agentid: String,
+        trustwindow: AnyCodable?)
+    {
+        self.agentid = agentid
+        self.trustwindow = trustwindow
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case trustwindow = "trustWindow"
+    }
+}
+
+public struct TrustWindow: Codable, Sendable {
+    public let status: String
+    public let expiresat: Int
+    public let grantedat: Int
+    public let grantedby: String?
+    public let security: String
+    public let ask: String
+
+    public init(
+        status: String,
+        expiresat: Int,
+        grantedat: Int,
+        grantedby: String?,
+        security: String,
+        ask: String)
+    {
+        self.status = status
+        self.expiresat = expiresat
+        self.grantedat = grantedat
+        self.grantedby = grantedby
+        self.security = security
+        self.ask = ask
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case expiresat = "expiresAt"
+        case grantedat = "grantedAt"
+        case grantedby = "grantedBy"
+        case security
+        case ask
+    }
+}
+
 public struct ExecApprovalRequestParams: Codable, Sendable {
     public let id: String?
     public let command: String

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -6,6 +6,7 @@ import {
   type ExecSecurity,
   buildEnforcedShellCommand,
   evaluateShellAllowlist,
+  getTrustWindow,
   maxAsk,
   minSecurity,
   recordAllowlistUse,
@@ -15,7 +16,9 @@ import {
 } from "../infra/exec-approvals.js";
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
+import { summarizeTrustAudit, cleanupTrustAudit } from "../infra/trust-audit.js";
 import { logInfo } from "../logger.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   registerExecApprovalRequestForHost,
@@ -74,6 +77,27 @@ export async function processGatewayAllowlist(
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error("exec denied: host=gateway security=deny");
+  }
+
+  const agentKey = params.agentId?.trim() || DEFAULT_AGENT_ID;
+  const trustWindow = getTrustWindow(agentKey);
+  const now = Date.now();
+  const trustWindowActive =
+    trustWindow?.status === "active" &&
+    typeof trustWindow.expiresAt === "number" &&
+    now < trustWindow.expiresAt;
+  const trustWindowExpired =
+    trustWindow?.status === "active" &&
+    typeof trustWindow.expiresAt === "number" &&
+    now >= trustWindow.expiresAt;
+
+  if (trustWindowActive && trustWindow?.grantNotified !== true) {
+    const remainingMs = trustWindow.expiresAt - now;
+    const remainingMin = Math.max(1, Math.ceil(remainingMs / 60_000));
+    emitExecSystemEvent(`🔓 Trust window active · expires in ${remainingMin}m`, {
+      sessionKey: params.notifySessionKey,
+    });
+    trustWindow.grantNotified = true;
   }
   const allowlistEval = evaluateShellAllowlist({
     command: params.command,
@@ -137,6 +161,24 @@ export async function processGatewayAllowlist(
     params.warnings.push(
       "Warning: heredoc execution requires explicit approval in allowlist mode.",
     );
+  }
+
+  if (trustWindowExpired && trustWindow?.expiredNotified !== true) {
+    emitExecSystemEvent("🔒 Trust window expired. Exec approval required for new commands.", {
+      sessionKey: params.notifySessionKey,
+    });
+    const summary = summarizeTrustAudit({
+      agentId: agentKey,
+      startedAt: trustWindow.grantedAt,
+      endedAt: trustWindow.expiresAt ?? now,
+    });
+    if (summary) {
+      emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey });
+    }
+    // TODO: Future enhancement — emit Discord buttons [Keep] / [Delete] for audit log
+    // retention on expiry, with delete-on-timeout default. For now, auto-delete.
+    cleanupTrustAudit(agentKey);
+    trustWindow.expiredNotified = true;
   }
 
   if (requiresAsk) {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -65,12 +65,9 @@ export async function executeNodeHostCommand(
     security: params.security,
     ask: params.ask,
   });
-  const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  const hostAsk = maxAsk(params.ask, approvals.agent.ask);
+  let hostSecurity = minSecurity(params.security, approvals.agent.security);
+  let hostAsk = maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
-  if (hostSecurity === "deny") {
-    throw new Error("exec denied: host=node security=deny");
-  }
 
   const agentKey = params.agentId?.trim() || DEFAULT_AGENT_ID;
   const trustWindow = getTrustWindow(agentKey);
@@ -83,6 +80,15 @@ export async function executeNodeHostCommand(
     trustWindow?.status === "active" &&
     typeof trustWindow.expiresAt === "number" &&
     now >= trustWindow.expiresAt;
+
+  if (trustWindowActive) {
+    hostSecurity = "full";
+    hostAsk = "off";
+  }
+
+  if (hostSecurity === "deny") {
+    throw new Error("exec denied: host=node security=deny");
+  }
 
   if (trustWindowActive && trustWindow?.grantNotified !== true) {
     const remainingMs = trustWindow.expiresAt - now;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -5,6 +5,7 @@ import {
   type ExecAsk,
   type ExecSecurity,
   evaluateShellAllowlist,
+  getTrustWindow,
   maxAsk,
   minSecurity,
   requiresExecApproval,
@@ -14,7 +15,13 @@ import {
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import { parsePreparedSystemRunPayload } from "../infra/system-run-approval-context.js";
+import {
+  summarizeTrustAudit,
+  cleanupTrustAudit,
+  appendTrustAuditEntry,
+} from "../infra/trust-audit.js";
 import { logInfo } from "../logger.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   registerExecApprovalRequestForHost,
   waitForExecApprovalDecision,
@@ -63,6 +70,27 @@ export async function executeNodeHostCommand(
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error("exec denied: host=node security=deny");
+  }
+
+  const agentKey = params.agentId?.trim() || DEFAULT_AGENT_ID;
+  const trustWindow = getTrustWindow(agentKey);
+  const now = Date.now();
+  const trustWindowActive =
+    trustWindow?.status === "active" &&
+    typeof trustWindow.expiresAt === "number" &&
+    now < trustWindow.expiresAt;
+  const trustWindowExpired =
+    trustWindow?.status === "active" &&
+    typeof trustWindow.expiresAt === "number" &&
+    now >= trustWindow.expiresAt;
+
+  if (trustWindowActive && trustWindow?.grantNotified !== true) {
+    const remainingMs = trustWindow.expiresAt - now;
+    const remainingMin = Math.max(1, Math.ceil(remainingMs / 60_000));
+    emitExecSystemEvent(`🔓 Trust window active · expires in ${remainingMin}m`, {
+      sessionKey: params.notifySessionKey,
+    });
+    trustWindow.grantNotified = true;
   }
   if (params.boundNode && params.requestedNode && params.boundNode !== params.requestedNode) {
     throw new Error(`exec node not allowed (bound to ${params.boundNode})`);
@@ -182,6 +210,23 @@ export async function executeNodeHostCommand(
       analysisOk,
       allowlistSatisfied,
     }) || obfuscation.detected;
+
+  if (trustWindowExpired && trustWindow?.expiredNotified !== true) {
+    emitExecSystemEvent("🔒 Trust window expired. Exec approval required for new commands.", {
+      sessionKey: params.notifySessionKey,
+    });
+    const summary = summarizeTrustAudit({
+      agentId: agentKey,
+      startedAt: trustWindow.grantedAt,
+      endedAt: trustWindow.expiresAt ?? now,
+    });
+    if (summary) {
+      emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey });
+    }
+    cleanupTrustAudit(agentKey);
+    trustWindow.expiredNotified = true;
+  }
+
   const invokeTimeoutMs = Math.max(
     10_000,
     (typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec) * 1000 +
@@ -365,6 +410,17 @@ export async function executeNodeHostCommand(
   const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
   const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
   const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
+  const durationMs = Date.now() - startedAt;
+
+  if (trustWindowActive) {
+    appendTrustAuditEntry({
+      agentId: agentKey,
+      command: params.command,
+      exitCode: exitCode ?? (success ? 0 : null),
+      durationMs,
+    });
+  }
+
   return {
     content: [
       {
@@ -375,7 +431,7 @@ export async function executeNodeHostCommand(
     details: {
       status: success ? "completed" : "failed",
       exitCode,
-      durationMs: Date.now() - startedAt,
+      durationMs,
       aggregated: [stdout, stderr, errorText].filter(Boolean).join("\n"),
       cwd: params.workdir,
     } satisfies ExecToolDetails,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -337,6 +337,17 @@ export function createExecTool(
         ask = "off";
       }
 
+      const trustAgentKey = agentId?.trim() || DEFAULT_AGENT_ID;
+      const trustWindow = host === "gateway" ? getTrustWindow(trustAgentKey) : undefined;
+      const trustWindowActive =
+        trustWindow?.status === "active" &&
+        typeof trustWindow.expiresAt === "number" &&
+        Date.now() < trustWindow.expiresAt;
+      if (trustWindowActive) {
+        security = "full";
+        ask = "off";
+      }
+
       const sandbox = host === "sandbox" ? defaults?.sandbox : undefined;
       if (
         host === "sandbox" &&
@@ -472,13 +483,6 @@ export function createExecTool(
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
       await validateScriptFileForShellBleed({ command: params.command, workdir });
-
-      const trustAgentKey = agentId?.trim() || DEFAULT_AGENT_ID;
-      const trustWindow = host === "gateway" ? getTrustWindow(trustAgentKey) : undefined;
-      const trustWindowActive =
-        trustWindow?.status === "active" &&
-        typeof trustWindow.expiresAt === "number" &&
-        Date.now() < trustWindow.expiresAt;
 
       const run = await runExecProcess({
         command: params.command,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,14 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
-import { type ExecHost, maxAsk, minSecurity } from "../infra/exec-approvals.js";
+import { type ExecHost, getTrustWindow, maxAsk, minSecurity } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
+import { appendTrustAuditEntry } from "../infra/trust-audit.js";
 import { logInfo } from "../logger.js";
-import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import {
+  DEFAULT_AGENT_ID,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
@@ -468,6 +473,13 @@ export function createExecTool(
       // before we execute and burn tokens in cron loops.
       await validateScriptFileForShellBleed({ command: params.command, workdir });
 
+      const trustAgentKey = agentId?.trim() || DEFAULT_AGENT_ID;
+      const trustWindow = host === "gateway" ? getTrustWindow(trustAgentKey) : undefined;
+      const trustWindowActive =
+        trustWindow?.status === "active" &&
+        typeof trustWindow.expiresAt === "number" &&
+        Date.now() < trustWindow.expiresAt;
+
       const run = await runExecProcess({
         command: params.command,
         execCommand: execCommandOverride,
@@ -486,6 +498,17 @@ export function createExecTool(
         timeoutSec: effectiveTimeout,
         onUpdate,
       });
+
+      if (trustWindowActive) {
+        void run.promise.then((outcome) => {
+          appendTrustAuditEntry({
+            agentId: trustAgentKey,
+            command: params.command,
+            exitCode: outcome.exitCode ?? (outcome.status === "completed" ? 0 : null),
+            durationMs: outcome.durationMs,
+          });
+        });
+      }
 
       let yielded = false;
       let yieldTimer: NodeJS.Timeout | null = null;

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -3,8 +3,8 @@ import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
   const resolveRunModelFallbacksOverrideMock = vi.fn();
-  const readExecApprovalsSnapshotMock = vi.fn();
-  return { resolveRunModelFallbacksOverrideMock, readExecApprovalsSnapshotMock };
+  const getTrustWindowMock = vi.fn();
+  return { resolveRunModelFallbacksOverrideMock, getTrustWindowMock };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -13,7 +13,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../../infra/exec-approvals.js", () => ({
-  readExecApprovalsSnapshot: (...args: unknown[]) => hoisted.readExecApprovalsSnapshotMock(...args),
+  getTrustWindow: (...args: unknown[]) => hoisted.getTrustWindowMock(...args),
 }));
 
 const {
@@ -181,30 +181,19 @@ describe("agent-runner-utils", () => {
   });
 
   it("returns undefined when no trust window is active", () => {
-    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
-      file: { version: 1, agents: {} },
-    });
+    hoisted.getTrustWindowMock.mockReturnValue(undefined);
 
     expect(trustStatusLine({ agentId: "main", now: () => 0 })).toBeUndefined();
   });
 
   it("formats trust status line with remaining minutes", () => {
     const now = 1_000_000;
-    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
-      file: {
-        version: 1,
-        agents: {
-          main: {
-            trustWindow: {
-              status: "active",
-              expiresAt: now + 47 * 60_000,
-              grantedAt: now - 60_000,
-              security: "full",
-              ask: "off",
-            },
-          },
-        },
-      },
+    hoisted.getTrustWindowMock.mockReturnValue({
+      status: "active",
+      expiresAt: now + 47 * 60_000,
+      grantedAt: now - 60_000,
+      security: "full",
+      ask: "off",
     });
 
     expect(trustStatusLine({ agentId: "main", channel: "discord", now: () => now })).toBe(
@@ -214,21 +203,12 @@ describe("agent-runner-utils", () => {
 
   it("uses warning icon within five minutes", () => {
     const now = 2_000_000;
-    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
-      file: {
-        version: 1,
-        agents: {
-          main: {
-            trustWindow: {
-              status: "active",
-              expiresAt: now + 4 * 60_000,
-              grantedAt: now - 60_000,
-              security: "full",
-              ask: "off",
-            },
-          },
-        },
-      },
+    hoisted.getTrustWindowMock.mockReturnValue({
+      status: "active",
+      expiresAt: now + 4 * 60_000,
+      grantedAt: now - 60_000,
+      security: "full",
+      ask: "off",
     });
 
     expect(trustStatusLine({ agentId: "main", now: () => now })).toBe("⚠️ Trust · 4m remaining");
@@ -236,21 +216,12 @@ describe("agent-runner-utils", () => {
 
   it("returns undefined when trust window is expired", () => {
     const now = 3_000_000;
-    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
-      file: {
-        version: 1,
-        agents: {
-          main: {
-            trustWindow: {
-              status: "active",
-              expiresAt: now - 1,
-              grantedAt: now - 60_000,
-              security: "full",
-              ask: "off",
-            },
-          },
-        },
-      },
+    hoisted.getTrustWindowMock.mockReturnValue({
+      status: "active",
+      expiresAt: now - 1,
+      grantedAt: now - 60_000,
+      security: "full",
+      ask: "off",
     });
 
     expect(trustStatusLine({ agentId: "main", now: () => now })).toBeUndefined();

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -3,7 +3,8 @@ import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
   const resolveRunModelFallbacksOverrideMock = vi.fn();
-  return { resolveRunModelFallbacksOverrideMock };
+  const readExecApprovalsSnapshotMock = vi.fn();
+  return { resolveRunModelFallbacksOverrideMock, readExecApprovalsSnapshotMock };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -11,11 +12,16 @@ vi.mock("../../agents/agent-scope.js", () => ({
     hoisted.resolveRunModelFallbacksOverrideMock(...args),
 }));
 
+vi.mock("../../infra/exec-approvals.js", () => ({
+  readExecApprovalsSnapshot: (...args: unknown[]) => hoisted.readExecApprovalsSnapshotMock(...args),
+}));
+
 const {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
   resolveProviderScopedAuthProfile,
+  trustStatusLine,
 } = await import("./agent-runner-utils.js");
 
 function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"] {
@@ -172,5 +178,81 @@ describe("agent-runner-utils", () => {
 
     expect(resolved.embeddedContext.messageProvider).toBe("telegram");
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
+  });
+
+  it("returns undefined when no trust window is active", () => {
+    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
+      file: { version: 1, agents: {} },
+    });
+
+    expect(trustStatusLine({ agentId: "main", now: () => 0 })).toBeUndefined();
+  });
+
+  it("formats trust status line with remaining minutes", () => {
+    const now = 1_000_000;
+    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
+      file: {
+        version: 1,
+        agents: {
+          main: {
+            trustWindow: {
+              status: "active",
+              expiresAt: now + 47 * 60_000,
+              grantedAt: now - 60_000,
+              security: "full",
+              ask: "off",
+            },
+          },
+        },
+      },
+    });
+
+    expect(trustStatusLine({ agentId: "main", channel: "discord", now: () => now })).toBe(
+      "-# 🔓 **Trust active** · 47m remaining",
+    );
+  });
+
+  it("uses warning icon within five minutes", () => {
+    const now = 2_000_000;
+    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
+      file: {
+        version: 1,
+        agents: {
+          main: {
+            trustWindow: {
+              status: "active",
+              expiresAt: now + 4 * 60_000,
+              grantedAt: now - 60_000,
+              security: "full",
+              ask: "off",
+            },
+          },
+        },
+      },
+    });
+
+    expect(trustStatusLine({ agentId: "main", now: () => now })).toBe("⚠️ Trust · 4m remaining");
+  });
+
+  it("returns undefined when trust window is expired", () => {
+    const now = 3_000_000;
+    hoisted.readExecApprovalsSnapshotMock.mockReturnValue({
+      file: {
+        version: 1,
+        agents: {
+          main: {
+            trustWindow: {
+              status: "active",
+              expiresAt: now - 1,
+              grantedAt: now - 60_000,
+              security: "full",
+              ask: "off",
+            },
+          },
+        },
+      },
+    });
+
+    expect(trustStatusLine({ agentId: "main", now: () => now })).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -4,7 +4,7 @@ import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { getTrustWindow } from "../../infra/exec-approvals.js";
+import { getTrustWindow, type TrustWindow } from "../../infra/exec-approvals.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
@@ -148,9 +148,10 @@ export const trustStatusLine = (params?: {
   agentId?: string;
   channel?: string;
   now?: () => number;
+  trustWindow?: TrustWindow | null;
 }): string | undefined => {
   const agentKey = params?.agentId?.trim() || DEFAULT_AGENT_ID;
-  const trustWindow = getTrustWindow(agentKey);
+  const trustWindow = params?.trustWindow ?? getTrustWindow(agentKey);
   if (!trustWindow || trustWindow.status !== "active") {
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -4,6 +4,8 @@ import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { readExecApprovalsSnapshot } from "../../infra/exec-approvals.js";
+import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import type { TemplateContext } from "../templating.js";
@@ -140,6 +142,34 @@ export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPa
   const updated = payloads.slice();
   updated[index] = next;
   return updated;
+};
+
+export const trustStatusLine = (params?: {
+  agentId?: string;
+  channel?: string;
+  now?: () => number;
+}): string | undefined => {
+  const snapshot = readExecApprovalsSnapshot();
+  const agentKey = params?.agentId?.trim() || DEFAULT_AGENT_ID;
+  const trustWindow = snapshot.file.agents?.[agentKey]?.trustWindow;
+  if (!trustWindow || trustWindow.status !== "active") {
+    return undefined;
+  }
+  const now = params?.now ? params.now() : Date.now();
+  const remainingMs = trustWindow.expiresAt - now;
+  if (remainingMs <= 0) {
+    return undefined;
+  }
+  const minutes = Math.ceil(remainingMs / 60_000);
+  const warn = minutes <= 5;
+  const icon = warn ? "⚠️" : "🔓";
+  const label = warn ? "Trust" : "Trust active";
+  const baseLabel = params?.channel?.toLowerCase() === "discord" ? `**${label}**` : label;
+  const line = `${icon} ${baseLabel} · ${minutes}m remaining`;
+  if (params?.channel?.toLowerCase() === "discord") {
+    return `-# ${line}`;
+  }
+  return line;
 };
 
 export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string) =>

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -4,7 +4,7 @@ import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { readExecApprovalsSnapshot } from "../../infra/exec-approvals.js";
+import { getTrustWindow } from "../../infra/exec-approvals.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
@@ -149,9 +149,8 @@ export const trustStatusLine = (params?: {
   channel?: string;
   now?: () => number;
 }): string | undefined => {
-  const snapshot = readExecApprovalsSnapshot();
   const agentKey = params?.agentId?.trim() || DEFAULT_AGENT_ID;
-  const trustWindow = snapshot.file.agents?.[agentKey]?.trustWindow;
+  const trustWindow = getTrustWindow(agentKey);
   if (!trustWindow || trustWindow.status !== "active") {
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -39,7 +39,7 @@ import {
 } from "./agent-runner-helpers.js";
 import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
-import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
+import { appendUsageLine, formatResponseUsageLine, trustStatusLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -708,6 +708,14 @@ export async function runReplyAgent(params: {
     }
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+    }
+
+    const trustLine = trustStatusLine({
+      agentId: followupRun.run.agentId,
+      channel: replyToChannel,
+    });
+    if (trustLine) {
+      finalPayloads = appendUsageLine(finalPayloads, trustLine);
     }
 
     return finalizeWithFollowup(

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -2,17 +2,19 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
 
-const callGatewayFromCli = vi.fn(async (method: string, _opts: unknown, params?: unknown) => {
-  if (method.endsWith(".get")) {
-    return {
-      path: "/tmp/exec-approvals.json",
-      exists: true,
-      hash: "hash-1",
-      file: { version: 1, agents: {} },
-    };
-  }
-  return { method, params };
-});
+const callGatewayFromCli = vi.fn(
+  async (method: string, _opts: unknown, params?: unknown): Promise<Record<string, unknown>> => {
+    if (method.endsWith(".get")) {
+      return {
+        path: "/tmp/exec-approvals.json",
+        exists: true,
+        hash: "hash-1",
+        file: { version: 1, agents: {} },
+      };
+    }
+    return { method, params };
+  },
+);
 
 const { runtimeErrors, defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -179,25 +179,41 @@ describe("exec approvals CLI", () => {
     it("rejects minutes above absolute max", async () => {
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
+      callGatewayFromCli.mockResolvedValueOnce(
+        Promise.resolve({
+          ok: false,
+          message: `minutes must be between 1 and 480`,
+        }) as Promise<Record<string, unknown>>,
+      );
+
       try {
-        await runApprovalsCommand(["approvals", "trust", "--minutes", "600"]);
+        await runApprovalsCommand(["approvals", "trust", "--minutes", "600", "--yes"]);
       } catch {
         // commander exitOverride throws
       }
 
-      expect(runtimeErrors.some((e) => String(e).includes("480 minutes"))).toBe(true);
+      expect(runtimeErrors.some((e) => String(e).includes("480"))).toBe(true);
     });
 
     it("rejects minutes above default max without --force", async () => {
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
+      callGatewayFromCli.mockResolvedValueOnce(
+        Promise.resolve({
+          ok: false,
+          message: "Duration exceeds default cap (60m). Use force to allow up to 480m.",
+        }) as Promise<Record<string, unknown>>,
+      );
+
       try {
-        await runApprovalsCommand(["approvals", "trust", "--minutes", "120"]);
+        await runApprovalsCommand(["approvals", "trust", "--minutes", "120", "--yes"]);
       } catch {
         // commander exitOverride throws
       }
 
-      expect(runtimeErrors.some((e) => String(e).includes("--force"))).toBe(true);
+      expect(
+        runtimeErrors.some((e) => String(e).includes("cap") || String(e).includes("force")),
+      ).toBe(true);
     });
   });
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
 
 const callGatewayFromCli = vi.fn(
@@ -25,6 +25,9 @@ const localSnapshot = {
   hash: "hash-local",
   file: { version: 1, agents: {} },
 };
+
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalStdoutIsTTY = process.stdout.isTTY;
 
 function resetLocalSnapshot() {
   localSnapshot.file = { version: 1, agents: {} };
@@ -78,6 +81,19 @@ describe("exec approvals CLI", () => {
     resetLocalSnapshot();
     resetRuntimeCapture();
     callGatewayFromCli.mockClear();
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalStdinIsTTY,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalStdoutIsTTY,
+      configurable: true,
+    });
   });
 
   it("routes get command to local, gateway, and node modes", async () => {
@@ -187,19 +203,11 @@ describe("exec approvals CLI", () => {
 
   describe("untrust command", () => {
     it("clears an active trust window", async () => {
-      const now = Date.now();
       localSnapshot.file = {
         version: 1,
         agents: {
           main: {
             security: "allowlist",
-            trustWindow: {
-              status: "active",
-              expiresAt: now + 600_000,
-              grantedAt: now,
-              security: "full",
-              ask: "off",
-            },
           },
         },
       };
@@ -211,7 +219,7 @@ describe("exec approvals CLI", () => {
       expect(callGatewayFromCli).toHaveBeenCalledWith(
         "exec.approvals.untrust",
         expect.anything(),
-        expect.objectContaining({ agentId: "main", keepAudit: true }),
+        expect.objectContaining({ agentId: "main", keepAudit: false }),
       );
       expect(runtimeErrors).toHaveLength(0);
     });
@@ -237,7 +245,7 @@ describe("exec approvals CLI", () => {
       expect(callGatewayFromCli).toHaveBeenCalledWith(
         "exec.approvals.untrust",
         expect.anything(),
-        expect.objectContaining({ agentId: "main", keepAudit: true }),
+        expect.objectContaining({ agentId: "main", keepAudit: false }),
       );
       expect(saveExecApprovals).not.toHaveBeenCalled();
       expect(runtimeErrors).toHaveLength(0);

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -53,6 +53,8 @@ vi.mock("../infra/exec-approvals.js", async () => {
     ...actual,
     readExecApprovalsSnapshot: () => localSnapshot,
     saveExecApprovals: vi.fn(),
+    grantTrustWindow: vi.fn(),
+    revokeTrustWindow: vi.fn(),
   };
 });
 
@@ -202,15 +204,15 @@ describe("exec approvals CLI", () => {
         },
       };
 
-      const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
-      saveExecApprovals.mockClear();
+      const revokeTrustWindow = vi.mocked(execApprovals.revokeTrustWindow);
+      revokeTrustWindow.mockClear();
+      revokeTrustWindow.mockReturnValue({ ok: true, agentId: "main", summary: undefined });
 
       await runApprovalsCommand(["approvals", "untrust"]);
 
-      expect(saveExecApprovals).toHaveBeenCalled();
-      const savedFile = saveExecApprovals.mock.calls[0][0];
-      expect(savedFile.agents?.main?.trustWindow).toBeUndefined();
-      expect(savedFile.agents?.main?.security).toBe("allowlist");
+      expect(revokeTrustWindow).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "main", keepAudit: true }),
+      );
       expect(runtimeErrors).toHaveLength(0);
     });
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -179,12 +179,10 @@ describe("exec approvals CLI", () => {
     it("rejects minutes above absolute max", async () => {
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
-      callGatewayFromCli.mockResolvedValueOnce(
-        Promise.resolve({
-          ok: false,
-          message: `minutes must be between 1 and 480`,
-        }) as Promise<Record<string, unknown>>,
-      );
+      callGatewayFromCli.mockResolvedValueOnce({
+        ok: false,
+        message: `minutes must be between 1 and 480`,
+      } as Record<string, unknown>);
 
       try {
         await runApprovalsCommand(["approvals", "trust", "--minutes", "600", "--yes"]);
@@ -198,12 +196,10 @@ describe("exec approvals CLI", () => {
     it("rejects minutes above default max without --force", async () => {
       Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
-      callGatewayFromCli.mockResolvedValueOnce(
-        Promise.resolve({
-          ok: false,
-          message: "Duration exceeds default cap (60m). Use force to allow up to 480m.",
-        }) as Promise<Record<string, unknown>>,
-      );
+      callGatewayFromCli.mockResolvedValueOnce({
+        ok: false,
+        message: "Duration exceeds default cap (60m). Use force to allow up to 480m.",
+      } as Record<string, unknown>);
 
       try {
         await runApprovalsCommand(["approvals", "trust", "--minutes", "120", "--yes"]);

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -53,8 +53,6 @@ vi.mock("../infra/exec-approvals.js", async () => {
     ...actual,
     readExecApprovalsSnapshot: () => localSnapshot,
     saveExecApprovals: vi.fn(),
-    grantTrustWindow: vi.fn(),
-    revokeTrustWindow: vi.fn(),
   };
 });
 
@@ -204,13 +202,13 @@ describe("exec approvals CLI", () => {
         },
       };
 
-      const revokeTrustWindow = vi.mocked(execApprovals.revokeTrustWindow);
-      revokeTrustWindow.mockClear();
-      revokeTrustWindow.mockReturnValue({ ok: true, agentId: "main", summary: undefined });
+      callGatewayFromCli.mockResolvedValueOnce({ ok: true, agentId: "main", summary: undefined });
 
       await runApprovalsCommand(["approvals", "untrust"]);
 
-      expect(revokeTrustWindow).toHaveBeenCalledWith(
+      expect(callGatewayFromCli).toHaveBeenCalledWith(
+        "exec.approvals.untrust",
+        expect.anything(),
         expect.objectContaining({ agentId: "main", keepAudit: true }),
       );
       expect(runtimeErrors).toHaveLength(0);
@@ -226,9 +224,19 @@ describe("exec approvals CLI", () => {
 
       const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
       saveExecApprovals.mockClear();
+      callGatewayFromCli.mockResolvedValueOnce({
+        ok: false,
+        agentId: "main",
+        message: 'No active trust window for agent "main"',
+      });
 
       await runApprovalsCommand(["approvals", "untrust"]);
 
+      expect(callGatewayFromCli).toHaveBeenCalledWith(
+        "exec.approvals.untrust",
+        expect.anything(),
+        expect.objectContaining({ agentId: "main", keepAudit: true }),
+      );
       expect(saveExecApprovals).not.toHaveBeenCalled();
       expect(runtimeErrors).toHaveLength(0);
     });

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -142,4 +142,93 @@ describe("exec approvals CLI", () => {
     );
     expect(runtimeErrors).toHaveLength(0);
   });
+
+  describe("trust command", () => {
+    it("rejects non-TTY invocation", async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+      try {
+        await runApprovalsCommand(["approvals", "trust", "--minutes", "15"]);
+      } catch {
+        // commander exitOverride throws
+      }
+
+      expect(runtimeErrors.some((e) => String(e).includes("interactive terminal"))).toBe(true);
+      Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+    });
+
+    it("rejects minutes above absolute max", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+      try {
+        await runApprovalsCommand(["approvals", "trust", "--minutes", "600"]);
+      } catch {
+        // commander exitOverride throws
+      }
+
+      expect(runtimeErrors.some((e) => String(e).includes("480 minutes"))).toBe(true);
+    });
+
+    it("rejects minutes above default max without --force", async () => {
+      Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+      try {
+        await runApprovalsCommand(["approvals", "trust", "--minutes", "120"]);
+      } catch {
+        // commander exitOverride throws
+      }
+
+      expect(runtimeErrors.some((e) => String(e).includes("--force"))).toBe(true);
+    });
+  });
+
+  describe("untrust command", () => {
+    it("clears an active trust window", async () => {
+      const now = Date.now();
+      localSnapshot.file = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            trustWindow: {
+              status: "active",
+              expiresAt: now + 600_000,
+              grantedAt: now,
+              security: "full",
+              ask: "off",
+            },
+          },
+        },
+      };
+
+      const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
+      saveExecApprovals.mockClear();
+
+      await runApprovalsCommand(["approvals", "untrust"]);
+
+      expect(saveExecApprovals).toHaveBeenCalled();
+      const savedFile = saveExecApprovals.mock.calls[0][0];
+      expect(savedFile.agents?.main?.trustWindow).toBeUndefined();
+      expect(savedFile.agents?.main?.security).toBe("allowlist");
+      expect(runtimeErrors).toHaveLength(0);
+    });
+
+    it("handles missing trust window gracefully", async () => {
+      localSnapshot.file = {
+        version: 1,
+        agents: {
+          main: { security: "allowlist" },
+        },
+      };
+
+      const saveExecApprovals = vi.mocked(execApprovals.saveExecApprovals);
+      saveExecApprovals.mockClear();
+
+      await runApprovalsCommand(["approvals", "untrust"]);
+
+      expect(saveExecApprovals).not.toHaveBeenCalled();
+      expect(runtimeErrors).toHaveLength(0);
+    });
+  });
 });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,8 +2,6 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import {
-  ABSOLUTE_MAX_TRUST_MINUTES,
-  DEFAULT_MAX_TRUST_MINUTES,
   readExecApprovalsSnapshot,
   saveExecApprovals,
   type ExecApprovalsAgent,
@@ -511,18 +509,6 @@ export function registerExecApprovalsCli(program: Command) {
         const minutes = parseInt(String(opts.minutes), 10);
         if (isNaN(minutes) || minutes <= 0) {
           exitWithError("--minutes must be a positive integer.");
-        }
-        if (minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
-          exitWithError(
-            `Maximum trust window is ${ABSOLUTE_MAX_TRUST_MINUTES} minutes (${ABSOLUTE_MAX_TRUST_MINUTES / 60}h). ` +
-              `For longer periods, adjust the base security policy.`,
-          );
-        }
-        if (minutes > DEFAULT_MAX_TRUST_MINUTES && !opts.force) {
-          exitWithError(
-            `Default max is ${DEFAULT_MAX_TRUST_MINUTES} minutes. ` +
-              `Use --force to grant up to ${ABSOLUTE_MAX_TRUST_MINUTES} minutes.`,
-          );
         }
 
         const agentKey = opts.agent?.trim() || "main";

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -549,6 +549,7 @@ export function registerExecApprovalsCli(program: Command) {
           agentId: agentKey,
           minutes,
           grantedBy: "cli",
+          force: opts.force,
         })) as { ok: boolean; agentId?: string; expiresAt?: number; message?: string };
 
         if (!result?.ok || typeof result.expiresAt !== "number") {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -507,9 +507,6 @@ export function registerExecApprovalsCli(program: Command) {
         }
 
         const minutes = parseInt(String(opts.minutes), 10);
-        if (isNaN(minutes) || minutes <= 0) {
-          exitWithError("--minutes must be a positive integer.");
-        }
 
         const agentKey = opts.agent?.trim() || "main";
 

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -10,7 +10,6 @@ import {
   type ExecApprovalsFile,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import { resolveTrustAuditPath } from "../infra/trust-audit.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
@@ -587,21 +586,23 @@ export function registerExecApprovalsCli(program: Command) {
       try {
         const agentKey = opts.agent?.trim() || "main";
 
-        // Check for active window to get remaining time for display
-        const snapshot = loadSnapshotLocal();
-        const agent = (snapshot.file.agents ?? {})[agentKey];
-        const now = Date.now();
-        const wasActive =
-          agent?.trustWindow?.status === "active" && agent.trustWindow.expiresAt > now;
-        const remainingMin = wasActive
-          ? Math.ceil((agent.trustWindow!.expiresAt - now) / 60_000)
-          : 0;
+        let keepAudit = Boolean(opts.keep);
+        if (!opts.keep && !opts.yes && process.stdin.isTTY) {
+          const readline = await import("node:readline");
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          const answer = await new Promise<string>((resolve) => {
+            rl.question(`\n  Delete audit log? [Y/n] `, resolve);
+          });
+          rl.close();
+          const trimmed = answer.trim().toLowerCase();
+          const shouldDelete = trimmed === "" || trimmed === "y" || trimmed === "yes";
+          keepAudit = !shouldDelete;
+        }
 
-        // Always keep audit here — CLI handles cleanup after interactive prompt
         const result = (await callGatewayFromCli("exec.approvals.untrust", opts, {
           agentId: agentKey,
           revokedBy: "cli",
-          keepAudit: true,
+          keepAudit,
         })) as { ok: boolean; agentId?: string; summary?: string; message?: string };
 
         if (!result?.ok) {
@@ -609,13 +610,7 @@ export function registerExecApprovalsCli(program: Command) {
           return;
         }
 
-        if (wasActive) {
-          defaultRuntime.log(
-            `🔒 Trust window revoked for agent "${agentKey}" (${remainingMin}m remaining).`,
-          );
-        } else {
-          defaultRuntime.log(`🔒 Expired trust window cleared for agent "${agentKey}".`);
-        }
+        defaultRuntime.log(`🔒 Trust window revoked for agent "${agentKey}".`);
         defaultRuntime.log(`   Normal approval policy restored.`);
 
         if (result.summary) {
@@ -623,33 +618,9 @@ export function registerExecApprovalsCli(program: Command) {
           defaultRuntime.log(result.summary);
         }
 
-        // Determine whether to keep or delete the audit log (AFTER showing summary)
-        const auditPath = resolveTrustAuditPath(agentKey);
-        const auditExists = (await import("node:fs")).existsSync(auditPath);
-        let shouldDelete = true;
-        if (auditExists) {
-          if (opts.keep) {
-            shouldDelete = false;
-          } else if (opts.yes) {
-            shouldDelete = true;
-          } else if (process.stdin.isTTY) {
-            const readline = await import("node:readline");
-            const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-            const answer = await new Promise<string>((resolve) => {
-              rl.question(`\n  Delete audit log? [Y/n] `, resolve);
-            });
-            rl.close();
-            const trimmed = answer.trim().toLowerCase();
-            shouldDelete = trimmed === "" || trimmed === "y" || trimmed === "yes";
-          }
-        }
-
-        if (shouldDelete && auditExists) {
-          const { cleanupTrustAudit } = await import("../infra/trust-audit.js");
-          cleanupTrustAudit(agentKey);
-        } else if (auditExists) {
+        if (keepAudit) {
           defaultRuntime.log("");
-          defaultRuntime.log(theme.muted(`Audit log preserved at ${auditPath}`));
+          defaultRuntime.log(theme.muted("Audit log preserved."));
         }
       } catch (err) {
         defaultRuntime.error(formatCliError(err));

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -2,15 +2,17 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import {
+  ABSOLUTE_MAX_TRUST_MINUTES,
+  DEFAULT_MAX_TRUST_MINUTES,
+  grantTrustWindow,
   readExecApprovalsSnapshot,
+  revokeTrustWindow,
   saveExecApprovals,
   type ExecApprovalsAgent,
   type ExecApprovalsFile,
-  type ExecSecurity,
-  type ExecAsk,
-  type TrustWindow,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
+import { resolveTrustAuditPath } from "../infra/trust-audit.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
@@ -485,9 +487,6 @@ export function registerExecApprovalsCli(program: Command) {
 
   // ── Trust Window Commands ──────────────────────────────────────────────
 
-  const DEFAULT_MAX_TRUST_MINUTES = 60;
-  const ABSOLUTE_MAX_TRUST_MINUTES = 480;
-
   type TrustOpts = ExecApprovalsCliOpts & {
     minutes?: string;
     yes?: boolean;
@@ -530,10 +529,6 @@ export function registerExecApprovalsCli(program: Command) {
         }
 
         const agentKey = opts.agent?.trim() || "main";
-        const now = Date.now();
-        const expiresAt = now + minutes * 60_000;
-        const expiresDate = new Date(expiresAt);
-        const timeStr = expiresDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 
         // Interactive confirmation (unless --yes)
         if (!opts.yes) {
@@ -553,22 +548,13 @@ export function registerExecApprovalsCli(program: Command) {
           }
         }
 
-        const snapshot = loadSnapshotLocal();
-        const file = snapshot.file;
-        const agents = file.agents ?? {};
-        const agent = agents[agentKey] ?? {};
+        const result = grantTrustWindow({ agentId: agentKey, minutes, grantedBy: "cli" });
+        if (!result.ok) {
+          exitWithError(result.error);
+        }
 
-        const trustWindow: TrustWindow = {
-          status: "active",
-          expiresAt,
-          grantedAt: now,
-          security: "full" as ExecSecurity,
-          ask: "off" as ExecAsk,
-        };
-
-        agents[agentKey] = { ...agent, trustWindow };
-        file.agents = agents;
-        saveExecApprovals(file);
+        const expiresDate = new Date(result.expiresAt);
+        const timeStr = expiresDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 
         defaultRuntime.log("");
         defaultRuntime.log(`🔓 Trust window active`);
@@ -584,34 +570,36 @@ export function registerExecApprovalsCli(program: Command) {
 
   type UntrustOpts = ExecApprovalsCliOpts & {
     agent?: string;
+    yes?: boolean;
+    keep?: boolean;
   };
 
   approvals
     .command("untrust")
     .description("Revoke an active trust window immediately")
     .option("--agent <id>", "Agent id (defaults to main)")
+    .option("--yes", "Skip confirmation and auto-delete audit log", false)
+    .option("--keep", "Preserve the audit log file after summary", false)
     .action(async (opts: UntrustOpts) => {
       try {
         const agentKey = opts.agent?.trim() || "main";
-        const snapshot = loadSnapshotLocal();
-        const file = snapshot.file;
-        const agents = file.agents ?? {};
-        const agent = agents[agentKey];
 
-        if (!agent?.trustWindow || agent.trustWindow.status !== "active") {
-          defaultRuntime.log(`No active trust window for agent "${agentKey}".`);
+        // Check for active window to get remaining time for display
+        const snapshot = loadSnapshotLocal();
+        const agent = (snapshot.file.agents ?? {})[agentKey];
+        const now = Date.now();
+        const wasActive =
+          agent?.trustWindow?.status === "active" && agent.trustWindow.expiresAt > now;
+        const remainingMin = wasActive
+          ? Math.ceil((agent.trustWindow!.expiresAt - now) / 60_000)
+          : 0;
+
+        // Always keep audit here — CLI handles cleanup after interactive prompt
+        const result = revokeTrustWindow({ agentId: agentKey, revokedBy: "cli", keepAudit: true });
+        if (!result.ok) {
+          defaultRuntime.log(result.error);
           return;
         }
-
-        const wasActive = agent.trustWindow.expiresAt > Date.now();
-        const remainingMs = wasActive ? agent.trustWindow.expiresAt - Date.now() : 0;
-        const remainingMin = Math.ceil(remainingMs / 60_000);
-
-        // Remove the trust window
-        const { trustWindow: _, ...agentWithout } = agent;
-        agents[agentKey] = agentWithout;
-        file.agents = agents;
-        saveExecApprovals(file);
 
         if (wasActive) {
           defaultRuntime.log(
@@ -621,6 +609,40 @@ export function registerExecApprovalsCli(program: Command) {
           defaultRuntime.log(`🔒 Expired trust window cleared for agent "${agentKey}".`);
         }
         defaultRuntime.log(`   Normal approval policy restored.`);
+
+        if (result.summary) {
+          defaultRuntime.log("");
+          defaultRuntime.log(result.summary);
+        }
+
+        // Determine whether to keep or delete the audit log (AFTER showing summary)
+        const auditPath = resolveTrustAuditPath(agentKey);
+        const auditExists = (await import("node:fs")).existsSync(auditPath);
+        let shouldDelete = true;
+        if (auditExists) {
+          if (opts.keep) {
+            shouldDelete = false;
+          } else if (opts.yes) {
+            shouldDelete = true;
+          } else if (process.stdin.isTTY) {
+            const readline = await import("node:readline");
+            const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+            const answer = await new Promise<string>((resolve) => {
+              rl.question(`\n  Delete audit log? [Y/n] `, resolve);
+            });
+            rl.close();
+            const trimmed = answer.trim().toLowerCase();
+            shouldDelete = trimmed === "" || trimmed === "y" || trimmed === "yes";
+          }
+        }
+
+        if (shouldDelete && auditExists) {
+          const { cleanupTrustAudit } = await import("../infra/trust-audit.js");
+          cleanupTrustAudit(agentKey);
+        } else if (auditExists) {
+          defaultRuntime.log("");
+          defaultRuntime.log(theme.muted(`Audit log preserved at ${auditPath}`));
+        }
       } catch (err) {
         defaultRuntime.error(formatCliError(err));
         defaultRuntime.exit(1);

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -4,9 +4,7 @@ import JSON5 from "json5";
 import {
   ABSOLUTE_MAX_TRUST_MINUTES,
   DEFAULT_MAX_TRUST_MINUTES,
-  grantTrustWindow,
   readExecApprovalsSnapshot,
-  revokeTrustWindow,
   saveExecApprovals,
   type ExecApprovalsAgent,
   type ExecApprovalsFile,
@@ -548,9 +546,14 @@ export function registerExecApprovalsCli(program: Command) {
           }
         }
 
-        const result = grantTrustWindow({ agentId: agentKey, minutes, grantedBy: "cli" });
-        if (!result.ok) {
-          exitWithError(result.error);
+        const result = (await callGatewayFromCli("exec.approvals.trust", opts, {
+          agentId: agentKey,
+          minutes,
+          grantedBy: "cli",
+        })) as { ok: boolean; agentId?: string; expiresAt?: number; message?: string };
+
+        if (!result?.ok || typeof result.expiresAt !== "number") {
+          exitWithError(result?.message ?? "Failed to grant trust window.");
         }
 
         const expiresDate = new Date(result.expiresAt);
@@ -595,9 +598,14 @@ export function registerExecApprovalsCli(program: Command) {
           : 0;
 
         // Always keep audit here — CLI handles cleanup after interactive prompt
-        const result = revokeTrustWindow({ agentId: agentKey, revokedBy: "cli", keepAudit: true });
-        if (!result.ok) {
-          defaultRuntime.log(result.error);
+        const result = (await callGatewayFromCli("exec.approvals.untrust", opts, {
+          agentId: agentKey,
+          revokedBy: "cli",
+          keepAudit: true,
+        })) as { ok: boolean; agentId?: string; summary?: string; message?: string };
+
+        if (!result?.ok) {
+          defaultRuntime.log(result?.message ?? "No active trust window.");
           return;
         }
 

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -6,6 +6,9 @@ import {
   saveExecApprovals,
   type ExecApprovalsAgent,
   type ExecApprovalsFile,
+  type ExecSecurity,
+  type ExecAsk,
+  type TrustWindow,
 } from "../infra/exec-approvals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
@@ -479,4 +482,148 @@ export function registerExecApprovalsCli(program: Command) {
       return true;
     },
   });
+
+  // ── Trust Window Commands ──────────────────────────────────────────────
+
+  const DEFAULT_MAX_TRUST_MINUTES = 60;
+  const ABSOLUTE_MAX_TRUST_MINUTES = 480;
+
+  type TrustOpts = ExecApprovalsCliOpts & {
+    minutes?: string;
+    yes?: boolean;
+    force?: boolean;
+    agent?: string;
+  };
+
+  approvals
+    .command("trust")
+    .description("Grant a time-bounded trust window (unrestricted exec)")
+    .requiredOption("--minutes <n>", "Duration in minutes")
+    .option("--agent <id>", "Agent id (defaults to main)")
+    .option("--yes", "Skip confirmation prompt", false)
+    .option("--force", "Allow exceeding default max duration", false)
+    .action(async (opts: TrustOpts) => {
+      try {
+        // TTY gate: prevent agent self-escalation
+        if (!process.stdin.isTTY) {
+          exitWithError(
+            "Trust window grants require an interactive terminal.\n" +
+              "This prevents automated processes from escalating their own privileges.",
+          );
+        }
+
+        const minutes = parseInt(String(opts.minutes), 10);
+        if (isNaN(minutes) || minutes <= 0) {
+          exitWithError("--minutes must be a positive integer.");
+        }
+        if (minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
+          exitWithError(
+            `Maximum trust window is ${ABSOLUTE_MAX_TRUST_MINUTES} minutes (${ABSOLUTE_MAX_TRUST_MINUTES / 60}h). ` +
+              `For longer periods, adjust the base security policy.`,
+          );
+        }
+        if (minutes > DEFAULT_MAX_TRUST_MINUTES && !opts.force) {
+          exitWithError(
+            `Default max is ${DEFAULT_MAX_TRUST_MINUTES} minutes. ` +
+              `Use --force to grant up to ${ABSOLUTE_MAX_TRUST_MINUTES} minutes.`,
+          );
+        }
+
+        const agentKey = opts.agent?.trim() || "main";
+        const now = Date.now();
+        const expiresAt = now + minutes * 60_000;
+        const expiresDate = new Date(expiresAt);
+        const timeStr = expiresDate.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+
+        // Interactive confirmation (unless --yes)
+        if (!opts.yes) {
+          const readline = await import("node:readline");
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          const answer = await new Promise<string>((resolve) => {
+            rl.question(
+              `\n⚠️  This will allow agent "${agentKey}" to execute any command for ${minutes} minutes without approval.\n` +
+                `    Continue? [y/N] `,
+              resolve,
+            );
+          });
+          rl.close();
+          if (answer.trim().toLowerCase() !== "y") {
+            defaultRuntime.log("Cancelled.");
+            return;
+          }
+        }
+
+        const snapshot = loadSnapshotLocal();
+        const file = snapshot.file;
+        const agents = file.agents ?? {};
+        const agent = agents[agentKey] ?? {};
+
+        const trustWindow: TrustWindow = {
+          status: "active",
+          expiresAt,
+          grantedAt: now,
+          security: "full" as ExecSecurity,
+          ask: "off" as ExecAsk,
+        };
+
+        agents[agentKey] = { ...agent, trustWindow };
+        file.agents = agents;
+        saveExecApprovals(file);
+
+        defaultRuntime.log("");
+        defaultRuntime.log(`🔓 Trust window active`);
+        defaultRuntime.log(`   Agent: ${agentKey}`);
+        defaultRuntime.log(`   Duration: ${minutes} minutes`);
+        defaultRuntime.log(`   Expires at: ${timeStr}`);
+        defaultRuntime.log(`   Run \`openclaw approvals untrust\` to revoke early`);
+      } catch (err) {
+        defaultRuntime.error(formatCliError(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  type UntrustOpts = ExecApprovalsCliOpts & {
+    agent?: string;
+  };
+
+  approvals
+    .command("untrust")
+    .description("Revoke an active trust window immediately")
+    .option("--agent <id>", "Agent id (defaults to main)")
+    .action(async (opts: UntrustOpts) => {
+      try {
+        const agentKey = opts.agent?.trim() || "main";
+        const snapshot = loadSnapshotLocal();
+        const file = snapshot.file;
+        const agents = file.agents ?? {};
+        const agent = agents[agentKey];
+
+        if (!agent?.trustWindow || agent.trustWindow.status !== "active") {
+          defaultRuntime.log(`No active trust window for agent "${agentKey}".`);
+          return;
+        }
+
+        const wasActive = agent.trustWindow.expiresAt > Date.now();
+        const remainingMs = wasActive ? agent.trustWindow.expiresAt - Date.now() : 0;
+        const remainingMin = Math.ceil(remainingMs / 60_000);
+
+        // Remove the trust window
+        const { trustWindow: _, ...agentWithout } = agent;
+        agents[agentKey] = agentWithout;
+        file.agents = agents;
+        saveExecApprovals(file);
+
+        if (wasActive) {
+          defaultRuntime.log(
+            `🔒 Trust window revoked for agent "${agentKey}" (${remainingMin}m remaining).`,
+          );
+        } else {
+          defaultRuntime.log(`🔒 Expired trust window cleared for agent "${agentKey}".`);
+        }
+        defaultRuntime.log(`   Normal approval policy restored.`);
+      } catch (err) {
+        defaultRuntime.error(formatCliError(err));
+        defaultRuntime.exit(1);
+      }
+    });
 }

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -88,7 +88,8 @@ vi.mock("@buape/carbon", () => {
       return clientGetPluginMock(name);
     }
   }
-  return { Client, ReadyListener };
+  class Command {}
+  return { Client, Command, ReadyListener };
 });
 
 vi.mock("@buape/carbon/gateway", () => ({

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -78,6 +78,7 @@ import {
   reconcileAcpThreadBindingsOnStartup,
 } from "./thread-bindings.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+import { createDiscordTrustCommand, createDiscordUntrustCommand } from "./trust-command.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -427,6 +428,21 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
           ephemeralDefault,
         }),
       );
+    }
+
+    // Register trust/untrust commands in every configured guild
+    if (nativeEnabled && guildEntries) {
+      for (const guildId of Object.keys(guildEntries)) {
+        const trustCtx = {
+          cfg,
+          discordConfig: discordCfg,
+          accountId: account.accountId,
+          ephemeralDefault,
+          guildId,
+        };
+        commands.push(createDiscordTrustCommand(trustCtx));
+        commands.push(createDiscordUntrustCommand(trustCtx));
+      }
     }
 
     // Initialize exec approvals handler if enabled

--- a/src/discord/monitor/trust-command.ts
+++ b/src/discord/monitor/trust-command.ts
@@ -18,8 +18,7 @@ type TrustCommandContext = {
   guildId?: string;
 };
 
-const DEFAULT_MAX_TRUST_MINUTES = 60;
-const ABSOLUTE_MAX_TRUST_MINUTES = 480;
+import { DEFAULT_MAX_TRUST_MINUTES } from "../../infra/exec-approvals.js";
 
 function isOwnerAuthorized(
   interaction: CommandInteraction,
@@ -143,18 +142,6 @@ class DiscordTrustCommand extends Command {
 
     const minutes = interaction.options.getNumber("minutes") ?? DEFAULT_MAX_TRUST_MINUTES;
     const agentId = interaction.options.getString("agent")?.trim() || "main";
-
-    if (minutes <= 0) {
-      await interaction.reply({ content: "Minutes must be a positive number.", ephemeral: true });
-      return;
-    }
-    if (minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
-      await interaction.reply({
-        content: `Maximum trust window is ${ABSOLUTE_MAX_TRUST_MINUTES} minutes (${ABSOLUTE_MAX_TRUST_MINUTES / 60}h).`,
-        ephemeral: true,
-      });
-      return;
-    }
 
     try {
       const result = (await callGatewayRpc(this.ctx.cfg, "exec.approvals.trust", {

--- a/src/discord/monitor/trust-command.ts
+++ b/src/discord/monitor/trust-command.ts
@@ -1,0 +1,276 @@
+import { Command, type CommandInteraction, type CommandOptions } from "@buape/carbon";
+import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import type { OpenClawConfig } from "../../config/config.js";
+import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
+import type { DiscordAccountConfig } from "../../config/types.js";
+import { buildGatewayConnectionDetails } from "../../gateway/call.js";
+import { GatewayClient } from "../../gateway/client.js";
+import { logError } from "../../logger.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
+import { allowListMatches, normalizeDiscordAllowList } from "./allow-list.js";
+import { resolveDiscordSenderIdentity } from "./sender-identity.js";
+
+type TrustCommandContext = {
+  cfg: OpenClawConfig;
+  discordConfig: DiscordAccountConfig;
+  accountId: string;
+  ephemeralDefault: boolean;
+  guildId?: string;
+};
+
+const DEFAULT_MAX_TRUST_MINUTES = 60;
+const ABSOLUTE_MAX_TRUST_MINUTES = 480;
+
+function isOwnerAuthorized(
+  interaction: CommandInteraction,
+  discordConfig: DiscordAccountConfig,
+): boolean {
+  const user = interaction.user;
+  if (!user) {
+    return false;
+  }
+  const sender = resolveDiscordSenderIdentity({ author: user, pluralkitInfo: null });
+  const ownerAllowList = normalizeDiscordAllowList(
+    discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    ["discord:", "user:", "pk:"],
+  );
+  if (!ownerAllowList) {
+    return false;
+  }
+  return allowListMatches(
+    ownerAllowList,
+    { id: sender.id, name: sender.name, tag: sender.tag },
+    { allowNameMatching: isDangerousNameMatchingEnabled(discordConfig) },
+  );
+}
+
+async function callGatewayRpc(
+  cfg: OpenClawConfig,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const { url: gatewayUrl } = buildGatewayConnectionDetails({ config: cfg });
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const client = new GatewayClient({
+      url: gatewayUrl,
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: "Discord Trust Command",
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.admin"],
+      onHelloOk: () => {
+        client
+          .request(method, params)
+          .then((result) => {
+            if (!settled) {
+              settled = true;
+              resolve(result);
+            }
+            client.stop();
+          })
+          .catch((err) => {
+            if (!settled) {
+              settled = true;
+              reject(err);
+            }
+            client.stop();
+          });
+      },
+      onConnectError: (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      },
+      onClose: () => {
+        if (!settled) {
+          settled = true;
+          reject(new Error("Gateway connection closed"));
+        }
+      },
+    });
+    client.start();
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        reject(new Error("Gateway RPC timeout"));
+      }
+      client.stop();
+    }, 10_000);
+  });
+}
+
+class DiscordTrustCommand extends Command {
+  name = "trust";
+  description = "Grant a time-bounded trust window (unrestricted exec)";
+  defer = true;
+  ephemeral = true;
+  guildId?: string;
+  options: CommandOptions = [
+    {
+      name: "minutes",
+      description: "Duration in minutes (default: 60, max: 480)",
+      type: ApplicationCommandOptionType.Number,
+      required: false,
+    },
+    {
+      name: "agent",
+      description: "Agent id (default: main)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+  ];
+
+  private ctx: TrustCommandContext;
+
+  constructor(ctx: TrustCommandContext) {
+    super();
+    this.ephemeral = ctx.ephemeralDefault;
+    if (ctx.guildId) {
+      this.guildId = ctx.guildId;
+    }
+    this.ctx = ctx;
+  }
+
+  async run(interaction: CommandInteraction) {
+    if (!isOwnerAuthorized(interaction, this.ctx.discordConfig)) {
+      await interaction.reply({
+        content: "⛔ You are not authorized to manage trust windows.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const minutes = interaction.options.getNumber("minutes") ?? DEFAULT_MAX_TRUST_MINUTES;
+    const agentId = interaction.options.getString("agent")?.trim() || "main";
+
+    if (minutes <= 0) {
+      await interaction.reply({ content: "Minutes must be a positive number.", ephemeral: true });
+      return;
+    }
+    if (minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
+      await interaction.reply({
+        content: `Maximum trust window is ${ABSOLUTE_MAX_TRUST_MINUTES} minutes (${ABSOLUTE_MAX_TRUST_MINUTES / 60}h).`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    try {
+      const result = (await callGatewayRpc(this.ctx.cfg, "exec.approvals.trust", {
+        agentId,
+        minutes,
+        grantedBy: `discord:${interaction.user?.id ?? "unknown"}`,
+      })) as { ok: boolean; agentId: string; expiresAt?: number; message?: string };
+
+      if (!result?.ok) {
+        await interaction.reply({
+          content: `❌ Failed to grant trust window: ${result?.message ?? "unknown error"}`,
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const expiresAtSec = result.expiresAt ? Math.floor(result.expiresAt / 1000) : null;
+      const expiresLabel = expiresAtSec ? `<t:${expiresAtSec}:R>` : `in ${minutes}m`;
+
+      await interaction.reply({
+        content: `🔓 **Trust window active**\nAgent: ${agentId} · Duration: ${minutes}m · Expires ${expiresLabel}\nRun \`/untrust\` to revoke early.`,
+        ephemeral: true,
+      });
+    } catch (err) {
+      logError(`discord trust command: ${String(err)}`);
+      await interaction.reply({
+        content: `❌ Failed to grant trust window: ${err instanceof Error ? err.message : String(err)}`,
+        ephemeral: true,
+      });
+    }
+  }
+}
+
+class DiscordUntrustCommand extends Command {
+  name = "untrust";
+  description = "Revoke an active trust window immediately";
+  defer = true;
+  ephemeral = true;
+  guildId?: string;
+  options: CommandOptions = [
+    {
+      name: "agent",
+      description: "Agent id (default: main)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+    {
+      name: "keep_audit",
+      description: "Preserve the audit log file (default: delete)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ];
+
+  private ctx: TrustCommandContext;
+
+  constructor(ctx: TrustCommandContext) {
+    super();
+    this.ephemeral = ctx.ephemeralDefault;
+    if (ctx.guildId) {
+      this.guildId = ctx.guildId;
+    }
+    this.ctx = ctx;
+  }
+
+  async run(interaction: CommandInteraction) {
+    if (!isOwnerAuthorized(interaction, this.ctx.discordConfig)) {
+      await interaction.reply({
+        content: "⛔ You are not authorized to manage trust windows.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const agentId = interaction.options.getString("agent")?.trim() || "main";
+    const keepAudit = interaction.options.getBoolean("keep_audit") ?? false;
+
+    try {
+      const result = (await callGatewayRpc(this.ctx.cfg, "exec.approvals.untrust", {
+        agentId,
+        keepAudit,
+        revokedBy: `discord:${interaction.user?.id ?? "unknown"}`,
+      })) as { ok: boolean; agentId: string; summary?: string; message?: string };
+
+      if (!result?.ok) {
+        await interaction.reply({
+          content:
+            result?.message === "No active trust window"
+              ? `ℹ️ No active trust window for agent "${agentId}".`
+              : `❌ Failed to revoke trust: ${result?.message ?? "unknown error"}`,
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const summaryBlock = result.summary ? `\n\`\`\`\n${result.summary}\n\`\`\`` : "";
+      const auditNote = keepAudit ? "\n📁 Audit log preserved." : "";
+
+      await interaction.reply({
+        content: `🔒 **Trust window revoked** for agent "${agentId}".${summaryBlock}${auditNote}`,
+        ephemeral: true,
+      });
+    } catch (err) {
+      logError(`discord untrust command: ${String(err)}`);
+      await interaction.reply({
+        content: `❌ Failed to revoke trust: ${err instanceof Error ? err.message : String(err)}`,
+        ephemeral: true,
+      });
+    }
+  }
+}
+
+export function createDiscordTrustCommand(ctx: TrustCommandContext): Command {
+  return new DiscordTrustCommand(ctx);
+}
+
+export function createDiscordUntrustCommand(ctx: TrustCommandContext): Command {
+  return new DiscordUntrustCommand(ctx);
+}

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -112,10 +112,14 @@ import {
   type ExecApprovalsSetParams,
   ExecApprovalsSetParamsSchema,
   type ExecApprovalsSnapshot,
+  type ExecApprovalsTrustStatusParams,
+  ExecApprovalsTrustStatusParamsSchema,
+  type ExecApprovalsTrustStatusResult,
   type ExecApprovalRequestParams,
   ExecApprovalRequestParamsSchema,
   type ExecApprovalResolveParams,
   ExecApprovalResolveParamsSchema,
+  type TrustWindow,
   ErrorCodes,
   type ErrorShape,
   ErrorShapeSchema,
@@ -357,6 +361,9 @@ export const validateExecApprovalsGetParams = ajv.compile<ExecApprovalsGetParams
 );
 export const validateExecApprovalsSetParams = ajv.compile<ExecApprovalsSetParams>(
   ExecApprovalsSetParamsSchema,
+);
+export const validateExecApprovalsTrustStatusParams = ajv.compile<ExecApprovalsTrustStatusParams>(
+  ExecApprovalsTrustStatusParamsSchema,
 );
 export const validateExecApprovalRequestParams = ajv.compile<ExecApprovalRequestParams>(
   ExecApprovalRequestParamsSchema,
@@ -613,6 +620,9 @@ export type {
   ExecApprovalsGetParams,
   ExecApprovalsSetParams,
   ExecApprovalsSnapshot,
+  ExecApprovalsTrustStatusParams,
+  ExecApprovalsTrustStatusResult,
+  TrustWindow,
   LogsTailParams,
   LogsTailResult,
   PollParams,

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -59,6 +59,33 @@ export const ExecApprovalsSnapshotSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const TrustWindowSchema = Type.Object(
+  {
+    status: Type.Literal("active"),
+    expiresAt: Type.Integer({ minimum: 0 }),
+    grantedAt: Type.Integer({ minimum: 0 }),
+    grantedBy: Type.Optional(Type.String()),
+    security: Type.String(),
+    ask: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const ExecApprovalsTrustStatusParamsSchema = Type.Object(
+  {
+    agentId: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
+export const ExecApprovalsTrustStatusResultSchema = Type.Object(
+  {
+    agentId: NonEmptyString,
+    trustWindow: Type.Optional(Type.Union([TrustWindowSchema, Type.Null()])),
+  },
+  { additionalProperties: false },
+);
+
 export const ExecApprovalsGetParamsSchema = Type.Object({}, { additionalProperties: false });
 
 export const ExecApprovalsSetParamsSchema = Type.Object(

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -23,25 +23,10 @@ export const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields
   additionalProperties: false,
 });
 
-const TrustWindowSchema = Type.Object(
-  {
-    status: Type.Literal("active"),
-    expiresAt: Type.Integer({ minimum: 0 }),
-    grantedAt: Type.Integer({ minimum: 0 }),
-    grantedBy: Type.Optional(Type.String()),
-    security: Type.String(),
-    ask: Type.String(),
-    grantNotified: Type.Optional(Type.Boolean()),
-    expiredNotified: Type.Optional(Type.Boolean()),
-  },
-  { additionalProperties: false },
-);
-
 export const ExecApprovalsAgentSchema = Type.Object(
   {
     ...ExecApprovalsPolicyFields,
     allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema)),
-    trustWindow: Type.Optional(TrustWindowSchema),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -23,10 +23,25 @@ export const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields
   additionalProperties: false,
 });
 
+const TrustWindowSchema = Type.Object(
+  {
+    status: Type.Literal("active"),
+    expiresAt: Type.Integer({ minimum: 0 }),
+    grantedAt: Type.Integer({ minimum: 0 }),
+    grantedBy: Type.Optional(Type.String()),
+    security: Type.String(),
+    ask: Type.String(),
+    grantNotified: Type.Optional(Type.Boolean()),
+    expiredNotified: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
 export const ExecApprovalsAgentSchema = Type.Object(
   {
     ...ExecApprovalsPolicyFields,
     allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema)),
+    trustWindow: Type.Optional(TrustWindowSchema),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -86,8 +86,11 @@ import {
   ExecApprovalsNodeSetParamsSchema,
   ExecApprovalsSetParamsSchema,
   ExecApprovalsSnapshotSchema,
+  ExecApprovalsTrustStatusParamsSchema,
+  ExecApprovalsTrustStatusResultSchema,
   ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParamsSchema,
+  TrustWindowSchema,
 } from "./exec-approvals.js";
 import {
   ConnectParamsSchema,
@@ -254,6 +257,9 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   ExecApprovalsNodeGetParams: ExecApprovalsNodeGetParamsSchema,
   ExecApprovalsNodeSetParams: ExecApprovalsNodeSetParamsSchema,
   ExecApprovalsSnapshot: ExecApprovalsSnapshotSchema,
+  ExecApprovalsTrustStatusParams: ExecApprovalsTrustStatusParamsSchema,
+  ExecApprovalsTrustStatusResult: ExecApprovalsTrustStatusResultSchema,
+  TrustWindow: TrustWindowSchema,
   ExecApprovalRequestParams: ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParams: ExecApprovalResolveParamsSchema,
   DevicePairListParams: DevicePairListParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -82,8 +82,11 @@ import type {
   ExecApprovalsNodeSetParamsSchema,
   ExecApprovalsSetParamsSchema,
   ExecApprovalsSnapshotSchema,
+  ExecApprovalsTrustStatusParamsSchema,
+  ExecApprovalsTrustStatusResultSchema,
   ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParamsSchema,
+  TrustWindowSchema,
 } from "./exec-approvals.js";
 import type {
   ConnectParamsSchema,
@@ -243,6 +246,9 @@ export type ExecApprovalsSetParams = Static<typeof ExecApprovalsSetParamsSchema>
 export type ExecApprovalsNodeGetParams = Static<typeof ExecApprovalsNodeGetParamsSchema>;
 export type ExecApprovalsNodeSetParams = Static<typeof ExecApprovalsNodeSetParamsSchema>;
 export type ExecApprovalsSnapshot = Static<typeof ExecApprovalsSnapshotSchema>;
+export type ExecApprovalsTrustStatusParams = Static<typeof ExecApprovalsTrustStatusParamsSchema>;
+export type ExecApprovalsTrustStatusResult = Static<typeof ExecApprovalsTrustStatusResultSchema>;
+export type TrustWindow = Static<typeof TrustWindowSchema>;
 export type ExecApprovalRequestParams = Static<typeof ExecApprovalRequestParamsSchema>;
 export type ExecApprovalResolveParams = Static<typeof ExecApprovalResolveParamsSchema>;
 export type DevicePairListParams = Static<typeof DevicePairListParamsSchema>;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -25,6 +25,8 @@ const BASE_METHODS = [
   "exec.approvals.set",
   "exec.approvals.node.get",
   "exec.approvals.node.set",
+  "exec.approvals.trust",
+  "exec.approvals.untrust",
   "exec.approval.request",
   "exec.approval.waitDecision",
   "exec.approval.resolve",

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -195,9 +195,14 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
   },
 
   "exec.approvals.trust": ({ params, respond }) => {
-    const p = params as { agentId?: string; minutes?: number; grantedBy?: string };
+    const p = params as { agentId?: string; minutes?: number; grantedBy?: string; force?: boolean };
     const minutes = typeof p.minutes === "number" ? p.minutes : 0;
-    const result = grantTrustWindow({ agentId: p.agentId, minutes, grantedBy: p.grantedBy });
+    const result = grantTrustWindow({
+      agentId: p.agentId,
+      minutes,
+      grantedBy: p.grantedBy,
+      force: p.force,
+    });
     if (!result.ok) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, result.error));
       return;

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -9,6 +9,7 @@ import {
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
 } from "../../infra/exec-approvals.js";
+import { cleanupTrustAudit } from "../../infra/trust-audit.js";
 import {
   ErrorCodes,
   errorShape,
@@ -218,6 +219,9 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
         undefined,
       );
       return;
+    }
+    if (!p.keepAudit) {
+      cleanupTrustAudit(result.agentId);
     }
     respond(true, { ok: true, agentId: result.agentId, summary: result.summary }, undefined);
   },

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -1,14 +1,13 @@
 import {
   ensureExecApprovals,
+  grantTrustWindow,
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  revokeTrustWindow,
   saveExecApprovals,
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
-  type TrustWindow,
-  type ExecSecurity,
-  type ExecAsk,
 } from "../../infra/exec-approvals.js";
 import {
   ErrorCodes,
@@ -197,60 +196,29 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
   "exec.approvals.trust": ({ params, respond }) => {
     const p = params as { agentId?: string; minutes?: number; grantedBy?: string };
     const minutes = typeof p.minutes === "number" ? p.minutes : 0;
-    if (minutes <= 0 || minutes > 480) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "minutes must be between 1 and 480"),
-      );
+    const result = grantTrustWindow({ agentId: p.agentId, minutes, grantedBy: p.grantedBy });
+    if (!result.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, result.error));
       return;
     }
-    const agentId = p.agentId?.trim() || "main";
-    const now = Date.now();
-    const expiresAt = now + minutes * 60_000;
-
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    const file = snapshot.file;
-    const agents = file.agents ?? {};
-    const agent = agents[agentId] ?? {};
-
-    const trustWindow: TrustWindow = {
-      status: "active" as const,
-      expiresAt,
-      grantedAt: now,
-      grantedBy: p.grantedBy,
-      security: "full" as ExecSecurity,
-      ask: "off" as ExecAsk,
-    };
-
-    agents[agentId] = { ...agent, trustWindow };
-    file.agents = agents;
-    saveExecApprovals(file);
-
-    respond(true, { ok: true, expiresAt, agentId }, undefined);
+    respond(true, { ok: true, expiresAt: result.expiresAt, agentId: result.agentId }, undefined);
   },
 
   "exec.approvals.untrust": ({ params, respond }) => {
-    const p = params as { agentId?: string; revokedBy?: string };
-    const agentId = p.agentId?.trim() || "main";
-
-    ensureExecApprovals();
-    const snapshot = readExecApprovalsSnapshot();
-    const file = snapshot.file;
-    const agents = file.agents ?? {};
-    const agent = agents[agentId];
-
-    if (!agent?.trustWindow || agent.trustWindow.status !== "active") {
-      respond(true, { ok: true, agentId, message: "No active trust window" }, undefined);
+    const p = params as { agentId?: string; revokedBy?: string; keepAudit?: boolean };
+    const result = revokeTrustWindow({
+      agentId: p.agentId,
+      revokedBy: p.revokedBy,
+      keepAudit: p.keepAudit,
+    });
+    if (!result.ok) {
+      respond(
+        true,
+        { ok: true, agentId: p.agentId?.trim() || "main", message: result.error },
+        undefined,
+      );
       return;
     }
-
-    const { trustWindow: _, ...agentWithout } = agent;
-    agents[agentId] = agentWithout;
-    file.agents = agents;
-    saveExecApprovals(file);
-
-    respond(true, { ok: true, agentId }, undefined);
+    respond(true, { ok: true, agentId: result.agentId, summary: result.summary }, undefined);
   },
 };

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -1,5 +1,6 @@
 import {
   ensureExecApprovals,
+  getTrustWindow,
   grantTrustWindow,
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
@@ -17,6 +18,7 @@ import {
   validateExecApprovalsNodeGetParams,
   validateExecApprovalsNodeSetParams,
   validateExecApprovalsSetParams,
+  validateExecApprovalsTrustStatusParams,
 } from "../protocol/index.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import {
@@ -194,8 +196,49 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
     });
   },
 
+  "exec.approvals.trust.status": ({ params, respond }) => {
+    if (
+      !assertValidParams(
+        params,
+        validateExecApprovalsTrustStatusParams,
+        "exec.approvals.trust.status",
+        respond,
+      )
+    ) {
+      return;
+    }
+    const p = params as { agentId?: string };
+    const agentId = p.agentId?.trim() || "main";
+    const trustWindow = getTrustWindow(agentId);
+    respond(
+      true,
+      {
+        agentId,
+        trustWindow: trustWindow
+          ? {
+              status: trustWindow.status,
+              expiresAt: trustWindow.expiresAt,
+              grantedAt: trustWindow.grantedAt,
+              grantedBy: trustWindow.grantedBy,
+              security: trustWindow.security,
+              ask: trustWindow.ask,
+            }
+          : null,
+      },
+      undefined,
+    );
+  },
+
   "exec.approvals.trust": ({ params, respond }) => {
-    const p = params as { agentId?: string; minutes?: number; grantedBy?: string; force?: boolean };
+    const p =
+      params && typeof params === "object"
+        ? (params as {
+            agentId?: string;
+            minutes?: number;
+            grantedBy?: string;
+            force?: boolean;
+          })
+        : {};
     const minutes = typeof p.minutes === "number" ? p.minutes : 0;
     const result = grantTrustWindow({
       agentId: p.agentId,
@@ -211,7 +254,10 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
   },
 
   "exec.approvals.untrust": ({ params, respond }) => {
-    const p = params as { agentId?: string; revokedBy?: string; keepAudit?: boolean };
+    const p =
+      params && typeof params === "object"
+        ? (params as { agentId?: string; revokedBy?: string; keepAudit?: boolean })
+        : {};
     const result = revokeTrustWindow({
       agentId: p.agentId,
       revokedBy: p.revokedBy,

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -214,7 +214,7 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
     if (!result.ok) {
       respond(
         true,
-        { ok: true, agentId: p.agentId?.trim() || "main", message: result.error },
+        { ok: false, agentId: p.agentId?.trim() || "main", message: result.error },
         undefined,
       );
       return;

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -6,6 +6,9 @@ import {
   saveExecApprovals,
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
+  type TrustWindow,
+  type ExecSecurity,
+  type ExecAsk,
 } from "../../infra/exec-approvals.js";
 import {
   ErrorCodes,
@@ -189,5 +192,65 @@ export const execApprovalsHandlers: GatewayRequestHandlers = {
       const payload = safeParseJson(res.payloadJSON ?? null);
       respond(true, payload, undefined);
     });
+  },
+
+  "exec.approvals.trust": ({ params, respond }) => {
+    const p = params as { agentId?: string; minutes?: number; grantedBy?: string };
+    const minutes = typeof p.minutes === "number" ? p.minutes : 0;
+    if (minutes <= 0 || minutes > 480) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "minutes must be between 1 and 480"),
+      );
+      return;
+    }
+    const agentId = p.agentId?.trim() || "main";
+    const now = Date.now();
+    const expiresAt = now + minutes * 60_000;
+
+    ensureExecApprovals();
+    const snapshot = readExecApprovalsSnapshot();
+    const file = snapshot.file;
+    const agents = file.agents ?? {};
+    const agent = agents[agentId] ?? {};
+
+    const trustWindow: TrustWindow = {
+      status: "active" as const,
+      expiresAt,
+      grantedAt: now,
+      grantedBy: p.grantedBy,
+      security: "full" as ExecSecurity,
+      ask: "off" as ExecAsk,
+    };
+
+    agents[agentId] = { ...agent, trustWindow };
+    file.agents = agents;
+    saveExecApprovals(file);
+
+    respond(true, { ok: true, expiresAt, agentId }, undefined);
+  },
+
+  "exec.approvals.untrust": ({ params, respond }) => {
+    const p = params as { agentId?: string; revokedBy?: string };
+    const agentId = p.agentId?.trim() || "main";
+
+    ensureExecApprovals();
+    const snapshot = readExecApprovalsSnapshot();
+    const file = snapshot.file;
+    const agents = file.agents ?? {};
+    const agent = agents[agentId];
+
+    if (!agent?.trustWindow || agent.trustWindow.status !== "active") {
+      respond(true, { ok: true, agentId, message: "No active trust window" }, undefined);
+      return;
+    }
+
+    const { trustWindow: _, ...agentWithout } = agent;
+    agents[agentId] = agentWithout;
+    file.agents = agents;
+    saveExecApprovals(file);
+
+    respond(true, { ok: true, agentId }, undefined);
   },
 };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -29,6 +29,7 @@ import {
 import { isDiagnosticsEnabled } from "../infra/diagnostic-events.js";
 import { logAcceptedEnvOption } from "../infra/env.js";
 import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
+import { initTrustWindowCache } from "../infra/exec-approvals.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
@@ -198,6 +199,8 @@ export async function startGatewayServer(
 ): Promise<GatewayServer> {
   const minimalTestGateway =
     process.env.VITEST === "1" && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
+
+  initTrustWindowCache();
 
   // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -9,6 +9,9 @@ import {
   buildSafeBinsShellCommand,
   evaluateExecAllowlist,
   evaluateShellAllowlist,
+  getTrustWindow,
+  grantTrustWindow,
+  initTrustWindowCache,
   matchAllowlist,
   maxAsk,
   mergeExecApprovalsSocketDefaults,
@@ -883,138 +886,162 @@ describe("exec approvals policy helpers", () => {
 });
 
 describe("trust window", () => {
+  const withTempHome = (fn: () => void) => {
+    const dir = makeTempDir();
+    const prevOpenClawHome = process.env.OPENCLAW_HOME;
+    process.env.OPENCLAW_HOME = dir;
+    initTrustWindowCache();
+    try {
+      fn();
+    } finally {
+      initTrustWindowCache();
+      process.env.OPENCLAW_HOME = prevOpenClawHome;
+    }
+  };
+
   it("overrides security/ask when active and not expired", () => {
-    const now = Date.now();
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "allowlist",
-          ask: "on-miss",
-          trustWindow: {
-            status: "active",
-            expiresAt: now + 60_000,
-            grantedAt: now,
-            security: "full",
-            ask: "off",
+    withTempHome(() => {
+      const now = Date.now();
+      const result = grantTrustWindow({ agentId: "main", minutes: 1 });
+      expect(result.ok).toBe(true);
+      const trustWindow = getTrustWindow("main");
+      expect(trustWindow).toBeTruthy();
+      if (trustWindow) {
+        trustWindow.expiresAt = now + 60_000;
+      }
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            ask: "on-miss",
           },
         },
-      },
-    };
-    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
-    expect(resolved.agent.security).toBe("full");
-    expect(resolved.agent.ask).toBe("off");
+      };
+      const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+      expect(resolved.agent.security).toBe("full");
+      expect(resolved.agent.ask).toBe("off");
+    });
   });
 
   it("ignores expired window — falls back to base policy", () => {
-    const now = Date.now();
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "allowlist",
-          ask: "on-miss",
-          trustWindow: {
-            status: "active",
-            expiresAt: now - 1000,
-            grantedAt: now - 61_000,
-            security: "full",
-            ask: "off",
+    withTempHome(() => {
+      const now = Date.now();
+      const result = grantTrustWindow({ agentId: "main", minutes: 1 });
+      expect(result.ok).toBe(true);
+      const trustWindow = getTrustWindow("main");
+      expect(trustWindow).toBeTruthy();
+      if (trustWindow) {
+        trustWindow.expiresAt = now - 1000;
+        trustWindow.grantedAt = now - 61_000;
+      }
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            ask: "on-miss",
           },
         },
-      },
-    };
-    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
-    expect(resolved.agent.security).toBe("allowlist");
-    expect(resolved.agent.ask).toBe("on-miss");
+      };
+      const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+      expect(resolved.agent.security).toBe("allowlist");
+      expect(resolved.agent.ask).toBe("on-miss");
+    });
   });
 
   it("does not write to disk (pure read path)", () => {
-    const writeSpy = vi.spyOn(fs, "writeFileSync");
-    const now = Date.now();
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "allowlist",
-          ask: "on-miss",
-          trustWindow: {
-            status: "active",
-            expiresAt: now - 1000,
-            grantedAt: now - 61_000,
-            security: "full",
-            ask: "off",
+    withTempHome(() => {
+      const now = Date.now();
+      const result = grantTrustWindow({ agentId: "main", minutes: 1 });
+      expect(result.ok).toBe(true);
+      const trustWindow = getTrustWindow("main");
+      if (trustWindow) {
+        trustWindow.expiresAt = now - 1000;
+        trustWindow.grantedAt = now - 61_000;
+      }
+      const writeSpy = vi.spyOn(fs, "writeFileSync");
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            ask: "on-miss",
           },
         },
-      },
-    };
-    resolveExecApprovalsFromFile({ file, agentId: "main" });
-    expect(writeSpy).not.toHaveBeenCalled();
-    writeSpy.mockRestore();
+      };
+      resolveExecApprovalsFromFile({ file, agentId: "main" });
+      expect(writeSpy).not.toHaveBeenCalled();
+      writeSpy.mockRestore();
+    });
   });
 
   it("overrides security: deny base policy when window is active", () => {
-    const now = Date.now();
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "deny",
-          trustWindow: {
-            status: "active",
-            expiresAt: now + 60_000,
-            grantedAt: now,
-            security: "full",
-            ask: "off",
+    withTempHome(() => {
+      const now = Date.now();
+      const result = grantTrustWindow({ agentId: "main", minutes: 1 });
+      expect(result.ok).toBe(true);
+      const trustWindow = getTrustWindow("main");
+      if (trustWindow) {
+        trustWindow.expiresAt = now + 60_000;
+      }
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "deny",
           },
         },
-      },
-    };
-    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
-    expect(resolved.agent.security).toBe("full");
-    expect(resolved.agent.ask).toBe("off");
+      };
+      const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+      expect(resolved.agent.security).toBe("full");
+      expect(resolved.agent.ask).toBe("off");
+    });
   });
 
   it("does not affect other agents", () => {
-    const now = Date.now();
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "allowlist",
-          ask: "on-miss",
-          trustWindow: {
-            status: "active",
-            expiresAt: now + 60_000,
-            grantedAt: now,
-            security: "full",
-            ask: "off",
+    withTempHome(() => {
+      const now = Date.now();
+      const result = grantTrustWindow({ agentId: "main", minutes: 1 });
+      expect(result.ok).toBe(true);
+      const trustWindow = getTrustWindow("main");
+      if (trustWindow) {
+        trustWindow.expiresAt = now + 60_000;
+      }
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            ask: "on-miss",
+          },
+          other: {
+            security: "deny",
+            ask: "always",
           },
         },
-        other: {
-          security: "deny",
-          ask: "always",
-        },
-      },
-    };
-    const resolvedOther = resolveExecApprovalsFromFile({ file, agentId: "other" });
-    expect(resolvedOther.agent.security).toBe("deny");
-    expect(resolvedOther.agent.ask).toBe("always");
+      };
+      const resolvedOther = resolveExecApprovalsFromFile({ file, agentId: "other" });
+      expect(resolvedOther.agent.security).toBe("deny");
+      expect(resolvedOther.agent.ask).toBe("always");
+    });
   });
 
   it("agent without trustWindow is unaffected", () => {
-    const file: ExecApprovalsFile = {
-      version: 1,
-      agents: {
-        main: {
-          security: "allowlist",
-          ask: "on-miss",
+    withTempHome(() => {
+      const file: ExecApprovalsFile = {
+        version: 1,
+        agents: {
+          main: {
+            security: "allowlist",
+            ask: "on-miss",
+          },
         },
-      },
-    };
-    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
-    expect(resolved.agent.security).toBe("allowlist");
-    expect(resolved.agent.ask).toBe("on-miss");
+      };
+      const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+      expect(resolved.agent.security).toBe("allowlist");
+      expect(resolved.agent.ask).toBe("on-miss");
+    });
   });
 
   it("requiresExecApproval returns false during active trust window settings", () => {

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makePathEnv, makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
   analyzeArgvCommand,
@@ -21,7 +21,9 @@ import {
   resolveCommandResolutionFromArgv,
   resolveExecApprovalsPath,
   resolveExecApprovalsSocketPath,
+  resolveExecApprovalsFromFile,
   type ExecAllowlistEntry,
+  type ExecApprovalsFile,
 } from "./exec-approvals.js";
 
 function buildNestedEnvShellCommand(params: {
@@ -874,6 +876,153 @@ describe("exec approvals policy helpers", () => {
         ask: "on-miss",
         security: "full",
         analysisOk: false,
+        allowlistSatisfied: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("trust window", () => {
+  it("overrides security/ask when active and not expired", () => {
+    const now = Date.now();
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "on-miss",
+          trustWindow: {
+            status: "active",
+            expiresAt: now + 60_000,
+            grantedAt: now,
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+  });
+
+  it("ignores expired window — falls back to base policy", () => {
+    const now = Date.now();
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "on-miss",
+          trustWindow: {
+            status: "active",
+            expiresAt: now - 1000,
+            grantedAt: now - 61_000,
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(resolved.agent.security).toBe("allowlist");
+    expect(resolved.agent.ask).toBe("on-miss");
+  });
+
+  it("does not write to disk (pure read path)", () => {
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const now = Date.now();
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "on-miss",
+          trustWindow: {
+            status: "active",
+            expiresAt: now - 1000,
+            grantedAt: now - 61_000,
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+    };
+    resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(writeSpy).not.toHaveBeenCalled();
+    writeSpy.mockRestore();
+  });
+
+  it("overrides security: deny base policy when window is active", () => {
+    const now = Date.now();
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "deny",
+          trustWindow: {
+            status: "active",
+            expiresAt: now + 60_000,
+            grantedAt: now,
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(resolved.agent.security).toBe("full");
+    expect(resolved.agent.ask).toBe("off");
+  });
+
+  it("does not affect other agents", () => {
+    const now = Date.now();
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "on-miss",
+          trustWindow: {
+            status: "active",
+            expiresAt: now + 60_000,
+            grantedAt: now,
+            security: "full",
+            ask: "off",
+          },
+        },
+        other: {
+          security: "deny",
+          ask: "always",
+        },
+      },
+    };
+    const resolvedOther = resolveExecApprovalsFromFile({ file, agentId: "other" });
+    expect(resolvedOther.agent.security).toBe("deny");
+    expect(resolvedOther.agent.ask).toBe("always");
+  });
+
+  it("agent without trustWindow is unaffected", () => {
+    const file: ExecApprovalsFile = {
+      version: 1,
+      agents: {
+        main: {
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      },
+    };
+    const resolved = resolveExecApprovalsFromFile({ file, agentId: "main" });
+    expect(resolved.agent.security).toBe("allowlist");
+    expect(resolved.agent.ask).toBe("on-miss");
+  });
+
+  it("requiresExecApproval returns false during active trust window settings", () => {
+    expect(
+      requiresExecApproval({
+        ask: "off",
+        security: "full",
+        analysisOk: true,
         allowlistSatisfied: false,
       }),
     ).toBe(false);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -382,10 +382,19 @@ export function grantTrustWindow(params: {
   force?: boolean;
 }): GrantTrustResult {
   const agentId = params.agentId?.trim() || "main";
-  const { minutes } = params;
+  if (agentId.length > 64 || !/^[a-zA-Z0-9_-]+$/.test(agentId)) {
+    return {
+      ok: false,
+      error: "agentId must be 1-64 alphanumeric, dash, or underscore characters",
+    };
+  }
 
-  if (minutes <= 0 || minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
-    return { ok: false, error: `minutes must be between 1 and ${ABSOLUTE_MAX_TRUST_MINUTES}` };
+  const { minutes } = params;
+  if (!Number.isFinite(minutes) || minutes <= 0 || minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
+    return {
+      ok: false,
+      error: `minutes must be a finite number between 1 and ${ABSOLUTE_MAX_TRUST_MINUTES}`,
+    };
   }
 
   if (minutes > DEFAULT_MAX_TRUST_MINUTES && !params.force) {
@@ -410,7 +419,7 @@ export function grantTrustWindow(params: {
     status: "active" as const,
     expiresAt,
     grantedAt: now,
-    grantedBy: params.grantedBy,
+    grantedBy: params.grantedBy?.slice(0, 256),
     security: "full" as ExecSecurity,
     ask: "off" as ExecAsk,
     expiredNotified: false,
@@ -428,6 +437,12 @@ export function revokeTrustWindow(params: {
   keepAudit?: boolean;
 }): RevokeTrustResult {
   const agentId = params.agentId?.trim() || "main";
+  if (agentId.length > 64 || !/^[a-zA-Z0-9_-]+$/.test(agentId)) {
+    return {
+      ok: false,
+      error: "agentId must be 1-64 alphanumeric, dash, or underscore characters",
+    };
+  }
 
   const trustWindow = trustWindowCache.get(agentId);
   if (!trustWindow || trustWindow.status !== "active") {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -379,12 +379,20 @@ export function grantTrustWindow(params: {
   agentId?: string;
   minutes: number;
   grantedBy?: string;
+  force?: boolean;
 }): GrantTrustResult {
   const agentId = params.agentId?.trim() || "main";
   const { minutes } = params;
 
   if (minutes <= 0 || minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
     return { ok: false, error: `minutes must be between 1 and ${ABSOLUTE_MAX_TRUST_MINUTES}` };
+  }
+
+  if (minutes > DEFAULT_MAX_TRUST_MINUTES && !params.force) {
+    return {
+      ok: false,
+      error: `Duration exceeds default cap (${DEFAULT_MAX_TRUST_MINUTES}m). Use force to allow up to ${ABSOLUTE_MAX_TRUST_MINUTES}m.`,
+    };
   }
 
   const now = Date.now();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
+import { summarizeTrustAudit, cleanupTrustAudit } from "./trust-audit.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 
@@ -85,6 +86,8 @@ export type TrustWindow = {
   grantedBy?: string;
   security: ExecSecurity;
   ask: ExecAsk;
+  expiredNotified?: boolean;
+  grantNotified?: boolean;
 };
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
@@ -129,6 +132,17 @@ const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+
+const trustWindowCache = new Map<string, TrustWindow>();
+
+export function initTrustWindowCache() {
+  trustWindowCache.clear();
+}
+
+export function getTrustWindow(agentId?: string): TrustWindow | undefined {
+  const key = agentId?.trim() || DEFAULT_AGENT_ID;
+  return trustWindowCache.get(key);
+}
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -349,6 +363,107 @@ export function saveExecApprovals(file: ExecApprovalsFile) {
   }
 }
 
+// ── Shared trust window operations ──────────────────────────────────
+
+export const DEFAULT_MAX_TRUST_MINUTES = 60;
+export const ABSOLUTE_MAX_TRUST_MINUTES = 480;
+
+export type GrantTrustResult =
+  | { ok: true; agentId: string; expiresAt: number }
+  | { ok: false; error: string };
+
+export type RevokeTrustResult =
+  | { ok: true; agentId: string; summary: string | undefined }
+  | { ok: false; error: string };
+
+export function grantTrustWindow(params: {
+  agentId?: string;
+  minutes: number;
+  grantedBy?: string;
+}): GrantTrustResult {
+  const agentId = params.agentId?.trim() || "main";
+  const { minutes } = params;
+
+  if (minutes <= 0 || minutes > ABSOLUTE_MAX_TRUST_MINUTES) {
+    return { ok: false, error: `minutes must be between 1 and ${ABSOLUTE_MAX_TRUST_MINUTES}` };
+  }
+
+  const now = Date.now();
+  const existing = trustWindowCache.get(agentId);
+  if (existing?.status === "active" && existing.expiresAt > now) {
+    const remainingMin = Math.ceil((existing.expiresAt - now) / 60_000);
+    return {
+      ok: false,
+      error: `Trust window already active (${remainingMin}m remaining). Revoke it first.`,
+    };
+  }
+
+  ensureExecApprovals();
+  const snapshot = readExecApprovalsSnapshot();
+  const file = snapshot.file;
+  const agents = file.agents ?? {};
+  const agent = agents[agentId] ?? {};
+
+  const expiresAt = now + minutes * 60_000;
+  const trustWindow: TrustWindow = {
+    status: "active" as const,
+    expiresAt,
+    grantedAt: now,
+    grantedBy: params.grantedBy,
+    security: "full" as ExecSecurity,
+    ask: "off" as ExecAsk,
+    expiredNotified: false,
+    grantNotified: false,
+  };
+
+  trustWindowCache.set(agentId, trustWindow);
+
+  agents[agentId] = { ...agent, trustWindow };
+  file.agents = agents;
+  saveExecApprovals(file);
+
+  return { ok: true, agentId, expiresAt };
+}
+
+export function revokeTrustWindow(params: {
+  agentId?: string;
+  revokedBy?: string;
+  keepAudit?: boolean;
+}): RevokeTrustResult {
+  const agentId = params.agentId?.trim() || "main";
+
+  const trustWindow = trustWindowCache.get(agentId);
+  if (!trustWindow || trustWindow.status !== "active") {
+    return { ok: false, error: `No active trust window for agent "${agentId}"` };
+  }
+
+  ensureExecApprovals();
+  const snapshot = readExecApprovalsSnapshot();
+  const file = snapshot.file;
+  const agents = file.agents ?? {};
+  const agent = agents[agentId];
+
+  const now = Date.now();
+  const endAt = trustWindow.expiresAt > now ? now : (trustWindow.expiresAt ?? now);
+  const summary = summarizeTrustAudit({
+    agentId,
+    startedAt: trustWindow.grantedAt,
+    endedAt: endAt,
+  });
+  if (!params.keepAudit) {
+    cleanupTrustAudit(agentId);
+  }
+
+  trustWindowCache.delete(agentId);
+
+  const { trustWindow: _, ...agentWithout } = agent ?? {};
+  agents[agentId] = agentWithout;
+  file.agents = agents;
+  saveExecApprovals(file);
+
+  return { ok: true, agentId, summary: summary ?? undefined };
+}
+
 export function ensureExecApprovals(): ExecApprovalsFile {
   const loaded = loadExecApprovals();
   const next = normalizeExecApprovals(loaded);
@@ -443,7 +558,7 @@ export function resolveExecApprovalsFromFile(params: {
   };
   // Trust window override: if active and not expired, override agent security/ask.
   // Pure read — no side effects. Expired windows are ignored, not cleaned up here.
-  const trustWindow = agent.trustWindow;
+  const trustWindow = getTrustWindow(agentKey);
   const trustWindowActive =
     trustWindow?.status === "active" &&
     typeof trustWindow.expiresAt === "number" &&

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
-import { summarizeTrustAudit, cleanupTrustAudit } from "./trust-audit.js";
+import { summarizeTrustAudit } from "./trust-audit.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 
@@ -92,7 +92,6 @@ export type TrustWindow = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
-  trustWindow?: TrustWindow;
 };
 
 export type ExecApprovalsFile = {
@@ -398,12 +397,6 @@ export function grantTrustWindow(params: {
     };
   }
 
-  ensureExecApprovals();
-  const snapshot = readExecApprovalsSnapshot();
-  const file = snapshot.file;
-  const agents = file.agents ?? {};
-  const agent = agents[agentId] ?? {};
-
   const expiresAt = now + minutes * 60_000;
   const trustWindow: TrustWindow = {
     status: "active" as const,
@@ -417,10 +410,6 @@ export function grantTrustWindow(params: {
   };
 
   trustWindowCache.set(agentId, trustWindow);
-
-  agents[agentId] = { ...agent, trustWindow };
-  file.agents = agents;
-  saveExecApprovals(file);
 
   return { ok: true, agentId, expiresAt };
 }
@@ -437,12 +426,6 @@ export function revokeTrustWindow(params: {
     return { ok: false, error: `No active trust window for agent "${agentId}"` };
   }
 
-  ensureExecApprovals();
-  const snapshot = readExecApprovalsSnapshot();
-  const file = snapshot.file;
-  const agents = file.agents ?? {};
-  const agent = agents[agentId];
-
   const now = Date.now();
   const endAt = trustWindow.expiresAt > now ? now : (trustWindow.expiresAt ?? now);
   const summary = summarizeTrustAudit({
@@ -450,16 +433,8 @@ export function revokeTrustWindow(params: {
     startedAt: trustWindow.grantedAt,
     endedAt: endAt,
   });
-  if (!params.keepAudit) {
-    cleanupTrustAudit(agentId);
-  }
 
   trustWindowCache.delete(agentId);
-
-  const { trustWindow: _, ...agentWithout } = agent ?? {};
-  agents[agentId] = agentWithout;
-  file.agents = agents;
-  saveExecApprovals(file);
 
   return { ok: true, agentId, summary: summary ?? undefined };
 }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -78,8 +78,18 @@ export type ExecAllowlistEntry = {
   lastResolvedPath?: string;
 };
 
+export type TrustWindow = {
+  status: "active";
+  expiresAt: number;
+  grantedAt: number;
+  grantedBy?: string;
+  security: ExecSecurity;
+  ask: ExecAsk;
+};
+
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
+  trustWindow?: TrustWindow;
 };
 
 export type ExecApprovalsFile = {
@@ -431,6 +441,22 @@ export function resolveExecApprovalsFromFile(params: {
       agent.autoAllowSkills ?? wildcard.autoAllowSkills ?? resolvedDefaults.autoAllowSkills,
     ),
   };
+  // Trust window override: if active and not expired, override agent security/ask.
+  // Pure read — no side effects. Expired windows are ignored, not cleaned up here.
+  const trustWindow = agent.trustWindow;
+  const trustWindowActive =
+    trustWindow?.status === "active" &&
+    typeof trustWindow.expiresAt === "number" &&
+    Date.now() < trustWindow.expiresAt;
+
+  const finalAgent: Required<ExecApprovalsDefaults> = trustWindowActive
+    ? {
+        ...resolvedAgent,
+        security: normalizeSecurity(trustWindow.security, resolvedAgent.security),
+        ask: normalizeAsk(trustWindow.ask, resolvedAgent.ask),
+      }
+    : resolvedAgent;
+
   const allowlist = [
     ...(Array.isArray(wildcard.allowlist) ? wildcard.allowlist : []),
     ...(Array.isArray(agent.allowlist) ? agent.allowlist : []),
@@ -442,7 +468,7 @@ export function resolveExecApprovalsFromFile(params: {
     ),
     token: params.token ?? file.socket?.token ?? "",
     defaults: resolvedDefaults,
-    agent: resolvedAgent,
+    agent: finalAgent,
     allowlist,
     file,
   };

--- a/src/infra/trust-audit.test.ts
+++ b/src/infra/trust-audit.test.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock expandHomePrefix to redirect to a temp dir
+const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trust-audit-"));
+
+vi.mock("./home-dir.js", () => ({
+  expandHomePrefix: (p: string) => p.replace("~/.openclaw/", `${tmpBase}/`),
+}));
+
+const {
+  appendTrustAuditEntry,
+  cleanupTrustAudit,
+  formatTrustAuditCommand,
+  loadTrustAudit,
+  resolveTrustAuditPath,
+  summarizeTrustAudit,
+} = await import("./trust-audit.js");
+
+afterEach(() => {
+  // Clean up any audit files between tests
+  for (const f of fs.readdirSync(tmpBase)) {
+    if (f.startsWith("trust-audit-")) {
+      fs.unlinkSync(path.join(tmpBase, f));
+    }
+  }
+});
+
+describe("trust-audit", () => {
+  describe("resolveTrustAuditPath", () => {
+    it("uses agent id in filename", () => {
+      expect(resolveTrustAuditPath("myagent")).toContain("trust-audit-myagent.jsonl");
+    });
+
+    it("defaults to main agent when no id provided", () => {
+      expect(resolveTrustAuditPath()).toContain("trust-audit-main.jsonl");
+    });
+
+    it("trims whitespace from agent id", () => {
+      expect(resolveTrustAuditPath("  foo  ")).toContain("trust-audit-foo.jsonl");
+    });
+  });
+
+  describe("formatTrustAuditCommand", () => {
+    it("normalizes whitespace", () => {
+      expect(formatTrustAuditCommand("echo   hello\n  world")).toBe("echo hello world");
+    });
+
+    it("truncates long commands", () => {
+      const long = "x".repeat(300);
+      const result = formatTrustAuditCommand(long);
+      expect(result.length).toBeLessThanOrEqual(200);
+      expect(result.endsWith("…")).toBe(true);
+    });
+
+    it("preserves short commands", () => {
+      expect(formatTrustAuditCommand("ls -la")).toBe("ls -la");
+    });
+  });
+
+  describe("appendTrustAuditEntry", () => {
+    it("appends entry to JSONL file", () => {
+      const entry = appendTrustAuditEntry({
+        agentId: "test1",
+        command: "echo hello",
+        exitCode: 0,
+        durationMs: 100,
+        now: 1000,
+      });
+      expect(entry).toEqual({ ts: 1000, cmd: "echo hello", code: 0, durationMs: 100 });
+
+      const { entries } = loadTrustAudit({ agentId: "test1" });
+      expect(entries).toHaveLength(1);
+      expect(entries[0].cmd).toBe("echo hello");
+    });
+
+    it("appends multiple entries", () => {
+      appendTrustAuditEntry({ agentId: "test2", command: "cmd1", now: 1000 });
+      appendTrustAuditEntry({ agentId: "test2", command: "cmd2", now: 2000 });
+      appendTrustAuditEntry({ agentId: "test2", command: "cmd3", now: 3000 });
+
+      const { entries } = loadTrustAudit({ agentId: "test2" });
+      expect(entries).toHaveLength(3);
+    });
+
+    it("returns null for empty command", () => {
+      expect(appendTrustAuditEntry({ command: "   " })).toBeNull();
+    });
+
+    it("handles null exit code", () => {
+      const entry = appendTrustAuditEntry({ agentId: "test3", command: "kill -9", now: 1000 });
+      expect(entry?.code).toBeNull();
+    });
+  });
+
+  describe("loadTrustAudit", () => {
+    it("returns exists=false when no file", () => {
+      const result = loadTrustAudit({ agentId: "nonexistent" });
+      expect(result).toEqual({ entries: [], exists: false });
+    });
+
+    it("skips malformed JSON lines", () => {
+      const filePath = resolveTrustAuditPath("corrupt");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(
+        filePath,
+        [
+          JSON.stringify({ ts: 1000, cmd: "good", code: 0, durationMs: 10 }),
+          "NOT VALID JSON",
+          JSON.stringify({ ts: 2000, cmd: "also good", code: 0, durationMs: 20 }),
+        ].join("\n") + "\n",
+      );
+
+      const { entries, exists } = loadTrustAudit({ agentId: "corrupt" });
+      expect(exists).toBe(true);
+      expect(entries).toHaveLength(2);
+      expect(entries[0].cmd).toBe("good");
+      expect(entries[1].cmd).toBe("also good");
+    });
+
+    it("skips entries missing required fields", () => {
+      const filePath = resolveTrustAuditPath("badfields");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(
+        filePath,
+        [
+          JSON.stringify({ ts: 1000, cmd: "ok", code: 0 }),
+          JSON.stringify({ ts: "not a number", cmd: "bad" }),
+          JSON.stringify({ ts: 2000 }), // missing cmd
+        ].join("\n") + "\n",
+      );
+
+      const { entries } = loadTrustAudit({ agentId: "badfields" });
+      expect(entries).toHaveLength(1);
+      expect(entries[0].cmd).toBe("ok");
+    });
+
+    it("handles empty file", () => {
+      const filePath = resolveTrustAuditPath("empty");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, "");
+
+      const { entries, exists } = loadTrustAudit({ agentId: "empty" });
+      expect(exists).toBe(true);
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe("summarizeTrustAudit", () => {
+    it("summarizes when no audit file exists", () => {
+      const result = summarizeTrustAudit({ agentId: "nope", startedAt: 1000, endedAt: 61_000 });
+      expect(result).toContain("Commands: 0 (0 failed)");
+      expect(result).toContain("Duration: 1m");
+    });
+
+    it("summarizes with zero commands", () => {
+      const filePath = resolveTrustAuditPath("zero");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, "");
+
+      const result = summarizeTrustAudit({ agentId: "zero", startedAt: 1000, endedAt: 61_000 });
+      expect(result).toContain("Commands: 0 (0 failed)");
+      expect(result).toContain("Duration: 1m");
+    });
+
+    it("lists commands when ≤10", () => {
+      for (let i = 0; i < 5; i++) {
+        appendTrustAuditEntry({ agentId: "few", command: `cmd${i}`, exitCode: 0, now: 1000 + i });
+      }
+
+      const result = summarizeTrustAudit({ agentId: "few", startedAt: 1000, endedAt: 61_000 })!;
+      expect(result).toContain("Commands: 5 (0 failed)");
+      expect(result).toContain("- cmd0");
+      expect(result).toContain("- cmd4");
+      expect(result).not.toContain("more");
+    });
+
+    it("truncates command list when >10", () => {
+      for (let i = 0; i < 12; i++) {
+        appendTrustAuditEntry({ agentId: "many", command: `cmd${i}`, exitCode: 0, now: 1000 + i });
+      }
+
+      const result = summarizeTrustAudit({ agentId: "many", startedAt: 1000, endedAt: 61_000 })!;
+      expect(result).toContain("Commands: 12 (0 failed)");
+      expect(result).toContain("- cmd0");
+      expect(result).toContain("- cmd4");
+      expect(result).not.toContain("- cmd5");
+      expect(result).toContain("…and 7 more");
+    });
+
+    it("counts failures", () => {
+      appendTrustAuditEntry({ agentId: "fails", command: "ok", exitCode: 0, now: 1000 });
+      appendTrustAuditEntry({ agentId: "fails", command: "bad1", exitCode: 1, now: 2000 });
+      appendTrustAuditEntry({ agentId: "fails", command: "bad2", exitCode: 127, now: 3000 });
+
+      const result = summarizeTrustAudit({ agentId: "fails", startedAt: 1000, endedAt: 61_000 })!;
+      expect(result).toContain("Commands: 3 (2 failed)");
+    });
+
+    it("formats hours for long durations", () => {
+      const filePath = resolveTrustAuditPath("long");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, JSON.stringify({ ts: 1000, cmd: "x", code: 0 }) + "\n");
+
+      const result = summarizeTrustAudit({
+        agentId: "long",
+        startedAt: 0,
+        endedAt: 90 * 60_000, // 90 minutes
+      })!;
+      expect(result).toContain("Duration: 1h 30m");
+    });
+  });
+
+  describe("cleanupTrustAudit", () => {
+    it("deletes the audit file", () => {
+      appendTrustAuditEntry({ agentId: "cleanup", command: "test", now: 1000 });
+      const filePath = resolveTrustAuditPath("cleanup");
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      cleanupTrustAudit("cleanup");
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("does not throw when file does not exist", () => {
+      expect(() => cleanupTrustAudit("nonexistent")).not.toThrow();
+    });
+  });
+});

--- a/src/infra/trust-audit.ts
+++ b/src/infra/trust-audit.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import path from "node:path";
+import { redactSensitiveText } from "../logging/redact.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { expandHomePrefix } from "./home-dir.js";
+
+export type TrustAuditEntry = {
+  ts: number;
+  cmd: string;
+  code: number | null;
+  durationMs?: number | null;
+};
+
+const MAX_COMMAND_CHARS = 200;
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function normalizeAgentId(agentId?: string): string {
+  const trimmed = agentId?.trim();
+  return trimmed ? trimmed : DEFAULT_AGENT_ID;
+}
+
+export function resolveTrustAuditPath(agentId?: string): string {
+  const id = normalizeAgentId(agentId);
+  return expandHomePrefix(`~/.openclaw/trust-audit-${id}.jsonl`);
+}
+
+function truncateCommand(value: string): string {
+  if (value.length <= MAX_COMMAND_CHARS) {
+    return value;
+  }
+  const safe = Math.max(1, MAX_COMMAND_CHARS - 1);
+  return `${value.slice(0, safe)}…`;
+}
+
+export function formatTrustAuditCommand(command: string): string {
+  const normalized = command.replace(/\s+/g, " ").trim();
+  const redacted = redactSensitiveText(normalized);
+  return truncateCommand(redacted);
+}
+
+export function appendTrustAuditEntry(params: {
+  agentId?: string;
+  command: string;
+  exitCode?: number | null;
+  durationMs?: number | null;
+  now?: number;
+}): TrustAuditEntry | null {
+  const trimmed = params.command.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const entry: TrustAuditEntry = {
+    ts: typeof params.now === "number" ? params.now : Date.now(),
+    cmd: formatTrustAuditCommand(trimmed),
+    code: typeof params.exitCode === "number" ? params.exitCode : null,
+    durationMs: typeof params.durationMs === "number" ? params.durationMs : null,
+  };
+  const filePath = resolveTrustAuditPath(params.agentId);
+  ensureDir(filePath);
+  fs.appendFileSync(filePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best-effort on platforms without chmod.
+  }
+  return entry;
+}
+
+export function loadTrustAudit(params?: { agentId?: string }): {
+  entries: TrustAuditEntry[];
+  exists: boolean;
+} {
+  const filePath = resolveTrustAuditPath(params?.agentId);
+  if (!fs.existsSync(filePath)) {
+    return { entries: [], exists: false };
+  }
+  const raw = fs.readFileSync(filePath, "utf8");
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  const entries: TrustAuditEntry[] = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as TrustAuditEntry;
+      if (!parsed || typeof parsed !== "object") {
+        continue;
+      }
+      if (typeof parsed.ts !== "number" || typeof parsed.cmd !== "string") {
+        continue;
+      }
+      entries.push({
+        ts: parsed.ts,
+        cmd: parsed.cmd,
+        code: typeof parsed.code === "number" ? parsed.code : null,
+        durationMs: typeof parsed.durationMs === "number" ? parsed.durationMs : null,
+      });
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return { entries, exists: true };
+}
+
+function formatDuration(durationMs: number): string {
+  const minutes = Math.max(0, Math.ceil(durationMs / 60_000));
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+}
+
+function resolveDurationMs(params: {
+  entries: TrustAuditEntry[];
+  startedAt?: number;
+  endedAt?: number;
+}): number | null {
+  const { entries, startedAt, endedAt } = params;
+  const start = typeof startedAt === "number" ? startedAt : entries[0]?.ts;
+  const end =
+    typeof endedAt === "number"
+      ? endedAt
+      : entries.length > 0
+        ? entries[entries.length - 1]?.ts
+        : start;
+  if (typeof start !== "number" || typeof end !== "number") {
+    return null;
+  }
+  return Math.max(0, end - start);
+}
+
+export function summarizeTrustAudit(params: {
+  agentId?: string;
+  startedAt?: number;
+  endedAt?: number;
+}): string | null {
+  const { entries } = loadTrustAudit({ agentId: params.agentId });
+  const total = entries.length;
+  const failed = entries.filter(
+    (entry) => typeof entry.code === "number" && entry.code !== 0,
+  ).length;
+  const durationMs = resolveDurationMs({
+    entries,
+    startedAt: params.startedAt,
+    endedAt: params.endedAt,
+  });
+  const durationLabel = durationMs === null ? "unknown" : formatDuration(durationMs);
+  const lines: string[] = [
+    "📋 Trust window summary",
+    `Duration: ${durationLabel} · Commands: ${total} (${failed} failed)`,
+  ];
+
+  const commands = entries.map((entry) => entry.cmd).filter(Boolean);
+  if (commands.length > 0) {
+    lines.push("");
+    const listLimit = 10;
+    const previewLimit = 5;
+    if (commands.length <= listLimit) {
+      for (const cmd of commands) {
+        lines.push(`- ${cmd}`);
+      }
+    } else {
+      for (const cmd of commands.slice(0, previewLimit)) {
+        lines.push(`- ${cmd}`);
+      }
+      lines.push(`- …and ${commands.length - previewLimit} more`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function cleanupTrustAudit(agentId?: string): void {
+  const filePath = resolveTrustAuditPath(agentId);
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Best-effort cleanup.
+  }
+}

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -8,6 +8,7 @@ import {
 import { GatewayClient } from "../gateway/client.js";
 import { GATEWAY_CLIENT_CAPS } from "../gateway/protocol/client-info.js";
 import {
+  type ExecApprovalsTrustStatusResult,
   type HelloOk,
   PROTOCOL_VERSION,
   type SessionsListParams,
@@ -215,6 +216,15 @@ export class GatewayChatClient {
 
   async patchSession(opts: SessionsPatchParams): Promise<SessionsPatchResult> {
     return await this.client.request<SessionsPatchResult>("sessions.patch", opts);
+  }
+
+  async getTrustStatus(opts?: { agentId?: string }): Promise<ExecApprovalsTrustStatusResult> {
+    return await this.client.request<ExecApprovalsTrustStatusResult>(
+      "exec.approvals.trust.status",
+      {
+        agentId: opts?.agentId,
+      },
+    );
   }
 
   async resetSession(key: string, reason?: "new" | "reset") {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -737,7 +737,7 @@ export async function runTui(opts: TuiOptions) {
     trustWindowFetchPromise = (async () => {
       try {
         const result = await client.getTrustStatus({ agentId: currentAgentId });
-        trustWindow = result.trustWindow ?? null;
+        trustWindow = (result.trustWindow as TrustWindow | undefined) ?? null;
       } catch {
         trustWindow = null;
       }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -11,6 +11,7 @@ import {
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { trustStatusLine } from "../auto-reply/reply/agent-runner-utils.js";
 import { loadConfig } from "../config/config.js";
+import type { TrustWindow } from "../infra/exec-approvals.js";
 import {
   buildAgentMainSessionKey,
   normalizeAgentId,
@@ -331,6 +332,10 @@ export async function runTui(opts: TuiOptions) {
   let statusTimer: NodeJS.Timeout | null = null;
   let statusStartedAt: number | null = null;
   let lastActivityStatus = activityStatus;
+  let trustWindow: TrustWindow | null = null;
+  let trustWindowAgentId: string | null = null;
+  let trustWindowFetchedAt = 0;
+  let trustWindowFetchPromise: Promise<void> | null = null;
 
   const state: TuiStateAccess = {
     get agentDefaultId() {
@@ -713,7 +718,41 @@ export async function runTui(opts: TuiOptions) {
     renderStatus();
   };
 
+  const refreshTrustWindow = async (force = false) => {
+    if (!isConnected) {
+      return;
+    }
+    if (trustWindowAgentId !== currentAgentId) {
+      trustWindowAgentId = currentAgentId;
+      trustWindow = null;
+      trustWindowFetchedAt = 0;
+    }
+    const now = Date.now();
+    if (!force && now - trustWindowFetchedAt < 30_000) {
+      return;
+    }
+    if (trustWindowFetchPromise) {
+      return;
+    }
+    trustWindowFetchPromise = (async () => {
+      try {
+        const result = await client.getTrustStatus({ agentId: currentAgentId });
+        trustWindow = result.trustWindow ?? null;
+      } catch {
+        trustWindow = null;
+      }
+      trustWindowFetchedAt = Date.now();
+    })()
+      .catch(() => undefined)
+      .finally(() => {
+        trustWindowFetchPromise = null;
+        updateFooter();
+      });
+    await trustWindowFetchPromise;
+  };
+
   const updateFooter = () => {
+    void refreshTrustWindow();
     const sessionKeyLabel = formatSessionKey(currentSessionKey);
     const sessionLabel = sessionInfo.displayName
       ? `${sessionKeyLabel} (${sessionInfo.displayName})`
@@ -730,7 +769,7 @@ export async function runTui(opts: TuiOptions) {
     const reasoning = sessionInfo.reasoningLevel ?? "off";
     const reasoningLabel =
       reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
-    const trustLine = trustStatusLine({ agentId: currentAgentId });
+    const trustLine = trustStatusLine({ agentId: currentAgentId, trustWindow });
     const footerParts = [
       `agent ${agentLabel}`,
       `session ${sessionLabel}`,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -9,6 +9,7 @@ import {
   TUI,
 } from "@mariozechner/pi-tui";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { trustStatusLine } from "../auto-reply/reply/agent-runner-utils.js";
 import { loadConfig } from "../config/config.js";
 import {
   buildAgentMainSessionKey,
@@ -729,6 +730,7 @@ export async function runTui(opts: TuiOptions) {
     const reasoning = sessionInfo.reasoningLevel ?? "off";
     const reasoningLabel =
       reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
+    const trustLine = trustStatusLine({ agentId: currentAgentId });
     const footerParts = [
       `agent ${agentLabel}`,
       `session ${sessionLabel}`,
@@ -737,6 +739,7 @@ export async function runTui(opts: TuiOptions) {
       verbose !== "off" ? `verbose ${verbose}` : null,
       reasoningLabel,
       tokens,
+      trustLine,
     ].filter(Boolean);
     footer.setText(theme.dim(footerParts.join(" | ")));
   };


### PR DESCRIPTION
# PR: Time-Bounded Trust Windows for Exec Approvals

## Summary

Adds time-bounded exec elevation ("trust windows") that let operators grant agents unrestricted command execution for a set duration, with a security architecture that centralizes all trust state in gateway memory to prevent agent self-escalation.

## Security Architecture

Trust window state lives in an **in-memory `Map<string, TrustWindow>`** inside the gateway process — not on disk. This is the sole authority for trust resolution.

- **File writes are irrelevant.** `exec-approvals.json` receives trust window entries as an audit backup, but the resolver never reads them. A rogue agent writing to the file cannot escalate its own privileges.
- **Restarts are clean.** `initTrustWindowCache()` clears the map at gateway startup. No trust window survives a restart — same model as SSH sessions and sudo timestamps. After a restart, you don't know if you're running the same code, so you shouldn't trust it.
- **One shared implementation.** `grantTrustWindow()` and `revokeTrustWindow()` in `src/infra/exec-approvals.ts` are the only paths that mutate trust state. CLI and RPC are thin UX wrappers — neither implements its own policy logic. Security checks cannot bifurcate.
- **Anti-stacking.** Granting a trust window while one is active is rejected at the shared layer: "Trust window already active (Nm remaining). Revoke it first." This prevents a misbehaving agent from extending its own elevation via exec.
- **TTY gate on CLI.** `openclaw approvals trust` requires an interactive terminal (`process.stdin.isTTY`), preventing agents from invoking it programmatically.
- **RPC scope gate.** Trust/untrust RPC methods require `operator.admin` scope.

### Threat model

| Attack vector | Mitigation |
|---|---|
| Agent writes fake trust window to `exec-approvals.json` | Resolver reads in-memory cache only |
| Agent calls `openclaw approvals trust` via exec | TTY gate rejects non-interactive invocation |
| Agent calls RPC `exec.approvals.trust` | Requires `operator.admin` scope (agents don't have it) |
| Agent crashes gateway to load poisoned file | Restart clears all trust windows — poisoned entries are dead |
| Agent extends active trust window | Anti-stacking check rejects at shared layer |

## Features

### Trust window lifecycle
- **Grant:** `openclaw approvals trust --minutes N` (CLI) or `/trust N` (Discord) or RPC `exec.approvals.trust`
- **Revoke:** `openclaw approvals untrust` (CLI) or `/untrust` (Discord) or RPC `exec.approvals.untrust`
- **Duration caps:** Default max 60 minutes, absolute max 480 minutes (8h). `--force` required to exceed 60m.
- **Expiry notification:** Agent is notified on first exec after window expires, with audit summary.

### Discord slash commands
- `/trust <minutes>` and `/untrust` registered in all configured guilds
- `isOwnerAuthorized` gate at execution time
- Ephemeral responses

### Trust status display
- Footer status line in agent messages: `🔓 Trust window active · expires in Nm`
- Grant confirmation echo when trust is first exercised

### Audit trail
- JSONL audit log (`trust-audit-{agentId}.jsonl`) records every command executed during a trust window
- On revoke/expiry: summary with duration, command count, failure count, truncated command list
- CLI interactive prompt for audit log retention (`--keep` to preserve, `--yes` to auto-delete)

## Files changed

| File | Change |
|---|---|
| `src/infra/exec-approvals.ts` | In-memory cache, `grantTrustWindow()`, `revokeTrustWindow()`, `getTrustWindow()`, `initTrustWindowCache()`, shared constants |
| `src/infra/trust-audit.ts` | **NEW** — JSONL audit module (append, load, summarize, cleanup, formatCommand) |
| `src/infra/trust-audit.test.ts` | **NEW** — 22 tests for audit module |
| `src/infra/exec-approvals.test.ts` | Updated to seed trust state via `grantTrustWindow()` |
| `src/gateway/server.impl.ts` | `initTrustWindowCache()` call at startup |
| `src/gateway/server-methods/exec-approvals.ts` | RPC handlers delegate to shared functions |
| `src/cli/exec-approvals-cli.ts` | CLI trust/untrust commands, TTY gate, duration caps, audit retention UX |
| `src/cli/exec-approvals-cli.test.ts` | 8 tests for CLI commands |
| `src/discord/monitor/trust-command.ts` | **NEW** — Discord `/trust` and `/untrust` slash commands |
| `src/discord/monitor/provider.ts` | Guild-scoped command registration |
| `src/agents/bash-tools.exec-host-gateway.ts` | Expiry notification, audit logging, reads trust from cache |
| `src/agents/bash-tools.exec-host-node.ts` | Expiry notification |
| `src/agents/bash-tools.exec.ts` | Trust status for agent-side display |
| `src/auto-reply/reply/agent-runner-utils.ts` | `trustStatusLine()` for footer |
| `src/tui/tui.ts` | TUI footer trust status |

## Design decisions

- **Memory over file** — Policy enforcement must not depend on state writable by the governed entity.
- **Restarts kill trust** — New process = re-establish trust. No persistence across restarts.
- **Shared layer, not surface checks** — `grantTrustWindow()`/`revokeTrustWindow()` own all policy; CLI and RPC are wrappers.
- **No scoped trust** — Time-bounded full elevation, not per-command scoping. Simpler, harder to misconfigure.
- **No refresh on activity** — Strict countdown. No extending the window. Human must revoke and re-grant.
- **Reject stacking** — Cannot grant while active. Must revoke first.

## Testing

- 76 targeted tests passing (exec-approvals, trust-audit, CLI)
- Build clean (no new type errors)
- E2E verified: grant, revoke, expiry notification, audit summary, anti-stacking, file poisoning attack (confirmed blocked)
