### PR TITLE
fix: suppress NO_REPLY token in Discord send (parity with Slack)

### DIFF
--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { serializePayload, type MessagePayloadObject, type RequestClient } from "@buape/carbon";
 import { ChannelType, Routes } from "discord-api-types/v10";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -131,6 +132,10 @@ export async function sendMessageDiscord(
   text: string,
   opts: DiscordSendOpts = {},
 ): Promise<DiscordSendResult> {
+  const trimmedText = text?.trim() ?? "";
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl && !opts.components) {
+    return { messageId: "suppressed", channelId: "" };
+  }
   const cfg = loadConfig();
   const accountInfo = resolveDiscordAccount({
     cfg,

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -174,6 +174,26 @@ describe("sendMessageDiscord", () => {
     expect(res.channelId).toBe("chan1");
   });
 
+  it("suppresses NO_REPLY token without making an API call", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const res = await sendMessageDiscord("channel:789", "NO_REPLY", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual({ messageId: "suppressed", channelId: "" });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses NO_REPLY token with surrounding whitespace", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const res = await sendMessageDiscord("channel:789", "  NO_REPLY  ", {
+      rest,
+      token: "t",
+    });
+    expect(res).toEqual({ messageId: "suppressed", channelId: "" });
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
   it("rejects bare numeric IDs as ambiguous", async () => {
     const { rest } = makeDiscordRest();
     await expect(


### PR DESCRIPTION
## Problem

The NO_REPLY sentinel token was leaking to Discord channels because `sendMessageDiscord` did not have the `isSilentReplyText` guard that `sendMessageSlack` has in `src/slack/send.ts`.

## Root Cause

In #27529, the NO_REPLY suppression was added to Slack's send path. Discord's send path was overlooked. The core delivery layer filters NO_REPLY in many cases, but the block-streaming preview path can bypass those filters in edge cases, causing the literal text "NO_REPLY" to appear in Discord.

## Fix

Adds the same guard to `sendMessageDiscord` in `src/discord/send.outbound.ts`:

- Returns early with `{messageId: 'suppressed', channelId: ''}` when text is exactly NO_REPLY (whitespace-trimmed)
- Skips suppression if `mediaUrl` or `components` are present (substantive payload)

## Tests

Added two unit tests to `src/discord/send.sends-basic-channel-messages.test.ts`:
- "suppresses NO_REPLY token without making an API call"
- "suppresses NO_REPLY token with surrounding whitespace"

All 29 tests pass.

## Related

- Resolves #27387 (for Discord)
- Parity with Slack implementation from #27529