### PR TITLE
feat(adapters): add sendPayload to batch-a (BlueBubbles, iMessage, Signal, Telegram, WhatsApp)

### DIFF
--- a/extensions/bluebubbles/src/channel.sendpayload.test.ts
+++ b/extensions/bluebubbles/src/channel.sendpayload.test.ts
@@ -111,6 +111,24 @@ describe("bluebubblesPlugin sendPayload", () => {
     expect(result).toEqual({ channel: "bluebubbles", messageId: "" });
   });
 
+  it("returns no-op when chunker produces empty array", async () => {
+    // Simulate a chunker that strips whitespace-only input to nothing
+    // BlueBubbles has no chunker by default, so we attach one that returns []
+    bluebubblesPlugin.outbound!.chunker = vi.fn().mockReturnValue([]);
+    const sendTextSpy = vi.spyOn(bluebubblesPlugin.outbound!, "sendText");
+
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "   " },
+    } as never);
+
+    expect(sendTextSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "" });
+
+    // Clean up the manually attached chunker so subsequent tests use the default fallback
+    delete (bluebubblesPlugin.outbound as Record<string, unknown>).chunker;
+  });
+
   it("sends text as single chunk when no chunker is defined", async () => {
     // BlueBubbles has no chunker, so text is sent as a single chunk via [text] fallback
     const sendTextSpy = vi

--- a/extensions/bluebubbles/src/channel.sendpayload.test.ts
+++ b/extensions/bluebubbles/src/channel.sendpayload.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./send.js", () => ({
+  sendMessageBlueBubbles: vi.fn().mockResolvedValue({ messageId: "bb-msg-1" }),
+}));
+
+vi.mock("./media-send.js", () => ({
+  sendBlueBubblesMedia: vi.fn().mockResolvedValue({ messageId: "bb-media-1" }),
+}));
+
+vi.mock("./monitor.js", () => ({
+  resolveBlueBubblesMessageId: vi.fn().mockReturnValue(""),
+  monitorBlueBubblesProvider: vi.fn(),
+  resolveWebhookPathFromConfig: vi.fn().mockReturnValue("/webhook"),
+}));
+
+vi.mock("./probe.js", () => ({
+  probeBlueBubbles: vi.fn(),
+}));
+
+import { bluebubblesPlugin } from "./channel.js";
+
+describe("bluebubblesPlugin sendPayload", () => {
+  const cfg = { channels: { bluebubbles: {} } };
+  const baseCtx = {
+    cfg,
+    to: "chat_guid:iMessage;-;+15551234567",
+    text: "",
+    accountId: "default",
+    payload: {},
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates text-only payload to sendText", async () => {
+    const sendTextSpy = vi
+      .spyOn(bluebubblesPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "bluebubbles", messageId: "b-1" });
+
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "hello bb" },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello bb" }));
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "b-1" });
+  });
+
+  it("delegates single media URL to sendMedia with caption", async () => {
+    const sendMediaSpy = vi
+      .spyOn(bluebubblesPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "bluebubbles", messageId: "bm-1" });
+
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "caption", mediaUrl: "https://example.com/pic.png" },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledOnce();
+    expect(sendMediaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrl: "https://example.com/pic.png",
+      }),
+    );
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "bm-1" });
+  });
+
+  it("iterates multiple media URLs with caption on first only", async () => {
+    const sendMediaSpy = vi
+      .spyOn(bluebubblesPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "bluebubbles", messageId: "bm-last" });
+
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {
+        text: "cap",
+        mediaUrls: [
+          "https://example.com/a.png",
+          "https://example.com/b.png",
+          "https://example.com/c.png",
+        ],
+      },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledTimes(3);
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "cap", mediaUrl: "https://example.com/a.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/b.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/c.png" }),
+    );
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "bm-last" });
+  });
+
+  it("returns no-op result for empty payload", async () => {
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {},
+    } as never);
+
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "" });
+  });
+
+  it("sends text as single chunk when no chunker is defined", async () => {
+    // BlueBubbles has no chunker, so text is sent as a single chunk via [text] fallback
+    const sendTextSpy = vi
+      .spyOn(bluebubblesPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "bluebubbles", messageId: "b-full" });
+
+    const longText = "w".repeat(9000);
+
+    const result = await bluebubblesPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: longText },
+    } as never);
+
+    // No chunker means the entire text is sent as one chunk
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: longText }));
+    expect(result).toEqual({ channel: "bluebubbles", messageId: "b-full" });
+  });
+});

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -341,6 +341,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       const outbound = bluebubblesPlugin.outbound!;
       const limit = outbound.textChunkLimit;
       const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      if (!chunks.length) return { channel: "bluebubbles", messageId: "" };
       let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
       for (const chunk of chunks) {
         lastResult = await outbound.sendText!({ ...ctx, text: chunk });

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -334,7 +334,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
         }
         return lastResult;
       }
-      return bluebubblesPlugin.outbound!.sendText!({ ...ctx });
+      return bluebubblesPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
     },
     sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const rawReplyToId = typeof replyToId === "string" ? replyToId.trim() : "";

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -320,15 +320,19 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
           ? [ctx.payload.mediaUrl]
           : [];
       if (urls.length > 0) {
-        let lastResult;
-        for (let i = 0; i < urls.length; i++) {
+        let lastResult = await bluebubblesPlugin.outbound!.sendMedia!({
+          ...ctx,
+          text: ctx.payload.text ?? "",
+          mediaUrl: urls[0],
+        });
+        for (let i = 1; i < urls.length; i++) {
           lastResult = await bluebubblesPlugin.outbound!.sendMedia!({
             ...ctx,
-            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            text: "",
             mediaUrl: urls[i],
           });
         }
-        return lastResult!;
+        return lastResult;
       }
       return bluebubblesPlugin.outbound!.sendText!({ ...ctx });
     },

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -313,6 +313,25 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       }
       return { ok: true, to: trimmed };
     },
+    sendPayload: async (ctx) => {
+      const urls = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (urls.length > 0) {
+        let lastResult;
+        for (let i = 0; i < urls.length; i++) {
+          lastResult = await bluebubblesPlugin.outbound!.sendMedia!({
+            ...ctx,
+            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            mediaUrl: urls[i],
+          });
+        }
+        return lastResult!;
+      }
+      return bluebubblesPlugin.outbound!.sendText!({ ...ctx });
+    },
     sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const rawReplyToId = typeof replyToId === "string" ? replyToId.trim() : "";
       // Resolve short ID (e.g., "5") to full UUID

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -314,15 +314,19 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
       return { ok: true, to: trimmed };
     },
     sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
       const urls = ctx.payload.mediaUrls?.length
         ? ctx.payload.mediaUrls
         : ctx.payload.mediaUrl
           ? [ctx.payload.mediaUrl]
           : [];
+      if (!text && urls.length === 0) {
+        return { channel: "bluebubbles", messageId: "" };
+      }
       if (urls.length > 0) {
         let lastResult = await bluebubblesPlugin.outbound!.sendMedia!({
           ...ctx,
-          text: ctx.payload.text ?? "",
+          text,
           mediaUrl: urls[0],
         });
         for (let i = 1; i < urls.length; i++) {
@@ -334,7 +338,14 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount> = {
         }
         return lastResult;
       }
-      return bluebubblesPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
+      const outbound = bluebubblesPlugin.outbound!;
+      const limit = outbound.textChunkLimit;
+      const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
+      for (const chunk of chunks) {
+        lastResult = await outbound.sendText!({ ...ctx, text: chunk });
+      }
+      return lastResult!;
     },
     sendText: async ({ cfg, to, text, accountId, replyToId }) => {
       const rawReplyToId = typeof replyToId === "string" ? replyToId.trim() : "";

--- a/extensions/imessage/src/channel.outbound.test.ts
+++ b/extensions/imessage/src/channel.outbound.test.ts
@@ -1,4 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getIMessageRuntime: () => ({
+    channel: {
+      imessage: {
+        sendMessageIMessage: vi.fn().mockResolvedValue({ messageId: "im-msg-1" }),
+      },
+      text: {
+        chunkText: vi.fn((text: string, limit: number) => {
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks.length > 0 ? chunks : [text];
+        }),
+      },
+    },
+  }),
+}));
+
 import { imessagePlugin } from "./channel.js";
 
 describe("imessagePlugin outbound", () => {
@@ -91,5 +111,131 @@ describe("imessagePlugin outbound", () => {
       }),
     );
     expect(result).toEqual({ channel: "imessage", messageId: "m-media-local" });
+  });
+});
+
+describe("imessagePlugin sendPayload", () => {
+  const cfg = {
+    channels: {
+      imessage: {
+        mediaMaxMb: 3,
+      },
+    },
+  };
+  const baseCtx = {
+    cfg,
+    to: "chat_id:12",
+    text: "",
+    accountId: "default",
+    payload: {},
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates text-only payload to sendText", async () => {
+    const sendTextSpy = vi
+      .spyOn(imessagePlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "imessage", messageId: "i-1" });
+
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "hello imessage" },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello imessage" }));
+    expect(result).toEqual({ channel: "imessage", messageId: "i-1" });
+  });
+
+  it("delegates single media URL to sendMedia with caption", async () => {
+    const sendMediaSpy = vi
+      .spyOn(imessagePlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "imessage", messageId: "im-1" });
+
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "caption", mediaUrl: "https://example.com/pic.png" },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledOnce();
+    expect(sendMediaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrl: "https://example.com/pic.png",
+      }),
+    );
+    expect(result).toEqual({ channel: "imessage", messageId: "im-1" });
+  });
+
+  it("iterates multiple media URLs with caption on first only", async () => {
+    const sendMediaSpy = vi
+      .spyOn(imessagePlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "imessage", messageId: "im-last" });
+
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {
+        text: "cap",
+        mediaUrls: [
+          "https://example.com/a.png",
+          "https://example.com/b.png",
+          "https://example.com/c.png",
+        ],
+      },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledTimes(3);
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "cap", mediaUrl: "https://example.com/a.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/b.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/c.png" }),
+    );
+    expect(result).toEqual({ channel: "imessage", messageId: "im-last" });
+  });
+
+  it("returns no-op result for empty payload", async () => {
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {},
+    } as never);
+
+    expect(result).toEqual({ channel: "imessage", messageId: "" });
+  });
+
+  it("chunks long text via text chunker", async () => {
+    const sendTextSpy = vi
+      .spyOn(imessagePlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "imessage", messageId: "chunk-last" });
+
+    const longText = "a".repeat(9000);
+
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: longText },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledTimes(3);
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "a".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "a".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "a".repeat(1000) }),
+    );
+    expect(result).toEqual({ channel: "imessage", messageId: "chunk-last" });
   });
 });

--- a/extensions/imessage/src/channel.outbound.test.ts
+++ b/extensions/imessage/src/channel.outbound.test.ts
@@ -211,6 +211,20 @@ describe("imessagePlugin sendPayload", () => {
     expect(result).toEqual({ channel: "imessage", messageId: "" });
   });
 
+  it("returns no-op when chunker produces empty array", async () => {
+    // Simulate a chunker that strips whitespace-only input to nothing
+    vi.spyOn(imessagePlugin.outbound!, "chunker").mockReturnValue([]);
+    const sendTextSpy = vi.spyOn(imessagePlugin.outbound!, "sendText");
+
+    const result = await imessagePlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "   " },
+    } as never);
+
+    expect(sendTextSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "imessage", messageId: "" });
+  });
+
   it("chunks long text via text chunker", async () => {
     const sendTextSpy = vi
       .spyOn(imessagePlugin.outbound!, "sendText")

--- a/extensions/imessage/src/channel.outbound.test.ts
+++ b/extensions/imessage/src/channel.outbound.test.ts
@@ -213,7 +213,7 @@ describe("imessagePlugin sendPayload", () => {
 
   it("returns no-op when chunker produces empty array", async () => {
     // Simulate a chunker that strips whitespace-only input to nothing
-    vi.spyOn(imessagePlugin.outbound!, "chunker").mockReturnValue([]);
+    vi.spyOn(imessagePlugin.outbound! as any, "chunker").mockReturnValue([]);
     const sendTextSpy = vi.spyOn(imessagePlugin.outbound!, "sendText");
 
     const result = await imessagePlugin.outbound!.sendPayload!({

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -232,15 +232,19 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
     chunkerMode: "text",
     textChunkLimit: 4000,
     sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
       const urls = ctx.payload.mediaUrls?.length
         ? ctx.payload.mediaUrls
         : ctx.payload.mediaUrl
           ? [ctx.payload.mediaUrl]
           : [];
+      if (!text && urls.length === 0) {
+        return { channel: "imessage", messageId: "" };
+      }
       if (urls.length > 0) {
         let lastResult = await imessagePlugin.outbound!.sendMedia!({
           ...ctx,
-          text: ctx.payload.text ?? "",
+          text,
           mediaUrl: urls[0],
         });
         for (let i = 1; i < urls.length; i++) {
@@ -252,7 +256,14 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
         }
         return lastResult;
       }
-      return imessagePlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
+      const outbound = imessagePlugin.outbound!;
+      const limit = outbound.textChunkLimit;
+      const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
+      for (const chunk of chunks) {
+        lastResult = await outbound.sendText!({ ...ctx, text: chunk });
+      }
+      return lastResult!;
     },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       const result = await sendIMessageOutbound({

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -252,7 +252,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
         }
         return lastResult;
       }
-      return imessagePlugin.outbound!.sendText!({ ...ctx });
+      return imessagePlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
     },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       const result = await sendIMessageOutbound({

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -259,6 +259,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
       const outbound = imessagePlugin.outbound!;
       const limit = outbound.textChunkLimit;
       const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      if (!chunks.length) return { channel: "imessage", messageId: "" };
       let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
       for (const chunk of chunks) {
         lastResult = await outbound.sendText!({ ...ctx, text: chunk });

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -231,6 +231,25 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
     chunker: (text, limit) => getIMessageRuntime().channel.text.chunkText(text, limit),
     chunkerMode: "text",
     textChunkLimit: 4000,
+    sendPayload: async (ctx) => {
+      const urls = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (urls.length > 0) {
+        let lastResult;
+        for (let i = 0; i < urls.length; i++) {
+          lastResult = await imessagePlugin.outbound!.sendMedia!({
+            ...ctx,
+            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            mediaUrl: urls[i],
+          });
+        }
+        return lastResult!;
+      }
+      return imessagePlugin.outbound!.sendText!({ ...ctx });
+    },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId }) => {
       const result = await sendIMessageOutbound({
         cfg,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -238,15 +238,19 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount> = {
           ? [ctx.payload.mediaUrl]
           : [];
       if (urls.length > 0) {
-        let lastResult;
-        for (let i = 0; i < urls.length; i++) {
+        let lastResult = await imessagePlugin.outbound!.sendMedia!({
+          ...ctx,
+          text: ctx.payload.text ?? "",
+          mediaUrl: urls[0],
+        });
+        for (let i = 1; i < urls.length; i++) {
           lastResult = await imessagePlugin.outbound!.sendMedia!({
             ...ctx,
-            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            text: "",
             mediaUrl: urls[i],
           });
         }
-        return lastResult!;
+        return lastResult;
       }
       return imessagePlugin.outbound!.sendText!({ ...ctx });
     },

--- a/extensions/signal/src/channel.sendpayload.test.ts
+++ b/extensions/signal/src/channel.sendpayload.test.ts
@@ -112,6 +112,20 @@ describe("signalPlugin sendPayload", () => {
     expect(result).toEqual({ channel: "signal", messageId: "" });
   });
 
+  it("returns no-op when chunker produces empty array", async () => {
+    // Simulate a chunker that strips whitespace-only input to nothing
+    vi.spyOn(signalPlugin.outbound!, "chunker").mockReturnValue([]);
+    const sendTextSpy = vi.spyOn(signalPlugin.outbound!, "sendText");
+
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "   " },
+    } as never);
+
+    expect(sendTextSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "signal", messageId: "" });
+  });
+
   it("chunks long text via text chunker", async () => {
     const sendTextSpy = vi
       .spyOn(signalPlugin.outbound!, "sendText")

--- a/extensions/signal/src/channel.sendpayload.test.ts
+++ b/extensions/signal/src/channel.sendpayload.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getSignalRuntime: () => ({
+    channel: {
+      signal: {
+        sendMessageSignal: vi.fn().mockResolvedValue({ messageId: "sig-msg-1" }),
+      },
+      text: {
+        chunkText: vi.fn((text: string, limit: number) => {
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks.length > 0 ? chunks : [text];
+        }),
+      },
+    },
+  }),
+}));
+
+import { signalPlugin } from "./channel.js";
+
+describe("signalPlugin sendPayload", () => {
+  const cfg = { channels: { signal: {} } };
+  const baseCtx = {
+    cfg,
+    to: "+15551234567",
+    text: "",
+    accountId: "default",
+    payload: {},
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates text-only payload to sendText", async () => {
+    const sendTextSpy = vi
+      .spyOn(signalPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "signal", messageId: "s-1" });
+
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "hello signal" },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello signal" }));
+    expect(result).toEqual({ channel: "signal", messageId: "s-1" });
+  });
+
+  it("delegates single media URL to sendMedia with caption", async () => {
+    const sendMediaSpy = vi
+      .spyOn(signalPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "signal", messageId: "sm-1" });
+
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "caption", mediaUrl: "https://example.com/pic.png" },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledOnce();
+    expect(sendMediaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrl: "https://example.com/pic.png",
+      }),
+    );
+    expect(result).toEqual({ channel: "signal", messageId: "sm-1" });
+  });
+
+  it("iterates multiple media URLs with caption on first only", async () => {
+    const sendMediaSpy = vi
+      .spyOn(signalPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "signal", messageId: "sm-last" });
+
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {
+        text: "cap",
+        mediaUrls: [
+          "https://example.com/a.png",
+          "https://example.com/b.png",
+          "https://example.com/c.png",
+        ],
+      },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledTimes(3);
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "cap", mediaUrl: "https://example.com/a.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/b.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/c.png" }),
+    );
+    expect(result).toEqual({ channel: "signal", messageId: "sm-last" });
+  });
+
+  it("returns no-op result for empty payload", async () => {
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {},
+    } as never);
+
+    expect(result).toEqual({ channel: "signal", messageId: "" });
+  });
+
+  it("chunks long text via text chunker", async () => {
+    const sendTextSpy = vi
+      .spyOn(signalPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "signal", messageId: "chunk-last" });
+
+    const longText = "y".repeat(9000);
+
+    const result = await signalPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: longText },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledTimes(3);
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "y".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "y".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "y".repeat(1000) }),
+    );
+    expect(result).toEqual({ channel: "signal", messageId: "chunk-last" });
+  });
+});

--- a/extensions/signal/src/channel.sendpayload.test.ts
+++ b/extensions/signal/src/channel.sendpayload.test.ts
@@ -114,7 +114,7 @@ describe("signalPlugin sendPayload", () => {
 
   it("returns no-op when chunker produces empty array", async () => {
     // Simulate a chunker that strips whitespace-only input to nothing
-    vi.spyOn(signalPlugin.outbound!, "chunker").mockReturnValue([]);
+    vi.spyOn(signalPlugin.outbound! as any, "chunker").mockReturnValue([]);
     const sendTextSpy = vi.spyOn(signalPlugin.outbound!, "sendText");
 
     const result = await signalPlugin.outbound!.sendPayload!({

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -263,6 +263,25 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     chunker: (text, limit) => getSignalRuntime().channel.text.chunkText(text, limit),
     chunkerMode: "text",
     textChunkLimit: 4000,
+    sendPayload: async (ctx) => {
+      const urls = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (urls.length > 0) {
+        let lastResult;
+        for (let i = 0; i < urls.length; i++) {
+          lastResult = await signalPlugin.outbound!.sendMedia!({
+            ...ctx,
+            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            mediaUrl: urls[i],
+          });
+        }
+        return lastResult!;
+      }
+      return signalPlugin.outbound!.sendText!({ ...ctx });
+    },
     sendText: async ({ cfg, to, text, accountId, deps }) => {
       const result = await sendSignalOutbound({
         cfg,

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -270,15 +270,19 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
           ? [ctx.payload.mediaUrl]
           : [];
       if (urls.length > 0) {
-        let lastResult;
-        for (let i = 0; i < urls.length; i++) {
+        let lastResult = await signalPlugin.outbound!.sendMedia!({
+          ...ctx,
+          text: ctx.payload.text ?? "",
+          mediaUrl: urls[0],
+        });
+        for (let i = 1; i < urls.length; i++) {
           lastResult = await signalPlugin.outbound!.sendMedia!({
             ...ctx,
-            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            text: "",
             mediaUrl: urls[i],
           });
         }
-        return lastResult!;
+        return lastResult;
       }
       return signalPlugin.outbound!.sendText!({ ...ctx });
     },

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -284,7 +284,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         }
         return lastResult;
       }
-      return signalPlugin.outbound!.sendText!({ ...ctx });
+      return signalPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
     },
     sendText: async ({ cfg, to, text, accountId, deps }) => {
       const result = await sendSignalOutbound({

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -264,15 +264,19 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
     chunkerMode: "text",
     textChunkLimit: 4000,
     sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
       const urls = ctx.payload.mediaUrls?.length
         ? ctx.payload.mediaUrls
         : ctx.payload.mediaUrl
           ? [ctx.payload.mediaUrl]
           : [];
+      if (!text && urls.length === 0) {
+        return { channel: "signal", messageId: "" };
+      }
       if (urls.length > 0) {
         let lastResult = await signalPlugin.outbound!.sendMedia!({
           ...ctx,
-          text: ctx.payload.text ?? "",
+          text,
           mediaUrl: urls[0],
         });
         for (let i = 1; i < urls.length; i++) {
@@ -284,7 +288,14 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
         }
         return lastResult;
       }
-      return signalPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
+      const outbound = signalPlugin.outbound!;
+      const limit = outbound.textChunkLimit;
+      const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
+      for (const chunk of chunks) {
+        lastResult = await outbound.sendText!({ ...ctx, text: chunk });
+      }
+      return lastResult!;
     },
     sendText: async ({ cfg, to, text, accountId, deps }) => {
       const result = await sendSignalOutbound({

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -291,6 +291,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
       const outbound = signalPlugin.outbound!;
       const limit = outbound.textChunkLimit;
       const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      if (!chunks.length) return { channel: "signal", messageId: "" };
       let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
       for (const chunk of chunks) {
         lastResult = await outbound.sendText!({ ...ctx, text: chunk });

--- a/extensions/telegram/src/channel.sendpayload.test.ts
+++ b/extensions/telegram/src/channel.sendpayload.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getTelegramRuntime: () => ({
+    channel: {
+      telegram: {
+        sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "tg-msg-1" }),
+        resolveTelegramToken: vi.fn().mockReturnValue({ token: "test-token" }),
+      },
+      text: {
+        chunkMarkdownText: vi.fn((text: string, limit: number) => {
+          // Actually split text into chunks at the limit boundary
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks.length > 0 ? chunks : [text];
+        }),
+      },
+    },
+  }),
+}));
+
+import { telegramPlugin } from "./channel.js";
+
+describe("telegramPlugin sendPayload", () => {
+  const cfg = { channels: { telegram: {} } };
+  const baseCtx = {
+    cfg,
+    to: "chat:123",
+    text: "",
+    accountId: "default",
+    payload: {},
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates text-only payload to sendText", async () => {
+    const sendTextSpy = vi
+      .spyOn(telegramPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "telegram", messageId: "t-1" });
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "hello world" },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello world" }));
+    expect(result).toEqual({ channel: "telegram", messageId: "t-1" });
+  });
+
+  it("delegates single media URL to sendMedia with caption", async () => {
+    const sendMediaSpy = vi
+      .spyOn(telegramPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "telegram", messageId: "m-1" });
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "caption", mediaUrl: "https://example.com/pic.png" },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledOnce();
+    expect(sendMediaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrl: "https://example.com/pic.png",
+      }),
+    );
+    expect(result).toEqual({ channel: "telegram", messageId: "m-1" });
+  });
+
+  it("iterates multiple media URLs with caption on first only", async () => {
+    const sendMediaSpy = vi
+      .spyOn(telegramPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "telegram", messageId: "m-last" });
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {
+        text: "cap",
+        mediaUrls: [
+          "https://example.com/a.png",
+          "https://example.com/b.png",
+          "https://example.com/c.png",
+        ],
+      },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledTimes(3);
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "cap", mediaUrl: "https://example.com/a.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/b.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/c.png" }),
+    );
+    expect(result).toEqual({ channel: "telegram", messageId: "m-last" });
+  });
+
+  it("returns no-op result for empty payload", async () => {
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {},
+    } as never);
+
+    expect(result).toEqual({ channel: "telegram", messageId: "" });
+  });
+
+  it("chunks long text via markdown chunker", async () => {
+    const sendTextSpy = vi
+      .spyOn(telegramPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "telegram", messageId: "chunk-last" });
+
+    // Create text longer than the 4000-char limit
+    const longText = "x".repeat(9000);
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: longText },
+    } as never);
+
+    // Should split into 3 chunks: 4000 + 4000 + 1000
+    expect(sendTextSpy).toHaveBeenCalledTimes(3);
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "x".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "x".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "x".repeat(1000) }),
+    );
+    expect(result).toEqual({ channel: "telegram", messageId: "chunk-last" });
+  });
+});

--- a/extensions/telegram/src/channel.sendpayload.test.ts
+++ b/extensions/telegram/src/channel.sendpayload.test.ts
@@ -114,6 +114,20 @@ describe("telegramPlugin sendPayload", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "" });
   });
 
+  it("returns no-op when chunker produces empty array", async () => {
+    // Simulate a chunker that strips whitespace-only input to nothing
+    vi.spyOn(telegramPlugin.outbound!, "chunker").mockReturnValue([]);
+    const sendTextSpy = vi.spyOn(telegramPlugin.outbound!, "sendText");
+
+    const result = await telegramPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "   " },
+    } as never);
+
+    expect(sendTextSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "" });
+  });
+
   it("chunks long text via markdown chunker", async () => {
     const sendTextSpy = vi
       .spyOn(telegramPlugin.outbound!, "sendText")

--- a/extensions/telegram/src/channel.sendpayload.test.ts
+++ b/extensions/telegram/src/channel.sendpayload.test.ts
@@ -116,7 +116,7 @@ describe("telegramPlugin sendPayload", () => {
 
   it("returns no-op when chunker produces empty array", async () => {
     // Simulate a chunker that strips whitespace-only input to nothing
-    vi.spyOn(telegramPlugin.outbound!, "chunker").mockReturnValue([]);
+    vi.spyOn(telegramPlugin.outbound! as any, "chunker").mockReturnValue([]);
     const sendTextSpy = vi.spyOn(telegramPlugin.outbound!, "sendText");
 
     const result = await telegramPlugin.outbound!.sendPayload!({

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -327,15 +327,19 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
           ? [ctx.payload.mediaUrl]
           : [];
       if (urls.length > 0) {
-        let lastResult;
-        for (let i = 0; i < urls.length; i++) {
+        let lastResult = await telegramPlugin.outbound!.sendMedia!({
+          ...ctx,
+          text: ctx.payload.text ?? "",
+          mediaUrl: urls[0],
+        });
+        for (let i = 1; i < urls.length; i++) {
           lastResult = await telegramPlugin.outbound!.sendMedia!({
             ...ctx,
-            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            text: "",
             mediaUrl: urls[i],
           });
         }
-        return lastResult!;
+        return lastResult;
       }
       return telegramPlugin.outbound!.sendText!({ ...ctx });
     },

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -341,7 +341,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         }
         return lastResult;
       }
-      return telegramPlugin.outbound!.sendText!({ ...ctx });
+      return telegramPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
     },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -321,15 +321,20 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     textChunkLimit: 4000,
     pollMaxOptions: 10,
     sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
       const urls = ctx.payload.mediaUrls?.length
         ? ctx.payload.mediaUrls
         : ctx.payload.mediaUrl
           ? [ctx.payload.mediaUrl]
           : [];
+      // No-op for empty payloads (channelData-only with no sendable content)
+      if (!text && urls.length === 0) {
+        return { channel: "telegram", messageId: "" };
+      }
       if (urls.length > 0) {
         let lastResult = await telegramPlugin.outbound!.sendMedia!({
           ...ctx,
-          text: ctx.payload.text ?? "",
+          text,
           mediaUrl: urls[0],
         });
         for (let i = 1; i < urls.length; i++) {
@@ -341,7 +346,15 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         }
         return lastResult;
       }
-      return telegramPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
+      // Chunk text before sending to respect textChunkLimit
+      const outbound = telegramPlugin.outbound!;
+      const limit = outbound.textChunkLimit;
+      const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
+      for (const chunk of chunks) {
+        lastResult = await outbound.sendText!({ ...ctx, text: chunk });
+      }
+      return lastResult!;
     },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -320,6 +320,25 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
     chunkerMode: "markdown",
     textChunkLimit: 4000,
     pollMaxOptions: 10,
+    sendPayload: async (ctx) => {
+      const urls = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (urls.length > 0) {
+        let lastResult;
+        for (let i = 0; i < urls.length; i++) {
+          lastResult = await telegramPlugin.outbound!.sendMedia!({
+            ...ctx,
+            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            mediaUrl: urls[i],
+          });
+        }
+        return lastResult!;
+      }
+      return telegramPlugin.outbound!.sendText!({ ...ctx });
+    },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendTelegram ?? getTelegramRuntime().channel.telegram.sendMessageTelegram;
       const replyToMessageId = parseTelegramReplyToMessageId(replyToId);

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -350,6 +350,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
       const outbound = telegramPlugin.outbound!;
       const limit = outbound.textChunkLimit;
       const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      if (!chunks.length) return { channel: "telegram", messageId: "" };
       let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
       for (const chunk of chunks) {
         lastResult = await outbound.sendText!({ ...ctx, text: chunk });

--- a/extensions/whatsapp/src/channel.sendpayload.test.ts
+++ b/extensions/whatsapp/src/channel.sendpayload.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: () => ({
+    channel: {
+      whatsapp: {
+        sendMessageWhatsApp: vi.fn().mockResolvedValue({ messageId: "wa-msg-1" }),
+        webAuthExists: vi.fn().mockResolvedValue(true),
+        readWebSelfId: vi.fn().mockReturnValue({ e164: null, jid: null }),
+        createLoginTool: vi.fn().mockReturnValue({}),
+      },
+      text: {
+        chunkText: vi.fn((text: string, limit: number) => {
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks.length > 0 ? chunks : [text];
+        }),
+      },
+    },
+    logging: {
+      shouldLogVerbose: vi.fn().mockReturnValue(false),
+    },
+  }),
+}));
+
+import { whatsappPlugin } from "./channel.js";
+
+describe("whatsappPlugin sendPayload", () => {
+  const cfg = { channels: { whatsapp: {} } };
+  const baseCtx = {
+    cfg,
+    to: "+15551234567@s.whatsapp.net",
+    text: "",
+    accountId: "default",
+    payload: {},
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates text-only payload to sendText", async () => {
+    const sendTextSpy = vi
+      .spyOn(whatsappPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "whatsapp", messageId: "w-1" });
+
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "hello whatsapp" },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledOnce();
+    expect(sendTextSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello whatsapp" }));
+    expect(result).toEqual({ channel: "whatsapp", messageId: "w-1" });
+  });
+
+  it("delegates single media URL to sendMedia with caption", async () => {
+    const sendMediaSpy = vi
+      .spyOn(whatsappPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "whatsapp", messageId: "wm-1" });
+
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "caption", mediaUrl: "https://example.com/pic.png" },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledOnce();
+    expect(sendMediaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "caption",
+        mediaUrl: "https://example.com/pic.png",
+      }),
+    );
+    expect(result).toEqual({ channel: "whatsapp", messageId: "wm-1" });
+  });
+
+  it("iterates multiple media URLs with caption on first only", async () => {
+    const sendMediaSpy = vi
+      .spyOn(whatsappPlugin.outbound!, "sendMedia")
+      .mockResolvedValue({ channel: "whatsapp", messageId: "wm-last" });
+
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {
+        text: "cap",
+        mediaUrls: [
+          "https://example.com/a.png",
+          "https://example.com/b.png",
+          "https://example.com/c.png",
+        ],
+      },
+    } as never);
+
+    expect(sendMediaSpy).toHaveBeenCalledTimes(3);
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "cap", mediaUrl: "https://example.com/a.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/b.png" }),
+    );
+    expect(sendMediaSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "", mediaUrl: "https://example.com/c.png" }),
+    );
+    expect(result).toEqual({ channel: "whatsapp", messageId: "wm-last" });
+  });
+
+  it("returns no-op result for empty payload", async () => {
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: {},
+    } as never);
+
+    expect(result).toEqual({ channel: "whatsapp", messageId: "" });
+  });
+
+  it("chunks long text via text chunker", async () => {
+    const sendTextSpy = vi
+      .spyOn(whatsappPlugin.outbound!, "sendText")
+      .mockResolvedValue({ channel: "whatsapp", messageId: "chunk-last" });
+
+    const longText = "z".repeat(9000);
+
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: longText },
+    } as never);
+
+    expect(sendTextSpy).toHaveBeenCalledTimes(3);
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "z".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "z".repeat(4000) }),
+    );
+    expect(sendTextSpy).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "z".repeat(1000) }),
+    );
+    expect(result).toEqual({ channel: "whatsapp", messageId: "chunk-last" });
+  });
+});

--- a/extensions/whatsapp/src/channel.sendpayload.test.ts
+++ b/extensions/whatsapp/src/channel.sendpayload.test.ts
@@ -118,6 +118,20 @@ describe("whatsappPlugin sendPayload", () => {
     expect(result).toEqual({ channel: "whatsapp", messageId: "" });
   });
 
+  it("returns no-op when chunker produces empty array", async () => {
+    // Simulate a chunker that strips whitespace-only input to nothing
+    vi.spyOn(whatsappPlugin.outbound!, "chunker").mockReturnValue([]);
+    const sendTextSpy = vi.spyOn(whatsappPlugin.outbound!, "sendText");
+
+    const result = await whatsappPlugin.outbound!.sendPayload!({
+      ...baseCtx,
+      payload: { text: "   " },
+    } as never);
+
+    expect(sendTextSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "whatsapp", messageId: "" });
+  });
+
   it("chunks long text via text chunker", async () => {
     const sendTextSpy = vi
       .spyOn(whatsappPlugin.outbound!, "sendText")

--- a/extensions/whatsapp/src/channel.sendpayload.test.ts
+++ b/extensions/whatsapp/src/channel.sendpayload.test.ts
@@ -120,7 +120,7 @@ describe("whatsappPlugin sendPayload", () => {
 
   it("returns no-op when chunker produces empty array", async () => {
     // Simulate a chunker that strips whitespace-only input to nothing
-    vi.spyOn(whatsappPlugin.outbound!, "chunker").mockReturnValue([]);
+    vi.spyOn(whatsappPlugin.outbound! as any, "chunker").mockReturnValue([]);
     const sendTextSpy = vi.spyOn(whatsappPlugin.outbound!, "sendText");
 
     const result = await whatsappPlugin.outbound!.sendPayload!({

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -286,6 +286,25 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     pollMaxOptions: 12,
     resolveTarget: ({ to, allowFrom, mode }) =>
       resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+    sendPayload: async (ctx) => {
+      const urls = ctx.payload.mediaUrls?.length
+        ? ctx.payload.mediaUrls
+        : ctx.payload.mediaUrl
+          ? [ctx.payload.mediaUrl]
+          : [];
+      if (urls.length > 0) {
+        let lastResult;
+        for (let i = 0; i < urls.length; i++) {
+          lastResult = await whatsappPlugin.outbound!.sendMedia!({
+            ...ctx,
+            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            mediaUrl: urls[i],
+          });
+        }
+        return lastResult!;
+      }
+      return whatsappPlugin.outbound!.sendText!({ ...ctx });
+    },
     sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;
       const result = await send(to, text, {

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -293,15 +293,19 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           ? [ctx.payload.mediaUrl]
           : [];
       if (urls.length > 0) {
-        let lastResult;
-        for (let i = 0; i < urls.length; i++) {
+        let lastResult = await whatsappPlugin.outbound!.sendMedia!({
+          ...ctx,
+          text: ctx.payload.text ?? "",
+          mediaUrl: urls[0],
+        });
+        for (let i = 1; i < urls.length; i++) {
           lastResult = await whatsappPlugin.outbound!.sendMedia!({
             ...ctx,
-            text: i === 0 ? (ctx.payload.text ?? "") : "",
+            text: "",
             mediaUrl: urls[i],
           });
         }
-        return lastResult!;
+        return lastResult;
       }
       return whatsappPlugin.outbound!.sendText!({ ...ctx });
     },

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -287,15 +287,19 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     resolveTarget: ({ to, allowFrom, mode }) =>
       resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
     sendPayload: async (ctx) => {
+      const text = ctx.payload.text ?? "";
       const urls = ctx.payload.mediaUrls?.length
         ? ctx.payload.mediaUrls
         : ctx.payload.mediaUrl
           ? [ctx.payload.mediaUrl]
           : [];
+      if (!text && urls.length === 0) {
+        return { channel: "whatsapp", messageId: "" };
+      }
       if (urls.length > 0) {
         let lastResult = await whatsappPlugin.outbound!.sendMedia!({
           ...ctx,
-          text: ctx.payload.text ?? "",
+          text,
           mediaUrl: urls[0],
         });
         for (let i = 1; i < urls.length; i++) {
@@ -307,7 +311,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         }
         return lastResult;
       }
-      return whatsappPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
+      const outbound = whatsappPlugin.outbound!;
+      const limit = outbound.textChunkLimit;
+      const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
+      for (const chunk of chunks) {
+        lastResult = await outbound.sendText!({ ...ctx, text: chunk });
+      }
+      return lastResult!;
     },
     sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -307,7 +307,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         }
         return lastResult;
       }
-      return whatsappPlugin.outbound!.sendText!({ ...ctx });
+      return whatsappPlugin.outbound!.sendText!({ ...ctx, text: ctx.payload.text ?? "" });
     },
     sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
       const send = deps?.sendWhatsApp ?? getWhatsAppRuntime().channel.whatsapp.sendMessageWhatsApp;

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -314,6 +314,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       const outbound = whatsappPlugin.outbound!;
       const limit = outbound.textChunkLimit;
       const chunks = limit && outbound.chunker ? outbound.chunker(text, limit) : [text];
+      if (!chunks.length) return { channel: "whatsapp", messageId: "" };
       let lastResult: Awaited<ReturnType<NonNullable<typeof outbound.sendText>>>;
       for (const chunk of chunks) {
         lastResult = await outbound.sendText!({ ...ctx, text: chunk });


### PR DESCRIPTION
Part of Message Reliability: Durable SQLite Outbox, Recovery Worker, and Unified sendPayload (#32063)

## Summary

- Problem: Channel adapters lack a unified `sendPayload` method for the delivery pipeline
- Why it matters: The outbox-based delivery pipeline (#29997) needs `sendPayload` per adapter
- What changed: Added `sendPayload` to batch-a adapters (Telegram, iMessage, Signal, Matrix). All iterate `mediaUrls` and delegate to existing sendText/sendMedia
- What did NOT change: Existing sendText/sendMedia methods unchanged

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #29997

## User-visible / Behavior Changes

None — additive internal method only.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Telegram, iMessage, Signal, Matrix

### Steps
1. pnpm check passes
2. Send messages through affected channels — delivery unchanged

### Expected
- No behavior change; new method available for delivery pipeline

### Actual
- Same as expected

## Evidence

- [x] Failing test/log before + passing after (CI green)

## Human Verification (required)

- Verified scenarios: TypeScript compilation, existing test suite
- Edge cases checked: Media-only, text-only, mixed payloads via sendPayload
- What you did **not** verify: Live delivery through all 4 channels (covered by existing sendText/sendMedia tests)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; sendPayload unused until #29997 activates it
- Files/config to restore: Adapter source files
- Known bad symptoms: None expected (additive only)

## Risks and Mitigations

None — additive change.
