### PR TITLE
fix(discord): default bare numeric IDs to channel kind, classify ambiguous recipient as permanent error

### DIFF
--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -86,6 +86,7 @@ export async function parseAndResolveRecipient(
   // First try to resolve using directory lookup (handles usernames)
   const trimmed = raw.trim();
   const parseOptions = {
+    defaultKind: "channel" as const,
     ambiguousMessage: `Ambiguous Discord recipient "${trimmed}". Use "user:${trimmed}" for DMs or "channel:${trimmed}" for channel messages.`,
   };
 

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -58,6 +58,7 @@ function normalizeReactionEmoji(raw: string) {
 
 function parseRecipient(raw: string): DiscordRecipient {
   const target = parseDiscordTarget(raw, {
+    defaultKind: "channel",
     ambiguousMessage: `Ambiguous Discord recipient "${raw.trim()}". Use "user:${raw.trim()}" for DMs or "channel:${raw.trim()}" for channel messages.`,
   });
   if (!target) {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -386,6 +386,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /chat_id is empty/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
+  /ambiguous discord recipient/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** Bare numeric Discord IDs (e.g. `1466624220632059934`) thrown as "Ambiguous Discord recipient" errors, causing messages to accumulate in the delivery queue with infinite retries.
- **Why it matters:** Any send operation using a raw channel/user ID (common in cron tasks and programmatic sends) fails silently and fills up the queue, requiring manual purge.
- **What changed:** (1) `parseRecipient` in `send.shared.ts` now defaults bare numeric IDs to `channel` kind instead of throwing ambiguous errors. (2) `delivery-queue.ts` classifies "ambiguous discord recipient" as a permanent error to stop retry loops if the error ever surfaces through another path.
- **What did NOT change:** Behavior for explicitly prefixed targets (`user:ID`, `channel:ID`) is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related: delivery queue retry buildup on ambiguous Discord recipient errors

## User-visible / Behavior Changes

Bare numeric Discord IDs passed to `--target` or `to:` now resolve to a channel instead of erroring. Users who previously needed `channel:ID` prefix for programmatic sends can now use the raw ID.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11 (x64)
- Runtime/container: Node 22, openclaw gateway
- Integration/channel: Discord

### Steps

1. Configure a Discord send target as a bare numeric ID (e.g. in a cron job or skill using `channel: "1466624220632059934"`)
2. Trigger a send
3. Observe delivery queue

### Expected

- Message delivered to the channel

### Actual (before fix)

- `Ambiguous Discord recipient "1466624220632059934"` error thrown
- Message enters retry loop; queue accumulates

## Evidence

- [x] Trace/log snippets

Before fix:
```
Error: Ambiguous Discord recipient "1466624220632059934". Use "user:..." for DMs or "channel:..." for channel messages.
```

After fix: message delivered without error.

Also cleared 7 accumulated messages from delivery queue after applying the fix.

## Human Verification (required)

- Verified scenarios: bare numeric channel ID, bare numeric DM ID, explicit `channel:ID` prefix (unchanged), explicit `user:ID` prefix (unchanged)
- Edge cases checked: non-numeric bare strings still go through normal resolution
- What you did **not** verify: voice channels, thread IDs as bare IDs

## Compatibility / Migration

- Backward compatible? Yes — explicit `channel:` / `user:` prefixes still work as before; only bare IDs change behavior (was error, now defaults to channel)
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: remove `defaultKind: "channel"` from `send.shared.ts` and the `/ambiguous discord recipient/i` entry from `delivery-queue.ts`
- Known bad symptoms: if a bare ID was intended as a user DM but gets routed to a channel — add explicit `user:` prefix

## Risks and Mitigations

- Risk: bare numeric ID that is a user ID gets sent to a channel with the same numeric ID (if one exists)
  - Mitigation: channel resolution is attempted first; Discord user IDs and channel IDs share the same snowflake space but channels are looked up first in the guild cache. Users who need explicit DM sends should use `user:ID`.
