### PR TITLE
feat(docker): install GitHub CLI (gh) in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,21 @@ FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
+# Install GitHub CLI (gh) for PR workflows and automation.
+# Authenticates automatically via GITHUB_TOKEN env var when present.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget \
+ && mkdir -p -m 755 /etc/apt/keyrings \
+ && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Add `gh` CLI to the base Dockerfile for Railway and other container deployments.

## Problem

`gh` (GitHub CLI) is not installed in the container by default. When installed manually at runtime, it gets lost on container restarts.

## Solution

Install `gh` using GitHub's official apt repository during the Docker build. This ensures `gh` is available persistently.

The CLI automatically authenticates via the `GITHUB_TOKEN` env var when present, enabling PR workflows and automation in containerized environments.

## Changes

- Added GitHub CLI apt repository setup
- Installed `gh` package
- Cleaned up apt caches to minimize image size

## Testing

- `gh --version` should work in the built container
- `gh auth status` should show authenticated when `GITHUB_TOKEN` is set