### PR TITLE
feat: add openclaw update cron subcommand for automatic updates

### DIFF
--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -4,6 +4,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { formatHelpExamples } from "./help-format.js";
+import { registerUpdateCronCommand } from "./update-cli/cron.js";
 import {
   type UpdateCommandOptions,
   type UpdateStatusOptions,
@@ -149,4 +150,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
         defaultRuntime.exit(1);
       }
     });
+
+  // Register the cron subcommand for automatic updates
+  registerUpdateCronCommand(update);
 }

--- a/src/cli/update-cli/cron.test.ts
+++ b/src/cli/update-cli/cron.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
+
+// Mock modules before imports
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../gateway-rpc.js", () => ({
+  callGatewayFromCli: vi.fn(),
+  addGatewayClientOptions: vi.fn((cmd) => cmd),
+}));
+
+import { Command } from "commander";
+import { defaultRuntime } from "../../runtime.js";
+import { callGatewayFromCli } from "../gateway-rpc.js";
+import { registerUpdateCronCommand, UPDATE_CRON_JOB_NAME } from "./cron.js";
+
+describe("update cron", () => {
+  let parentCommand: Command;
+  let mockCallGateway: Mock;
+  let mockLog: Mock;
+  let mockError: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parentCommand = new Command("update");
+    registerUpdateCronCommand(parentCommand);
+    mockCallGateway = callGatewayFromCli as Mock;
+    mockLog = defaultRuntime.log as Mock;
+    mockError = defaultRuntime.error as Mock;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constants", () => {
+    it("exports the cron job name constant", () => {
+      expect(UPDATE_CRON_JOB_NAME).toBe("openclaw-auto-update");
+    });
+  });
+
+  describe("enable subcommand", () => {
+    it("creates a cron job for automatic updates with default schedule", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true, job: { name: UPDATE_CRON_JOB_NAME } });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith(
+        "cron.add",
+        expect.anything(),
+        expect.objectContaining({
+          name: UPDATE_CRON_JOB_NAME,
+          description: "Automatic OpenClaw updates",
+          enabled: true,
+          sessionTarget: "main",
+          payload: {
+            kind: "systemEvent",
+            text: expect.stringContaining("openclaw update"),
+          },
+        }),
+      );
+    });
+
+    it("uses daily schedule by default (4am)", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith(
+        "cron.add",
+        expect.anything(),
+        expect.objectContaining({
+          schedule: expect.objectContaining({
+            kind: "cron",
+            expr: "0 4 * * *",
+          }),
+        }),
+      );
+    });
+
+    it("accepts custom schedule via --schedule", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync([
+        "node",
+        "update",
+        "cron",
+        "enable",
+        "--schedule",
+        "0 2 * * 0",
+      ]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith(
+        "cron.add",
+        expect.anything(),
+        expect.objectContaining({
+          schedule: expect.objectContaining({
+            kind: "cron",
+            expr: "0 2 * * 0",
+          }),
+        }),
+      );
+    });
+
+    it("accepts --channel to persist update channel", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable", "--channel", "beta"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith(
+        "cron.add",
+        expect.anything(),
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            text: expect.stringContaining("--channel beta"),
+          }),
+        }),
+      );
+    });
+
+    it("accepts --every for interval-based scheduling", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable", "--every", "12h"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith(
+        "cron.add",
+        expect.anything(),
+        expect.objectContaining({
+          schedule: expect.objectContaining({
+            kind: "every",
+          }),
+        }),
+      );
+    });
+
+    it("removes existing job before creating new one", async () => {
+      mockCallGateway
+        .mockResolvedValueOnce({ ok: true }) // delete existing
+        .mockResolvedValueOnce({ ok: true }); // add new
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith("cron.delete", expect.anything(), {
+        name: UPDATE_CRON_JOB_NAME,
+      });
+    });
+
+    it("outputs success message", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("enabled"));
+    });
+  });
+
+  describe("disable subcommand", () => {
+    it("deletes the update cron job", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "disable"]);
+
+      expect(mockCallGateway).toHaveBeenCalledWith("cron.delete", expect.anything(), {
+        name: UPDATE_CRON_JOB_NAME,
+      });
+    });
+
+    it("outputs success message", async () => {
+      mockCallGateway.mockResolvedValue({ ok: true });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "disable"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("disabled"));
+    });
+
+    it("handles already-disabled gracefully", async () => {
+      mockCallGateway.mockRejectedValue(new Error("Job not found"));
+
+      await parentCommand.parseAsync(["node", "update", "cron", "disable"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("not configured"));
+    });
+  });
+
+  describe("status subcommand", () => {
+    it("shows enabled status when job exists", async () => {
+      mockCallGateway.mockResolvedValue({
+        jobs: [
+          {
+            name: UPDATE_CRON_JOB_NAME,
+            enabled: true,
+            schedule: { kind: "cron", expr: "0 4 * * *" },
+            nextRun: "2026-03-01T04:00:00Z",
+          },
+        ],
+      });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "status"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Enabled"));
+    });
+
+    it("shows disabled status when job does not exist", async () => {
+      mockCallGateway.mockResolvedValue({ jobs: [] });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "status"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Disabled"));
+    });
+
+    it("shows schedule in human-readable format", async () => {
+      mockCallGateway.mockResolvedValue({
+        jobs: [
+          {
+            name: UPDATE_CRON_JOB_NAME,
+            enabled: true,
+            schedule: { kind: "cron", expr: "0 4 * * *" },
+          },
+        ],
+      });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "status"]);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("0 4 * * *"));
+    });
+
+    it("supports --json output", async () => {
+      mockCallGateway.mockResolvedValue({
+        jobs: [
+          {
+            name: UPDATE_CRON_JOB_NAME,
+            enabled: true,
+            schedule: { kind: "cron", expr: "0 4 * * *" },
+          },
+        ],
+      });
+
+      await parentCommand.parseAsync(["node", "update", "cron", "status", "--json"]);
+
+      const logCalls = mockLog.mock.calls;
+      const jsonOutput = logCalls.find((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonOutput).toBeDefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("reports gateway errors on enable", async () => {
+      mockCallGateway.mockRejectedValue(new Error("Gateway unavailable"));
+
+      await parentCommand.parseAsync(["node", "update", "cron", "enable"]);
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Gateway unavailable"));
+    });
+
+    it("reports gateway errors on status", async () => {
+      mockCallGateway.mockRejectedValue(new Error("Gateway unavailable"));
+
+      await parentCommand.parseAsync(["node", "update", "cron", "status"]);
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Gateway unavailable"));
+    });
+  });
+});

--- a/src/cli/update-cli/cron.ts
+++ b/src/cli/update-cli/cron.ts
@@ -1,0 +1,250 @@
+import type { Command } from "commander";
+import type { CronJob } from "../../cron/types.js";
+import { danger, success } from "../../globals.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { parseDurationMs } from "../cron-cli/shared.js";
+import type { GatewayRpcOpts } from "../gateway-rpc.js";
+import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+
+/** The well-known name for the automatic update cron job. */
+export const UPDATE_CRON_JOB_NAME = "openclaw-auto-update";
+
+/** Default cron schedule: daily at 4am */
+const DEFAULT_CRON_SCHEDULE = "0 4 * * *";
+
+interface EnableOptions extends GatewayRpcOpts {
+  schedule?: string;
+  every?: string;
+  channel?: string;
+  json?: boolean;
+}
+
+interface StatusOptions extends GatewayRpcOpts {
+  json?: boolean;
+}
+
+/**
+ * Build the system event text for the update cron job.
+ * This runs `openclaw update` with optional channel flag.
+ */
+function buildUpdateCommand(channel?: string): string {
+  const parts = ["openclaw update --yes"];
+  if (channel) {
+    parts.push(`--channel ${channel}`);
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Try to delete an existing update cron job (ignore errors if not found).
+ */
+async function deleteExistingJob(opts: GatewayRpcOpts): Promise<void> {
+  try {
+    await callGatewayFromCli("cron.delete", opts, { name: UPDATE_CRON_JOB_NAME });
+  } catch {
+    // Ignore - job may not exist
+  }
+}
+
+async function enableUpdateCron(opts: EnableOptions): Promise<void> {
+  try {
+    // Remove existing job first (idempotent)
+    await deleteExistingJob(opts);
+
+    // Determine schedule
+    const schedule = (() => {
+      if (opts.every) {
+        const everyMs = parseDurationMs(opts.every);
+        if (!everyMs) {
+          throw new Error("Invalid --every; use e.g. 12h, 1d");
+        }
+        return { kind: "every" as const, everyMs };
+      }
+      const expr = opts.schedule || DEFAULT_CRON_SCHEDULE;
+      return { kind: "cron" as const, expr };
+    })();
+
+    // Build the update command
+    const commandText = buildUpdateCommand(opts.channel);
+
+    // Create the cron job
+    const params = {
+      name: UPDATE_CRON_JOB_NAME,
+      description: "Automatic OpenClaw updates",
+      enabled: true,
+      sessionTarget: "main" as const,
+      wakeMode: "now" as const,
+      schedule,
+      payload: {
+        kind: "systemEvent" as const,
+        text: commandText,
+      },
+    };
+
+    const res = await callGatewayFromCli("cron.add", opts, params);
+
+    if (opts.json) {
+      defaultRuntime.log(JSON.stringify({ enabled: true, ...res }, null, 2));
+    } else {
+      const scheduleDesc =
+        schedule.kind === "every" ? `every ${opts.every}` : `schedule: ${schedule.expr}`;
+      defaultRuntime.log(success(`Automatic updates enabled (${scheduleDesc})`));
+      if (opts.channel) {
+        defaultRuntime.log(theme.muted(`Update channel: ${opts.channel}`));
+      }
+    }
+  } catch (err) {
+    defaultRuntime.error(danger(String(err)));
+    defaultRuntime.exit(1);
+  }
+}
+
+async function disableUpdateCron(opts: GatewayRpcOpts & { json?: boolean }): Promise<void> {
+  try {
+    await callGatewayFromCli("cron.delete", opts, { name: UPDATE_CRON_JOB_NAME });
+
+    if (opts.json) {
+      defaultRuntime.log(JSON.stringify({ enabled: false }, null, 2));
+    } else {
+      defaultRuntime.log(success("Automatic updates disabled"));
+    }
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("not found") || msg.includes("Not found")) {
+      if (opts.json) {
+        defaultRuntime.log(JSON.stringify({ enabled: false, wasConfigured: false }, null, 2));
+      } else {
+        defaultRuntime.log(theme.muted("Automatic updates not configured"));
+      }
+    } else {
+      defaultRuntime.error(danger(msg));
+      defaultRuntime.exit(1);
+    }
+  }
+}
+
+async function showUpdateCronStatus(opts: StatusOptions): Promise<void> {
+  try {
+    const res = (await callGatewayFromCli("cron.list", opts, {
+      includeDisabled: true,
+    })) as { jobs?: CronJob[] } | null;
+
+    const jobs = res?.jobs ?? [];
+    const updateJob = jobs.find((j) => j.name === UPDATE_CRON_JOB_NAME);
+
+    if (opts.json) {
+      defaultRuntime.log(
+        JSON.stringify(
+          {
+            enabled: Boolean(updateJob?.enabled),
+            configured: Boolean(updateJob),
+            job: updateJob ?? null,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    if (!updateJob) {
+      defaultRuntime.log(`${theme.heading("Automatic Updates:")} ${theme.muted("Disabled")}`);
+      defaultRuntime.log(
+        theme.muted(
+          `\nRun ${theme.command("openclaw update cron enable")} to enable automatic updates.`,
+        ),
+      );
+      return;
+    }
+
+    const statusText = updateJob.enabled ? theme.success("Enabled") : theme.warning("Paused");
+    defaultRuntime.log(`${theme.heading("Automatic Updates:")} ${statusText}`);
+
+    // Show schedule
+    const schedule = updateJob.schedule;
+    if (schedule) {
+      if ("expr" in schedule && schedule.expr) {
+        defaultRuntime.log(`${theme.muted("Schedule:")} ${schedule.expr}`);
+      } else if ("everyMs" in schedule && schedule.everyMs) {
+        const hours = Math.round(schedule.everyMs / 3600000);
+        defaultRuntime.log(`${theme.muted("Schedule:")} every ${hours}h`);
+      }
+    }
+
+    // Show next run
+    if (updateJob.nextRun) {
+      const nextRun = new Date(updateJob.nextRun);
+      defaultRuntime.log(`${theme.muted("Next run:")} ${nextRun.toLocaleString()}`);
+    }
+
+    // Show last run
+    if (updateJob.lastRun) {
+      const lastRun = new Date(updateJob.lastRun);
+      defaultRuntime.log(`${theme.muted("Last run:")} ${lastRun.toLocaleString()}`);
+    }
+  } catch (err) {
+    defaultRuntime.error(danger(String(err)));
+    defaultRuntime.exit(1);
+  }
+}
+
+export function registerUpdateCronCommand(parent: Command): void {
+  const cron = parent
+    .command("cron")
+    .description("Manage automatic update scheduling")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}
+  ${theme.command("openclaw update cron enable")}           ${theme.muted("# Enable daily updates at 4am")}
+  ${theme.command("openclaw update cron enable --every 12h")} ${theme.muted("# Update every 12 hours")}
+  ${theme.command("openclaw update cron enable --schedule '0 2 * * 0'")} ${theme.muted("# Weekly on Sunday 2am")}
+  ${theme.command("openclaw update cron disable")}          ${theme.muted("# Disable automatic updates")}
+  ${theme.command("openclaw update cron status")}           ${theme.muted("# Show current status")}
+
+${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
+    );
+
+  addGatewayClientOptions(
+    cron
+      .command("enable")
+      .description("Enable automatic updates via cron")
+      .option(
+        "--schedule <cron>",
+        `Cron expression (default: "${DEFAULT_CRON_SCHEDULE}" = daily 4am)`,
+      )
+      .option("--every <duration>", "Run every duration (e.g. 12h, 1d)")
+      .option("--channel <stable|beta|dev>", "Update channel to use")
+      .option("--json", "Output JSON", false)
+      .action(async (opts: EnableOptions) => {
+        if (opts.schedule && opts.every) {
+          defaultRuntime.error(danger("Choose either --schedule or --every, not both"));
+          defaultRuntime.exit(1);
+          return;
+        }
+        await enableUpdateCron(opts);
+      }),
+  );
+
+  addGatewayClientOptions(
+    cron
+      .command("disable")
+      .description("Disable automatic updates")
+      .option("--json", "Output JSON", false)
+      .action(async (opts: GatewayRpcOpts & { json?: boolean }) => {
+        await disableUpdateCron(opts);
+      }),
+  );
+
+  addGatewayClientOptions(
+    cron
+      .command("status")
+      .description("Show automatic update status")
+      .option("--json", "Output JSON", false)
+      .action(async (opts: StatusOptions) => {
+        await showUpdateCronStatus(opts);
+      }),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new `openclaw update cron` subcommand that allows users to schedule automatic OpenClaw updates via the cron system.

## Commands

- `openclaw update cron enable` - Enable automatic updates (daily 4am default)
- `openclaw update cron enable --every 12h` - Update every 12 hours
- `openclaw update cron enable --schedule '0 2 * * 0'` - Custom cron schedule
- `openclaw update cron enable --channel beta` - Use specific update channel
- `openclaw update cron disable` - Disable automatic updates
- `openclaw update cron status` - Show current status

## Features

- Creates a well-known cron job `openclaw-auto-update`
- Supports cron expressions and interval-based scheduling
- Integrates with existing update command (`--yes` flag for non-interactive)
- JSON output support for scripting
- Idempotent: re-enabling replaces the existing job

## Testing

Includes comprehensive test coverage with 17 tests covering:
- Enable/disable functionality
- Schedule customization
- Channel configuration
- Status reporting
- Error handling

## Related

Notion ticket: https://www.notion.so/openclaw-update-cron-3157eb0c1292809994ffcc24cb4fc836