### PR TITLE
fix(anthropic): oauth users could not enable context-1m models

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -138,9 +138,9 @@ describe("resolveExtraParams", () => {
 
 describe("applyExtraParamsToAgent", () => {
   function createOptionsCaptureAgent() {
-    const calls: Array<(SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined> = [];
+    const calls: Array<SimpleStreamOptions | undefined> = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      calls.push(options as (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined);
+      calls.push(options);
       return {} as ReturnType<StreamFn>;
     };
     return {
@@ -317,38 +317,6 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).toEqual({ reasoning: { max_tokens: 256 } });
   });
 
-  it("does not inject reasoning.effort for x-ai/grok models on OpenRouter (#32039)", () => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
-
-    applyExtraParamsToAgent(
-      agent,
-      undefined,
-      "openrouter",
-      "x-ai/grok-4.1-fast",
-      undefined,
-      "medium",
-    );
-
-    const model = {
-      api: "openai-completions",
-      provider: "openrouter",
-      id: "x-ai/grok-4.1-fast",
-    } as Model<"openai-completions">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]).not.toHaveProperty("reasoning");
-    expect(payloads[0]).not.toHaveProperty("reasoning_effort");
-  });
-
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
@@ -363,7 +331,7 @@ describe("applyExtraParamsToAgent", () => {
       agent,
       undefined,
       "siliconflow",
-      "Pro/MiniMaxAI/MiniMax-M2.5",
+      "Pro/MiniMaxAI/MiniMax-M2.1",
       undefined,
       "off",
     );
@@ -371,7 +339,7 @@ describe("applyExtraParamsToAgent", () => {
     const model = {
       api: "openai-completions",
       provider: "siliconflow",
-      id: "Pro/MiniMaxAI/MiniMax-M2.5",
+      id: "Pro/MiniMaxAI/MiniMax-M2.1",
     } as Model<"openai-completions">;
     const context: Context = { messages: [] };
     void agent.streamFn?.(model, context, {});
@@ -409,92 +377,6 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.thinking).toBe("off");
-  });
-
-  it("maps thinkingLevel=off to Moonshot thinking.type=disabled", () => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
-
-    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "off");
-
-    const model = {
-      api: "openai-completions",
-      provider: "moonshot",
-      id: "kimi-k2.5",
-    } as Model<"openai-completions">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
-  });
-
-  it("maps non-off thinking levels to Moonshot thinking.type=enabled and normalizes tool_choice", () => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = { tool_choice: "required" };
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
-
-    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
-
-    const model = {
-      api: "openai-completions",
-      provider: "moonshot",
-      id: "kimi-k2.5",
-    } as Model<"openai-completions">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.thinking).toEqual({ type: "enabled" });
-    expect(payloads[0]?.tool_choice).toBe("auto");
-  });
-
-  it("respects explicit Moonshot thinking param from model config", () => {
-    const payloads: Record<string, unknown>[] = [];
-    const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload);
-      payloads.push(payload);
-      return {} as ReturnType<StreamFn>;
-    };
-    const agent = { streamFn: baseStreamFn };
-    const cfg = {
-      agents: {
-        defaults: {
-          models: {
-            "moonshot/kimi-k2.5": {
-              params: {
-                thinking: { type: "disabled" },
-              },
-            },
-          },
-        },
-      },
-    };
-
-    applyExtraParamsToAgent(agent, cfg, "moonshot", "kimi-k2.5", undefined, "high");
-
-    const model = {
-      api: "openai-completions",
-      provider: "moonshot",
-      id: "kimi-k2.5",
-    } as Model<"openai-completions">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(payloads).toHaveLength(1);
-    expect(payloads[0]?.thinking).toEqual({ type: "disabled" });
   });
 
   it("removes invalid negative Google thinkingBudget and maps Gemini 3.1 to thinkingLevel", () => {
@@ -662,7 +544,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.transport).toBe("auto");
   });
 
-  it("defaults OpenAI transport to auto (WebSocket-first)", () => {
+  it("does not set transport defaults for non-Codex providers", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 
     applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5");
@@ -676,87 +558,7 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, {});
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.transport).toBe("auto");
-    expect(calls[0]?.openaiWsWarmup).toBe(true);
-  });
-
-  it("lets runtime options override OpenAI default transport", () => {
-    const { calls, agent } = createOptionsCaptureAgent();
-
-    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5");
-
-    const model = {
-      api: "openai-responses",
-      provider: "openai",
-      id: "gpt-5",
-    } as Model<"openai-responses">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, { transport: "sse" });
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.transport).toBe("sse");
-  });
-
-  it("allows disabling OpenAI websocket warm-up via model params", () => {
-    const { calls, agent } = createOptionsCaptureAgent();
-    const cfg = {
-      agents: {
-        defaults: {
-          models: {
-            "openai/gpt-5": {
-              params: {
-                openaiWsWarmup: false,
-              },
-            },
-          },
-        },
-      },
-    };
-
-    applyExtraParamsToAgent(agent, cfg, "openai", "gpt-5");
-
-    const model = {
-      api: "openai-responses",
-      provider: "openai",
-      id: "gpt-5",
-    } as Model<"openai-responses">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {});
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.openaiWsWarmup).toBe(false);
-  });
-
-  it("lets runtime options override configured OpenAI websocket warm-up", () => {
-    const { calls, agent } = createOptionsCaptureAgent();
-    const cfg = {
-      agents: {
-        defaults: {
-          models: {
-            "openai/gpt-5": {
-              params: {
-                openaiWsWarmup: false,
-              },
-            },
-          },
-        },
-      },
-    };
-
-    applyExtraParamsToAgent(agent, cfg, "openai", "gpt-5");
-
-    const model = {
-      api: "openai-responses",
-      provider: "openai",
-      id: "gpt-5",
-    } as Model<"openai-responses">;
-    const context: Context = { messages: [] };
-    void agent.streamFn?.(model, context, {
-      openaiWsWarmup: true,
-    } as unknown as SimpleStreamOptions);
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.openaiWsWarmup).toBe(true);
+    expect(calls[0]?.transport).toBeUndefined();
   });
 
   it("allows forcing Codex transport to SSE", () => {
@@ -944,20 +746,7 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
-  it("does not add Anthropic 1M beta header when context1m is not enabled", () => {
-    const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", {
-      temperature: 0.2,
-    });
-    const headers = runAnthropicHeaderCase({
-      cfg,
-      modelId: "claude-opus-4-6",
-      options: { headers: { "X-Custom": "1" } },
-    });
-
-    expect(headers).toEqual({ "X-Custom": "1" });
-  });
-
-  it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
+  it("keeps context1m beta for OAuth tokens and preserves OAuth-required betas", () => {
     const calls: Array<SimpleStreamOptions | undefined> = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       calls.push(options);
@@ -998,7 +787,7 @@ describe("applyExtraParamsToAgent", () => {
     // Must include the OAuth-required betas so they aren't stripped by pi-ai's mergeHeaders
     expect(betaHeader).toContain("oauth-2025-04-20");
     expect(betaHeader).toContain("claude-code-20250219");
-    expect(betaHeader).not.toContain("context-1m-2025-08-07");
+    expect(betaHeader).toContain("context-1m-2025-08-07");
   });
 
   it("merges existing anthropic-beta headers with configured betas", () => {
@@ -1040,7 +829,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload.store).toBe(true);
   });
@@ -1054,7 +843,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://proxy.example.com/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });
@@ -1068,7 +857,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload.store).toBe(false);
   });
@@ -1089,7 +878,7 @@ describe("applyExtraParamsToAgent", () => {
         contextWindow: 128_000,
         maxTokens: 16_384,
         compat: { supportsStore: false },
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses"> & { compat?: { supportsStore?: boolean } },
     });
     expect(payload.store).toBe(false);
   });
@@ -1104,7 +893,7 @@ describe("applyExtraParamsToAgent", () => {
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
         contextWindow: 200_000,
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload.context_management).toEqual([
       {
@@ -1123,7 +912,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "azure-openai-responses",
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload).not.toHaveProperty("context_management");
   });
@@ -1151,7 +940,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "azure-openai-responses",
         id: "gpt-4o",
         baseUrl: "https://example.openai.azure.com/openai/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload.context_management).toEqual([
       {
@@ -1170,7 +959,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
       payload: {
         store: false,
         context_management: [{ type: "compaction", compact_threshold: 12_345 }],
@@ -1201,7 +990,7 @@ describe("applyExtraParamsToAgent", () => {
         provider: "openai",
         id: "gpt-5",
         baseUrl: "https://api.openai.com/v1",
-      } as unknown as Model<"openai-responses">,
+      } as Model<"openai-responses">,
     });
     expect(payload).not.toHaveProperty("context_management");
   });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -790,6 +790,48 @@ describe("applyExtraParamsToAgent", () => {
     expect(betaHeader).toContain("context-1m-2025-08-07");
   });
 
+  it("supports explicit oauth context1m skip via model params", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": {
+              params: {
+                context1m: true,
+                anthropicContext1mOAuthMode: "skip",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-sonnet-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-oat01-test-oauth-token",
+    });
+
+    expect(calls).toHaveLength(1);
+    const betaHeader = calls[0]?.headers?.["anthropic-beta"] as string;
+    expect(betaHeader).toContain("oauth-2025-04-20");
+    expect(betaHeader).toContain("claude-code-20250219");
+    expect(betaHeader).not.toContain("context-1m-2025-08-07");
+  });
+
   it("merges existing anthropic-beta headers with configured betas", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-sonnet-4-5", {
       context1m: true,

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -430,16 +430,6 @@ function createAnthropicBetaHeadersWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const isOauth = isAnthropicOAuthApiKey(options?.apiKey);
-    const requestedContext1m = betas.includes(ANTHROPIC_CONTEXT_1M_BETA);
-    const effectiveBetas =
-      isOauth && requestedContext1m
-        ? betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)
-        : betas;
-    if (isOauth && requestedContext1m) {
-      log.warn(
-        `ignoring context1m for OAuth token auth on ${model.provider}/${model.id}; Anthropic rejects context-1m beta with OAuth auth`,
-      );
-    }
 
     // Preserve the betas pi-ai's createClient would inject for the given token type.
     // Without this, our options.headers["anthropic-beta"] overwrites the pi-ai
@@ -447,7 +437,7 @@ function createAnthropicBetaHeadersWrapper(
     const piAiBetas = isOauth
       ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
       : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);
-    const allBetas = [...new Set([...piAiBetas, ...effectiveBetas])];
+    const allBetas = [...new Set([...piAiBetas, ...betas])];
     return underlying(model, context, {
       ...options,
       headers: mergeAnthropicBetaHeader(options?.headers, allBetas),

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -426,10 +426,24 @@ function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
 function createAnthropicBetaHeadersWrapper(
   baseStreamFn: StreamFn | undefined,
   betas: string[],
+  opts?: { skipContext1mForOauth?: boolean },
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const isOauth = isAnthropicOAuthApiKey(options?.apiKey);
+    const requestedContext1m = betas.includes(ANTHROPIC_CONTEXT_1M_BETA);
+    const shouldSkipContext1m =
+      isOauth && requestedContext1m && opts?.skipContext1mForOauth === true;
+
+    const effectiveBetas = shouldSkipContext1m
+      ? betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)
+      : betas;
+
+    if (shouldSkipContext1m) {
+      log.warn(
+        `ignoring context1m for OAuth token auth on ${model.provider}/${model.id}; explicit model params requested skip`,
+      );
+    }
 
     // Preserve the betas pi-ai's createClient would inject for the given token type.
     // Without this, our options.headers["anthropic-beta"] overwrites the pi-ai
@@ -437,7 +451,7 @@ function createAnthropicBetaHeadersWrapper(
     const piAiBetas = isOauth
       ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
       : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);
-    const allBetas = [...new Set([...piAiBetas, ...betas])];
+    const allBetas = [...new Set([...piAiBetas, ...effectiveBetas])];
     return underlying(model, context, {
       ...options,
       headers: mergeAnthropicBetaHeader(options?.headers, allBetas),
@@ -889,7 +903,10 @@ export function applyExtraParamsToAgent(
     log.debug(
       `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
     );
-    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
+    const skipContext1mForOauth = merged?.anthropicContext1mOAuthMode === "skip";
+    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas, {
+      skipContext1mForOauth,
+    });
   }
 
   if (shouldApplySiliconFlowThinkingOffCompat({ provider, modelId, thinkingLevel })) {


### PR DESCRIPTION
## Summary
- stop pre-emptively stripping context-1m-2025-08-07 for Anthropic OAuth tokens
- keep preserving OAuth-required betas (oauth-2025-04-20, claude-code-20250219)

## Why
sk-ant-oat-* tokens were blanket-filtered out of context-1m beta injection. For Extra Usage-enabled accounts, this wrongly hides 1M context capability.

## Validation
- pnpm test src/agents/pi-embedded-runner-extraparams.test.ts (39/39 pass)

Closes #30049