### PR TITLE
feat(subagents): add allowGeneric option to block generic subagent spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Subagents/Spawn: add `subagents.allowGeneric` option to block generic (unnamed) subagent spawns, enabling strict agent hierarchy enforcement. (#29982)
 - Web UI/i18n: add German (`de`) locale support and auto-render language options from supported locale constants in Overview settings. (#28495) thanks @dsantoreis.
 - Discord/Thread bindings: replace fixed TTL lifecycle with inactivity (`idleHours`, default 24h) plus optional hard `maxAgeHours` lifecycle controls, and add `/session idle` + `/session max-age` commands for focused thread-bound sessions. (#27845) Thanks @osolmaz.
 - Android/Nodes: add `camera.list`, `device.permissions`, `device.health`, and `notifications.actions` (`open`/`dismiss`/`reply`) on Android nodes, plus first-class node-tool actions for the new device/notification commands. (#28260) Thanks @obviyus.

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -251,6 +251,19 @@ export async function spawnSubagentDirect(
     ctx.requesterAgentIdOverride ?? parseAgentSessionKey(requesterInternalKey)?.agentId,
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+
+  // Block generic (no agentId) spawns when allowGeneric is explicitly false.
+  if (!requestedAgentId) {
+    const allowGeneric = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowGeneric ?? true;
+    if (!allowGeneric) {
+      return {
+        status: "forbidden",
+        error:
+          "Generic subagent spawns (without agentId) are not allowed for this agent. Specify an agentId from the allowAgents list.",
+      };
+    }
+  }
+
   if (targetAgentId !== requesterAgentId) {
     const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -24,6 +24,8 @@ export type AgentConfig = {
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];
+    /** When false, block generic subagent spawns (no agentId). Defaults to true. */
+    allowGeneric?: boolean;
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
   };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -687,6 +687,7 @@ export const AgentEntrySchema = z
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),
+        allowGeneric: z.boolean().optional(),
         model: z
           .union([
             z.string(),


### PR DESCRIPTION
## Summary

- **Feature**: Add `subagents.allowGeneric` config option to block generic (unnamed) subagent spawns
- **Root cause**: `spawnSubagentDirect()` in `subagent-spawn.ts` defaults `targetAgentId` to `requesterAgentId` when no `agentId` is provided, skipping the `allowAgents` check entirely
- **Fix**: Add `allowGeneric` boolean to subagents config; when `false`, reject spawns that omit `agentId`

Fixes #29982

## Problem

When using `subagents.allowAgents` to enforce a strict agent hierarchy (e.g. `main → lead → backend → review`), agents can bypass the hierarchy by calling `sessions_spawn(task="...")` without an `agentId`. This works because the spawn logic defaults `targetAgentId` to the requester's own agent ID, making `targetAgentId === requesterAgentId` always true, which skips the allowlist check.

There was no config option to prevent this.

**Before fix:**
```json
{ "subagents": { "allowAgents": ["lead"] } }
```
`sessions_spawn(task="bypass")` (no agentId) → `accepted` (always)

## Changes

- `src/config/types.agents.ts` — Add `allowGeneric?: boolean` to subagents type
- `src/config/zod-schema.agent-runtime.ts` — Add `allowGeneric: z.boolean().optional()` to schema
- `src/agents/subagent-spawn.ts` — Check `allowGeneric` before the existing `allowAgents` check; when `false`, return `forbidden` for spawns without `agentId`
- `src/gateway/server-cron.ts` — Fixed pre-existing type error: `agentEntry` has type `false | AgentConfig` due to `&&` short-circuit; replaced `agentEntry?.heartbeat` with `agentEntry && agentEntry.heartbeat`

**After fix:**
```json
{ "subagents": { "allowAgents": ["lead"], "allowGeneric": false } }
```
`sessions_spawn(task="bypass")` (no agentId) → `forbidden`
`sessions_spawn(agentId="lead", task="...")` → `accepted`

## Reproduction & verification

**Bug reproduced on main (vitest integration test):**
- Configured `allowAgents: ["lead"]` on agent "main"
- Called `sessions_spawn(task="bypass hierarchy")` without agentId
- Result: `status: "accepted"` — generic spawn bypassed allowAgents entirely
- Output: `❌ FAIL — BUG CONFIRMED: generic spawn accepted despite strict allowAgents`

**Fix verified on PR branch (vitest integration test):**
- 9/9 allowlist tests pass, including 4 new `allowGeneric` tests:
  - `blocks generic spawn when allowGeneric is false` ✅ → `status: "forbidden"`
  - `allows generic spawn when allowGeneric is true` ✅ → `status: "accepted"`
  - `allows generic spawn by default (allowGeneric not set)` ✅ → backward compatible
  - `blocks generic but still allows named agents from allowAgents` ✅

## Test plan

- [x] New test: blocks generic spawn when `allowGeneric` is `false`
- [x] New test: allows generic spawn when `allowGeneric` is `true`
- [x] New test: allows generic spawn by default (backward compatible)
- [x] New test: blocks generic but still allows named agents from `allowAgents`
- [x] All 9 allowlist tests pass (5 existing + 4 new)
- [x] Format check passes

## Effect on User Experience

**Before:** No way to prevent agents from spawning generic subagents, making strict agent hierarchies unenforceable via config alone.
**After:** Setting `allowGeneric: false` provides a hard technical gate that forces agents to use named `agentId` from the `allowAgents` list.