### PR TITLE
fix: isolated sessions inherit config.env variables (#29886)

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -32,6 +32,7 @@ import {
 } from "../../auto-reply/thinking.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { applyConfigEnvVars } from "../../config/env-vars.js";
 import {
   resolveSessionTranscriptPath,
   setSessionRuntimeModel,
@@ -100,6 +101,10 @@ export async function runCronIsolatedAgentTurn(params: {
 }): Promise<RunCronAgentTurnResult> {
   const abortSignal = params.abortSignal ?? params.signal;
   const isAborted = () => abortSignal?.aborted === true;
+  
+  // Apply config.env to process.env so isolated sessions can access
+  // provider API keys and other environment variables (#29886)
+  applyConfigEnvVars(params.cfg, process.env);
   const abortReason = () => {
     const reason = abortSignal?.reason;
     return typeof reason === "string" && reason.trim()


### PR DESCRIPTION
## Problem

Isolated sessions (cron jobs, subagents) cannot access environment variables defined in `openclaw.json` `env` section. This causes:
- Telegram delivery failures (botToken not accessible)
- Twitter/X API failures (X_API_* vars not accessible)
- Other provider authentication issues in isolated context

## Root Cause

`runCronIsolatedAgentTurn` runs in an isolated session context that doesn't inherit the main session's `process.env`. Config-defined env vars are never applied.

## Solution

Call `applyConfigEnvVars(params.cfg, process.env)` at the start of `runCronIsolatedAgentTurn` to apply config.env variables before the agent run begins.

## Testing

Verified with:
- Telegram botToken delivery to topics
- Twitter/X OAuth 1.0a posting from isolated cron jobs

## Related

Fixes #29886