### PR TITLE
fix(ui): expand agent files textarea and allow resize to grow panel

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2414,6 +2414,11 @@
   border-radius: var(--radius-lg);
   padding: 16px;
   background: var(--card);
+  overflow: auto;
+}
+
+.agent-files-editor .field textarea {
+  min-height: 400px;
 }
 
 .agent-file-header {


### PR DESCRIPTION
Fixes #30001

The Content textarea in Agent > Files was rendered at the global minimum height of 160px — too small for most workspace files. Additionally, dragging the resize handle had no visible effect because the parent panel had no overflow setting.

**Changes:**
- Add \overflow: auto\ to \.agent-files-editor\ so textarea resize expands the panel
- Add scoped \.agent-files-editor .field textarea { min-height: 400px }\ for a usable default height