### PR TITLE
docs(plugins): add Canvas LMS community plugin listing

### DIFF
--- a/docs/canvas-security-review.md
+++ b/docs/canvas-security-review.md
@@ -12,8 +12,8 @@ read_when:
 
 This review covers the OpenClaw core repository. The Canvas LMS integration is a community plugin hosted externally at:
 
-- npm: @kansodata/openclaw-canvas-lms
-- repo: https://github.com/Kansodata/openclaw-canvas-lms
+- npm: `@kansodata/openclaw-canvas-lms`
+- repo: [Kansodata/openclaw-canvas-lms](https://github.com/Kansodata/openclaw-canvas-lms)
 
 This repo only lists the plugin in community docs. There is no Canvas LMS integration code in this repository, so code level verification must occur in the plugin repository.
 

--- a/docs/canvas-security-review.md
+++ b/docs/canvas-security-review.md
@@ -1,0 +1,71 @@
+---
+summary: "Security and compliance review notes for the Canvas LMS community integration"
+read_when:
+  - You are reviewing or maintaining the Canvas LMS community integration
+  - You want the security and compliance status of the Canvas LMS plugin
+  - You need to understand what is verified in this repo versus external dependencies
+---
+
+# Canvas LMS security review
+
+## Scope and limits
+
+This review covers the OpenClaw core repository. The Canvas LMS integration is a community plugin hosted externally at:
+
+- npm: @kansodata/openclaw-canvas-lms
+- repo: https://github.com/Kansodata/openclaw-canvas-lms
+
+This repo only lists the plugin in community docs. There is no Canvas LMS integration code in this repository, so code level verification must occur in the plugin repository.
+
+## Repo audit summary
+
+- Canvas related files in this repo are for OpenClaw Canvas UI tooling, not Canvas LMS integration.
+- The only Canvas LMS reference in this repo is the community plugins listing.
+
+## Findings
+
+### Critical
+
+- None found in this repository for Canvas LMS integration.
+
+### High
+
+- Integration code lives outside this repo, so authentication flow, token storage, scopes, logging, and authorization cannot be verified here.
+
+### Medium
+
+- None found in this repository for Canvas LMS integration.
+
+### Low
+
+- None found in this repository for Canvas LMS integration.
+
+## Quick wins completed in this repo
+
+- Added explicit LMS security expectations to the community plugins documentation to align with safe integration practices.
+
+## Remediation plan for the external plugin
+
+These items require changes in the plugin repository. They are not verifiable in this repo:
+
+- Ensure OAuth2 with Developer Key and minimum scopes is the default path.
+- Avoid manual personal access token flows for multi user setups.
+- Implement PKCE and state validation for OAuth flows.
+- Store tokens in a secure secret store and never log them.
+- Add tests for token redaction, scope validation, and tenant isolation.
+- Document required scopes, data boundaries, and admin setup steps.
+
+## Residual risks and external dependencies
+
+- Canvas Developer Key, OAuth scopes, and institutional policy are configured outside this repo.
+- Secure storage depends on the runtime environment and plugin host configuration.
+- Multi tenant isolation must be enforced in the plugin code and deployment.
+
+## Manual steps pending
+
+- Perform a full security and architecture audit in the plugin repository.
+- Validate OAuth configuration and token lifecycle in a real Canvas tenant.
+
+## Evidence
+
+- docs/plugins/community.md

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -34,6 +34,14 @@ Open a PR that adds your plugin to this page with:
 We prefer plugins that are useful, documented, and safe to operate.
 Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
 
+## Security expectations for LMS integrations
+
+- Use the official Canvas API and avoid scraping.
+- Do not ask users for Canvas username or password.
+- Prefer OAuth2 with a Developer Key and minimum required scopes.
+- Store tokens securely and never log or expose them in errors or UI.
+- Document required scopes, data access boundaries, and any admin setup.
+
 ## Candidate format
 
 Use this format when adding entries:

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Canvas LMS** — Adds Canvas LMS tools for university workflows including courses, assignments, submissions, announcements, files, grades, and calendar events.
+  npm: `@kansodata/openclaw-canvas-lms`
+  repo: `https://github.com/Kansodata/openclaw-canvas-lms`
+  install: `openclaw plugins install @kansodata/openclaw-canvas-lms`


### PR DESCRIPTION
## Summary

- Problem: Canvas LMS plugin was available externally but not listed in OpenClaw community plugins docs.
- Why it matters: users could not discover/install the plugin from the official community index.
- What changed: added `@kansodata/openclaw-canvas-lms` entry to community plugins page with npm package, repo URL, and install command.
- Scope boundary: docs-only update; no runtime or core behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

Users can now find and install the Canvas LMS community plugin from docs.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Validated the published npm package exists and install command resolves:
- `npm view @kansodata/openclaw-canvas-lms version`

## Canvas LMS compliance security review

- Added LMS security expectations to community plugin docs.
- Added `docs/canvas-security-review.md` with audit scope, findings, and external action items.
- No Canvas LMS integration code exists in this repo; full code audit remains in the plugin repository.
