### PR TITLE
fix: do not carry over model/provider override on session reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1026,6 +1026,50 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("does NOT carry over modelOverride/providerOverride on /new", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-override-");
+    const sessionKey = "agent:main:telegram:dm:user-model-override";
+    const existingSessionId = "existing-session-model";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: {
+        modelOverride: "fallback-model",
+        providerOverride: "fallback-provider",
+        verboseLevel: "on",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-model-override",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    // Model overrides should NOT persist — new session uses configured primary.
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    // Behavior overrides (verbose, thinking, etc.) SHOULD persist.
+    expect(result.sessionEntry.verboseLevel).toBe("on");
+  });
+
   it("archives the old session store entry on /new", async () => {
     const storePath = await createStorePath("openclaw-archive-old-");
     const sessionKey = "agent:main:telegram:dm:user-archive";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1026,48 +1026,55 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
-  it("does NOT carry over modelOverride/providerOverride on /new", async () => {
-    const storePath = await createStorePath("openclaw-reset-model-override-");
-    const sessionKey = "agent:main:telegram:dm:user-model-override";
-    const existingSessionId = "existing-session-model";
-    await seedSessionStoreWithOverrides({
-      storePath,
-      sessionKey,
-      sessionId: existingSessionId,
-      overrides: {
-        modelOverride: "fallback-model",
-        providerOverride: "fallback-provider",
-        verboseLevel: "on",
-      },
-    });
+  it("does NOT carry over modelOverride/providerOverride on /new or /reset", async () => {
+    const cases = [
+      { name: "/new clears model overrides", body: "/new" },
+      { name: "/reset clears model overrides", body: "/reset" },
+    ] as const;
 
-    const cfg = {
-      session: { store: storePath, idleMinutes: 999 },
-    } as OpenClawConfig;
+    for (const testCase of cases) {
+      const storePath = await createStorePath("openclaw-reset-model-override-");
+      const sessionKey = "agent:main:telegram:dm:user-model-override";
+      const existingSessionId = "existing-session-model";
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: {
+          modelOverride: "fallback-model",
+          providerOverride: "fallback-provider",
+          verboseLevel: "on",
+        },
+      });
 
-    const result = await initSessionState({
-      ctx: {
-        Body: "/new",
-        RawBody: "/new",
-        CommandBody: "/new",
-        From: "user-model-override",
-        To: "bot",
-        ChatType: "direct",
-        SessionKey: sessionKey,
-        Provider: "telegram",
-        Surface: "telegram",
-      },
-      cfg,
-      commandAuthorized: true,
-    });
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
 
-    expect(result.isNewSession).toBe(true);
-    expect(result.resetTriggered).toBe(true);
-    // Model overrides should NOT persist — new session uses configured primary.
-    expect(result.sessionEntry.modelOverride).toBeUndefined();
-    expect(result.sessionEntry.providerOverride).toBeUndefined();
-    // Behavior overrides (verbose, thinking, etc.) SHOULD persist.
-    expect(result.sessionEntry.verboseLevel).toBe("on");
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "user-model-override",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      // Model overrides should NOT persist — new session uses configured primary.
+      expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
+      // Behavior overrides (verbose, thinking, etc.) SHOULD persist.
+      expect(result.sessionEntry.verboseLevel, testCase.name).toBe("on");
+    }
   });
 
   it("archives the old session store entry on /new", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -325,8 +325,9 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
+      // Do NOT carry over modelOverride / providerOverride on /new or /reset.
+      // These may have been set by a cron or subagent session using a fallback
+      // model, and the new session should start with the configured primary.
       persistedLabel = entry.label;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #30109 — `/new` and `/reset` commands no longer carry over `modelOverride`/`providerOverride` from the previous session entry.

**Root cause**: `initSessionState` in `session.ts` preserved `modelOverride`/`providerOverride` from the previous session entry when `resetTriggered` is true (lines 328-329). If a cron or subagent session used a fallback model, that override was carried into the new session, causing:
1. The delivery-mirror greeting to display the fallback model instead of the configured primary
2. The system prompt `Runtime: model=` line to display the wrong model

The actual model used by the session was correct (resolved via `resolveDefaultModel`), but the announcements were misleading.

**Fix**: Remove `modelOverride`/`providerOverride` from the reset-triggered carry-over block. Behavior-preference overrides (`thinkingLevel`, `verboseLevel`, `reasoningLevel`, `ttsAuto`, `label`) continue to be preserved as intended.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/session.ts` | Remove model/provider override carry-over on reset (+3/-2) |
| `src/auto-reply/reply/session.test.ts` | Add test: model overrides NOT preserved on `/new` while behavior overrides ARE (+44) |

## Test plan

- [x] Existing `session.test.ts`: 36/36 pass (was 35, +1 new)
- [x] New test verifies: `modelOverride` and `providerOverride` are `undefined` after `/new`, while `verboseLevel` is preserved
- [x] Build: PASS (tsc --noEmit)
- [x] Lint: 0 warnings/errors (oxlint)

lobster-biscuit