### PR TITLE
fix(models): prefer config baseUrl over stale models.json values

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -134,7 +134,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("prefers non-empty config apiKey/baseUrl for matching providers in merge mode", async () => {
     await withTempHome(async () => {
       const agentDir = resolveOpenClawAgentDir();
       await fs.mkdir(agentDir, { recursive: true });
@@ -184,8 +184,8 @@ describe("models-config", () => {
       const parsed = await readGeneratedModelsJson<{
         providers: Record<string, { apiKey?: string; baseUrl?: string }>;
       }>();
-      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 
@@ -241,6 +241,59 @@ describe("models-config", () => {
       }>();
       expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("falls back to existing apiKey/baseUrl when config leaves them unset", async () => {
+    await withTempHome(async () => {
+      const agentDir = resolveOpenClawAgentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://agent.example/v1",
+                apiKey: "AGENT_KEY",
+                api: "openai-responses",
+                models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              api: "openai-responses",
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
+      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
     });
   });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -630,7 +630,7 @@ export const FIELD_HELP: Record<string, string> = {
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":
-    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs preserve non-empty agent models.json apiKey/baseUrl values and fall back to config when agent values are empty or missing; matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
+    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs prefer non-empty config apiKey/baseUrl values and fall back to non-empty agent models.json values only when config leaves them empty; matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
   "models.providers":
     "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
   "models.providers.*.baseUrl":


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: in `models.mode = merge`, non-empty `apiKey/baseUrl` from existing `models.json` always overrode provider values from `openclaw.json`.
- Why it matters: after fixing a custom provider endpoint in config, runtime could still route to stale old URLs from generated catalog state.
- What changed: matching providers now prefer non-empty config `apiKey/baseUrl`, and only fall back to non-empty existing `models.json` values when config leaves those fields empty.
- What did NOT change (scope boundary): model capability merge behavior and provider/model discovery logic remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29977
- Related #20438

## User-visible / Behavior Changes

Custom provider URL/key updates in `openclaw.json` now take effect after restart instead of being silently shadowed by stale `models.json` values.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js + pnpm test runner
- Model/provider: custom OpenAI-compatible providers (e.g. opencode-go)
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.mode=merge` with explicit provider `baseUrl`

### Steps

1. Create `models.json` with provider `custom.baseUrl = https://agent.example/v1`.
2. Configure `openclaw.json` with `models.mode=merge` and same provider `custom.baseUrl = https://config.example/v1`.
3. Regenerate models catalog and inspect resulting provider values.

### Expected

- Regenerated provider uses non-empty config URL/key and does not stay pinned to stale generated state.

### Actual

- Before fix, stale non-empty `models.json` URL/key overrode config values.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- --run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`.
- Edge cases checked: config-empty fallback still preserves non-empty existing `models.json` credentials/base URL.
- What you did **not** verify: end-to-end live gateway run against opencode-go.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/models-config.ts`, `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`, `src/config/schema.help.ts`.
- Known bad symptoms reviewers should watch for: provider URL/key unexpectedly reverting to stale values across restarts.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users who relied on stale generated overrides may observe config now taking precedence.
  - Mitigation: fallback behavior is preserved when config leaves `apiKey/baseUrl` empty.
