### PR TITLE
feat: ACP subagent completion notification with requester mention

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "oxfmt": "0.35.0",
     "oxlint": "^1.50.0",
     "oxlint-tsgolint": "^0.15.0",
+    "rolldown": "1.0.0-rc.6",
     "signal-utils": "0.21.1",
     "tsdown": "^0.20.3",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.15.0
         version: 0.15.0
+      rolldown:
+        specifier: 1.0.0-rc.6
+        version: 1.0.0-rc.6
       signal-utils:
         specifier: 0.21.1
         version: 0.21.1(signal-polyfill@0.2.2)
@@ -1895,6 +1898,9 @@ packages:
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
 
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     resolution: {integrity: sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2254,8 +2260,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.6':
+    resolution: {integrity: sha512-kvjTSWGcrv+BaR2vge57rsKiYdVR8V8CoS0vgKrc570qRBfty4bT+1X0z3j2TaVV+kAYzA0PjeB9+mdZyqUZlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.6':
+    resolution: {integrity: sha512-+tJhD21KvGNtUrpLXrZQlT+j5HZKiEwR2qtcZb3vNOUpvoT9QjEykr75ZW/Kr0W89gose/HVXU6351uVZD8Qvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2266,8 +2284,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.6':
+    resolution: {integrity: sha512-DKNhjMk38FAWaHwUt1dFR3rA/qRAvn2NUvSG2UGvxvlMxSmN/qqww/j4ABAbXhNRXtGQNmrAINMXRuwHl16ZHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.6':
+    resolution: {integrity: sha512-8TThsRkCPAnfyMBShxrGdtoOE6h36QepqRQI97iFaQSCRbHFWHcDHppcojZnzXoruuhPnjMEygzaykvPVJsMRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2278,8 +2308,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.6':
+    resolution: {integrity: sha512-ZfmFoOwPUZCWtGOVC9/qbQzfc0249FrRUOzV2XabSMUV60Crp211OWLQN1zmQAsRIVWRcEwhJ46Z1mXGo/L/nQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.6':
+    resolution: {integrity: sha512-ZsGzbNETxPodGlLTYHaCSGVhNN/rvkMDCJYHdT7PZr5jFJRmBfmDi2awhF64Dt2vxrJqY6VeeYSgOzEbHRsb7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2290,8 +2332,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
+    resolution: {integrity: sha512-elPpdevtCdUOqziemR86C4CSCr/5sUxalzDrf/CJdMT+kZt2C556as++qHikNOz0vuFf52h+GJNXZM08eWgGPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
+    resolution: {integrity: sha512-IBwXsf56o3xhzAyaZxdM1CX8UFiBEUFCjiVUgny67Q8vPIqkjzJj0YKhd3TbBHanuxThgBa59f6Pgutg2OGk5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2302,8 +2356,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
+    resolution: {integrity: sha512-vOk7G8V9Zm+8a6PL6JTpCea61q491oYlGtO6CvnsbhNLlKdf0bbCPytFzGQhYmCKZDKkEbmnkcIprTEGCURnwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
+    resolution: {integrity: sha512-ASjEDI4MRv7XCQb2JVaBzfEYO98JKCGrAgoW6M03fJzH/ilCnC43Mb3ptB9q/lzsaahoJyIBoAGKAYEjUvpyvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2313,8 +2379,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.6':
+    resolution: {integrity: sha512-mYa1+h2l6Zc0LvmwUh0oXKKYihnw/1WC73vTqw+IgtfEtv47A+rWzzcWwVDkW73+UDr0d/Ie/HRXoaOY22pQDw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.6':
+    resolution: {integrity: sha512-e2ABskbNH3MRUBMjgxaMjYIw11DSwjLJxBII3UgpF6WClGLIh8A20kamc+FKH5vIaFVnYQInmcLYSUVpqMPLow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2325,8 +2402,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.6':
+    resolution: {integrity: sha512-dJVc3ifhaRXxIEh1xowLohzFrlQXkJ66LepHm+CmSprTWgVrPa8Fx3OL57xwIqDEH9hufcKkDX2v65rS3NZyRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rolldown/pluginutils@1.0.0-rc.6':
+    resolution: {integrity: sha512-Y0+JT8Mi1mmW08K6HieG315XNRu4L0rkfCpA364HtytjgiqYnMYRdFPcxRl+BQQqNXzecL2S9nii+RUpO93XIA==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -5105,6 +5191,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.0.0-rc.6:
+    resolution: {integrity: sha512-B8vFPV1ADyegoYfhg+E7RAucYKv0xdVlwYYsIJgfPNeiSxZGWNxts9RqhyGzC11ULK/VaeXyKezGCwpMiH8Ktw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7596,6 +7687,8 @@ snapshots:
 
   '@oxc-project/types@0.112.0': {}
 
+  '@oxc-project/types@0.115.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.35.0':
     optional: true
 
@@ -7801,31 +7894,61 @@ snapshots:
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
@@ -7833,13 +7956,26 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.6':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.6':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.6': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -11084,6 +11220,25 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
+
+  rolldown@1.0.0-rc.6:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.6
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.6
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.6
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.6
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.6
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.6
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.6
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.6
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.6
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.6
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.6
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.6
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.6
 
   rollup@4.59.0:
     dependencies:

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -162,6 +162,7 @@ export function createOpenClawTools(options?: {
       agentGroupSpace: options?.agentGroupSpace,
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
+      requesterSenderId: options?.requesterSenderId,
     }),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -7,6 +7,7 @@ import {
   resolveAgentIdFromSessionKey,
   resolveMainSessionKey,
   resolveStorePath,
+  type SessionEntry,
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
@@ -71,12 +72,14 @@ function buildCompletionDeliveryMessage(params: {
   spawnMode?: SpawnSubagentMode;
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
+  requesterUserId?: string;
 }): string {
   const findingsText = params.findings.trim();
   if (isAnnounceSkip(findingsText)) {
     return "";
   }
   const hasFindings = findingsText.length > 0 && findingsText !== "(no output)";
+  const mention = params.requesterUserId ? `<@${params.requesterUserId}> ` : "";
   // Cron completions are standalone messages — skip the subagent status header.
   if (params.announceType === "cron job") {
     return hasFindings ? findingsText : "";
@@ -84,22 +87,42 @@ function buildCompletionDeliveryMessage(params: {
   const header = (() => {
     if (params.outcome?.status === "error") {
       return params.spawnMode === "session"
-        ? `❌ Subagent ${params.subagentName} failed this task (session remains active)`
-        : `❌ Subagent ${params.subagentName} failed`;
+        ? `${mention}❌ Subagent ${params.subagentName} failed this task (session remains active)`
+        : `${mention}❌ Subagent ${params.subagentName} failed`;
     }
     if (params.outcome?.status === "timeout") {
       return params.spawnMode === "session"
-        ? `⏱️ Subagent ${params.subagentName} timed out on this task (session remains active)`
-        : `⏱️ Subagent ${params.subagentName} timed out`;
+        ? `${mention}⏱️ Subagent ${params.subagentName} timed out on this task (session remains active)`
+        : `${mention}⏱️ Subagent ${params.subagentName} timed out`;
     }
     return params.spawnMode === "session"
-      ? `✅ Subagent ${params.subagentName} completed this task (session remains active)`
-      : `✅ Subagent ${params.subagentName} finished`;
+      ? `${mention}✅ Subagent ${params.subagentName} completed this task (session remains active)`
+      : `${mention}✅ Subagent ${params.subagentName} finished`;
   })();
   if (!hasFindings) {
     return header;
   }
   return `${header}\n\n${findingsText}`;
+}
+
+function extractUserIdFromSessionEntry(entry?: SessionEntry | null): string | undefined {
+  // Prefer raw sender fields captured by session persistence when available.
+  const rawSenderId =
+    entry && typeof entry === "object"
+      ? ((entry as unknown as { senderId?: unknown; SenderId?: unknown }).senderId ??
+        (entry as unknown as { senderId?: unknown; SenderId?: unknown }).SenderId)
+      : undefined;
+  if (typeof rawSenderId === "string" && /^\d+$/.test(rawSenderId.trim())) {
+    return rawSenderId.trim();
+  }
+  // Fallback: try to extract from origin.from for DMs (format: "discord:${userId}")
+  if (entry?.origin?.from?.startsWith("discord:")) {
+    const parts = entry.origin.from.split(":");
+    if (parts.length >= 2 && parts[1] && /^\d+$/.test(parts[1])) {
+      return parts[1];
+    }
+  }
+  return undefined;
 }
 
 function summarizeDeliveryError(error: unknown): string {
@@ -1060,6 +1083,8 @@ export async function runSubagentAnnounceFlow(params: {
   childRunId: string;
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
+  /** Trusted requester sender id captured at spawn time (e.g. Discord user id). */
+  requesterSenderId?: string;
   requesterDisplayKey: string;
   task: string;
   timeoutMs: number;
@@ -1278,12 +1303,19 @@ export async function runSubagentAnnounceFlow(params: {
       startedAt: params.startedAt,
       endedAt: params.endedAt,
     });
+    // Prefer trusted sender id captured at spawn time; fallback to session entry heuristics.
+    const { entry: requesterEntry } = loadRequesterSessionEntry(targetRequesterSessionKey);
+    const requesterUserId =
+      (typeof params.requesterSenderId === "string" && /^\d+$/.test(params.requesterSenderId)
+        ? params.requesterSenderId
+        : undefined) ?? extractUserIdFromSessionEntry(requesterEntry);
     completionMessage = buildCompletionDeliveryMessage({
       findings,
       subagentName,
       spawnMode: params.spawnMode,
       outcome,
       announceType,
+      requesterUserId,
     });
     const internalSummaryMessage = [
       `[System Message] [sessionId: ${announceSessionId}] A ${announceType} "${taskLabel}" just ${statusLabel}.`,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -387,6 +387,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     childRunId: entry.runId,
     requesterSessionKey: entry.requesterSessionKey,
     requesterOrigin,
+    requesterSenderId: entry.requesterSenderId,
     requesterDisplayKey: entry.requesterDisplayKey,
     task: entry.task,
     timeoutMs: SUBAGENT_ANNOUNCE_TIMEOUT_MS,
@@ -897,6 +898,7 @@ export function registerSubagentRun(params: {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
+  requesterSenderId?: string;
   requesterDisplayKey: string;
   task: string;
   cleanup: "delete" | "keep";
@@ -920,6 +922,7 @@ export function registerSubagentRun(params: {
     childSessionKey: params.childSessionKey,
     requesterSessionKey: params.requesterSessionKey,
     requesterOrigin,
+    requesterSenderId: params.requesterSenderId,
     requesterDisplayKey: params.requesterDisplayKey,
     task: params.task,
     cleanup: params.cleanup,

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -8,6 +8,8 @@ export type SubagentRunRecord = {
   childSessionKey: string;
   requesterSessionKey: string;
   requesterOrigin?: DeliveryContext;
+  /** Trusted requester sender id captured at spawn time (e.g. Discord user id). */
+  requesterSenderId?: string;
   requesterDisplayKey: string;
   task: string;
   cleanup: "delete" | "keep";

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -49,6 +49,8 @@ export type SpawnSubagentContext = {
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
   requesterAgentIdOverride?: string;
+  /** Trusted requester sender id from inbound context (e.g. Discord user id). */
+  requesterSenderId?: string;
 };
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
@@ -490,6 +492,7 @@ export async function spawnSubagentDirect(
     childSessionKey,
     requesterSessionKey: requesterInternalKey,
     requesterOrigin,
+    requesterSenderId: ctx.requesterSenderId,
     requesterDisplayKey,
     task,
     cleanup,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -36,6 +36,8 @@ export function createSessionsSpawnTool(opts?: {
   sandboxed?: boolean;
   /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
   requesterAgentIdOverride?: string;
+  /** Trusted requester sender id from inbound context (e.g. Discord user id). */
+  requesterSenderId?: string | null;
 }): AnyAgentTool {
   return {
     label: "Sessions",
@@ -110,6 +112,7 @@ export function createSessionsSpawnTool(opts?: {
                 agentGroupChannel: opts?.agentGroupChannel,
                 agentGroupSpace: opts?.agentGroupSpace,
                 requesterAgentIdOverride: opts?.requesterAgentIdOverride,
+                requesterSenderId: opts?.requesterSenderId ?? undefined,
               },
             );
 

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -30,8 +30,8 @@ export type StatusReactionTiming = {
   debounceMs?: number; // Default: 700
   stallSoftMs?: number; // Default: 10000
   stallHardMs?: number; // Default: 30000
-  doneHoldMs?: number; // Default: 1500 (not used in controller, but exported for callers)
-  errorHoldMs?: number; // Default: 2500 (not used in controller, but exported for callers)
+  doneHoldMs?: number; // Default: 2000 (not used in controller, but exported for callers)
+  errorHoldMs?: number; // Default: 2000 (not used in controller, but exported for callers)
 };
 
 export type StatusReactionController = {
@@ -64,8 +64,8 @@ export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
   debounceMs: 700,
   stallSoftMs: 10_000,
   stallHardMs: 30_000,
-  doneHoldMs: 1500,
-  errorHoldMs: 2500,
+  doneHoldMs: 2000,
+  errorHoldMs: 2000,
 };
 
 export const CODING_TOOL_TOKENS: string[] = [

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1344,7 +1344,7 @@ export const FIELD_HELP: Record<string, string> = {
   "messages.statusReactions.emojis":
     "Override default status reaction emojis. Keys: thinking, tool, coding, web, done, error, stallSoft, stallHard. Must be valid Telegram reaction emojis.",
   "messages.statusReactions.timing":
-    "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
+    "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (2000), errorHoldMs (2000).",
   "messages.inbound.debounceMs":
     "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
   "channels.telegram.dmPolicy":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -67,9 +67,9 @@ export type StatusReactionsTimingConfig = {
   stallSoftMs?: number;
   /** Hard stall warning timeout (ms). Default: 60000. */
   stallHardMs?: number;
-  /** How long to hold done emoji before cleanup (ms). Default: 1500. */
+  /** How long to hold done emoji before cleanup (ms). Default: 2000. */
   doneHoldMs?: number;
-  /** How long to hold error emoji before cleanup (ms). Default: 2500. */
+  /** How long to hold error emoji before cleanup (ms). Default: 2000. */
   errorHoldMs?: number;
 };
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -15,6 +15,7 @@ import { shouldAckReaction as shouldAckReactionGate } from "../../channels/ack-r
 import { logTypingFailure, logAckFailure } from "../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
+import { DEFAULT_TIMING } from "../../channels/status-reactions.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
@@ -119,6 +120,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     accountId,
   });
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+  const statusReactionTiming = cfg.messages?.statusReactions?.timing;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -182,7 +184,16 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     statusLifecycleSettled = true;
     await statusReactions.complete(succeeded);
     if (removeAckAfterReply) {
-      statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
+      const configuredHoldMs = succeeded
+        ? statusReactionTiming?.doneHoldMs
+        : statusReactionTiming?.errorHoldMs;
+      const holdMs =
+        typeof configuredHoldMs === "number" && configuredHoldMs >= 0
+          ? configuredHoldMs
+          : succeeded
+            ? DEFAULT_TIMING.doneHoldMs
+            : DEFAULT_TIMING.errorHoldMs;
+      statusReactions.clearAfterHold(holdMs ?? DISCORD_STATUS_CLEAR_HOLD_MS);
     }
   };
 

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -45,6 +45,7 @@ import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-
 import { deliverDiscordReply } from "./reply-delivery.js";
 import {
   createDiscordStatusReactionLifecycle,
+  DISCORD_STATUS_CLEAR_HOLD_MS,
   resolveDiscordStatusReactionProjection,
   type DiscordStatusReactionAdapter,
 } from "./status-reaction-lifecycle.js";
@@ -117,6 +118,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
+  const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -179,6 +181,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     }
     statusLifecycleSettled = true;
     await statusReactions.complete(succeeded);
+    if (removeAckAfterReply) {
+      statusReactions.clearAfterHold(DISCORD_STATUS_CLEAR_HOLD_MS);
+    }
   };
 
   try {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -15,11 +15,6 @@ import { shouldAckReaction as shouldAckReactionGate } from "../../channels/ack-r
 import { logTypingFailure, logAckFailure } from "../../channels/logging.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
-import {
-  createStatusReactionController,
-  DEFAULT_TIMING,
-  type StatusReactionAdapter,
-} from "../../channels/status-reactions.js";
 import { createTypingCallbacks } from "../../channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-streaming.js";
@@ -48,14 +43,18 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import {
+  createDiscordStatusReactionLifecycle,
+  resolveDiscordStatusReactionProjection,
+  type DiscordStatusReactionAdapter,
+} from "./status-reaction-lifecycle.js";
+import {
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+  waitForDiscordStatusReactionQueueTurn,
+} from "./status-reaction-queue.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import { sendTyping } from "./typing.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 export async function processDiscordMessage(ctx: DiscordMessagePreflightContext) {
   const {
@@ -104,13 +103,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     discordRestFetch,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
-  const forwardedMediaList = await resolveForwardedMediaList(
-    message,
-    mediaMaxBytes,
-    discordRestFetch,
-  );
-  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose("discord: drop message " + message.id + " (empty content)");
@@ -125,7 +117,6 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     channel: "discord",
     accountId,
   });
-  const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
@@ -141,7 +132,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }),
     );
   const statusReactionsEnabled = shouldAckReaction();
-  const discordAdapter: StatusReactionAdapter = {
+  let statusQueueClaimed = false;
+  let queueTurnPromise: Promise<void> | null = null;
+  const discordAdapter: DiscordStatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: client.rest as never,
@@ -153,12 +146,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
     },
   };
-  const statusReactions = createStatusReactionController({
+  const statusReactions = createDiscordStatusReactionLifecycle({
     enabled: statusReactionsEnabled,
+    messageId: message.id,
     adapter: discordAdapter,
-    initialEmoji: ackReaction,
-    emojis: cfg.messages?.statusReactions?.emojis,
-    timing: cfg.messages?.statusReactions?.timing,
+    projection: resolveDiscordStatusReactionProjection(
+      cfg.messages?.statusReactions?.emojis,
+      ackReaction,
+    ),
     onError: (err) => {
       logAckFailure({
         log: logVerbose,
@@ -169,466 +164,465 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     },
   });
   if (statusReactionsEnabled) {
-    void statusReactions.setQueued();
-  }
-
-  const fromLabel = isDirectMessage
-    ? buildDirectLabel(author)
-    : buildGuildLabel({
-        guild: data.guild ?? undefined,
-        channelName: channelName ?? messageChannelId,
-        channelId: messageChannelId,
-      });
-  const senderLabel = sender.label;
-  const isForumParent =
-    threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
-  const forumParentSlug =
-    isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
-  const threadChannelId = threadChannel?.id;
-  const isForumStarter =
-    Boolean(threadChannelId && isForumParent && forumParentSlug) && message.id === threadChannelId;
-  const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
-  const groupChannel = isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
-  const groupSubject = isDirectMessage ? undefined : groupChannel;
-  const untrustedChannelMetadata = isGuildMessage
-    ? buildUntrustedChannelMetadata({
-        source: "discord",
-        label: "Discord channel topic",
-        entries: [channelInfo?.topic],
-      })
-    : undefined;
-  const senderName = sender.isPluralKit
-    ? (sender.name ?? author.username)
-    : (data.member?.nickname ?? author.globalName ?? author.username);
-  const senderUsername = sender.isPluralKit
-    ? (sender.tag ?? sender.name ?? author.username)
-    : author.username;
-  const senderTag = sender.tag;
-  const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
-    (entry): entry is string => Boolean(entry),
-  );
-  const groupSystemPrompt =
-    systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
-  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
-  });
-  const storePath = resolveStorePath(cfg.session?.store, {
-    agentId: route.agentId,
-  });
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const previousTimestamp = readSessionUpdatedAt({
-    storePath,
-    sessionKey: route.sessionKey,
-  });
-  let combinedBody = formatInboundEnvelope({
-    channel: "Discord",
-    from: fromLabel,
-    timestamp: resolveTimestampMs(message.timestamp),
-    body: text,
-    chatType: isDirectMessage ? "direct" : "channel",
-    senderLabel,
-    previousTimestamp,
-    envelope: envelopeOptions,
-  });
-  const shouldIncludeChannelHistory =
-    !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
-  if (shouldIncludeChannelHistory) {
-    combinedBody = buildPendingHistoryContextFromMap({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-      currentMessage: combinedBody,
-      formatEntry: (entry) =>
-        formatInboundEnvelope({
-          channel: "Discord",
-          from: fromLabel,
-          timestamp: entry.timestamp,
-          body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
-          chatType: "channel",
-          senderLabel: entry.sender,
-          envelope: envelopeOptions,
-        }),
-    });
-  }
-  const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
-  if (forumContextLine) {
-    combinedBody = `${combinedBody}\n${forumContextLine}`;
-  }
-
-  let threadStarterBody: string | undefined;
-  let threadLabel: string | undefined;
-  let parentSessionKey: string | undefined;
-  if (threadChannel) {
-    const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
-    if (includeThreadStarter) {
-      const starter = await resolveDiscordThreadStarter({
-        channel: threadChannel,
-        client,
-        parentId: threadParentId,
-        parentType: threadParentType,
-        resolveTimestampMs,
-      });
-      if (starter?.text) {
-        // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
-        threadStarterBody = starter.text;
-      }
-    }
-    const parentName = threadParentName ?? "parent";
-    threadLabel = threadName
-      ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
-      : `Discord thread #${normalizeDiscordSlug(parentName)}`;
-    if (threadParentId) {
-      parentSessionKey = buildAgentSessionKey({
-        agentId: route.agentId,
-        channel: route.channel,
-        peer: { kind: "channel", id: threadParentId },
-      });
+    const claim = claimDiscordStatusReactionQueue(messageChannelId, message.id);
+    statusQueueClaimed = true;
+    void statusReactions.enterWaiting(claim.hasPriorPendingWork);
+    if (claim.hasPriorPendingWork) {
+      queueTurnPromise = waitForDiscordStatusReactionQueueTurn(messageChannelId, message.id);
     }
   }
-  const mediaPayload = buildDiscordMediaPayload(mediaList);
-  const threadKeys = resolveThreadSessionKeys({
-    baseSessionKey,
-    threadId: threadChannel ? messageChannelId : undefined,
-    parentSessionKey,
-    useSuffix: false,
-  });
-  const replyPlan = await resolveDiscordAutoThreadReplyPlan({
-    client,
-    message,
-    messageChannelId,
-    isGuildMessage,
-    channelConfig,
-    threadChannel,
-    channelType: channelInfo?.type,
-    baseText: baseText ?? "",
-    combinedBody,
-    replyToMode,
-    agentId: route.agentId,
-    channel: route.channel,
-  });
-  const deliverTarget = replyPlan.deliverTarget;
-  const replyTarget = replyPlan.replyTarget;
-  const replyReference = replyPlan.replyReference;
-  const autoThreadContext = replyPlan.autoThreadContext;
-
-  const effectiveFrom = isDirectMessage
-    ? `discord:${author.id}`
-    : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
-  const effectiveTo = autoThreadContext?.To ?? replyTarget;
-  if (!effectiveTo) {
-    runtime.error?.(danger("discord: missing reply target"));
-    return;
-  }
-  // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
-  const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
-
-  const inboundHistory =
-    shouldIncludeChannelHistory && historyLimit > 0
-      ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
-      : undefined;
-
-  const ctxPayload = finalizeInboundContext({
-    Body: combinedBody,
-    BodyForAgent: baseText ?? text,
-    InboundHistory: inboundHistory,
-    RawBody: baseText,
-    CommandBody: baseText,
-    From: effectiveFrom,
-    To: effectiveTo,
-    SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
-    AccountId: route.accountId,
-    ChatType: isDirectMessage ? "direct" : "channel",
-    ConversationLabel: fromLabel,
-    SenderName: senderName,
-    SenderId: sender.id,
-    SenderUsername: senderUsername,
-    SenderTag: senderTag,
-    GroupSubject: groupSubject,
-    GroupChannel: groupChannel,
-    UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
-    GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
-    GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
-    OwnerAllowFrom: ownerAllowFrom,
-    Provider: "discord" as const,
-    Surface: "discord" as const,
-    WasMentioned: effectiveWasMentioned,
-    MessageSid: message.id,
-    ReplyToId: replyContext?.id,
-    ReplyToBody: replyContext?.body,
-    ReplyToSender: replyContext?.sender,
-    ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
-    MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
-    ThreadStarterBody: threadStarterBody,
-    ThreadLabel: threadLabel,
-    Timestamp: resolveTimestampMs(message.timestamp),
-    ...mediaPayload,
-    CommandAuthorized: commandAuthorized,
-    CommandSource: "text" as const,
-    // Originating channel for reply routing.
-    OriginatingChannel: "discord" as const,
-    OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
-  });
-  const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
-
-  await recordInboundSession({
-    storePath,
-    sessionKey: persistedSessionKey,
-    ctx: ctxPayload,
-    updateLastRoute: {
-      sessionKey: persistedSessionKey,
-      channel: "discord",
-      to: lastRouteTo,
-      accountId: route.accountId,
-    },
-    onRecordError: (err) => {
-      logVerbose(`discord: failed updating session meta: ${String(err)}`);
-    },
-  });
-
-  if (shouldLogVerbose()) {
-    const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
-    logVerbose(
-      `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
-    );
-  }
-
-  const typingChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-
-  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
-    cfg,
-    agentId: route.agentId,
-    channel: "discord",
-    accountId: route.accountId,
-  });
-  const tableMode = resolveMarkdownTableMode({
-    cfg,
-    channel: "discord",
-    accountId,
-  });
-  const chunkMode = resolveChunkMode(cfg, "discord", accountId);
-
-  const typingCallbacks = createTypingCallbacks({
-    start: () => sendTyping({ client, channelId: typingChannelId }),
-    onStartError: (err) => {
-      logTypingFailure({
-        log: logVerbose,
-        channel: "discord",
-        target: typingChannelId,
-        error: err,
-      });
-    },
-  });
-
-  // --- Discord draft stream (edit-based preview streaming) ---
-  const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
-  const draftMaxChars = Math.min(textLimit, 2000);
-  const accountBlockStreamingEnabled =
-    typeof discordConfig?.blockStreaming === "boolean"
-      ? discordConfig.blockStreaming
-      : cfg.agents?.defaults?.blockStreamingDefault === "on";
-  const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
-  const draftReplyToMessageId = () => replyReference.use();
-  const deliverChannelId = deliverTarget.startsWith("channel:")
-    ? deliverTarget.slice("channel:".length)
-    : messageChannelId;
-  const draftStream = canStreamDraft
-    ? createDiscordDraftStream({
-        rest: client.rest,
-        channelId: deliverChannelId,
-        maxChars: draftMaxChars,
-        replyToMessageId: draftReplyToMessageId,
-        minInitialChars: 30,
-        throttleMs: 1200,
-        log: logVerbose,
-        warn: logVerbose,
-      })
-    : undefined;
-  const draftChunking =
-    draftStream && discordStreamMode === "block"
-      ? resolveDiscordDraftStreamingChunking(cfg, accountId)
-      : undefined;
-  const shouldSplitPreviewMessages = discordStreamMode === "block";
-  const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
-  let lastPartialText = "";
-  let draftText = "";
-  let hasStreamedMessage = false;
-  let finalizedViaPreviewMessage = false;
-
-  const resolvePreviewFinalText = (text?: string) => {
-    if (typeof text !== "string") {
-      return undefined;
+  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
+  let statusLifecycleSettled = false;
+  const finalizeStatusReactions = async (succeeded: boolean): Promise<void> => {
+    if (!statusReactionsEnabled || statusLifecycleSettled) {
+      return;
     }
-    const formatted = convertMarkdownTables(text, tableMode);
-    const chunks = chunkDiscordTextWithMode(formatted, {
-      maxChars: draftMaxChars,
-      maxLines: discordConfig?.maxLinesPerMessage,
-      chunkMode,
-    });
-    if (!chunks.length && formatted) {
-      chunks.push(formatted);
-    }
-    if (chunks.length !== 1) {
-      return undefined;
-    }
-    const trimmed = chunks[0].trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
-    if (
-      currentPreviewText &&
-      currentPreviewText.startsWith(trimmed) &&
-      trimmed.length < currentPreviewText.length
-    ) {
-      return undefined;
-    }
-    return trimmed;
+    statusLifecycleSettled = true;
+    await statusReactions.complete(succeeded);
   };
 
-  const updateDraftFromPartial = (text?: string) => {
-    if (!draftStream || !text) {
-      return;
+  try {
+    await queueTurnPromise;
+    const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch);
+    const forwardedMediaList = await resolveForwardedMediaList(
+      message,
+      mediaMaxBytes,
+      discordRestFetch,
+    );
+    mediaList.push(...forwardedMediaList);
+
+    const fromLabel = isDirectMessage
+      ? buildDirectLabel(author)
+      : buildGuildLabel({
+          guild: data.guild ?? undefined,
+          channelName: channelName ?? messageChannelId,
+          channelId: messageChannelId,
+        });
+    const senderLabel = sender.label;
+    const isForumParent =
+      threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
+    const forumParentSlug =
+      isForumParent && threadParentName ? normalizeDiscordSlug(threadParentName) : "";
+    const threadChannelId = threadChannel?.id;
+    const isForumStarter =
+      Boolean(threadChannelId && isForumParent && forumParentSlug) &&
+      message.id === threadChannelId;
+    const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
+    const groupChannel =
+      isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
+    const groupSubject = isDirectMessage ? undefined : groupChannel;
+    const untrustedChannelMetadata = isGuildMessage
+      ? buildUntrustedChannelMetadata({
+          source: "discord",
+          label: "Discord channel topic",
+          entries: [channelInfo?.topic],
+        })
+      : undefined;
+    const senderName = sender.isPluralKit
+      ? (sender.name ?? author.username)
+      : (data.member?.nickname ?? author.globalName ?? author.username);
+    const senderUsername = sender.isPluralKit
+      ? (sender.tag ?? sender.name ?? author.username)
+      : author.username;
+    const senderTag = sender.tag;
+    const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
+      (entry): entry is string => Boolean(entry),
+    );
+    const groupSystemPrompt =
+      systemPromptParts.length > 0 ? systemPromptParts.join("\n\n") : undefined;
+    const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
+      channelConfig,
+      guildInfo,
+      sender: { id: sender.id, name: sender.name, tag: sender.tag },
+      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+    });
+    const storePath = resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+    const previousTimestamp = readSessionUpdatedAt({
+      storePath,
+      sessionKey: route.sessionKey,
+    });
+    let combinedBody = formatInboundEnvelope({
+      channel: "Discord",
+      from: fromLabel,
+      timestamp: resolveTimestampMs(message.timestamp),
+      body: text,
+      chatType: isDirectMessage ? "direct" : "channel",
+      senderLabel,
+      previousTimestamp,
+      envelope: envelopeOptions,
+    });
+    const shouldIncludeChannelHistory =
+      !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
+    if (shouldIncludeChannelHistory) {
+      combinedBody = buildPendingHistoryContextFromMap({
+        historyMap: guildHistories,
+        historyKey: messageChannelId,
+        limit: historyLimit,
+        currentMessage: combinedBody,
+        formatEntry: (entry) =>
+          formatInboundEnvelope({
+            channel: "Discord",
+            from: fromLabel,
+            timestamp: entry.timestamp,
+            body: `${entry.body} [id:${entry.messageId ?? "unknown"} channel:${messageChannelId}]`,
+            chatType: "channel",
+            senderLabel: entry.sender,
+            envelope: envelopeOptions,
+          }),
+      });
     }
-    // Strip reasoning/thinking tags that may leak through the stream.
-    const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
-    // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
-    if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
-      return;
-    }
-    if (cleaned === lastPartialText) {
-      return;
-    }
-    hasStreamedMessage = true;
-    if (discordStreamMode === "partial") {
-      // Keep the longer preview to avoid visible punctuation flicker.
-      if (
-        lastPartialText &&
-        lastPartialText.startsWith(cleaned) &&
-        cleaned.length < lastPartialText.length
-      ) {
-        return;
-      }
-      lastPartialText = cleaned;
-      draftStream.update(cleaned);
-      return;
+    const replyContext = resolveReplyContext(message, resolveDiscordMessageText);
+    if (forumContextLine) {
+      combinedBody = `${combinedBody}\n${forumContextLine}`;
     }
 
-    let delta = cleaned;
-    if (cleaned.startsWith(lastPartialText)) {
-      delta = cleaned.slice(lastPartialText.length);
-    } else {
-      // Streaming buffer reset (or non-monotonic stream). Start fresh.
-      draftChunker?.reset();
-      draftText = "";
+    let threadStarterBody: string | undefined;
+    let threadLabel: string | undefined;
+    let parentSessionKey: string | undefined;
+    if (threadChannel) {
+      const includeThreadStarter = channelConfig?.includeThreadStarter !== false;
+      if (includeThreadStarter) {
+        const starter = await resolveDiscordThreadStarter({
+          channel: threadChannel,
+          client,
+          parentId: threadParentId,
+          parentType: threadParentType,
+          resolveTimestampMs,
+        });
+        if (starter?.text) {
+          // Keep thread starter as raw text; metadata is provided out-of-band in the system prompt.
+          threadStarterBody = starter.text;
+        }
+      }
+      const parentName = threadParentName ?? "parent";
+      threadLabel = threadName
+        ? `Discord thread #${normalizeDiscordSlug(parentName)} › ${threadName}`
+        : `Discord thread #${normalizeDiscordSlug(parentName)}`;
+      if (threadParentId) {
+        parentSessionKey = buildAgentSessionKey({
+          agentId: route.agentId,
+          channel: route.channel,
+          peer: { kind: "channel", id: threadParentId },
+        });
+      }
     }
-    lastPartialText = cleaned;
-    if (!delta) {
+    const mediaPayload = buildDiscordMediaPayload(mediaList);
+    const threadKeys = resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: threadChannel ? messageChannelId : undefined,
+      parentSessionKey,
+      useSuffix: false,
+    });
+    const replyPlan = await resolveDiscordAutoThreadReplyPlan({
+      client,
+      message,
+      messageChannelId,
+      isGuildMessage,
+      channelConfig,
+      threadChannel,
+      channelType: channelInfo?.type,
+      baseText: baseText ?? "",
+      combinedBody,
+      replyToMode,
+      agentId: route.agentId,
+      channel: route.channel,
+    });
+    const deliverTarget = replyPlan.deliverTarget;
+    const replyTarget = replyPlan.replyTarget;
+    const replyReference = replyPlan.replyReference;
+    const autoThreadContext = replyPlan.autoThreadContext;
+
+    const effectiveFrom = isDirectMessage
+      ? `discord:${author.id}`
+      : (autoThreadContext?.From ?? `discord:channel:${messageChannelId}`);
+    const effectiveTo = autoThreadContext?.To ?? replyTarget;
+    if (!effectiveTo) {
+      runtime.error?.(danger("discord: missing reply target"));
       return;
     }
-    if (!draftChunker) {
-      draftText = cleaned;
-      draftStream.update(draftText);
-      return;
-    }
-    draftChunker.append(delta);
-    draftChunker.drain({
-      force: false,
-      emit: (chunk) => {
-        draftText += chunk;
-        draftStream.update(draftText);
+    // Keep DM routes user-addressed so follow-up sends resolve direct session keys.
+    const lastRouteTo = isDirectMessage ? `user:${author.id}` : effectiveTo;
+
+    const inboundHistory =
+      shouldIncludeChannelHistory && historyLimit > 0
+        ? (guildHistories.get(messageChannelId) ?? []).map((entry) => ({
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+          }))
+        : undefined;
+
+    const ctxPayload = finalizeInboundContext({
+      Body: combinedBody,
+      BodyForAgent: baseText ?? text,
+      InboundHistory: inboundHistory,
+      RawBody: baseText,
+      CommandBody: baseText,
+      From: effectiveFrom,
+      To: effectiveTo,
+      SessionKey: boundSessionKey ?? autoThreadContext?.SessionKey ?? threadKeys.sessionKey,
+      AccountId: route.accountId,
+      ChatType: isDirectMessage ? "direct" : "channel",
+      ConversationLabel: fromLabel,
+      SenderName: senderName,
+      SenderId: sender.id,
+      SenderUsername: senderUsername,
+      SenderTag: senderTag,
+      GroupSubject: groupSubject,
+      GroupChannel: groupChannel,
+      UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
+      GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
+      GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
+      OwnerAllowFrom: ownerAllowFrom,
+      Provider: "discord" as const,
+      Surface: "discord" as const,
+      WasMentioned: effectiveWasMentioned,
+      MessageSid: message.id,
+      ReplyToId: replyContext?.id,
+      ReplyToBody: replyContext?.body,
+      ReplyToSender: replyContext?.sender,
+      ParentSessionKey: autoThreadContext?.ParentSessionKey ?? threadKeys.parentSessionKey,
+      MessageThreadId: threadChannel?.id ?? autoThreadContext?.createdThreadId ?? undefined,
+      ThreadStarterBody: threadStarterBody,
+      ThreadLabel: threadLabel,
+      Timestamp: resolveTimestampMs(message.timestamp),
+      ...mediaPayload,
+      CommandAuthorized: commandAuthorized,
+      CommandSource: "text" as const,
+      // Originating channel for reply routing.
+      OriginatingChannel: "discord" as const,
+      OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    });
+    const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+
+    await recordInboundSession({
+      storePath,
+      sessionKey: persistedSessionKey,
+      ctx: ctxPayload,
+      updateLastRoute: {
+        sessionKey: persistedSessionKey,
+        channel: "discord",
+        to: lastRouteTo,
+        accountId: route.accountId,
+      },
+      onRecordError: (err) => {
+        logVerbose(`discord: failed updating session meta: ${String(err)}`);
       },
     });
-  };
 
-  const flushDraft = async () => {
-    if (!draftStream) {
-      return;
+    if (shouldLogVerbose()) {
+      const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");
+      logVerbose(
+        `discord inbound: channel=${messageChannelId} deliver=${deliverTarget} from=${ctxPayload.From} preview="${preview}"`,
+      );
     }
-    if (draftChunker?.hasBuffered()) {
-      draftChunker.drain({
-        force: true,
-        emit: (chunk) => {
-          draftText += chunk;
-        },
-      });
-      draftChunker.reset();
-      if (draftText) {
-        draftStream.update(draftText);
+
+    const typingChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+
+    const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+      cfg,
+      agentId: route.agentId,
+      channel: "discord",
+      accountId: route.accountId,
+    });
+    const tableMode = resolveMarkdownTableMode({
+      cfg,
+      channel: "discord",
+      accountId,
+    });
+    const chunkMode = resolveChunkMode(cfg, "discord", accountId);
+
+    const typingCallbacks = createTypingCallbacks({
+      start: () => sendTyping({ client, channelId: typingChannelId }),
+      onStartError: (err) => {
+        logTypingFailure({
+          log: logVerbose,
+          channel: "discord",
+          target: typingChannelId,
+          error: err,
+        });
+      },
+    });
+
+    // --- Discord draft stream (edit-based preview streaming) ---
+    const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
+    const draftMaxChars = Math.min(textLimit, 2000);
+    const accountBlockStreamingEnabled =
+      typeof discordConfig?.blockStreaming === "boolean"
+        ? discordConfig.blockStreaming
+        : cfg.agents?.defaults?.blockStreamingDefault === "on";
+    const canStreamDraft = discordStreamMode !== "off" && !accountBlockStreamingEnabled;
+    const draftReplyToMessageId = () => replyReference.use();
+    const deliverChannelId = deliverTarget.startsWith("channel:")
+      ? deliverTarget.slice("channel:".length)
+      : messageChannelId;
+    const draftStream = canStreamDraft
+      ? createDiscordDraftStream({
+          rest: client.rest,
+          channelId: deliverChannelId,
+          maxChars: draftMaxChars,
+          replyToMessageId: draftReplyToMessageId,
+          minInitialChars: 30,
+          throttleMs: 1200,
+          log: logVerbose,
+          warn: logVerbose,
+        })
+      : undefined;
+    const draftChunking =
+      draftStream && discordStreamMode === "block"
+        ? resolveDiscordDraftStreamingChunking(cfg, accountId)
+        : undefined;
+    const shouldSplitPreviewMessages = discordStreamMode === "block";
+    const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
+    let lastPartialText = "";
+    let draftText = "";
+    let hasStreamedMessage = false;
+    let finalizedViaPreviewMessage = false;
+
+    const resolvePreviewFinalText = (text?: string) => {
+      if (typeof text !== "string") {
+        return undefined;
       }
-    }
-    await draftStream.flush();
-  };
+      const formatted = convertMarkdownTables(text, tableMode);
+      const chunks = chunkDiscordTextWithMode(formatted, {
+        maxChars: draftMaxChars,
+        maxLines: discordConfig?.maxLinesPerMessage,
+        chunkMode,
+      });
+      if (!chunks.length && formatted) {
+        chunks.push(formatted);
+      }
+      if (chunks.length !== 1) {
+        return undefined;
+      }
+      const trimmed = chunks[0].trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
+      if (
+        currentPreviewText &&
+        currentPreviewText.startsWith(trimmed) &&
+        trimmed.length < currentPreviewText.length
+      ) {
+        return undefined;
+      }
+      return trimmed;
+    };
 
-  // When draft streaming is active, suppress block streaming to avoid double-streaming.
-  const disableBlockStreamingForDraft = draftStream ? true : undefined;
-
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
-    ...prefixOptions,
-    humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    typingCallbacks,
-    deliver: async (payload: ReplyPayload, info) => {
-      const isFinal = info.kind === "final";
-      if (payload.isReasoning) {
-        // Reasoning/thinking payloads should not be delivered to Discord.
+    const updateDraftFromPartial = (text?: string) => {
+      if (!draftStream || !text) {
         return;
       }
-      if (draftStream && isFinal) {
-        await flushDraft();
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-        const finalText = payload.text;
-        const previewFinalText = resolvePreviewFinalText(finalText);
-        const previewMessageId = draftStream.messageId();
-
-        // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
-        const canFinalizeViaPreviewEdit =
-          !finalizedViaPreviewMessage &&
-          !hasMedia &&
-          typeof previewFinalText === "string" &&
-          typeof previewMessageId === "string" &&
-          !payload.isError;
-
-        if (canFinalizeViaPreviewEdit) {
-          await draftStream.stop();
-          try {
-            await editMessageDiscord(
-              deliverChannelId,
-              previewMessageId,
-              { content: previewFinalText },
-              { rest: client.rest },
-            );
-            finalizedViaPreviewMessage = true;
-            replyReference.markSent();
-            return;
-          } catch (err) {
-            logVerbose(
-              `discord: preview final edit failed; falling back to standard send (${String(err)})`,
-            );
-          }
+      // Strip reasoning/thinking tags that may leak through the stream.
+      const cleaned = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
+      // Skip pure-reasoning messages (e.g. "Reasoning:\n…") that contain no answer text.
+      if (!cleaned || cleaned.startsWith("Reasoning:\n")) {
+        return;
+      }
+      if (cleaned === lastPartialText) {
+        return;
+      }
+      hasStreamedMessage = true;
+      if (discordStreamMode === "partial") {
+        // Keep the longer preview to avoid visible punctuation flicker.
+        if (
+          lastPartialText &&
+          lastPartialText.startsWith(cleaned) &&
+          cleaned.length < lastPartialText.length
+        ) {
+          return;
         }
+        lastPartialText = cleaned;
+        draftStream.update(cleaned);
+        return;
+      }
 
-        // Check if stop() flushed a message we can edit
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.stop();
-          const messageIdAfterStop = draftStream.messageId();
-          if (
-            typeof messageIdAfterStop === "string" &&
-            typeof previewFinalText === "string" &&
+      let delta = cleaned;
+      if (cleaned.startsWith(lastPartialText)) {
+        delta = cleaned.slice(lastPartialText.length);
+      } else {
+        // Streaming buffer reset (or non-monotonic stream). Start fresh.
+        draftChunker?.reset();
+        draftText = "";
+      }
+      lastPartialText = cleaned;
+      if (!delta) {
+        return;
+      }
+      if (!draftChunker) {
+        draftText = cleaned;
+        draftStream.update(draftText);
+        return;
+      }
+      draftChunker.append(delta);
+      draftChunker.drain({
+        force: false,
+        emit: (chunk) => {
+          draftText += chunk;
+          draftStream.update(draftText);
+        },
+      });
+    };
+
+    const flushDraft = async () => {
+      if (!draftStream) {
+        return;
+      }
+      if (draftChunker?.hasBuffered()) {
+        draftChunker.drain({
+          force: true,
+          emit: (chunk) => {
+            draftText += chunk;
+          },
+        });
+        draftChunker.reset();
+        if (draftText) {
+          draftStream.update(draftText);
+        }
+      }
+      await draftStream.flush();
+    };
+
+    // When draft streaming is active, suppress block streaming to avoid double-streaming.
+    const disableBlockStreamingForDraft = draftStream ? true : undefined;
+
+    const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      deliver: async (payload: ReplyPayload, info) => {
+        const isFinal = info.kind === "final";
+        if (payload.isReasoning) {
+          // Reasoning/thinking payloads should not be delivered to Discord.
+          return;
+        }
+        if (draftStream && isFinal) {
+          await flushDraft();
+          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const finalText = payload.text;
+          const previewFinalText = resolvePreviewFinalText(finalText);
+          const previewMessageId = draftStream.messageId();
+
+          // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
+          const canFinalizeViaPreviewEdit =
+            !finalizedViaPreviewMessage &&
             !hasMedia &&
-            !payload.isError
-          ) {
+            typeof previewFinalText === "string" &&
+            typeof previewMessageId === "string" &&
+            !payload.isError;
+
+          if (canFinalizeViaPreviewEdit) {
+            await draftStream.stop();
             try {
               await editMessageDiscord(
                 deliverChannelId,
-                messageIdAfterStop,
+                previewMessageId,
                 { content: previewFinalText },
                 { rest: client.rest },
               );
@@ -637,127 +631,157 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               return;
             } catch (err) {
               logVerbose(
-                `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                `discord: preview final edit failed; falling back to standard send (${String(err)})`,
               );
             }
           }
+
+          // Check if stop() flushed a message we can edit
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.stop();
+            const messageIdAfterStop = draftStream.messageId();
+            if (
+              typeof messageIdAfterStop === "string" &&
+              typeof previewFinalText === "string" &&
+              !hasMedia &&
+              !payload.isError
+            ) {
+              try {
+                await editMessageDiscord(
+                  deliverChannelId,
+                  messageIdAfterStop,
+                  { content: previewFinalText },
+                  { rest: client.rest },
+                );
+                finalizedViaPreviewMessage = true;
+                replyReference.markSent();
+                return;
+              } catch (err) {
+                logVerbose(
+                  `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
+                );
+              }
+            }
+          }
+
+          // Clear the preview and fall through to standard delivery
+          if (!finalizedViaPreviewMessage) {
+            await draftStream.clear();
+          }
         }
 
-        // Clear the preview and fall through to standard delivery
-        if (!finalizedViaPreviewMessage) {
-          await draftStream.clear();
-        }
-      }
-
-      const replyToId = replyReference.use();
-      await deliverDiscordReply({
-        replies: [payload],
-        target: deliverTarget,
-        token,
-        accountId,
-        rest: client.rest,
-        runtime,
-        replyToId,
-        replyToMode,
-        textLimit,
-        maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
-        tableMode,
-        chunkMode,
-        sessionKey: ctxPayload.SessionKey,
-        threadBindings,
-      });
-      replyReference.markSent();
-    },
-    onError: (err, info) => {
-      runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
-    },
-    onReplyStart: async () => {
-      await typingCallbacks.onReplyStart();
-      await statusReactions.setThinking();
-    },
-  });
-
-  let dispatchResult: Awaited<ReturnType<typeof dispatchInboundMessage>> | null = null;
-  let dispatchError = false;
-  try {
-    dispatchResult = await dispatchInboundMessage({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        skillFilter: channelConfig?.skills,
-        disableBlockStreaming:
-          disableBlockStreamingForDraft ??
-          (typeof discordConfig?.blockStreaming === "boolean"
-            ? !discordConfig.blockStreaming
-            : undefined),
-        onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
-        onAssistantMessageStart: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onReasoningEnd: draftStream
-          ? () => {
-              if (shouldSplitPreviewMessages && hasStreamedMessage) {
-                logVerbose("discord: calling forceNewMessage() for draft stream");
-                draftStream.forceNewMessage();
-              }
-              lastPartialText = "";
-              draftText = "";
-              draftChunker?.reset();
-            }
-          : undefined,
-        onModelSelected,
-        onReasoningStream: async () => {
-          await statusReactions.setThinking();
-        },
-        onToolStart: async (payload) => {
-          await statusReactions.setTool(payload.name);
-        },
+        const replyToId = replyReference.use();
+        await deliverDiscordReply({
+          replies: [payload],
+          target: deliverTarget,
+          token,
+          accountId,
+          rest: client.rest,
+          runtime,
+          replyToId,
+          replyToMode,
+          textLimit,
+          maxLinesPerMessage: discordConfig?.maxLinesPerMessage,
+          tableMode,
+          chunkMode,
+          sessionKey: ctxPayload.SessionKey,
+          threadBindings,
+        });
+        replyReference.markSent();
+      },
+      onError: (err, info) => {
+        runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
+      },
+      onReplyStart: async () => {
+        await typingCallbacks.onReplyStart();
+        void statusReactions.enterActive();
       },
     });
-  } catch (err) {
-    dispatchError = true;
-    throw err;
-  } finally {
-    try {
-      // Must stop() first to flush debounced content before clear() wipes state.
-      await draftStream?.stop();
-      if (!finalizedViaPreviewMessage) {
-        await draftStream?.clear();
-      }
-    } catch (err) {
-      // Draft cleanup should never keep typing alive.
-      logVerbose(`discord: draft cleanup failed: ${String(err)}`);
-    } finally {
-      markDispatchIdle();
-    }
-    if (statusReactionsEnabled) {
-      if (dispatchError) {
-        await statusReactions.setError();
-      } else {
-        await statusReactions.setDone();
-      }
-      if (removeAckAfterReply) {
-        void (async () => {
-          await sleep(dispatchError ? DEFAULT_TIMING.errorHoldMs : DEFAULT_TIMING.doneHoldMs);
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
-      }
-    }
-  }
 
-  if (!dispatchResult?.queuedFinal) {
+    let dispatchError = false;
+    try {
+      await statusReactions.enterActive();
+      dispatchResult = await dispatchInboundMessage({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          skillFilter: channelConfig?.skills,
+          disableBlockStreaming:
+            disableBlockStreamingForDraft ??
+            (typeof discordConfig?.blockStreaming === "boolean"
+              ? !discordConfig.blockStreaming
+              : undefined),
+          onPartialReply: draftStream
+            ? (payload) => updateDraftFromPartial(payload.text)
+            : undefined,
+          onAssistantMessageStart: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onReasoningEnd: draftStream
+            ? () => {
+                if (shouldSplitPreviewMessages && hasStreamedMessage) {
+                  logVerbose("discord: calling forceNewMessage() for draft stream");
+                  draftStream.forceNewMessage();
+                }
+                lastPartialText = "";
+                draftText = "";
+                draftChunker?.reset();
+              }
+            : undefined,
+          onModelSelected,
+          onReasoningStream: () => {
+            void statusReactions.enterActive();
+          },
+          onToolStart: (_payload) => {
+            void statusReactions.enterActive();
+          },
+        },
+      });
+    } catch (err) {
+      dispatchError = true;
+      throw err;
+    } finally {
+      try {
+        // Must stop() first to flush debounced content before clear() wipes state.
+        await draftStream?.stop();
+        if (!finalizedViaPreviewMessage) {
+          await draftStream?.clear();
+        }
+      } catch (err) {
+        // Draft cleanup should never keep typing alive.
+        logVerbose(`discord: draft cleanup failed: ${String(err)}`);
+      } finally {
+        markDispatchIdle();
+      }
+      await finalizeStatusReactions(!dispatchError);
+    }
+
+    if (!dispatchResult?.queuedFinal) {
+      if (isGuildMessage) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: guildHistories,
+          historyKey: messageChannelId,
+          limit: historyLimit,
+        });
+      }
+      return;
+    }
+    if (shouldLogVerbose()) {
+      const finalCount = dispatchResult.counts.final;
+      logVerbose(
+        `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
+      );
+    }
     if (isGuildMessage) {
       clearHistoryEntriesIfEnabled({
         historyMap: guildHistories,
@@ -765,19 +789,12 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         limit: historyLimit,
       });
     }
-    return;
-  }
-  if (shouldLogVerbose()) {
-    const finalCount = dispatchResult.counts.final;
-    logVerbose(
-      `discord: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${replyTarget}`,
-    );
-  }
-  if (isGuildMessage) {
-    clearHistoryEntriesIfEnabled({
-      historyMap: guildHistories,
-      historyKey: messageChannelId,
-      limit: historyLimit,
-    });
+  } finally {
+    if (statusQueueClaimed && !statusLifecycleSettled) {
+      await finalizeStatusReactions(false);
+    }
+    if (statusQueueClaimed) {
+      releaseDiscordStatusReactionQueue(messageChannelId, message.id);
+    }
   }
 }

--- a/src/discord/monitor/status-reaction-lifecycle.test.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  createDiscordStatusReactionLifecycle,
+  resolveDiscordStatusReactionProjection,
+} from "./status-reaction-lifecycle.js";
+
+describe("status-reaction-lifecycle", () => {
+  it("keeps waiting-fresh and waiting-backlog mutually exclusive per message", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const removeReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m1",
+      adapter: { setReaction, removeReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toContain("⏳");
+    expect(emojis).not.toContain("👀");
+  });
+
+  it("keeps waiting when active interruption fails", async () => {
+    let activeFailed = false;
+    const setReaction = vi.fn(async (emoji: string) => {
+      if (emoji === "🤔" && !activeFailed) {
+        activeFailed = true;
+        throw new Error("active failed");
+      }
+    });
+    const onError = vi.fn();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m2",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+      onError,
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+    await lifecycle.complete(true);
+
+    const emojis = setReaction.mock.calls.map((call) => call[0]);
+    expect(emojis).toEqual(["👀", "🤔"]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps waiting until an active interruption is requested", async () => {
+    const setReaction = vi.fn(async (_emoji: string) => {});
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m3",
+      adapter: { setReaction },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(true);
+    await lifecycle.complete(true);
+
+    expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["⏳"]);
+  });
+
+  it("records failed transition when active update fails", async () => {
+    __testing.resetTraceEntriesForTests();
+    const lifecycle = createDiscordStatusReactionLifecycle({
+      enabled: true,
+      messageId: "m4",
+      adapter: {
+        setReaction: async (emoji: string) => {
+          if (emoji === "🤔") {
+            throw new Error("boom");
+          }
+        },
+      },
+      projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+    });
+
+    await lifecycle.enterWaiting(false);
+    await lifecycle.enterActive();
+
+    const failed = __testing
+      .getTraceEntriesForTests()
+      .filter((entry) => entry.messageId === "m4" && entry.stage === "failed")
+      .map((entry) => entry.state);
+    expect(failed).toContain("active");
+  });
+});
+
+it("requires a completed active transition before terminal transition", async () => {
+  __testing.resetTraceEntriesForTests();
+  const releaseActiveRef: { current?: () => void } = {};
+  const setReaction = vi.fn((emoji: string) => {
+    if (emoji === "🤔") {
+      return new Promise<void>((resolve) => {
+        releaseActiveRef.current = resolve;
+      });
+    }
+    return Promise.resolve();
+  });
+  const lifecycle = createDiscordStatusReactionLifecycle({
+    enabled: true,
+    messageId: "m5",
+    adapter: { setReaction },
+    projection: resolveDiscordStatusReactionProjection(undefined, "👀"),
+  });
+
+  await lifecycle.enterWaiting(false);
+  const activePromise = lifecycle.enterActive();
+  await Promise.resolve();
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
+
+  const blockedComplete = lifecycle.complete(true);
+  await Promise.resolve();
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔"]);
+
+  releaseActiveRef.current?.();
+  await activePromise;
+  await blockedComplete;
+  await lifecycle.complete(true);
+
+  expect(setReaction.mock.calls.map((call) => call[0])).toEqual(["👀", "🤔", "✅"]);
+});

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -84,7 +84,8 @@ function canTransition(
     return isWaitingState(to) || to === "active";
   }
   if (isWaitingState(from)) {
-    return to === "active";
+    // Keep normal flow strict (waiting -> active), but allow explicit failure fallback.
+    return to === "active" || to === "error";
   }
   if (from === "active") {
     return to === "done" || to === "error";

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -40,7 +40,7 @@ export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection 
   error: "❌",
 };
 
-export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 2000;
 
 const MAX_TRACE_ENTRIES = 2000;
 const traceEntries: DiscordStatusTraceEntry[] = [];

--- a/src/discord/monitor/status-reaction-lifecycle.ts
+++ b/src/discord/monitor/status-reaction-lifecycle.ts
@@ -1,0 +1,333 @@
+import type { StatusReactionEmojis } from "../../channels/status-reactions.js";
+
+export type DiscordStatusLifecycleState =
+  | "idle"
+  | "waiting-fresh"
+  | "waiting-backlog"
+  | "active"
+  | "done"
+  | "error"
+  | "cleared";
+
+type DiscordStatusTraceStage = "queued" | "applied" | "ignored" | "failed";
+
+export type DiscordStatusTraceEntry = {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  at: number;
+};
+
+export type DiscordStatusReactionAdapter = {
+  setReaction: (emoji: string) => Promise<void>;
+  removeReaction?: (emoji: string) => Promise<void>;
+};
+
+export type DiscordStatusReactionProjection = {
+  waitingFresh: string;
+  waitingBacklog: string;
+  active: string;
+  done: string;
+  error: string;
+};
+
+export const DISCORD_STATUS_DEFAULT_PROJECTION: DiscordStatusReactionProjection = {
+  waitingFresh: "👀",
+  waitingBacklog: "⏳",
+  active: "🤔",
+  done: "✅",
+  error: "❌",
+};
+
+export const DISCORD_STATUS_CLEAR_HOLD_MS = 1500;
+
+const MAX_TRACE_ENTRIES = 2000;
+const traceEntries: DiscordStatusTraceEntry[] = [];
+
+function pushTrace(entry: DiscordStatusTraceEntry): void {
+  traceEntries.push(entry);
+  if (traceEntries.length > MAX_TRACE_ENTRIES) {
+    traceEntries.splice(0, traceEntries.length - MAX_TRACE_ENTRIES);
+  }
+}
+
+function resolveEmojiForState(
+  state: DiscordStatusLifecycleState,
+  projection: DiscordStatusReactionProjection,
+): string | null {
+  switch (state) {
+    case "waiting-fresh":
+      return projection.waitingFresh;
+    case "waiting-backlog":
+      return projection.waitingBacklog;
+    case "active":
+      return projection.active;
+    case "done":
+      return projection.done;
+    case "error":
+      return projection.error;
+    default:
+      return null;
+  }
+}
+
+function isWaitingState(state: DiscordStatusLifecycleState): boolean {
+  return state === "waiting-fresh" || state === "waiting-backlog";
+}
+
+function canTransition(
+  from: DiscordStatusLifecycleState,
+  to: DiscordStatusLifecycleState,
+): boolean {
+  if (from === "idle") {
+    return isWaitingState(to) || to === "active";
+  }
+  if (isWaitingState(from)) {
+    return to === "active";
+  }
+  if (from === "active") {
+    return to === "done" || to === "error";
+  }
+  if (from === "done" || from === "error") {
+    return to === "cleared";
+  }
+  return false;
+}
+
+function canEnqueueTransition(params: {
+  state: DiscordStatusLifecycleState;
+  lastRequestedState: DiscordStatusLifecycleState | null;
+  nextState: DiscordStatusLifecycleState;
+}): boolean {
+  if (canTransition(params.state, params.nextState)) {
+    return true;
+  }
+  if (
+    isWaitingState(params.state) &&
+    params.lastRequestedState === "active" &&
+    (params.nextState === "done" || params.nextState === "error")
+  ) {
+    // Allow terminal transition to queue behind an in-flight active transition.
+    return true;
+  }
+  return false;
+}
+
+function trackTransition(params: {
+  messageId: string;
+  state: DiscordStatusLifecycleState;
+  stage: DiscordStatusTraceStage;
+  emoji: string | null;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}): void {
+  const entry: DiscordStatusTraceEntry = {
+    messageId: params.messageId,
+    state: params.state,
+    stage: params.stage,
+    emoji: params.emoji,
+    at: Date.now(),
+  };
+  pushTrace(entry);
+  params.onTrace?.(entry);
+}
+
+export function resolveDiscordStatusReactionProjection(
+  overrides?: StatusReactionEmojis,
+  waitingFreshFallback?: string,
+): DiscordStatusReactionProjection {
+  const normalizedWaitingFreshFallback = waitingFreshFallback?.trim() || undefined;
+  return {
+    waitingFresh:
+      overrides?.queued ??
+      normalizedWaitingFreshFallback ??
+      DISCORD_STATUS_DEFAULT_PROJECTION.waitingFresh,
+    waitingBacklog: overrides?.stallSoft ?? DISCORD_STATUS_DEFAULT_PROJECTION.waitingBacklog,
+    active: overrides?.thinking ?? DISCORD_STATUS_DEFAULT_PROJECTION.active,
+    done: overrides?.done ?? DISCORD_STATUS_DEFAULT_PROJECTION.done,
+    error: overrides?.error ?? DISCORD_STATUS_DEFAULT_PROJECTION.error,
+  };
+}
+
+export function createDiscordStatusReactionLifecycle(params: {
+  enabled: boolean;
+  messageId: string;
+  adapter: DiscordStatusReactionAdapter;
+  projection: DiscordStatusReactionProjection;
+  onError?: (err: unknown) => void;
+  onTrace?: (entry: DiscordStatusTraceEntry) => void;
+}) {
+  const { enabled, messageId, adapter, projection, onError, onTrace } = params;
+  let state: DiscordStatusLifecycleState = "idle";
+  let lastRequestedState: DiscordStatusLifecycleState | null = null;
+  let currentEmoji: string | null = null;
+  let chain = Promise.resolve();
+  let clearTimer: NodeJS.Timeout | null = null;
+  const knownEmojis = new Set<string>([
+    projection.waitingFresh,
+    projection.waitingBacklog,
+    projection.active,
+    projection.done,
+    projection.error,
+  ]);
+
+  function transition(nextState: DiscordStatusLifecycleState): Promise<void> {
+    const nextEmoji = resolveEmojiForState(nextState, projection);
+    trackTransition({
+      messageId,
+      state: nextState,
+      stage: "queued",
+      emoji: nextEmoji,
+      onTrace,
+    });
+
+    if (!enabled) {
+      state = nextState;
+      return Promise.resolve();
+    }
+    if (nextState === state || nextState === lastRequestedState) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+    if (!canEnqueueTransition({ state, lastRequestedState, nextState })) {
+      trackTransition({
+        messageId,
+        state: nextState,
+        stage: "ignored",
+        emoji: nextEmoji,
+        onTrace,
+      });
+      return chain;
+    }
+
+    lastRequestedState = nextState;
+    chain = chain.then(async () => {
+      const fromState = state;
+      try {
+        if (!canTransition(fromState, nextState)) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: nextEmoji,
+            onTrace,
+          });
+          return;
+        }
+
+        if (nextState === "cleared") {
+          let hadFailure = false;
+          if (adapter.removeReaction) {
+            for (const emoji of knownEmojis) {
+              try {
+                await adapter.removeReaction(emoji);
+              } catch (err) {
+                hadFailure = true;
+                onError?.(err);
+              }
+            }
+          }
+
+          if (hadFailure) {
+            state = fromState;
+            trackTransition({
+              messageId,
+              state: nextState,
+              stage: "failed",
+              emoji: null,
+              onTrace,
+            });
+            return;
+          }
+
+          state = nextState;
+          currentEmoji = null;
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "applied",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        if (!nextEmoji) {
+          trackTransition({
+            messageId,
+            state: nextState,
+            stage: "ignored",
+            emoji: null,
+            onTrace,
+          });
+          return;
+        }
+
+        const previousEmoji = currentEmoji;
+        await adapter.setReaction(nextEmoji);
+        if (adapter.removeReaction && previousEmoji && previousEmoji !== nextEmoji) {
+          await adapter.removeReaction(previousEmoji);
+        }
+        state = nextState;
+        currentEmoji = nextEmoji;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "applied",
+          emoji: nextEmoji,
+          onTrace,
+        });
+      } catch (err) {
+        state = fromState;
+        trackTransition({
+          messageId,
+          state: nextState,
+          stage: "failed",
+          emoji: nextEmoji,
+          onTrace,
+        });
+        onError?.(err);
+      } finally {
+        if (lastRequestedState === nextState) {
+          lastRequestedState = null;
+        }
+      }
+    });
+    return chain;
+  }
+
+  return {
+    enterWaiting: (hasPriorPendingWork: boolean): Promise<void> =>
+      transition(hasPriorPendingWork ? "waiting-backlog" : "waiting-fresh"),
+    enterActive: (): Promise<void> => transition("active"),
+    complete: (succeeded: boolean): Promise<void> => transition(succeeded ? "done" : "error"),
+    clearAfterHold: (holdMs = DISCORD_STATUS_CLEAR_HOLD_MS): void => {
+      if (!enabled || clearTimer) {
+        return;
+      }
+      clearTimer = setTimeout(() => {
+        clearTimer = null;
+        void transition("cleared");
+      }, holdMs);
+    },
+  };
+}
+
+function resetTraceEntriesForTests(): void {
+  traceEntries.length = 0;
+}
+
+function getTraceEntriesForTests(): DiscordStatusTraceEntry[] {
+  return traceEntries.map((entry) => ({ ...entry }));
+}
+
+export const __testing = {
+  getTraceEntriesForTests,
+  resetTraceEntriesForTests,
+};

--- a/src/discord/monitor/status-reaction-queue.test.ts
+++ b/src/discord/monitor/status-reaction-queue.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __testing,
+  claimDiscordStatusReactionQueue,
+  releaseDiscordStatusReactionQueue,
+  waitForDiscordStatusReactionQueueTurn,
+} from "./status-reaction-queue.js";
+
+afterEach(() => {
+  __testing.resetQueueForTests();
+});
+
+describe("status-reaction-queue", () => {
+  it("marks only later messages in same channel as backlog", () => {
+    const first = claimDiscordStatusReactionQueue("c1", "m1");
+    const second = claimDiscordStatusReactionQueue("c1", "m2");
+
+    expect(first).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(second).toMatchObject({ hasPriorPendingWork: true, position: 1 });
+  });
+
+  it("isolates queue lanes by channel", () => {
+    const c1 = claimDiscordStatusReactionQueue("c1", "m1");
+    const c2 = claimDiscordStatusReactionQueue("c2", "m2");
+
+    expect(c1.hasPriorPendingWork).toBe(false);
+    expect(c2.hasPriorPendingWork).toBe(false);
+  });
+
+  it("waits until the message reaches the lane head", async () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+
+    let resolved = false;
+    const waitTurn = waitForDiscordStatusReactionQueueTurn("c1", "m2").then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseDiscordStatusReactionQueue("c1", "m1");
+    await waitTurn;
+    expect(resolved).toBe(true);
+  });
+
+  it("is idempotent for duplicate claims and cleans up on release", () => {
+    claimDiscordStatusReactionQueue("c1", "m1");
+    const duplicate = claimDiscordStatusReactionQueue("c1", "m1");
+    claimDiscordStatusReactionQueue("c1", "m2");
+    releaseDiscordStatusReactionQueue("c1", "m1");
+
+    expect(duplicate).toMatchObject({ hasPriorPendingWork: false, position: 0 });
+    expect(__testing.getQueueSnapshot()).toEqual({
+      size: 1,
+      lanes: [{ channelId: "c1", messageIds: ["m2"] }],
+    });
+  });
+});

--- a/src/discord/monitor/status-reaction-queue.ts
+++ b/src/discord/monitor/status-reaction-queue.ts
@@ -1,0 +1,164 @@
+type QueueLaneSnapshot = {
+  channelId: string;
+  messageIds: string[];
+};
+
+type QueueSnapshot = {
+  size: number;
+  lanes: QueueLaneSnapshot[];
+};
+
+const lanes = new Map<string, string[]>();
+const laneWaiters = new Map<string, Map<string, Set<() => void>>>();
+
+function normalizeChannelId(channelId: string): string {
+  return channelId.trim();
+}
+
+function normalizeMessageId(messageId: string): string {
+  return messageId.trim();
+}
+
+function resolveWaiters(channelId: string, messageId: string): void {
+  const channelWaiters = laneWaiters.get(channelId);
+  if (!channelWaiters) {
+    return;
+  }
+  const waiters = channelWaiters.get(messageId);
+  if (!waiters || waiters.size === 0) {
+    return;
+  }
+  channelWaiters.delete(messageId);
+  if (channelWaiters.size === 0) {
+    laneWaiters.delete(channelId);
+  }
+  for (const resolve of waiters) {
+    resolve();
+  }
+}
+
+function notifyHeadWaiters(channelId: string): void {
+  const lane = lanes.get(channelId);
+  if (!lane || lane.length === 0) {
+    return;
+  }
+  const head = lane[0];
+  if (!head) {
+    return;
+  }
+  resolveWaiters(channelId, head);
+}
+
+/**
+ * Claim a queue slot for a Discord message lifecycle within a channel lane.
+ * hasPriorPendingWork means this message is not first in that lane.
+ */
+export function claimDiscordStatusReactionQueue(
+  channelId: string,
+  messageId: string,
+): {
+  hasPriorPendingWork: boolean;
+  position: number;
+} {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return { hasPriorPendingWork: false, position: 0 };
+  }
+
+  const lane = lanes.get(laneKey) ?? [];
+  let position = lane.indexOf(normalizedMessageId);
+  if (position < 0) {
+    lane.push(normalizedMessageId);
+    position = lane.length - 1;
+  }
+  lanes.set(laneKey, lane);
+  if (position === 0) {
+    notifyHeadWaiters(laneKey);
+  }
+  return {
+    hasPriorPendingWork: position > 0,
+    position,
+  };
+}
+
+/**
+ * Wait until this claimed message reaches the head of its channel lane.
+ */
+export function waitForDiscordStatusReactionQueueTurn(
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return Promise.resolve();
+  }
+
+  const lane = lanes.get(laneKey);
+  if (!lane) {
+    return Promise.resolve();
+  }
+  const position = lane.indexOf(normalizedMessageId);
+  if (position <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let channelWaiters = laneWaiters.get(laneKey);
+    if (!channelWaiters) {
+      channelWaiters = new Map<string, Set<() => void>>();
+      laneWaiters.set(laneKey, channelWaiters);
+    }
+    let waiters = channelWaiters.get(normalizedMessageId);
+    if (!waiters) {
+      waiters = new Set<() => void>();
+      channelWaiters.set(normalizedMessageId, waiters);
+    }
+    waiters.add(resolve);
+  });
+}
+
+/**
+ * Release a previously claimed queue slot.
+ */
+export function releaseDiscordStatusReactionQueue(channelId: string, messageId: string): void {
+  const laneKey = normalizeChannelId(channelId);
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!laneKey || !normalizedMessageId) {
+    return;
+  }
+  const lane = lanes.get(laneKey);
+  if (!lane) {
+    return;
+  }
+  const nextLane = lane.filter((entry) => entry !== normalizedMessageId);
+  resolveWaiters(laneKey, normalizedMessageId);
+  if (nextLane.length === 0) {
+    lanes.delete(laneKey);
+    laneWaiters.delete(laneKey);
+    return;
+  }
+  lanes.set(laneKey, nextLane);
+  notifyHeadWaiters(laneKey);
+}
+
+function getQueueSnapshot(): QueueSnapshot {
+  const laneEntries = Array.from(lanes.entries())
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([channelId, messageIds]) => ({ channelId, messageIds: [...messageIds] }));
+  return {
+    size: laneEntries.reduce((sum, lane) => sum + lane.messageIds.length, 0),
+    lanes: laneEntries,
+  };
+}
+
+function resetQueueForTests(): void {
+  lanes.clear();
+  laneWaiters.clear();
+}
+
+export const __testing = {
+  getQueueSnapshot,
+  resetQueueForTests,
+};

--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -23,6 +23,11 @@ describe("sameFileIdentity", () => {
     expect(sameFileIdentity(stat(7, 11), stat(0, 11), "win32")).toBe(true);
   });
 
+  it("accepts win32 inode mismatch when either side reports ino=0", () => {
+    expect(sameFileIdentity(stat(7, 0), stat(7, 11), "win32")).toBe(true);
+    expect(sameFileIdentity(stat(7, 11), stat(7, 0), "win32")).toBe(true);
+  });
+
   it("keeps dev strictness on win32 when both dev values are non-zero", () => {
     expect(sameFileIdentity(stat(7, 11), stat(8, 11), "win32")).toBe(false);
   });

--- a/src/infra/file-identity.ts
+++ b/src/infra/file-identity.ts
@@ -13,7 +13,11 @@ export function sameFileIdentity(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (left.ino !== right.ino) {
-    return false;
+    // On Windows, path-based stat can report ino=0 while fd-based stat has the
+    // real file index. Treat zero inode as unknown and fall back to device check.
+    if (!(platform === "win32" && (isZero(left.ino) || isZero(right.ino)))) {
+      return false;
+    }
   }
 
   // On Windows, path-based stat calls can report dev=0 while fd-based stat


### PR DESCRIPTION
## Summary

- Problem: ACP subagent completion notifications do not return to the originating Discord channel/thread and lack requester mention
- Why it matters: Users lose track of spawned tasks; no notification when ACP tasks complete; breaks user workflow continuity
- What changed: Added requesterSenderId propagation through subagent spawn chain; updated completion message builder to include Discord mention
- What did NOT change: ACP runtime behavior; subagent execution logic; message routing rules beyond mention injection

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: ACP completion notification backflow pain point discussion

## User-visible / Behavior Changes

- Subagent completion notifications now return to the originating channel/thread
- Completion messages include Discord mention of the original requester (`<@userId>` format)
- Users receive notification when their spawned ACP tasks complete

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 25.2.1
- Model/provider: ACP/Codex
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Spawn ACP subagent via Discord thread using `sessions_spawn`
2. Wait for task completion
3. Verify completion notification appears in originating thread
4. Verify message includes requester mention

### Expected

- Notification returns to thread where task was spawned
- Message includes Discord mention of original requester

### Actual

- Pending verification (blocked by `acp.dispatch.enabled` config issue)

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Note: Core logic verified through unit tests; integration test pending ACP config resolution

## Human Verification (required)

- Verified scenarios: Unit tests pass (50 tests in subagent-announce.format.test.ts)
- Edge cases checked: Empty sender ID, non-Discord contexts
- What you did **not** verify: Full ACP end-to-end flow (blocked by dispatch config)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Malformed Discord mentions, missing completion notifications

## Risks and Mitigations

- Risk: Discord mention format may be incorrect in certain contexts
  - Mitigation: Uses standard `<@userId>` format; falls back gracefully if sender ID unavailable
- Risk: sender ID extraction may fail for non-Discord channels
  - Mitigation: Fallback to session entry heuristics; mention omitted if no valid ID found