### PR TITLE
feat: improve prompt caching for OpenRouter Anthropic models

### DIFF
--- a/src/agents/cache-utilization.test.ts
+++ b/src/agents/cache-utilization.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCacheUtilization,
+  formatCacheUtilizationSummary,
+  type CacheUtilizationMetrics,
+} from "./cache-utilization.js";
+
+describe("computeCacheUtilization", () => {
+  it("computes cache hit ratio when cache read is present", () => {
+    const metrics = computeCacheUtilization({
+      input: 1000,
+      output: 500,
+      cacheRead: 2000,
+      cacheWrite: 300,
+    });
+    expect(metrics.cacheHitTokens).toBe(2000);
+    expect(metrics.cacheMissTokens).toBe(1300); // input + cacheWrite
+    expect(metrics.totalPromptTokens).toBe(3300); // input + cacheRead + cacheWrite
+    expect(metrics.cacheHitRatio).toBeCloseTo(0.606, 2); // 2000 / 3300
+  });
+
+  it("handles zero cache read (all cache misses)", () => {
+    const metrics = computeCacheUtilization({
+      input: 1000,
+      output: 500,
+      cacheRead: 0,
+      cacheWrite: 500,
+    });
+    expect(metrics.cacheHitTokens).toBe(0);
+    expect(metrics.cacheMissTokens).toBe(1500);
+    expect(metrics.totalPromptTokens).toBe(1500);
+    expect(metrics.cacheHitRatio).toBe(0);
+  });
+
+  it("handles all cache hits (warm cache)", () => {
+    const metrics = computeCacheUtilization({
+      input: 0,
+      output: 500,
+      cacheRead: 5000,
+      cacheWrite: 0,
+    });
+    expect(metrics.cacheHitTokens).toBe(5000);
+    expect(metrics.cacheMissTokens).toBe(0);
+    expect(metrics.totalPromptTokens).toBe(5000);
+    expect(metrics.cacheHitRatio).toBe(1);
+  });
+
+  it("handles undefined cache fields", () => {
+    const metrics = computeCacheUtilization({
+      input: 1000,
+      output: 500,
+    });
+    expect(metrics.cacheHitTokens).toBe(0);
+    expect(metrics.cacheMissTokens).toBe(1000);
+    expect(metrics.totalPromptTokens).toBe(1000);
+    expect(metrics.cacheHitRatio).toBe(0);
+  });
+
+  it("handles undefined input", () => {
+    const metrics = computeCacheUtilization({});
+    expect(metrics.cacheHitTokens).toBe(0);
+    expect(metrics.cacheMissTokens).toBe(0);
+    expect(metrics.totalPromptTokens).toBe(0);
+    expect(metrics.cacheHitRatio).toBe(0);
+  });
+
+  it("handles null usage", () => {
+    const metrics = computeCacheUtilization(null);
+    expect(metrics.cacheHitTokens).toBe(0);
+    expect(metrics.cacheMissTokens).toBe(0);
+    expect(metrics.totalPromptTokens).toBe(0);
+    expect(metrics.cacheHitRatio).toBe(0);
+  });
+});
+
+describe("formatCacheUtilizationSummary", () => {
+  it("formats cache utilization as human-readable string", () => {
+    const metrics: CacheUtilizationMetrics = {
+      cacheHitTokens: 2000,
+      cacheMissTokens: 1000,
+      totalPromptTokens: 3000,
+      cacheHitRatio: 0.667,
+    };
+    const summary = formatCacheUtilizationSummary(metrics);
+    expect(summary).toBe("cache: 66.7% hit (2000/3000 tokens)");
+  });
+
+  it("formats zero cache utilization", () => {
+    const metrics: CacheUtilizationMetrics = {
+      cacheHitTokens: 0,
+      cacheMissTokens: 1000,
+      totalPromptTokens: 1000,
+      cacheHitRatio: 0,
+    };
+    const summary = formatCacheUtilizationSummary(metrics);
+    expect(summary).toBe("cache: 0.0% hit (0/1000 tokens)");
+  });
+
+  it("formats perfect cache utilization", () => {
+    const metrics: CacheUtilizationMetrics = {
+      cacheHitTokens: 5000,
+      cacheMissTokens: 0,
+      totalPromptTokens: 5000,
+      cacheHitRatio: 1,
+    };
+    const summary = formatCacheUtilizationSummary(metrics);
+    expect(summary).toBe("cache: 100.0% hit (5000/5000 tokens)");
+  });
+
+  it("returns empty string for zero total tokens", () => {
+    const metrics: CacheUtilizationMetrics = {
+      cacheHitTokens: 0,
+      cacheMissTokens: 0,
+      totalPromptTokens: 0,
+      cacheHitRatio: 0,
+    };
+    const summary = formatCacheUtilizationSummary(metrics);
+    expect(summary).toBe("");
+  });
+});

--- a/src/agents/cache-utilization.ts
+++ b/src/agents/cache-utilization.ts
@@ -1,0 +1,61 @@
+import type { NormalizedUsage } from "./usage.js";
+
+/**
+ * Metrics for cache utilization tracking.
+ */
+export type CacheUtilizationMetrics = {
+  /** Tokens served from cache (cache read) */
+  cacheHitTokens: number;
+  /** Tokens that had to be processed (input + cache write) */
+  cacheMissTokens: number;
+  /** Total prompt tokens (input + cacheRead + cacheWrite) */
+  totalPromptTokens: number;
+  /** Cache hit ratio (0-1) */
+  cacheHitRatio: number;
+};
+
+/**
+ * Compute cache utilization metrics from normalized usage.
+ *
+ * Cache hit ratio = cacheRead / (input + cacheRead + cacheWrite)
+ *
+ * This helps understand how effectively prompt caching is being utilized.
+ * A higher cache hit ratio means more tokens are being served from cache,
+ * reducing both latency and cost.
+ */
+export function computeCacheUtilization(
+  usage: Partial<NormalizedUsage> | null | undefined,
+): CacheUtilizationMetrics {
+  const input = usage?.input ?? 0;
+  const cacheRead = usage?.cacheRead ?? 0;
+  const cacheWrite = usage?.cacheWrite ?? 0;
+
+  const cacheHitTokens = cacheRead;
+  const cacheMissTokens = input + cacheWrite;
+  const totalPromptTokens = input + cacheRead + cacheWrite;
+
+  const cacheHitRatio = totalPromptTokens > 0 ? cacheHitTokens / totalPromptTokens : 0;
+
+  return {
+    cacheHitTokens,
+    cacheMissTokens,
+    totalPromptTokens,
+    cacheHitRatio,
+  };
+}
+
+/**
+ * Format cache utilization metrics as a human-readable summary string.
+ *
+ * Example: "cache: 66.7% hit (2000/3000 tokens)"
+ *
+ * Returns empty string if there are no prompt tokens.
+ */
+export function formatCacheUtilizationSummary(metrics: CacheUtilizationMetrics): string {
+  if (metrics.totalPromptTokens === 0) {
+    return "";
+  }
+
+  const percentage = (metrics.cacheHitRatio * 100).toFixed(1);
+  return `cache: ${percentage}% hit (${metrics.cacheHitTokens}/${metrics.totalPromptTokens} tokens)`;
+}

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-tool-cache.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-tool-cache.test.ts
@@ -1,0 +1,143 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+type StreamPayload = {
+  messages: Array<{
+    role: string;
+    content: unknown;
+  }>;
+  tools?: Array<{
+    name: string;
+    description?: string;
+    input_schema?: unknown;
+    cache_control?: { type: string };
+  }>;
+};
+
+function runOpenRouterPayloadWithTools(payload: StreamPayload, modelId: string) {
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return createAssistantMessageEventStream();
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, "openrouter", modelId);
+
+  const model = {
+    api: "openai-completions",
+    provider: "openrouter",
+    id: modelId,
+  } as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+
+  void agent.streamFn?.(model, context, {});
+}
+
+describe("extra-params: OpenRouter Anthropic tool cache_control", () => {
+  it("injects cache_control into last tool for OpenRouter Anthropic models", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [
+        { name: "read", description: "Read a file" },
+        { name: "write", description: "Write a file" },
+        { name: "exec", description: "Execute a command" },
+      ],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-opus-4-6");
+
+    // Only the last tool should have cache_control
+    expect(payload.tools?.[0].cache_control).toBeUndefined();
+    expect(payload.tools?.[1].cache_control).toBeUndefined();
+    expect(payload.tools?.[2].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("does not inject tool cache_control for OpenRouter non-Anthropic models", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [
+        { name: "read", description: "Read a file" },
+        { name: "write", description: "Write a file" },
+      ],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "google/gemini-3-pro");
+
+    expect(payload.tools?.[0].cache_control).toBeUndefined();
+    expect(payload.tools?.[1].cache_control).toBeUndefined();
+  });
+
+  it("handles empty tools array", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-opus-4-6");
+
+    expect(payload.tools).toEqual([]);
+  });
+
+  it("handles single tool", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [{ name: "read", description: "Read a file" }],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-opus-4-6");
+
+    expect(payload.tools?.[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("handles payload without tools property", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-opus-4-6");
+
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("does not overwrite existing cache_control on tools", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [
+        { name: "read", description: "Read a file", cache_control: { type: "ephemeral" } },
+        { name: "write", description: "Write a file" },
+      ],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-opus-4-6");
+
+    // First tool keeps its existing cache_control
+    expect(payload.tools?.[0].cache_control).toEqual({ type: "ephemeral" });
+    // Last tool gets cache_control added
+    expect(payload.tools?.[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("handles claude-sonnet models", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [{ name: "read", description: "Read a file" }],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-sonnet-4");
+
+    expect(payload.tools?.[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("handles claude-haiku models", () => {
+    const payload: StreamPayload = {
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [{ name: "read", description: "Read a file" }],
+    };
+
+    runOpenRouterPayloadWithTools(payload, "anthropic/claude-3.5-haiku");
+
+    expect(payload.tools?.[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -442,10 +442,21 @@ type PayloadMessage = {
   content?: unknown;
 };
 
+type PayloadTool = {
+  name?: string;
+  description?: string;
+  input_schema?: unknown;
+  cache_control?: { type: string };
+};
+
 /**
- * Inject cache_control into the system message for OpenRouter Anthropic models.
+ * Inject cache_control into the system message and tools for OpenRouter Anthropic models.
  * OpenRouter passes through Anthropic's cache_control field — caching the system
- * prompt avoids re-processing it on every request.
+ * prompt and tool definitions avoids re-processing them on every request.
+ *
+ * For tools, we inject cache_control on the last tool only. This creates a single
+ * cache breakpoint that covers all tool definitions, following Anthropic's
+ * recommendation for optimal caching behavior.
  */
 function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -462,7 +473,10 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
     return underlying(model, context, {
       ...options,
       onPayload: (payload) => {
-        const messages = (payload as Record<string, unknown>)?.messages;
+        const payloadObj = payload as Record<string, unknown>;
+
+        // Inject cache_control into system messages
+        const messages = payloadObj?.messages;
         if (Array.isArray(messages)) {
           for (const msg of messages as PayloadMessage[]) {
             if (msg.role !== "system" && msg.role !== "developer") {
@@ -480,6 +494,17 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
             }
           }
         }
+
+        // Inject cache_control into the last tool definition
+        // This creates a single cache breakpoint covering all tools
+        const tools = payloadObj?.tools;
+        if (Array.isArray(tools) && tools.length > 0) {
+          const lastTool = tools[tools.length - 1] as PayloadTool;
+          if (lastTool && typeof lastTool === "object") {
+            lastTool.cache_control = { type: "ephemeral" };
+          }
+        }
+
         originalOnPayload?.(payload);
       },
     });


### PR DESCRIPTION
## Summary

This PR improves prompt caching for OpenRouter Anthropic models with two enhancements:

### 1. Tool Definition Caching

Adds `cache_control` injection for tool definitions when using OpenRouter Anthropic models. Previously, only system prompts were cached. Now tool definitions are also cached by placing a single cache breakpoint on the last tool, following Anthropic's recommended strategy.

### 2. Cache Utilization Metrics Module

Adds a new `cache-utilization.ts` module with:
- `computeCacheUtilization()` - calculates cache hit ratio and token breakdown
- `formatCacheUtilizationSummary()` - formats metrics as human-readable string

This provides better observability for understanding how effectively prompt caching is being utilized.

## Changes

- `src/agents/pi-embedded-runner/extra-params.ts`: Extended `createOpenRouterSystemCacheWrapper` to also inject `cache_control` on tools
- `src/agents/cache-utilization.ts`: New module for cache utilization metrics
- Added comprehensive test coverage for both features

## Testing

- 8 new tests for tool caching behavior
- 10 new tests for cache utilization metrics
- All existing tests continue to pass

## Related Ticket

Closes: should we revisit prompt caching