### PR TITLE
Telegram: add throttle config to fix ~54s group delays during block streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/Reactions: add inbound `im.message.reaction.created_v1` handling, route verified reactions through synthetic inbound turns, and harden verification with timeout + fail-closed filtering so non-bot or unverified reactions are dropped. (#16716) Thanks @schumilin.
 - Feishu/Chat tooling: add `feishu_chat` tool actions for chat info and member queries, with configurable enablement under `channels.feishu.tools.chat`. (#14674)
 - Memory/LanceDB: support custom OpenAI `baseUrl` and embedding dimensions for LanceDB memory. (#17874) Thanks @rish2jain and @vincentkoc.
+- Telegram/Throttler: add `channels.telegram.throttle` config to control the grammY API throttler — set `enabled: false` to disable it entirely (fixes ~54s group message delays when block streaming exhausts the group reservoir), or tune `group` params (`reservoir`, `reservoirRefreshAmount`, `reservoirRefreshInterval`, `minTime`, `maxConcurrent`) to match your workload. (#29822)
 
 ### Fixes
 

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -22,6 +22,30 @@ export type TelegramActionConfig = {
   createForumTopic?: boolean;
 };
 
+export type TelegramThrottleGroupConfig = {
+  /** Reservoir size (max burst of group messages). Default: 20. */
+  reservoir?: number;
+  /** Messages to add per refresh interval. Default: 20. */
+  reservoirRefreshAmount?: number;
+  /** Reservoir refresh interval in ms. Default: 60000. */
+  reservoirRefreshInterval?: number;
+  /** Minimum time between group API calls in ms. Default: 1000. */
+  minTime?: number;
+  /** Max concurrent group API calls. Default: 1. */
+  maxConcurrent?: number;
+};
+
+export type TelegramThrottleConfig = {
+  /**
+   * Set to false to disable the API throttler entirely.
+   * Useful when block streaming causes group message delays (~54s) from
+   * reservoir exhaustion. Default: true.
+   */
+  enabled?: boolean;
+  /** Group chat (negative chat_id) throttler overrides. */
+  group?: TelegramThrottleGroupConfig;
+};
+
 export type TelegramNetworkConfig = {
   /** Override Node's autoSelectFamily behavior (true = enable, false = disable). */
   autoSelectFamily?: boolean;
@@ -152,6 +176,14 @@ export type TelegramAccountConfig = {
    * - "extensive": agent can react liberally when appropriate
    */
   reactionLevel?: "off" | "ack" | "minimal" | "extensive";
+  /**
+   * API throttler configuration.
+   *
+   * Set `enabled: false` to disable the throttler entirely (e.g. to avoid
+   * ~54s group message delays when block streaming exhausts the group reservoir).
+   * Customize `group` params to tune the per-group rate limit bucket.
+   */
+  throttle?: TelegramThrottleConfig;
   /** Heartbeat visibility settings for this channel. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Controls whether link previews are shown in outbound messages. Default: true. */

--- a/src/telegram/bot.create-telegram-bot.test-harness.ts
+++ b/src/telegram/bot.create-telegram-bot.test-harness.ts
@@ -182,7 +182,7 @@ vi.mock("@grammyjs/runner", () => ({
 export const throttlerSpy: AnyMock = vi.fn(() => "throttler");
 
 vi.mock("@grammyjs/transformer-throttler", () => ({
-  apiThrottler: () => throttlerSpy(),
+  apiThrottler: (opts?: unknown) => throttlerSpy(opts),
 }));
 
 export const replySpy: MockFn<
@@ -319,5 +319,6 @@ beforeEach(() => {
   middlewareUseSpy.mockReset();
   sequentializeSpy.mockReset();
   botCtorSpy.mockReset();
+  throttlerSpy.mockClear();
   sequentializeKey = undefined;
 });

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -61,9 +61,46 @@ describe("createTelegramBot", () => {
 
   // groupPolicy tests
 
-  it("installs grammY throttler", () => {
+  it("installs grammY throttler with empty opts by default", () => {
     createTelegramBot({ token: "tok" });
     expect(throttlerSpy).toHaveBeenCalledTimes(1);
+    expect(throttlerSpy).toHaveBeenCalledWith({});
+    expect(useSpy).toHaveBeenCalledWith("throttler");
+  });
+  it("skips throttler when throttle.enabled is false", () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"], throttle: { enabled: false } } },
+    });
+    createTelegramBot({ token: "tok" });
+    expect(throttlerSpy).not.toHaveBeenCalled();
+    expect(useSpy).not.toHaveBeenCalledWith("throttler");
+  });
+  it("passes custom group config to throttler when throttle.group is set", () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          throttle: {
+            group: {
+              reservoir: 1,
+              reservoirRefreshAmount: 1,
+              reservoirRefreshInterval: 3000,
+            },
+          },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    expect(throttlerSpy).toHaveBeenCalledWith({
+      group: {
+        maxConcurrent: 1,
+        minTime: 1000,
+        reservoir: 1,
+        reservoirRefreshAmount: 1,
+        reservoirRefreshInterval: 3000,
+      },
+    });
     expect(useSpy).toHaveBeenCalledWith("throttler");
   });
   it("uses wrapped fetch when global fetch is available", () => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -142,7 +142,24 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       : undefined;
 
   const bot = new Bot(opts.token, client ? { client } : undefined);
-  bot.api.config.use(apiThrottler());
+  // Allow disabling or customizing the throttler via config (e.g. to fix
+  // ~54s group delays when block streaming exhausts the group reservoir).
+  const throttleCfg = telegramCfg.throttle;
+  if (throttleCfg?.enabled !== false) {
+    const groupOverride = throttleCfg?.group;
+    const throttlerOpts = groupOverride
+      ? {
+          group: {
+            maxConcurrent: groupOverride.maxConcurrent ?? 1,
+            minTime: groupOverride.minTime ?? 1000,
+            reservoir: groupOverride.reservoir ?? 20,
+            reservoirRefreshAmount: groupOverride.reservoirRefreshAmount ?? 20,
+            reservoirRefreshInterval: groupOverride.reservoirRefreshInterval ?? 60000,
+          },
+        }
+      : {};
+    bot.api.config.use(apiThrottler(throttlerOpts));
+  }
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));


### PR DESCRIPTION
## Summary

Fixes #29822.

`apiThrottler()` default group config uses `reservoir: 20, reservoirRefreshInterval: 60000` — block streaming to a group rapidly exhausts the 20-message bucket, then all subsequent group messages stall ~54 seconds waiting for the 60s reservoir refresh.

- Add `channels.telegram.throttle.enabled` (`false` disables the throttler entirely)
- Add `channels.telegram.throttle.group` to override group throttler params (`reservoir`, `reservoirRefreshAmount`, `reservoirRefreshInterval`, `minTime`, `maxConcurrent`)
- Default behavior is unchanged (throttler stays on with library defaults)

**Workaround for streaming-heavy setups:**
```yaml
channels:
  telegram:
    throttle:
      enabled: false
```

Or use a smoother 20/min bucket (1 per 3s instead of burst-20-then-wait-60s):
```yaml
channels:
  telegram:
    throttle:
      group:
        reservoir: 1
        reservoirRefreshAmount: 1
        reservoirRefreshInterval: 3000
```

## Test plan

- [x] Existing throttler test updated to verify empty opts passed by default
- [x] New test: `throttle.enabled: false` skips throttler entirely
- [x] New test: `throttle.group` overrides are forwarded to `apiThrottler()` correctly
- [x] All 47 tests in `bot.create-telegram-bot.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)