### PR TITLE
fix(ui): increase agent files textarea min-height and allow unbounded resize

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2439,6 +2439,11 @@
   gap: 8px;
 }
 
+.agent-files-editor .field textarea {
+  min-height: 50vh;
+  max-height: none;
+}
+
 .agent-tools-meta {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Problem

The Content textarea in **Agent > Files** panel was rendered with a very short default height (160px from `.field textarea`), making it impractical to read or edit workspace files like SOUL.md or AGENTS.md. Additionally, resizing the textarea via the drag handle could not expand it beyond the parent constraints.

## Fix

Added a scoped CSS override for `.agent-files-editor .field textarea`:
- `min-height: 50vh` — gives the editor a sensible starting height
- `max-height: none` — allows the resize handle to expand without constraint

This is a 5-line CSS-only change with zero JS impact.

Closes #30001