### PR TITLE
feat: detect stale Slack sockets and auto-restart

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -427,6 +427,8 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         abortSignal: ctx.abortSignal,
         mediaMaxMb: account.config.mediaMaxMb,
         slashCommand: account.config.slashCommand,
+        setStatus: ctx.setStatus as (next: Record<string, unknown>) => void,
+        getStatus: ctx.getStatus as () => Record<string, unknown>,
       });
     },
   },

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -10,12 +10,21 @@ const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 3;
 const ONE_HOUR_MS = 60 * 60_000;
 
+/**
+ * How long a connected channel can go without receiving any event before
+ * the health monitor treats it as a "stale socket" and triggers a restart.
+ * This catches the half-dead WebSocket scenario where the connection appears
+ * alive (health checks pass) but Slack silently stops delivering events.
+ */
+const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
+
 export type ChannelHealthMonitorDeps = {
   channelManager: ChannelManager;
   checkIntervalMs?: number;
   startupGraceMs?: number;
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
+  staleEventThresholdMs?: number;
   abortSignal?: AbortSignal;
 };
 
@@ -32,12 +41,17 @@ function isManagedAccount(snapshot: { enabled?: boolean; configured?: boolean })
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
-function isChannelHealthy(snapshot: {
-  running?: boolean;
-  connected?: boolean;
-  enabled?: boolean;
-  configured?: boolean;
-}): boolean {
+function isChannelHealthy(
+  snapshot: {
+    running?: boolean;
+    connected?: boolean;
+    enabled?: boolean;
+    configured?: boolean;
+    lastEventAt?: number | null;
+    lastStartAt?: number | null;
+  },
+  opts: { now: number; staleEventThresholdMs: number },
+): boolean {
   if (!isManagedAccount(snapshot)) {
     return true;
   }
@@ -47,6 +61,22 @@ function isChannelHealthy(snapshot: {
   if (snapshot.connected === false) {
     return false;
   }
+
+  // Stale socket detection: if the channel has been running long enough
+  // (past the stale threshold) and we have never received an event, or the
+  // last event was received longer ago than the threshold, treat as unhealthy.
+  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
+    const upSince = snapshot.lastStartAt ?? 0;
+    const upDuration = opts.now - upSince;
+    if (upDuration > opts.staleEventThresholdMs) {
+      const lastEvent = snapshot.lastEventAt ?? 0;
+      const eventAge = opts.now - lastEvent;
+      if (eventAge > opts.staleEventThresholdMs) {
+        return false;
+      }
+    }
+  }
+
   return true;
 }
 
@@ -57,6 +87,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     startupGraceMs = DEFAULT_STARTUP_GRACE_MS,
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
+    staleEventThresholdMs = DEFAULT_STALE_EVENT_THRESHOLD_MS,
     abortSignal,
   } = deps;
 
@@ -101,7 +132,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
-          if (isChannelHealthy(status)) {
+          if (isChannelHealthy(status, { now, staleEventThresholdMs })) {
             continue;
           }
 
@@ -123,11 +154,19 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
+          const isStaleSocket =
+            status.running &&
+            status.connected !== false &&
+            status.lastEventAt != null &&
+            now - (status.lastEventAt ?? 0) > staleEventThresholdMs;
+
           const reason = !status.running
             ? status.reconnectAttempts && status.reconnectAttempts >= 10
               ? "gave-up"
               : "stopped"
-            : "stuck";
+            : isStaleSocket
+              ? "stale-socket"
+              : "stuck";
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 

--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -12,14 +12,16 @@ export function registerSlackMonitorEvents(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
   handleSlackMessage: SlackMessageHandler;
+  /** Called on each inbound event to update liveness tracking. */
+  trackEvent?: () => void;
 }) {
   registerSlackMessageEvents({
     ctx: params.ctx,
     handleSlackMessage: params.handleSlackMessage,
   });
-  registerSlackReactionEvents({ ctx: params.ctx });
-  registerSlackMemberEvents({ ctx: params.ctx });
-  registerSlackChannelEvents({ ctx: params.ctx });
-  registerSlackPinEvents({ ctx: params.ctx });
+  registerSlackReactionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackMemberEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackChannelEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackInteractionEvents({ ctx: params.ctx });
 }

--- a/src/slack/monitor/events/channels.test.ts
+++ b/src/slack/monitor/events/channels.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerSlackChannelEvents } from "./channels.js";
+import { createSlackSystemEventTestHarness } from "./system-event-test-harness.js";
+
+const enqueueSystemEventMock = vi.fn();
+
+vi.mock("../../../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+type SlackChannelHandler = (args: {
+  event: Record<string, unknown>;
+  body: unknown;
+}) => Promise<void>;
+
+function createChannelContext(params?: {
+  trackEvent?: () => void;
+  shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+}) {
+  const harness = createSlackSystemEventTestHarness();
+  if (params?.shouldDropMismatchedSlackEvent) {
+    harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
+  }
+  registerSlackChannelEvents({ ctx: harness.ctx, trackEvent: params?.trackEvent });
+  return {
+    getCreatedHandler: () => harness.getHandler("channel_created") as SlackChannelHandler | null,
+  };
+}
+
+describe("registerSlackChannelEvents", () => {
+  it("does not track mismatched events", async () => {
+    const trackEvent = vi.fn();
+    const { getCreatedHandler } = createChannelContext({
+      trackEvent,
+      shouldDropMismatchedSlackEvent: () => true,
+    });
+    const createdHandler = getCreatedHandler();
+    expect(createdHandler).toBeTruthy();
+
+    await createdHandler!({
+      event: {
+        channel: { id: "C1", name: "general" },
+      },
+      body: { api_app_id: "A_OTHER" },
+    });
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks accepted events", async () => {
+    const trackEvent = vi.fn();
+    const { getCreatedHandler } = createChannelContext({ trackEvent });
+    const createdHandler = getCreatedHandler();
+    expect(createdHandler).toBeTruthy();
+
+    await createdHandler!({
+      event: {
+        channel: { id: "C1", name: "general" },
+      },
+      body: {},
+    });
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slack/monitor/events/channels.ts
+++ b/src/slack/monitor/events/channels.ts
@@ -12,8 +12,11 @@ import type {
   SlackChannelRenamedEvent,
 } from "../types.js";
 
-export function registerSlackChannelEvents(params: { ctx: SlackMonitorContext }) {
-  const { ctx } = params;
+export function registerSlackChannelEvents(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   const enqueueChannelSystemEvent = (params: {
     kind: "created" | "renamed";
@@ -48,6 +51,7 @@ export function registerSlackChannelEvents(params: { ctx: SlackMonitorContext })
     "channel_created",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_created">) => {
       try {
+        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }
@@ -66,6 +70,7 @@ export function registerSlackChannelEvents(params: { ctx: SlackMonitorContext })
     "channel_rename",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_rename">) => {
       try {
+        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }
@@ -84,6 +89,7 @@ export function registerSlackChannelEvents(params: { ctx: SlackMonitorContext })
     "channel_id_changed",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_id_changed">) => {
       try {
+        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }

--- a/src/slack/monitor/events/channels.ts
+++ b/src/slack/monitor/events/channels.ts
@@ -51,10 +51,10 @@ export function registerSlackChannelEvents(params: {
     "channel_created",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_created">) => {
       try {
-        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }
+        trackEvent?.();
 
         const payload = event as SlackChannelCreatedEvent;
         const channelId = payload.channel?.id;
@@ -70,10 +70,10 @@ export function registerSlackChannelEvents(params: {
     "channel_rename",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_rename">) => {
       try {
-        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }
+        trackEvent?.();
 
         const payload = event as SlackChannelRenamedEvent;
         const channelId = payload.channel?.id;
@@ -89,10 +89,10 @@ export function registerSlackChannelEvents(params: {
     "channel_id_changed",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_id_changed">) => {
       try {
-        trackEvent?.();
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
         }
+        trackEvent?.();
 
         const payload = event as SlackChannelIdChangedEvent;
         const oldChannelId = payload.old_channel_id;

--- a/src/slack/monitor/events/members.ts
+++ b/src/slack/monitor/events/members.ts
@@ -5,8 +5,11 @@ import type { SlackMonitorContext } from "../context.js";
 import type { SlackMemberChannelEvent } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
 
-export function registerSlackMemberEvents(params: { ctx: SlackMonitorContext }) {
-  const { ctx } = params;
+export function registerSlackMemberEvents(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   const handleMemberChannelEvent = async (params: {
     verb: "joined" | "left";
@@ -14,6 +17,7 @@ export function registerSlackMemberEvents(params: { ctx: SlackMonitorContext }) 
     body: unknown;
   }) => {
     try {
+      trackEvent?.();
       if (ctx.shouldDropMismatchedSlackEvent(params.body)) {
         return;
       }

--- a/src/slack/monitor/events/members.ts
+++ b/src/slack/monitor/events/members.ts
@@ -17,10 +17,10 @@ export function registerSlackMemberEvents(params: {
     body: unknown;
   }) => {
     try {
-      trackEvent?.();
       if (ctx.shouldDropMismatchedSlackEvent(params.body)) {
         return;
       }
+      trackEvent?.();
       const payload = params.event;
       const channelId = payload.channel;
       const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : {};

--- a/src/slack/monitor/events/pins.ts
+++ b/src/slack/monitor/events/pins.ts
@@ -7,18 +7,20 @@ import { authorizeAndResolveSlackSystemEventContext } from "./system-event-conte
 
 async function handleSlackPinEvent(params: {
   ctx: SlackMonitorContext;
+  trackEvent?: () => void;
   body: unknown;
   event: unknown;
   action: "pinned" | "unpinned";
   contextKeySuffix: "added" | "removed";
   errorLabel: string;
 }): Promise<void> {
-  const { ctx, body, event, action, contextKeySuffix, errorLabel } = params;
+  const { ctx, trackEvent, body, event, action, contextKeySuffix, errorLabel } = params;
 
   try {
     if (ctx.shouldDropMismatchedSlackEvent(body)) {
       return;
     }
+    trackEvent?.();
 
     const payload = event as SlackPinEvent;
     const channelId = payload.channel_id;
@@ -54,9 +56,9 @@ export function registerSlackPinEvents(params: {
   const { ctx, trackEvent } = params;
 
   ctx.app.event("pin_added", async ({ event, body }: SlackEventMiddlewareArgs<"pin_added">) => {
-    trackEvent?.();
     await handleSlackPinEvent({
       ctx,
+      trackEvent,
       body,
       event,
       action: "pinned",
@@ -66,9 +68,9 @@ export function registerSlackPinEvents(params: {
   });
 
   ctx.app.event("pin_removed", async ({ event, body }: SlackEventMiddlewareArgs<"pin_removed">) => {
-    trackEvent?.();
     await handleSlackPinEvent({
       ctx,
+      trackEvent,
       body,
       event,
       action: "unpinned",

--- a/src/slack/monitor/events/pins.ts
+++ b/src/slack/monitor/events/pins.ts
@@ -47,10 +47,14 @@ async function handleSlackPinEvent(params: {
   }
 }
 
-export function registerSlackPinEvents(params: { ctx: SlackMonitorContext }) {
-  const { ctx } = params;
+export function registerSlackPinEvents(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   ctx.app.event("pin_added", async ({ event, body }: SlackEventMiddlewareArgs<"pin_added">) => {
+    trackEvent?.();
     await handleSlackPinEvent({
       ctx,
       body,
@@ -62,6 +66,7 @@ export function registerSlackPinEvents(params: { ctx: SlackMonitorContext }) {
   });
 
   ctx.app.event("pin_removed", async ({ event, body }: SlackEventMiddlewareArgs<"pin_removed">) => {
+    trackEvent?.();
     await handleSlackPinEvent({
       ctx,
       body,

--- a/src/slack/monitor/events/reactions.ts
+++ b/src/slack/monitor/events/reactions.ts
@@ -12,12 +12,12 @@ export function registerSlackReactionEvents(params: {
   const { ctx, trackEvent } = params;
 
   const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
-    trackEvent?.();
     try {
       const item = event.item;
       if (!item || item.type !== "message") {
         return;
       }
+      trackEvent?.();
 
       const ingressContext = await authorizeAndResolveSlackSystemEventContext({
         ctx,

--- a/src/slack/monitor/events/reactions.ts
+++ b/src/slack/monitor/events/reactions.ts
@@ -5,10 +5,14 @@ import type { SlackMonitorContext } from "../context.js";
 import type { SlackReactionEvent } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
 
-export function registerSlackReactionEvents(params: { ctx: SlackMonitorContext }) {
-  const { ctx } = params;
+export function registerSlackReactionEvents(params: {
+  ctx: SlackMonitorContext;
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
 
   const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
+    trackEvent?.();
     try {
       const item = event.item;
       if (!item || item.type !== "message") {

--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackMessageHandler } from "./message-handler.js";
+
+const enqueueMock = vi.fn(async (_entry: unknown) => {});
+const resolveThreadTsMock = vi.fn(async ({ message }: { message: Record<string, unknown> }) => ({
+  ...message,
+}));
+
+vi.mock("../../auto-reply/inbound-debounce.js", () => ({
+  resolveInboundDebounceMs: () => 10,
+  createInboundDebouncer: () => ({
+    enqueue: (entry: unknown) => enqueueMock(entry),
+  }),
+}));
+
+vi.mock("./thread-resolution.js", () => ({
+  createSlackThreadTsResolver: () => ({
+    resolve: (entry: { message: Record<string, unknown> }) => resolveThreadTsMock(entry),
+  }),
+}));
+
+function createContext(overrides?: {
+  markMessageSeen?: (channel: string | undefined, ts: string | undefined) => boolean;
+}) {
+  return {
+    cfg: {},
+    accountId: "default",
+    app: {
+      client: {},
+    },
+    runtime: {},
+    markMessageSeen: (channel: string | undefined, ts: string | undefined) =>
+      overrides?.markMessageSeen?.(channel, ts) ?? false,
+  } as Parameters<typeof createSlackMessageHandler>[0]["ctx"];
+}
+
+describe("createSlackMessageHandler", () => {
+  beforeEach(() => {
+    enqueueMock.mockClear();
+    resolveThreadTsMock.mockClear();
+  });
+
+  it("does not track invalid non-message events from the message stream", async () => {
+    const trackEvent = vi.fn();
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+      trackEvent,
+    });
+
+    await handler(
+      {
+        type: "reaction_added",
+        channel: "D1",
+        ts: "123.456",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(resolveThreadTsMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("does not track duplicate messages that are already seen", async () => {
+    const trackEvent = vi.fn();
+    const handler = createSlackMessageHandler({
+      ctx: createContext({ markMessageSeen: () => true }),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+      trackEvent,
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        ts: "123.456",
+        text: "hello",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(resolveThreadTsMock).not.toHaveBeenCalled();
+    expect(enqueueMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks accepted non-duplicate messages", async () => {
+    const trackEvent = vi.fn();
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+      trackEvent,
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "D1",
+        ts: "123.456",
+        text: "hello",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -19,8 +19,10 @@ export type SlackMessageHandler = (
 export function createSlackMessageHandler(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
+  /** Called on each inbound event to update liveness tracking. */
+  trackEvent?: () => void;
 }): SlackMessageHandler {
-  const { ctx, account } = params;
+  const { ctx, account, trackEvent } = params;
   const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
 
@@ -99,6 +101,7 @@ export function createSlackMessageHandler(params: {
   });
 
   return async (message, opts) => {
+    trackEvent?.();
     if (opts.source === "message" && message.type !== "message") {
       return;
     }

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -101,7 +101,6 @@ export function createSlackMessageHandler(params: {
   });
 
   return async (message, opts) => {
-    trackEvent?.();
     if (opts.source === "message" && message.type !== "message") {
       return;
     }
@@ -116,6 +115,7 @@ export function createSlackMessageHandler(params: {
     if (ctx.markMessageSeen(message.channel, message.ts)) {
       return;
     }
+    trackEvent?.();
     const resolvedMessage = await threadTsResolver.resolve({ message, source: opts.source });
     await debouncer.enqueue({ message: resolvedMessage, opts });
   };

--- a/src/slack/monitor/types.ts
+++ b/src/slack/monitor/types.ts
@@ -12,6 +12,10 @@ export type MonitorSlackOpts = {
   abortSignal?: AbortSignal;
   mediaMaxMb?: number;
   slashCommand?: SlackSlashCommandConfig;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
+  /** Callback to read the current channel account status snapshot. */
+  getStatus?: () => Record<string, unknown>;
 };
 
 export type SlackReactionEvent = {


### PR DESCRIPTION
## Summary

- **Track event liveness on every inbound Slack event** (messages, reactions, member join/leave, channel create/rename/id-change, pins) by calling `setStatus({ lastEventAt, lastInboundAt })` to populate the already-existing `ChannelAccountSnapshot` fields
- **Extend the channel health monitor** to detect stale sockets: if a channel has been running longer than a configurable threshold (default 30 min) and `lastEventAt` is older than that threshold, flag it as unhealthy and trigger an automatic restart
- **Log restart reason as `stale-socket`** for observability, distinct from existing `stuck`, `stopped`, and `gave-up` reasons

## Problem

Slack Socket Mode WebSocket connections can silently stop delivering events while still appearing connected — health checks pass, the socket stays open, but no messages arrive. This "half-dead socket" problem causes all messages across all channels to go unanswered until a manual restart.

The existing health monitor only checked `running` and `connected` flags, so it never detected this failure mode.

## Approach

**Layer 1 — Event liveness tracking** (`src/slack/monitor/`):

Every inbound Slack event handler now calls a `trackEvent()` callback that updates `lastEventAt` and `lastInboundAt` on the channel account snapshot via `setStatus`. The `MonitorSlackOpts` type gains `setStatus` and `getStatus` callbacks, and the Slack channel plugin passes them through from the gateway context.

Files changed: `types.ts`, `provider.ts`, `message-handler.ts`, `events.ts`, `events/messages.ts`, `events/reactions.ts`, `events/members.ts`, `events/channels.ts`, `events/pins.ts`, `extensions/slack/src/channel.ts`

**Layer 2 — Health monitor stale socket detection** (`src/gateway/channel-health-monitor.ts`):

`isChannelHealthy()` now accepts `lastEventAt` and `lastStartAt` from the snapshot and checks whether the channel has gone too long without events. The logic:

1. If channel uptime > stale threshold AND last event age > stale threshold → unhealthy
2. New channels or recently started channels get a natural grace period (uptime must exceed the threshold first)
3. Channels that never populated `lastEventAt`/`lastStartAt` (non-Slack channels) are unaffected

The threshold is configurable via `staleEventThresholdMs` on `ChannelHealthMonitorDeps` (default: 30 minutes). Existing cooldown (2 cycles) and rate limiting (3 restarts/hour) prevent restart storms.

## Test plan

- [x] All 16 existing health monitor tests pass unchanged
- [x] 5 new tests for stale socket detection:
  - Restarts channel with no events past stale threshold
  - Skips channels with recent events
  - Skips channels still within startup grace window
  - Restarts channel that never received any event past threshold
  - Respects custom `staleEventThresholdMs`
- [ ] Manual testing: deploy to a live gateway and verify `lastEventAt` is populated in health snapshots
- [ ] Manual testing: simulate stale socket by blocking Slack events and verify auto-restart triggers