### PR TITLE
fix(whatsapp): allow explicit outbound sends to external direct targets

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -189,6 +189,22 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectAllowedForTarget({ allowFrom: undefined, mode: undefined });
     });
 
+    it("bypasses allowList in explicit mode", () => {
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce("+19876543210") // for allowFrom[0] (processed first)
+        .mockReturnValueOnce("+11234567890"); // for 'to' param
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      expectResolutionOk(
+        {
+          to: "+11234567890",
+          allowFrom: ["+19876543210"],
+          mode: "explicit",
+        },
+        "+11234567890",
+      );
+    });
+
     it("enforces allowList in custom mode string", () => {
       mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "broadcast" });

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -31,8 +31,13 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
-    // Group destinations are handled by group policy and are allowed above.
+    // Explicit outbound sends (e.g. `openclaw message send --target ...`) should
+    // accept any valid direct target. `allowFrom` is an inbound/implicit guard.
+    if (params.mode === "explicit") {
+      return { ok: true, to: normalizedTo };
+    }
+
+    // For implicit/heartbeat delivery, keep allowFrom enforcement.
     if (hasWildcard || allowList.length === 0) {
       return { ok: true, to: normalizedTo };
     }


### PR DESCRIPTION
## Summary
- Fixes #30087
- allow explicit WhatsApp outbound targets (CLI/message send) even when target is not in `allowFrom`
- keep `allowFrom` enforcement for implicit/heartbeat paths

## Why
`allowFrom` is an inbound/implicit routing guard. Applying it to explicit sends blocks valid external direct targets and causes `Delivering to WhatsApp requires target <E.164|group JID>` for non-self numbers.

## Tests
- updated `src/whatsapp/resolve-outbound-target.test.ts`
  - add explicit-mode test that bypasses allowlist mismatch
- ran:
  - `pnpm -s vitest run src/whatsapp/resolve-outbound-target.test.ts`
  - `pnpm -s vitest run src/channels/plugins/plugins-channel.test.ts src/infra/outbound/targets.test.ts`
