### PR TITLE
fix(providers): plumb ModelProviderConfig.headers into LLM stream + set kimi-coding User-Agent

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -638,6 +638,7 @@ export function buildKimiCodingProvider(): ProviderConfig {
   return {
     baseUrl: KIMI_CODING_BASE_URL,
     api: "anthropic-messages",
+    headers: { "User-Agent": "claude-code/0.1.0" },
     models: [
       {
         id: KIMI_CODING_DEFAULT_MODEL_ID,

--- a/src/agents/pi-embedded-runner/extra-params.provider-headers.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.provider-headers.test.ts
@@ -1,0 +1,143 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent, createProviderHeadersWrapper } from "./extra-params.js";
+
+// Mock streamSimple for testing
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+describe("createProviderHeadersWrapper", () => {
+  it("injects provider headers into the stream call", () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      capturedHeaders = options?.headers;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createProviderHeadersWrapper(baseFn, { "User-Agent": "claude-code/0.1.0" });
+    const model = {
+      api: "anthropic-messages",
+      provider: "kimi-coding",
+      id: "k2p5",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void wrapped(model, context, {});
+
+    expect(capturedHeaders).toEqual({ "User-Agent": "claude-code/0.1.0" });
+  });
+
+  it("allows call-site headers to override provider headers", () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      capturedHeaders = options?.headers;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createProviderHeadersWrapper(baseFn, {
+      "User-Agent": "provider-default",
+      "X-Custom": "from-provider",
+    });
+    const model = {
+      api: "anthropic-messages",
+      provider: "test",
+      id: "m1",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void wrapped(model, context, {
+      headers: { "User-Agent": "call-site-override" },
+    } as SimpleStreamOptions);
+
+    expect(capturedHeaders).toEqual({
+      "User-Agent": "call-site-override",
+      "X-Custom": "from-provider",
+    });
+  });
+});
+
+describe("applyExtraParamsToAgent with providerHeaders", () => {
+  it("injects provider headers when providerHeaders is provided", () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    const baseFn: StreamFn = (_model, _context, options) => {
+      capturedHeaders = options?.headers;
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "kimi-coding",
+      "k2p5",
+      undefined,
+      undefined,
+      undefined,
+      { "User-Agent": "claude-code/0.1.0" },
+    );
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "kimi-coding",
+      id: "k2p5",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(capturedHeaders).toEqual({ "User-Agent": "claude-code/0.1.0" });
+  });
+
+  it("does not wrap streamFn when providerHeaders is empty", () => {
+    const baseFn: StreamFn = (_model, _context, _options) => {
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "some-provider",
+      "some-model",
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    // streamFn will be wrapped by other wrappers (e.g. Google thinking sanitizer,
+    // OpenAI Responses), but not by the provider headers wrapper.
+    // We verify by calling and checking no provider headers appear.
+    let capturedHeaders: Record<string, string> | undefined;
+    const probeBaseFn: StreamFn = (_model, _context, options) => {
+      capturedHeaders = options?.headers;
+      return {} as ReturnType<StreamFn>;
+    };
+    const probeAgent = { streamFn: probeBaseFn };
+
+    applyExtraParamsToAgent(
+      probeAgent,
+      undefined,
+      "some-provider",
+      "some-model",
+      undefined,
+      undefined,
+      undefined,
+      {},
+    );
+
+    const model = {
+      api: "openai-completions",
+      provider: "some-provider",
+      id: "some-model",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void probeAgent.streamFn?.(model, context, {});
+
+    expect(capturedHeaders).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -717,6 +717,24 @@ function createZaiToolStreamWrapper(
 }
 
 /**
+ * Wrap a streamFn to inject provider-level headers into every stream call.
+ * Call-site headers (options.headers) take precedence over provider headers.
+ *
+ * @internal Exported for testing
+ */
+export function createProviderHeadersWrapper(
+  baseStreamFn: StreamFn | undefined,
+  headers: Record<string, string>,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      headers: { ...headers, ...options?.headers },
+    });
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
  *
@@ -730,6 +748,7 @@ export function applyExtraParamsToAgent(
   extraParamsOverride?: Record<string, unknown>,
   thinkingLevel?: ThinkLevel,
   agentId?: string,
+  providerHeaders?: Record<string, string>,
 ): void {
   const extraParams = resolveExtraParams({
     cfg,
@@ -806,4 +825,9 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Inject provider-level headers (e.g. kimi-coding's required User-Agent).
+  if (providerHeaders && Object.keys(providerHeaders).length > 0) {
+    agent.streamFn = createProviderHeadersWrapper(agent.streamFn, providerHeaders);
+  }
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -900,6 +900,7 @@ export async function runEmbeddedAttempt(
         params.streamParams,
         params.thinkLevel,
         sessionAgentId,
+        params.config?.models?.providers?.[params.provider]?.headers,
       );
 
       if (cacheTrace) {


### PR DESCRIPTION
Fixes #30099.

## Problem

The `kimi-coding` provider requires `User-Agent: claude-code/0.1.0` for subscription-tier authentication. OpenClaw's built-in kimi-coding provider didn't set this header, causing subscription users to get authentication failures or silent pay-per-use fallback.

Separately, `ModelProviderConfig.headers` (already defined in `src/config/types.models.ts`) was never plumbed into the actual LLM stream call — meaning custom `headers:` in any user-defined provider config were silently ignored.

## Fix

**1. Add `User-Agent: claude-code/0.1.0` to the built-in kimi-coding provider** (`src/agents/models-config.providers.ts`)

**2. Plumb `ModelProviderConfig.headers` through to the stream call:**
- Added `createProviderHeadersWrapper` in `extra-params.ts` — injects provider-level headers with call-site override support (call-site wins)
- Added `providerHeaders` param to `applyExtraParamsToAgent`
- In `attempt.ts`, pass `config?.models?.providers?.[params.provider]?.headers` to `applyExtraParamsToAgent`

This makes `headers:` in any custom provider config actually work, not just kimi-coding.

## Tests

4 new tests in `extra-params.provider-headers.test.ts`:
- Provider headers are injected into stream options ✅
- Call-site headers override provider headers ✅  
- Empty headers object is a no-op ✅
- `applyExtraParamsToAgent` with providerHeaders injects them ✅

All 18 extra-params tests pass.