### PR TITLE
feat(matrix): add historyLimit and dmHistoryLimit config support

### DIFF
--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -52,6 +52,8 @@ export const MatrixConfigSchema = z.object({
   textChunkLimit: z.number().optional(),
   chunkMode: z.enum(["length", "newline"]).optional(),
   responsePrefix: z.string().optional(),
+  historyLimit: z.number().int().min(0).optional(),
+  dmHistoryLimit: z.number().int().min(0).optional(),
   mediaMaxMb: z.number().optional(),
   autoJoin: z.enum(["always", "allowlist", "off"]).optional(),
   autoJoinAllowlist: z.array(allowFromEntry).optional(),

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -79,6 +79,10 @@ export type MatrixConfig = {
   chunkMode?: "length" | "newline";
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Max group/channel messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
   /** Max outbound media size in MB. */
   mediaMaxMb?: number;
   /** Auto-join invites (always|allowlist|off). Default: always. */


### PR DESCRIPTION
The core agent runner already supports per-channel history limiting via
  getHistoryLimitFromSessionKey(), which reads channels.<provider>.historyLimit
  and channels.<provider>.dmHistoryLimit. However, the Matrix plugin's Zod
  schema and TypeScript types did not declare these fields, causing them to be
  stripped during config validation.

  This adds historyLimit and dmHistoryLimit to the Matrix config schema and type
   definition, matching the WhatsApp plugin's existing support. No runtime code
  changes needed — the core handles history truncation generically.

  Fixes #18709

  Summary

  - Problem: Matrix plugin config schema does not include historyLimit or
  dmHistoryLimit, so these values are stripped during Zod validation even though
   the core agent runner supports them for all channels
  - Why it matters: Matrix DMs and group chats lose all conversation context on
  agent restart, unlike WhatsApp which retains recent history
  - What changed: Added historyLimit and dmHistoryLimit to the Matrix Zod schema
   (config-schema.ts) and TypeScript type (types.ts)
  - What did NOT change: No runtime code, no core changes, no other plugins
  affected

  Change Type:
  - [x] Bug fix                                                                 
  - [x] Feature                                             
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  Scope:
  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  Linked Issue/PR

  - Closes #18709
  - Related #18718

  User-visible / Behavior Changes

  Users can now set channels.matrix.dmHistoryLimit and
  channels.matrix.historyLimit in openclaw.json to control how many recent
  conversation turns are retained in the agent's context. Previously these
  values were silently stripped by schema validation.

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: macOS Darwin 25.1.0
  - Runtime/container: Docker (openclaw:base 2026.2.27)
  - Model/provider: Any
  - Integration/channel: Matrix (@vector-im/matrix-bot-sdk)
  - Relevant config: channels.matrix.dmHistoryLimit: 10

  Steps

  1. Set channels.matrix.dmHistoryLimit: 10 in openclaw.json
  2. Start a Matrix DM conversation, exchange >10 user messages
  3. Restart the agent container
  4. Send a new message referencing earlier conversation

  Expected

  - Agent retains last 10 user turns of context after restart

  Actual (before fix)

  - Agent has zero conversation context after restart; dmHistoryLimit silently
  stripped by Zod schema

  Evidence

  - Trace/log snippets: Confirmed dmHistoryLimit present in validated config
  after schema change; confirmed getHistoryLimitFromSessionKey() returns the
  configured value for matrix:direct:* session keys

  Human Verification (required)

  - Verified scenarios: Config value passes Zod validation, core
  getHistoryLimitFromSessionKey resolves Matrix DM and group session keys
  correctly
  - Edge cases checked: historyLimit: 0 (disables), omitted (undefined = no
  limit)
  - What you did not verify: Large-scale multi-room Matrix deployments

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No (new optional fields only)
  - Migration needed? No

  Failure Recovery (if this breaks)

  - How to disable/revert: Remove historyLimit/dmHistoryLimit from Matrix
  config; values revert to undefined (no limiting)
  - Known bad symptoms: None expected; these are optional config fields with no
  default

  Risks and Mitigations

  None — additive optional config fields only, matching existing WhatsApp
  implementation pattern.