### PR TITLE
fix: session_status tool shows correct thinking/verbose/reasoning levels

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -90,6 +90,28 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("falls back to sessionEntry levels when resolved levels are not passed", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+        reasoningLevel: "on",
+      },
+      sessionKey: "agent:main:main",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Think: high");
+    expect(normalized).toContain("verbose:full");
+    expect(normalized).toContain("Reasoning: on");
+  });
+
   it("notes channel model overrides in status output", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -506,9 +506,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel =
+    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+  const verboseLevel =
+    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??


### PR DESCRIPTION
## Summary

- Problem: `session_status` tool always shows `Think: off` regardless of the actual `/think` level set at runtime. Similarly, verbose and reasoning levels are always shown as `off`.
- Why it matters: Agents report incorrect status to users, causing confusion and repeated attempts to set the level.
- What changed: `buildStatusMessage()` now falls back to `sessionEntry.thinkingLevel`, `sessionEntry.verboseLevel`, and `sessionEntry.reasoningLevel` when `resolvedThink`/`resolvedVerbose`/`resolvedReasoning` are not passed — consistent with how `elevatedLevel` already worked.
- What did NOT change (scope boundary): The `/status` slash command path is unaffected (it already passes resolved levels explicitly). The `session_status` tool handler itself is unchanged; the fix is entirely in the shared `buildStatusMessage()` function.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30126

## User-visible / Behavior Changes

- `session_status` tool now correctly reports the runtime thinking, verbose, and reasoning levels stored in the session entry instead of always showing `off`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 24.0.0
- Runtime/container: Node.js via pnpm
- Model/provider: N/A (unit tested)

### Steps

1. Set `/think high` in a session
2. Call `session_status` tool

### Expected

- Status shows `Think: high`

### Actual (before fix)

- Status showed `Think: off`

## Evidence

- [x] Failing test/log before + passing after

Added test: "falls back to sessionEntry levels when resolved levels are not passed" — verifies `Think: high`, `verbose:full`, and `Reasoning: on` are rendered from session entry when no `resolvedThink`/`resolvedVerbose`/`resolvedReasoning` args are passed. All 26 tests pass.

## Human Verification (required)

- Verified scenarios: `pnpm vitest run src/auto-reply/status.test.ts` (26 tests pass), `pnpm tsgo`, `pnpm lint`
- Edge cases checked: existing test confirms `resolvedThink` still takes priority over `sessionEntry.thinkingLevel`; new test confirms session entry fallback works
- What you did **not** verify: end-to-end with a live session and real `/think` command

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/auto-reply/status.ts`
- Known bad symptoms reviewers should watch for: If session entry has stale `thinkingLevel` values, status might show an outdated level (this is the same behavior `elevatedLevel` already has)

## Risks and Mitigations

- Risk: Session entry `thinkingLevel` could be stale if the session store wasn't updated after a `/think` command
  - Mitigation: This is the same trust model as `elevatedLevel` which already reads from session entry; the `/think` command handler already persists the level to the session store