### PR TITLE
feat(webchat): enhance inline tool flow and session sync

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -78,16 +78,29 @@ function resolveGatewaySessionTargetFromKey(key: string) {
   return { cfg, target, storePath: target.storePath };
 }
 
+function isWebchatClient(params: {
+  client: GatewayClient | null;
+  isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
+}): boolean {
+  return Boolean(params.client?.connect && params.isWebchatConnect(params.client.connect));
+}
+
+function isLabelOnlyPatch(params: Record<string, unknown>): boolean {
+  const patchKeys = Object.keys(params).filter((key) => key !== "key");
+  return patchKeys.length === 1 && patchKeys[0] === "label";
+}
+
 function rejectWebchatSessionMutation(params: {
   action: "patch" | "delete";
   client: GatewayClient | null;
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;
 }): boolean {
-  if (!params.client?.connect || !params.isWebchatConnect(params.client.connect)) {
+  if (!isWebchatClient({ client: params.client, isWebchatConnect: params.isWebchatConnect })) {
     return false;
   }
-  if (params.client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
+  const clientId = params.client?.connect?.client?.id;
+  if (clientId === GATEWAY_CLIENT_IDS.CONTROL_UI) {
     return false;
   }
   params.respond(
@@ -99,6 +112,10 @@ function rejectWebchatSessionMutation(params: {
     ),
   );
   return true;
+}
+
+function isControlUiClient(client: GatewayClient | null): boolean {
+  return client?.connect?.client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
 }
 
 function migrateAndPruneSessionStoreKey(params: {
@@ -407,11 +424,23 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const p = params;
-    const key = requireSessionKey(p.key, respond);
-    if (!key) {
+    if (
+      isWebchatClient({ client, isWebchatConnect }) &&
+      !isControlUiClient(client) &&
+      !isLabelOnlyPatch(p as Record<string, unknown>)
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "webchat clients can only patch session labels; use chat.send for session-scoped updates",
+        ),
+      );
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })) {
+    const key = requireSessionKey(p.key, respond);
+    if (!key) {
       return;
     }
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1208,7 +1208,7 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  test("webchat clients cannot patch or delete sessions", async () => {
+  test("webchat clients can patch labels but cannot patch other fields or delete sessions", async () => {
     await createSessionStoreDir();
 
     await writeSessionStore({
@@ -1239,12 +1239,22 @@ describe("gateway server sessions", () => {
       scopes: ["operator.admin"],
     });
 
+    const labelPatched = await rpcReq<{
+      ok: true;
+      entry: { label?: string };
+    }>(ws, "sessions.patch", {
+      key: "agent:main:discord:group:dev",
+      label: "briefing",
+    });
+    expect(labelPatched.ok).toBe(true);
+    expect(labelPatched.payload?.entry.label).toBe("briefing");
+
     const patched = await rpcReq(ws, "sessions.patch", {
       key: "agent:main:discord:group:dev",
-      label: "should-fail",
+      verboseLevel: "off",
     });
     expect(patched.ok).toBe(false);
-    expect(patched.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
+    expect(patched.error?.message ?? "").toMatch(/webchat clients can only patch session labels/i);
 
     const deleted = await rpcReq(ws, "sessions.delete", {
       key: "agent:main:discord:group:dev",
@@ -1287,6 +1297,17 @@ describe("gateway server sessions", () => {
       },
       scopes: ["operator.admin"],
     });
+
+    const patched = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: { verboseLevel?: string };
+    }>(ws, "sessions.patch", {
+      key: "agent:main:discord:group:dev",
+      verboseLevel: "off",
+    });
+    expect(patched.ok).toBe(true);
+    expect(patched.payload?.entry.verboseLevel).toBe("off");
 
     const deleted = await rpcReq<{ ok: true; deleted: boolean }>(ws, "sessions.delete", {
       key: "agent:main:discord:group:dev",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -110,6 +110,7 @@ export const en: TranslationMap = {
     disconnected: "Disconnected from gateway.",
     refreshTitle: "Refresh chat data",
     thinkingToggle: "Toggle assistant thinking/working output",
+    toolFlowToggle: "Toggle inline detailed tool flow in chat thread",
     focusToggle: "Toggle focus mode (hide sidebar + page header)",
     hideCronSessions: "Hide cron sessions",
     showCronSessions: "Show cron sessions",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -478,4 +478,5 @@
   .chat-controls__session {
     min-width: 120px;
   }
+
 }

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -94,6 +94,45 @@
   font-size: 13px;
 }
 
+.sidebar-markdown .code-block--diff {
+  border: 1px solid var(--border);
+  background: var(--secondary);
+  padding: 0;
+}
+
+.sidebar-markdown .code-block--diff code {
+  display: block;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.sidebar-markdown .code-block--diff .diff-line {
+  display: block;
+  margin: 0;
+  padding: 2px 10px;
+  white-space: pre-wrap;
+}
+
+.sidebar-markdown .code-block--diff .diff-line--meta {
+  color: var(--muted);
+  background: rgba(128, 128, 128, 0.08);
+}
+
+.sidebar-markdown .code-block--diff .diff-line--hunk {
+  color: var(--accent-2);
+  background: var(--accent-2-subtle);
+}
+
+.sidebar-markdown .code-block--diff .diff-line--add {
+  color: var(--ok);
+  background: var(--ok-subtle);
+}
+
+.sidebar-markdown .code-block--diff .diff-line--del {
+  color: var(--danger);
+  background: var(--danger-subtle);
+}
+
 /* Mobile: Full-screen modal */
 @media (max-width: 768px) {
   .chat-split-container--open {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -200,3 +200,9 @@
     transform: scale(1);
   }
 }
+
+/* Keep the left timeline card minimal; full output stays in sidebar. */
+.chat-tool-card__preview,
+.chat-tool-card__inline {
+  display: none;
+}

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -293,6 +293,54 @@
   gap: 1px;
 }
 
+.nav-chat-agent-picker {
+  margin: 0 0 0 16px;
+  padding-left: 8px;
+  border-left: 1px solid var(--border);
+  display: grid;
+  gap: 1px;
+}
+
+.nav-item--agent {
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  text-align: left;
+  font: inherit;
+}
+
+.nav-item--agent .nav-item__text {
+  font-size: 12px;
+}
+
+.nav-item__icon--agent {
+  width: 14px;
+  height: 14px;
+  opacity: 0.45;
+}
+
+.nav-item__icon--agent-emoji {
+  width: 16px;
+  height: 16px;
+  opacity: 1;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.nav-item--agent.active .nav-item__icon--agent {
+  opacity: 1;
+}
+
+.nav-item--agent:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.nav-item--agent:disabled:hover {
+  color: var(--muted);
+  background: transparent;
+}
+
 .nav-group--collapsed .nav-group__items {
   display: none;
 }
@@ -593,6 +641,10 @@
     grid-auto-flow: column;
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
     margin-bottom: 0;
+  }
+
+  .nav-chat-agent-picker {
+    display: none;
   }
 
   .grid-cols-2,

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -5,6 +5,7 @@ import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts"
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
   options: { clientVersion?: string };
   emitClose: (info: {
     code: number;
@@ -32,6 +33,7 @@ vi.mock("./gateway.ts", () => {
   class GatewayBrowserClient {
     readonly start = vi.fn();
     readonly stop = vi.fn();
+    readonly request = vi.fn(async () => ({}));
 
     constructor(
       private opts: {
@@ -48,6 +50,7 @@ vi.mock("./gateway.ts", () => {
       gatewayClientInstances.push({
         start: this.start,
         stop: this.stop,
+        request: this.request,
         options: { clientVersion: this.opts.clientVersion },
         emitClose: (info) => {
           this.opts.onClose?.({
@@ -105,7 +108,14 @@ function createHost() {
     assistantAgentId: null,
     serverVersion: null,
     sessionKey: "main",
+    chatMessages: [],
+    chatToolMessages: [],
+    chatStream: null,
+    chatStreamStartedAt: null,
     chatRunId: null,
+    toolStreamById: new Map<string, unknown>(),
+    toolStreamOrder: [],
+    toolStreamSyncTimer: null,
     refreshSessionsAfterChat: new Set<string>(),
     execApprovalQueue: [],
     execApprovalError: null,
@@ -229,6 +239,235 @@ describe("connectGateway", () => {
 
     expect(host.lastError).toContain("gateway token mismatch");
     expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
+  });
+
+  it("keeps streamed tool cards visible after final chat event", () => {
+    const host = createHost() as unknown as {
+      chatRunId: string | null;
+      chatToolMessages: unknown[];
+    };
+    host.chatRunId = "run-1";
+
+    connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 1,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "call-read-1",
+          name: "read",
+          phase: "start",
+          args: { path: "README.md" },
+        },
+      },
+    });
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 2,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "call-read-1",
+          name: "read",
+          phase: "result",
+          result: { text: "hello from read" },
+        },
+      },
+    });
+    expect(host.chatToolMessages).toHaveLength(1);
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      },
+    });
+
+    expect(host.chatToolMessages).toHaveLength(1);
+  });
+
+  it("hydrates read tool output from final assistant message when tool result is empty", () => {
+    const host = createHost() as unknown as {
+      chatRunId: string | null;
+      chatToolMessages: Array<Record<string, unknown>>;
+    };
+    host.chatRunId = "run-1";
+
+    connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 1,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "read-1",
+          name: "read",
+          phase: "start",
+          args: { path: "C:/mylog.log" },
+        },
+      },
+    });
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 2,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "read-1",
+          name: "read",
+          phase: "result",
+        },
+      },
+    });
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "读取到了，内容如下：\n```txt\n[InstallShield Silent]\nVersion=v7.00\n```",
+            },
+          ],
+        },
+      },
+    });
+
+    const toolMessage = host.chatToolMessages[0] as Record<string, unknown> | undefined;
+    const content = Array.isArray(toolMessage?.content)
+      ? (toolMessage?.content as Array<Record<string, unknown>>)
+      : [];
+    const toolResult = content.find((item) => item.type === "toolresult");
+    expect(typeof toolResult?.text).toBe("string");
+    expect(String(toolResult?.text)).toContain("[InstallShield Silent]");
+    expect(String(toolResult?.text)).toContain("Version=v7.00");
+  });
+
+  it("hydrates read output from latest assistant message fallback when final payload has no message", () => {
+    const host = createHost() as unknown as {
+      chatRunId: string | null;
+      chatMessages: unknown[];
+      chatToolMessages: Array<Record<string, unknown>>;
+    };
+    host.chatRunId = "run-1";
+    host.chatMessages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "已用 read 读取到 C:/RHDSetup.log。\n关键信息：ResultCode=0",
+          },
+        ],
+      },
+    ];
+
+    connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 1,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "read-1",
+          name: "read",
+          phase: "start",
+          args: { path: "C:/RHDSetup.log" },
+        },
+      },
+    });
+    client.emitEvent({
+      event: "agent",
+      payload: {
+        runId: "run-1",
+        seq: 2,
+        stream: "tool",
+        ts: Date.now(),
+        sessionKey: "main",
+        data: {
+          toolCallId: "read-1",
+          name: "read",
+          phase: "result",
+        },
+      },
+    });
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "other-run",
+        sessionKey: "main",
+        state: "final",
+      },
+    });
+
+    const toolMessage = host.chatToolMessages[0] as Record<string, unknown> | undefined;
+    const content = Array.isArray(toolMessage?.content)
+      ? (toolMessage?.content as Array<Record<string, unknown>>)
+      : [];
+    const toolResult = content.find((item) => item.type === "toolresult");
+    expect(typeof toolResult?.text).toBe("string");
+    expect(String(toolResult?.text)).toContain("ResultCode=0");
+  });
+
+  it("reloads chat history for final events even when refreshSessionsAfterChat is not queued", () => {
+    const host = createHost() as unknown as { chatRunId: string | null };
+    host.chatRunId = "run-user";
+
+    connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+    (host as unknown as { connected: boolean }).connected = true;
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "run-announce",
+        sessionKey: "main",
+        state: "final",
+      },
+    });
+
+    expect(client.request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 200,
+    });
   });
 });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -10,9 +10,15 @@ import {
   refreshActiveTab,
   setLastActiveSessionKey,
 } from "./app-settings.ts";
-import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
+import {
+  handleAgentEvent,
+  hydrateReadToolOutputFromFinalMessage,
+  resetToolStream,
+  type AgentEventPayload,
+} from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
-import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
+import { extractText } from "./chat/message-extract.ts";
+import { loadAgentIdentities } from "./controllers/agent-identity.ts";
 import { loadAgents, loadToolsCatalog } from "./controllers/agents.ts";
 import { loadAssistantIdentity } from "./controllers/assistant-identity.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
@@ -201,7 +207,13 @@ export function connectGateway(host: GatewayHost) {
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
       void loadAssistantIdentity(host as unknown as OpenClawApp);
-      void loadAgents(host as unknown as OpenClawApp);
+      void (async () => {
+        await loadAgents(host as unknown as OpenClawApp);
+        const agentIds = host.agentsList?.agents?.map((entry) => entry.id) ?? [];
+        if (agentIds.length > 0) {
+          void loadAgentIdentities(host as unknown as OpenClawApp, agentIds);
+        }
+      })();
       void loadToolsCatalog(host as unknown as OpenClawApp);
       void loadNodes(host as unknown as OpenClawApp, { quiet: true });
       void loadDevices(host as unknown as OpenClawApp, { quiet: true });
@@ -262,8 +274,15 @@ function handleTerminalChatEvent(
   if (state !== "final" && state !== "error" && state !== "aborted") {
     return;
   }
-  resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
+  // Keep the latest tool stream visible after terminal events so users can inspect
+  // tool calls/results without requiring a manual refresh.
   void flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);
+  // Always refresh transcript state after final chat events, even when the run
+  // was not explicitly queued for session-list refresh (for example sub-agent
+  // final events that append transcript content without /new or /reset).
+  if (state === "final") {
+    void loadChatHistory(host as unknown as OpenClawApp);
+  }
   const runId = payload?.runId;
   if (!runId || !host.refreshSessionsAfterChat.has(runId)) {
     return;
@@ -284,10 +303,42 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     );
   }
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
-  handleTerminalChatEvent(host, payload, state);
-  if (state === "final" && shouldReloadHistoryForFinalEvent(payload)) {
-    void loadChatHistory(host as unknown as OpenClawApp);
+  if (state === "final") {
+    const payloadText =
+      payload && Object.prototype.hasOwnProperty.call(payload, "message") && payload.message
+        ? extractText(payload.message)
+        : null;
+    const fallbackText = (() => {
+      const messages = (host as unknown as { chatMessages?: unknown[] }).chatMessages;
+      if (!Array.isArray(messages) || messages.length === 0) {
+        return null;
+      }
+      for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const candidate = messages[index] as Record<string, unknown> | undefined;
+        if (!candidate || typeof candidate !== "object") {
+          continue;
+        }
+        const role = typeof candidate.role === "string" ? candidate.role.toLowerCase() : "";
+        if (role !== "assistant") {
+          continue;
+        }
+        const text = extractText(candidate);
+        if (typeof text === "string" && text.trim()) {
+          return text;
+        }
+      }
+      return null;
+    })();
+    hydrateReadToolOutputFromFinalMessage(
+      host as unknown as Parameters<typeof hydrateReadToolOutputFromFinalMessage>[0],
+      {
+        runId: payload?.runId,
+        sessionKey: payload?.sessionKey ?? host.sessionKey,
+        text: payloadText ?? fallbackText ?? undefined,
+      },
+    );
   }
+  handleTerminalChatEvent(host, payload, state);
 }
 
 function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -17,6 +17,8 @@ function createHost() {
     chatMessages: [],
     chatToolMessages: [],
     chatStream: null,
+    chatRunId: null,
+    chatRunPollInterval: null,
     logsAutoFollow: false,
     logsAtBottom: true,
     logsEntries: [],

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -6,6 +6,8 @@ import {
   stopNodesPolling,
   startDebugPolling,
   stopDebugPolling,
+  startChatRunPolling,
+  stopChatRunPolling,
 } from "./app-polling.ts";
 import { observeTopbar, scheduleChatScroll, scheduleLogsScroll } from "./app-scroll.ts";
 import {
@@ -35,6 +37,8 @@ type LifecycleHost = {
   chatMessages: unknown[];
   chatToolMessages: unknown[];
   chatStream: string;
+  chatRunId: string | null;
+  chatRunPollInterval: number | null;
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];
@@ -58,6 +62,7 @@ export function handleConnected(host: LifecycleHost) {
     connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   });
   startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
+  startChatRunPolling(host as unknown as Parameters<typeof startChatRunPolling>[0]);
   if (host.tab === "logs") {
     startLogsPolling(host as unknown as Parameters<typeof startLogsPolling>[0]);
   }
@@ -74,6 +79,7 @@ export function handleDisconnected(host: LifecycleHost) {
   host.connectGeneration += 1;
   window.removeEventListener("popstate", host.popStateHandler);
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);
+  stopChatRunPolling(host as unknown as Parameters<typeof stopChatRunPolling>[0]);
   stopLogsPolling(host as unknown as Parameters<typeof stopLogsPolling>[0]);
   stopDebugPolling(host as unknown as Parameters<typeof stopDebugPolling>[0]);
   host.client?.stop();

--- a/ui/src/ui/app-polling.ts
+++ b/ui/src/ui/app-polling.ts
@@ -1,4 +1,5 @@
 import type { OpenClawApp } from "./app.ts";
+import { syncChatHistoryDuringRun } from "./controllers/chat.ts";
 import { loadDebug } from "./controllers/debug.ts";
 import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
@@ -7,6 +8,9 @@ type PollingHost = {
   nodesPollInterval: number | null;
   logsPollInterval: number | null;
   debugPollInterval: number | null;
+  chatRunPollInterval: number | null;
+  connected: boolean;
+  chatRunId: string | null;
   tab: string;
 };
 
@@ -66,4 +70,24 @@ export function stopDebugPolling(host: PollingHost) {
   }
   clearInterval(host.debugPollInterval);
   host.debugPollInterval = null;
+}
+
+export function startChatRunPolling(host: PollingHost) {
+  if (host.chatRunPollInterval != null) {
+    return;
+  }
+  host.chatRunPollInterval = window.setInterval(() => {
+    if (host.tab !== "chat" || !host.connected || !host.chatRunId) {
+      return;
+    }
+    void syncChatHistoryDuringRun(host as unknown as OpenClawApp);
+  }, 1000);
+}
+
+export function stopChatRunPolling(host: PollingHost) {
+  if (host.chatRunPollInterval == null) {
+    return;
+  }
+  clearInterval(host.chatRunPollInterval);
+  host.chatRunPollInterval = null;
 }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,35 +1,208 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { CHAT_SESSIONS_ACTIVE_MINUTES, refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
+import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { GatewayAgentRow, SessionsListResult } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
+  defaultAgentId?: string;
   mainSessionKey?: string;
   mainKey?: string;
 };
 
-function resolveSidebarChatSessionKey(state: AppViewState): string {
+export type SessionAgentFilter = {
+  agentId?: string | null;
+  defaultAgentId?: string | null;
+};
+
+function normalizeAgentId(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized || "main";
+}
+
+function resolveDefaultAgentId(state: AppViewState): string {
   const snapshot = state.hello?.snapshot as
     | { sessionDefaults?: SessionDefaultsSnapshot }
     | undefined;
-  const mainSessionKey = snapshot?.sessionDefaults?.mainSessionKey?.trim();
-  if (mainSessionKey) {
-    return mainSessionKey;
+  const fromSnapshot = snapshot?.sessionDefaults?.defaultAgentId;
+  if (typeof fromSnapshot === "string" && fromSnapshot.trim()) {
+    return normalizeAgentId(fromSnapshot);
   }
-  const mainKey = snapshot?.sessionDefaults?.mainKey?.trim();
-  if (mainKey) {
-    return mainKey;
+  if (typeof state.agentsList?.defaultId === "string" && state.agentsList.defaultId.trim()) {
+    return normalizeAgentId(state.agentsList.defaultId);
   }
   return "main";
+}
+
+function resolveMainKey(state: AppViewState): string {
+  const snapshot = state.hello?.snapshot as
+    | { sessionDefaults?: SessionDefaultsSnapshot }
+    | undefined;
+  const raw = snapshot?.sessionDefaults?.mainKey;
+  const trimmed = (raw ?? "").trim().toLowerCase();
+  return trimmed || "main";
+}
+
+function sessionBelongsToAgent(params: {
+  sessionKey: string;
+  agentId: string;
+  defaultAgentId: string;
+}): boolean {
+  const key = params.sessionKey.trim();
+  if (!key) {
+    return false;
+  }
+  const targetAgent = normalizeAgentId(params.agentId);
+  const defaultAgent = normalizeAgentId(params.defaultAgentId);
+  const parsed = parseAgentSessionKey(key);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId) === targetAgent;
+  }
+  const lowered = key.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return false;
+  }
+  if (lowered.startsWith("agent:")) {
+    return false;
+  }
+  return targetAgent === defaultAgent;
+}
+
+export function resolveChatAgentId(state: AppViewState): string {
+  const parsed = parseAgentSessionKey(state.sessionKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  if (typeof state.agentsSelectedId === "string" && state.agentsSelectedId.trim()) {
+    return normalizeAgentId(state.agentsSelectedId);
+  }
+  return resolveDefaultAgentId(state);
+}
+
+function resolveAgentMainSessionKey(state: AppViewState, agentId: string): string {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const defaultAgentId = resolveDefaultAgentId(state);
+  const snapshot = state.hello?.snapshot as
+    | { sessionDefaults?: SessionDefaultsSnapshot }
+    | undefined;
+  const scopedMain = snapshot?.sessionDefaults?.mainSessionKey?.trim();
+  if (scopedMain) {
+    const parsed = parseAgentSessionKey(scopedMain);
+    if (parsed?.agentId && normalizeAgentId(parsed.agentId) === normalizedAgentId) {
+      return scopedMain;
+    }
+    if (!parsed && normalizedAgentId === defaultAgentId) {
+      return scopedMain;
+    }
+  }
+  return `agent:${normalizedAgentId}:${resolveMainKey(state)}`;
+}
+
+function pickSessionKeyForAgent(state: AppViewState, agentId: string): string {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const defaultAgentId = resolveDefaultAgentId(state);
+  if (
+    sessionBelongsToAgent({
+      sessionKey: state.sessionKey,
+      agentId: normalizedAgentId,
+      defaultAgentId,
+    })
+  ) {
+    return state.sessionKey;
+  }
+  const preferredMainKey = resolveAgentMainSessionKey(state, normalizedAgentId);
+  if (state.sessionsResult?.sessions?.some((row) => row.key === preferredMainKey)) {
+    return preferredMainKey;
+  }
+  const firstMatching = state.sessionsResult?.sessions?.find((row) =>
+    sessionBelongsToAgent({
+      sessionKey: row.key,
+      agentId: normalizedAgentId,
+      defaultAgentId,
+    }),
+  );
+  return firstMatching?.key ?? preferredMainKey;
+}
+
+function switchChatAgent(state: AppViewState, agentId: string) {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const nextSessionKey = pickSessionKeyForAgent(state, normalizedAgentId);
+  state.agentsSelectedId = normalizedAgentId;
+  if (state.sessionKey !== nextSessionKey) {
+    resetChatStateForSessionSwitch(state, nextSessionKey);
+    syncUrlWithSessionKey(
+      state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
+      nextSessionKey,
+      true,
+    );
+  }
+  void state.loadAssistantIdentity();
+  void loadChatHistory(state as unknown as ChatState);
+  void loadSessions(state as unknown as OpenClawApp, {
+    activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
+    agentId: normalizedAgentId,
+  });
+}
+
+function resolveChatAgentOptionLabel(agent: GatewayAgentRow): string {
+  const agentId = normalizeAgentId(agent.id);
+  const displayName =
+    agent.identity?.name?.trim() || agent.name?.trim() || agent.id.trim() || agentId;
+  return displayName;
+}
+
+function isLikelyEmoji(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.length > 16) {
+    return false;
+  }
+  let hasNonAscii = false;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    if (trimmed.charCodeAt(i) > 127) {
+      hasNonAscii = true;
+      break;
+    }
+  }
+  if (!hasNonAscii) {
+    return false;
+  }
+  if (trimmed.includes("://") || trimmed.includes("/") || trimmed.includes(".")) {
+    return false;
+  }
+  return true;
+}
+
+function resolveChatAgentOptionEmoji(state: AppViewState, agent: GatewayAgentRow): string {
+  const normalizedAgentId = normalizeAgentId(agent.id);
+  const identity =
+    state.agentIdentityById[agent.id] ?? state.agentIdentityById[normalizedAgentId] ?? null;
+  const identityEmoji = identity?.emoji?.trim();
+  if (identityEmoji && isLikelyEmoji(identityEmoji)) {
+    return identityEmoji;
+  }
+  const configuredEmoji = agent.identity?.emoji?.trim();
+  if (configuredEmoji && isLikelyEmoji(configuredEmoji)) {
+    return configuredEmoji;
+  }
+  return "";
+}
+
+function resolveSidebarChatSessionKey(state: AppViewState): string {
+  const activeAgentId = resolveChatAgentId(state);
+  return resolveAgentMainSessionKey(state, activeAgentId);
 }
 
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
@@ -123,7 +296,9 @@ function renderCronFilterIcon(hiddenCount: number) {
 }
 
 export function renderChatControls(state: AppViewState) {
-  const mainSessionKey = resolveMainSessionKey(state.hello, state.sessionsResult);
+  const activeAgentId = resolveChatAgentId(state);
+  const defaultAgentId = resolveDefaultAgentId(state);
+  const mainSessionKey = resolveAgentMainSessionKey(state, activeAgentId);
   const hideCron = state.sessionsHideCron ?? true;
   const hiddenCronCount = hideCron
     ? countHiddenCronSessions(state.sessionKey, state.sessionsResult)
@@ -132,11 +307,19 @@ export function renderChatControls(state: AppViewState) {
     state.sessionKey,
     state.sessionsResult,
     mainSessionKey,
-    hideCron,
+    {
+      hideCron,
+      filter: {
+        agentId: activeAgentId,
+        defaultAgentId,
+      },
+    },
   );
   const disableThinkingToggle = state.onboarding;
+  const disableInlineToolFlowToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
+  const inlineToolFlowActive = state.onboarding ? false : state.settings.chatShowInlineToolFlow;
   const focusActive = state.onboarding ? true : state.settings.chatFocusMode;
   // Refresh icon
   const refreshIcon = html`
@@ -181,6 +364,12 @@ export function renderChatControls(state: AppViewState) {
           @change=${(e: Event) => {
             const next = (e.target as HTMLSelectElement).value;
             state.sessionKey = next;
+            const parsed = parseAgentSessionKey(next);
+            if (parsed?.agentId) {
+              state.agentsSelectedId = normalizeAgentId(parsed.agentId);
+            } else if (next.trim().toLowerCase() === "main") {
+              state.agentsSelectedId = defaultAgentId;
+            }
             state.chatMessage = "";
             state.chatStream = null;
             (state as unknown as OpenClawApp).chatStreamStartedAt = null;
@@ -244,15 +433,38 @@ export function renderChatControls(state: AppViewState) {
           if (disableThinkingToggle) {
             return;
           }
+          const nextThinking = !state.settings.chatShowThinking;
           state.applySettings({
             ...state.settings,
-            chatShowThinking: !state.settings.chatShowThinking,
+            chatShowThinking: nextThinking,
+            chatShowInlineToolFlow: nextThinking ? false : state.settings.chatShowInlineToolFlow,
           });
         }}
         aria-pressed=${showThinking}
         title=${disableThinkingToggle ? t("chat.onboardingDisabled") : t("chat.thinkingToggle")}
       >
         ${icons.brain}
+      </button>
+      <button
+        class="btn btn--sm btn--icon ${inlineToolFlowActive ? "active" : ""}"
+        ?disabled=${disableInlineToolFlowToggle}
+        @click=${() => {
+          if (disableInlineToolFlowToggle) {
+            return;
+          }
+          const nextInlineFlow = !state.settings.chatShowInlineToolFlow;
+          state.applySettings({
+            ...state.settings,
+            chatShowInlineToolFlow: nextInlineFlow,
+            chatShowThinking: nextInlineFlow ? false : state.settings.chatShowThinking,
+          });
+        }}
+        aria-pressed=${inlineToolFlowActive}
+        title=${
+          disableInlineToolFlowToggle ? t("chat.onboardingDisabled") : t("chat.toolFlowToggle")
+        }
+      >
+        ${icons.fileCode}
       </button>
       <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"
@@ -291,23 +503,50 @@ export function renderChatControls(state: AppViewState) {
   `;
 }
 
-function resolveMainSessionKey(
-  hello: AppViewState["hello"],
-  sessions: SessionsListResult | null,
-): string | null {
-  const snapshot = hello?.snapshot as { sessionDefaults?: SessionDefaultsSnapshot } | undefined;
-  const mainSessionKey = snapshot?.sessionDefaults?.mainSessionKey?.trim();
-  if (mainSessionKey) {
-    return mainSessionKey;
+export function renderChatNavAgentPicker(state: AppViewState) {
+  const agents = state.agentsList?.agents ?? [];
+  if (agents.length === 0) {
+    return nothing;
   }
-  const mainKey = snapshot?.sessionDefaults?.mainKey?.trim();
-  if (mainKey) {
-    return mainKey;
-  }
-  if (sessions?.sessions?.some((row) => row.key === "main")) {
-    return "main";
-  }
-  return null;
+  const selectedAgentId = resolveChatAgentId(state);
+  const pickerDisabled = !state.connected;
+  return html`
+    <div class="nav-chat-agent-picker" role="radiogroup" aria-label=${t("chat.agentPickerLabel")}>
+      ${repeat(
+        agents,
+        (agent) => agent.id,
+        (agent) => {
+          const normalizedAgentId = normalizeAgentId(agent.id);
+          const isActive = normalizedAgentId === selectedAgentId;
+          const optionEmoji = resolveChatAgentOptionEmoji(state, agent);
+          return html`
+            <button
+              type="button"
+              class="nav-item nav-item--agent ${isActive ? "active" : ""}"
+              role="radio"
+              aria-checked=${isActive}
+              ?disabled=${pickerDisabled}
+              @click=${() => {
+                if (pickerDisabled || isActive) {
+                  return;
+                }
+                switchChatAgent(state, normalizedAgentId);
+              }}
+              title=${t("chat.agentPickerTitle")}
+            >
+              <span
+                class="nav-item__icon ${optionEmoji ? "nav-item__icon--agent-emoji" : "nav-item__icon--agent"}"
+                aria-hidden="true"
+              >
+                ${optionEmoji || icons.circle}
+              </span>
+              <span class="nav-item__text">${resolveChatAgentOptionLabel(agent)}</span>
+            </button>
+          `;
+        },
+      )}
+    </div>
+  `;
 }
 
 /* ── Channel display labels ────────────────────────────── */
@@ -431,20 +670,43 @@ export function isCronSessionKey(key: string): boolean {
   return rest.startsWith("cron:");
 }
 
-function resolveSessionOptions(
+export function resolveSessionOptions(
   sessionKey: string,
   sessions: SessionsListResult | null,
   mainSessionKey?: string | null,
-  hideCron = false,
+  opts?: {
+    hideCron?: boolean;
+    filter?: SessionAgentFilter;
+  },
 ) {
+  const hideCron = opts?.hideCron === true;
+  const filter = opts?.filter;
   const seen = new Set<string>();
   const options: Array<{ key: string; displayName?: string }> = [];
+  const normalizedFilterAgentId =
+    typeof filter?.agentId === "string" && filter.agentId.trim()
+      ? normalizeAgentId(filter.agentId)
+      : "";
+  const normalizedDefaultAgentId =
+    typeof filter?.defaultAgentId === "string" && filter.defaultAgentId.trim()
+      ? normalizeAgentId(filter.defaultAgentId)
+      : "main";
+  const shouldIncludeKey = (key: string): boolean => {
+    if (!normalizedFilterAgentId) {
+      return true;
+    }
+    return sessionBelongsToAgent({
+      sessionKey: key,
+      agentId: normalizedFilterAgentId,
+      defaultAgentId: normalizedDefaultAgentId,
+    });
+  };
 
   const resolvedMain = mainSessionKey && sessions?.sessions?.find((s) => s.key === mainSessionKey);
   const resolvedCurrent = sessions?.sessions?.find((s) => s.key === sessionKey);
 
   // Add main session key first
-  if (mainSessionKey) {
+  if (mainSessionKey && shouldIncludeKey(mainSessionKey)) {
     seen.add(mainSessionKey);
     options.push({
       key: mainSessionKey,
@@ -452,8 +714,8 @@ function resolveSessionOptions(
     });
   }
 
-  // Add current session key next — always include it even if it's a cron session,
-  // so the active session is never silently dropped from the select.
+  // Add current session key next — always include it even if it is hidden by
+  // filters, so the active session is never silently dropped from the select.
   if (!seen.has(sessionKey)) {
     seen.add(sessionKey);
     options.push({
@@ -465,7 +727,13 @@ function resolveSessionOptions(
   // Add sessions from the result, optionally filtering out cron sessions.
   if (sessions?.sessions) {
     for (const s of sessions.sessions) {
-      if (!seen.has(s.key) && !(hideCron && isCronSessionKey(s.key))) {
+      if (!shouldIncludeKey(s.key)) {
+        continue;
+      }
+      if (!seen.has(s.key)) {
+        if (hideCron && isCronSessionKey(s.key) && s.key !== sessionKey) {
+          continue;
+        }
         seen.add(s.key);
         options.push({
           key: s.key,
@@ -473,6 +741,13 @@ function resolveSessionOptions(
         });
       }
     }
+  }
+
+  if (options.length === 0 && sessionKey.trim()) {
+    options.push({
+      key: sessionKey,
+      displayName: resolveSessionDisplayName(sessionKey, resolvedCurrent),
+    });
   }
 
   return options;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3,7 +3,12 @@ import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
-import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
+import {
+  renderChatControls,
+  renderChatNavAgentPicker,
+  renderTab,
+  renderThemeToggle,
+} from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
@@ -156,6 +161,7 @@ export function renderApp(state: AppViewState) {
   const isChat = state.tab === "chat";
   const chatFocus = isChat && (state.settings.chatFocusMode || state.onboarding);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
+  const showInlineToolFlow = state.onboarding ? false : state.settings.chatShowInlineToolFlow;
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
   const configValue =
@@ -283,6 +289,7 @@ export function renderApp(state: AppViewState) {
               </button>
               <div class="nav-group__items">
                 ${group.tabs.map((tab) => renderTab(state, tab))}
+                ${group.tabs.some((tab) => tab === "chat") ? renderChatNavAgentPicker(state) : nothing}
               </div>
             </div>
           `;
@@ -1022,6 +1029,7 @@ export function renderApp(state: AppViewState) {
                 },
                 thinkingLevel: state.chatThinkingLevel,
                 showThinking,
+                showInlineToolFlow,
                 loading: state.chatLoading,
                 sending: state.chatSending,
                 compactionStatus: state.compactionStatus,

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -16,6 +16,7 @@ const createHost = (tab: Tab): SettingsHost => ({
     theme: "system",
     chatFocusMode: false,
     chatShowThinking: true,
+    chatShowInlineToolFlow: false,
     splitRatio: 0.6,
     navCollapsed: false,
     navGroupsCollapsed: {},

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -1,5 +1,10 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { handleAgentEvent, type FallbackStatus, type ToolStreamEntry } from "./app-tool-stream.ts";
+import {
+  handleAgentEvent,
+  hydrateReadToolOutputFromFinalMessage,
+  type FallbackStatus,
+  type ToolStreamEntry,
+} from "./app-tool-stream.ts";
 
 type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
 type MutableHost = ToolStreamHost & {
@@ -23,6 +28,22 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
     fallbackClearTimer: null,
     ...overrides,
   };
+}
+
+function findToolEntry(
+  host: MutableHost,
+  params: { toolCallId: string; runId?: string },
+): ToolStreamEntry | undefined {
+  for (const entry of host.toolStreamById.values()) {
+    if (entry.toolCallId !== params.toolCallId) {
+      continue;
+    }
+    if (params.runId && entry.runId !== params.runId) {
+      continue;
+    }
+    return entry;
+  }
+  return undefined;
 }
 
 describe("app-tool-stream fallback lifecycle handling", () => {
@@ -135,5 +156,366 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.fallbackStatus?.phase).toBe("cleared");
     expect(host.fallbackStatus?.previous).toBe("deepinfra/moonshotai/Kimi-K2.5");
     vi.useRealTimers();
+  });
+
+  it("hydrates missing read output from final assistant text", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-1",
+        args: { path: "C:/mylog.log" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-1",
+      },
+    });
+
+    const hydrated = hydrateReadToolOutputFromFinalMessage(host, {
+      runId: "run-1",
+      text: "读取到了，内容如下：\n```txt\n[InstallShield Silent]\nVersion=v7.00\n```",
+    });
+
+    expect(hydrated).toBe(true);
+    const entry = findToolEntry(host, { toolCallId: "read-1", runId: "run-1" });
+    expect(entry?.output).toContain("[InstallShield Silent]");
+    expect(entry?.output).toContain("Version=v7.00");
+  });
+
+  it("hydrates latest read output by session when runId does not match", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-1",
+        args: { path: "C:/RHDSetup.log" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-1",
+      },
+    });
+
+    const hydrated = hydrateReadToolOutputFromFinalMessage(host, {
+      runId: "different-run",
+      sessionKey: "main",
+      text: "ResultCode=0",
+    });
+
+    expect(hydrated).toBe(true);
+    const entry = findToolEntry(host, { toolCallId: "read-1", runId: "run-1" });
+    expect(entry?.output).toContain("ResultCode=0");
+  });
+
+  it("hydrates by alias-equivalent session key when runId does not match", () => {
+    const host = createHost({ chatRunId: "run-1", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-alias-1",
+        args: { path: "C:/RHDSetup.log" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-alias-1",
+      },
+    });
+
+    const hydrated = hydrateReadToolOutputFromFinalMessage(host, {
+      runId: "different-run",
+      sessionKey: "agent:main:main",
+      text: "AliasResult=ok",
+    });
+
+    expect(hydrated).toBe(true);
+    const entry = findToolEntry(host, { toolCallId: "read-alias-1", runId: "run-1" });
+    expect(entry?.output).toContain("AliasResult=ok");
+  });
+
+  it("hydrates earlier empty read card for the same run when latest card already has output", () => {
+    const host = createHost({ chatRunId: "run-1", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-empty",
+        args: { path: "C:/older.log" },
+      },
+    });
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-empty",
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-filled",
+        args: { path: "C:/newer.log" },
+      },
+    });
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 4,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-filled",
+        result: { text: "already populated" },
+      },
+    });
+
+    const hydrated = hydrateReadToolOutputFromFinalMessage(host, {
+      runId: "run-1",
+      text: "Recovered=ok",
+    });
+
+    expect(hydrated).toBe(true);
+    expect(findToolEntry(host, { toolCallId: "read-empty", runId: "run-1" })?.output).toContain(
+      "Recovered=ok",
+    );
+    expect(findToolEntry(host, { toolCallId: "read-filled", runId: "run-1" })?.output).toBe(
+      "already populated",
+    );
+  });
+
+  it("does not overwrite prior run cards when toolCallId is reused in another run", () => {
+    const host = createHost({ chatRunId: "client-run-id", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "server-run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-shared",
+        args: { path: "README.md" },
+      },
+    });
+    handleAgentEvent(host, {
+      runId: "server-run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-shared",
+        result: { text: "run1 output" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "server-run-2",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "read-shared",
+        args: { path: "CHANGELOG.md" },
+      },
+    });
+    handleAgentEvent(host, {
+      runId: "server-run-2",
+      seq: 4,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "read-shared",
+        result: { text: "run2 output" },
+      },
+    });
+
+    expect(host.chatToolMessages).toHaveLength(2);
+    expect(findToolEntry(host, { toolCallId: "read-shared", runId: "server-run-1" })?.output).toBe(
+      "run1 output",
+    );
+    expect(findToolEntry(host, { toolCallId: "read-shared", runId: "server-run-2" })?.output).toBe(
+      "run2 output",
+    );
+  });
+
+  it("accepts active-run tool events when session key uses a different alias", () => {
+    const host = createHost({ chatRunId: "run-1", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "agent:main:main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "alias-read-1",
+        args: { path: "README.md" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "run-1",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "agent:main:main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "alias-read-1",
+        result: { text: "alias ok" },
+      },
+    });
+
+    expect(host.chatToolMessages).toHaveLength(1);
+  });
+
+  it("accepts session-scoped tool events when runId differs from active client run id", () => {
+    const host = createHost({ chatRunId: "client-run-id", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "server-run-id",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "run-mismatch-read-1",
+        args: { path: "README.md" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "server-run-id",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "run-mismatch-read-1",
+        result: { text: "run mismatch ok" },
+      },
+    });
+
+    expect(host.chatToolMessages).toHaveLength(1);
+  });
+
+  it("accepts run-mismatch tool events when session key is the main alias", () => {
+    const host = createHost({ chatRunId: "client-run-id", sessionKey: "main" });
+
+    handleAgentEvent(host, {
+      runId: "server-run-id",
+      seq: 1,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "agent:main:main",
+      data: {
+        phase: "start",
+        name: "read",
+        toolCallId: "run-mismatch-alias-read-1",
+        args: { path: "README.md" },
+      },
+    });
+
+    handleAgentEvent(host, {
+      runId: "server-run-id",
+      seq: 2,
+      stream: "tool",
+      ts: Date.now(),
+      sessionKey: "agent:main:main",
+      data: {
+        phase: "result",
+        name: "read",
+        toolCallId: "run-mismatch-alias-read-1",
+        result: { text: "run mismatch alias ok" },
+      },
+    });
+
+    expect(host.chatToolMessages).toHaveLength(1);
   });
 });

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -1,3 +1,4 @@
+import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { truncateText } from "./format.ts";
 
 const TOOL_STREAM_LIMIT = 50;
@@ -33,6 +34,40 @@ type ToolStreamHost = {
   chatToolMessages: Record<string, unknown>[];
   toolStreamSyncTimer: number | null;
 };
+
+function buildToolStreamEntryKey(runId: string, toolCallId: string): string {
+  return `${runId}::${toolCallId}`;
+}
+
+function normalizeSessionKey(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function sessionKeysEquivalent(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeSessionKey(left);
+  const normalizedRight = normalizeSessionKey(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  if (normalizedLeft === normalizedRight) {
+    return true;
+  }
+
+  const parsedLeft = parseAgentSessionKey(normalizedLeft);
+  const parsedRight = parseAgentSessionKey(normalizedRight);
+  if (parsedLeft && parsedRight) {
+    return parsedLeft.agentId === parsedRight.agentId && parsedLeft.rest === parsedRight.rest;
+  }
+
+  if (parsedLeft && parsedLeft.agentId === "main" && parsedLeft.rest === normalizedRight) {
+    return true;
+  }
+  if (parsedRight && parsedRight.agentId === "main" && parsedRight.rest === normalizedLeft) {
+    return true;
+  }
+
+  return false;
+}
 
 function toTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") {
@@ -237,6 +272,110 @@ export function resetToolStream(host: ToolStreamHost) {
   flushToolStreamSync(host);
 }
 
+function isReadToolName(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  return normalized === "read" || /(^|[.:/_-])read$/.test(normalized);
+}
+
+function extractCodeFenceBodies(text: string): string[] {
+  const matches = text.matchAll(/```[^\n]*\n([\s\S]*?)```/g);
+  const blocks: string[] = [];
+  for (const match of matches) {
+    const body = match[1];
+    if (typeof body !== "string") {
+      continue;
+    }
+    const trimmed = body.trim();
+    if (trimmed) {
+      blocks.push(trimmed);
+    }
+  }
+  return blocks;
+}
+
+function normalizeFallbackToolOutput(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const truncated = truncateText(trimmed, TOOL_OUTPUT_CHAR_LIMIT);
+  if (!truncated.truncated) {
+    return truncated.text;
+  }
+  return `${truncated.text}\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`;
+}
+
+export function hydrateReadToolOutputFromFinalMessage(
+  host: ToolStreamHost,
+  params: { runId?: string; sessionKey?: string; text?: string },
+): boolean {
+  const runId = toTrimmedString(params.runId);
+  const sessionKey = toTrimmedString(params.sessionKey);
+  const text = toTrimmedString(params.text);
+  if (!text) {
+    return false;
+  }
+
+  const codeBlocks = extractCodeFenceBodies(text);
+  const preferred = codeBlocks.length > 0 ? codeBlocks.join("\n\n") : text;
+  const normalizedOutput = normalizeFallbackToolOutput(preferred);
+  if (!normalizedOutput) {
+    return false;
+  }
+
+  const now = Date.now();
+  const staleWindowMs = 5 * 60 * 1000;
+
+  const tryHydrateEntry = (entry: ToolStreamEntry): boolean => {
+    if (!isReadToolName(entry.name)) {
+      return false;
+    }
+    if (typeof entry.output === "string" && entry.output.trim()) {
+      return false;
+    }
+    entry.output = normalizedOutput;
+    entry.updatedAt = Date.now();
+    entry.message = buildToolStreamMessage(entry);
+    scheduleToolStreamSync(host, true);
+    return true;
+  };
+
+  // Prefer exact run match when available.
+  if (runId) {
+    for (let index = host.toolStreamOrder.length - 1; index >= 0; index -= 1) {
+      const entryKey = host.toolStreamOrder[index];
+      const entry = host.toolStreamById.get(entryKey);
+      if (!entry || entry.runId !== runId) {
+        continue;
+      }
+      if (tryHydrateEntry(entry)) {
+        return true;
+      }
+      // Keep scanning older entries from the same run.
+    }
+  }
+
+  // Fallback: use the latest empty read card in the same session.
+  for (let index = host.toolStreamOrder.length - 1; index >= 0; index -= 1) {
+    const entryKey = host.toolStreamOrder[index];
+    const entry = host.toolStreamById.get(entryKey);
+    if (!entry) {
+      continue;
+    }
+    if (sessionKey && entry.sessionKey && !sessionKeysEquivalent(entry.sessionKey, sessionKey)) {
+      continue;
+    }
+    if (entry.updatedAt < now - staleWindowMs) {
+      continue;
+    }
+    if (tryHydrateEntry(entry)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export type CompactionStatus = {
   active: boolean;
   startedAt: number | null;
@@ -301,23 +440,34 @@ function resolveAcceptedSession(
   },
 ): { accepted: boolean; sessionKey?: string } {
   const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
-  if (sessionKey && sessionKey !== host.sessionKey) {
-    return { accepted: false };
+  const runMatchesActive =
+    Boolean(host.chatRunId) &&
+    typeof payload.runId === "string" &&
+    payload.runId === host.chatRunId;
+  const sessionMatchesHost = sessionKeysEquivalent(sessionKey, host.sessionKey);
+  if (sessionKey) {
+    if (!sessionMatchesHost && !runMatchesActive) {
+      return { accepted: false };
+    }
+    if (!host.chatRunId) {
+      if (options?.allowSessionScopedWhenIdle) {
+        return { accepted: true, sessionKey: host.sessionKey };
+      }
+      return { accepted: false };
+    }
+    // When session key matches, accept tool events even if runId differs.
+    // Some gateway paths can emit a server-side run id distinct from the client idempotency key.
+    return { accepted: true, sessionKey: host.sessionKey };
   }
-  if (!host.chatRunId && options?.allowSessionScopedWhenIdle && sessionKey) {
-    return { accepted: true, sessionKey };
-  }
-  // Fallback: only accept session-less events for the active run.
-  if (!sessionKey && host.chatRunId && payload.runId !== host.chatRunId) {
-    return { accepted: false };
-  }
-  if (host.chatRunId && payload.runId !== host.chatRunId) {
-    return { accepted: false };
-  }
+
+  // Session-less events must still match the active run.
   if (!host.chatRunId) {
     return { accepted: false };
   }
-  return { accepted: true, sessionKey };
+  if (payload.runId !== host.chatRunId) {
+    return { accepted: false };
+  }
+  return { accepted: true };
 }
 
 function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventPayload) {
@@ -423,7 +573,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
         : undefined;
 
   const now = Date.now();
-  let entry = host.toolStreamById.get(toolCallId);
+  const entryKey = buildToolStreamEntryKey(payload.runId, toolCallId);
+  let entry = host.toolStreamById.get(entryKey);
   if (!entry) {
     entry = {
       toolCallId,
@@ -436,8 +587,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       updatedAt: now,
       message: {},
     };
-    host.toolStreamById.set(toolCallId, entry);
-    host.toolStreamOrder.push(toolCallId);
+    host.toolStreamById.set(entryKey, entry);
+    host.toolStreamOrder.push(entryKey);
   } else {
     entry.name = name;
     if (args !== undefined) {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -383,6 +383,7 @@ export class OpenClawApp extends LitElement {
   private chatUserNearBottom = true;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
+  private chatRunPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
   private debugPollInterval: number | null = null;
   private logsScrollFrame: number | null = null;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -12,7 +12,12 @@ import {
   formatReasoningMarkdown,
 } from "./message-extract.ts";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
-import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
+import {
+  enrichToolCardsWithLookup,
+  extractToolCards,
+  renderToolCardSidebar,
+  type ToolCardOutputLookup,
+} from "./tool-cards.ts";
 
 type ImageBlock = {
   url: string;
@@ -112,6 +117,7 @@ export function renderMessageGroup(
     showReasoning: boolean;
     assistantName?: string;
     assistantAvatar?: string | null;
+    toolOutputLookup?: ToolCardOutputLookup;
   },
 ) {
   const normalizedRole = normalizeRoleForGrouping(group.role);
@@ -136,16 +142,19 @@ export function renderMessageGroup(
         avatar: opts.assistantAvatar ?? null,
       })}
       <div class="chat-group-messages">
-        ${group.messages.map((item, index) =>
-          renderGroupedMessage(
+        ${group.messages.map((item, index) => {
+          const readFallbackText = resolveReadFallbackTextInGroup(group.messages, index);
+          return renderGroupedMessage(
             item.message,
             {
               isStreaming: group.isStreaming && index === group.messages.length - 1,
               showReasoning: opts.showReasoning,
+              readFallbackText,
+              toolOutputLookup: opts.toolOutputLookup,
             },
             opts.onOpenSidebar,
-          ),
-        )}
+          );
+        })}
         <div class="chat-group-footer">
           <span class="chat-sender-name">${who}</span>
           <span class="chat-group-timestamp">${timestamp}</span>
@@ -223,7 +232,12 @@ function renderMessageImages(images: ImageBlock[]) {
 
 function renderGroupedMessage(
   message: unknown,
-  opts: { isStreaming: boolean; showReasoning: boolean },
+  opts: {
+    isStreaming: boolean;
+    showReasoning: boolean;
+    readFallbackText?: string;
+    toolOutputLookup?: ToolCardOutputLookup;
+  },
   onOpenSidebar?: (content: string) => void,
 ) {
   const m = message as Record<string, unknown>;
@@ -235,7 +249,10 @@ function renderGroupedMessage(
     typeof m.toolCallId === "string" ||
     typeof m.tool_call_id === "string";
 
-  const toolCards = extractToolCards(message);
+  const toolCards = enrichToolCardsWithLookup(
+    extractToolCards(message, { readFallbackText: opts.readFallbackText }),
+    opts.toolOutputLookup,
+  );
   const hasToolCards = toolCards.length > 0;
   const images = extractImages(message);
   const hasImages = images.length > 0;
@@ -284,4 +301,46 @@ function renderGroupedMessage(
       ${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}
     </div>
   `;
+}
+
+function hasEmptyReadToolCard(message: unknown): boolean {
+  return extractToolCards(message).some(
+    (card) =>
+      isReadToolName(card.name) && (typeof card.text !== "string" || card.text.trim().length === 0),
+  );
+}
+
+function isReadToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  return normalized === "read" || /(^|[.:/_-])read$/.test(normalized);
+}
+
+export function resolveReadFallbackTextInGroup(
+  groupMessages: Array<{ message: unknown; key: string }>,
+  messageIndex: number,
+): string | undefined {
+  if (messageIndex < 0 || messageIndex >= groupMessages.length) {
+    return undefined;
+  }
+  if (!hasEmptyReadToolCard(groupMessages[messageIndex].message)) {
+    return undefined;
+  }
+
+  const neighboringIndexes = [messageIndex + 1, messageIndex - 1];
+  for (const index of neighboringIndexes) {
+    if (index < 0 || index >= groupMessages.length) {
+      continue;
+    }
+    const candidate = groupMessages[index].message;
+    // Only borrow from adjacent plain assistant text bubbles to avoid
+    // accidentally attributing output across unrelated tool cards.
+    if (extractToolCards(candidate).length > 0) {
+      continue;
+    }
+    const text = extractTextCached(candidate);
+    if (typeof text === "string" && text.trim()) {
+      return text;
+    }
+  }
+  return undefined;
 }

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -332,6 +332,80 @@ describe("tool-cards", () => {
     expect(enriched[1]?.text).toBe("longer and richer read output body");
   });
 
+  it("does not reuse another run's output when toolCallId is reused", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      runId: "run-2",
+      toolCallId: "shared-read-1",
+      content: [
+        {
+          type: "toolcall",
+          name: "read",
+          arguments: { path: "logs/current.log" },
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        runId: "run-1",
+        toolCallId: "shared-read-1",
+        content: [
+          { type: "toolcall", name: "read", arguments: { path: "logs/previous.log" } },
+          { type: "toolresult", name: "read", text: "previous run output" },
+        ],
+      },
+      {
+        role: "assistant",
+        runId: "run-2",
+        toolCallId: "shared-read-1",
+        content: [{ type: "toolcall", name: "read", arguments: { path: "logs/current.log" } }],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.args).toEqual({ path: "logs/current.log" });
+    expect(enriched[0]?.text).toBeUndefined();
+  });
+
+  it("does not reuse another run's output when toolCallId and args are both reused", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      runId: "run-2",
+      toolCallId: "shared-read-2",
+      content: [
+        {
+          type: "toolcall",
+          name: "read",
+          arguments: { path: "logs/shared.log" },
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        runId: "run-1",
+        toolCallId: "shared-read-2",
+        content: [
+          { type: "toolcall", name: "read", arguments: { path: "logs/shared.log" } },
+          { type: "toolresult", name: "read", text: "stale previous run output" },
+        ],
+      },
+      {
+        role: "assistant",
+        runId: "run-2",
+        toolCallId: "shared-read-2",
+        content: [{ type: "toolcall", name: "read", arguments: { path: "logs/shared.log" } }],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.args).toEqual({ path: "logs/shared.log" });
+    expect(enriched[0]?.text).toBeUndefined();
+  });
+
   it("hydrates missing command args from lookup when tool result card only has output", () => {
     const resultOnlyCards = extractToolCards({
       role: "toolresult",
@@ -463,7 +537,7 @@ describe("tool-cards", () => {
     expect(enriched[1]?.text).toBe("latest concise summary");
   });
 
-  it("replaces metadata-only exec summary with richer lookup output on non-id match", () => {
+  it("does not replace metadata-only exec summary from tool-name-only lookup", () => {
     const cards = extractToolCards({
       role: "assistant",
       content: [
@@ -490,6 +564,56 @@ describe("tool-cards", () => {
         content: [
           {
             type: "text",
+            text: "git status output from a different exec call",
+          },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.text).toBe(
+      "Command: openclaw system --help\nWorking Dir: C:\\Users\\test\\.openclaw\\workspace",
+    );
+    expect(enriched[1]?.text).toBe(
+      "Command: openclaw system --help\nWorking Dir: C:\\Users\\test\\.openclaw\\workspace",
+    );
+  });
+
+  it("replaces metadata-only exec summary with richer lookup output on signature match", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "exec",
+          arguments: {
+            command: "openclaw system --help",
+            cwd: "C:\\Users\\test\\.openclaw\\workspace",
+          },
+        },
+        {
+          type: "toolresult",
+          name: "exec",
+          text: "Command: openclaw system --help\nWorking Dir: C:\\Users\\test\\.openclaw\\workspace",
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "exec",
+            arguments: {
+              command: "openclaw system --help",
+              cwd: "C:\\Users\\test\\.openclaw\\workspace",
+            },
+          },
+          {
+            type: "toolresult",
+            name: "exec",
             text: "🦞 OpenClaw 2026.2.26\n\nUsage: openclaw system [options] [command]\n\nSystem tools...",
           },
         ],
@@ -499,9 +623,5 @@ describe("tool-cards", () => {
     const enriched = enrichToolCardsWithLookup(cards, lookup);
     expect(enriched[0]?.text).toContain("Usage: openclaw system");
     expect(enriched[1]?.text).toContain("Usage: openclaw system");
-    expect(enriched[0]?.args).toEqual({
-      command: "openclaw system --help",
-      cwd: "C:\\Users\\test\\.openclaw\\workspace",
-    });
   });
 });

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildToolCardOutputLookup,
+  buildToolSidebarContent,
+  enrichToolCardsWithLookup,
+  extractToolCards,
+} from "./tool-cards.ts";
+
+describe("tool-cards", () => {
+  it("propagates result text and call arguments across paired tool cards", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "toolresult",
+          name: "read",
+          text: "README contents",
+        },
+      ],
+    });
+
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "read",
+      text: "README contents",
+      args: { path: "README.md" },
+    });
+    expect(cards[1]).toMatchObject({
+      kind: "result",
+      name: "read",
+      text: "README contents",
+      args: { path: "README.md" },
+    });
+  });
+
+  it("appends enhanced read output after official tool info", () => {
+    const sidebar = buildToolSidebarContent({
+      displayLabel: "Read",
+      detail: "from docs/readme.md",
+      hasSidebarOutput: true,
+      formattedOutput: "### Read Files\n\n- `docs/readme.md`\n\n```txt\nhello\n```",
+      rawOutput: "hello",
+    });
+
+    expect(sidebar).toContain("## Read");
+    expect(sidebar).toContain("**Command:** `from docs/readme.md`");
+    expect(sidebar).toContain("---");
+    expect(sidebar).toContain("### Read Files");
+    expect(sidebar).not.toContain("### Raw Output");
+  });
+
+  it("keeps official info and formatted output for non read/edit tools", () => {
+    const sidebar = buildToolSidebarContent({
+      displayLabel: "Exec",
+      detail: "ls -la",
+      hasSidebarOutput: true,
+      formattedOutput: "```sh\nok\n```",
+      rawOutput: "ok",
+    });
+
+    expect(sidebar).toContain("## Exec");
+    expect(sidebar).toContain("**Command:** `ls -la`");
+    expect(sidebar).toContain("```sh\nok\n```");
+    expect(sidebar).not.toContain("### Raw Output");
+  });
+
+  it("appends raw output when formatted output is transformed", () => {
+    const sidebar = buildToolSidebarContent({
+      displayLabel: "Exec",
+      detail: "npm test",
+      hasSidebarOutput: true,
+      formattedOutput: "### Execution Result\n\n- **Exit Code:** 1",
+      rawOutput: '{"exitCode":1,"stderr":"boom"}',
+    });
+
+    expect(sidebar).toContain("### Execution Result");
+    expect(sidebar).toContain("### Raw Output");
+    expect(sidebar).toContain("exitCode");
+  });
+
+  it("extracts tool result text from structured content arrays", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "toolresult",
+          name: "read",
+          content: [
+            { type: "text", text: "line 1" },
+            { type: "text", text: "line 2" },
+          ],
+        },
+      ],
+    });
+
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "read",
+      text: "line 1\nline 2",
+      args: { path: "README.md" },
+    });
+    expect(cards[1]).toMatchObject({
+      kind: "result",
+      name: "read",
+      text: "line 1\nline 2",
+      args: { path: "README.md" },
+    });
+  });
+
+  it("applies read fallback text when read card output is empty", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "read",
+            arguments: { path: "C:\\RHDSetup.log" },
+          },
+        ],
+      },
+      { readFallbackText: "[ResponseResult]\nResultCode=0" },
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "read",
+      text: "[ResponseResult]\nResultCode=0",
+    });
+  });
+
+  it("does not override existing read tool output with fallback text", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "read",
+            arguments: { path: "README.md" },
+          },
+          {
+            type: "toolresult",
+            name: "read",
+            text: "actual file content",
+          },
+        ],
+      },
+      { readFallbackText: "fallback content" },
+    );
+
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "read",
+      text: "actual file content",
+    });
+    expect(cards[1]).toMatchObject({
+      kind: "result",
+      name: "read",
+      text: "actual file content",
+    });
+  });
+
+  it("does not apply read fallback text to non-read tools", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "exec_command",
+            arguments: { cmd: "pwd" },
+          },
+        ],
+      },
+      { readFallbackText: "should not be used" },
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "exec_command",
+    });
+    expect(cards[0].text).toBeUndefined();
+  });
+
+  it("captures toolCallId from message-level fields", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      toolCallId: "fetch-1",
+      content: [
+        {
+          type: "toolcall",
+          name: "web_fetch",
+          arguments: { url: "https://status.deepseek.com/" },
+        },
+      ],
+    });
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      kind: "call",
+      name: "web_fetch",
+      toolCallId: "fetch-1",
+    });
+  });
+
+  it("enriches terse tool cards with richer output from lookup by signature", () => {
+    const terseCards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "web_fetch",
+          arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        toolCallId: "fetch-live-1",
+        content: [
+          {
+            type: "toolcall",
+            name: "web_fetch",
+            arguments: { mode: "text", url: "https://api-docs.deepseek.com/quick_start/pricing" },
+          },
+          {
+            type: "toolresult",
+            name: "web_fetch",
+            text: '{"url":"https://api-docs.deepseek.com/quick_start/pricing","status":200,"text":"full body"}',
+          },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(terseCards, lookup);
+    expect(enriched[0]?.text).toContain('"status":200');
+  });
+
+  it("prefers latest lookup text for shared signatures instead of longest historical text", () => {
+    const terseCards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "web_fetch",
+          arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "web_fetch",
+            arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+          },
+          {
+            type: "toolresult",
+            name: "web_fetch",
+            text: "older verbose output with many details that should no longer win by length",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolcall",
+            name: "web_fetch",
+            arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+          },
+          { type: "toolresult", name: "web_fetch", text: "latest output" },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(terseCards, lookup);
+    expect(enriched[0]?.text).toBe("latest output");
+  });
+
+  it("enriches tool cards by exact toolCallId match", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      toolCallId: "read-1",
+      content: [
+        {
+          type: "toolcall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "toolresult",
+          name: "read",
+          text: "short",
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        toolCallId: "read-1",
+        content: [
+          { type: "toolcall", name: "read", arguments: { path: "README.md" } },
+          { type: "toolresult", name: "read", text: "longer and richer read output body" },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.text).toBe("longer and richer read output body");
+    expect(enriched[1]?.text).toBe("longer and richer read output body");
+  });
+
+  it("hydrates missing command args from lookup when tool result card only has output", () => {
+    const resultOnlyCards = extractToolCards({
+      role: "toolresult",
+      toolName: "read",
+      toolCallId: "read-lookup-args-1",
+      content: [{ type: "text", text: "live output body" }],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        toolCallId: "read-lookup-args-1",
+        content: [
+          { type: "toolcall", name: "read", arguments: { path: "workspace/memory/daily.md" } },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(resultOnlyCards, lookup);
+    expect(enriched[0]?.text).toBe("live output body");
+    expect(enriched[0]?.args).toEqual({ path: "workspace/memory/daily.md" });
+  });
+
+  it("keeps command args from history when live tool stream card carries empty args", () => {
+    const liveCards = extractToolCards({
+      role: "assistant",
+      toolCallId: "read-lookup-args-2",
+      content: [
+        { type: "toolcall", name: "read", arguments: {} },
+        { type: "toolresult", name: "read", text: "latest detailed output" },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        toolCallId: "read-lookup-args-2",
+        content: [
+          {
+            type: "toolcall",
+            name: "read",
+            arguments: {
+              path: "C:\\Users\\test\\.openclaw\\workspace\\memory\\daily\\2026-03-01.md",
+            },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        toolCallId: "read-lookup-args-2",
+        content: [
+          { type: "toolcall", name: "read", arguments: {} },
+          { type: "toolresult", name: "read", text: "latest detailed output" },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(liveCards, lookup);
+    for (const card of enriched) {
+      expect(card.text).toBe("latest detailed output");
+      expect(card.args).toEqual({
+        path: "C:\\Users\\test\\.openclaw\\workspace\\memory\\daily\\2026-03-01.md",
+      });
+    }
+  });
+
+  it("enriches by resource hint when signature and toolCallId are unavailable", () => {
+    const terseCards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "web_fetch",
+          arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolresult",
+            name: "web_fetch",
+            text: '{"url":"https://api-docs.deepseek.com/quick_start/pricing","status":200,"text":"rich body"}',
+          },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(terseCards, lookup);
+    expect(enriched[0]?.text).toContain('"status":200');
+    expect(enriched[0]?.text).toContain("rich body");
+  });
+
+  it("does not replace non-empty card text from non-id lookup matches", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "web_fetch",
+          arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing", mode: "text" },
+        },
+        {
+          type: "toolresult",
+          name: "web_fetch",
+          text: "latest concise summary",
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolresult",
+            name: "web_fetch",
+            text: "stale historical output with extra verbose details",
+          },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.text).toBe("latest concise summary");
+    expect(enriched[1]?.text).toBe("latest concise summary");
+  });
+
+  it("replaces metadata-only exec summary with richer lookup output on non-id match", () => {
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          name: "exec",
+          arguments: {
+            command: "openclaw system --help",
+            cwd: "C:\\Users\\test\\.openclaw\\workspace",
+          },
+        },
+        {
+          type: "toolresult",
+          name: "exec",
+          text: "Command: openclaw system --help\nWorking Dir: C:\\Users\\test\\.openclaw\\workspace",
+        },
+      ],
+    });
+
+    const lookup = buildToolCardOutputLookup([
+      {
+        role: "toolresult",
+        toolName: "exec",
+        content: [
+          {
+            type: "text",
+            text: "🦞 OpenClaw 2026.2.26\n\nUsage: openclaw system [options] [command]\n\nSystem tools...",
+          },
+        ],
+      },
+    ]);
+
+    const enriched = enrichToolCardsWithLookup(cards, lookup);
+    expect(enriched[0]?.text).toContain("Usage: openclaw system");
+    expect(enriched[1]?.text).toContain("Usage: openclaw system");
+    expect(enriched[0]?.args).toEqual({
+      command: "openclaw system --help",
+      cwd: "C:\\Users\\test\\.openclaw\\workspace",
+    });
+  });
+});

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -7,9 +7,50 @@ import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
 import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
 
-export function extractToolCards(message: unknown): ToolCard[] {
+type ToolSidebarContentInput = {
+  displayLabel: string;
+  detail?: string;
+  hasSidebarOutput: boolean;
+  formattedOutput: string;
+  rawOutput?: string;
+};
+
+export type ToolCardOutputLookup = {
+  byToolCallId: Map<string, ToolLookupEntry>;
+  bySignature: Map<string, ToolLookupEntry>;
+  byResourceHint: Map<string, ToolLookupEntry>;
+  byToolName: Map<string, ToolLookupEntry>;
+};
+
+type ToolLookupSource = "toolCallId" | "signature" | "resourceHint" | "toolName";
+
+type ToolLookupMatch = {
+  source: ToolLookupSource;
+  text?: string;
+  args?: unknown;
+};
+
+type ToolLookupEntry = {
+  text?: string;
+  args?: unknown;
+};
+
+type ToolLookupCandidate = {
+  source: ToolLookupSource;
+  entry: ToolLookupEntry;
+};
+
+type ExtractToolCardsOptions = {
+  readFallbackText?: string;
+};
+
+export function extractToolCards(
+  message: unknown,
+  options: ExtractToolCardsOptions = {},
+): ToolCard[] {
   const m = message as Record<string, unknown>;
   const content = normalizeContent(m.content);
+  const fallbackToolCallId = resolveToolCallId(m);
   const cards: ToolCard[] = [];
 
   for (const item of content) {
@@ -22,6 +63,7 @@ export function extractToolCards(message: unknown): ToolCard[] {
         kind: "call",
         name: (item.name as string) ?? "tool",
         args: coerceArgs(item.arguments ?? item.args),
+        toolCallId: resolveToolCallId(item, fallbackToolCallId),
       });
     }
   }
@@ -33,7 +75,12 @@ export function extractToolCards(message: unknown): ToolCard[] {
     }
     const text = extractToolText(item);
     const name = typeof item.name === "string" ? item.name : "tool";
-    cards.push({ kind: "result", name, text });
+    cards.push({
+      kind: "result",
+      name,
+      text,
+      toolCallId: resolveToolCallId(item, fallbackToolCallId),
+    });
   }
 
   if (isToolResultMessage(message) && !cards.some((card) => card.kind === "result")) {
@@ -42,35 +89,102 @@ export function extractToolCards(message: unknown): ToolCard[] {
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text });
+    cards.push({ kind: "result", name, text, toolCallId: fallbackToolCallId });
   }
 
-  return cards;
+  const merged = mergeToolCards(cards);
+  applyReadFallbackText(merged, options.readFallbackText);
+  return merged;
+}
+
+export function buildToolCardOutputLookup(messages: unknown[]): ToolCardOutputLookup {
+  const lookup: ToolCardOutputLookup = {
+    byToolCallId: new Map<string, ToolLookupEntry>(),
+    bySignature: new Map<string, ToolLookupEntry>(),
+    byResourceHint: new Map<string, ToolLookupEntry>(),
+    byToolName: new Map<string, ToolLookupEntry>(),
+  };
+  for (const message of messages) {
+    const cards = extractToolCards(message);
+    for (const card of cards) {
+      const text = normalizeToolText(card.text);
+      const args = normalizeToolArgs(card.args);
+      if (!text && !hasMeaningfulArgs(args)) {
+        continue;
+      }
+      const toolCallId = normalizeToolCallId(card.toolCallId);
+      if (toolCallId) {
+        upsertLookupEntry(lookup.byToolCallId, toolCallId, { text: text ?? undefined, args });
+      }
+      const signature = buildToolSignature(card.name, card.args);
+      if (signature) {
+        upsertLookupEntry(lookup.bySignature, signature, { text: text ?? undefined, args });
+      }
+      const resourceHint = buildResourceHint(card);
+      if (resourceHint) {
+        upsertLookupEntry(lookup.byResourceHint, resourceHint, { text: text ?? undefined, args });
+      }
+      const toolName = normalizeToolName(card.name);
+      if (toolName) {
+        upsertLookupEntry(lookup.byToolName, toolName, { text: text ?? undefined, args });
+      }
+    }
+  }
+  return lookup;
+}
+
+export function enrichToolCardsWithLookup(
+  cards: ToolCard[],
+  lookup: ToolCardOutputLookup | undefined,
+): ToolCard[] {
+  if (!lookup) {
+    return cards;
+  }
+  return cards.map((card) => {
+    const candidate = resolveLookupMatch(card, lookup);
+    if (!candidate) {
+      return card;
+    }
+    let next = card;
+    if (shouldApplyLookupText(next, candidate) && candidate.text) {
+      next = { ...next, text: candidate.text };
+    }
+    if (shouldApplyLookupArgs(next, candidate)) {
+      next = { ...next, args: candidate.args };
+    }
+    return next;
+  });
 }
 
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {
   const display = resolveToolDisplay({ name: card.name, args: card.args });
   const detail = formatToolDetail(display);
   const hasText = Boolean(card.text?.trim());
+  const formattedOutput = formatToolOutputForSidebar(card.text ?? "", {
+    toolName: card.name,
+    args: card.args,
+  });
+  const hasSidebarOutput = formattedOutput.trim().length > 0;
+  const sidebarContent = buildToolSidebarContent({
+    displayLabel: display.label,
+    detail,
+    hasSidebarOutput,
+    formattedOutput,
+    rawOutput: card.text ?? "",
+  });
 
   const canClick = Boolean(onOpenSidebar);
   const handleClick = canClick
     ? () => {
-        if (hasText) {
-          onOpenSidebar!(formatToolOutputForSidebar(card.text!));
-          return;
-        }
-        const info = `## ${display.label}\n\n${
-          detail ? `**Command:** \`${detail}\`\n\n` : ""
-        }*No output — tool completed successfully.*`;
-        onOpenSidebar!(info);
+        onOpenSidebar!(sidebarContent);
       }
     : undefined;
 
   const isShort = hasText && (card.text?.length ?? 0) <= TOOL_INLINE_THRESHOLD;
   const showCollapsed = hasText && !isShort;
   const showInline = hasText && isShort;
-  const isEmpty = !hasText;
+  const isEmpty = !hasText && !hasSidebarOutput;
+  const canView = hasText || hasSidebarOutput;
 
   return html`
     <div
@@ -97,7 +211,7 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
         </div>
         ${
           canClick
-            ? html`<span class="chat-tool-card__action">${hasText ? "View" : ""} ${icons.check}</span>`
+            ? html`<span class="chat-tool-card__action">${canView ? "View " : ""}${icons.check}</span>`
             : nothing
         }
         ${isEmpty && !canClick ? html`<span class="chat-tool-card__status">${icons.check}</span>` : nothing}
@@ -118,6 +232,396 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
       ${showInline ? html`<div class="chat-tool-card__inline mono">${card.text}</div>` : nothing}
     </div>
   `;
+}
+
+export function buildToolSidebarContent(input: ToolSidebarContentInput): string {
+  const official = buildOfficialToolInfo({
+    displayLabel: input.displayLabel,
+    detail: input.detail,
+    includeNoOutput: !input.hasSidebarOutput,
+  });
+  if (!input.hasSidebarOutput) {
+    return official;
+  }
+  const sections = [official, input.formattedOutput];
+  const rawSection = buildRawOutputSection(input.rawOutput, input.formattedOutput);
+  if (rawSection) {
+    sections.push(rawSection);
+  }
+  return sections.join("\n\n---\n\n");
+}
+
+function buildOfficialToolInfo(params: {
+  displayLabel: string;
+  detail?: string;
+  includeNoOutput: boolean;
+}): string {
+  const lines = [`## ${params.displayLabel}`, ""];
+  if (params.detail) {
+    lines.push(`**Command:** \`${escapeInlineCode(params.detail)}\``);
+  }
+  if (params.includeNoOutput) {
+    if (params.detail) {
+      lines.push("");
+    }
+    lines.push("*No output - tool completed successfully.*");
+  }
+  return lines.join("\n");
+}
+
+function escapeInlineCode(value: string): string {
+  return value.replace(/`/g, "\\`");
+}
+
+function buildRawOutputSection(
+  rawOutput: string | undefined,
+  formattedOutput: string,
+): string | null {
+  const raw = typeof rawOutput === "string" ? rawOutput.trim() : "";
+  if (!raw) {
+    return null;
+  }
+  if (isRawAlreadyVisible(raw, formattedOutput)) {
+    return null;
+  }
+  return `### Raw Output\n\n${createCodeFence(raw, "text")}`;
+}
+
+function isReadToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  return normalized === "read" || /(^|[.:/_-])read$/.test(normalized);
+}
+
+function isRawAlreadyVisible(raw: string, formattedOutput: string): boolean {
+  const formatted = formattedOutput.trim();
+  if (!formatted) {
+    return false;
+  }
+  if (formatted === raw) {
+    return true;
+  }
+  const unwrapped = unwrapSingleCodeFence(formatted);
+  if (unwrapped && unwrapped.trim() === raw) {
+    return true;
+  }
+  const fencedBodies = extractCodeFenceBodies(formatted);
+  if (fencedBodies.some((body) => body.trim() === raw)) {
+    return true;
+  }
+  if (formatted.includes(raw)) {
+    return true;
+  }
+  return false;
+}
+
+function unwrapSingleCodeFence(markdown: string): string | null {
+  const match = markdown.trim().match(/^(`{3,})[^\n]*\n([\s\S]*?)\n\1$/);
+  if (!match) {
+    return null;
+  }
+  return match[2];
+}
+
+function createCodeFence(content: string, language = ""): string {
+  const runs = content.match(/`+/g) ?? [];
+  const requiredLength = runs.reduce((max, run) => Math.max(max, run.length + 1), 3);
+  const fence = "`".repeat(requiredLength);
+  const lang = language.trim();
+  return `${fence}${lang}\n${content}\n${fence}`;
+}
+
+function extractCodeFenceBodies(markdown: string): string[] {
+  const blocks: string[] = [];
+  const matches = markdown.matchAll(/(`{3,})[^\n]*\n([\s\S]*?)\n\1/g);
+  for (const match of matches) {
+    const body = match[2];
+    if (typeof body === "string") {
+      blocks.push(body);
+    }
+  }
+  return blocks;
+}
+
+function applyReadFallbackText(cards: ToolCard[], fallbackText: string | undefined) {
+  const normalizedFallback = typeof fallbackText === "string" ? fallbackText.trim() : "";
+  if (!normalizedFallback) {
+    return;
+  }
+  for (const card of cards) {
+    if (!isReadToolName(card.name)) {
+      continue;
+    }
+    if (typeof card.text === "string" && card.text.trim()) {
+      continue;
+    }
+    card.text = normalizedFallback;
+  }
+}
+
+function mergeToolCards(cards: ToolCard[]): ToolCard[] {
+  for (let i = 0; i < cards.length; i += 1) {
+    const resultCard = cards[i];
+    if (resultCard.kind !== "result") {
+      continue;
+    }
+    for (let j = i - 1; j >= 0; j -= 1) {
+      const callCard = cards[j];
+      if (callCard.kind !== "call" || callCard.name !== resultCard.name) {
+        continue;
+      }
+      if (
+        callCard.toolCallId &&
+        resultCard.toolCallId &&
+        normalizeToolCallId(callCard.toolCallId) !== normalizeToolCallId(resultCard.toolCallId)
+      ) {
+        continue;
+      }
+      if (!callCard.text && resultCard.text) {
+        callCard.text = resultCard.text;
+      }
+      if (resultCard.args === undefined && callCard.args !== undefined) {
+        resultCard.args = callCard.args;
+      }
+      if (!callCard.toolCallId && resultCard.toolCallId) {
+        callCard.toolCallId = resultCard.toolCallId;
+      }
+      if (!resultCard.toolCallId && callCard.toolCallId) {
+        resultCard.toolCallId = callCard.toolCallId;
+      }
+      break;
+    }
+  }
+  return cards;
+}
+
+function resolveToolCallId(value: Record<string, unknown>, fallback?: string): string | undefined {
+  const direct =
+    (typeof value.toolCallId === "string" && value.toolCallId) ||
+    (typeof value.tool_call_id === "string" && value.tool_call_id) ||
+    fallback;
+  const normalized = normalizeToolCallId(direct);
+  return normalized || undefined;
+}
+
+function normalizeToolCallId(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function normalizeToolText(value: string | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function shouldApplyLookupText(card: ToolCard, candidate: ToolLookupMatch): boolean {
+  if (!candidate.text) {
+    return false;
+  }
+  const normalizedCurrent = normalizeToolText(card.text);
+  if (!normalizedCurrent) {
+    return true;
+  }
+  if (candidate.source === "toolCallId") {
+    return normalizedCurrent !== candidate.text;
+  }
+  // Non-id matches (signature/resource hint) should usually keep current text to
+  // avoid stale overrides, except when current text is metadata-only summary.
+  return (
+    normalizedCurrent !== candidate.text &&
+    isLikelyMetadataOnlyToolText(normalizedCurrent) &&
+    !isLikelyMetadataOnlyToolText(candidate.text)
+  );
+}
+
+function shouldApplyLookupArgs(card: ToolCard, candidate: ToolLookupMatch): boolean {
+  if (!hasMeaningfulArgs(candidate.args)) {
+    return false;
+  }
+  if (!hasMeaningfulArgs(card.args)) {
+    return true;
+  }
+  return (
+    candidate.source === "toolCallId" &&
+    stableSerialize(stableNormalize(card.args)) !== stableSerialize(stableNormalize(candidate.args))
+  );
+}
+
+function resolveLookupMatch(
+  card: ToolCard,
+  lookup: ToolCardOutputLookup,
+): ToolLookupMatch | undefined {
+  const toolCallId = normalizeToolCallId(card.toolCallId);
+  const byId: ToolLookupCandidate | undefined = toolCallId
+    ? (() => {
+        const entry = lookup.byToolCallId.get(toolCallId);
+        return entry ? { source: "toolCallId", entry } : undefined;
+      })()
+    : undefined;
+  const signature = buildToolSignature(card.name, card.args);
+  const resourceHint = buildResourceHint(card);
+  const bySignature: ToolLookupCandidate | undefined = signature
+    ? (() => {
+        const entry = lookup.bySignature.get(signature);
+        return entry ? { source: "signature", entry } : undefined;
+      })()
+    : undefined;
+  const byResourceHint: ToolLookupCandidate | undefined = resourceHint
+    ? (() => {
+        const entry = lookup.byResourceHint.get(resourceHint);
+        return entry ? { source: "resourceHint", entry } : undefined;
+      })()
+    : undefined;
+  const toolName = normalizeToolName(card.name);
+  const byToolName: ToolLookupCandidate | undefined = toolName
+    ? (() => {
+        const entry = lookup.byToolName.get(toolName);
+        return entry ? { source: "toolName", entry } : undefined;
+      })()
+    : undefined;
+
+  const textCandidate = pickPreferredTextCandidate(byId, bySignature, byResourceHint, byToolName);
+  const argsCandidate = pickPreferredArgsCandidate(byId, bySignature, byResourceHint, byToolName);
+  if (!textCandidate && !argsCandidate) {
+    return undefined;
+  }
+  return {
+    source: textCandidate?.source ?? argsCandidate?.source ?? "toolCallId",
+    text: textCandidate?.entry.text,
+    args: argsCandidate?.entry.args ?? textCandidate?.entry.args,
+  };
+}
+
+function buildToolSignature(name: string, args: unknown): string {
+  const normalizedName = normalizeToolName(name);
+  if (!normalizedName) {
+    return "";
+  }
+  const argsKey = stableSerialize(args);
+  return `${normalizedName}::${argsKey}`;
+}
+
+function stableSerialize(value: unknown): string {
+  try {
+    return JSON.stringify(stableNormalize(value));
+  } catch {
+    if (value === undefined) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value);
+    }
+    if (typeof value === "symbol") {
+      return value.description ? `Symbol(${value.description})` : "Symbol()";
+    }
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function stableNormalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableNormalize(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  const sortedKeys = Object.keys(record).toSorted((a, b) => a.localeCompare(b));
+  const normalized: Record<string, unknown> = {};
+  for (const key of sortedKeys) {
+    normalized[key] = stableNormalize(record[key]);
+  }
+  return normalized;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function pickString(record: Record<string, unknown> | null, keys: string[]): string | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return null;
+}
+
+function buildResourceHint(card: ToolCard): string {
+  const normalizedName = normalizeToolName(card.name);
+  if (!normalizedName) {
+    return "";
+  }
+  const resource = resolveResourceHint(card);
+  if (!resource) {
+    return "";
+  }
+  return `${normalizedName}::${resource}`;
+}
+
+function resolveResourceHint(card: ToolCard): string | null {
+  const argsRecord = asRecord(card.args);
+  const fromArgs =
+    pickString(argsRecord, [
+      "url",
+      "uri",
+      "path",
+      "file",
+      "filePath",
+      "file_path",
+      "cmd",
+      "command",
+      "query",
+    ]) ?? null;
+  if (fromArgs) {
+    return normalizeResourceHintValue(fromArgs);
+  }
+  const fromText = extractFirstUrl(card.text) ?? extractFirstPathLikeToken(card.text);
+  if (!fromText) {
+    return null;
+  }
+  return normalizeResourceHintValue(fromText);
+}
+
+function normalizeResourceHintValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function extractFirstUrl(value: string | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = value.match(/https?:\/\/[^\s"')\]}]+/i);
+  if (!match) {
+    return null;
+  }
+  return match[0];
+}
+
+function extractFirstPathLikeToken(value: string | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = value.match(/[A-Za-z]:\\[^\s"']+|\/[^\s"']+/);
+  if (!match) {
+    return null;
+  }
+  return match[0];
 }
 
 function normalizeContent(content: unknown): Array<Record<string, unknown>> {
@@ -145,12 +649,188 @@ function coerceArgs(value: unknown): unknown {
   }
 }
 
+function hasMeaningfulArgs(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return false;
+}
+
+function normalizeToolArgs(value: unknown): unknown {
+  return hasMeaningfulArgs(value) ? value : undefined;
+}
+
+function upsertLookupEntry(
+  map: Map<string, ToolLookupEntry>,
+  key: string,
+  incoming: ToolLookupEntry,
+) {
+  const existing = map.get(key);
+  if (!existing) {
+    map.set(key, incoming);
+    return;
+  }
+  map.set(key, {
+    text: incoming.text ?? existing.text,
+    args: incoming.args ?? existing.args,
+  });
+}
+
+function pickPreferredTextCandidate(
+  byId?: ToolLookupCandidate,
+  bySignature?: ToolLookupCandidate,
+  byResourceHint?: ToolLookupCandidate,
+  byToolName?: ToolLookupCandidate,
+): ToolLookupCandidate | undefined {
+  const preferables = [bySignature, byResourceHint, byToolName].filter(
+    (candidate): candidate is ToolLookupCandidate =>
+      typeof candidate?.entry.text === "string" && candidate.entry.text.trim().length > 0,
+  );
+  const nonMetadataPreferables = preferables.filter(
+    (candidate) => !isLikelyMetadataOnlyToolText(candidate.entry.text ?? ""),
+  );
+  if (byId?.entry.text) {
+    if (!isLikelyMetadataOnlyToolText(byId.entry.text)) {
+      return byId;
+    }
+    return pickBestTextCandidate(nonMetadataPreferables) ?? byId;
+  }
+  return pickBestTextCandidate(
+    nonMetadataPreferables.length > 0 ? nonMetadataPreferables : preferables,
+  );
+}
+
+function pickPreferredArgsCandidate(
+  byId?: ToolLookupCandidate,
+  bySignature?: ToolLookupCandidate,
+  byResourceHint?: ToolLookupCandidate,
+  byToolName?: ToolLookupCandidate,
+): ToolLookupCandidate | undefined {
+  if (hasMeaningfulArgs(byId?.entry.args)) {
+    return byId;
+  }
+  if (hasMeaningfulArgs(bySignature?.entry.args)) {
+    return bySignature;
+  }
+  if (hasMeaningfulArgs(byResourceHint?.entry.args)) {
+    return byResourceHint;
+  }
+  if (hasMeaningfulArgs(byToolName?.entry.args)) {
+    return byToolName;
+  }
+  return undefined;
+}
+
+function normalizeToolName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isLikelyMetadataOnlyToolText(value: string): boolean {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0 || lines.length > 8) {
+    return false;
+  }
+  const metadataLine = (line: string): boolean =>
+    /^(command|working dir|cwd|exit code|status|duration|signal|timed out|timeout):/i.test(line);
+  let metadataCount = 0;
+  for (const line of lines) {
+    if (metadataLine(line)) {
+      metadataCount += 1;
+      continue;
+    }
+    if (
+      /^[-*]\s+(command|working dir|cwd|exit code|status|duration|signal|timed out|timeout):/i.test(
+        line,
+      )
+    ) {
+      metadataCount += 1;
+      continue;
+    }
+    return false;
+  }
+  return metadataCount === lines.length;
+}
+
+function pickBestTextCandidate(candidates: ToolLookupCandidate[]): ToolLookupCandidate | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const scoreCandidate = (candidate: ToolLookupCandidate): number => {
+    const metadataScore = isLikelyMetadataOnlyToolText(candidate.entry.text ?? "") ? 0 : 10;
+    const sourceScore =
+      candidate.source === "signature"
+        ? 3
+        : candidate.source === "resourceHint"
+          ? 2
+          : candidate.source === "toolName"
+            ? 1
+            : 4;
+    return metadataScore + sourceScore;
+  };
+  return candidates.reduce((best, candidate) =>
+    scoreCandidate(candidate) > scoreCandidate(best) ? candidate : best,
+  );
+}
+
 function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.text === "string") {
     return item.text;
   }
   if (typeof item.content === "string") {
     return item.content;
+  }
+  if (Array.isArray(item.content)) {
+    const parts = item.content
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+        const record = entry as Record<string, unknown>;
+        if (record.type === "text" && typeof record.text === "string") {
+          return record.text;
+        }
+        if (typeof record.text === "string") {
+          return record.text;
+        }
+        return null;
+      })
+      .filter((part): part is string => Boolean(part));
+    if (parts.length > 0) {
+      return parts.join("\n");
+    }
+  }
+  if (item.content && typeof item.content === "object") {
+    const record = item.content as Record<string, unknown>;
+    if (typeof record.text === "string") {
+      return record.text;
+    }
+    if (typeof record.content === "string") {
+      return record.content;
+    }
+  }
+  if (item.result && typeof item.result === "object") {
+    const record = item.result as Record<string, unknown>;
+    if (typeof record.text === "string") {
+      return record.text;
+    }
+    if (typeof record.content === "string") {
+      return record.content;
+    }
   }
   return undefined;
 }

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -51,6 +51,7 @@ export function extractToolCards(
   const m = message as Record<string, unknown>;
   const content = normalizeContent(m.content);
   const fallbackToolCallId = resolveToolCallId(m);
+  const runId = normalizeRunId(m.runId ?? m.run_id);
   const cards: ToolCard[] = [];
 
   for (const item of content) {
@@ -64,6 +65,7 @@ export function extractToolCards(
         name: (item.name as string) ?? "tool",
         args: coerceArgs(item.arguments ?? item.args),
         toolCallId: resolveToolCallId(item, fallbackToolCallId),
+        runId,
       });
     }
   }
@@ -80,6 +82,7 @@ export function extractToolCards(
       name,
       text,
       toolCallId: resolveToolCallId(item, fallbackToolCallId),
+      runId,
     });
   }
 
@@ -89,7 +92,7 @@ export function extractToolCards(
       (typeof m.tool_name === "string" && m.tool_name) ||
       "tool";
     const text = extractTextCached(message) ?? undefined;
-    cards.push({ kind: "result", name, text, toolCallId: fallbackToolCallId });
+    cards.push({ kind: "result", name, text, toolCallId: fallbackToolCallId, runId });
   }
 
   const merged = mergeToolCards(cards);
@@ -114,7 +117,17 @@ export function buildToolCardOutputLookup(messages: unknown[]): ToolCardOutputLo
       }
       const toolCallId = normalizeToolCallId(card.toolCallId);
       if (toolCallId) {
-        upsertLookupEntry(lookup.byToolCallId, toolCallId, { text: text ?? undefined, args });
+        // Keep tool output scoped to the originating run so reused ids like
+        // `call_1` do not leak stale content across runs.
+        upsertLookupEntry(lookup.byToolCallId, buildToolCallLookupKey(toolCallId, card.runId), {
+          text: text ?? undefined,
+          args,
+        });
+        // Preserve a loose args-only fallback so split call/result cards can
+        // still recover command details when only one side carried arguments.
+        if (card.runId && hasMeaningfulArgs(args)) {
+          upsertLookupEntry(lookup.byToolCallId, toolCallId, { args });
+        }
       }
       const signature = buildToolSignature(card.name, card.args);
       if (signature) {
@@ -388,6 +401,12 @@ function mergeToolCards(cards: ToolCard[]): ToolCard[] {
       if (!resultCard.toolCallId && callCard.toolCallId) {
         resultCard.toolCallId = callCard.toolCallId;
       }
+      if (!callCard.runId && resultCard.runId) {
+        callCard.runId = resultCard.runId;
+      }
+      if (!resultCard.runId && callCard.runId) {
+        resultCard.runId = callCard.runId;
+      }
       break;
     }
   }
@@ -405,6 +424,23 @@ function resolveToolCallId(value: Record<string, unknown>, fallback?: string): s
 
 function normalizeToolCallId(value: string | undefined): string {
   return value?.trim() ?? "";
+}
+
+function normalizeRunId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function buildToolCallLookupKey(toolCallId: string, runId?: string): string {
+  const normalizedToolCallId = normalizeToolCallId(toolCallId);
+  if (!normalizedToolCallId) {
+    return "";
+  }
+  const normalizedRunId = normalizeRunId(runId);
+  return normalizedRunId ? `${normalizedRunId}::${normalizedToolCallId}` : normalizedToolCallId;
 }
 
 function normalizeToolText(value: string | undefined): string | null {
@@ -455,10 +491,19 @@ function resolveLookupMatch(
   const toolCallId = normalizeToolCallId(card.toolCallId);
   const byId: ToolLookupCandidate | undefined = toolCallId
     ? (() => {
-        const entry = lookup.byToolCallId.get(toolCallId);
+        const entry = lookup.byToolCallId.get(buildToolCallLookupKey(toolCallId, card.runId));
         return entry ? { source: "toolCallId", entry } : undefined;
       })()
     : undefined;
+  const byIdLoose: ToolLookupCandidate | undefined =
+    toolCallId && card.runId
+      ? (() => {
+          // Cross-run fallback is args-only; text stays run-scoped to avoid
+          // showing another run's tool output on the current card.
+          const entry = lookup.byToolCallId.get(toolCallId);
+          return entry ? { source: "toolCallId", entry } : undefined;
+        })()
+      : undefined;
   const signature = buildToolSignature(card.name, card.args);
   const resourceHint = buildResourceHint(card);
   const bySignature: ToolLookupCandidate | undefined = signature
@@ -474,15 +519,29 @@ function resolveLookupMatch(
       })()
     : undefined;
   const toolName = normalizeToolName(card.name);
-  const byToolName: ToolLookupCandidate | undefined = toolName
-    ? (() => {
-        const entry = lookup.byToolName.get(toolName);
-        return entry ? { source: "toolName", entry } : undefined;
-      })()
-    : undefined;
+  const byToolName: ToolLookupCandidate | undefined =
+    !toolCallId && !signature && !resourceHint && toolName
+      ? (() => {
+          const entry = lookup.byToolName.get(toolName);
+          return entry ? { source: "toolName", entry } : undefined;
+        })()
+      : undefined;
+  const hasRunScopedToolIdentity = Boolean(toolCallId && card.runId);
 
-  const textCandidate = pickPreferredTextCandidate(byId, bySignature, byResourceHint, byToolName);
-  const argsCandidate = pickPreferredArgsCandidate(byId, bySignature, byResourceHint, byToolName);
+  // Once a card is tied to a concrete run + toolCallId, keep text hydration
+  // on that exact boundary. We still allow loose args recovery below, but we
+  // do not let same-signature/resource lookups pull stale output across runs.
+  const textCandidate = hasRunScopedToolIdentity
+    ? typeof byId?.entry.text === "string" && byId.entry.text.trim().length > 0
+      ? byId
+      : undefined
+    : pickPreferredTextCandidate(byId, bySignature, byResourceHint, byToolName);
+  const argsCandidate = pickPreferredArgsCandidate(
+    hasMeaningfulArgs(byId?.entry.args) ? byId : byIdLoose,
+    bySignature,
+    byResourceHint,
+    byToolName,
+  );
   if (!textCandidate && !argsCandidate) {
     return undefined;
   }
@@ -682,6 +741,24 @@ function upsertLookupEntry(
     map.set(key, incoming);
     return;
   }
+
+  const existingArgsKey = hasMeaningfulArgs(existing.args)
+    ? stableSerialize(stableNormalize(existing.args))
+    : "";
+  const incomingArgsKey = hasMeaningfulArgs(incoming.args)
+    ? stableSerialize(stableNormalize(incoming.args))
+    : "";
+  const hasConflictingArgs =
+    existingArgsKey.length > 0 && incomingArgsKey.length > 0 && existingArgsKey !== incomingArgsKey;
+
+  if (hasConflictingArgs) {
+    map.set(key, {
+      text: incoming.text,
+      args: incoming.args,
+    });
+    return;
+  }
+
   map.set(key, {
     text: incoming.text ?? existing.text,
     args: incoming.args ?? existing.args,

--- a/ui/src/ui/chat/tool-helpers.test.ts
+++ b/ui/src/ui/chat/tool-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
 
 describe("tool-helpers", () => {
@@ -37,25 +37,23 @@ describe("tool-helpers", () => {
       expect(result).toContain('"inner"');
     });
 
-    it("returns plain text for non-JSON content", () => {
+    it("formats plain text into an output section", () => {
       const input = "This is plain text output";
       const result = formatToolOutputForSidebar(input);
 
-      expect(result).toBe("This is plain text output");
+      expect(result).toContain("### Output");
+      expect(result).toContain("```text");
+      expect(result).toContain("This is plain text output");
     });
 
-    it("returns as-is for invalid JSON starting with {", () => {
-      const input = "{not valid json";
-      const result = formatToolOutputForSidebar(input);
+    it("formats invalid JSON-like strings as plain output", () => {
+      const resultObject = formatToolOutputForSidebar("{not valid json");
+      const resultArray = formatToolOutputForSidebar("[not valid json");
 
-      expect(result).toBe("{not valid json");
-    });
-
-    it("returns as-is for invalid JSON starting with [", () => {
-      const input = "[not valid json";
-      const result = formatToolOutputForSidebar(input);
-
-      expect(result).toBe("[not valid json");
+      expect(resultObject).toContain("### Output");
+      expect(resultObject).toContain("{not valid json");
+      expect(resultArray).toContain("### Output");
+      expect(resultArray).toContain("[not valid json");
     });
 
     it("trims whitespace before detecting JSON", () => {
@@ -75,6 +73,199 @@ describe("tool-helpers", () => {
       const result = formatToolOutputForSidebar("   ");
       expect(result).toBe("   ");
     });
+
+    it("extracts read content from structured JSON payload", () => {
+      const input = JSON.stringify({
+        path: "src/app.ts",
+        content: "line one\nline two",
+      });
+      const result = formatToolOutputForSidebar(input, {
+        toolName: "read",
+        args: { path: "src/app.ts" },
+      });
+
+      expect(result).toContain("src/app.ts");
+      expect(result).toContain("line one");
+      expect(result).toContain("line two");
+      expect(result).toContain("```");
+      expect(result).toContain("Read Files");
+    });
+
+    it("uses args path for plain-text read output", () => {
+      const result = formatToolOutputForSidebar("alpha\nbeta", {
+        toolName: "read",
+        args: { path: "docs/readme.md" },
+      });
+
+      expect(result).toContain("Read Files");
+      expect(result).toContain("docs/readme.md");
+      expect(result).toContain("alpha");
+      expect(result).toContain("beta");
+    });
+
+    it("shows read file path even when content is missing", () => {
+      const result = formatToolOutputForSidebar("", {
+        toolName: "read",
+        args: { file_path: "docs/empty.md" },
+      });
+
+      expect(result).toContain("Read Files");
+      expect(result).toContain("docs/empty.md");
+      expect(result).toContain("No file content captured");
+    });
+
+    it("renders edit arguments as diff even without tool result text", () => {
+      const result = formatToolOutputForSidebar("", {
+        toolName: "edit",
+        args: {
+          path: "src/app.ts",
+          old_string: "alpha\nbeta",
+          new_string: "alpha\ngamma",
+        },
+      });
+
+      expect(result).toContain("```diff");
+      expect(result).toContain("-beta");
+      expect(result).toContain("+gamma");
+      expect(result).toContain("src/app.ts");
+    });
+
+    it("formats exec output with status and stdio sections", () => {
+      const result = formatToolOutputForSidebar(
+        JSON.stringify({
+          exitCode: 1,
+          durationMs: 245,
+          cwd: "H:/AIProjects/openclaw",
+          stdout: "ok line",
+          stderr: "failure line",
+        }),
+        {
+          toolName: "exec",
+          args: { cmd: "pnpm test" },
+        },
+      );
+
+      expect(result).toContain("Execution Result");
+      expect(result).toContain("Exit Code");
+      expect(result).toContain("Stdout");
+      expect(result).toContain("Stderr");
+    });
+
+    it("formats web_fetch output with request metadata", () => {
+      const result = formatToolOutputForSidebar(
+        JSON.stringify({
+          status: 200,
+          contentType: "text/html",
+          content: "<html>Hello</html>",
+        }),
+        {
+          toolName: "web_fetch",
+          args: { url: "https://openclaw.ai" },
+        },
+      );
+
+      expect(result).toContain("Fetch Result");
+      expect(result).toContain("https://openclaw.ai");
+      expect(result).toContain("Status");
+      expect(result).toContain("Body Preview");
+    });
+
+    it("formats web_search output into ranked results", () => {
+      const result = formatToolOutputForSidebar(
+        JSON.stringify({
+          results: [
+            { title: "OpenClaw Docs", url: "https://docs.openclaw.ai", snippet: "Docs home" },
+          ],
+        }),
+        {
+          toolName: "web_search",
+          args: { query: "openclaw docs" },
+        },
+      );
+
+      expect(result).toContain("Search Results");
+      expect(result).toContain("Matches");
+      expect(result).toContain("OpenClaw Docs");
+      expect(result).toContain("docs.openclaw.ai");
+    });
+
+    it("formats write output with file metadata and preview", () => {
+      const result = formatToolOutputForSidebar("", {
+        toolName: "write",
+        args: {
+          path: "docs/notes.md",
+          content: "line one\nline two",
+        },
+      });
+
+      expect(result).toContain("Write Result");
+      expect(result).toContain("docs/notes.md");
+      expect(result).toContain("Content Preview");
+      expect(result).toContain("line one");
+    });
+
+    it("formats browser actions with target and result", () => {
+      const result = formatToolOutputForSidebar("snapshot completed", {
+        toolName: "browser",
+        args: {
+          action: "snapshot",
+          targetUrl: "https://example.com",
+        },
+      });
+
+      expect(result).toContain("Browser Action");
+      expect(result).toContain("snapshot");
+      expect(result).toContain("https://example.com");
+      expect(result).toContain("Result");
+    });
+
+    it("formats messaging actions for slack/discord tools", () => {
+      const result = formatToolOutputForSidebar("sent", {
+        toolName: "discord",
+        args: {
+          action: "sendMessage",
+          channelId: "123",
+          content: "hello",
+        },
+      });
+
+      expect(result).toContain("Discord Action");
+      expect(result).toContain("sendMessage");
+      expect(result).toContain("123");
+      expect(result).toContain("Message Preview");
+    });
+
+    it("formats nodes actions with device metadata", () => {
+      const result = formatToolOutputForSidebar("captured", {
+        toolName: "nodes",
+        args: {
+          action: "camera_snap",
+          nodeId: "android-01",
+          durationMs: 1200,
+        },
+      });
+
+      expect(result).toContain("Node Action");
+      expect(result).toContain("camera_snap");
+      expect(result).toContain("android-01");
+      expect(result).toContain("Duration");
+    });
+
+    it("formats gateway actions with reason and delay", () => {
+      const result = formatToolOutputForSidebar("scheduled", {
+        toolName: "gateway",
+        args: {
+          action: "restart",
+          reason: "config apply",
+          delayMs: 1500,
+        },
+      });
+
+      expect(result).toContain("Gateway Action");
+      expect(result).toContain("restart");
+      expect(result).toContain("config apply");
+      expect(result).toContain("Delay");
+    });
   });
 
   describe("getTruncatedPreview", () => {
@@ -90,22 +281,21 @@ describe("tool-helpers", () => {
       const result = getTruncatedPreview(input);
 
       expect(result.length).toBe(101); // 100 chars + ellipsis
-      expect(result.endsWith("…")).toBe(true);
+      expect(result.endsWith("\u2026")).toBe(true);
     });
 
     it("truncates to max lines", () => {
       const input = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
       const result = getTruncatedPreview(input);
 
-      // Should only show first 2 lines (PREVIEW_MAX_LINES = 2)
-      expect(result).toBe("Line 1\nLine 2…");
+      expect(result).toBe(`Line 1\nLine 2\u2026`);
     });
 
     it("adds ellipsis when lines are truncated", () => {
       const input = "Line 1\nLine 2\nLine 3";
       const result = getTruncatedPreview(input);
 
-      expect(result.endsWith("…")).toBe(true);
+      expect(result.endsWith("\u2026")).toBe(true);
     });
 
     it("does not add ellipsis when all lines fit", () => {
@@ -113,7 +303,7 @@ describe("tool-helpers", () => {
       const result = getTruncatedPreview(input);
 
       expect(result).toBe("Line 1\nLine 2");
-      expect(result.endsWith("…")).toBe(false);
+      expect(result.endsWith("\u2026")).toBe(false);
     });
 
     it("handles single line within limits", () => {
@@ -129,13 +319,12 @@ describe("tool-helpers", () => {
     });
 
     it("truncates by chars even within line limit", () => {
-      // Two lines but very long content
       const longLine = "x".repeat(80);
       const input = `${longLine}\n${longLine}`;
       const result = getTruncatedPreview(input);
 
       expect(result.length).toBe(101); // 100 + ellipsis
-      expect(result.endsWith("…")).toBe(true);
+      expect(result.endsWith("\u2026")).toBe(true);
     });
   });
 });

--- a/ui/src/ui/chat/tool-helpers.ts
+++ b/ui/src/ui/chat/tool-helpers.ts
@@ -4,22 +4,870 @@
 
 import { PREVIEW_MAX_CHARS, PREVIEW_MAX_LINES } from "./constants.ts";
 
+type ToolOutputFormatOptions = {
+  toolName?: string;
+  args?: unknown;
+};
+
+type ToolFormatContext = {
+  toolName: string;
+  argsRecord: Record<string, unknown> | null;
+  parsedOutput: unknown;
+  rawText: string;
+  trimmedText: string;
+};
+
+type ReadEntry = {
+  path: string | null;
+  content: string | null;
+};
+
+type SearchResult = {
+  title: string;
+  url: string | null;
+  snippet: string | null;
+  source: string | null;
+};
+
 /**
  * Format tool output content for display in the sidebar.
- * Detects JSON and wraps it in a code block with formatting.
  */
-export function formatToolOutputForSidebar(text: string): string {
+export function formatToolOutputForSidebar(
+  text: string,
+  options: ToolOutputFormatOptions = {},
+): string {
+  const normalizedToolName = normalizeToolName(options.toolName);
   const trimmed = text.trim();
-  // Try to detect and format JSON
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+  const parsedOutput = parseJsonLoose(trimmed);
+  const argsRecord = asRecord(options.args);
+
+  const context: ToolFormatContext = {
+    toolName: normalizedToolName,
+    argsRecord,
+    parsedOutput,
+    rawText: text,
+    trimmedText: trimmed,
+  };
+
+  const readMarkdown = formatReadToolOutput(context);
+  if (readMarkdown) {
+    return readMarkdown;
+  }
+
+  const editMarkdown = formatEditToolOutput(context);
+  if (editMarkdown) {
+    return editMarkdown;
+  }
+
+  const writeMarkdown = formatWriteToolOutput(context);
+  if (writeMarkdown) {
+    return writeMarkdown;
+  }
+
+  const execMarkdown = formatExecToolOutput(context);
+  if (execMarkdown) {
+    return execMarkdown;
+  }
+
+  const webFetchMarkdown = formatWebFetchToolOutput(context);
+  if (webFetchMarkdown) {
+    return webFetchMarkdown;
+  }
+
+  const webSearchMarkdown = formatWebSearchToolOutput(context);
+  if (webSearchMarkdown) {
+    return webSearchMarkdown;
+  }
+
+  const browserMarkdown = formatBrowserToolOutput(context);
+  if (browserMarkdown) {
+    return browserMarkdown;
+  }
+
+  const messagingMarkdown = formatMessagingToolOutput(context);
+  if (messagingMarkdown) {
+    return messagingMarkdown;
+  }
+
+  const nodesMarkdown = formatNodesToolOutput(context);
+  if (nodesMarkdown) {
+    return nodesMarkdown;
+  }
+
+  const gatewayMarkdown = formatGatewayToolOutput(context);
+  if (gatewayMarkdown) {
+    return gatewayMarkdown;
+  }
+
+  if (parsedOutput != null) {
     try {
-      const parsed = JSON.parse(trimmed);
-      return "```json\n" + JSON.stringify(parsed, null, 2) + "\n```";
+      return createCodeFence(JSON.stringify(parsedOutput, null, 2), "json");
     } catch {
-      // Not valid JSON, return as-is
+      // Not serializable, continue to plain fallback.
     }
   }
+
+  if (trimmed) {
+    return renderOutputSection("Output", trimmed);
+  }
+
   return text;
+}
+
+function normalizeToolName(value: string | undefined): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function hasToolSuffix(normalizedName: string, suffix: string): boolean {
+  return normalizedName === suffix || new RegExp(`(^|[.:/_-])${suffix}$`).test(normalizedName);
+}
+
+function isReadToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "read");
+}
+
+function isEditToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "edit");
+}
+
+function isWriteToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "write");
+}
+
+function isExecToolName(normalizedName: string): boolean {
+  return (
+    hasToolSuffix(normalizedName, "exec") ||
+    hasToolSuffix(normalizedName, "bash") ||
+    hasToolSuffix(normalizedName, "process") ||
+    hasToolSuffix(normalizedName, "exec_command")
+  );
+}
+
+function isWebFetchToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "web_fetch") || hasToolSuffix(normalizedName, "fetch");
+}
+
+function isWebSearchToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "web_search") || hasToolSuffix(normalizedName, "search");
+}
+
+function isBrowserToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "browser") || hasToolSuffix(normalizedName, "playwright");
+}
+
+function isMessagingToolName(normalizedName: string): boolean {
+  return (
+    hasToolSuffix(normalizedName, "discord") ||
+    hasToolSuffix(normalizedName, "slack") ||
+    hasToolSuffix(normalizedName, "sendmessage") ||
+    hasToolSuffix(normalizedName, "readmessages")
+  );
+}
+
+function isNodesToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "nodes") || hasToolSuffix(normalizedName, "node");
+}
+
+function isGatewayToolName(normalizedName: string): boolean {
+  return hasToolSuffix(normalizedName, "gateway");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function pickValue(record: Record<string, unknown> | null, keys: string[]): unknown {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickString(record: Record<string, unknown> | null, keys: string[]): string | null {
+  const value = pickValue(record, keys);
+  return toOptionalString(value);
+}
+
+function pickNumber(record: Record<string, unknown> | null, keys: string[]): number | null {
+  const value = pickValue(record, keys);
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const num = Number(value);
+    if (Number.isFinite(num)) {
+      return num;
+    }
+  }
+  return null;
+}
+
+function pickBoolean(record: Record<string, unknown> | null, keys: string[]): boolean | null {
+  const value = pickValue(record, keys);
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (lowered === "true") {
+      return true;
+    }
+    if (lowered === "false") {
+      return false;
+    }
+  }
+  return null;
+}
+
+function toOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolvePath(value: unknown): string | null {
+  const record = asRecord(value);
+  return pickString(record, ["path", "file_path", "filePath"]);
+}
+
+function resolveDuration(durationMs: number | null): string | null {
+  if (durationMs === null) {
+    return null;
+  }
+  if (durationMs < 1_000) {
+    return `${durationMs} ms`;
+  }
+  return `${(durationMs / 1_000).toFixed(durationMs >= 10_000 ? 0 : 2)} s`;
+}
+
+function truncateForPreview(text: string, maxChars = 4_000): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}\n... truncated (${text.length} chars total)`;
+}
+
+function appendBullet(lines: string[], label: string, value: string | number | null | undefined) {
+  if (value === null || value === undefined) {
+    return;
+  }
+  const rendered = typeof value === "number" ? String(value) : value;
+  if (!rendered.trim()) {
+    return;
+  }
+  lines.push(`- **${label}:** ${rendered}`);
+}
+
+function renderOutputSection(title: string, output: string, language = "text"): string {
+  return [`### ${title}`, "", createCodeFence(output, language)].join("\n");
+}
+
+function createCodeFence(content: string, language = ""): string {
+  const runs = content.match(/`+/g) ?? [];
+  const requiredLength = runs.reduce((max, run) => Math.max(max, run.length + 1), 3);
+  const fence = "`".repeat(requiredLength);
+  const lang = language.trim();
+  return `${fence}${lang}\n${content}\n${fence}`;
+}
+
+function parseJsonLoose(value: string): unknown {
+  if (!value || (!value.startsWith("{") && !value.startsWith("["))) {
+    return null;
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function extractTextFromContentArray(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const parts = value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const record = entry as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        return record.text;
+      }
+      return null;
+    })
+    .filter((part): part is string => Boolean(part));
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join("\n");
+}
+
+function extractOutputText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const simpleArray = value
+      .map((entry) => (typeof entry === "string" ? entry : null))
+      .filter((entry): entry is string => Boolean(entry));
+    if (simpleArray.length > 0) {
+      return simpleArray.join("\n");
+    }
+    return extractTextFromContentArray(value);
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const directText =
+    pickString(record, ["text", "content", "body", "stdout", "stderr", "output", "result"]) ??
+    extractTextFromContentArray(record.content);
+  if (directText) {
+    return directText;
+  }
+  return null;
+}
+
+function formatReadToolOutput(context: ToolFormatContext): string | null {
+  if (!isReadToolName(context.toolName)) {
+    return null;
+  }
+  const entries = collectReadEntries(context);
+  if (entries.length === 0) {
+    return null;
+  }
+  const lines = ["### Read Files", ""];
+  for (const entry of entries) {
+    const pathLabel = entry.path ?? "(unknown path)";
+    lines.push(`- \`${pathLabel}\``);
+  }
+  const entriesWithContent = entries.filter((entry) => typeof entry.content === "string");
+  if (entriesWithContent.length === 0) {
+    lines.push("", "_No file content captured in tool output._");
+    return lines.join("\n");
+  }
+
+  for (const [index, entry] of entriesWithContent.entries()) {
+    const sectionTitle = entry.path ?? `File ${index + 1}`;
+    lines.push("", `#### ${sectionTitle}`, "", createCodeFence(entry.content!, "text"));
+  }
+  return lines.join("\n");
+}
+
+function collectReadEntries(context: ToolFormatContext): ReadEntry[] {
+  const entries: ReadEntry[] = [];
+  collectReadEntriesFromValue(context.parsedOutput, entries);
+
+  const argPath = resolvePath(context.argsRecord);
+  const normalizedRawText = context.rawText.trim() ? context.rawText : null;
+  if (entries.length === 0 && (argPath || normalizedRawText)) {
+    entries.push({
+      path: argPath,
+      content: normalizedRawText,
+    });
+  }
+
+  return dedupeReadEntries(entries);
+}
+
+function collectReadEntriesFromValue(value: unknown, out: ReadEntry[]) {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectReadEntriesFromValue(entry, out);
+    }
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return;
+  }
+
+  const path = resolvePath(record);
+  const content =
+    pickString(record, ["content", "text"]) ?? extractTextFromContentArray(record.content);
+  if (path || content) {
+    out.push({ path, content });
+  }
+
+  const files = record.files;
+  if (Array.isArray(files)) {
+    collectReadEntriesFromValue(files, out);
+  }
+}
+
+function dedupeReadEntries(entries: ReadEntry[]): ReadEntry[] {
+  const seen = new Set<string>();
+  const out: ReadEntry[] = [];
+  for (const entry of entries) {
+    const path = entry.path?.trim() || null;
+    const content = entry.content ?? null;
+    if (!path && !content) {
+      continue;
+    }
+    const key = `${path ?? ""}\u0000${content ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push({ path, content });
+  }
+  return out;
+}
+
+function formatEditToolOutput(context: ToolFormatContext): string | null {
+  if (!isEditToolName(context.toolName)) {
+    return null;
+  }
+  const record = context.argsRecord;
+  const oldText = pickString(record, ["old_string", "oldText"]);
+  const newText = pickString(record, ["new_string", "newText", "content"]);
+  if (oldText == null || newText == null) {
+    return null;
+  }
+  const oldLines = oldText.replace(/\r\n/g, "\n").split("\n");
+  const newLines = newText.replace(/\r\n/g, "\n").split("\n");
+  const diffBody = createLineDiff(oldLines, newLines);
+  const path = resolvePath(record);
+  const lines = ["### Edit Diff"];
+  if (path) {
+    lines.push("", `**File:** \`${path}\``);
+  }
+  lines.push("", createCodeFence(diffBody, "diff"));
+  return lines.join("\n");
+}
+
+function formatWriteToolOutput(context: ToolFormatContext): string | null {
+  if (!isWriteToolName(context.toolName)) {
+    return null;
+  }
+
+  const outputRecord = asRecord(context.parsedOutput);
+  const path = resolvePath(context.argsRecord) ?? resolvePath(outputRecord);
+  const bytes =
+    pickNumber(outputRecord, ["bytes", "size", "written", "writtenBytes"]) ??
+    pickNumber(context.argsRecord, ["bytes", "size"]);
+  const append = pickBoolean(context.argsRecord, ["append"]);
+  const created = pickBoolean(outputRecord, ["created", "isNew"]);
+  const updated = pickBoolean(outputRecord, ["updated", "overwritten", "replaced"]);
+
+  let mode: string | null = null;
+  if (created === true) {
+    mode = "created";
+  } else if (updated === true) {
+    mode = "updated";
+  } else if (append === true) {
+    mode = "appended";
+  }
+
+  const preview =
+    pickString(context.argsRecord, ["content", "text"]) ??
+    pickString(outputRecord, ["content", "text"]) ??
+    extractTextFromContentArray(outputRecord?.content);
+
+  const lines = ["### Write Result", ""];
+  appendBullet(lines, "File", path ? `\`${path}\`` : null);
+  appendBullet(lines, "Bytes", bytes);
+  appendBullet(lines, "Mode", mode);
+
+  if (preview) {
+    lines.push(
+      "",
+      "#### Content Preview",
+      "",
+      createCodeFence(truncateForPreview(preview), "text"),
+    );
+  } else if (context.trimmedText && context.parsedOutput == null) {
+    lines.push("", createCodeFence(context.trimmedText, "text"));
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatExecToolOutput(context: ToolFormatContext): string | null {
+  if (!isExecToolName(context.toolName)) {
+    return null;
+  }
+  const outputRecord = asRecord(context.parsedOutput);
+  const command = pickString(context.argsRecord, ["command", "cmd", "script"]);
+  const exitCode = pickNumber(outputRecord, ["exitCode", "exit_code", "status", "code"]);
+  const durationMs = pickNumber(outputRecord, [
+    "durationMs",
+    "duration_ms",
+    "elapsedMs",
+    "elapsed",
+  ]);
+  const cwd =
+    pickString(outputRecord, ["cwd", "workdir", "workingDirectory"]) ??
+    pickString(context.argsRecord, ["cwd", "workdir"]);
+  const stdout =
+    pickString(outputRecord, ["stdout"]) ?? extractTextFromContentArray(outputRecord?.stdout);
+  const stderr = pickString(outputRecord, ["stderr", "error", "err"]);
+  const genericOutput = extractOutputText(context.parsedOutput);
+
+  const lines = ["### Execution Result", ""];
+  appendBullet(lines, "Command", command ? `\`${command}\`` : null);
+  appendBullet(lines, "Exit Code", exitCode);
+  appendBullet(lines, "Duration", resolveDuration(durationMs));
+  appendBullet(lines, "Working Dir", cwd ? `\`${cwd}\`` : null);
+
+  if (stdout) {
+    lines.push("", "#### Stdout", "", createCodeFence(truncateForPreview(stdout), "text"));
+  }
+  if (stderr) {
+    lines.push("", "#### Stderr", "", createCodeFence(truncateForPreview(stderr), "text"));
+  }
+
+  if (!stdout && !stderr && genericOutput && genericOutput !== context.trimmedText) {
+    lines.push("", "#### Output", "", createCodeFence(truncateForPreview(genericOutput), "text"));
+  }
+  if (!stdout && !stderr && !genericOutput && context.trimmedText && context.parsedOutput == null) {
+    lines.push(
+      "",
+      "#### Output",
+      "",
+      createCodeFence(truncateForPreview(context.trimmedText), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatWebFetchToolOutput(context: ToolFormatContext): string | null {
+  if (!isWebFetchToolName(context.toolName)) {
+    return null;
+  }
+
+  const outputRecord = asRecord(context.parsedOutput);
+  const url =
+    pickString(context.argsRecord, ["url", "targetUrl"]) ??
+    pickString(outputRecord, ["url", "targetUrl", "finalUrl", "final_url"]);
+  const status =
+    pickNumber(outputRecord, ["status", "statusCode", "status_code"]) ??
+    pickString(outputRecord, ["status", "statusCode", "status_code"]);
+  const contentType = pickString(outputRecord, ["contentType", "content_type", "mimeType"]);
+  const method = pickString(context.argsRecord, ["method"]);
+  const body =
+    pickString(outputRecord, ["content", "text", "body", "markdown", "html"]) ??
+    extractTextFromContentArray(outputRecord?.content) ??
+    (context.parsedOutput == null ? context.trimmedText : null);
+
+  const lines = ["### Fetch Result", ""];
+  appendBullet(lines, "URL", url ?? null);
+  appendBullet(lines, "Method", method);
+  appendBullet(lines, "Status", status ? String(status) : null);
+  appendBullet(lines, "Content Type", contentType);
+
+  if (body) {
+    lines.push(
+      "",
+      "#### Body Preview",
+      "",
+      createCodeFence(truncateForPreview(body, 8_000), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatWebSearchToolOutput(context: ToolFormatContext): string | null {
+  if (!isWebSearchToolName(context.toolName)) {
+    return null;
+  }
+
+  const results = collectSearchResults(context.parsedOutput);
+  const query = pickString(context.argsRecord, ["query", "q", "search"]);
+  if (results.length === 0 && !query && !context.trimmedText) {
+    return null;
+  }
+
+  const lines = ["### Search Results", ""];
+  appendBullet(lines, "Query", query ? `\`${query}\`` : null);
+  appendBullet(lines, "Matches", results.length);
+
+  if (results.length === 0 && context.trimmedText) {
+    lines.push("", createCodeFence(truncateForPreview(context.trimmedText), "text"));
+    return lines.join("\n");
+  }
+
+  const limit = Math.min(results.length, 10);
+  for (let index = 0; index < limit; index += 1) {
+    const result = results[index];
+    lines.push("", `#### ${index + 1}. ${result.title}`);
+    appendBullet(lines, "URL", result.url);
+    appendBullet(lines, "Source", result.source);
+    if (result.snippet) {
+      lines.push("", createCodeFence(truncateForPreview(result.snippet, 2_000), "text"));
+    }
+  }
+
+  if (results.length > limit) {
+    lines.push("", `_Showing first ${limit} of ${results.length} results._`);
+  }
+  return lines.join("\n");
+}
+
+function collectSearchResults(value: unknown): SearchResult[] {
+  const out: SearchResult[] = [];
+  const pushResult = (entry: unknown) => {
+    const record = asRecord(entry);
+    if (!record) {
+      return;
+    }
+    const title =
+      pickString(record, ["title", "name", "headline"]) ??
+      pickString(record, ["url", "link"]) ??
+      "Result";
+    const url = pickString(record, ["url", "link"]);
+    const snippet = pickString(record, ["snippet", "text", "description", "content"]);
+    const source = pickString(record, ["source", "domain", "site"]);
+    out.push({ title, url, snippet, source });
+  };
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      pushResult(entry);
+    }
+    return out;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return out;
+  }
+
+  const containers = [
+    record.results,
+    record.items,
+    record.hits,
+    record.data,
+    record.documents,
+    record.web,
+  ];
+  for (const container of containers) {
+    if (!Array.isArray(container)) {
+      continue;
+    }
+    for (const entry of container) {
+      pushResult(entry);
+    }
+  }
+
+  if (out.length === 0) {
+    pushResult(record);
+  }
+
+  return out;
+}
+
+function formatBrowserToolOutput(context: ToolFormatContext): string | null {
+  if (!isBrowserToolName(context.toolName)) {
+    return null;
+  }
+  const action = pickString(context.argsRecord, ["action", "fn", "tool"]) ?? "act";
+  const target =
+    pickString(context.argsRecord, ["targetUrl", "url", "targetId", "ref", "element"]) ??
+    pickString(context.argsRecord, ["node", "nodeId"]);
+  const outputText =
+    extractOutputText(context.parsedOutput) ??
+    (context.parsedOutput == null ? context.trimmedText : null);
+
+  const lines = ["### Browser Action", ""];
+  appendBullet(lines, "Action", action);
+  appendBullet(lines, "Target", target);
+
+  if (outputText) {
+    lines.push(
+      "",
+      "#### Result",
+      "",
+      createCodeFence(truncateForPreview(outputText, 8_000), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatMessagingToolOutput(context: ToolFormatContext): string | null {
+  if (!isMessagingToolName(context.toolName)) {
+    return null;
+  }
+  const channel = hasToolSuffix(context.toolName, "discord") ? "Discord" : "Slack";
+  const action = pickString(context.argsRecord, ["action", "fn", "tool"]) ?? "operation";
+  const target =
+    pickString(context.argsRecord, ["to", "channelId", "guildId", "userId"]) ??
+    pickString(context.argsRecord, ["messageId"]);
+  const messagePreview = pickString(context.argsRecord, ["content", "text", "question"]);
+  const outputText =
+    extractOutputText(context.parsedOutput) ??
+    (context.parsedOutput == null ? context.trimmedText : null);
+
+  const lines = [`### ${channel} Action`, ""];
+  appendBullet(lines, "Action", action);
+  appendBullet(lines, "Target", target);
+  if (messagePreview) {
+    lines.push(
+      "",
+      "#### Message Preview",
+      "",
+      createCodeFence(truncateForPreview(messagePreview, 2_000), "text"),
+    );
+  }
+  if (outputText) {
+    lines.push(
+      "",
+      "#### Result",
+      "",
+      createCodeFence(truncateForPreview(outputText, 8_000), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatNodesToolOutput(context: ToolFormatContext): string | null {
+  if (!isNodesToolName(context.toolName)) {
+    return null;
+  }
+  const action = pickString(context.argsRecord, ["action", "fn", "tool"]) ?? "operation";
+  const node = pickString(context.argsRecord, ["node", "nodeId", "id"]);
+  const duration =
+    pickNumber(context.argsRecord, ["durationMs", "duration_ms", "duration"]) ??
+    pickNumber(asRecord(context.parsedOutput), ["durationMs", "duration_ms", "duration"]);
+  const media = pickString(context.argsRecord, ["facing", "deviceId", "screenIndex"]);
+  const outputText =
+    extractOutputText(context.parsedOutput) ??
+    (context.parsedOutput == null ? context.trimmedText : null);
+
+  const lines = ["### Node Action", ""];
+  appendBullet(lines, "Action", action);
+  appendBullet(lines, "Node", node);
+  appendBullet(lines, "Duration", resolveDuration(duration));
+  appendBullet(lines, "Media", media);
+  if (outputText) {
+    lines.push(
+      "",
+      "#### Result",
+      "",
+      createCodeFence(truncateForPreview(outputText, 8_000), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function formatGatewayToolOutput(context: ToolFormatContext): string | null {
+  if (!isGatewayToolName(context.toolName)) {
+    return null;
+  }
+  const action = pickString(context.argsRecord, ["action", "fn", "tool"]) ?? "operation";
+  const reason = pickString(context.argsRecord, ["reason"]);
+  const delay =
+    pickNumber(context.argsRecord, ["delayMs", "restartDelayMs"]) ??
+    pickNumber(asRecord(context.parsedOutput), ["delayMs", "restartDelayMs"]);
+  const outputText =
+    extractOutputText(context.parsedOutput) ??
+    (context.parsedOutput == null ? context.trimmedText : null);
+
+  const lines = ["### Gateway Action", ""];
+  appendBullet(lines, "Action", action);
+  appendBullet(lines, "Reason", reason);
+  appendBullet(lines, "Delay", resolveDuration(delay));
+  if (outputText) {
+    lines.push(
+      "",
+      "#### Result",
+      "",
+      createCodeFence(truncateForPreview(outputText, 8_000), "text"),
+    );
+  }
+
+  if (lines.length <= 2 && !context.trimmedText) {
+    return null;
+  }
+  return lines.join("\n");
+}
+
+function createLineDiff(oldLines: string[], newLines: string[]): string {
+  const maxGrid = 50_000;
+  if (oldLines.length * newLines.length > maxGrid) {
+    const removed = oldLines.map((line) => `-${line}`);
+    const added = newLines.map((line) => `+${line}`);
+    return [...removed, ...added].join("\n");
+  }
+
+  const rows = oldLines.length + 1;
+  const cols = newLines.length + 1;
+  const lcs = Array.from({ length: rows }, () => Array.from({ length: cols }, () => 0));
+
+  for (let i = oldLines.length - 1; i >= 0; i -= 1) {
+    for (let j = newLines.length - 1; j >= 0; j -= 1) {
+      if (oldLines[i] === newLines[j]) {
+        lcs[i][j] = lcs[i + 1][j + 1] + 1;
+      } else {
+        lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      }
+    }
+  }
+
+  const out: string[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldLines.length && j < newLines.length) {
+    if (oldLines[i] === newLines[j]) {
+      out.push(` ${oldLines[i]}`);
+      i += 1;
+      j += 1;
+      continue;
+    }
+    if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push(`-${oldLines[i]}`);
+      i += 1;
+      continue;
+    }
+    out.push(`+${newLines[j]}`);
+    j += 1;
+  }
+
+  while (i < oldLines.length) {
+    out.push(`-${oldLines[i]}`);
+    i += 1;
+  }
+  while (j < newLines.length) {
+    out.push(`+${newLines[j]}`);
+    j += 1;
+  }
+  return out.join("\n");
 }
 
 /**

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
+import {
+  handleChatEvent,
+  loadChatHistory,
+  syncChatHistoryDuringRun,
+  type ChatEventPayload,
+  type ChatState,
+} from "./chat.ts";
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
@@ -34,6 +40,49 @@ describe("handleChatEvent", () => {
       state: "final",
     };
     expect(handleChatEvent(state, payload)).toBe(null);
+  });
+
+  it("accepts own-run final events even when sessionKey alias differs", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "in progress",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+
+  it("accepts same-session final events for main alias without run id match", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "done via alias" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toHaveLength(1);
   });
 
   it("returns null for delta from another run", () => {
@@ -564,5 +613,88 @@ describe("loadChatHistory", () => {
     expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
     expect(state.lastError).toBeNull();
+  });
+});
+
+describe("syncChatHistoryDuringRun", () => {
+  it("applies history while run/session context is unchanged", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "fresh" }] }],
+      thinkingLevel: "high",
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [],
+      chatThinkingLevel: null,
+    });
+
+    await syncChatHistoryDuringRun(state);
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "fresh" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("high");
+  });
+
+  it("filters silent assistant replies while syncing history", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [
+        { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+        { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+        { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
+      ],
+      thinkingLevel: "high",
+    });
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [],
+      chatThinkingLevel: null,
+    });
+
+    await syncChatHistoryDuringRun(state);
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
+      { role: "user", content: [{ type: "text", text: "NO_REPLY" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("high");
+  });
+
+  it("drops stale poll responses when active run changes in flight", async () => {
+    let resolveRequest:
+      | ((value: { messages?: Array<unknown>; thinkingLevel?: string }) => void)
+      | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<{ messages?: Array<unknown>; thinkingLevel?: string }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    const originalMessages = [{ role: "assistant", content: [{ type: "text", text: "current" }] }];
+    const state = createState({
+      client: { request } as unknown as ChatState["client"],
+      connected: true,
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: originalMessages,
+      chatThinkingLevel: "medium",
+    });
+
+    const pending = syncChatHistoryDuringRun(state);
+    state.chatRunId = "run-2";
+    resolveRequest?.({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "stale" }] }],
+      thinkingLevel: "high",
+    });
+    await pending;
+
+    expect(state.chatMessages).toBe(originalMessages);
+    expect(state.chatThinkingLevel).toBe("medium");
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,3 +1,4 @@
+import { parseAgentSessionKey } from "../../../../src/sessions/session-key-utils.js";
 import { extractText } from "../chat/message-extract.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ChatAttachment } from "../ui-types.ts";
@@ -50,6 +51,36 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
+function normalizeSessionKey(value: string | undefined | null): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function sessionKeysEquivalent(left: string | undefined | null, right: string | undefined | null) {
+  const normalizedLeft = normalizeSessionKey(left);
+  const normalizedRight = normalizeSessionKey(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  if (normalizedLeft === normalizedRight) {
+    return true;
+  }
+
+  const parsedLeft = parseAgentSessionKey(normalizedLeft);
+  const parsedRight = parseAgentSessionKey(normalizedRight);
+  if (parsedLeft && parsedRight) {
+    return parsedLeft.agentId === parsedRight.agentId && parsedLeft.rest === parsedRight.rest;
+  }
+
+  if (parsedLeft && parsedLeft.agentId === "main" && parsedLeft.rest === normalizedRight) {
+    return true;
+  }
+  if (parsedRight && parsedRight.agentId === "main" && parsedRight.rest === normalizedLeft) {
+    return true;
+  }
+
+  return false;
+}
+
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
@@ -71,6 +102,40 @@ export async function loadChatHistory(state: ChatState) {
     state.lastError = String(err);
   } finally {
     state.chatLoading = false;
+  }
+}
+
+export async function syncChatHistoryDuringRun(state: ChatState) {
+  if (!state.client || !state.connected || !state.chatRunId) {
+    return;
+  }
+  const requestClient = state.client;
+  const requestRunId = state.chatRunId;
+  const requestSessionKey = state.sessionKey;
+  try {
+    const res = await requestClient.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
+      "chat.history",
+      {
+        sessionKey: requestSessionKey,
+        limit: 200,
+      },
+    );
+    if (!state.client || state.client !== requestClient || !state.connected) {
+      return;
+    }
+    if (!state.chatRunId || state.chatRunId !== requestRunId) {
+      return;
+    }
+    if (!sessionKeysEquivalent(state.sessionKey, requestSessionKey)) {
+      return;
+    }
+    const nextMessages = Array.isArray(res.messages) ? res.messages : [];
+    state.chatMessages = nextMessages.filter((message) => !isAssistantSilentReply(message));
+    if (typeof res.thinkingLevel === "string") {
+      state.chatThinkingLevel = res.thinkingLevel;
+    }
+  } catch {
+    // Best-effort realtime sync while a run is active.
   }
 }
 
@@ -245,7 +310,10 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
   }
-  if (payload.sessionKey !== state.sessionKey) {
+  const sameSession = sessionKeysEquivalent(payload.sessionKey, state.sessionKey);
+  const runMatchesActive =
+    Boolean(payload.runId) && Boolean(state.chatRunId) && payload.runId === state.chatRunId;
+  if (!sameSession && !runMatchesActive) {
     return null;
   }
 

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteSession, deleteSessionAndRefresh, type SessionsState } from "./sessions.ts";
+import {
+  deleteSession,
+  deleteSessionAndRefresh,
+  loadSessions,
+  type SessionsState,
+} from "./sessions.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -100,5 +105,26 @@ describe("deleteSession", () => {
 
     expect(deleted).toBe(false);
     expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadSessions", () => {
+  it("forwards agentId filter when provided", async () => {
+    const request = vi.fn(async () => undefined);
+    const state = createState(request, {
+      sessionsIncludeGlobal: false,
+      sessionsIncludeUnknown: false,
+      sessionsFilterActive: "0",
+      sessionsFilterLimit: "0",
+    });
+
+    await loadSessions(state, { agentId: "  helper-agent  " });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeGlobal: false,
+      includeUnknown: false,
+      agentId: "helper-agent",
+    });
   });
 });

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -21,6 +21,7 @@ export async function loadSessions(
     limit?: number;
     includeGlobal?: boolean;
     includeUnknown?: boolean;
+    agentId?: string;
   },
 ) {
   if (!state.client || !state.connected) {
@@ -40,6 +41,10 @@ export async function loadSessions(
       includeGlobal,
       includeUnknown,
     };
+    const agentId = overrides?.agentId?.trim();
+    if (agentId) {
+      params.agentId = agentId;
+    }
     if (activeMinutes > 0) {
       params.activeMinutes = activeMinutes;
     }

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -1,5 +1,6 @@
 import { buildDeviceAuthPayload } from "../../../src/gateway/device-auth.js";
 import {
+  GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   type GatewayClientMode,
@@ -241,7 +242,7 @@ export class GatewayBrowserClient {
       role,
       scopes,
       device,
-      caps: [],
+      caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
       auth,
       userAgent: navigator.userAgent,
       locale: navigator.language,

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -29,6 +29,19 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
+  it("adds per-line classes for diff code blocks", () => {
+    const html = toSanitizedMarkdownHtml(
+      ["```diff", "--- a.txt", "+++ b.txt", "@@ -1 +1 @@", "-old", "+new", " same", "```"].join(
+        "\n",
+      ),
+    );
+    expect(html).toContain("code-block--diff");
+    expect(html).toContain("diff-line diff-line--meta");
+    expect(html).toContain("diff-line diff-line--hunk");
+    expect(html).toContain("diff-line diff-line--del");
+    expect(html).toContain("diff-line diff-line--add");
+  });
+
   it("preserves img tags with src and alt from markdown images (#15437)", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
     expect(html).toContain("<img");

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -105,10 +105,11 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     const escaped = escapeHtml(`${truncated.text}${suffix}`);
     const html = `<pre class="code-block">${escaped}</pre>`;
     const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
+    const enhanced = decorateDiffCodeBlocks(sanitized);
     if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
-      setCachedMarkdown(input, sanitized);
+      setCachedMarkdown(input, enhanced);
     }
-    return sanitized;
+    return enhanced;
   }
   const rendered = marked.parse(`${truncated.text}${suffix}`, {
     renderer: htmlEscapeRenderer,
@@ -116,10 +117,11 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     breaks: true,
   }) as string;
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
+  const enhanced = decorateDiffCodeBlocks(sanitized);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
-    setCachedMarkdown(input, sanitized);
+    setCachedMarkdown(input, enhanced);
   }
-  return sanitized;
+  return enhanced;
 }
 
 // Prevent raw HTML in chat messages from being rendered as formatted HTML.
@@ -136,4 +138,41 @@ function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+function decorateDiffCodeBlocks(html: string): string {
+  return html.replace(
+    /<pre><code class="([^"]*\blanguage-diff\b[^"]*)">([\s\S]*?)<\/code><\/pre>/g,
+    (_match, classNames: string, diffContent: string) => {
+      const renderedLines = renderDiffLines(diffContent);
+      return `<pre class="code-block code-block--diff"><code class="${classNames}">${renderedLines}</code></pre>`;
+    },
+  );
+}
+
+function renderDiffLines(diffContent: string): string {
+  return diffContent
+    .split("\n")
+    .map((line) => {
+      const lineClass = classifyDiffLine(line);
+      const content = line.length > 0 ? line : " ";
+      return `<span class="diff-line ${lineClass}">${content}</span>`;
+    })
+    .join("\n");
+}
+
+function classifyDiffLine(line: string): string {
+  if (line.startsWith("@@")) {
+    return "diff-line--hunk";
+  }
+  if (line.startsWith("+++ ") || line.startsWith("--- ")) {
+    return "diff-line--meta";
+  }
+  if (line.startsWith("+")) {
+    return "diff-line--add";
+  }
+  if (line.startsWith("-")) {
+    return "diff-line--del";
+  }
+  return "diff-line--context";
 }

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -74,9 +74,34 @@ describe("control UI routing", () => {
 
     await app.updateComplete;
     expect(app.tab).toBe("chat");
-    expect(app.sessionKey).toBe("main");
+    expect(app.sessionKey).toBe("agent:main:main");
     expect(window.location.pathname).toBe("/chat");
-    expect(window.location.search).toBe("?session=main");
+    expect(window.location.search).toBe("?session=agent%3Amain%3Amain");
+  });
+
+  it("renders the chat agent picker in nav when agent list is available", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    app.agentsList = {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "global",
+      agents: [
+        { id: "main", name: "Main Agent" },
+        { id: "coder", identity: { name: "Coder Agent" } },
+      ],
+    };
+    app.agentsSelectedId = "main";
+    await app.updateComplete;
+
+    const picker = app.querySelector(".nav-chat-agent-picker");
+    expect(picker).not.toBeNull();
+    const options = app.querySelectorAll(".nav-item--agent");
+    expect(options.length).toBe(2);
+    const text = picker?.textContent ?? "";
+    expect(text).toContain("Main Agent");
+    expect(text).toContain("Coder Agent");
   });
 
   it("keeps chat and nav usable on narrow viewports", async () => {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -12,6 +12,7 @@ export type UiSettings = {
   theme: ThemeMode;
   chatFocusMode: boolean;
   chatShowThinking: boolean;
+  chatShowInlineToolFlow: boolean;
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
   navCollapsed: boolean; // Collapsible sidebar state
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
@@ -39,6 +40,7 @@ export function loadSettings(): UiSettings {
     theme: "system",
     chatFocusMode: false,
     chatShowThinking: true,
+    chatShowInlineToolFlow: false,
     splitRatio: 0.6,
     navCollapsed: false,
     navGroupsCollapsed: {},
@@ -50,6 +52,18 @@ export function loadSettings(): UiSettings {
       return defaults;
     }
     const parsed = JSON.parse(raw) as Partial<UiSettings>;
+    const parsedShowThinking =
+      typeof parsed.chatShowThinking === "boolean"
+        ? parsed.chatShowThinking
+        : defaults.chatShowThinking;
+    const parsedShowInlineToolFlow =
+      typeof parsed.chatShowInlineToolFlow === "boolean"
+        ? parsed.chatShowInlineToolFlow
+        : defaults.chatShowInlineToolFlow;
+    // Keep toggle modes mutually exclusive; prefer inline flow when both were previously enabled.
+    const chatShowInlineToolFlow = parsedShowInlineToolFlow;
+    const chatShowThinking =
+      parsedShowInlineToolFlow && parsedShowThinking ? false : parsedShowThinking;
     return {
       gatewayUrl:
         typeof parsed.gatewayUrl === "string" && parsed.gatewayUrl.trim()
@@ -71,10 +85,8 @@ export function loadSettings(): UiSettings {
           : defaults.theme,
       chatFocusMode:
         typeof parsed.chatFocusMode === "boolean" ? parsed.chatFocusMode : defaults.chatFocusMode,
-      chatShowThinking:
-        typeof parsed.chatShowThinking === "boolean"
-          ? parsed.chatShowThinking
-          : defaults.chatShowThinking,
+      chatShowThinking,
+      chatShowInlineToolFlow,
       splitRatio:
         typeof parsed.splitRatio === "number" &&
         parsed.splitRatio >= 0.4 &&

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -42,4 +42,5 @@ export type ToolCard = {
   args?: unknown;
   text?: string;
   toolCallId?: string;
+  runId?: string;
 };

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -41,4 +41,5 @@ export type ToolCard = {
   name: string;
   args?: unknown;
   text?: string;
+  toolCallId?: string;
 };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -19,6 +19,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onSessionKeyChange: () => undefined,
     thinkingLevel: null,
     showThinking: false,
+    showInlineToolFlow: false,
     loading: false,
     sending: false,
     canAbort: false,
@@ -50,6 +51,376 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
 }
 
 describe("chat view", () => {
+  it("shows reasoning while hiding tool details in main thread when reasoning is enabled", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          sessions: {
+            ...createSessions(),
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                reasoningLevel: "medium",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "step one then step two" },
+                { type: "text", text: "Final answer text" },
+              ],
+              timestamp: Date.now(),
+            },
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "history-tool-1",
+              content: [{ type: "text", text: "HISTORY TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "live-tool-1",
+              content: [{ type: "text", text: "LIVE TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const thread = container.querySelector(".chat-thread");
+    const threadText = thread?.textContent ?? "";
+    expect(threadText).toContain("Reasoning:");
+    expect(threadText).toContain("step one then step two");
+    expect(threadText).toContain("Final answer text");
+    expect(threadText).not.toContain("HISTORY TOOL DETAILS");
+    expect(threadText).not.toContain("LIVE TOOL DETAILS");
+  });
+
+  it("uses hidden tool-stream output to enrich assistant exec cards when inline tool flow is off", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          showInlineToolFlow: false,
+          sessions: {
+            ...createSessions(),
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                reasoningLevel: "medium",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "toolcall",
+                  name: "exec",
+                  arguments: {
+                    command: "openclaw system --help",
+                    cwd: "C:\\Users\\test\\.openclaw\\workspace",
+                  },
+                },
+                {
+                  type: "toolresult",
+                  name: "exec",
+                  text: "Command: openclaw system --help\nWorking Dir: C:\\Users\\test\\.openclaw\\workspace",
+                },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              toolName: "exec",
+              content: [
+                {
+                  type: "text",
+                  text: "Usage: openclaw system [options] [command]\nSystem tools...",
+                },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const threadText = container.querySelector(".chat-thread")?.textContent ?? "";
+    expect(threadText).toContain("Usage: openclaw system [options] [command]");
+    expect(threadText).not.toContain("Working Dir: C:\\Users\\test\\.openclaw\\workspace");
+  });
+
+  it("shows detailed tool flow inline when both thinking and inline flow are enabled", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          showInlineToolFlow: true,
+          sessions: {
+            ...createSessions(),
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                reasoningLevel: "medium",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "step one then step two" },
+                { type: "text", text: "Final answer text" },
+              ],
+              timestamp: Date.now(),
+            },
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "history-tool-1",
+              content: [{ type: "text", text: "HISTORY TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "live-tool-1",
+              content: [{ type: "text", text: "LIVE TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const thread = container.querySelector(".chat-thread");
+    const threadText = thread?.textContent ?? "";
+    expect(threadText).toContain("Reasoning:");
+    expect(threadText).toContain("Final answer text");
+    expect(threadText).toContain("HISTORY TOOL DETAILS");
+    expect(threadText).toContain("LIVE TOOL DETAILS");
+  });
+
+  it("shows full inline flow when only inline flow is enabled", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: false,
+          showInlineToolFlow: true,
+          sessions: {
+            ...createSessions(),
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                reasoningLevel: "medium",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "single-toggle reasoning" },
+                { type: "text", text: "Single-toggle final answer" },
+              ],
+              timestamp: Date.now(),
+            },
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "history-tool-inline-only",
+              content: [{ type: "text", text: "INLINE ONLY HISTORY TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              toolName: "read",
+              toolCallId: "live-tool-inline-only",
+              content: [{ type: "text", text: "INLINE ONLY LIVE TOOL DETAILS" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const thread = container.querySelector(".chat-thread");
+    const threadText = thread?.textContent ?? "";
+    expect(threadText).toContain("Reasoning:");
+    expect(threadText).toContain("single-toggle reasoning");
+    expect(threadText).toContain("Single-toggle final answer");
+    expect(threadText).toContain("INLINE ONLY HISTORY TOOL DETAILS");
+    expect(threadText).toContain("INLINE ONLY LIVE TOOL DETAILS");
+  });
+
+  it("deduplicates inline tool cards that already exist in history", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showInlineToolFlow: true,
+          sessions: {
+            ...createSessions(),
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: Date.now(),
+                reasoningLevel: "medium",
+              },
+            ],
+          },
+          messages: [
+            {
+              role: "assistant",
+              toolCallId: "dup-web-fetch-1",
+              content: [
+                { type: "text", text: "Summary before tool card" },
+                {
+                  type: "toolcall",
+                  name: "web_fetch",
+                  arguments: { url: "https://api-docs.deepseek.com/quick_start/pricing" },
+                },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              toolName: "web_fetch",
+              toolCallId: "dup-web-fetch-1",
+              content: [{ type: "text", text: "LIVE TOOL DETAILS THAT SHOULD NOT DUPLICATE CARD" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const cards = container.querySelectorAll(".chat-tool-card");
+    expect(cards.length).toBe(1);
+    const threadText = container.querySelector(".chat-thread")?.textContent ?? "";
+    expect(threadText).toContain("Summary before tool card");
+  });
+
+  it("keeps live inline tool cards when toolCallId matches but runId differs", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showInlineToolFlow: true,
+          messages: [
+            {
+              role: "toolresult",
+              runId: "run-history",
+              toolName: "web_fetch",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "history output" }],
+              timestamp: Date.now() - 10_000,
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              runId: "run-live",
+              toolName: "web_fetch",
+              toolCallId: "call_1",
+              content: [{ type: "text", text: "live output" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const cards = container.querySelectorAll(".chat-tool-card");
+    expect(cards.length).toBe(2);
+    const threadText = container.querySelector(".chat-thread")?.textContent ?? "";
+    expect(threadText).toContain("history output");
+    expect(threadText).toContain("live output");
+  });
+
+  it("hydrates command detail on live tool cards from history when output and args split across cards", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showInlineToolFlow: true,
+          messages: [
+            {
+              role: "assistant",
+              runId: "run-history",
+              toolCallId: "split-read-1",
+              content: [
+                {
+                  type: "toolcall",
+                  name: "read",
+                  arguments: { path: "workspace/memory/daily/2026-03-01.md" },
+                },
+              ],
+              timestamp: Date.now() - 10_000,
+            },
+          ],
+          toolMessages: [
+            {
+              role: "toolresult",
+              runId: "run-live",
+              toolName: "read",
+              toolCallId: "split-read-1",
+              content: [{ type: "text", text: "live file output" }],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const cards = container.querySelectorAll(".chat-tool-card");
+    expect(cards.length).toBe(2);
+    const details = Array.from(container.querySelectorAll(".chat-tool-card__detail")).map(
+      (node) => node.textContent ?? "",
+    );
+    expect(details).toHaveLength(2);
+    expect(details[0]).toContain("from workspace/memory/daily/2026-03-01.md");
+    expect(details[1]).toContain("from workspace/memory/daily/2026-03-01.md");
+  });
+
   it("renders compacting indicator as a badge", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -149,11 +149,19 @@ describe("chat view", () => {
           ],
           toolMessages: [
             {
-              role: "toolresult",
-              toolName: "exec",
+              role: "assistant",
               content: [
                 {
-                  type: "text",
+                  type: "toolcall",
+                  name: "exec",
+                  arguments: {
+                    command: "openclaw system --help",
+                    cwd: "C:\\Users\\test\\.openclaw\\workspace",
+                  },
+                },
+                {
+                  type: "toolresult",
+                  name: "exec",
                   text: "Usage: openclaw system [options] [command]\nSystem tools...",
                 },
               ],
@@ -373,6 +381,10 @@ describe("chat view", () => {
     const threadText = container.querySelector(".chat-thread")?.textContent ?? "";
     expect(threadText).toContain("history output");
     expect(threadText).toContain("live output");
+    const cardTexts = Array.from(container.querySelectorAll(".chat-tool-card__inline")).map(
+      (node) => node.textContent ?? "",
+    );
+    expect(cardTexts).toEqual(["history output", "live output"]);
   });
 
   it("hydrates command detail on live tool cards from history when output and args split across cards", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -7,6 +7,7 @@ import {
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../chat/message-normalizer.ts";
+import { buildToolCardOutputLookup, extractToolCards } from "../chat/tool-cards.ts";
 import { icons } from "../icons.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { SessionsListResult } from "../types.ts";
@@ -36,6 +37,7 @@ export type ChatProps = {
   onSessionKeyChange: (next: string) => void;
   thinkingLevel: string | null;
   showThinking: boolean;
+  showInlineToolFlow: boolean;
   loading: boolean;
   sending: boolean;
   canAbort?: boolean;
@@ -243,7 +245,8 @@ export function renderChat(props: ChatProps) {
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";
-  const showReasoning = props.showThinking && reasoningLevel !== "off";
+  const showReasoning =
+    (props.showThinking || props.showInlineToolFlow) && reasoningLevel !== "off";
   const assistantIdentity = {
     name: props.assistantName,
     avatar: props.assistantAvatar ?? props.assistantAvatarUrl ?? null,
@@ -258,6 +261,9 @@ export function renderChat(props: ChatProps) {
 
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
+  const historyMessages = Array.isArray(props.messages) ? props.messages : [];
+  const toolMessages = Array.isArray(props.toolMessages) ? props.toolMessages : [];
+  const toolOutputLookup = buildToolCardOutputLookup([...historyMessages, ...toolMessages]);
   const thread = html`
     <div
       class="chat-thread"
@@ -305,6 +311,7 @@ export function renderChat(props: ChatProps) {
               showReasoning,
               assistantName: props.assistantName,
               assistantAvatar: assistantIdentity.avatar,
+              toolOutputLookup,
             });
           }
 
@@ -522,10 +529,27 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
+type ToolCallRef = {
+  toolCallId: string;
+  runId?: string;
+};
+
 function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
+  const showInlineToolFlow = props.showInlineToolFlow;
+  const historyToolCallRefs = showInlineToolFlow ? collectToolCallRefs(history) : [];
+  const historyToolCallsByRun = new Set<string>();
+  for (const entry of historyToolCallRefs) {
+    if (!entry.runId) {
+      continue;
+    }
+    historyToolCallsByRun.add(buildToolCallRunKey(entry.toolCallId, entry.runId));
+  }
+  const historyToolCallsWithoutRun = new Set<string>(
+    historyToolCallRefs.filter((entry) => !entry.runId).map((entry) => entry.toolCallId),
+  );
   const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
   if (historyStart > 0) {
     items.push({
@@ -556,7 +580,13 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       continue;
     }
 
-    if (!props.showThinking && normalized.role.toLowerCase() === "toolresult") {
+    const rawRole = typeof raw.role === "string" ? raw.role.toLowerCase() : "";
+    const isStandaloneToolMessage =
+      rawRole === "toolresult" ||
+      rawRole === "tool_result" ||
+      rawRole === "tool" ||
+      rawRole === "function";
+    if (!showInlineToolFlow && isStandaloneToolMessage) {
       continue;
     }
 
@@ -566,8 +596,18 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
       message: msg,
     });
   }
-  if (props.showThinking) {
-    for (let i = 0; i < tools.length; i++) {
+
+  if (props.showInlineToolFlow) {
+    for (let i = 0; i < tools.length; i += 1) {
+      const liveRefs = collectToolCallRefs([tools[i]]);
+      const duplicateWithHistory = liveRefs.some((entry) =>
+        entry.runId
+          ? historyToolCallsByRun.has(buildToolCallRunKey(entry.toolCallId, entry.runId))
+          : historyToolCallsWithoutRun.has(entry.toolCallId),
+      );
+      if (duplicateWithHistory) {
+        continue;
+      }
       items.push({
         kind: "message",
         key: messageKey(tools[i], i + history.length),
@@ -593,11 +633,60 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   return groupMessages(items);
 }
 
+function normalizeToken(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function buildToolCallRunKey(toolCallId: string, runId: string): string {
+  return `${runId}::${toolCallId}`;
+}
+
+function collectToolCallRefs(messages: unknown[]): ToolCallRef[] {
+  const refs: ToolCallRef[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    const record = message as Record<string, unknown>;
+    const runId = normalizeToken(record.runId) || undefined;
+    const appendRef = (toolCallId: unknown) => {
+      const normalizedToolCallId = normalizeToken(toolCallId);
+      if (!normalizedToolCallId) {
+        return;
+      }
+      const key = runId
+        ? buildToolCallRunKey(normalizedToolCallId, runId)
+        : `norun::${normalizedToolCallId}`;
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      refs.push({ toolCallId: normalizedToolCallId, runId });
+    };
+    const directToolCallId =
+      typeof record.toolCallId === "string"
+        ? record.toolCallId
+        : typeof record.tool_call_id === "string"
+          ? record.tool_call_id
+          : "";
+    appendRef(directToolCallId);
+    const cards = extractToolCards(message);
+    for (const card of cards) {
+      appendRef(card.toolCallId);
+    }
+  }
+  return refs;
+}
+
 function messageKey(message: unknown, index: number): string {
   const m = message as Record<string, unknown>;
-  const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
+  const toolCallId =
+    typeof m.toolCallId === "string"
+      ? m.toolCallId
+      : typeof m.tool_call_id === "string"
+        ? m.tool_call_id
+        : "";
   if (toolCallId) {
-    return `tool:${toolCallId}`;
+    const runId = normalizeToken(m.runId);
+    return runId ? `tool:${runId}:${toolCallId}` : `tool:${toolCallId}`;
   }
   const id = typeof m.id === "string" ? m.id : "";
   if (id) {


### PR DESCRIPTION

## Summary

This PR improves the webchat experience around tool execution, transcript hydration, and session scoping.

It does three main things:
1. makes inline tool flow much richer in the chat thread
2. keeps tool cards and transcript state in sync more reliably across final events and session aliases
3. tightens session mutation behavior for webchat clients

This branch is now independent from `main` and includes the additional follow-up fix needed to keep run-history sync working without depending on the separate thread-metadata branch.

## What changed

### Richer inline tool flow in webchat
- Add a new inline tool-flow toggle in the chat UI
- Keep thinking mode and inline tool-flow mode mutually exclusive in settings persistence
- Render richer tool cards with:
  - lookup-based enrichment by tool call id / signature / resource hint / tool name
  - improved read/edit/exec/web fetch/web search formatting
  - better sidebar content for tool outputs
- Deduplicate live tool cards that are already represented in transcript history

Key files:
- `ui/src/ui/chat/tool-cards.ts`
- `ui/src/ui/chat/tool-helpers.ts`
- `ui/src/ui/views/chat.ts`
- `ui/src/ui/storage.ts`
- `ui/src/i18n/locales/en.ts`

### Better tool/output hydration after final events
- Keep tool stream visible after terminal chat events instead of clearing immediately
- Hydrate missing read tool output from final assistant text when tool result payloads are empty or incomplete
- Use run-scoped tool-stream keys so reused `toolCallId`s from different runs do not collide
- Scope tool-card text hydration by `runId` + `toolCallId` to prevent stale output leaking across runs when IDs or args are reused, while keeping a loose args-only fallback for split call/result cards
- Accept alias-equivalent session keys and session-scoped tool events more reliably

Key files:
- `ui/src/ui/app-gateway.ts`
- `ui/src/ui/app-tool-stream.ts`
- `ui/src/ui/controllers/chat.ts`

### Run-time transcript sync
- Add periodic chat-history sync while a run is active
- Refresh transcript state on final chat events even when session refresh was not explicitly queued
- Include the standalone follow-up fix that makes this work directly against `main` by exporting and using the browser chat-history sync helper independently

Key files:
- `ui/src/ui/app-polling.ts`
- `ui/src/ui/app-lifecycle.ts`
- `ui/src/ui/controllers/chat.ts`

### Session scoping / navigation improvements
- Add chat-agent picker support in navigation
- Filter session lists by active agent in the web UI
- Pass `agentId` through `sessions.list`
- Normalize main-session behavior around agent-scoped session keys

Key files:
- `ui/src/ui/app-render.helpers.ts`
- `ui/src/ui/app-render.ts`
- `ui/src/ui/controllers/sessions.ts`
- `ui/src/ui/navigation.browser.test.ts`

### Webchat session mutation guardrails
- Restrict webchat clients so they can patch labels only
- Reject other session patches from webchat clients
- Keep delete available for control-ui clients

Key files:
- `src/gateway/server-methods/sessions.ts`
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`

### Rendering / styling polish
- Diff-aware markdown rendering for tool output
- chat/sidebar/layout styling for the new inline tool flow and nav agent picker

Key files:
- `ui/src/ui/markdown.ts`
- `ui/src/styles/chat/layout.css`
- `ui/src/styles/chat/sidebar.css`
- `ui/src/styles/chat/tool-cards.css`
- `ui/src/styles/layout.css`

## Why

The previous webchat flow could lose tool detail, clear transient tool state too early, or fail to hydrate useful output when final assistant messages arrived separately from tool result payloads. It also did not clearly separate “show thinking” from “show inline tool flow”, and session-scoped UI behavior around agent/main aliases was brittle.

This PR makes webchat tool execution easier to inspect and keeps the chat transcript, live tool cards, and session scoping behavior aligned.

## Testing

### Root
- `npx vitest run src/gateway/server-methods/chat.directive-tags.test.ts src/routing/session-key.test.ts src/tui/tui-command-handlers.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `npx tsc --noEmit --pretty false --project tsconfig.json`

### UI
- `cd ui && npx vitest run --config vitest.config.ts src/ui/app-tool-stream.node.test.ts src/ui/app-gateway.node.test.ts src/ui/controllers/chat.test.ts src/ui/chat/tool-helpers.test.ts src/ui/chat/tool-cards.test.ts src/ui/views/chat.test.ts src/ui/controllers/sessions.test.ts src/ui/markdown.test.ts`
- `cd ui && npm run build`

All passed locally.

## Reviewer focus

Please focus review on:
1. tool-card enrichment / hydration matching logic in `ui/src/ui/chat/tool-cards.ts`
2. session alias and run matching rules in `ui/src/ui/app-tool-stream.ts` and `ui/src/ui/controllers/chat.ts`
3. the webchat-only session mutation restrictions in `src/gateway/server-methods/sessions.ts`
4. whether the agent-scoped navigation/session filtering behavior matches intended control-ui UX
