### PR TITLE
fix(status): read thinking/verbose/reasoning levels from session entry

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -506,9 +506,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel =
+    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+  const verboseLevel =
+    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -765,7 +765,7 @@ export async function loadSessionUsageTimeSeries(params: {
     config: params.config,
     onEntry: (entry) => {
       const ts = entry.timestamp?.getTime();
-      if (!ts) {
+      if (!ts || !entry.usage) {
         return;
       }
 


### PR DESCRIPTION
## Summary

This PR includes two fixes:

### Fix 1: Session status think level persistence
When `buildStatusMessage()` is called without `resolvedThink`/`resolvedVerbose`/`resolvedReasoning` parameters (e.g., from `session_status` tool), it now falls back to reading these values from the session entry, consistent with how `elevatedLevel` is already handled.

This fixes issue #30126 where `session_status` tool always shows 'Think: off' regardless of the /think level set by the user.

### Fix 2: Guard against undefined usage in session usage tracking
Add null check for `entry.usage` in `loadSessionUsageTimeSeries` to prevent TypeError when accessing usage properties. This fixes a potential crash when session entries lack usage data (e.g., after hook-based compaction).

Related to issue #30134: Session stuck after hook-based compaction - TypeError: Cannot read properties of undefined (reading 'totalTokens')

## Changes

- `src/auto-reply/status.ts`: Added session entry fallback for thinkLevel, verboseLevel, and reasoningLevel in `buildStatusMessage()` function
- `src/infra/session-cost-usage.ts`: Add guard `!entry.usage` to the early return check

## Testing

- All existing tests pass (25 tests in status.test.ts)

## Note

The fix for issue #30134 also requires a patch to the `pi-coding-agent` package. A temporary patch has been applied to:

`node_modules/.pnpm/@mariozechner+pi-coding-agent@0.55.1_ws@8.19.0_zod@4.3.6/node_modules/@mariozechner/pi-coding-agent/dist/core/compaction/compaction.js`

The fix adds: `if (!usage) return 0;` at the start of the `calculateContextTokens` function.