### PR TITLE
feat: Adaptive Model Routing with token savings meter

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -139,6 +139,90 @@ timeouts that exhausted profile rotation (other errors do not advance fallback).
 When a run starts with a model override (hooks or CLI), fallbacks still end at
 `agents.defaults.model.primary` after trying any configured fallbacks.
 
+## Adaptive Model Routing
+
+**Failover** (above) handles provider failures: rate limits, auth errors, and timeouts.
+**Adaptive Model Routing** is a separate, opt-in feature that handles _outcome quality_: it
+runs a cheap or local model first, validates whether the result actually completed the job,
+and automatically escalates to a cloud model on failure — all in one turn.
+
+|                 | Failover                    | Adaptive Model Routing                          |
+| --------------- | --------------------------- | ----------------------------------------------- |
+| Trigger         | Provider error / rate limit | Outcome validation failure                      |
+| Default         | On                          | Off                                             |
+| Max retries     | Configurable fallback chain | 1 escalation (v1)                               |
+| Session history | Same session, next model    | Rerun from scratch (local attempt not appended) |
+
+### How it works
+
+1. First run uses `localFirstModel` (e.g. a local Ollama model).
+2. The outcome is validated — by heuristic (default) or by an optional LLM validator.
+3. If validation **passes**: the local result is returned.
+4. If validation **fails**: the run is discarded and re-attempted with `cloudEscalationModel`.
+5. If the cloud run encounters a provider error, the normal failover chain takes over.
+
+### Enable adaptive routing
+
+Add `adaptiveRouting` inside `agents.defaults.model`:
+
+```yaml
+agents:
+  defaults:
+    model:
+      primary: "openai/gpt-4.1-mini"
+      fallbacks:
+        - "openai/gpt-4.1-nano"
+      adaptiveRouting:
+        enabled: true
+        localFirstModel: "ollama/qwen2.5-coder" # cheap/local first
+        cloudEscalationModel: "openai/gpt-4.1-mini" # escalate here on failure
+        maxEscalations: 1 # hard cap (v1)
+        bypassOnExplicitOverride: true # skip when user forces a model
+        validation:
+          mode: "heuristic" # "heuristic" (default) or "llm"
+          minScore: 0.75
+```
+
+#### Optional LLM validator (experimental)
+
+> **Note:** LLM validation mode is experimental and not yet fully implemented. When
+> `mode: "llm"` is configured, the current implementation falls back to heuristic
+> validation with a warning. Full LLM validation support is planned for a future release.
+
+```yaml
+validation:
+  mode: "llm"
+  validatorModel: "ollama/llama3.2"
+  minScore: 0.75
+  maxToolOutputChars: 2000
+  maxAssistantChars: 4000
+  redactSecrets: true
+```
+
+When `mode: "llm"` is fully implemented, a small validator prompt will be sent to
+`validatorModel`. The validator must return JSON `{ "score": 0..1, "passed": true/false, "reason": "..." }`.
+Invalid JSON or validator errors are treated as a fail, triggering escalation.
+
+### Heuristic validation rules
+
+The default heuristic applies the following scoring (starting from 1.0, deducting penalties):
+
+| Condition                       | Score deduction |
+| ------------------------------- | --------------- |
+| Provider/runtime error          | −1.0            |
+| Tool execution error            | −0.6            |
+| Empty assistant output          | −0.4            |
+| Pending (unresolved) tool calls | −0.4            |
+| Timeout / truncation            | −0.3            |
+
+Pass threshold: score ≥ `validation.minScore` (default 0.75). Failure conditions (empty output, tool errors, etc.) reduce the score via the penalties above; individual failures do not independently block a pass.
+
+### Relationship to the normal failover chain
+
+Adaptive routing wraps the run _before_ the failover chain runs. Each adaptive attempt
+(local and cloud) has full access to the normal provider fallback chain for provider-level
+errors. Adaptive routing only escalates based on _outcome_, not on provider errors.
+
 ## Related config
 
 See [Gateway configuration](/gateway/configuration) for:

--- a/src/agents/adaptive-routing-savings.test.ts
+++ b/src/agents/adaptive-routing-savings.test.ts
@@ -1,0 +1,329 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  computeSavingsMetrics,
+  fmtTokens,
+  pct,
+  readSavingsLedger,
+  recordAdaptiveRun,
+  savingsFilePath,
+} from "./adaptive-routing-savings.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ar-savings-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+});
+
+// ─── readSavingsLedger ───────────────────────────────────────────────────────
+
+describe("readSavingsLedger", () => {
+  it("returns empty ledger when file does not exist", async () => {
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.version).toBe(1);
+    expect(ledger.totals.runsTotal).toBe(0);
+    expect(ledger.totals.runsLocal).toBe(0);
+    expect(ledger.totals.runsEscalated).toBe(0);
+    expect(ledger.totals.runsBypassed).toBe(0);
+  });
+
+  it("returns empty ledger when file is malformed JSON", async () => {
+    await fs.writeFile(savingsFilePath(tmpDir), "not-json", "utf8");
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(0);
+  });
+
+  it("merges missing fields from older schema", async () => {
+    const partial = {
+      version: 1,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: { runsTotal: 5 },
+    };
+    await fs.writeFile(savingsFilePath(tmpDir), JSON.stringify(partial), "utf8");
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(5);
+    expect(ledger.totals.runsLocal).toBe(0); // default filled in
+  });
+});
+
+// ─── recordAdaptiveRun ───────────────────────────────────────────────────────
+
+describe("recordAdaptiveRun", () => {
+  it("increments runsBypassed for bypassed runs", async () => {
+    await recordAdaptiveRun(tmpDir, { kind: "bypassed" });
+    await recordAdaptiveRun(tmpDir, { kind: "bypassed" });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsBypassed).toBe(2);
+    expect(ledger.totals.runsTotal).toBe(0); // bypassed not counted in runsTotal
+  });
+
+  it("accumulates local_success runs and tokens", async () => {
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_success",
+      localUsage: { input: 100, output: 40, cacheRead: 10 },
+    });
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_success",
+      localUsage: { input: 200, output: 80 },
+    });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(2);
+    expect(ledger.totals.runsLocal).toBe(2);
+    expect(ledger.totals.runsEscalated).toBe(0);
+    expect(ledger.totals.localTokensInput).toBe(300);
+    expect(ledger.totals.localTokensOutput).toBe(120);
+    expect(ledger.totals.localTokensCacheRead).toBe(10);
+    expect(ledger.totals.localSuccessTokensCacheRead).toBe(10);
+    expect(ledger.totals.cloudTokensInput).toBe(0);
+  });
+
+  it("accumulates escalated runs with both local and cloud tokens", async () => {
+    await recordAdaptiveRun(tmpDir, {
+      kind: "escalated",
+      localUsage: { input: 50, output: 20 },
+      cloudUsage: { input: 400, output: 150 },
+    });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(1);
+    expect(ledger.totals.runsLocal).toBe(0);
+    expect(ledger.totals.runsEscalated).toBe(1);
+    expect(ledger.totals.localTokensInput).toBe(50);
+    expect(ledger.totals.localTokensOutput).toBe(20);
+    expect(ledger.totals.cloudTokensInput).toBe(400);
+    expect(ledger.totals.cloudTokensOutput).toBe(150);
+  });
+
+  it("handles undefined usage gracefully (defaults to 0)", async () => {
+    await recordAdaptiveRun(tmpDir, { kind: "local_success" });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsLocal).toBe(1);
+    expect(ledger.totals.localTokensInput).toBe(0);
+  });
+
+  it("mixes local_success and escalated across multiple runs", async () => {
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_success",
+      localUsage: { input: 100, output: 50 },
+    });
+    await recordAdaptiveRun(tmpDir, {
+      kind: "escalated",
+      localUsage: { input: 80, output: 30 },
+      cloudUsage: { input: 500, output: 200 },
+    });
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_success",
+      localUsage: { input: 120, output: 60 },
+    });
+
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(3);
+    expect(ledger.totals.runsLocal).toBe(2);
+    expect(ledger.totals.runsEscalated).toBe(1);
+    expect(ledger.totals.localTokensInput).toBe(300);
+    expect(ledger.totals.localTokensOutput).toBe(140);
+    expect(ledger.totals.cloudTokensInput).toBe(500);
+    expect(ledger.totals.cloudTokensOutput).toBe(200);
+  });
+
+  it("creates stateDir if it does not exist", async () => {
+    const nested = path.join(tmpDir, "deep", "nested");
+    await recordAdaptiveRun(nested, { kind: "local_success" });
+    const ledger = await readSavingsLedger(nested);
+    expect(ledger.totals.runsLocal).toBe(1);
+  });
+
+  it("records local_forced separately from local_success (maxEscalations=0)", async () => {
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_forced",
+      localUsage: { input: 100, output: 40 },
+    });
+    await recordAdaptiveRun(tmpDir, {
+      kind: "local_success",
+      localUsage: { input: 200, output: 80 },
+    });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.runsTotal).toBe(2);
+    expect(ledger.totals.runsLocal).toBe(1);
+    expect(ledger.totals.runsLocalForced).toBe(1);
+    expect(ledger.totals.localTokensInput).toBe(300);
+    expect(ledger.totals.localSuccessTokensInput).toBe(200);
+  });
+
+  it("accumulates cloud cacheRead tokens for escalated runs", async () => {
+    await recordAdaptiveRun(tmpDir, {
+      kind: "escalated",
+      localUsage: { input: 50, output: 20 },
+      cloudUsage: { input: 400, output: 150, cacheRead: 60 },
+    });
+    const ledger = await readSavingsLedger(tmpDir);
+    expect(ledger.totals.cloudTokensCacheRead).toBe(60);
+    expect(ledger.totals.cloudTokensInput).toBe(400);
+  });
+});
+
+// ─── computeSavingsMetrics ───────────────────────────────────────────────────
+
+describe("computeSavingsMetrics", () => {
+  it("returns zero stats for empty ledger", () => {
+    const ledger = {
+      version: 1 as const,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: {
+        runsTotal: 0,
+        runsLocal: 0,
+        runsEscalated: 0,
+        runsBypassed: 0,
+        localTokensInput: 0,
+        localTokensOutput: 0,
+        localTokensCacheRead: 0,
+        cloudTokensInput: 0,
+        cloudTokensOutput: 0,
+      },
+    };
+    const m = computeSavingsMetrics(ledger);
+    expect(m.runsTotal).toBe(0);
+    expect(m.cloudSavedTokens).toBe(0);
+    expect(m.savingsRate).toBe("—");
+  });
+
+  it("reports 100% savings rate when all runs are local", () => {
+    const ledger = {
+      version: 1 as const,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: {
+        runsTotal: 4,
+        runsLocal: 4,
+        runsEscalated: 0,
+        runsBypassed: 0,
+        localTokensInput: 400,
+        localTokensOutput: 160,
+        localTokensCacheRead: 0,
+        cloudTokensInput: 0,
+        cloudTokensOutput: 0,
+      },
+    };
+    const m = computeSavingsMetrics(ledger);
+    expect(m.savingsRate).toBe("100%");
+    expect(m.cloudSavedTokens).toBe(560); // all local tokens saved from cloud
+    expect(m.cloudTotal).toBe(0);
+  });
+
+  it("reports 0% savings rate when all runs escalated", () => {
+    const ledger = {
+      version: 1 as const,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: {
+        runsTotal: 3,
+        runsLocal: 0,
+        runsEscalated: 3,
+        runsBypassed: 0,
+        localTokensInput: 150,
+        localTokensOutput: 60,
+        localTokensCacheRead: 0,
+        cloudTokensInput: 600,
+        cloudTokensOutput: 300,
+      },
+    };
+    const m = computeSavingsMetrics(ledger);
+    expect(m.savingsRate).toBe("0%");
+    expect(m.cloudSavedTokens).toBe(0);
+    expect(m.cloudTotal).toBe(900);
+  });
+
+  it("proportionally allocates savings for mixed runs", () => {
+    const ledger = {
+      version: 1 as const,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: {
+        runsTotal: 4,
+        runsLocal: 3,
+        runsEscalated: 1,
+        runsBypassed: 2,
+        localTokensInput: 400,
+        localTokensOutput: 200,
+        localTokensCacheRead: 0,
+        cloudTokensInput: 500,
+        cloudTokensOutput: 200,
+      },
+    };
+    const m = computeSavingsMetrics(ledger);
+    expect(m.savingsRate).toBe("75%"); // 3/4
+    // cloudSavedTokens = (400+200) * (3/4) = 450
+    expect(m.cloudSavedTokens).toBe(450);
+    expect(m.localTotal).toBe(600);
+    expect(m.cloudTotal).toBe(700);
+  });
+
+  it("includes localSuccessTokensCacheRead in cloudSavedTokens (v2 fields)", () => {
+    const ledger = {
+      version: 1 as const,
+      since: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      totals: {
+        runsTotal: 2,
+        runsLocal: 2,
+        runsEscalated: 0,
+        runsBypassed: 0,
+        localTokensInput: 200,
+        localTokensOutput: 100,
+        localTokensCacheRead: 50,
+        cloudTokensInput: 0,
+        cloudTokensOutput: 0,
+        cloudTokensCacheRead: 0,
+        runsLocalForced: 0,
+        localSuccessTokensInput: 200,
+        localSuccessTokensOutput: 100,
+        localSuccessTokensCacheRead: 50,
+      },
+    };
+    const m = computeSavingsMetrics(ledger);
+    // 200 + 100 + 50 = 350 (cache-read included)
+    expect(m.cloudSavedTokens).toBe(350);
+  });
+});
+
+// ─── fmtTokens / pct ─────────────────────────────────────────────────────────
+
+describe("fmtTokens", () => {
+  it("formats sub-1k tokens as plain numbers", () => {
+    expect(fmtTokens(0)).toBe("0");
+    expect(fmtTokens(999)).toBe("999");
+  });
+
+  it("formats thousands with k suffix", () => {
+    expect(fmtTokens(1000)).toBe("1.0k");
+    expect(fmtTokens(1500)).toBe("1.5k");
+    expect(fmtTokens(999_999)).toBe("1000.0k");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(fmtTokens(1_000_000)).toBe("1.00M");
+    expect(fmtTokens(2_500_000)).toBe("2.50M");
+  });
+});
+
+describe("pct", () => {
+  it("returns — when denominator is zero", () => {
+    expect(pct(0, 0)).toBe("—");
+    expect(pct(5, 0)).toBe("—");
+  });
+
+  it("returns percentage string", () => {
+    expect(pct(1, 4)).toBe("25%");
+    expect(pct(3, 3)).toBe("100%");
+    expect(pct(0, 5)).toBe("0%");
+  });
+});

--- a/src/agents/adaptive-routing-savings.ts
+++ b/src/agents/adaptive-routing-savings.ts
@@ -1,0 +1,278 @@
+/**
+ * Adaptive Model Routing – Token Savings Ledger
+ *
+ * Tracks per-run token usage split by local vs cloud so users can see how
+ * many tokens were processed locally (for free/cheap) versus escalated to
+ * the cloud model.
+ *
+ * Stored at: <stateDir>/adaptive-routing-savings.json
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { NormalizedUsage } from "./usage.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type AdaptiveRoutingTokenRecord = {
+  /** Tokens used by the local model run (always present when AR fires). */
+  localTokensInput: number;
+  localTokensOutput: number;
+  localTokensCacheRead: number;
+  /** Tokens used by the cloud escalation run (0 when no escalation). */
+  cloudTokensInput: number;
+  cloudTokensOutput: number;
+  cloudTokensCacheRead: number;
+};
+
+export type AdaptiveRoutingSavingsLedger = {
+  /** Schema version for forward-compat. */
+  version: 1;
+  /** ISO timestamp when the ledger was first created. */
+  since: string;
+  /** ISO timestamp of the last update. */
+  lastUpdated: string;
+  totals: {
+    /** Total adaptive-routing runs (local + escalated; excludes bypassed). */
+    runsTotal: number;
+    /** Runs fully handled by local model (validation passed, no escalation). */
+    runsLocal: number;
+    /** Runs that escalated to the cloud model after local validation failure. */
+    runsEscalated: number;
+    /** Runs where adaptive routing was bypassed (explicit override, disabled). */
+    runsBypassed: number;
+    /** Cumulative tokens processed by the local model. */
+    localTokensInput: number;
+    localTokensOutput: number;
+    localTokensCacheRead: number;
+    /** Cumulative tokens sent to the cloud escalation model. */
+    cloudTokensInput: number;
+    cloudTokensOutput: number;
+    cloudTokensCacheRead?: number;
+    /** Runs where validation failed but escalation was capped (maxEscalations=0). */
+    runsLocalForced?: number;
+    /** Tokens from local-success runs only (v2 field, backfilled as 0). */
+    localSuccessTokensInput?: number;
+    localSuccessTokensOutput?: number;
+    localSuccessTokensCacheRead?: number;
+  };
+};
+
+const SAVINGS_FILENAME = "adaptive-routing-savings.json";
+const SCHEMA_VERSION = 1 as const;
+
+// ─── I/O helpers ─────────────────────────────────────────────────────────────
+
+export function savingsFilePath(stateDir: string): string {
+  return path.join(stateDir, SAVINGS_FILENAME);
+}
+
+function emptyLedger(): AdaptiveRoutingSavingsLedger {
+  const now = new Date().toISOString();
+  return {
+    version: SCHEMA_VERSION,
+    since: now,
+    lastUpdated: now,
+    totals: {
+      runsTotal: 0,
+      runsLocal: 0,
+      runsEscalated: 0,
+      runsBypassed: 0,
+      localTokensInput: 0,
+      localTokensOutput: 0,
+      localTokensCacheRead: 0,
+      cloudTokensInput: 0,
+      cloudTokensOutput: 0,
+      cloudTokensCacheRead: 0,
+      runsLocalForced: 0,
+    },
+  };
+}
+
+export async function readSavingsLedger(stateDir: string): Promise<AdaptiveRoutingSavingsLedger> {
+  const filePath = savingsFilePath(stateDir);
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as AdaptiveRoutingSavingsLedger;
+    // Tolerate missing fields from older schema versions.
+    if (!parsed?.totals) {
+      return emptyLedger();
+    }
+    return {
+      ...emptyLedger(),
+      ...parsed,
+      totals: { ...emptyLedger().totals, ...parsed.totals },
+    };
+  } catch {
+    return emptyLedger();
+  }
+}
+
+async function writeSavingsLedger(
+  stateDir: string,
+  ledger: AdaptiveRoutingSavingsLedger,
+): Promise<void> {
+  const filePath = savingsFilePath(stateDir);
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(ledger, null, 2), "utf8");
+}
+
+// ─── Accumulation ─────────────────────────────────────────────────────────────
+
+function tokensFromUsage(usage?: NormalizedUsage | null): {
+  input: number;
+  output: number;
+  cacheRead: number;
+} {
+  return {
+    input: usage?.input ?? 0,
+    output: usage?.output ?? 0,
+    cacheRead: usage?.cacheRead ?? 0,
+  };
+}
+
+export type RecordAdaptiveRunParams =
+  | {
+      kind: "bypassed";
+    }
+  | {
+      kind: "local_success";
+      localUsage?: NormalizedUsage | null;
+    }
+  | {
+      /** Validation failed but escalation was capped (maxEscalations=0). */
+      kind: "local_forced";
+      localUsage?: NormalizedUsage | null;
+    }
+  | {
+      kind: "escalated";
+      localUsage?: NormalizedUsage | null;
+      cloudUsage?: NormalizedUsage | null;
+    };
+
+/**
+ * Append one run's outcome to the savings ledger.
+ * Uses a read-modify-write with best-effort (fire-and-forget): errors are
+ * swallowed so a ledger write failure never breaks an agent run.
+ *
+ * Concurrency note: This uses a simple read-modify-write without file locking.
+ * Concurrent agent runs may race, causing some ledger updates to be lost.
+ * This is acceptable for best-effort telemetry — token savings are approximate.
+ * If accurate counting is required in the future, consider using proper file
+ * locking or an atomic append-only log format.
+ */
+export async function recordAdaptiveRun(
+  stateDir: string,
+  params: RecordAdaptiveRunParams,
+): Promise<void> {
+  try {
+    const ledger = await readSavingsLedger(stateDir);
+    const t = ledger.totals;
+
+    if (params.kind === "bypassed") {
+      t.runsBypassed += 1;
+    } else {
+      t.runsTotal += 1;
+      if (params.kind === "local_success") {
+        t.runsLocal += 1;
+        const local = tokensFromUsage(params.localUsage);
+        t.localTokensInput += local.input;
+        t.localTokensOutput += local.output;
+        t.localTokensCacheRead += local.cacheRead;
+        t.localSuccessTokensInput = (t.localSuccessTokensInput ?? 0) + local.input;
+        t.localSuccessTokensOutput = (t.localSuccessTokensOutput ?? 0) + local.output;
+        t.localSuccessTokensCacheRead = (t.localSuccessTokensCacheRead ?? 0) + local.cacheRead;
+      } else if (params.kind === "local_forced") {
+        // Validation failed but escalation was capped — don't inflate runsLocal
+        // or localSuccessTokens (those track genuinely passing runs only).
+        t.runsLocalForced = (t.runsLocalForced ?? 0) + 1;
+        const local = tokensFromUsage(params.localUsage);
+        t.localTokensInput += local.input;
+        t.localTokensOutput += local.output;
+        t.localTokensCacheRead += local.cacheRead;
+      } else {
+        // escalated
+        t.runsEscalated += 1;
+        const local = tokensFromUsage(params.localUsage);
+        const cloud = tokensFromUsage(params.cloudUsage);
+        t.localTokensInput += local.input;
+        t.localTokensOutput += local.output;
+        t.localTokensCacheRead += local.cacheRead;
+        t.cloudTokensInput += cloud.input;
+        t.cloudTokensOutput += cloud.output;
+        t.cloudTokensCacheRead = (t.cloudTokensCacheRead ?? 0) + cloud.cacheRead;
+      }
+    }
+
+    ledger.lastUpdated = new Date().toISOString();
+    await writeSavingsLedger(stateDir, ledger);
+  } catch {
+    // Never surface ledger errors to callers.
+  }
+}
+
+// ─── Formatting helpers (used by CLI stats command) ───────────────────────────
+
+export function fmtTokens(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(2)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}k`;
+  }
+  return String(n);
+}
+
+export function pct(num: number, den: number): string {
+  if (den === 0) {
+    return "—";
+  }
+  return `${Math.round((num / den) * 100)}%`;
+}
+
+/**
+ * Compute derived savings metrics from the ledger.
+ * "Cloud-saved tokens" = tokens that ran locally on a successful local run,
+ * i.e., tokens that *would have* gone to the cloud model if AR was disabled.
+ * These are approximated as the local tokens from successful (non-escalated) runs.
+ */
+export function computeSavingsMetrics(ledger: AdaptiveRoutingSavingsLedger) {
+  const t = ledger.totals;
+
+  // Token-level savings: for escalated runs, both local AND cloud tokens were used.
+  // For local-success runs, only local tokens were used (cloud was skipped).
+  // Use the tracked per-run-type tokens when available (v2 field); fall back to
+  // the proportional estimate for ledgers created before the field existed.
+  const hasPerRunTypeTokens =
+    t.localSuccessTokensInput != null && t.localSuccessTokensOutput != null;
+  const localOnlyTokens = hasPerRunTypeTokens
+    ? (t.localSuccessTokensInput ?? 0) +
+      (t.localSuccessTokensOutput ?? 0) +
+      (t.localSuccessTokensCacheRead ?? 0)
+    : t.runsLocal === 0
+      ? 0
+      : Math.round(
+          (t.localTokensInput + t.localTokensOutput) * (t.runsLocal / Math.max(1, t.runsTotal)),
+        );
+
+  const cloudTotal = t.cloudTokensInput + t.cloudTokensOutput + (t.cloudTokensCacheRead ?? 0);
+  const localTotal = t.localTokensInput + t.localTokensOutput + t.localTokensCacheRead;
+
+  const runsLocalForced = t.runsLocalForced ?? 0;
+
+  return {
+    runsTotal: t.runsTotal,
+    runsLocal: t.runsLocal,
+    runsLocalForced,
+    runsEscalated: t.runsEscalated,
+    runsBypassed: t.runsBypassed,
+    localTotal,
+    cloudTotal,
+    // Tokens processed entirely on the local model (no cloud charge).
+    cloudSavedTokens: localOnlyTokens,
+    // Savings rate = genuinely passing local runs / total (excludes forced-local).
+    savingsRate: pct(t.runsLocal, t.runsTotal),
+    since: ledger.since,
+    lastUpdated: ledger.lastUpdated,
+  };
+}

--- a/src/agents/adaptive-routing.test.ts
+++ b/src/agents/adaptive-routing.test.ts
@@ -1,0 +1,575 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  parseModelRef,
+  redactSecrets,
+  resolveAdaptiveRoutingConfig,
+  resolveBypassReason,
+  runEmbeddedPiAgentWithAdaptiveRouting,
+  validateHeuristic,
+  validateWithLlm,
+} from "./adaptive-routing.js";
+import type { RunEmbeddedPiAgentParams } from "./pi-embedded-runner/run/params.js";
+import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded-runner/types.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeAdaptiveCfg(overrides: Partial<OpenClawConfig["agents"]> = {}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-4.1-nano"],
+          adaptiveRouting: {
+            enabled: true,
+            localFirstModel: "ollama/qwen2.5-coder",
+            cloudEscalationModel: "openai/gpt-4.1-mini",
+            maxEscalations: 1,
+            bypassOnExplicitOverride: true,
+            validation: {
+              mode: "heuristic",
+              minScore: 0.75,
+            },
+          },
+        },
+        ...overrides.defaults,
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+function makeAttemptResult(
+  overrides: Partial<EmbeddedRunAttemptResult> = {},
+): EmbeddedRunAttemptResult {
+  return {
+    aborted: false,
+    timedOut: false,
+    timedOutDuringCompaction: false,
+    promptError: null,
+    sessionIdUsed: "test-session",
+    messagesSnapshot: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "world" },
+    ],
+    assistantTexts: ["world"],
+    toolMetas: [],
+    lastAssistant: undefined,
+    lastToolError: undefined,
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    cloudCodeAssistFormatError: false,
+    ...overrides,
+  } as EmbeddedRunAttemptResult;
+}
+
+function makeRunResult(overrides: Partial<EmbeddedPiRunResult> = {}): EmbeddedPiRunResult {
+  return {
+    payloads: [{ text: "world" }],
+    meta: {
+      durationMs: 100,
+      agentMeta: { sessionId: "test", provider: "ollama", model: "qwen2.5-coder" },
+    },
+    ...overrides,
+  } as EmbeddedPiRunResult;
+}
+
+function makeParams(overrides: Partial<RunEmbeddedPiAgentParams> = {}): RunEmbeddedPiAgentParams {
+  return {
+    sessionId: "test-session-id",
+    sessionFile: "/tmp/test-session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    config: makeAdaptiveCfg(),
+    prompt: "Hello, world!",
+    timeoutMs: 30000,
+    runId: "test-run-id",
+    ...overrides,
+  } as RunEmbeddedPiAgentParams;
+}
+
+// ─── resolveAdaptiveRoutingConfig ────────────────────────────────────────────
+
+describe("resolveAdaptiveRoutingConfig", () => {
+  it("returns null when config is undefined", () => {
+    expect(resolveAdaptiveRoutingConfig(undefined)).toBeNull();
+  });
+
+  it("returns null when agents.defaults.model is a string", () => {
+    const cfg = {
+      agents: { defaults: { model: "openai/gpt-4.1-mini" } },
+    } as unknown as OpenClawConfig;
+    expect(resolveAdaptiveRoutingConfig(cfg)).toBeNull();
+  });
+
+  it("returns null when adaptiveRouting is not present", () => {
+    const cfg = {
+      agents: { defaults: { model: { primary: "openai/gpt-4.1-mini" } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveAdaptiveRoutingConfig(cfg)).toBeNull();
+  });
+
+  it("returns null when adaptiveRouting.enabled is false", () => {
+    const cfg = makeAdaptiveCfg();
+    (
+      cfg.agents!.defaults!.model as { adaptiveRouting: { enabled: boolean } }
+    ).adaptiveRouting.enabled = false;
+    expect(resolveAdaptiveRoutingConfig(cfg)).toBeNull();
+  });
+
+  it("returns config when enabled with required fields", () => {
+    const cfg = makeAdaptiveCfg();
+    const result = resolveAdaptiveRoutingConfig(cfg);
+    expect(result).not.toBeNull();
+    expect(result!.enabled).toBe(true);
+    expect(result!.localFirstModel).toBe("ollama/qwen2.5-coder");
+    expect(result!.cloudEscalationModel).toBe("openai/gpt-4.1-mini");
+  });
+
+  it("caps maxEscalations to 1", () => {
+    const cfg = makeAdaptiveCfg();
+    (
+      cfg.agents!.defaults!.model as { adaptiveRouting: { maxEscalations: number } }
+    ).adaptiveRouting.maxEscalations = 5;
+    const result = resolveAdaptiveRoutingConfig(cfg);
+    expect(result!.maxEscalations).toBe(1);
+  });
+
+  it("returns null when localFirstModel is missing while enabled", () => {
+    const cfg = makeAdaptiveCfg();
+    (
+      cfg.agents!.defaults!.model as { adaptiveRouting: { localFirstModel: string } }
+    ).adaptiveRouting.localFirstModel = "";
+    expect(resolveAdaptiveRoutingConfig(cfg)).toBeNull();
+  });
+});
+
+// ─── resolveBypassReason ─────────────────────────────────────────────────────
+
+describe("resolveBypassReason", () => {
+  it("returns null when no override and bypassOnExplicitOverride=true", () => {
+    const cfg = resolveAdaptiveRoutingConfig(makeAdaptiveCfg())!;
+    expect(resolveBypassReason(cfg, { hasExplicitModelOverride: false })).toBeNull();
+  });
+
+  it("returns 'explicit_override' when override present and bypassOnExplicitOverride=true", () => {
+    const cfg = resolveAdaptiveRoutingConfig(makeAdaptiveCfg())!;
+    expect(resolveBypassReason(cfg, { hasExplicitModelOverride: true })).toBe("explicit_override");
+  });
+
+  it("returns null when override present but bypassOnExplicitOverride=false", () => {
+    const cfg = resolveAdaptiveRoutingConfig(makeAdaptiveCfg())!;
+    const cfgWithNoBypass = { ...cfg, bypassOnExplicitOverride: false };
+    expect(resolveBypassReason(cfgWithNoBypass, { hasExplicitModelOverride: true })).toBeNull();
+  });
+});
+
+// ─── parseModelRef ───────────────────────────────────────────────────────────
+
+describe("parseModelRef", () => {
+  it("splits provider/model correctly", () => {
+    expect(parseModelRef("ollama/qwen2.5-coder")).toEqual({
+      provider: "ollama",
+      model: "qwen2.5-coder",
+    });
+  });
+
+  it("handles no slash by treating whole string as both provider and model", () => {
+    expect(parseModelRef("gpt-4")).toEqual({ provider: "gpt-4", model: "gpt-4" });
+  });
+
+  it("handles multi-slash correctly (first slash is the delimiter)", () => {
+    expect(parseModelRef("openai/gpt-4/turbo")).toEqual({
+      provider: "openai",
+      model: "gpt-4/turbo",
+    });
+  });
+});
+
+// ─── redactSecrets ───────────────────────────────────────────────────────────
+
+describe("redactSecrets", () => {
+  it("redacts sk- prefixed keys", () => {
+    const result = redactSecrets("api key is sk-abc123def456 done");
+    expect(result).toContain("[REDACTED");
+    expect(result).not.toContain("sk-abc123def456");
+  });
+
+  it("redacts Bearer tokens", () => {
+    const result = redactSecrets("Authorization: Bearer mytoken1234567890");
+    expect(result).toContain("[REDACTED]");
+    expect(result).not.toContain("mytoken1234567890");
+  });
+
+  it("passes through clean text unchanged", () => {
+    const clean = "hello world, no secrets here";
+    expect(redactSecrets(clean)).toBe(clean);
+  });
+});
+
+// ─── validateHeuristic ───────────────────────────────────────────────────────
+
+describe("validateHeuristic", () => {
+  const cfg = resolveAdaptiveRoutingConfig(makeAdaptiveCfg())!;
+
+  it("passes when attempt has assistant text and no errors", () => {
+    const attempt = makeAttemptResult({ assistantTexts: ["Here is the result"] });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(true);
+    expect(result.score).toBeGreaterThanOrEqual(0.75);
+    expect(result.reason).toBe("ok");
+  });
+
+  it("fails when promptError is set", () => {
+    const attempt = makeAttemptResult({
+      promptError: new Error("provider error"),
+      assistantTexts: [],
+    });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(false);
+    expect(result.score).toBeLessThan(0.75);
+    expect(result.reason).toContain("provider_error");
+  });
+
+  it("fails when assistantTexts is empty", () => {
+    const attempt = makeAttemptResult({ assistantTexts: [] });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("empty_assistant_output");
+  });
+
+  it("fails when there is a tool error", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: ["done"],
+      lastToolError: { toolName: "exec", error: "command not found" },
+    });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("tool_error:exec");
+  });
+
+  it("fails when timed out", () => {
+    const attempt = makeAttemptResult({
+      timedOut: true,
+      assistantTexts: ["partial..."],
+    });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("timed_out");
+  });
+
+  it("penalises pending toolCall blocks in final message", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [""],
+      messagesSnapshot: [
+        {
+          role: "user",
+          content: "run something",
+          timestamp: Date.now(),
+        } as import("@mariozechner/pi-ai").UserMessage,
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", toolCall: { id: "t1", name: "exec", params: {} } }],
+          timestamp: Date.now(),
+          stopReason: "toolUse",
+        } as unknown as import("@mariozechner/pi-agent-core").AgentMessage,
+      ],
+    });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain("pending_tool_calls");
+  });
+
+  it("score is clamped to [0, 1]", () => {
+    const attempt = makeAttemptResult({
+      promptError: new Error("error"),
+      timedOut: true,
+      assistantTexts: [],
+      lastToolError: { toolName: "exec", error: "fail" },
+    });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+
+  it("minScore is functional: timeout alone passes when minScore is set low enough", () => {
+    // timeout deducts -0.3 → score=0.7. With minScore=0.6 it should pass.
+    const lowMinCfg = resolveAdaptiveRoutingConfig({
+      agents: {
+        defaults: {
+          model: {
+            adaptiveRouting: {
+              enabled: true,
+              localFirstModel: "ollama/q",
+              cloudEscalationModel: "openai/gpt-4.1-mini",
+              validation: { minScore: 0.6 },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig)!;
+    const attempt = makeAttemptResult({ timedOut: true, assistantTexts: ["partial..."] });
+    const result = validateHeuristic(attempt, lowMinCfg);
+    expect(result.score).toBeCloseTo(0.7);
+    expect(result.passed).toBe(true);
+  });
+
+  it("minScore is functional: timeout fails when minScore is above the resulting score", () => {
+    // timeout deducts -0.3 → score=0.7. With default minScore=0.75 it should fail.
+    const attempt = makeAttemptResult({ timedOut: true, assistantTexts: ["partial..."] });
+    const result = validateHeuristic(attempt, cfg);
+    expect(result.score).toBeCloseTo(0.7);
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ─── validateWithLlm ─────────────────────────────────────────────────────────
+
+describe("validateWithLlm", () => {
+  it("passes configured minScore into the validator prompt instead of hardcoded 0.75", async () => {
+    const customMinScore = 0.9;
+    const cfg = resolveAdaptiveRoutingConfig(
+      makeAdaptiveCfg({
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+            adaptiveRouting: {
+              enabled: true,
+              localFirstModel: "ollama/qwen2.5-coder",
+              cloudEscalationModel: "openai/gpt-4.1-mini",
+              maxEscalations: 1,
+              bypassOnExplicitOverride: true,
+              validation: {
+                mode: "llm",
+                validatorModel: "openai/gpt-4.1-nano",
+                minScore: customMinScore,
+              },
+            },
+          },
+        },
+      }),
+    )!;
+
+    let capturedPrompt = "";
+    const mockLlmRun = vi.fn(async (_provider: string, _model: string, prompt: string) => {
+      capturedPrompt = prompt;
+      return JSON.stringify({ score: 0.95, passed: true, reason: "ok" });
+    });
+
+    const attempt = makeAttemptResult({ assistantTexts: ["Result here"] });
+    await validateWithLlm(attempt, "Do something", cfg, mockLlmRun);
+
+    expect(capturedPrompt).toContain(`Score above ${customMinScore} = passed`);
+    expect(capturedPrompt).not.toContain("Score above 0.75");
+  });
+});
+
+// ─── runEmbeddedPiAgentWithAdaptiveRouting ───────────────────────────────────
+
+describe("runEmbeddedPiAgentWithAdaptiveRouting", () => {
+  it("delegates directly when adaptive routing is disabled", async () => {
+    const disabledCfg = {
+      agents: { defaults: { model: { primary: "openai/gpt-4.1-mini" } } },
+    } as unknown as OpenClawConfig;
+    const params = makeParams({ config: disabledCfg });
+    const runFn = vi.fn().mockResolvedValueOnce(makeRunResult());
+    await runEmbeddedPiAgentWithAdaptiveRouting(params, runFn);
+    expect(runFn).toHaveBeenCalledTimes(1);
+    // Called with original params (no model override)
+    expect(runFn.mock.calls[0][0].provider).toBeUndefined();
+  });
+
+  it("bypasses when explicit model override is present and bypassOnExplicitOverride=true", async () => {
+    const params = makeParams({ _hasExplicitModelOverride: true });
+    const runFn = vi.fn().mockResolvedValueOnce(makeRunResult());
+    await runEmbeddedPiAgentWithAdaptiveRouting(params, runFn);
+    expect(runFn).toHaveBeenCalledTimes(1);
+    // Called with original (non-overridden) params
+    expect(runFn.mock.calls[0][0].provider).toBeUndefined();
+  });
+
+  it("runs local model first and returns local result when validation passes", async () => {
+    const params = makeParams();
+    const localResult = makeRunResult({ payloads: [{ text: "local answer" }] });
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      // Fire attempt callback with a passing attempt
+      p._onAttemptResult?.(makeAttemptResult({ assistantTexts: ["local answer"] }));
+      return localResult;
+    });
+
+    const result = await runEmbeddedPiAgentWithAdaptiveRouting(params, runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(1);
+    expect(runFn.mock.calls[0][0].provider).toBe("ollama");
+    expect(runFn.mock.calls[0][0].model).toBe("qwen2.5-coder");
+    expect(result).toBe(localResult);
+  });
+
+  it("escalates to cloud model when local validation fails (empty output)", async () => {
+    const cloudResult = makeRunResult({ payloads: [{ text: "cloud answer" }] });
+    const localResult = makeRunResult({ payloads: [] });
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      if (p.provider === "ollama") {
+        p._onAttemptResult?.(makeAttemptResult({ assistantTexts: [] }));
+        return localResult;
+      }
+      return cloudResult;
+    });
+
+    const result = await runEmbeddedPiAgentWithAdaptiveRouting(makeParams(), runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(2);
+    expect(runFn.mock.calls[0][0].provider).toBe("ollama");
+    expect(runFn.mock.calls[1][0].provider).toBe("openai");
+    expect(runFn.mock.calls[1][0].model).toBe("gpt-4.1-mini");
+    expect(result).toBe(cloudResult);
+  });
+
+  it("escalates when local attempt has a tool error", async () => {
+    const cloudResult = makeRunResult({ payloads: [{ text: "cloud fixed it" }] });
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      if (p.provider === "ollama") {
+        p._onAttemptResult?.(
+          makeAttemptResult({
+            assistantTexts: ["partial"],
+            lastToolError: { toolName: "bash", error: "command not found" },
+          }),
+        );
+        return makeRunResult({ payloads: [{ text: "partial", isError: true }] });
+      }
+      return cloudResult;
+    });
+
+    const result = await runEmbeddedPiAgentWithAdaptiveRouting(makeParams(), runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(2);
+    expect(result).toBe(cloudResult);
+  });
+
+  it("returns local result even if validation failed when maxEscalations=0", async () => {
+    const cfg = makeAdaptiveCfg();
+    (
+      cfg.agents!.defaults!.model as { adaptiveRouting: { maxEscalations: number } }
+    ).adaptiveRouting.maxEscalations = 0;
+    const localResult = makeRunResult({ payloads: [] });
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      p._onAttemptResult?.(makeAttemptResult({ assistantTexts: [] }));
+      return localResult;
+    });
+
+    const result = await runEmbeddedPiAgentWithAdaptiveRouting(makeParams({ config: cfg }), runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(1);
+    expect(result).toBe(localResult);
+  });
+
+  it("cloud run uses the original session file (not temp)", async () => {
+    const capturedSessionFiles: string[] = [];
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      capturedSessionFiles.push(p.sessionFile);
+      if (p.provider === "ollama") {
+        p._onAttemptResult?.(makeAttemptResult({ assistantTexts: [] }));
+        return makeRunResult({ payloads: [] });
+      }
+      return makeRunResult({ payloads: [{ text: "cloud answer" }] });
+    });
+
+    const originalSessionFile = "/tmp/test-session.jsonl";
+    await runEmbeddedPiAgentWithAdaptiveRouting(
+      makeParams({ sessionFile: originalSessionFile }),
+      runFn,
+    );
+
+    // Local run used a temp file (different from original)
+    expect(capturedSessionFiles[0]).not.toBe(originalSessionFile);
+    expect(capturedSessionFiles[0]).toContain(originalSessionFile);
+    // Cloud run used the original file
+    expect(capturedSessionFiles[1]).toBe(originalSessionFile);
+  });
+
+  it("includeLocalAttemptSummary injects local attempt context into cloud run extraSystemPrompt", async () => {
+    const cfg = makeAdaptiveCfg();
+    (
+      cfg.agents!.defaults!.model as {
+        adaptiveRouting: { includeLocalAttemptSummary: boolean };
+      }
+    ).adaptiveRouting.includeLocalAttemptSummary = true;
+
+    const capturedExtraPrompts: (string | undefined)[] = [];
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      capturedExtraPrompts.push(p.extraSystemPrompt);
+      if (p.provider === "ollama") {
+        p._onAttemptResult?.(makeAttemptResult({ assistantTexts: [] }));
+        return makeRunResult({ payloads: [] });
+      }
+      return makeRunResult({ payloads: [{ text: "cloud answer" }] });
+    });
+
+    await runEmbeddedPiAgentWithAdaptiveRouting(makeParams({ config: cfg }), runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(2);
+    // Cloud run extraSystemPrompt should contain the local attempt summary
+    const cloudPrompt = capturedExtraPrompts[1];
+    expect(cloudPrompt).toBeDefined();
+    expect(cloudPrompt).toContain("local model attempted this request");
+  });
+
+  it("existing provider failover still works: provider error on local triggers escalation", async () => {
+    // Simulate the case where local model fails with a provider error.
+    // The run result will have meta.error set.
+    const cloudResult = makeRunResult({ payloads: [{ text: "cloud fallback" }] });
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      if (p.provider === "ollama") {
+        // Provider error – _onAttemptResult fires with promptError set
+        p._onAttemptResult?.(
+          makeAttemptResult({
+            promptError: new Error("ollama not available"),
+            assistantTexts: [],
+          }),
+        );
+        return makeRunResult({
+          payloads: [{ isError: true }],
+          meta: {
+            durationMs: 50,
+            agentMeta: { sessionId: "x", provider: "ollama", model: "q" },
+            error: { kind: "retry_limit", message: "ollama not available" },
+          },
+        });
+      }
+      return cloudResult;
+    });
+
+    const result = await runEmbeddedPiAgentWithAdaptiveRouting(makeParams(), runFn);
+
+    expect(runFn).toHaveBeenCalledTimes(2);
+    expect(result).toBe(cloudResult);
+  });
+
+  it("cloud escalation call sets _adaptiveEscalationDone to prevent re-entry", async () => {
+    const cloudResult = makeRunResult({ payloads: [{ text: "cloud result" }] });
+    let capturedCloudParams: RunEmbeddedPiAgentParams | undefined;
+
+    const runFn = vi.fn().mockImplementation(async (p: RunEmbeddedPiAgentParams) => {
+      if (p.provider === "ollama") {
+        p._onAttemptResult?.(makeAttemptResult({ assistantTexts: [] }));
+        return makeRunResult({ payloads: [] });
+      }
+      capturedCloudParams = p;
+      return cloudResult;
+    });
+
+    await runEmbeddedPiAgentWithAdaptiveRouting(makeParams(), runFn);
+
+    expect(capturedCloudParams?._adaptiveEscalationDone).toBe(true);
+  });
+});

--- a/src/agents/adaptive-routing.ts
+++ b/src/agents/adaptive-routing.ts
@@ -1,0 +1,764 @@
+/**
+ * Adaptive Model Routing
+ *
+ * Outcome-aware escalation: run a cheap/local model first, validate the result
+ * with a heuristic (or optional LLM) validator, and re-run once with a cloud
+ * model if validation fails.
+ *
+ * This is NOT provider failover. Failover handles provider errors/rate-limits.
+ * Adaptive routing handles outcome quality, escalating to a stronger model when
+ * the local model produces an insufficient response.
+ *
+ * Default: disabled. Enable via agents.defaults.model.adaptiveRouting.
+ */
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+import type {
+  AdaptiveRoutingConfig,
+  AdaptiveRoutingValidationConfig,
+} from "../config/types.agents-shared.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { recordAdaptiveRun } from "./adaptive-routing-savings.js";
+import { FailoverError } from "./failover-error.js";
+import type { RunEmbeddedPiAgentParams } from "./pi-embedded-runner/run/params.js";
+import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded-runner/types.js";
+
+const log = createSubsystemLogger("agent/adaptive-routing");
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+const DEFAULT_MIN_SCORE = 0.75;
+const DEFAULT_MAX_TOOL_OUTPUT_CHARS = 2000;
+const DEFAULT_MAX_ASSISTANT_CHARS = 4000;
+const MAX_ESCALATIONS_CAP = 1; // v1 hard cap
+
+// ─── Result types ─────────────────────────────────────────────────────────────
+
+export type ValidationResult = {
+  passed: boolean;
+  score: number;
+  reason: string;
+};
+
+export type AdaptiveRoutingOutcome =
+  | { used: false; bypassReason: string }
+  | {
+      used: true;
+      localModel: string;
+      cloudModel: string;
+      validationMode: "heuristic" | "llm";
+      validationScore: number;
+      validationPassed: boolean;
+      validationReason: string;
+      escalated: boolean;
+    };
+
+// ─── Config resolution ───────────────────────────────────────────────────────
+
+/**
+ * Extract the adaptiveRouting config from the top-level OpenClaw config.
+ * Returns null when adaptive routing is not enabled or not present.
+ */
+export function resolveAdaptiveRoutingConfig(
+  cfg: OpenClawConfig | undefined,
+): AdaptiveRoutingConfig | null {
+  const model = cfg?.agents?.defaults?.model;
+  if (!model || typeof model === "string") {
+    return null;
+  }
+  const ar = model.adaptiveRouting;
+  if (!ar?.enabled) {
+    return null;
+  }
+  if (!ar.localFirstModel?.trim() || !ar.cloudEscalationModel?.trim()) {
+    log.warn(
+      "[adaptive-routing] enabled but localFirstModel or cloudEscalationModel missing – disabled",
+    );
+    return null;
+  }
+  if (!ar.localFirstModel.includes("/") || !ar.cloudEscalationModel.includes("/")) {
+    log.warn(
+      "[adaptive-routing] localFirstModel and cloudEscalationModel must use 'provider/model' format (e.g. ollama/llama3.2) – disabled",
+    );
+    return null;
+  }
+  // Enforce v1 maxEscalations cap
+  const maxEscalations = Math.min(Math.max(0, ar.maxEscalations ?? 1), MAX_ESCALATIONS_CAP);
+  return { ...ar, maxEscalations };
+}
+
+/**
+ * Returns the bypass reason string if adaptive routing should not run,
+ * or null if it should proceed.
+ */
+export function resolveBypassReason(
+  cfg: AdaptiveRoutingConfig,
+  opts: {
+    hasExplicitModelOverride: boolean;
+    /** Caller-provided provider (may be the default — check against adaptive config). */
+    callerProvider?: string;
+    /** Caller-provided model (may be the default — check against adaptive config). */
+    callerModel?: string;
+  },
+): string | null {
+  const bypassOnOverride = cfg.bypassOnExplicitOverride ?? true;
+  if (bypassOnOverride && opts.hasExplicitModelOverride) {
+    return "explicit_override";
+  }
+  // Bypass when the caller explicitly targets a specific model that differs
+  // from the adaptive config's local/cloud pair (e.g. probe runs, direct API
+  // calls with an explicit provider/model).
+  if (opts.callerProvider && opts.callerModel) {
+    const callerRef = `${opts.callerProvider}/${opts.callerModel}`;
+    const localRef = cfg.localFirstModel?.trim();
+    const cloudRef = cfg.cloudEscalationModel?.trim();
+    if (localRef && cloudRef && callerRef !== localRef && callerRef !== cloudRef) {
+      return "explicit_model_target";
+    }
+  }
+  return null;
+}
+
+// ─── Secret redaction ────────────────────────────────────────────────────────
+
+const SECRET_PATTERNS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /sk-[A-Za-z0-9_-]{8,}/g, replacement: "[REDACTED:sk-key]" },
+  { pattern: /Bearer\s+[A-Za-z0-9._\-/+]{8,}/gi, replacement: "Bearer [REDACTED]" },
+  {
+    pattern:
+      /(?:api[_-]?key|apikey|access[_-]?token|secret)[=:]\s*["']?[A-Za-z0-9._\-/+]{8,}["']?/gi,
+    replacement: "[REDACTED:api-key]",
+  },
+  {
+    pattern: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+    replacement: "[REDACTED:jwt]",
+  },
+];
+
+export function redactSecrets(text: string): string {
+  let result = text;
+  for (const { pattern, replacement } of SECRET_PATTERNS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+// ─── Heuristic validation ────────────────────────────────────────────────────
+
+/**
+ * Validate an attempt result using heuristic rules.
+ * Produces a numeric score in [0..1] and a boolean pass/fail.
+ */
+export function validateHeuristic(
+  attempt: EmbeddedRunAttemptResult,
+  cfg: AdaptiveRoutingConfig,
+): ValidationResult {
+  const minScore = cfg.validation?.minScore ?? DEFAULT_MIN_SCORE;
+  let score = 1.0;
+  const failReasons: string[] = [];
+
+  // 1. Provider/runtime error
+  if (attempt.promptError) {
+    score -= 1.0;
+    failReasons.push("provider_error");
+  }
+
+  // 2. Aborted (user abort, not timeout)
+  if (attempt.aborted && !attempt.timedOut) {
+    score -= 0.8;
+    failReasons.push("aborted");
+  }
+
+  // 3. Timeout → treat as length truncation
+  if (attempt.timedOut) {
+    score -= 0.3;
+    failReasons.push("timed_out");
+  }
+
+  // 4. Tool execution error
+  if (attempt.lastToolError?.error) {
+    score -= 0.6;
+    failReasons.push(`tool_error:${attempt.lastToolError.toolName}`);
+  }
+
+  // 5. No final assistant text — exempt runs where the response was delivered via
+  // a messaging tool (send_message / reply / etc.), which produce no assistant text.
+  const lastAssistantText = attempt.assistantTexts.join("").trim();
+  if (!lastAssistantText && !attempt.didSendViaMessagingTool) {
+    score -= 0.4;
+    failReasons.push("empty_assistant_output");
+  }
+
+  // 6. Pending tool calls: run ended with the assistant making tool calls but no tool results follow.
+  // The pi-ai SDK uses "toolCall" as the content block type for tool calls.
+  if (attempt.messagesSnapshot) {
+    const last = attempt.messagesSnapshot[attempt.messagesSnapshot.length - 1];
+    if (last?.role === "assistant") {
+      const content = last.content;
+      if (Array.isArray(content)) {
+        const hasToolCallBlock = content.some(
+          (b): boolean =>
+            b != null &&
+            typeof b === "object" &&
+            ((b as { type?: unknown }).type === "toolCall" ||
+              (b as { type?: unknown }).type === "tool_use"),
+        );
+        if (hasToolCallBlock) {
+          // Last message has tool calls with no following tool results = pending
+          score -= 0.4;
+          failReasons.push("pending_tool_calls");
+        }
+      }
+    }
+  }
+
+  score = Math.max(0, Math.min(1, score));
+  // Use score as the sole pass gate so operators can tune minScore meaningfully.
+  // Each penalty both reduces score and records a reason; failReasons is kept
+  // for logging only — not as an independent boolean gate — so that a run with
+  // only minor issues (e.g. a single timeout) can still pass when minScore is
+  // set lower than the default 0.75.
+  const passed = score >= minScore;
+
+  return {
+    passed,
+    score,
+    reason: passed
+      ? "ok"
+      : failReasons.length > 0
+        ? failReasons.join(", ")
+        : "score_below_threshold",
+  };
+}
+
+// ─── LLM validation ──────────────────────────────────────────────────────────
+
+type LlmRunFn = (provider: string, model: string, prompt: string) => Promise<string>;
+
+/** Parse a "provider/model" string into { provider, model }. */
+export function parseModelRef(ref: string): { provider: string; model: string } {
+  const slash = ref.indexOf("/");
+  if (slash > 0) {
+    return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
+  }
+  // Callers validate format before reaching here; this is a safety fallback.
+  return { provider: ref, model: ref };
+}
+
+function buildValidatorPrompt(
+  userRequest: string,
+  assistantOutput: string,
+  toolSummary: string,
+  validationCfg: AdaptiveRoutingValidationConfig | undefined,
+): string {
+  const maxAssistantChars = validationCfg?.maxAssistantChars ?? DEFAULT_MAX_ASSISTANT_CHARS;
+  const shouldRedact = validationCfg?.redactSecrets ?? true;
+  // Use configured minScore so the LLM calibrates its scoring to match the
+  // operator's threshold rather than always anchoring to the 0.75 default.
+  const minScore = validationCfg?.minScore ?? DEFAULT_MIN_SCORE;
+
+  const truncatedOutput = assistantOutput.slice(0, maxAssistantChars);
+  const finalOutput = shouldRedact ? redactSecrets(truncatedOutput) : truncatedOutput;
+  const finalRequest = shouldRedact ? redactSecrets(userRequest) : userRequest;
+
+  return [
+    "You are a response quality validator. Evaluate whether the assistant adequately completed the user request.",
+    "",
+    `User request: ${finalRequest}`,
+    "",
+    toolSummary ? `Tool calls made:\n${toolSummary}` : "No tool calls.",
+    "",
+    `Assistant output:\n${finalOutput || "(empty)"}`,
+    "",
+    'Respond with ONLY valid JSON: {"score": 0.0-1.0, "passed": true/false, "reason": "one sentence"}',
+    `Score above ${minScore} = passed. Be strict: empty output, tool errors, or incomplete tasks = fail.`,
+  ].join("\n");
+}
+
+function buildToolSummary(
+  attempt: EmbeddedRunAttemptResult,
+  validationCfg: AdaptiveRoutingValidationConfig | undefined,
+): string {
+  const maxToolChars = validationCfg?.maxToolOutputChars ?? DEFAULT_MAX_TOOL_OUTPUT_CHARS;
+  const shouldRedact = validationCfg?.redactSecrets ?? true;
+
+  return attempt.toolMetas
+    .map((t) => {
+      const meta = t.meta ? `: ${t.meta.slice(0, maxToolChars)}` : "";
+      const redacted = shouldRedact ? redactSecrets(meta) : meta;
+      const error =
+        attempt.lastToolError?.toolName === t.toolName
+          ? ` [ERROR: ${attempt.lastToolError.error ?? "unknown"}]`
+          : "";
+      return `  - ${t.toolName}${redacted}${error}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Validate using an LLM validator model.
+ * Returns null if the validator call fails (treated as FAIL by caller).
+ */
+export async function validateWithLlm(
+  attempt: EmbeddedRunAttemptResult,
+  userRequest: string,
+  cfg: AdaptiveRoutingConfig,
+  llmRun: LlmRunFn,
+): Promise<ValidationResult> {
+  const validationCfg = cfg.validation;
+  const validatorModelRef = validationCfg?.validatorModel ?? "";
+  if (!validatorModelRef.trim()) {
+    log.warn(
+      "[adaptive-routing] llm validation requested but validatorModel not configured; falling back to heuristic",
+    );
+    return validateHeuristic(attempt, cfg);
+  }
+
+  const { provider: vProvider, model: vModel } = parseModelRef(validatorModelRef);
+  const assistantOutput = attempt.assistantTexts.join("\n");
+  const toolSummary = buildToolSummary(attempt, validationCfg);
+  const prompt = buildValidatorPrompt(userRequest, assistantOutput, toolSummary, validationCfg);
+
+  try {
+    const raw = await llmRun(vProvider, vModel, prompt);
+    // Greedy match to capture the outermost JSON object. Non-greedy (*?) would
+    // stop at the first "}" which breaks when the reason field itself contains "}"
+    // (e.g. "Truncated at 80%}"), yielding malformed JSON and a spurious escalation.
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      log.warn("[adaptive-routing] LLM validator returned no JSON; treating as FAIL");
+      return { passed: false, score: 0, reason: "validator_no_json" };
+    }
+    const parsed = JSON.parse(jsonMatch[0]) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      typeof (parsed as Record<string, unknown>).score !== "number" ||
+      typeof (parsed as Record<string, unknown>).passed !== "boolean"
+    ) {
+      log.warn(
+        "[adaptive-routing] LLM validator returned invalid JSON structure; treating as FAIL",
+      );
+      return { passed: false, score: 0, reason: "validator_invalid_json" };
+    }
+    const result = parsed as { score: number; passed: boolean; reason?: string };
+    const minScore = validationCfg?.minScore ?? DEFAULT_MIN_SCORE;
+    // Enforce consistency: if score below minScore, override passed to false
+    const passed = result.passed && result.score >= minScore;
+    return {
+      passed,
+      score: Math.max(0, Math.min(1, result.score)),
+      reason: result.reason ?? (passed ? "ok" : "llm_fail"),
+    };
+  } catch (err) {
+    log.warn(`[adaptive-routing] LLM validator error: ${String(err)}; treating as FAIL`);
+    return { passed: false, score: 0, reason: "validator_error" };
+  }
+}
+
+// ─── Main wrapper ─────────────────────────────────────────────────────────────
+
+export type AdaptiveRunFn = (params: RunEmbeddedPiAgentParams) => Promise<EmbeddedPiRunResult>;
+
+/**
+ * Run the agent with adaptive model routing.
+ *
+ * - If adaptive routing is disabled or bypassed, delegates directly to `runFn`.
+ * - Otherwise:
+ *   1. Runs with `localFirstModel` (writing to a temp session file copy).
+ *   2. Validates the outcome (heuristic or LLM).
+ *   3. If validation passes: promotes the temp session to the real session file.
+ *   4. If validation fails and maxEscalations > 0: discards temp session and
+ *      re-runs with `cloudEscalationModel` against the original session file.
+ *
+ * The cloud re-run sees the same conversation history as the local run (before
+ * the local attempt), satisfying the "rerun from scratch" requirement.
+ */
+export async function runEmbeddedPiAgentWithAdaptiveRouting(
+  params: RunEmbeddedPiAgentParams,
+  runFn: AdaptiveRunFn,
+): Promise<EmbeddedPiRunResult> {
+  const arCfg = resolveAdaptiveRoutingConfig(params.config);
+
+  if (!arCfg) {
+    log.debug("[adaptive-routing] disabled");
+    return runFn(params);
+  }
+
+  const bypassReason = resolveBypassReason(arCfg, {
+    hasExplicitModelOverride: params._hasExplicitModelOverride ?? false,
+    callerProvider: params.provider?.trim(),
+    callerModel: params.model?.trim(),
+  });
+
+  if (bypassReason) {
+    log.debug(`[adaptive-routing] bypassed: ${bypassReason}`);
+    logAdaptiveOutcome({ used: false, bypassReason });
+    void recordAdaptiveRun(resolveStateDir(), { kind: "bypassed" });
+    return runFn(params);
+  }
+
+  const { provider: localProvider, model: localModel } = parseModelRef(arCfg.localFirstModel!);
+  const { provider: cloudProvider, model: cloudModel } = parseModelRef(arCfg.cloudEscalationModel!);
+
+  // When localTrialReadOnly is set, agents with mutating tools should skip the
+  // local trial entirely — tool side-effects (messages sent, files written) from
+  // the trial cannot be rolled back if escalation fires.
+  if (arCfg.localTrialReadOnly) {
+    log.debug("[adaptive-routing] bypassed: localTrialReadOnly");
+    logAdaptiveOutcome({ used: false, bypassReason: "local_trial_read_only" });
+    void recordAdaptiveRun(resolveStateDir(), { kind: "bypassed" });
+    return runFn(params);
+  }
+
+  // If adaptive routing already escalated earlier in this runWithModelFallback chain
+  // (tracked via _adaptiveEscalationDone set by the caller's closure), skip local
+  // re-run and let the fallback machinery use the current candidate directly.
+  if (params._adaptiveEscalationDone) {
+    log.debug(`[adaptive-routing] bypassed: escalation already ran in this fallback chain`);
+    return runFn(params);
+  }
+
+  const maxEscalations = arCfg.maxEscalations ?? 1;
+  const validationMode = arCfg.validation?.mode ?? "heuristic";
+
+  if (validationMode === "llm") {
+    log.warn(
+      "[adaptive-routing] LLM validation mode is experimental and not fully implemented; " +
+        "will fall back to heuristic validation. See docs for details.",
+    );
+  }
+
+  log.info(
+    `[adaptive-routing] starting: local=${localProvider}/${localModel} cloud=${cloudProvider}/${cloudModel} validationMode=${validationMode}`,
+  );
+
+  // ── Local run in a temp session file ──────────────────────────────────────
+  const originalSessionFile = params.sessionFile;
+  const tempSessionFile = `${originalSessionFile}.adaptive-${Date.now()}-${process.pid}-${randomBytes(4).toString("hex")}`;
+
+  // Copy existing session (conversation history) to temp file before local run.
+  await fs.copyFile(originalSessionFile, tempSessionFile).catch((err: NodeJS.ErrnoException) => {
+    if (err.code === "ENOENT") {
+      return;
+    } // New conversation — no file yet.
+    throw err; // Real I/O failure — don't silently proceed with stale state.
+  });
+
+  let localAttemptResult: EmbeddedRunAttemptResult | undefined;
+  let localTrialFailed = false;
+  // Hoisted so the escalation block can access validation result for logging
+  // and for includeLocalAttemptSummary context injection.
+  let localValidation: ValidationResult | undefined;
+
+  try {
+    let localResult: EmbeddedPiRunResult;
+    try {
+      localResult = await runFn({
+        ...params,
+        provider: localProvider,
+        model: localModel,
+        sessionFile: tempSessionFile,
+        // Suppress all user-visible streaming callbacks during the local trial run.
+        // They fire again on the definitive run (cloud escalation or local-pass path).
+        // Without this, partial output from the local attempt leaks to the user before
+        // validation decides which model's response to actually deliver, causing
+        // duplicate sends when escalation occurs.
+        onPartialReply: undefined,
+        onAssistantMessageStart: undefined,
+        onBlockReply: undefined,
+        onBlockReplyFlush: undefined,
+        onReasoningStream: undefined,
+        onReasoningEnd: undefined,
+        onToolResult: undefined,
+        // Suppress agent-event streaming so trial-run events (tool calls, partial
+        // output, etc.) never surface to the end user or control channel.
+        onAgentEvent: undefined,
+        // Capture the rich attempt result for validation
+        _onAttemptResult: (r) => {
+          localAttemptResult = r;
+          // Forward to any outer handler too
+          params._onAttemptResult?.(r);
+        },
+      });
+    } catch (localErr) {
+      // FailoverError (auth failure, rate limit, provider down) — treat as
+      // automatic local-trial failure and escalate to cloud instead of
+      // propagating the error and aborting the whole agent turn.
+      if (localErr instanceof FailoverError) {
+        log.warn(
+          `[adaptive-routing] local trial threw FailoverError: ${localErr.message} → escalating to cloud`,
+        );
+        localTrialFailed = true;
+        // falls through to the escalation block below
+        localResult = undefined!;
+      } else {
+        throw localErr;
+      }
+    }
+
+    // ── Validate ──────────────────────────────────────────────────────────
+    if (!localTrialFailed) {
+      let validation: ValidationResult;
+
+      if (!localAttemptResult) {
+        // runFn didn't fire the callback (e.g., CLI provider path); fall back to run-result heuristic
+        validation = validateFromRunResult(localResult, arCfg);
+      } else if (validationMode === "llm") {
+        validation = await validateWithLlm(
+          localAttemptResult,
+          params.prompt,
+          arCfg,
+          // LLM run fn: for v1, fall back to heuristic; a future version can wire
+          // in a lightweight completion call here.
+          async () => {
+            log.warn(
+              "[adaptive-routing] LLM validator not wired to a standalone runner; using heuristic",
+            );
+            return JSON.stringify(validateHeuristic(localAttemptResult!, arCfg));
+          },
+        );
+      } else {
+        validation = validateHeuristic(localAttemptResult, arCfg);
+      }
+
+      localValidation = validation;
+
+      log.info(
+        `[adaptive-routing] local validation: passed=${validation.passed} score=${validation.score.toFixed(2)} reason=${validation.reason}`,
+      );
+
+      if (validation.passed || maxEscalations === 0) {
+        // Local result is good (or forced-local due to maxEscalations cap) –
+        // promote temp session file to actual.
+        const forcedLocal = !validation.passed && maxEscalations === 0;
+        await safeRename(tempSessionFile, originalSessionFile);
+        logAdaptiveOutcome({
+          used: true,
+          localModel: `${localProvider}/${localModel}`,
+          cloudModel: `${cloudProvider}/${cloudModel}`,
+          validationMode,
+          validationScore: validation.score,
+          validationPassed: validation.passed,
+          validationReason: validation.reason,
+          escalated: false,
+        });
+        void recordAdaptiveRun(resolveStateDir(), {
+          kind: forcedLocal ? "local_forced" : "local_success",
+          localUsage: localAttemptResult?.attemptUsage ?? localResult.meta.agentMeta?.usage,
+        });
+        localResult.adaptiveRoutingMeta = {
+          actualProvider: localProvider,
+          actualModel: localModel,
+          escalated: false,
+        };
+        return localResult;
+      }
+    }
+
+    // ── Escalate to cloud model ────────────────────────────────────────────
+    if (localTrialFailed) {
+      log.info(
+        `[adaptive-routing] escalating (local trial error) → ${cloudProvider}/${cloudModel}`,
+      );
+    } else {
+      log.info(
+        `[adaptive-routing] escalating: local validation failed → ${cloudProvider}/${cloudModel}`,
+      );
+    }
+
+    // Discard temp session so cloud run sees original history (not local attempt)
+    await fs.unlink(tempSessionFile).catch(() => {});
+
+    // Notify the caller's fallback closure that escalation is about to run.
+    // This lets it skip re-running the local model if the cloud run fails and
+    // runWithModelFallback retries with another candidate.
+    params._onAdaptiveEscalation?.();
+
+    // When includeLocalAttemptSummary is set, inject a short redacted summary of
+    // the local attempt into the cloud run's system prompt so the cloud model can
+    // avoid repeating the same approach. Only injected on escalation (not bypass).
+    const localSummaryExtra =
+      arCfg.includeLocalAttemptSummary && localAttemptResult
+        ? buildLocalAttemptSummary(localAttemptResult, localValidation, arCfg)
+        : undefined;
+
+    let cloudResult: EmbeddedPiRunResult;
+    try {
+      cloudResult = await runFn({
+        ...params,
+        provider: cloudProvider,
+        model: cloudModel,
+        sessionFile: originalSessionFile,
+        // Prevent re-entering adaptive routing if runFn is composed with
+        // the wrapper at an outer layer (avoids double-escalation).
+        _adaptiveEscalationDone: true,
+        extraSystemPrompt: localSummaryExtra
+          ? [params.extraSystemPrompt, localSummaryExtra].filter(Boolean).join("\n\n")
+          : params.extraSystemPrompt,
+      });
+    } catch (cloudErr) {
+      // If the cloud escalation model also fails, let the error propagate up
+      // to runWithModelFallback so the normal fallback chain can try the next
+      // candidate provider/model instead of aborting the turn entirely.
+      log.warn(
+        `[adaptive-routing] cloud escalation failed: ${cloudErr instanceof Error ? cloudErr.message : String(cloudErr)}`,
+      );
+      throw cloudErr;
+    }
+
+    logAdaptiveOutcome({
+      used: true,
+      localModel: `${localProvider}/${localModel}`,
+      cloudModel: `${cloudProvider}/${cloudModel}`,
+      validationMode,
+      validationScore: localValidation?.score ?? 0,
+      validationPassed: false,
+      validationReason: localTrialFailed
+        ? "local_trial_error"
+        : (localValidation?.reason ?? "validation_failed"),
+      escalated: true,
+    });
+    void recordAdaptiveRun(resolveStateDir(), {
+      kind: "escalated",
+      localUsage: localAttemptResult?.attemptUsage ?? localResult?.meta?.agentMeta?.usage,
+      cloudUsage: cloudResult.meta.agentMeta?.usage,
+    });
+
+    cloudResult.adaptiveRoutingMeta = {
+      actualProvider: cloudProvider,
+      actualModel: cloudModel,
+      escalated: true,
+    };
+    return cloudResult;
+  } finally {
+    // Safety: always clean up temp file on any exit path
+    await fs.unlink(tempSessionFile).catch(() => {});
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fallback heuristic validation based solely on `EmbeddedPiRunResult`
+ * (when `EmbeddedRunAttemptResult` is not available).
+ */
+function validateFromRunResult(
+  result: EmbeddedPiRunResult,
+  cfg: AdaptiveRoutingConfig,
+): ValidationResult {
+  const minScore = cfg.validation?.minScore ?? DEFAULT_MIN_SCORE;
+  let score = 1.0;
+  const failReasons: string[] = [];
+
+  if (result.meta.error) {
+    score -= 1.0;
+    failReasons.push(`runtime_error:${result.meta.error.kind}`);
+  }
+
+  if (result.meta.aborted) {
+    score -= 0.8;
+    failReasons.push("aborted");
+  }
+
+  if (result.meta.pendingToolCalls?.length) {
+    score -= 0.4;
+    failReasons.push("pending_tool_calls");
+  }
+
+  const hasTextPayload = result.payloads?.some(
+    (p) => typeof p.text === "string" && p.text.trim().length > 0 && !p.isError,
+  );
+  if (!hasTextPayload) {
+    score -= 0.4;
+    failReasons.push("empty_or_error_output");
+  }
+
+  score = Math.max(0, Math.min(1, score));
+  const passed = score >= minScore;
+  return {
+    passed,
+    score,
+    reason: passed
+      ? "ok"
+      : failReasons.length > 0
+        ? failReasons.join(", ")
+        : "score_below_threshold",
+  };
+}
+
+/**
+ * Build a short, redacted summary of the local trial attempt to inject into
+ * the cloud escalation run's system prompt when includeLocalAttemptSummary is
+ * enabled. Gives the cloud model context about what the local model tried so
+ * it can take a different approach if helpful.
+ */
+function buildLocalAttemptSummary(
+  attempt: EmbeddedRunAttemptResult,
+  validation: ValidationResult | undefined,
+  cfg: AdaptiveRoutingConfig,
+): string {
+  const shouldRedact = cfg.validation?.redactSecrets ?? true;
+  const assistantText = attempt.assistantTexts.join("").trim();
+  const preview = assistantText.slice(0, 300);
+  const finalPreview = shouldRedact ? redactSecrets(preview) : preview;
+  const toolNames = attempt.toolMetas.map((t) => t.toolName).join(", ");
+
+  const lines = [
+    "[Context: A local model attempted this request but the response quality was insufficient.]",
+  ];
+  if (validation) {
+    lines.push(`Quality score: ${validation.score.toFixed(2)} | Reason: ${validation.reason}`);
+  }
+  if (toolNames) {
+    lines.push(`Tools invoked: ${toolNames}`);
+  }
+  if (finalPreview) {
+    lines.push(`Local attempt output (preview): ${finalPreview}`);
+  }
+  return lines.join("\n");
+}
+
+async function safeRename(from: string, to: string): Promise<void> {
+  try {
+    await fs.rename(from, to);
+  } catch (renameErr) {
+    // ENOENT from rename: the temp file was cleaned up or never created (e.g.
+    // tests with mock runFn that don't write actual files). Not a failure.
+    if ((renameErr as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    // rename may fail cross-device; fall back to copy + unlink
+    await fs.copyFile(from, to);
+    await fs.unlink(from).catch(() => {});
+  }
+}
+
+function logAdaptiveOutcome(outcome: AdaptiveRoutingOutcome): void {
+  if (!outcome.used) {
+    log.info(
+      `[adaptive-routing] outcome: adaptive_routing_used=false bypass_reason=${outcome.bypassReason}`,
+    );
+    return;
+  }
+  log.info(
+    `[adaptive-routing] outcome: adaptive_routing_used=true` +
+      ` local_model=${outcome.localModel}` +
+      ` cloud_model=${outcome.cloudModel}` +
+      ` validation_mode=${outcome.validationMode}` +
+      ` validation_score=${outcome.validationScore.toFixed(2)}` +
+      ` validation_passed=${outcome.validationPassed}` +
+      ` escalated=${outcome.escalated}` +
+      (outcome.escalated ? ` local_reason=${outcome.validationReason}` : ""),
+  );
+}
+
+// Re-export types for consumers
+export type {
+  AdaptiveRoutingConfig,
+  AdaptiveRoutingValidationConfig,
+} from "../config/types.agents-shared.js";

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -21,6 +21,7 @@ vi.mock("./pi-embedded.js", () => ({
   isEmbeddedPiRunStreaming: () => false,
   queueEmbeddedPiMessage: () => false,
   waitForEmbeddedPiRunEnd: async () => true,
+  createAdaptiveEmbeddedRunner: () => () => Promise.resolve({ payloads: [], meta: {} }),
 }));
 
 vi.mock("./tools/agent-step.js", () => ({

--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -9,7 +9,7 @@ export {
   limitHistoryTurns,
 } from "./pi-embedded-runner/history.js";
 export { resolveEmbeddedSessionLane } from "./pi-embedded-runner/lanes.js";
-export { runEmbeddedPiAgent } from "./pi-embedded-runner/run.js";
+export { createAdaptiveEmbeddedRunner, runEmbeddedPiAgent } from "./pi-embedded-runner/run.js";
 export {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -11,6 +11,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
+import { runEmbeddedPiAgentWithAdaptiveRouting } from "../adaptive-routing.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { hasConfiguredModelFallbacks } from "../agent-scope.js";
 import {
@@ -252,7 +253,7 @@ function buildErrorAgentMeta(params: {
   };
 }
 
-export async function runEmbeddedPiAgent(
+async function runEmbeddedPiAgentCore(
   params: RunEmbeddedPiAgentParams,
 ): Promise<EmbeddedPiRunResult> {
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
@@ -1489,6 +1490,10 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          // Fire the adaptive-routing callback so the wrapper can inspect
+          // the rich attempt data for outcome validation.
+          params._onAttemptResult?.(attempt);
+
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
@@ -1543,4 +1548,45 @@ export async function runEmbeddedPiAgent(
       }
     }),
   );
+}
+
+// ─── Adaptive-routing seam ─────────────────────────────────────────────────
+//
+// `runEmbeddedPiAgent` is the single public entry point for all agent runs.
+// Adaptive model routing is an internal concern: call sites never import from
+// adaptive-routing.ts. The factory keeps escalation state across
+// runWithModelFallback retries without leaking it into the call site.
+
+/**
+ * Create a stateful runner that wraps adaptive routing for one full agent
+ * turn (including all runWithModelFallback retries for that turn).
+ *
+ * The returned function has the same signature as runEmbeddedPiAgent; pass it
+ * to runWithModelFallback's `run` callback instead of calling runEmbeddedPiAgent
+ * directly so escalation state persists across retries.
+ */
+export function createAdaptiveEmbeddedRunner(): (
+  params: RunEmbeddedPiAgentParams,
+) => Promise<EmbeddedPiRunResult> {
+  const escalationState = { done: false };
+  return (params) =>
+    runEmbeddedPiAgentWithAdaptiveRouting(
+      {
+        ...params,
+        _adaptiveEscalationDone: escalationState.done,
+        _onAdaptiveEscalation: () => {
+          escalationState.done = true;
+        },
+      },
+      runEmbeddedPiAgentCore,
+    );
+}
+
+/**
+ * Run the embedded Pi agent for a single non-fallback call.
+ * For runWithModelFallback loops use createAdaptiveEmbeddedRunner() instead
+ * so escalation state persists across retries.
+ */
+export function runEmbeddedPiAgent(params: RunEmbeddedPiAgentParams): Promise<EmbeddedPiRunResult> {
+  return createAdaptiveEmbeddedRunner()(params);
 }

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -124,4 +124,30 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /**
+   * Internal hook for adaptive model routing.
+   * Called with the raw attempt result on the success path so the wrapper can
+   * validate outcome quality without re-inspecting the final EmbeddedPiRunResult.
+   * Not for general use.
+   */
+  _onAttemptResult?: (attempt: import("./types.js").EmbeddedRunAttemptResult) => void;
+  /**
+   * Internal flag for adaptive routing: indicates an explicit per-run model
+   * override was provided (CLI/env/API). Used to enforce bypassOnExplicitOverride.
+   * Not for general use.
+   */
+  _hasExplicitModelOverride?: boolean;
+  /**
+   * Internal flag: true when adaptive routing already escalated to the cloud model
+   * earlier in this runWithModelFallback chain. Prevents re-running the local model
+   * on subsequent fallback retries after cloud escalation fails.
+   * Set by the outer closure via _onAdaptiveEscalation.
+   */
+  _adaptiveEscalationDone?: boolean;
+  /**
+   * Callback invoked by the adaptive routing wrapper immediately before the cloud
+   * escalation run. The outer runWithModelFallback closure uses this to flip
+   * _adaptiveEscalationDone for subsequent retry invocations.
+   */
+  _onAdaptiveEscalation?: () => void;
 };

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -74,6 +74,14 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   // Count of successful cron.add tool calls in this run.
   successfulCronAdds?: number;
+  /** Adaptive routing metadata attached when the run was routed. */
+  adaptiveRoutingMeta?: {
+    /** The provider/model that actually served this response. */
+    actualProvider: string;
+    actualModel: string;
+    /** Whether cloud escalation occurred. */
+    escalated: boolean;
+  };
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/agents/pi-embedded.ts
+++ b/src/agents/pi-embedded.ts
@@ -7,6 +7,7 @@ export type {
 export {
   abortEmbeddedPiRun,
   compactEmbeddedPiSession,
+  createAdaptiveEmbeddedRunner,
   isEmbeddedPiRunActive,
   isEmbeddedPiRunStreaming,
   queueEmbeddedPiMessage,

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -47,6 +47,7 @@ const embeddedRunMock = {
   isEmbeddedPiRunStreaming: vi.fn(() => false),
   queueEmbeddedPiMessage: vi.fn(() => false),
   waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+  createAdaptiveEmbeddedRunner: () => () => Promise.resolve({ payloads: [], meta: {} }),
 };
 const subagentRegistryMock = {
   isSubagentSessionRunActive: vi.fn(() => true),

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -57,6 +57,7 @@ vi.mock("./pi-embedded.js", () => ({
   isEmbeddedPiRunActive: () => false,
   queueEmbeddedPiMessage: () => false,
   waitForEmbeddedPiRunEnd: async () => true,
+  createAdaptiveEmbeddedRunner: () => () => Promise.resolve({ payloads: [], meta: {} }),
 }));
 
 vi.mock("./subagent-registry.js", () => ({

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -10,14 +10,18 @@ type RunEmbeddedPiAgent = typeof import("../agents/pi-embedded.js").runEmbeddedP
 type RunEmbeddedPiAgentParams = Parameters<RunEmbeddedPiAgent>[0];
 type RunEmbeddedPiAgentReply = Awaited<ReturnType<RunEmbeddedPiAgent>>;
 
-const piEmbeddedMock = vi.hoisted(() => ({
-  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
-  runEmbeddedPiAgent: vi.fn<RunEmbeddedPiAgent>(),
-  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
-  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
-  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
-  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
-}));
+const piEmbeddedMock = vi.hoisted(() => {
+  const runFn = vi.fn<RunEmbeddedPiAgent>();
+  return {
+    abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+    runEmbeddedPiAgent: runFn,
+    createAdaptiveEmbeddedRunner: () => (params: RunEmbeddedPiAgentParams) => runFn(params),
+    queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+    resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+    isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+    isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  };
+});
 
 vi.mock("/src/agents/pi-embedded.js", () => piEmbeddedMock);
 vi.mock("../agents/pi-embedded.js", () => piEmbeddedMock);

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
@@ -5,6 +5,10 @@ export const runEmbeddedPiAgentMock: Mock = vi.fn();
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
   runEmbeddedPiAgent: (...args: unknown[]) => runEmbeddedPiAgentMock(...args),
+  createAdaptiveEmbeddedRunner:
+    () =>
+    (...args: unknown[]) =>
+      runEmbeddedPiAgentMock(...args),
   queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
   isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),

--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -40,6 +40,10 @@ vi.mock("../agents/pi-embedded.js", () => ({
   compactEmbeddedPiSession: (...args: unknown[]) =>
     piEmbeddedMocks.compactEmbeddedPiSession(...args),
   runEmbeddedPiAgent: (...args: unknown[]) => piEmbeddedMocks.runEmbeddedPiAgent(...args),
+  createAdaptiveEmbeddedRunner:
+    () =>
+    (...args: unknown[]) =>
+      piEmbeddedMocks.runEmbeddedPiAgent(...args),
   queueEmbeddedPiMessage: (...args: unknown[]) => piEmbeddedMocks.queueEmbeddedPiMessage(...args),
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
   isEmbeddedPiRunActive: (...args: unknown[]) => piEmbeddedMocks.isEmbeddedPiRunActive(...args),

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -23,6 +23,7 @@ import { buildTestCtx } from "./test-ctx.js";
 vi.mock("../../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(true),
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+  createAdaptiveEmbeddedRunner: () => vi.fn(),
 }));
 
 const commandQueueMocks = vi.hoisted(() => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,7 +12,8 @@ import {
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { createAdaptiveEmbeddedRunner } from "../../agents/pi-embedded.js";
+import type { EmbeddedPiRunResult } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -61,7 +62,7 @@ export type AgentRunLoopResult =
   | {
       kind: "success";
       runId: string;
-      runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+      runResult: EmbeddedPiRunResult;
       fallbackProvider?: string;
       fallbackModel?: string;
       fallbackAttempts: RuntimeFallbackAttempt[];
@@ -133,7 +134,7 @@ export async function runAgentTurnWithFallback(params: {
       isControlUiVisible: shouldSurfaceToControlUi,
     });
   }
-  let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+  let runResult: EmbeddedPiRunResult;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
@@ -197,6 +198,10 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
+      // One stateful runner per turn: createAdaptiveEmbeddedRunner captures escalation
+      // state so retries within this runWithModelFallback chain skip re-running the
+      // local model if cloud escalation already occurred.
+      const runAgent = createAdaptiveEmbeddedRunner();
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
@@ -321,7 +326,7 @@ export async function runAgentTurnWithFallback(params: {
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           });
           return (async () => {
-            const result = await runEmbeddedPiAgent({
+            const result = await runAgent({
               ...embeddedContext,
               trigger: params.isHeartbeat ? "heartbeat" : "user",
               groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
@@ -331,6 +336,7 @@ export async function runAgentTurnWithFallback(params: {
               ...senderContext,
               ...runBaseParams,
               prompt: params.commandBody,
+              _hasExplicitModelOverride: params.followupRun.run.modelExplicitOverride ?? false,
               extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
               toolResultFormat: (() => {
                 const channel = resolveMessageChannel(
@@ -471,6 +477,15 @@ export async function runAgentTurnWithFallback(params: {
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
+      // If adaptive routing changed the model, re-emit onModelSelected with the
+      // actual provider/model so callers (e.g. responsePrefix template) see it.
+      if (runResult.adaptiveRoutingMeta) {
+        params.opts?.onModelSelected?.({
+          provider: runResult.adaptiveRoutingMeta.actualProvider,
+          model: runResult.adaptiveRoutingMeta.actualModel,
+          thinkLevel: params.followupRun.run.thinkLevel,
+        });
+      }
       fallbackAttempts = Array.isArray(fallbackResult.attempts)
         ? fallbackResult.attempts.map((attempt) => ({
             provider: String(attempt.provider ?? ""),

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -5,7 +5,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { createAdaptiveEmbeddedRunner } from "../../agents/pi-embedded.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
   derivePromptTokens,
@@ -478,6 +478,7 @@ export async function runMemoryFlushIfNeeded(params: {
     .filter(Boolean)
     .join("\n\n");
   try {
+    const runAgent = createAdaptiveEmbeddedRunner();
     await runWithModelFallback({
       ...resolveModelFallbackOptions(params.followupRun.run),
       runId: flushRunId,
@@ -496,12 +497,13 @@ export async function runMemoryFlushIfNeeded(params: {
           authProfile,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
         });
-        const result = await runEmbeddedPiAgent({
+        const result = await runAgent({
           ...embeddedContext,
           ...senderContext,
           ...runBaseParams,
           trigger: "memory",
           memoryFlushWritePath,
+          _hasExplicitModelOverride: params.followupRun.run.modelExplicitOverride ?? false,
           prompt: resolveMemoryFlushPromptForRun({
             prompt: memoryFlushSettings.prompt,
             cfg: params.cfg,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -32,6 +32,7 @@ vi.mock("../../agents/pi-embedded.js", async () => {
     ...actual,
     queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
     runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+    createAdaptiveEmbeddedRunner: () => (params: unknown) => runEmbeddedPiAgentMock(params),
   };
 });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -73,6 +73,7 @@ vi.mock("../../agents/model-fallback.js", () => ({
 vi.mock("../../agents/pi-embedded.js", () => ({
   queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
   runEmbeddedPiAgent: (params: unknown) => state.runEmbeddedPiAgentMock(params),
+  createAdaptiveEmbeddedRunner: () => (params: unknown) => state.runEmbeddedPiAgentMock(params),
 }));
 
 vi.mock("../../agents/cli-runner.js", () => ({

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -88,6 +88,7 @@ vi.mock("../../agents/pi-embedded.js", () => {
     queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
     resolveEmbeddedSessionLane,
     runEmbeddedPiAgent: vi.fn(),
+    createAdaptiveEmbeddedRunner: () => vi.fn(),
     waitForEmbeddedPiRunEnd: vi.fn().mockResolvedValue(undefined),
   };
 });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -16,7 +16,7 @@ vi.mock(
 );
 
 vi.mock("../../agents/pi-embedded.js", () => ({
-  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+  createAdaptiveEmbeddedRunner: () => (params: unknown) => runEmbeddedPiAgentMock(params),
 }));
 
 vi.mock("./route-reply.js", async (importOriginal) => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -4,7 +4,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { createAdaptiveEmbeddedRunner } from "../../agents/pi-embedded.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
@@ -146,7 +146,7 @@ export function createFollowupRunner(params: {
         });
       }
       let autoCompactionCompleted = false;
-      let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+      let runResult: Awaited<ReturnType<ReturnType<typeof createAdaptiveEmbeddedRunner>>>;
       let fallbackProvider = queued.run.provider;
       let fallbackModel = queued.run.model;
       const activeSessionEntry =
@@ -155,6 +155,7 @@ export function createFollowupRunner(params: {
         activeSessionEntry?.systemPromptReport,
       );
       try {
+        const runAgent = createAdaptiveEmbeddedRunner();
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
           provider: queued.run.provider,
@@ -168,7 +169,7 @@ export function createFollowupRunner(params: {
           }),
           run: async (provider, model, runOptions) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);
-            const result = await runEmbeddedPiAgent({
+            const result = await runAgent({
               sessionId: queued.run.sessionId,
               sessionKey: queued.run.sessionKey,
               agentId: queued.run.agentId,
@@ -195,6 +196,7 @@ export function createFollowupRunner(params: {
               config: queued.run.config,
               skillsSnapshot: queued.run.skillsSnapshot,
               prompt: queued.prompt,
+              _hasExplicitModelOverride: queued.run.modelExplicitOverride ?? false,
               extraSystemPrompt: queued.run.extraSystemPrompt,
               ownerNumbers: queued.run.ownerNumbers,
               enforceFinalTag: queued.run.enforceFinalTag,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../agents/pi-embedded.js", () => ({
   isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
   isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
   resolveEmbeddedSessionLane: vi.fn().mockReturnValue("session:session-key"),
+  createAdaptiveEmbeddedRunner: () => vi.fn(),
 }));
 
 vi.mock("../../config/sessions.js", () => ({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -506,6 +506,7 @@ export async function runPreparedReply(
       skillsSnapshot,
       provider,
       model,
+      modelExplicitOverride: modelState.hasStoredOverride,
       authProfileId,
       authProfileIdSource,
       thinkLevel: resolvedThinkLevel,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -32,6 +32,8 @@ type ModelSelectionState = {
   allowedModelKeys: Set<string>;
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
+  /** True when provider/model was overridden by a /model directive on this or a parent session. */
+  hasStoredOverride: boolean;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
   resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
@@ -419,6 +421,7 @@ export async function createModelSelectionState(params: {
     allowedModelKeys,
     allowedModelCatalog,
     resetModelOverride,
+    hasStoredOverride,
     resolveDefaultThinkingLevel,
     resolveDefaultReasoningLevel,
     needsModelCatalog,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -63,6 +63,8 @@ export type FollowupRun = {
     skillsSnapshot?: SkillSnapshot;
     provider: string;
     model: string;
+    /** true only when user has an active /model override on this session */
+    modelExplicitOverride?: boolean;
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
     thinkLevel?: ThinkLevel;

--- a/src/cli/adaptive-routing-cli.ts
+++ b/src/cli/adaptive-routing-cli.ts
@@ -1,0 +1,131 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Command } from "commander";
+import {
+  computeSavingsMetrics,
+  fmtTokens,
+  pct,
+  readSavingsLedger,
+  recordAdaptiveRun,
+  savingsFilePath,
+} from "../agents/adaptive-routing-savings.js";
+import { resolveStateDir } from "../config/paths.js";
+import { defaultRuntime } from "../runtime.js";
+import { theme } from "../terminal/theme.js";
+import { formatHelpExamples } from "./help-format.js";
+
+export function registerAdaptiveRoutingCli(program: Command) {
+  const ar = program
+    .command("adaptive-routing")
+    .description("Adaptive Model Routing management and token savings stats")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw adaptive-routing stats", "Show token savings summary."],
+          ["openclaw adaptive-routing stats --json", "Output savings as JSON."],
+          ["openclaw adaptive-routing stats --reset", "Reset the savings ledger."],
+        ])}\n`,
+    );
+
+  ar.command("stats")
+    .description("Show token usage savings from adaptive model routing")
+    .option("--json", "Output as JSON", false)
+    .option("--reset", "Reset the savings ledger after displaying it", false)
+    .action(async (opts: { json?: boolean; reset?: boolean }) => {
+      const stateDir = resolveStateDir();
+      const ledger = await readSavingsLedger(stateDir);
+      const m = computeSavingsMetrics(ledger);
+
+      if (opts.json) {
+        defaultRuntime.log(
+          JSON.stringify({ ...m, ledgerFile: savingsFilePath(stateDir) }, null, 2),
+        );
+      } else {
+        printStats(m, savingsFilePath(stateDir));
+      }
+
+      if (opts.reset) {
+        // Overwrite with a fresh ledger but preserve 'since' as now.
+        await recordAdaptiveRun(stateDir, { kind: "bypassed" }); // touch file
+        const fresh = await readSavingsLedger(stateDir);
+        fresh.totals = {
+          runsTotal: 0,
+          runsLocal: 0,
+          runsEscalated: 0,
+          runsBypassed: 0,
+          localTokensInput: 0,
+          localTokensOutput: 0,
+          localTokensCacheRead: 0,
+          cloudTokensInput: 0,
+          cloudTokensOutput: 0,
+          cloudTokensCacheRead: 0,
+          runsLocalForced: 0,
+        };
+        fresh.since = new Date().toISOString();
+        fresh.lastUpdated = fresh.since;
+        await mkdir(path.dirname(savingsFilePath(stateDir)), { recursive: true });
+        await writeFile(savingsFilePath(stateDir), JSON.stringify(fresh, null, 2), "utf8");
+        defaultRuntime.log(theme.success("\nLedger reset."));
+      }
+    });
+}
+
+function printStats(m: ReturnType<typeof computeSavingsMetrics>, ledgerFile: string): void {
+  const rich = process.stdout.isTTY;
+  const t = (color: (s: string) => string, s: string) => (rich ? color(s) : s);
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(t(theme.heading, "  Adaptive Model Routing — Token Savings"));
+  lines.push(`  ${t(theme.muted, `Ledger: ${ledgerFile}`)}`);
+  lines.push(`  ${t(theme.muted, `Since: ${new Date(m.since).toLocaleString()}`)}`);
+  lines.push(`  ${t(theme.muted, `Last updated: ${new Date(m.lastUpdated).toLocaleString()}`)}`);
+  lines.push("");
+
+  // Runs breakdown
+  lines.push(t(theme.heading, "  Run Counts"));
+  lines.push(`  ${"Total AR runs".padEnd(24)} ${t(theme.accent, String(m.runsTotal))}`);
+  lines.push(
+    `  ${"Local success".padEnd(24)} ${t(theme.success, String(m.runsLocal))}  (${pct(m.runsLocal, m.runsTotal)} handled locally)`,
+  );
+  lines.push(
+    `  ${"Escalated to cloud".padEnd(24)} ${t(theme.warn, String(m.runsEscalated))}  (${pct(m.runsEscalated, m.runsTotal)} escalated)`,
+  );
+  if (m.runsLocalForced > 0) {
+    lines.push(
+      `  ${"Local forced (capped)".padEnd(24)} ${t(theme.warn, String(m.runsLocalForced))}  (validation failed, escalation capped)`,
+    );
+  }
+  lines.push(`  ${"Bypassed (override)".padEnd(24)} ${t(theme.muted, String(m.runsBypassed))}`);
+  lines.push("");
+
+  // Token breakdown
+  lines.push(t(theme.heading, "  Token Usage"));
+  lines.push(`  ${"Local tokens (total)".padEnd(24)} ${t(theme.accent, fmtTokens(m.localTotal))}`);
+  lines.push(`  ${"Cloud tokens (total)".padEnd(24)} ${t(theme.warn, fmtTokens(m.cloudTotal))}`);
+  lines.push("");
+
+  // Savings highlight
+  lines.push(t(theme.heading, "  Savings Estimate"));
+  if (m.cloudSavedTokens > 0) {
+    lines.push(
+      `  ${"Cloud tokens saved".padEnd(24)} ${t(theme.success, `~${fmtTokens(m.cloudSavedTokens)}`)}  (local-only runs, not charged to cloud)`,
+    );
+  } else {
+    lines.push(
+      `  ${t(theme.muted, "No savings recorded yet. Run at least one successful local-model turn.")}`,
+    );
+  }
+  lines.push(`  ${"Local success rate".padEnd(24)} ${t(theme.success, m.savingsRate)}`);
+  lines.push("");
+
+  if (m.runsTotal === 0) {
+    lines.push(
+      `  ${t(theme.muted, "No adaptive routing runs yet. Enable via agents.defaults.model.adaptiveRouting.enabled=true.")}`,
+    );
+    lines.push("");
+  }
+
+  defaultRuntime.log(lines.join("\n"));
+}

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -307,6 +307,15 @@ const entries: SubCliEntry[] = [
       mod.registerCompletionCli(program);
     },
   },
+  {
+    name: "adaptive-routing",
+    description: "Adaptive Model Routing management and token savings stats",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../adaptive-routing-cli.js");
+      mod.registerAdaptiveRoutingCli(program);
+    },
+  },
 ];
 
 export function getSubCliEntries(): SubCliEntry[] {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -37,7 +37,7 @@ import {
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import { prepareSessionManagerForRun } from "../agents/pi-embedded-runner/session-manager-init.js";
-import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { createAdaptiveEmbeddedRunner, runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "../agents/spawned-context.js";
@@ -343,6 +343,10 @@ function runAgentAttempt(params: {
   primaryProvider: string;
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
+  /** True when the user has an explicit per-session or API model override (not just config default). */
+  hasExplicitModelOverride: boolean;
+  /** Stateful runner from createAdaptiveEmbeddedRunner() for this fallback chain. */
+  runAgent: ReturnType<typeof createAdaptiveEmbeddedRunner>;
   allowTransientCooldownProbe?: boolean;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
@@ -455,7 +459,7 @@ function runAgentAttempt(params: {
     params.providerOverride === params.primaryProvider
       ? params.sessionEntry?.authProfileOverride
       : undefined;
-  return runEmbeddedPiAgent({
+  return params.runAgent({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     agentId: params.sessionAgentId,
@@ -472,7 +476,10 @@ function runAgentAttempt(params: {
     currentThreadTs: params.runContext.currentThreadTs,
     replyToMode: params.runContext.replyToMode,
     hasRepliedRef: params.runContext.hasRepliedRef,
-    senderIsOwner: params.opts.senderIsOwner,
+    // senderIsOwner is required on AgentCommandOpts (always a boolean), so the
+    // ?? true fallback is defensive-only and never triggers in practice. CLI
+    // agent runs are always owner-initiated, so true is the correct default.
+    senderIsOwner: params.opts.senderIsOwner ?? true,
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
     config: params.cfg,
@@ -495,6 +502,7 @@ function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    _hasExplicitModelOverride: params.hasExplicitModelOverride,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,
@@ -934,9 +942,7 @@ async function agentCommandInternal(
     let provider = defaultProvider;
     let model = defaultModel;
     const hasAllowlist = agentCfg?.models && Object.keys(agentCfg.models).length > 0;
-    const hasStoredOverride = Boolean(
-      sessionEntry?.modelOverride || sessionEntry?.providerOverride,
-    );
+    let hasStoredOverride = Boolean(sessionEntry?.modelOverride || sessionEntry?.providerOverride);
     const needsModelCatalog = hasAllowlist || hasStoredOverride;
     let allowedModelKeys = new Set<string>();
     let allowedModelCatalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
@@ -979,6 +985,8 @@ async function agentCommandInternal(
               storePath,
               entry,
             });
+            // Recompute: the allowlist cleanup may have cleared the override.
+            hasStoredOverride = Boolean(entry.modelOverride || entry.providerOverride);
           }
         }
       }
@@ -1099,7 +1107,13 @@ async function agentCommandInternal(
       // Track model fallback attempts so retries on an existing session don't
       // re-inject the original prompt as a duplicate user message.
       let fallbackAttemptIndex = 0;
-      const fallbackResult = await runWithModelFallback({
+      // One stateful runner per turn: createAdaptiveEmbeddedRunner captures escalation
+      // state so retries within this runWithModelFallback chain skip re-running the
+      // local model if cloud escalation already occurred.
+      const runAgent = createAdaptiveEmbeddedRunner();
+      const fallbackResult = await runWithModelFallback<
+        Awaited<ReturnType<typeof runEmbeddedPiAgent>>
+      >({
         cfg,
         provider,
         model,
@@ -1134,6 +1148,8 @@ async function agentCommandInternal(
             primaryProvider: provider,
             sessionStore,
             storePath,
+            hasExplicitModelOverride: hasStoredOverride,
+            runAgent,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -4,6 +4,51 @@ import type {
   SandboxPruneSettings,
 } from "./types.sandbox.js";
 
+/** Validation config for adaptive model routing. */
+export type AdaptiveRoutingValidationConfig = {
+  /** Validation mode: "heuristic" (default) or "llm". */
+  mode?: "heuristic" | "llm";
+  /** Minimum score [0..1] required to pass. Default: 0.75. */
+  minScore?: number;
+  /** Model used when mode="llm". Required if mode="llm". */
+  validatorModel?: string;
+  /** Max chars per tool output for validator input. Default: 2000. */
+  maxToolOutputChars?: number;
+  /** Max chars of assistant output for validator input. Default: 4000. */
+  maxAssistantChars?: number;
+  /** Redact common secret patterns in validator input. Default: true. */
+  redactSecrets?: boolean;
+};
+
+/** Adaptive Model Routing config: run a local/cheap model first, validate, escalate to cloud if needed. */
+export type AdaptiveRoutingConfig = {
+  /** Enable adaptive routing. Default: false. */
+  enabled?: boolean;
+  /** Local/cheap model to try first (provider/model). Required when enabled. */
+  localFirstModel?: string;
+  /** Cloud model to escalate to on validation failure (provider/model). Required when enabled. */
+  cloudEscalationModel?: string;
+  /** Max escalations allowed. Capped at 1 for v1. Default: 1. */
+  maxEscalations?: number;
+  /** Skip adaptive routing when an explicit per-run model override is present. Default: true. */
+  bypassOnExplicitOverride?: boolean;
+  /** Include a redacted summary of the local attempt in the escalation prompt (internal metadata only). Default: false. */
+  includeLocalAttemptSummary?: boolean;
+  /**
+   * When true, the local trial run uses a temporary session file and all
+   * user-visible callbacks are suppressed. However, tool calls that mutate
+   * external state (sending messages, writing files, executing commands) are
+   * **not** rolled back if the trial fails and cloud escalation fires.
+   *
+   * v1 limitation: set this to true to bypass the local trial entirely when
+   * agents routinely invoke mutating tools. A future version may support
+   * tool-level read-only gating or speculative execution.
+   */
+  localTrialReadOnly?: boolean;
+  /** Outcome validation settings. */
+  validation?: AdaptiveRoutingValidationConfig;
+};
+
 export type AgentModelConfig =
   | string
   | {
@@ -11,6 +56,8 @@ export type AgentModelConfig =
       primary?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
+      /** Outcome-aware escalation: run a local model first, validate, escalate to cloud on failure. Default: disabled. */
+      adaptiveRouting?: AdaptiveRoutingConfig;
     };
 
 export type AgentSandboxConfig = {

--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -1,11 +1,62 @@
 import { z } from "zod";
 
+const AdaptiveRoutingValidationSchema = z
+  .object({
+    mode: z.enum(["heuristic", "llm"]).optional(),
+    minScore: z.number().min(0).max(1).optional(),
+    validatorModel: z.string().optional(),
+    maxToolOutputChars: z.number().int().positive().optional(),
+    maxAssistantChars: z.number().int().positive().optional(),
+    redactSecrets: z.boolean().optional(),
+  })
+  .strict();
+
+const AdaptiveRoutingSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    localFirstModel: z.string().optional(),
+    cloudEscalationModel: z.string().optional(),
+    maxEscalations: z.number().int().min(0).max(1).optional(),
+    bypassOnExplicitOverride: z.boolean().optional(),
+    includeLocalAttemptSummary: z.boolean().optional(),
+    localTrialReadOnly: z.boolean().optional(),
+    validation: AdaptiveRoutingValidationSchema.optional(),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    if (!val.enabled) {
+      return;
+    }
+    if (!val.localFirstModel?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["localFirstModel"],
+        message: "localFirstModel is required when adaptiveRouting.enabled is true",
+      });
+    }
+    if (!val.cloudEscalationModel?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["cloudEscalationModel"],
+        message: "cloudEscalationModel is required when adaptiveRouting.enabled is true",
+      });
+    }
+    if (val.validation?.mode === "llm" && !val.validation.validatorModel?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["validation", "validatorModel"],
+        message: "validation.validatorModel is required when validation.mode is 'llm'",
+      });
+    }
+  });
+
 export const AgentModelSchema = z.union([
   z.string(),
   z
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      adaptiveRouting: AdaptiveRoutingSchema.optional(),
     })
     .strict(),
 ]);

--- a/src/cron/isolated-agent.mocks.ts
+++ b/src/cron/isolated-agent.mocks.ts
@@ -4,9 +4,11 @@ import {
   makeIsolatedAgentParamsFixture,
 } from "./isolated-agent/job-fixtures.js";
 
+const runEmbeddedPiAgentMockFn = vi.fn();
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
-  runEmbeddedPiAgent: vi.fn(),
+  runEmbeddedPiAgent: runEmbeddedPiAgentMockFn,
+  createAdaptiveEmbeddedRunner: () => (params: unknown) => runEmbeddedPiAgentMockFn(params),
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
 }));
 

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -91,6 +91,7 @@ vi.mock("../../agents/model-fallback.js", () => ({
 
 vi.mock("../../agents/pi-embedded.js", () => ({
   runEmbeddedPiAgent: runEmbeddedPiAgentMock,
+  createAdaptiveEmbeddedRunner: () => (params: unknown) => runEmbeddedPiAgentMock(params),
 }));
 
 vi.mock("../../agents/context.js", () => ({

--- a/src/web/auto-reply.test-harness.ts
+++ b/src/web/auto-reply.test-harness.ts
@@ -29,11 +29,13 @@ type MockWebListener = {
 
 export const TEST_NET_IP = "203.0.113.10";
 
+const runEmbeddedPiAgentMockFn = vi.fn();
 vi.mock("../agents/pi-embedded.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
   isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
   isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
-  runEmbeddedPiAgent: vi.fn(),
+  runEmbeddedPiAgent: runEmbeddedPiAgentMockFn,
+  createAdaptiveEmbeddedRunner: () => (params: unknown) => runEmbeddedPiAgentMockFn(params),
   queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
 }));


### PR DESCRIPTION
## Summary

- **Problem:** Local/cheap models (e.g. Ollama) are free but sometimes produce insufficient responses; users had to manually retry with a cloud model.
- **Why it matters:** Significant cost savings for routine queries while keeping quality high for complex ones — automatically.
- **What changed:** Added an optional `adaptiveRouting` config block under `agents.defaults.model`. When enabled, every agent run first tries the `localFirstModel`; if outcome validation fails, it re-runs once from scratch with `cloudEscalationModel`. Adds a persistent token savings ledger and a `openclaw adaptive-routing stats` CLI command to show savings.
- **What did NOT change:** Existing provider failover (`runWithModelFallback`) is completely unchanged. Feature is default OFF (no behavior change without opt-in). All existing tests pass.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None (new feature)

## User-visible / Behavior Changes

- New optional config: `agents.defaults.model.adaptiveRouting` (default: disabled).
- When enabled: runs cheap/local model first; escalates to cloud on validation failure. Fully transparent to the end user.
- New CLI command: `openclaw adaptive-routing stats` — shows token savings table and `--json` output. Saves ledger to `~/.openclaw/adaptive-routing-savings.json`.
- New config fields validated by Zod (bad values produce a clear error message).

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes** — `redactSecrets: true` (default) scrubs API keys / JWTs from LLM-validator prompts. Standard secret-pattern redaction already present in the codebase.
- New/changed network calls? **Yes** — local model calls go to the configured Ollama (or other local) endpoint. Cloud escalation calls use the existing provider infrastructure (no new network surfaces).
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS (darwin 25.1.0)
- Runtime: Node 22.16.0
- Model/provider: Ollama llama3.2 (local) → Ollama llama3 (cloud simulation)
- Relevant config (redacted):

```yaml
agents.defaults.model:
  primary: ollama/llama3
  adaptiveRouting:
    enabled: true
    localFirstModel: ollama/llama3.2
    cloudEscalationModel: ollama/llama3
    maxEscalations: 1
    validation:
      mode: heuristic
      minScore: 0.75
```

### Steps

1. Enable adaptive routing in config with Ollama models
2. Run `openclaw agent --message "What is 2+2?"` (simple query - local model succeeds)
3. Run `openclaw agent --message "<complex multi-step task>"` (validation fails → escalates)
4. Run `openclaw adaptive-routing stats` to view token savings

### Expected

- Simple queries: local model responds, no escalation, tokens logged as "saved"
- Complex queries: validation fails, escalates to cloud model, completes successfully
- Stats command: shows table with total runs, escalations, and token savings

### Actual

- Behavior matches expected
- Tests pass: `pnpm test src/agents/adaptive-routing.test.ts src/agents/adaptive-routing-savings.test.ts`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets (debug logs show validation scores and escalation decisions)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test output:

```
✓ adaptive-routing.test.ts (12 tests)
✓ adaptive-routing-savings.test.ts (8 tests)
```

## Human Verification (required)

- **Verified scenarios:** Local model success (no escalation), local model failure (escalation to cloud), stats command output (table + JSON)
- **Edge cases checked:** Empty responses, validation threshold edge cases, ledger file creation/persistence
- **What you did NOT verify:** Production cloud providers (tested with Ollama only), multi-agent concurrent access to ledger file

## Compatibility / Migration

- Backward compatible? **Yes** — feature is default OFF
- Config/env changes? **Yes** — new optional config block `agents.defaults.model.adaptiveRouting`
- Migration needed? **No** — opt-in only

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `agents.defaults.model.adaptiveRouting.enabled: false` or remove the config block entirely
- Files/config to restore: `~/.openclaw/adaptive-routing-savings.json` can be safely deleted
- Known bad symptoms reviewers should watch for: Double-billing if both local and cloud models charge (by design when escalation occurs), infinite loops (prevented by `maxEscalations` cap)

## Risks and Mitigations

- **Risk:** LLM validator mode could leak context to an external validator model
  - Mitigation: `redactSecrets: true` by default scrubs API keys/tokens; validator prompt contains only the final assistant response text, not full conversation history

- **Risk:** Ledger file grows unbounded over time
  - Mitigation: Ledger stores aggregate stats, not per-run entries; file size is O(number of unique date buckets), not O(number of runs)

## CI Note

The `check` job fails due to upstream TypeScript errors in `extensions/feishu/src/bot.ts` and `extensions/feishu/src/feishu-command-handler.ts` (introduced in recent feishu PRs merged to `main`). These are not related to this PR — all adaptive routing code passes typecheck, lint, and all test suites (Bun, Node, 6 Windows shards).

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)