### PR TITLE
fix(usage): support flat numeric usage.cost values

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -82,10 +82,19 @@ const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | unde
     return undefined;
   }
   const record = usageRaw as Record<string, unknown>;
-  const cost = record.cost as Record<string, unknown> | undefined;
-  if (!cost) {
+  const costRaw = record.cost;
+  if (typeof costRaw === "number") {
+    const total = toFiniteNumber(costRaw);
+    if (total === undefined || total < 0) {
+      return undefined;
+    }
+    return { total };
+  }
+
+  if (!costRaw || typeof costRaw !== "object") {
     return undefined;
   }
+  const cost = costRaw as Record<string, unknown>;
 
   const total = toFiniteNumber(cost.total);
   if (total === undefined || total < 0) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `usage.cost` can arrive as a flat number (for example from OpenRouter), but our parser only accepted object-shaped breakdowns.
- Why it matters: cost analytics could incorrectly show `$0` even when the provider already returned a valid cost.
- What changed: `extractCostBreakdown` now accepts both numeric `usage.cost` and object `usage.cost.total`; added regression test coverage for flat numeric cost.
- What did NOT change (scope boundary): no pricing fallback logic changes and no UI behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30204
- Related #

## User-visible / Behavior Changes

Session cost summaries now correctly include provider-reported cost when transcripts store `usage.cost` as a number.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local test config

### Steps

1. Create a transcript entry where assistant usage includes `cost: 0.0045` (number) instead of `cost: { total: ... }`.
2. Load cost usage summary.
3. Observe total cost aggregation.

### Expected

- Numeric `usage.cost` is treated as valid total cost and included in aggregates.

### Actual

- Before fix, numeric `usage.cost` was ignored and aggregate cost could stay at zero.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- --run src/infra/session-cost-usage.test.ts`, including the new flat-cost regression test.
- Edge cases checked: non-finite/negative numeric values still rejected by existing finite/negative guards.
- What you did **not** verify: dashboard manual UI validation.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/infra/session-cost-usage.ts`, `src/infra/session-cost-usage.test.ts`.
- Known bad symptoms reviewers should watch for: session cost totals unexpectedly drop to zero for providers that emit flat numeric cost.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: accepting malformed numeric input could skew totals.
  - Mitigation: parser keeps finite/non-negative validation and ignores invalid values.
