### PR TITLE
fix(sessions-send): terminate ping-pong chain when session replies NO_REPLY

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCallGateway,
+  mockRunAgentStep,
+  mockReadLatestAssistantReply,
+  mockResolveAnnounceTarget,
+} = vi.hoisted(() => {
+  return {
+    mockCallGateway: vi.fn(),
+    mockRunAgentStep: vi.fn(),
+    mockReadLatestAssistantReply: vi.fn(),
+    mockResolveAnnounceTarget: vi.fn(),
+  };
+});
+
+vi.mock("../../gateway/call.js", () => ({ callGateway: mockCallGateway }));
+vi.mock("./agent-step.js", () => ({
+  runAgentStep: mockRunAgentStep,
+  readLatestAssistantReply: mockReadLatestAssistantReply,
+}));
+vi.mock("./sessions-announce-target.js", () => ({
+  resolveAnnounceTarget: mockResolveAnnounceTarget,
+}));
+
+import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+
+const BASE_PARAMS = {
+  targetSessionKey: "agent:main:discord:channel:999",
+  displayKey: "agent:main:discord:channel:999",
+  message: "Hello from A",
+  announceTimeoutMs: 5_000,
+  maxPingPongTurns: 3,
+  requesterSessionKey: "agent:main:main",
+};
+
+describe("runSessionsSendA2AFlow — NO_REPLY termination (#29984)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveAnnounceTarget.mockResolvedValue(null);
+  });
+
+  it("returns early without entering ping-pong when roundOneReply is NO_REPLY", async () => {
+    await runSessionsSendA2AFlow({
+      ...BASE_PARAMS,
+      roundOneReply: "NO_REPLY",
+    });
+
+    // No runAgentStep calls at all — we must return before the ping-pong loop
+    // and before the announce step when the initial reply is a silent reply.
+    expect(mockRunAgentStep).not.toHaveBeenCalled();
+  });
+
+  it("returns early when roundOneReply is whitespace-padded NO_REPLY", async () => {
+    await runSessionsSendA2AFlow({
+      ...BASE_PARAMS,
+      roundOneReply: "  NO_REPLY  ",
+    });
+
+    expect(mockRunAgentStep).not.toHaveBeenCalled();
+  });
+
+  it("breaks loop after one turn when requester replies NO_REPLY and does not bounce back", async () => {
+    // Requester (session A) replies NO_REPLY to the target's substantive message.
+    // The loop must break, preventing the NO_REPLY from being forwarded back.
+    // The announce step still runs once at the end (latestReply unchanged =
+    // "I have something to say"), so total calls = 1 (ping-pong) + 1 (announce) = 2.
+    mockRunAgentStep.mockResolvedValueOnce("NO_REPLY"); // turn 1 — requester
+    mockRunAgentStep.mockResolvedValueOnce(undefined); // announce step — no announcement
+
+    await runSessionsSendA2AFlow({
+      ...BASE_PARAMS,
+      roundOneReply: "I have something to say",
+    });
+
+    expect(mockRunAgentStep).toHaveBeenCalledTimes(2);
+  });
+
+  it("runs all maxPingPongTurns and announce step when replies are substantive", async () => {
+    // All 3 turns return substantive content; announce step runs at the end.
+    mockRunAgentStep.mockResolvedValue("Sounds good, let me check.");
+
+    await runSessionsSendA2AFlow({
+      ...BASE_PARAMS,
+      roundOneReply: "Initial reply from target",
+    });
+
+    // maxPingPongTurns = 3 calls in the loop + 1 announce step = 4 total.
+    expect(mockRunAgentStep).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -47,7 +48,9 @@ export async function runSessionsSendA2AFlow(params: {
         latestReply = primaryReply;
       }
     }
-    if (!latestReply) {
+    // If the target replied with NO_REPLY (or nothing), there is nothing to
+    // route back to the requester — skip the ping-pong loop entirely.
+    if (!latestReply || isSilentReplyText(latestReply)) {
       return;
     }
 
@@ -88,7 +91,9 @@ export async function runSessionsSendA2AFlow(params: {
             nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
           sourceTool: "sessions_send",
         });
-        if (!replyText || isReplySkip(replyText)) {
+        // Break the ping-pong chain on explicit REPLY_SKIP, NO_REPLY, or an
+        // empty reply — any of these signal the session wants to stay silent.
+        if (!replyText || isReplySkip(replyText) || isSilentReplyText(replyText)) {
           break;
         }
         latestReply = replyText;


### PR DESCRIPTION
## Summary

Fixes #29984

When `sessions_send` was used for agent-to-agent messaging and the target session replied `NO_REPLY`, the reply was forwarded back to the requester as a new agent step instead of being treated as a silent termination. This caused a ping-pong loop (up to `maxPingPongTurns` wasted LLM calls) before the loop self-terminated.

**Root cause:** `runSessionsSendA2AFlow` only checked for `REPLY_SKIP` and empty replies to break the loop — it didn't check for `NO_REPLY` (the standard silent reply token used everywhere else in the codebase).

## Changes

- **`sessions-send-tool.a2a.ts`**: Add early return when the initial `roundOneReply` is a silent reply (`NO_REPLY`), skipping both the ping-pong loop and the announce step.
- **`sessions-send-tool.a2a.ts`**: Also break the ping-pong loop immediately when any session replies `NO_REPLY` during a turn (in addition to the existing `REPLY_SKIP` check).
- **`sessions-send-tool.a2a.test.ts`**: New test file covering all four cases: NO_REPLY roundOneReply (returns immediately), whitespace-padded NO_REPLY, mid-loop NO_REPLY break, and normal full-loop execution.

Both changes use the existing `isSilentReplyText()` helper which correctly matches the standard `NO_REPLY` token with optional surrounding whitespace.

## Before / After

**Before:** Session A sends → Session B replies `NO_REPLY` → forwarded to Session A → Session A replies `NO_REPLY` → bounces → loop (3+ wasted LLM calls over ~16s)

**After:** Session A sends → Session B replies `NO_REPLY` → `runSessionsSendA2AFlow` returns immediately, zero LLM calls wasted