### PR TITLE
feat(gateway): add Permissions-Policy header to default security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/security default response headers: add `Permissions-Policy: camera=(), microphone=(), geolocation=()` to baseline gateway HTTP security headers for all responses. (#30186) thanks @habakan.
 - Security/auth labels: remove token and API-key snippets from user-facing auth status labels so `/status` and `/models` do not expose credential fragments. (#33262) thanks @cu1ch3n.
 - Security/audit denyCommands guidance: suggest likely exact node command IDs for unknown `gateway.nodes.denyCommands` entries so ineffective denylist entries are easier to correct. (#29713) thanks @liquidhorizon88-bot.
 - Docs/security hardening guidance: document Docker `DOCKER-USER` + UFW policy and add cross-linking from Docker install docs for VPS/public-host setups. (#27613) thanks @dorukardahan.

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { setDefaultSecurityHeaders } from "./http-common.js";
+import { makeMockHttpResponse } from "./test-http-response.js";
+
+describe("setDefaultSecurityHeaders", () => {
+  it("sets X-Content-Type-Options", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff");
+  });
+
+  it("sets Referrer-Policy", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).toHaveBeenCalledWith("Referrer-Policy", "no-referrer");
+  });
+
+  it("sets Permissions-Policy", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).toHaveBeenCalledWith(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
+  it("sets Strict-Transport-Security when provided", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res, {
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+    });
+    expect(setHeader).toHaveBeenCalledWith(
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  });
+
+  it("does not set Strict-Transport-Security when not provided", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).not.toHaveBeenCalledWith("Strict-Transport-Security", expect.anything());
+  });
+
+  it("does not set Strict-Transport-Security for empty string", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res, { strictTransportSecurity: "" });
+    expect(setHeader).not.toHaveBeenCalledWith("Strict-Transport-Security", expect.anything());
+  });
+});

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -14,6 +14,7 @@ export function setDefaultSecurityHeaders(
 ) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Summary

- Add `Permissions-Policy: camera=(), microphone=(), geolocation=()` to `setDefaultSecurityHeaders()` in `src/gateway/http-common.ts`
- Add unit tests for `setDefaultSecurityHeaders()` in `src/gateway/http-common.test.ts`

## Context

Related to #20373 and #6906.

Most recommended security headers are already implemented:
- `X-Content-Type-Options: nosniff` — all responses (`http-common.ts`)
- `Referrer-Policy: no-referrer` — all responses (`http-common.ts`)
- `Strict-Transport-Security` — conditional, all responses (`http-common.ts`)
- `X-Frame-Options: DENY` — Control UI responses (`control-ui.ts`)
- `Content-Security-Policy` — Control UI (`control-ui-csp.ts`)

The only missing standard header was `Permissions-Policy`. This PR adds it to `setDefaultSecurityHeaders()`, which is called for all HTTP responses via `server-http.ts`, so it covers Control UI and API responses alike.

Control UI does not use camera, microphone, or geolocation (confirmed by code search), and the header is safely ignored by browsers for non-HTML responses.

## Test plan

- [x] `pnpm test src/gateway/http-common.test.ts` — 6 tests pass
- [x] `pnpm test src/gateway/control-ui.http.test.ts` — no regressions
- [x] `pnpm check` — lint/format clean