### PR TITLE
fix(ui): cron edit panel scrollable on desktop

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -608,6 +608,24 @@
 .cron-workspace-form {
   position: sticky;
   top: 74px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+@supports (height: 100dvh) {
+  .cron-workspace-form {
+    max-height: calc(100dvh - 90px);
+  }
+}
+
+@media (max-width: 1100px) {
+  .cron-workspace-form {
+    position: static;
+    order: -1;
+    max-height: none;
+    overflow: visible;
+  }
 }
 
 .cron-form {


### PR DESCRIPTION
Fixes #30155.

The Cron page right-side Edit Job panel (.cron-workspace-form) is sticky on desktop, but lacked an internal scroll container, making long forms unreachable.

Changes:
- Add max-height + overflow-y:auto + overscroll-behavior:contain on desktop.
- Prefer 100dvh when supported.
- Disable sticky + restore natural flow on narrow viewports (<1100px).