### PR TITLE
fix(status): show persisted think/verbose/reasoning levels in /status

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -169,6 +169,26 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Runtime: docker/all");
   });
 
+  it("falls back to persisted session levels when no inline overrides are provided", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: {
+        sessionId: "persisted-levels",
+        updatedAt: 0,
+        thinkingLevel: "low",
+        verboseLevel: "on",
+        reasoningLevel: "low",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(text).toContain("Think: low");
+    expect(text).toContain("verbose");
+    expect(text).toContain("Reasoning: low");
+  });
+
   it("shows verbose/elevated labels only when enabled", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -506,9 +506,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel =
+    args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
+  const verboseLevel =
+    args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
+  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??


### PR DESCRIPTION
## Summary
- make `buildStatusMessage` fall back to persisted `sessionEntry` levels when no inline override is provided
- include a unit test covering persisted think/verbose/reasoning fallback

Fixes #30126

## Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/auto-reply/status.test.ts`