### PR TITLE
fix(gateway): resolve TS2339 heartbeat property error in server-cron.ts

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -139,10 +139,10 @@ export function buildGatewayCronService(params: {
     const sessionKey =
       opts?.sessionKey && agentId
         ? resolveCronSessionKey({
-          runtimeConfig,
-          agentId,
-          requestedSessionKey: opts.sessionKey,
-        })
+            runtimeConfig,
+            agentId,
+            requestedSessionKey: opts.sessionKey,
+          })
         : undefined;
     return { runtimeConfig, agentId, sessionKey };
   };

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -139,10 +139,10 @@ export function buildGatewayCronService(params: {
     const sessionKey =
       opts?.sessionKey && agentId
         ? resolveCronSessionKey({
-            runtimeConfig,
-            agentId,
-            requestedSessionKey: opts.sessionKey,
-          })
+          runtimeConfig,
+          agentId,
+          requestedSessionKey: opts.sessionKey,
+        })
         : undefined;
     return { runtimeConfig, agentId, sessionKey };
   };
@@ -194,7 +194,7 @@ export function buildGatewayCronService(params: {
         );
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
-        ...agentEntry?.heartbeat,
+        ...(typeof agentEntry === "object" && agentEntry ? agentEntry.heartbeat : undefined),
       };
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }


### PR DESCRIPTION
## What does this PR do?
Fixes a TypeScript compilation error (`TS2339: Property 'heartbeat' does not exist on type 'false | AgentConfig'`) in `src/gateway/server-cron.ts` that is currently failing CI on the `main` branch.

## Why is this needed?
On line 197 of `server-cron.ts`, `agentEntry` can be inferred as the boolean `false` due to the way `runtimeConfig.agents.list.find()` interacts with the type system. Attempting to spread `...agentEntry?.heartbeat` causes `tsc` to fail.

This PR adds a runtime check `typeof agentEntry === "object" && agentEntry` to ensure `agentEntry` is indeed an object before accessing the `.heartbeat` property, satisfying the TypeScript compiler and restoring CI to a passing state.

## How was it tested?
- `pnpm exec tsc --noEmit` passes locally without the `TS2339` error.