### PR TITLE
docs: add D-Chat/nMobile community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **D-Chat / nMobile** — Decentralized E2E encrypted messaging over the NKN relay network. Supports DM, topics, private groups, and IPFS media.
+  npm: `@zbruceli/openclaw-dchat`
+  repo: `https://github.com/zbruceli/openclaw-dchat`
+  install: `openclaw plugins install @zbruceli/openclaw-dchat`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`

--- a/extensions/dchat/index.ts
+++ b/extensions/dchat/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { dchatPlugin } from "./src/channel.js";
+import { setDchatRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "dchat",
+  name: "D-Chat / nMobile",
+  description: "D-Chat/nMobile channel plugin (NKN relay network)",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setDchatRuntime(api.runtime);
+    api.registerChannel({ plugin: dchatPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/dchat/openclaw.plugin.json
+++ b/extensions/dchat/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "dchat",
+  "channels": ["dchat"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/dchat/package.json
+++ b/extensions/dchat/package.json
@@ -7,8 +7,8 @@
     "nkn-sdk": "^1.3.6",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": "*"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/dchat/package.json
+++ b/extensions/dchat/package.json
@@ -7,8 +7,8 @@
     "nkn-sdk": "^1.3.6",
     "zod": "^4.3.6"
   },
-  "peerDependencies": {
-    "openclaw": "*"
+  "devDependencies": {
+    "openclaw": "workspace:*"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/dchat/package.json
+++ b/extensions/dchat/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@openclaw/dchat",
+  "version": "2026.2.24",
+  "description": "OpenClaw D-Chat/nMobile channel plugin (NKN relay network)",
+  "type": "module",
+  "dependencies": {
+    "nkn-sdk": "^1.3.6",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "dchat",
+      "label": "D-Chat / nMobile",
+      "selectionLabel": "D-Chat (plugin)",
+      "docsPath": "/channels/dchat",
+      "docsLabel": "dchat",
+      "blurb": "decentralized E2E encrypted messaging over the NKN relay network.",
+      "order": 80,
+      "quickstartAllowFrom": true
+    },
+    "install": {
+      "npmSpec": "@openclaw/dchat",
+      "localPath": "extensions/dchat",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/dchat/src/channel.ts
+++ b/extensions/dchat/src/channel.ts
@@ -1,0 +1,578 @@
+import {
+  applyAccountNameToChannelSection,
+  buildChannelConfigSchema,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  formatPairingApproveHint,
+  normalizeAccountId,
+  resolveSenderCommandAuthorization,
+  setAccountEnabledInConfigSection,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import {
+  type CoreConfig,
+  DchatConfigSchema,
+  listDchatAccountIds,
+  resolveDchatAccount,
+  resolveDchatAccountConfig,
+  resolveDefaultDchatAccountId,
+} from "./config-schema.js";
+import { NknBus } from "./nkn-bus.js";
+import { dchatOnboardingAdapter } from "./onboarding.js";
+import { getDchatRuntime } from "./runtime.js";
+import { SeenTracker } from "./seen-tracker.js";
+import type { ResolvedDchatAccount } from "./types.js";
+import {
+  extractDmAddressFromSessionKey,
+  extractGroupIdFromSessionKey,
+  extractTopicFromSessionKey,
+  genTopicHash,
+  nknToInbound,
+  parseNknPayload,
+  receiptToNkn,
+  stripNknSubClientPrefix,
+  textToNkn,
+} from "./wire.js";
+
+// Per-account NKN bus instances, keyed by accountId
+const busMap = new Map<string, NknBus>();
+const seenTracker = new SeenTracker();
+
+const meta = {
+  id: "dchat",
+  label: "D-Chat / nMobile",
+  selectionLabel: "D-Chat (plugin)",
+  docsPath: "/channels/dchat",
+  docsLabel: "dchat",
+  blurb: "decentralized E2E encrypted messaging over the NKN relay network.",
+  order: 80,
+  quickstartAllowFrom: true,
+};
+
+function getBusForAccount(accountId: string): NknBus | undefined {
+  return busMap.get(accountId);
+}
+
+export const dchatPlugin: ChannelPlugin<ResolvedDchatAccount> = {
+  id: "dchat",
+  meta,
+  onboarding: dchatOnboardingAdapter,
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    media: false, // IPFS media support is a stretch goal for v2
+    threads: false,
+    reactions: false,
+    polls: false,
+  },
+  reload: { configPrefixes: ["channels.dchat"] },
+  configSchema: buildChannelConfigSchema(DchatConfigSchema),
+  pairing: {
+    idLabel: "nknAddress",
+    normalizeAllowEntry: (entry) => entry.replace(/^dchat:/i, ""),
+  },
+  config: {
+    listAccountIds: (cfg) => listDchatAccountIds(cfg as CoreConfig),
+    resolveAccount: (cfg, accountId) => resolveDchatAccount({ cfg: cfg as CoreConfig, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultDchatAccountId(cfg as CoreConfig),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "dchat",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg: cfg as CoreConfig,
+        sectionKey: "dchat",
+        accountId,
+        clearBaseFields: [
+          "name",
+          "seed",
+          "keystoreJson",
+          "keystorePassword",
+          "numSubClients",
+          "ipfsGateway",
+        ],
+      }),
+    isConfigured: (account) => account.configured,
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const dchatConfig = resolveDchatAccountConfig({ cfg: cfg as CoreConfig, accountId });
+      return (dchatConfig.dm?.allowFrom ?? []).map((entry: string | number) => String(entry));
+    },
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom.map((entry) => String(entry).replace(/^dchat:/i, "")),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => {
+      const accountId = account.accountId;
+      const prefix =
+        accountId && accountId !== "default"
+          ? `channels.dchat.accounts.${accountId}.dm`
+          : "channels.dchat.dm";
+      return {
+        policy: account.config.dm?.policy ?? "pairing",
+        allowFrom: account.config.dm?.allowFrom ?? [],
+        policyPath: `${prefix}.policy`,
+        allowFromPath: `${prefix}.allowFrom`,
+        approveHint: formatPairingApproveHint("dchat"),
+        normalizeEntry: (raw: string) => raw.replace(/^dchat:/i, ""),
+      };
+    },
+  },
+  messaging: {
+    normalizeTarget: (raw) => {
+      let normalized = raw.trim();
+      if (!normalized) return undefined;
+      if (normalized.toLowerCase().startsWith("dchat:")) {
+        normalized = normalized.slice("dchat:".length).trim();
+      }
+      return normalized || undefined;
+    },
+    targetResolver: {
+      looksLikeId: (raw) => {
+        const trimmed = raw.trim();
+        if (!trimmed) return false;
+        // NKN addresses are hex public keys (64+ chars)
+        if (/^[0-9a-f]{64}/i.test(trimmed)) return true;
+        // topic: or group: prefix
+        if (/^(topic|group):/i.test(trimmed)) return true;
+        return false;
+      },
+      hint: "<nkn-address|topic:name>",
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    chunker: (text, limit) => getDchatRuntime().channel.text.chunkMarkdownText(text, limit),
+    chunkerMode: "text",
+    textChunkLimit: 4000,
+    sendText: async ({ to, text, accountId }) => {
+      const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
+      const bus = getBusForAccount(resolvedAccountId);
+      if (!bus) {
+        throw new Error(`D-Chat account "${resolvedAccountId}" not connected`);
+      }
+
+      // Parse the target: could be a direct address or topic:name
+      const topicName = to.startsWith("topic:") ? to.slice("topic:".length) : undefined;
+      const groupId = to.startsWith("group:") ? to.slice("group:".length) : undefined;
+
+      const msgData = textToNkn(text, { topic: topicName, groupId });
+      const payload = JSON.stringify(msgData);
+
+      if (topicName) {
+        // Topic: send to all subscribers
+        const topicHash = genTopicHash(topicName);
+        const subscribers = await bus.getSubscribers(topicHash);
+        const selfAddr = bus.getAddress();
+        const dests = subscribers.filter((addr) => addr !== selfAddr);
+        if (dests.length > 0) {
+          bus.sendToMultiple(dests, payload);
+        }
+      } else if (groupId) {
+        // Private group: not yet supported, send to the group ID as direct
+        bus.sendNoReply(to, payload);
+      } else {
+        // Direct message: extract address from "dchat:addr" or raw address
+        const dest = to.replace(/^dchat:/i, "");
+        await bus.send(dest, payload);
+      }
+
+      return {
+        channel: "dchat",
+        messageId: msgData.id,
+      };
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg: cfg as CoreConfig,
+        channelKey: "dchat",
+        accountId,
+        name,
+      }),
+    validateInput: ({ input }) => {
+      if (input.useEnv) return null;
+      // Wallet seed is passed via accessToken field
+      const seed = input.accessToken?.trim();
+      if (!seed) {
+        return "D-Chat requires a wallet seed (--access-token with 64-char hex string)";
+      }
+      if (!/^[0-9a-f]{64}$/i.test(seed)) {
+        return "Wallet seed must be a 64-character hex string";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg: cfg as CoreConfig,
+        channelKey: "dchat",
+        accountId: DEFAULT_ACCOUNT_ID,
+        name: input.name,
+      });
+      const seed = input.accessToken?.trim();
+      return {
+        ...namedConfig,
+        channels: {
+          ...namedConfig.channels,
+          dchat: {
+            ...(namedConfig as CoreConfig).channels?.dchat,
+            enabled: true,
+            ...(seed ? { seed } : {}),
+          },
+        },
+      } as CoreConfig;
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    buildChannelSummary: ({ snapshot }) => ({
+      configured: snapshot.configured ?? false,
+      running: snapshot.running ?? false,
+      nknAddress: snapshot.baseUrl ?? null,
+      lastStartAt: snapshot.lastStartAt ?? null,
+      lastStopAt: snapshot.lastStopAt ?? null,
+      lastError: snapshot.lastError ?? null,
+    }),
+    buildAccountSnapshot: ({ account, runtime }) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      running: runtime?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? null,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
+    }),
+    collectStatusIssues: (accounts) =>
+      accounts.flatMap((account) => {
+        const lastError = typeof account.lastError === "string" ? account.lastError.trim() : "";
+        if (!lastError) return [];
+        return [
+          {
+            channel: "dchat",
+            accountId: account.accountId,
+            kind: "runtime",
+            message: `Channel error: ${lastError}`,
+          },
+        ];
+      }),
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      const account = ctx.account;
+      const core = getDchatRuntime();
+      const logger = core.logging.getChildLogger({ module: "dchat" });
+
+      if (!account.seed) {
+        logger.warn(`[${account.accountId}] no seed configured, skipping`);
+        return;
+      }
+
+      ctx.setStatus({ accountId: account.accountId });
+      logger.info(`[${account.accountId}] connecting to NKN relay network...`);
+
+      const bus = new NknBus();
+      busMap.set(account.accountId, bus);
+
+      try {
+        const address = await bus.connect(
+          { seed: account.seed, numSubClients: account.numSubClients },
+          ctx.abortSignal,
+        );
+
+        ctx.setStatus({
+          accountId: account.accountId,
+          baseUrl: address,
+          running: true,
+          lastStartAt: Date.now(),
+        });
+        logger.info(`[${account.accountId}] connected as ${address}`);
+
+        // Register inbound message handler
+        bus.onMessage((rawSrc, rawPayload) => {
+          void (async () => {
+            try {
+              // Strip NKN MultiClient sub-client prefix (__N__.) so addresses match allowlists
+              const src = stripNknSubClientPrefix(rawSrc);
+              const msg = parseNknPayload(rawPayload);
+              if (!msg) {
+                logger.warn(`[${account.accountId}] unparseable NKN payload from ${src}`);
+                return;
+              }
+
+              // Dedup
+              if (seenTracker.checkAndMark(msg.id)) {
+                return;
+              }
+
+              const selfAddress = bus.getAddress();
+              if (!selfAddress) return;
+
+              const inbound = nknToInbound(src, msg, selfAddress);
+              if (!inbound) {
+                // Control message (receipt, read, topic:subscribe, etc.) — skip
+                return;
+              }
+
+              // Send delivery receipt (fire-and-forget)
+              try {
+                const receipt = receiptToNkn(msg.id);
+                bus.sendNoReply(src, JSON.stringify(receipt));
+              } catch {
+                // receipt send failure is non-fatal
+              }
+
+              // Load config for reply dispatch
+              const cfg = core.config.loadConfig();
+
+              // Resolve command authorization for slash commands (/status, /stop, etc.)
+              const isGroup = inbound.chatType === "group";
+              const dmPolicy = account.config.dm?.policy ?? "pairing";
+              const configAllowFrom = (account.config.dm?.allowFrom ?? []).map((v) => String(v));
+
+              const isSenderAllowed = (senderId: string, allowFrom: string[]) => {
+                const lower = senderId.toLowerCase();
+                return allowFrom.some(
+                  (entry) => String(entry).toLowerCase() === lower || entry === "*",
+                );
+              };
+
+              const { senderAllowedForCommands, commandAuthorized } =
+                await resolveSenderCommandAuthorization({
+                  cfg,
+                  rawBody: inbound.body,
+                  isGroup,
+                  dmPolicy,
+                  configuredAllowFrom: configAllowFrom,
+                  senderId: src,
+                  isSenderAllowed,
+                  readAllowFromStore: () => core.channel.pairing.readAllowFromStore("dchat"),
+                  shouldComputeCommandAuthorized: (body, c) =>
+                    core.channel.commands.shouldComputeCommandAuthorized(body, c),
+                  resolveCommandAuthorizedFromAuthorizers: (params) =>
+                    core.channel.commands.resolveCommandAuthorizedFromAuthorizers(params),
+                });
+
+              // ── DM policy enforcement ──
+              if (!isGroup) {
+                if (dmPolicy === "disabled") {
+                  logger.info(`[${account.accountId}] drop DM sender=${src} (dmPolicy=disabled)`);
+                  return;
+                }
+                if (dmPolicy !== "open") {
+                  const storeAllowFrom =
+                    dmPolicy === "allowlist"
+                      ? []
+                      : await core.channel.pairing
+                          .readAllowFromStore("dchat")
+                          .catch(() => [] as string[]);
+                  const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom.map(String)];
+                  if (!isSenderAllowed(src, effectiveAllowFrom)) {
+                    if (dmPolicy === "pairing") {
+                      const { code, created } = await core.channel.pairing.upsertPairingRequest({
+                        channel: "dchat",
+                        id: src.toLowerCase(),
+                        meta: { name: src },
+                      });
+                      if (created) {
+                        try {
+                          const reply = core.channel.pairing.buildPairingReply({
+                            channel: "dchat",
+                            idLine: `Your NKN address: ${src}`,
+                            code,
+                          });
+                          bus.sendNoReply(src, JSON.stringify(textToNkn(reply)));
+                        } catch {
+                          // pairing reply send failure is non-fatal
+                        }
+                      }
+                    }
+                    logger.info(
+                      `[${account.accountId}] drop DM sender=${src} (dmPolicy=${dmPolicy})`,
+                    );
+                    return;
+                  }
+                }
+              }
+
+              // Drop unauthorized control commands in groups
+              if (
+                isGroup &&
+                core.channel.commands.isControlCommandMessage(inbound.body, cfg) &&
+                commandAuthorized !== true
+              ) {
+                return;
+              }
+
+              const storePath = core.channel.session.resolveStorePath(undefined, {});
+
+              const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
+              const previousTimestamp = core.channel.session.readSessionUpdatedAt({
+                storePath,
+                sessionKey: inbound.sessionKey,
+              });
+
+              const body = core.channel.reply.formatAgentEnvelope({
+                channel: "D-Chat",
+                from:
+                  inbound.chatType === "direct"
+                    ? inbound.senderName
+                    : (inbound.groupSubject ?? inbound.senderName),
+                timestamp: msg.timestamp,
+                previousTimestamp,
+                envelope: envelopeOptions,
+                body: inbound.body,
+              });
+
+              const ctxPayload = core.channel.reply.finalizeInboundContext({
+                Body: body,
+                BodyForAgent: inbound.body,
+                RawBody: inbound.body,
+                CommandBody: inbound.body,
+                From:
+                  inbound.chatType === "direct"
+                    ? `dchat:${src}`
+                    : `dchat:topic:${inbound.groupSubject ?? ""}`,
+                To:
+                  inbound.chatType === "direct"
+                    ? `dchat:${src}`
+                    : `topic:${inbound.groupSubject ?? ""}`,
+                SessionKey: inbound.sessionKey,
+                AccountId: account.accountId,
+                ChatType: inbound.chatType === "direct" ? "direct" : "channel",
+                ConversationLabel:
+                  inbound.chatType === "direct" ? inbound.senderName : (inbound.groupSubject ?? ""),
+                SenderName: inbound.senderName,
+                SenderId: inbound.senderId,
+                GroupSubject: inbound.groupSubject,
+                Provider: "dchat" as const,
+                Surface: "dchat" as const,
+                MessageSid: msg.id,
+                Timestamp: msg.timestamp,
+                CommandAuthorized: commandAuthorized,
+                CommandSource: "text" as const,
+                OriginatingChannel: "dchat" as const,
+                OriginatingTo:
+                  inbound.chatType === "direct"
+                    ? `dchat:${src}`
+                    : `topic:${inbound.groupSubject ?? ""}`,
+              });
+
+              // Record session
+              core.channel.session.recordInboundSession({
+                storePath,
+                sessionKey: ctxPayload.SessionKey ?? inbound.sessionKey,
+                ctx: ctxPayload,
+                updateLastRoute:
+                  inbound.chatType === "direct"
+                    ? {
+                        sessionKey: inbound.sessionKey,
+                        channel: "dchat",
+                        to: `dchat:${src}`,
+                        accountId: account.accountId,
+                      }
+                    : undefined,
+                onRecordError: (err) => {
+                  logger.warn("failed updating session meta", {
+                    error: String(err),
+                    storePath,
+                    sessionKey: inbound.sessionKey,
+                  });
+                },
+              });
+
+              // Dispatch reply via standard pipeline
+              const { dispatcher, replyOptions, markDispatchIdle } =
+                core.channel.reply.createReplyDispatcherWithTyping({
+                  deliver: async (payload) => {
+                    // Deliver reply back to NKN
+                    const replyText = payload.text ?? "";
+                    if (!replyText) return;
+
+                    const topic = extractTopicFromSessionKey(inbound.sessionKey);
+                    const groupIdFromKey = extractGroupIdFromSessionKey(inbound.sessionKey);
+                    const replyMsg = textToNkn(replyText, { topic, groupId: groupIdFromKey });
+                    const replyPayload = JSON.stringify(replyMsg);
+
+                    if (topic) {
+                      const topicHash = genTopicHash(topic);
+                      const subscribers = await bus.getSubscribers(topicHash);
+                      const dests = subscribers.filter((a) => a !== selfAddress);
+                      if (dests.length > 0) {
+                        bus.sendToMultiple(dests, replyPayload);
+                      }
+                    } else {
+                      bus.sendNoReply(src, replyPayload);
+                    }
+                  },
+                  humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, ""),
+                });
+
+              core.channel.reply
+                .dispatchReplyFromConfig({
+                  ctx: ctxPayload,
+                  cfg,
+                  dispatcher,
+                  replyOptions,
+                })
+                .then(({ queuedFinal }) => {
+                  if (queuedFinal) {
+                    markDispatchIdle?.();
+                  }
+                })
+                .catch((err) => {
+                  logger.error("reply dispatch failed", { error: String(err) });
+                  markDispatchIdle?.();
+                });
+            } catch (err) {
+              logger.error(`[${account.accountId}] inbound handler error`, { error: String(err) });
+            }
+          })();
+        });
+
+        // Wait for abort signal
+        if (ctx.abortSignal) {
+          await new Promise<void>((resolve) => {
+            ctx.abortSignal.addEventListener(
+              "abort",
+              () => {
+                resolve();
+              },
+              { once: true },
+            );
+          });
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        ctx.setStatus({
+          accountId: account.accountId,
+          lastError: errMsg,
+          lastStopAt: Date.now(),
+        });
+        logger.error(`[${account.accountId}] connection failed: ${errMsg}`);
+      } finally {
+        await bus.disconnect();
+        busMap.delete(account.accountId);
+      }
+    },
+  },
+};

--- a/extensions/dchat/src/channel.ts
+++ b/extensions/dchat/src/channel.ts
@@ -214,11 +214,12 @@ export const dchatPlugin: ChannelPlugin<ResolvedDchatAccount> = {
       }
       return null;
     },
-    applyAccountConfig: ({ cfg, input }) => {
+    applyAccountConfig: ({ cfg, input, accountId }) => {
+      const resolvedAccountId = accountId ?? DEFAULT_ACCOUNT_ID;
       const namedConfig = applyAccountNameToChannelSection({
         cfg: cfg as CoreConfig,
         channelKey: "dchat",
-        accountId: DEFAULT_ACCOUNT_ID,
+        accountId: resolvedAccountId,
         name: input.name,
       });
       const seed = input.accessToken?.trim();
@@ -330,7 +331,9 @@ export const dchatPlugin: ChannelPlugin<ResolvedDchatAccount> = {
               const selfAddress = bus.getAddress();
               if (!selfAddress) return;
 
-              const inbound = nknToInbound(src, msg, selfAddress);
+              const inbound = nknToInbound(src, msg, selfAddress, {
+                accountId: account.accountId,
+              });
               if (!inbound) {
                 // Control message (receipt, read, topic:subscribe, etc.) — skip
                 return;
@@ -426,7 +429,7 @@ export const dchatPlugin: ChannelPlugin<ResolvedDchatAccount> = {
                 return;
               }
 
-              const storePath = core.channel.session.resolveStorePath(undefined, {});
+              const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {});
 
               const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
               const previousTimestamp = core.channel.session.readSessionUpdatedAt({

--- a/extensions/dchat/src/config-schema.ts
+++ b/extensions/dchat/src/config-schema.ts
@@ -68,7 +68,13 @@ export function listDchatAccountIds(cfg: CoreConfig): string[] {
 }
 
 export function resolveDefaultDchatAccountId(cfg: CoreConfig): string {
-  return DEFAULT_ACCOUNT_ID;
+  const dchatConfig = cfg.channels?.dchat;
+  if (dchatConfig?.defaultAccount) return dchatConfig.defaultAccount;
+  // If top-level seed exists, treat as the default account
+  if (dchatConfig?.seed?.trim()) return DEFAULT_ACCOUNT_ID;
+  // Otherwise pick the first named account
+  const named = dchatConfig?.accounts ? Object.keys(dchatConfig.accounts) : [];
+  return named[0] ?? DEFAULT_ACCOUNT_ID;
 }
 
 export function resolveDchatAccountConfig(params: {
@@ -102,7 +108,7 @@ export function resolveDchatAccount(params: {
     accountId,
     name: accountConfig.name || accountId,
     enabled: accountConfig.enabled !== false,
-    configured: hasSeed || hasKeystore,
+    configured: hasSeed,
     seed: accountConfig.seed?.trim(),
     numSubClients: accountConfig.numSubClients ?? 4,
     ipfsGateway: accountConfig.ipfsGateway ?? "64.225.88.71:80",

--- a/extensions/dchat/src/config-schema.ts
+++ b/extensions/dchat/src/config-schema.ts
@@ -1,0 +1,111 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { z } from "zod";
+import type { DchatAccountConfig, ResolvedDchatAccount } from "./types.js";
+
+type CoreConfig = OpenClawConfig & {
+  channels?: {
+    dchat?: DchatAccountConfig & {
+      accounts?: Record<string, DchatAccountConfig>;
+      defaultAccount?: string;
+    };
+  };
+};
+
+export type { CoreConfig };
+
+const DEFAULT_ACCOUNT_ID = "default";
+
+/* ── Zod config schema (powers web UI form via buildChannelConfigSchema) ── */
+
+const dchatAccountSchema = z.object({
+  name: z.string().optional(),
+  enabled: z.boolean().optional(),
+  seed: z.string().optional(),
+  keystoreJson: z.string().optional(),
+  keystorePassword: z.string().optional(),
+  numSubClients: z.number().optional(),
+  ipfsGateway: z.string().optional(),
+  dm: z
+    .object({
+      policy: z.enum(["pairing", "allowlist", "open", "disabled"]).optional(),
+      allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    })
+    .optional(),
+});
+
+export const DchatConfigSchema = dchatAccountSchema.extend({
+  accounts: z.record(z.string(), dchatAccountSchema.optional()).optional(),
+  defaultAccount: z.string().optional(),
+});
+
+/* ── Config helpers ── */
+
+export function listDchatAccountIds(cfg: CoreConfig): string[] {
+  const dchatConfig = cfg.channels?.dchat;
+  if (!dchatConfig) return [];
+
+  const ids: string[] = [];
+
+  // Top-level config counts as the default account
+  if (dchatConfig.seed || dchatConfig.keystoreJson) {
+    ids.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  // Named accounts
+  if (dchatConfig.accounts) {
+    for (const id of Object.keys(dchatConfig.accounts)) {
+      if (!ids.includes(id)) {
+        ids.push(id);
+      }
+    }
+  }
+
+  if (ids.length === 0 && dchatConfig.enabled !== false) {
+    ids.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  return ids;
+}
+
+export function resolveDefaultDchatAccountId(cfg: CoreConfig): string {
+  return DEFAULT_ACCOUNT_ID;
+}
+
+export function resolveDchatAccountConfig(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): DchatAccountConfig {
+  const { cfg, accountId } = params;
+  const dchatConfig = cfg.channels?.dchat;
+  if (!dchatConfig) return { enabled: false };
+
+  if (accountId && accountId !== DEFAULT_ACCOUNT_ID && dchatConfig.accounts?.[accountId]) {
+    return dchatConfig.accounts[accountId];
+  }
+
+  // Top-level config
+  return dchatConfig;
+}
+
+export function resolveDchatAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): ResolvedDchatAccount {
+  const { cfg, accountId: rawAccountId } = params;
+  const accountId = rawAccountId || DEFAULT_ACCOUNT_ID;
+  const accountConfig = resolveDchatAccountConfig({ cfg, accountId });
+
+  const hasSeed = Boolean(accountConfig.seed?.trim());
+  const hasKeystore = Boolean(accountConfig.keystoreJson?.trim());
+
+  return {
+    accountId,
+    name: accountConfig.name || accountId,
+    enabled: accountConfig.enabled !== false,
+    configured: hasSeed || hasKeystore,
+    seed: accountConfig.seed?.trim(),
+    numSubClients: accountConfig.numSubClients ?? 4,
+    ipfsGateway: accountConfig.ipfsGateway ?? "64.225.88.71:80",
+    config: accountConfig,
+  };
+}

--- a/extensions/dchat/src/config-schema.ts
+++ b/extensions/dchat/src/config-schema.ts
@@ -85,11 +85,12 @@ export function resolveDchatAccountConfig(params: {
   const dchatConfig = cfg.channels?.dchat;
   if (!dchatConfig) return { enabled: false };
 
-  if (accountId && accountId !== DEFAULT_ACCOUNT_ID && dchatConfig.accounts?.[accountId]) {
+  if (accountId && dchatConfig.accounts?.[accountId]) {
+    // Named account (including "default" stored under accounts.default)
     return dchatConfig.accounts[accountId];
   }
 
-  // Top-level config
+  // Top-level config (default account without explicit accounts.default entry)
   return dchatConfig;
 }
 
@@ -104,10 +105,11 @@ export function resolveDchatAccount(params: {
   const hasSeed = Boolean(accountConfig.seed?.trim());
   const hasKeystore = Boolean(accountConfig.keystoreJson?.trim());
 
+  const baseEnabled = cfg.channels?.dchat?.enabled !== false;
   return {
     accountId,
     name: accountConfig.name || accountId,
-    enabled: accountConfig.enabled !== false,
+    enabled: baseEnabled && accountConfig.enabled !== false,
     configured: hasSeed,
     seed: accountConfig.seed?.trim(),
     numSubClients: accountConfig.numSubClients ?? 4,

--- a/extensions/dchat/src/config-schema.ts
+++ b/extensions/dchat/src/config-schema.ts
@@ -86,8 +86,13 @@ export function resolveDchatAccountConfig(params: {
   if (!dchatConfig) return { enabled: false };
 
   if (accountId && dchatConfig.accounts?.[accountId]) {
-    // Named account (including "default" stored under accounts.default)
-    return dchatConfig.accounts[accountId];
+    // Named account: merge channel-level fields (e.g. dm policy) as defaults
+    const acct = dchatConfig.accounts[accountId];
+    return {
+      ...dchatConfig,
+      ...acct,
+      dm: { ...dchatConfig.dm, ...acct.dm },
+    };
   }
 
   // Top-level config (default account without explicit accounts.default entry)

--- a/extensions/dchat/src/crypto.test.ts
+++ b/extensions/dchat/src/crypto.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { byteArrayToKey, decryptAesGcm, encryptAesGcm, keyToByteArray } from "./crypto.js";
+
+describe("AES-128-GCM crypto", () => {
+  it("encrypts and decrypts round-trip", () => {
+    const plaintext = Buffer.from("Hello, D-Chat!");
+    const { ciphertext, key } = encryptAesGcm(plaintext);
+
+    const decrypted = decryptAesGcm(ciphertext, key);
+    expect(decrypted.toString()).toBe("Hello, D-Chat!");
+  });
+
+  it("produces different ciphertext for same plaintext", () => {
+    const plaintext = Buffer.from("Same input");
+    const result1 = encryptAesGcm(plaintext);
+    const result2 = encryptAesGcm(plaintext);
+
+    // Different random keys/nonces should produce different ciphertext
+    expect(result1.ciphertext).not.toEqual(result2.ciphertext);
+  });
+
+  it("uses correct nonce and key sizes", () => {
+    const { key, nonce } = encryptAesGcm(Buffer.from("test"));
+    expect(key.length).toBe(16); // AES-128 = 16-byte key
+    expect(nonce.length).toBe(12); // GCM standard nonce
+  });
+
+  it("ciphertext format: nonce (12B) + encrypted + auth tag (16B)", () => {
+    const plaintext = Buffer.from("test data");
+    const { ciphertext, nonce } = encryptAesGcm(plaintext);
+
+    // First 12 bytes should be the nonce
+    expect(ciphertext.subarray(0, 12)).toEqual(nonce);
+
+    // Minimum size: 12 (nonce) + 1 (data) + 16 (auth tag) = 29
+    expect(ciphertext.length).toBeGreaterThanOrEqual(12 + 1 + 16);
+  });
+
+  it("fails to decrypt with wrong key", () => {
+    const plaintext = Buffer.from("secret");
+    const { ciphertext } = encryptAesGcm(plaintext);
+    const wrongKey = Buffer.alloc(16, 0xff);
+
+    expect(() => decryptAesGcm(ciphertext, wrongKey)).toThrow();
+  });
+
+  it("handles empty plaintext", () => {
+    const plaintext = Buffer.alloc(0);
+    const { ciphertext, key } = encryptAesGcm(plaintext);
+
+    const decrypted = decryptAesGcm(ciphertext, key);
+    expect(decrypted.length).toBe(0);
+  });
+
+  it("handles large plaintext", () => {
+    const plaintext = Buffer.alloc(1024 * 100, 0x42); // 100KB
+    const { ciphertext, key } = encryptAesGcm(plaintext);
+
+    const decrypted = decryptAesGcm(ciphertext, key);
+    expect(decrypted).toEqual(plaintext);
+  });
+});
+
+describe("key conversion helpers", () => {
+  it("converts key to byte array (nMobile wire format)", () => {
+    const key = Buffer.from([
+      0xb0, 0x71, 0x5a, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+      0x0b,
+    ]);
+    const bytes = keyToByteArray(key);
+    expect(bytes).toEqual([176, 113, 90, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  it("round-trips key through byte array", () => {
+    const original = Buffer.from([
+      0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+      0x0c,
+    ]);
+    const bytes = keyToByteArray(original);
+    const restored = byteArrayToKey(bytes);
+    expect(restored).toEqual(original);
+  });
+
+  it("encryption + byte array round-trip", () => {
+    const plaintext = Buffer.from("nMobile interop test");
+    const { ciphertext, key } = encryptAesGcm(plaintext);
+
+    // Simulate nMobile wire format: convert key to number[] and back
+    const keyBytes = keyToByteArray(key);
+    const restoredKey = byteArrayToKey(keyBytes);
+
+    const decrypted = decryptAesGcm(ciphertext, restoredKey);
+    expect(decrypted.toString()).toBe("nMobile interop test");
+  });
+});

--- a/extensions/dchat/src/crypto.ts
+++ b/extensions/dchat/src/crypto.ts
@@ -1,0 +1,56 @@
+import crypto from "crypto";
+
+const ALGORITHM = "aes-128-gcm";
+const KEY_BYTES = 16;
+const NONCE_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+export interface EncryptResult {
+  ciphertext: Buffer; // nonce (12 bytes) + encrypted data + auth tag (16 bytes)
+  key: Buffer; // 16-byte AES key
+  nonce: Buffer; // 12-byte nonce (also prepended to ciphertext)
+}
+
+/**
+ * Encrypt with AES-128-GCM, prepending nonce to ciphertext (nMobile convention).
+ * Output format: [nonce (12 bytes)] [encrypted data] [auth tag (16 bytes)]
+ */
+export function encryptAesGcm(plaintext: Buffer): EncryptResult {
+  const key = crypto.randomBytes(KEY_BYTES);
+  const nonce = crypto.randomBytes(NONCE_BYTES);
+
+  const cipher = crypto.createCipheriv(ALGORITHM, key, nonce);
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  const ciphertext = Buffer.concat([nonce, encrypted, authTag]);
+
+  return { ciphertext, key, nonce };
+}
+
+/**
+ * Decrypt AES-128-GCM with nonce prepended to ciphertext (nMobile convention).
+ * Input format: [nonce (12 bytes)] [encrypted data] [auth tag (16 bytes)]
+ */
+export function decryptAesGcm(data: Buffer, key: Buffer, nonceSize: number = NONCE_BYTES): Buffer {
+  const nonce = data.subarray(0, nonceSize);
+  const ciphertextWithTag = data.subarray(nonceSize);
+
+  const encrypted = ciphertextWithTag.subarray(0, ciphertextWithTag.length - AUTH_TAG_BYTES);
+  const authTag = ciphertextWithTag.subarray(ciphertextWithTag.length - AUTH_TAG_BYTES);
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, nonce);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+}
+
+/** Convert a Buffer key to a number[] array (nMobile wire format). */
+export function keyToByteArray(key: Buffer): number[] {
+  return Array.from(key);
+}
+
+/** Convert a number[] byte array back to Buffer. */
+export function byteArrayToKey(bytes: number[]): Buffer {
+  return Buffer.from(bytes);
+}

--- a/extensions/dchat/src/nkn-bus.ts
+++ b/extensions/dchat/src/nkn-bus.ts
@@ -1,0 +1,206 @@
+import { EventEmitter } from "events";
+import nkn from "nkn-sdk";
+import { NKN_SEED_RPC_SERVERS, type NknConnectionState } from "./types.js";
+
+export interface NknBusOptions {
+  seed: string;
+  numSubClients?: number;
+}
+
+/**
+ * NKN MultiClient wrapper for D-Chat wire-format messaging.
+ * Handles connect, send, receive, subscribe, and reconnection.
+ */
+export class NknBus extends EventEmitter {
+  private client: nkn.MultiClient | null = null;
+  private state: NknConnectionState = "disconnected";
+  private address: string | undefined;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private seed: string | undefined;
+  private numSubClients: number;
+  private abortSignal: AbortSignal | undefined;
+
+  constructor() {
+    super();
+    this.numSubClients = 4;
+  }
+
+  getState(): NknConnectionState {
+    return this.state;
+  }
+
+  getAddress(): string | undefined {
+    return this.address;
+  }
+
+  async connect(opts: NknBusOptions, abortSignal?: AbortSignal): Promise<string> {
+    if (this.client) {
+      await this.disconnect();
+    }
+
+    this.seed = opts.seed;
+    this.numSubClients = opts.numSubClients ?? 4;
+    this.abortSignal = abortSignal;
+    this.setState("connecting");
+
+    try {
+      this.client = new nkn.MultiClient({
+        seed: opts.seed,
+        numSubClients: this.numSubClients,
+        originalClient: false,
+        rpcServerAddr: NKN_SEED_RPC_SERVERS[0],
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("NKN connection timeout after 30s"));
+        }, 30000);
+
+        if (abortSignal?.aborted) {
+          clearTimeout(timeout);
+          reject(new Error("Aborted"));
+          return;
+        }
+
+        const onAbort = () => {
+          clearTimeout(timeout);
+          reject(new Error("Aborted"));
+        };
+        abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+        this.client!.onConnect(() => {
+          clearTimeout(timeout);
+          abortSignal?.removeEventListener("abort", onAbort);
+          resolve();
+        });
+      });
+
+      this.address = this.client.addr;
+      this.setState("connected");
+
+      // Register message handler: src may include __N__. sub-client prefix; caller should normalize
+      this.client.onMessage(({ src, payload }: { src: string; payload: Uint8Array | string }) => {
+        let data: string;
+        if (payload instanceof Uint8Array) {
+          data = new TextDecoder().decode(payload);
+        } else {
+          data = payload;
+        }
+        this.emit("message", src, data);
+      });
+
+      return this.address;
+    } catch (err) {
+      this.setState("disconnected");
+      this.client = null;
+      throw err;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.client) {
+      try {
+        this.client.close();
+      } catch {
+        // ignore close errors
+      }
+      this.client = null;
+    }
+    this.address = undefined;
+    this.setState("disconnected");
+  }
+
+  /**
+   * Send a message and wait for recipient ACK.
+   * Used for direct text messages.
+   */
+  async send(dest: string, payload: string): Promise<void> {
+    this.ensureConnected();
+    await this.client!.send(dest, payload, {
+      msgHoldingSeconds: 3600,
+    });
+  }
+
+  /**
+   * Send without waiting for ACK (fire-and-forget).
+   * Used for media messages and topic broadcasts.
+   */
+  sendNoReply(dest: string, payload: string): void {
+    this.ensureConnected();
+    this.client!.send(dest, payload, {
+      noReply: true,
+      msgHoldingSeconds: 3600,
+    });
+  }
+
+  /**
+   * Send to multiple destinations (topic broadcast).
+   * Fire-and-forget.
+   */
+  sendToMultiple(dests: string[], payload: string): void {
+    this.ensureConnected();
+    if (dests.length === 0) return;
+    this.client!.send(dests, payload, {
+      noReply: true,
+      msgHoldingSeconds: 3600,
+    });
+  }
+
+  /** Subscribe to a topic on the NKN blockchain. */
+  async subscribe(topicHash: string, duration = 400000, fee = "0"): Promise<string> {
+    this.ensureConnected();
+    const txnHash = await this.client!.subscribe(topicHash, duration, "", "", {
+      fee,
+      attrs: undefined,
+      buildOnly: undefined,
+    } as nkn.TransactionOptions);
+    return String(txnHash);
+  }
+
+  /** Unsubscribe from a topic. */
+  async unsubscribe(topicHash: string, fee = "0"): Promise<string> {
+    this.ensureConnected();
+    const txnHash = await this.client!.unsubscribe(topicHash, "", {
+      fee,
+      attrs: undefined,
+      buildOnly: undefined,
+    } as nkn.TransactionOptions);
+    return String(txnHash);
+  }
+
+  /** Fetch subscriber addresses for a topic. */
+  async getSubscribers(topicHash: string): Promise<string[]> {
+    this.ensureConnected();
+    const result = await this.client!.getSubscribers(topicHash, {
+      offset: 0,
+      limit: 1000,
+      txPool: true,
+    });
+    const subs = result.subscribers;
+    if (Array.isArray(subs)) {
+      return subs;
+    }
+    // Record<string, string> form — keys are addresses
+    return Object.keys(subs);
+  }
+
+  /** Register a handler for incoming NKN messages. */
+  onMessage(handler: (src: string, data: string) => void): void {
+    this.on("message", handler);
+  }
+
+  private ensureConnected(): void {
+    if (!this.client || this.state !== "connected") {
+      throw new Error("NKN client not connected");
+    }
+  }
+
+  private setState(next: NknConnectionState): void {
+    this.state = next;
+    this.emit("stateChange", next);
+  }
+}

--- a/extensions/dchat/src/nkn-bus.ts
+++ b/extensions/dchat/src/nkn-bus.ts
@@ -92,7 +92,14 @@ export class NknBus extends EventEmitter {
       return this.address;
     } catch (err) {
       this.setState("disconnected");
-      this.client = null;
+      if (this.client) {
+        try {
+          this.client.close();
+        } catch {
+          // ignore close errors during cleanup
+        }
+        this.client = null;
+      }
       throw err;
     }
   }

--- a/extensions/dchat/src/onboarding.ts
+++ b/extensions/dchat/src/onboarding.ts
@@ -1,0 +1,188 @@
+import type { DmPolicy } from "openclaw/plugin-sdk";
+import {
+  addWildcardAllowFrom,
+  mergeAllowFromEntries,
+  formatDocsLink,
+  type ChannelOnboardingAdapter,
+  type ChannelOnboardingDmPolicy,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk";
+import { resolveDchatAccount, type CoreConfig } from "./config-schema.js";
+
+const channel = "dchat" as const;
+
+function setDchatDmPolicy(cfg: CoreConfig, policy: DmPolicy) {
+  const allowFrom =
+    policy === "open" ? addWildcardAllowFrom(cfg.channels?.dchat?.dm?.allowFrom) : undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      dchat: {
+        ...cfg.channels?.dchat,
+        dm: {
+          ...cfg.channels?.dchat?.dm,
+          policy,
+          ...(allowFrom ? { allowFrom } : {}),
+        },
+      },
+    },
+  };
+}
+
+async function promptDchatAllowFrom(params: {
+  cfg: CoreConfig;
+  prompter: WizardPrompter;
+}): Promise<CoreConfig> {
+  const { cfg, prompter } = params;
+  const existingAllowFrom = cfg.channels?.dchat?.dm?.allowFrom ?? [];
+
+  const entry = await prompter.text({
+    message: "NKN address to allow (full public key hex)",
+    placeholder: "abc123...def456 (64-char hex NKN address)",
+    initialValue: existingAllowFrom[0] ? String(existingAllowFrom[0]) : undefined,
+    validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+  });
+
+  const parts = String(entry)
+    .split(/[\n,;]+/g)
+    .map((e) => e.trim())
+    .filter(Boolean);
+
+  const unique = mergeAllowFromEntries(existingAllowFrom, parts);
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      dchat: {
+        ...cfg.channels?.dchat,
+        enabled: true,
+        dm: {
+          ...cfg.channels?.dchat?.dm,
+          policy: "allowlist",
+          allowFrom: unique,
+        },
+      },
+    },
+  };
+}
+
+const dmPolicy: ChannelOnboardingDmPolicy = {
+  label: "D-Chat",
+  channel,
+  policyKey: "channels.dchat.dm.policy",
+  allowFromKey: "channels.dchat.dm.allowFrom",
+  getCurrent: (cfg) => ((cfg as CoreConfig).channels?.dchat?.dm?.policy as DmPolicy) ?? "pairing",
+  setPolicy: (cfg, policy) => setDchatDmPolicy(cfg as CoreConfig, policy),
+  promptAllowFrom: promptDchatAllowFrom,
+};
+
+export const dchatOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const account = resolveDchatAccount({ cfg: cfg as CoreConfig });
+    return {
+      channel,
+      configured: account.configured,
+      statusLines: [`D-Chat: ${account.configured ? "configured" : "needs wallet seed"}`],
+      selectionHint: account.configured ? "configured" : "needs seed",
+    };
+  },
+  configure: async ({ cfg, prompter, forceAllowFrom }) => {
+    let next = cfg as CoreConfig;
+    const existing = next.channels?.dchat ?? {};
+    const account = resolveDchatAccount({ cfg: next });
+
+    if (!account.configured) {
+      await prompter.note(
+        [
+          "D-Chat uses the NKN relay network for decentralized E2E encrypted messaging.",
+          "You need a wallet seed (64-character hex string) to connect.",
+          "Generate one with nkn-sdk or use an existing seed from D-Chat/nMobile.",
+          `Docs: ${formatDocsLink("/channels/dchat", "channels/dchat")}`,
+        ].join("\n"),
+        "D-Chat setup",
+      );
+    }
+
+    // Check for env var
+    const envSeed = process.env.DCHAT_SEED?.trim() || process.env.NKN_SEED?.trim();
+    if (envSeed && !existing.seed) {
+      const useEnv = await prompter.confirm({
+        message: "NKN seed env var detected. Use env value?",
+        initialValue: true,
+      });
+      if (useEnv) {
+        next = {
+          ...next,
+          channels: {
+            ...next.channels,
+            dchat: {
+              ...next.channels?.dchat,
+              enabled: true,
+              seed: envSeed,
+            },
+          },
+        };
+        if (forceAllowFrom) {
+          next = await promptDchatAllowFrom({ cfg: next, prompter });
+        }
+        return { cfg: next };
+      }
+    }
+
+    // Prompt for seed
+    let seed = existing.seed ?? "";
+    if (seed) {
+      const keep = await prompter.confirm({
+        message: "Wallet seed already configured. Keep it?",
+        initialValue: true,
+      });
+      if (!keep) {
+        seed = "";
+      }
+    }
+
+    if (!seed) {
+      seed = String(
+        await prompter.text({
+          message: "NKN wallet seed (64-char hex)",
+          validate: (value) => {
+            const raw = String(value ?? "").trim();
+            if (!raw) return "Required";
+            if (!/^[0-9a-f]{64}$/i.test(raw)) {
+              return "Must be a 64-character hex string";
+            }
+            return undefined;
+          },
+        }),
+      ).trim();
+    }
+
+    next = {
+      ...next,
+      channels: {
+        ...next.channels,
+        dchat: {
+          ...next.channels?.dchat,
+          enabled: true,
+          seed,
+        },
+      },
+    };
+
+    if (forceAllowFrom) {
+      next = await promptDchatAllowFrom({ cfg: next, prompter });
+    }
+
+    return { cfg: next };
+  },
+  dmPolicy,
+  disable: (cfg) => ({
+    ...(cfg as CoreConfig),
+    channels: {
+      ...(cfg as CoreConfig).channels,
+      dchat: { ...(cfg as CoreConfig).channels?.dchat, enabled: false },
+    },
+  }),
+};

--- a/extensions/dchat/src/runtime.ts
+++ b/extensions/dchat/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setDchatRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getDchatRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("D-Chat runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/dchat/src/seen-tracker.test.ts
+++ b/extensions/dchat/src/seen-tracker.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { SeenTracker } from "./seen-tracker.js";
+
+describe("SeenTracker", () => {
+  it("tracks seen message IDs", () => {
+    const tracker = new SeenTracker();
+    expect(tracker.hasSeen("msg-1")).toBe(false);
+    tracker.markSeen("msg-1");
+    expect(tracker.hasSeen("msg-1")).toBe(true);
+  });
+
+  it("checkAndMark returns false for new, true for seen", () => {
+    const tracker = new SeenTracker();
+    expect(tracker.checkAndMark("msg-1")).toBe(false);
+    expect(tracker.checkAndMark("msg-1")).toBe(true);
+    expect(tracker.checkAndMark("msg-2")).toBe(false);
+  });
+
+  it("tracks size correctly", () => {
+    const tracker = new SeenTracker();
+    expect(tracker.size).toBe(0);
+    tracker.markSeen("a");
+    tracker.markSeen("b");
+    tracker.markSeen("c");
+    expect(tracker.size).toBe(3);
+  });
+
+  it("evicts oldest entries when over capacity", () => {
+    const tracker = new SeenTracker(3);
+    tracker.markSeen("a");
+    tracker.markSeen("b");
+    tracker.markSeen("c");
+    expect(tracker.size).toBe(3);
+
+    // Adding a 4th should evict "a" (oldest)
+    tracker.markSeen("d");
+    expect(tracker.size).toBe(3);
+    expect(tracker.hasSeen("a")).toBe(false);
+    expect(tracker.hasSeen("b")).toBe(true);
+    expect(tracker.hasSeen("c")).toBe(true);
+    expect(tracker.hasSeen("d")).toBe(true);
+  });
+
+  it("re-marking refreshes position (LRU behavior)", () => {
+    const tracker = new SeenTracker(3);
+    tracker.markSeen("a");
+    tracker.markSeen("b");
+    tracker.markSeen("c");
+
+    // Re-mark "a" to move it to the end
+    tracker.markSeen("a");
+
+    // Now "b" is oldest; adding "d" should evict "b"
+    tracker.markSeen("d");
+    expect(tracker.hasSeen("b")).toBe(false);
+    expect(tracker.hasSeen("a")).toBe(true);
+    expect(tracker.hasSeen("c")).toBe(true);
+    expect(tracker.hasSeen("d")).toBe(true);
+  });
+
+  it("clear removes all entries", () => {
+    const tracker = new SeenTracker();
+    tracker.markSeen("a");
+    tracker.markSeen("b");
+    expect(tracker.size).toBe(2);
+    tracker.clear();
+    expect(tracker.size).toBe(0);
+    expect(tracker.hasSeen("a")).toBe(false);
+  });
+
+  it("handles default max size of 10000", () => {
+    const tracker = new SeenTracker();
+    for (let i = 0; i < 10001; i++) {
+      tracker.markSeen(`msg-${i}`);
+    }
+    expect(tracker.size).toBe(10000);
+    // First entry should have been evicted
+    expect(tracker.hasSeen("msg-0")).toBe(false);
+    expect(tracker.hasSeen("msg-10000")).toBe(true);
+  });
+});

--- a/extensions/dchat/src/seen-tracker.ts
+++ b/extensions/dchat/src/seen-tracker.ts
@@ -1,0 +1,56 @@
+/**
+ * LRU-based dedup tracker for incoming NKN message IDs.
+ * Prevents duplicate processing when the same message arrives
+ * via multiple NKN sub-clients.
+ */
+export class SeenTracker {
+  private seen: Map<string, true>;
+  private maxSize: number;
+
+  constructor(maxSize = 10_000) {
+    this.seen = new Map();
+    this.maxSize = maxSize;
+  }
+
+  /** Returns true if the ID was already seen. */
+  hasSeen(id: string): boolean {
+    return this.seen.has(id);
+  }
+
+  /** Mark an ID as seen. Evicts oldest entries if over capacity. */
+  markSeen(id: string): void {
+    if (this.seen.has(id)) {
+      // Move to end (most recent) by deleting and re-inserting
+      this.seen.delete(id);
+    }
+    this.seen.set(id, true);
+    this.evict();
+  }
+
+  /** Check + mark in one call. Returns true if already seen. */
+  checkAndMark(id: string): boolean {
+    if (this.seen.has(id)) {
+      return true;
+    }
+    this.markSeen(id);
+    return false;
+  }
+
+  get size(): number {
+    return this.seen.size;
+  }
+
+  clear(): void {
+    this.seen.clear();
+  }
+
+  private evict(): void {
+    while (this.seen.size > this.maxSize) {
+      // Map iterates in insertion order; first key is oldest
+      const oldest = this.seen.keys().next().value;
+      if (oldest !== undefined) {
+        this.seen.delete(oldest);
+      }
+    }
+  }
+}

--- a/extensions/dchat/src/types.ts
+++ b/extensions/dchat/src/types.ts
@@ -1,0 +1,144 @@
+/**
+ * D-Chat/nMobile wire format types.
+ * Matches the MessageData envelope sent over NKN relay for full interop
+ * with D-Chat Desktop and nMobile.
+ */
+
+export type MessageContentType =
+  | "text"
+  | "textExtension"
+  | "image"
+  | "audio"
+  | "video"
+  | "file"
+  | "ipfs"
+  | "piece"
+  | "receipt"
+  | "contact"
+  | "contactOptions"
+  | "deviceInfo"
+  | "deviceRequest"
+  | "topic:subscribe"
+  | "topic:unsubscribe"
+  | "privateGroup:invitation"
+  | "privateGroup:accept"
+  | "privateGroup:subscribe"
+  | "privateGroup:quit"
+  | "privateGroup:optionRequest"
+  | "privateGroup:optionResponse"
+  | "privateGroup:memberRequest"
+  | "privateGroup:memberResponse"
+  | "read"
+  | "discovery:broadcast";
+
+/** Control content types that should not be forwarded to the agent. */
+export const CONTROL_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  "receipt",
+  "read",
+  "contact",
+  "contactOptions",
+  "deviceInfo",
+  "deviceRequest",
+  "topic:subscribe",
+  "topic:unsubscribe",
+  "privateGroup:invitation",
+  "privateGroup:accept",
+  "privateGroup:subscribe",
+  "privateGroup:quit",
+  "privateGroup:optionRequest",
+  "privateGroup:optionResponse",
+  "privateGroup:memberRequest",
+  "privateGroup:memberResponse",
+  "discovery:broadcast",
+]);
+
+/** Content types that carry displayable message content. */
+export const DISPLAYABLE_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "textExtension",
+  "image",
+  "audio",
+  "video",
+  "file",
+  "ipfs",
+]);
+
+export interface MessageOptions {
+  deleteAfterSeconds?: number;
+  updateBurnAfterAt?: number;
+  profileVersion?: string;
+
+  // Full image IPFS (nMobile format)
+  ipfsHash?: string;
+  ipfsIp?: string;
+  ipfsEncrypt?: number;
+  ipfsEncryptAlgorithm?: string; // "AES/GCM/NoPadding"
+  ipfsEncryptKeyBytes?: number[]; // byte array (16 bytes for AES-128)
+  ipfsEncryptNonceSize?: number; // 12 — nonce prepended to ciphertext
+
+  // Thumbnail IPFS (nMobile format)
+  ipfsThumbnailHash?: string;
+  ipfsThumbnailIp?: string;
+  ipfsThumbnailEncrypt?: number;
+  ipfsThumbnailEncryptAlgorithm?: string;
+  ipfsThumbnailEncryptKeyBytes?: number[];
+  ipfsThumbnailEncryptNonceSize?: number;
+
+  // File info
+  fileType?: number | string; // 0=file, 1=image, 2=audio, 3=video
+  fileName?: string;
+  fileExt?: string;
+  fileMimeType?: string;
+  fileSize?: number;
+  mediaWidth?: number;
+  mediaHeight?: number;
+  mediaDuration?: number; // seconds (float), used for audio/video
+}
+
+/** Wire format message envelope sent over NKN relay. */
+export interface MessageData {
+  id: string;
+  contentType: MessageContentType;
+  content?: string;
+  options?: MessageOptions;
+  topic?: string;
+  groupId?: string;
+  targetID?: string; // receipt: references original message ID
+  readIds?: string[]; // read receipt: array of message IDs
+  timestamp: number;
+}
+
+export type NknConnectionState = "disconnected" | "connecting" | "connected";
+
+export interface DchatAccountConfig {
+  seed?: string; // hex wallet seed (64 chars)
+  keystoreJson?: string; // alternative: nkn-sdk keystore JSON
+  keystorePassword?: string;
+  numSubClients?: number; // default: 4
+  ipfsGateway?: string; // default: "64.225.88.71:80"
+  enabled?: boolean;
+  name?: string;
+  dm?: {
+    allowFrom?: Array<string | number>;
+    policy?: string;
+  };
+}
+
+export interface ResolvedDchatAccount {
+  accountId: string;
+  name: string;
+  enabled: boolean;
+  configured: boolean;
+  seed?: string;
+  numSubClients: number;
+  ipfsGateway: string;
+  config: DchatAccountConfig;
+}
+
+/** NKN seed RPC servers for client bootstrap. */
+export const NKN_SEED_RPC_SERVERS = [
+  "http://seed.nkn.org:30003",
+  "http://mainnet-seed-0001.nkn.org:30003",
+  "http://mainnet-seed-0002.nkn.org:30003",
+  "http://mainnet-seed-0003.nkn.org:30003",
+];

--- a/extensions/dchat/src/wire.test.ts
+++ b/extensions/dchat/src/wire.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import type { MessageData } from "./types.js";
+import {
+  extractDmAddressFromSessionKey,
+  extractGroupIdFromSessionKey,
+  extractTopicFromSessionKey,
+  genTopicHash,
+  isControlMessage,
+  isDisplayableMessage,
+  nknToInbound,
+  parseNknPayload,
+  receiptToNkn,
+  stripNknSubClientPrefix,
+  textToNkn,
+} from "./wire.js";
+
+describe("genTopicHash", () => {
+  it("generates topic hash with dchat prefix", () => {
+    const hash = genTopicHash("general");
+    expect(hash).toMatch(/^dchat[0-9a-f]{40}$/);
+  });
+
+  it("strips leading # characters", () => {
+    expect(genTopicHash("#general")).toBe(genTopicHash("general"));
+    expect(genTopicHash("##general")).toBe(genTopicHash("general"));
+  });
+
+  it("produces consistent hashes", () => {
+    expect(genTopicHash("d-chat")).toBe(genTopicHash("d-chat"));
+  });
+
+  it("produces different hashes for different topics", () => {
+    expect(genTopicHash("alpha")).not.toBe(genTopicHash("beta"));
+  });
+});
+
+describe("parseNknPayload", () => {
+  it("parses valid JSON message", () => {
+    const msg: MessageData = {
+      id: "test-123",
+      contentType: "text",
+      content: "hello",
+      timestamp: Date.now(),
+    };
+    const result = parseNknPayload(JSON.stringify(msg));
+    expect(result).toEqual(msg);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseNknPayload("not json")).toBeNull();
+  });
+
+  it("returns null for missing required fields", () => {
+    expect(parseNknPayload(JSON.stringify({ id: "test" }))).toBeNull();
+    expect(parseNknPayload(JSON.stringify({ contentType: "text" }))).toBeNull();
+  });
+
+  it("returns null for non-object values", () => {
+    expect(parseNknPayload(JSON.stringify(42))).toBeNull();
+    expect(parseNknPayload(JSON.stringify(null))).toBeNull();
+  });
+});
+
+describe("isControlMessage / isDisplayableMessage", () => {
+  it("identifies control messages", () => {
+    expect(isControlMessage("receipt")).toBe(true);
+    expect(isControlMessage("read")).toBe(true);
+    expect(isControlMessage("contact")).toBe(true);
+    expect(isControlMessage("topic:subscribe")).toBe(true);
+    expect(isControlMessage("discovery:broadcast")).toBe(true);
+  });
+
+  it("identifies displayable messages", () => {
+    expect(isDisplayableMessage("text")).toBe(true);
+    expect(isDisplayableMessage("textExtension")).toBe(true);
+    expect(isDisplayableMessage("ipfs")).toBe(true);
+    expect(isDisplayableMessage("audio")).toBe(true);
+  });
+
+  it("control messages are not displayable", () => {
+    expect(isDisplayableMessage("receipt")).toBe(false);
+    expect(isControlMessage("text")).toBe(false);
+  });
+});
+
+describe("nknToInbound", () => {
+  const selfAddr = "self-address-abc123";
+
+  it("translates direct text message", () => {
+    const msg: MessageData = {
+      id: "msg-1",
+      contentType: "text",
+      content: "Hello from NKN",
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender-addr-xyz789", msg, selfAddr);
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe("Hello from NKN");
+    expect(result!.chatType).toBe("direct");
+    expect(result!.sessionKey).toBe("dchat:dm:sender-addr-xyz789");
+    expect(result!.senderId).toBe("sender-addr-xyz789");
+  });
+
+  it("translates topic message", () => {
+    const msg: MessageData = {
+      id: "msg-2",
+      contentType: "text",
+      content: "Hello topic",
+      topic: "general",
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender-addr", msg, selfAddr);
+    expect(result).not.toBeNull();
+    expect(result!.chatType).toBe("group");
+    expect(result!.sessionKey).toBe("dchat:topic:general");
+    expect(result!.groupSubject).toBe("#general");
+  });
+
+  it("translates IPFS image message", () => {
+    const msg: MessageData = {
+      id: "msg-3",
+      contentType: "ipfs",
+      content: "QmXyz...",
+      options: { fileType: 1, ipfsHash: "QmXyz..." },
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender", msg, selfAddr);
+    expect(result).not.toBeNull();
+    expect(result!.body).toBe("[Image]");
+    expect(result!.ipfsHash).toBe("QmXyz...");
+  });
+
+  it("translates IPFS file message", () => {
+    const msg: MessageData = {
+      id: "msg-4",
+      contentType: "ipfs",
+      content: "QmAbc...",
+      options: { fileType: 0, fileName: "report.pdf" },
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender", msg, selfAddr);
+    expect(result!.body).toBe("[File: report.pdf]");
+  });
+
+  it("translates audio message", () => {
+    const msg: MessageData = {
+      id: "msg-5",
+      contentType: "audio",
+      content: "base64data...",
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender", msg, selfAddr);
+    expect(result!.body).toBe("[Voice Message]");
+  });
+
+  it("returns null for control messages", () => {
+    const receipt: MessageData = {
+      id: "msg-6",
+      contentType: "receipt",
+      targetID: "msg-1",
+      timestamp: Date.now(),
+    };
+    expect(nknToInbound("sender", receipt, selfAddr)).toBeNull();
+
+    const readReceipt: MessageData = {
+      id: "msg-7",
+      contentType: "read",
+      readIds: ["msg-1"],
+      timestamp: Date.now(),
+    };
+    expect(nknToInbound("sender", readReceipt, selfAddr)).toBeNull();
+  });
+
+  it("handles textExtension content type", () => {
+    const msg: MessageData = {
+      id: "msg-8",
+      contentType: "textExtension",
+      content: "burn after read message",
+      options: { deleteAfterSeconds: 3600 },
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender", msg, selfAddr);
+    expect(result!.body).toBe("burn after read message");
+  });
+});
+
+describe("textToNkn", () => {
+  it("creates text MessageData", () => {
+    const msg = textToNkn("Hello world");
+    expect(msg.contentType).toBe("text");
+    expect(msg.content).toBe("Hello world");
+    expect(msg.id).toBeTruthy();
+    expect(msg.timestamp).toBeGreaterThan(0);
+    expect(msg.topic).toBeUndefined();
+  });
+
+  it("sets topic field for topic messages", () => {
+    const msg = textToNkn("Hello topic", { topic: "general" });
+    expect(msg.topic).toBe("general");
+  });
+
+  it("sets groupId for group messages", () => {
+    const msg = textToNkn("Hello group", { groupId: "group-123" });
+    expect(msg.groupId).toBe("group-123");
+  });
+});
+
+describe("receiptToNkn", () => {
+  it("creates receipt MessageData", () => {
+    const msg = receiptToNkn("original-msg-id");
+    expect(msg.contentType).toBe("receipt");
+    expect(msg.targetID).toBe("original-msg-id");
+  });
+});
+
+describe("session key extractors", () => {
+  it("extracts topic from session key", () => {
+    expect(extractTopicFromSessionKey("dchat:topic:general")).toBe("general");
+    expect(extractTopicFromSessionKey("dchat:dm:addr")).toBeUndefined();
+  });
+
+  it("extracts group ID from session key", () => {
+    expect(extractGroupIdFromSessionKey("dchat:group:abc123")).toBe("abc123");
+    expect(extractGroupIdFromSessionKey("dchat:dm:addr")).toBeUndefined();
+  });
+
+  it("extracts DM address from session key", () => {
+    expect(extractDmAddressFromSessionKey("dchat:dm:some-nkn-addr")).toBe("some-nkn-addr");
+    expect(extractDmAddressFromSessionKey("dchat:topic:general")).toBeUndefined();
+  });
+});
+
+describe("stripNknSubClientPrefix", () => {
+  it("strips __N__. prefix", () => {
+    expect(stripNknSubClientPrefix("__0__.cd3530abcdef")).toBe("cd3530abcdef");
+    expect(stripNknSubClientPrefix("__3__.cd3530abcdef")).toBe("cd3530abcdef");
+    expect(stripNknSubClientPrefix("__12__.cd3530abcdef")).toBe("cd3530abcdef");
+  });
+
+  it("leaves plain addresses unchanged", () => {
+    expect(stripNknSubClientPrefix("cd3530abcdef")).toBe("cd3530abcdef");
+  });
+});

--- a/extensions/dchat/src/wire.test.ts
+++ b/extensions/dchat/src/wire.test.ts
@@ -101,6 +101,25 @@ describe("nknToInbound", () => {
     expect(result!.senderId).toBe("sender-addr-xyz789");
   });
 
+  it("scopes DM session key to account identity", () => {
+    const msg: MessageData = {
+      id: "msg-acct",
+      contentType: "text",
+      content: "multi-account test",
+      timestamp: Date.now(),
+    };
+    const result = nknToInbound("sender-addr", msg, selfAddr, { accountId: "work" });
+    expect(result!.sessionKey).toBe("dchat:work:dm:sender-addr");
+
+    // default account omits the account prefix for backwards compat
+    const resultDefault = nknToInbound("sender-addr", msg, selfAddr, { accountId: "default" });
+    expect(resultDefault!.sessionKey).toBe("dchat:dm:sender-addr");
+
+    // no accountId also omits prefix
+    const resultNone = nknToInbound("sender-addr", msg, selfAddr);
+    expect(resultNone!.sessionKey).toBe("dchat:dm:sender-addr");
+  });
+
   it("translates topic message", () => {
     const msg: MessageData = {
       id: "msg-2",
@@ -227,6 +246,10 @@ describe("session key extractors", () => {
   it("extracts DM address from session key", () => {
     expect(extractDmAddressFromSessionKey("dchat:dm:some-nkn-addr")).toBe("some-nkn-addr");
     expect(extractDmAddressFromSessionKey("dchat:topic:general")).toBeUndefined();
+  });
+
+  it("extracts DM address from account-scoped session key", () => {
+    expect(extractDmAddressFromSessionKey("dchat:work:dm:some-nkn-addr")).toBe("some-nkn-addr");
   });
 });
 

--- a/extensions/dchat/src/wire.ts
+++ b/extensions/dchat/src/wire.ts
@@ -69,6 +69,7 @@ export function nknToInbound(
   src: string,
   msg: MessageData,
   selfAddress: string,
+  opts?: { accountId?: string },
 ): InboundMessageResult | null {
   if (isControlMessage(msg.contentType)) {
     return null;
@@ -92,7 +93,9 @@ export function nknToInbound(
     sessionKey = `dchat:group:${msg.groupId}`;
     groupSubject = msg.groupId;
   } else {
-    sessionKey = `dchat:dm:${src}`;
+    // Include account identity to prevent session key collisions in multi-account setups
+    const acct = opts?.accountId;
+    sessionKey = acct && acct !== "default" ? `dchat:${acct}:dm:${src}` : `dchat:dm:${src}`;
   }
 
   // Extract body text
@@ -219,8 +222,9 @@ export function extractGroupIdFromSessionKey(sessionKey: string): string | undef
 /**
  * Extract a direct message address from a session key.
  * dchat:dm:addr -> "addr"
+ * dchat:<accountId>:dm:addr -> "addr"
  */
 export function extractDmAddressFromSessionKey(sessionKey: string): string | undefined {
-  const match = sessionKey.match(/^dchat:dm:(.+)$/);
+  const match = sessionKey.match(/^dchat:(?:[^:]+:)?dm:(.+)$/);
   return match?.[1];
 }

--- a/extensions/dchat/src/wire.ts
+++ b/extensions/dchat/src/wire.ts
@@ -1,0 +1,226 @@
+import crypto from "crypto";
+import {
+  CONTROL_CONTENT_TYPES,
+  DISPLAYABLE_CONTENT_TYPES,
+  type MessageContentType,
+  type MessageData,
+  type MessageOptions,
+} from "./types.js";
+
+/**
+ * Generate the NKN topic hash from a human-readable topic name.
+ * nMobile convention: strip leading '#', SHA-1 hash, hex-encode, prefix with "dchat".
+ */
+export function genTopicHash(topicName: string): string {
+  const cleaned = topicName.replace(/^#+/, "");
+  const hash = crypto.createHash("sha1").update(cleaned).digest("hex");
+  return "dchat" + hash;
+}
+
+/**
+ * Parse a raw NKN payload string into a MessageData object.
+ * Returns null if the payload is not valid JSON or missing required fields.
+ */
+export function parseNknPayload(raw: string): MessageData | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    if (!parsed.id || !parsed.contentType) return null;
+    return parsed as MessageData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip NKN MultiClient sub-client prefix (__N__.) from an address.
+ * e.g. "__0__.cd3530..." → "cd3530..."
+ */
+export function stripNknSubClientPrefix(addr: string): string {
+  return addr.replace(/^__\d+__\./, "");
+}
+
+/** Returns true if the content type is a control message (not forwarded to agent). */
+export function isControlMessage(contentType: string): boolean {
+  return CONTROL_CONTENT_TYPES.has(contentType);
+}
+
+/** Returns true if the content type carries displayable content. */
+export function isDisplayableMessage(contentType: string): boolean {
+  return DISPLAYABLE_CONTENT_TYPES.has(contentType);
+}
+
+export interface InboundMessageResult {
+  body: string;
+  chatType: "direct" | "group";
+  sessionKey: string;
+  senderId: string;
+  senderName: string;
+  groupSubject?: string;
+  ipfsHash?: string;
+  ipfsOptions?: MessageOptions;
+}
+
+/**
+ * Translate an inbound NKN MessageData to OpenClaw inbound context fields.
+ * Returns null for control messages that should not be forwarded.
+ */
+export function nknToInbound(
+  src: string,
+  msg: MessageData,
+  selfAddress: string,
+): InboundMessageResult | null {
+  if (isControlMessage(msg.contentType)) {
+    return null;
+  }
+
+  if (!isDisplayableMessage(msg.contentType)) {
+    return null;
+  }
+
+  // Determine chat type and session key
+  const hasTopic = Boolean(msg.topic);
+  const hasGroupId = Boolean(msg.groupId);
+  const chatType: "direct" | "group" = hasTopic || hasGroupId ? "group" : "direct";
+
+  let sessionKey: string;
+  let groupSubject: string | undefined;
+  if (hasTopic) {
+    sessionKey = `dchat:topic:${msg.topic}`;
+    groupSubject = `#${msg.topic}`;
+  } else if (hasGroupId) {
+    sessionKey = `dchat:group:${msg.groupId}`;
+    groupSubject = msg.groupId;
+  } else {
+    sessionKey = `dchat:dm:${src}`;
+  }
+
+  // Extract body text
+  let body: string;
+  const ct = msg.contentType;
+
+  if (ct === "text" || ct === "textExtension") {
+    body = msg.content ?? "";
+  } else if (ct === "ipfs") {
+    const fileType = msg.options?.fileType;
+    const isImage = fileType === 1 || fileType === "1" || fileType === undefined;
+    const isAudio = fileType === 2 || fileType === "2";
+    const isFile = fileType === 0 || fileType === "0";
+    if (isImage) {
+      body = "[Image]";
+    } else if (isAudio) {
+      body = "[Audio]";
+    } else if (isFile) {
+      const fileName = msg.options?.fileName;
+      body = fileName ? `[File: ${fileName}]` : "[File]";
+    } else {
+      body = "[IPFS content]";
+    }
+  } else if (ct === "audio") {
+    body = "[Voice Message]";
+  } else if (ct === "image") {
+    body = "[Image]";
+  } else if (ct === "video") {
+    body = "[Video]";
+  } else if (ct === "file") {
+    body = "[File]";
+  } else {
+    body = msg.content ?? "";
+  }
+
+  // Short sender name: first 8 chars of NKN address
+  const senderName = src.length > 16 ? src.substring(0, 8) + "..." : src;
+
+  return {
+    body,
+    chatType,
+    sessionKey,
+    senderId: src,
+    senderName,
+    groupSubject,
+    ipfsHash: msg.options?.ipfsHash || (ct === "ipfs" ? msg.content : undefined),
+    ipfsOptions: ct === "ipfs" || ct === "audio" ? msg.options : undefined,
+  };
+}
+
+/**
+ * Build an outbound NKN MessageData from text.
+ * Sets appropriate content type and topic/groupId fields.
+ */
+export function textToNkn(
+  text: string,
+  opts?: {
+    topic?: string;
+    groupId?: string;
+  },
+): MessageData {
+  return {
+    id: crypto.randomUUID(),
+    contentType: "text" as MessageContentType,
+    content: text,
+    ...(opts?.topic ? { topic: opts.topic } : {}),
+    ...(opts?.groupId ? { groupId: opts.groupId } : {}),
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Build an outbound NKN MessageData for IPFS media (image/file).
+ */
+export function ipfsToNkn(
+  options: MessageOptions,
+  opts?: {
+    topic?: string;
+    groupId?: string;
+  },
+): MessageData {
+  return {
+    id: crypto.randomUUID(),
+    contentType: "ipfs" as MessageContentType,
+    content: options.ipfsHash,
+    options,
+    ...(opts?.topic ? { topic: opts.topic } : {}),
+    ...(opts?.groupId ? { groupId: opts.groupId } : {}),
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Build a delivery receipt MessageData.
+ */
+export function receiptToNkn(targetMessageId: string): MessageData {
+  return {
+    id: crypto.randomUUID(),
+    contentType: "receipt" as MessageContentType,
+    targetID: targetMessageId,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Extract a topic name from a session key.
+ * dchat:topic:general -> "general"
+ * dchat:dm:addr -> undefined
+ */
+export function extractTopicFromSessionKey(sessionKey: string): string | undefined {
+  const match = sessionKey.match(/^dchat:topic:(.+)$/);
+  return match?.[1];
+}
+
+/**
+ * Extract a group ID from a session key.
+ * dchat:group:abc123 -> "abc123"
+ */
+export function extractGroupIdFromSessionKey(sessionKey: string): string | undefined {
+  const match = sessionKey.match(/^dchat:group:(.+)$/);
+  return match?.[1];
+}
+
+/**
+ * Extract a direct message address from a session key.
+ * dchat:dm:addr -> "addr"
+ */
+export function extractDmAddressFromSessionKey(sessionKey: string): string | undefined {
+  const match = sessionKey.match(/^dchat:dm:(.+)$/);
+  return match?.[1];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,12 +276,13 @@ importers:
       nkn-sdk:
         specifier: ^1.3.6
         version: 1.3.6
-      openclaw:
-        specifier: '*'
-        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/diagnostics-otel:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,13 +276,12 @@ importers:
       nkn-sdk:
         specifier: ^1.3.6
         version: 1.3.6
+      openclaw:
+        specifier: '*'
+        version: 2026.2.24(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.15.1(typescript@5.9.3))
       zod:
         specifier: ^4.3.6
         version: 4.3.6
-    devDependencies:
-      openclaw:
-        specifier: workspace:*
-        version: link:../..
 
   extensions/diagnostics-otel:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
       '@grammyjs/types':
         specifier: ^3.24.0
@@ -256,10 +260,6 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
 
   extensions/acpx:
     dependencies:
@@ -270,6 +270,19 @@ importers:
   extensions/bluebubbles: {}
 
   extensions/copilot-proxy: {}
+
+  extensions/dchat:
+    dependencies:
+      nkn-sdk:
+        specifier: ^1.3.6
+        version: 1.3.6
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/diagnostics-otel:
     dependencies:
@@ -717,6 +730,10 @@ packages:
     resolution: {integrity: sha512-6HyyU5l1yK/7h9Ki52i5h6mDAx4qJdiLQO4FdCyJNoB/gy3T3GGJdhQzzbZgvgZCugYBvwtQiWRt94QKedHnkA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  '@babel/polyfill@7.12.1':
+    resolution: {integrity: sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==}
+    deprecated: 🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -1265,7 +1282,6 @@ packages:
   '@lancedb/lancedb@0.26.2':
     resolution: {integrity: sha512-umk4WMCTwJntLquwvUbpqE+TXREolcQVL9MHcxr8EhRjsha88+ATJ4QuS/hpyiE1CG3R/XcgrMgJAGkziPC/gA==}
     engines: {node: '>= 18'}
-    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -1516,6 +1532,9 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@nkn/ncp@1.1.2':
+    resolution: {integrity: sha512-HNQtIdAx/fQERvRQxIMZ2YrDqH9iDI/VhBSBfI0fp1owqawOP3996M7f/td4hjEgjh3Q72A9N/QYdu07AFLEEw==}
 
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
@@ -3260,6 +3279,9 @@ packages:
       bare-abort-controller:
         optional: true
 
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3315,6 +3337,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bun-types@1.3.9:
     resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
@@ -3468,6 +3493,16 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js-pure@3.48.0:
+    resolution: {integrity: sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==}
+
+  core-js@2.6.12:
+    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
+    deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
+
+  core-js@3.48.0:
+    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -3481,6 +3516,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -3523,6 +3561,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3609,6 +3650,9 @@ packages:
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ed2curve@0.3.0:
+    resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3933,6 +3977,9 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3977,6 +4024,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  heap@0.2.7:
+    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -4135,6 +4185,11 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -4235,6 +4290,12 @@ packages:
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+
+  libsodium-wrappers@0.7.16:
+    resolution: {integrity: sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==}
+
+  libsodium@0.7.16:
+    resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -4460,6 +4521,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memory-cache@0.2.0:
+    resolution: {integrity: sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
@@ -4567,6 +4631,9 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
+
+  nkn-sdk@1.3.6:
+    resolution: {integrity: sha512-r73B7P+JHjvXrhWpcZJH6gCeZnLzVTfLE7mZsV+e9wIThm+Be0u5zw9swVqaEDUTDnVfSevajf9fuJRSa08HYw==}
 
   node-addon-api@8.5.0:
     resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
@@ -5033,11 +5100,14 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   request-promise-core@1.1.3:
     resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      request: ^2.34
+      request: npm:@cypress/request@3.0.10
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -5126,6 +5196,9 @@ packages:
 
   sanitize-html@2.17.1:
     resolution: {integrity: sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==}
+
+  scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -5360,6 +5433,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
@@ -5499,6 +5576,9 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -5689,6 +5769,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webworkify@1.5.0:
+    resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -5727,6 +5810,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -6277,6 +6372,11 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.1
 
+  '@babel/polyfill@7.12.1':
+    dependencies:
+      core-js: 2.6.12
+      regenerator-runtime: 0.13.11
+
   '@babel/runtime@7.28.6': {}
 
   '@babel/types@7.29.0':
@@ -6729,7 +6829,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -7155,6 +7255,13 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@nkn/ncp@1.1.2':
+    dependencies:
+      core-js-pure: 3.48.0
+      google-protobuf: 3.21.4
+      heap: 0.2.7
+      setimmediate: 1.0.5
 
   '@noble/ciphers@2.1.1': {}
 
@@ -8967,6 +9074,10 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   base64-js@1.5.1: {}
 
   basic-auth@2.0.1:
@@ -9033,6 +9144,11 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bun-types@1.3.9:
     dependencies:
@@ -9184,6 +9300,12 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js-pure@3.48.0: {}
+
+  core-js@2.6.12: {}
+
+  core-js@3.48.0: {}
+
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
@@ -9195,6 +9317,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-js@4.2.0: {}
 
   css-select@5.2.2:
     dependencies:
@@ -9225,6 +9349,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-extend@0.6.0: {}
 
@@ -9297,6 +9423,10 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  ed2curve@0.3.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   ee-first@1.1.1: {}
 
@@ -9735,6 +9865,8 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  google-protobuf@3.21.4: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9781,6 +9913,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  heap@0.2.7: {}
 
   highlight.js@10.7.3: {}
 
@@ -9963,6 +10097,10 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  isomorphic-ws@4.0.1(ws@7.5.10):
+    dependencies:
+      ws: 7.5.10
+
   isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -10078,6 +10216,12 @@ snapshots:
   koffi@2.15.1: {}
 
   leac@0.6.0: {}
+
+  libsodium-wrappers@0.7.16:
+    dependencies:
+      libsodium: 0.7.16
+
+  libsodium@0.7.16: {}
 
   lie@3.3.0:
     dependencies:
@@ -10271,6 +10415,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memory-cache@0.2.0: {}
+
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
@@ -10362,6 +10508,33 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
+
+  nkn-sdk@1.3.6:
+    dependencies:
+      '@babel/polyfill': 7.12.1
+      '@nkn/ncp': 1.1.2
+      axios: 1.13.5
+      base-x: 3.0.11
+      buffer: 5.7.1
+      core-js: 3.48.0
+      core-js-pure: 3.48.0
+      crypto-js: 4.2.0
+      decimal.js: 10.6.0
+      ed2curve: 0.3.0
+      google-protobuf: 3.21.4
+      heap: 0.2.7
+      isomorphic-ws: 4.0.1(ws@7.5.10)
+      libsodium-wrappers: 0.7.16
+      memory-cache: 0.2.0
+      pako: 1.0.11
+      scrypt-js: 3.0.1
+      tweetnacl: 1.0.3
+      webworkify: 1.5.0
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
 
   node-addon-api@8.5.0: {}
 
@@ -11007,6 +11180,8 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  regenerator-runtime@0.13.11: {}
+
   request-promise-core@1.1.3(@cypress/request@3.0.10):
     dependencies:
       lodash: 4.17.23
@@ -11139,6 +11314,8 @@ snapshots:
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
       postcss: 8.5.6
+
+  scrypt-js@3.0.1: {}
 
   selderee@0.11.0:
     dependencies:
@@ -11457,6 +11634,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
@@ -11597,6 +11778,8 @@ snapshots:
 
   tweetnacl@0.14.5: {}
 
+  tweetnacl@1.0.3: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -11731,6 +11914,8 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webworkify@1.5.0: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -11771,6 +11956,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@7.5.10: {}
 
   ws@8.19.0: {}
 


### PR DESCRIPTION
## Summary

- Adds **D-Chat / nMobile** to the community plugins listing page
- npm: `@zbruceli/openclaw-dchat` ([npmjs](https://www.npmjs.com/package/@zbruceli/openclaw-dchat))
- repo: https://github.com/zbruceli/openclaw-dchat
- Decentralized E2E encrypted messaging over the NKN relay network — supports DM, topics, private groups, and IPFS media

## Context

Extracted from the in-repo `extensions/dchat/` implementation (PR #26721 feedback → community plugin). All 46 tests pass in the standalone repo. Published as `@zbruceli/openclaw-dchat@0.1.0` on npm.

Install: `openclaw plugins install @zbruceli/openclaw-dchat`