### PR TITLE
fix(gateway): honor device-auth bypass after successful control-ui auth

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -63,6 +63,11 @@ describe("ws connect policy", () => {
       controlUiConfig: { allowInsecureAuth: true, dangerouslyDisableDeviceAuth: false },
       deviceRaw: null,
     });
+    const controlUiBypass = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: null,
+    });
     // Remote Control UI with allowInsecureAuth -> still rejected.
     expect(
       evaluateMissingDeviceIdentity({
@@ -90,6 +95,22 @@ describe("ws connect policy", () => {
         authOk: true,
         hasSharedAuth: true,
         isLocalClient: true,
+      }).kind,
+    ).toBe("allow");
+
+    // Dangerous bypass should skip device checks after auth passes,
+    // even if sharedAuthOk is false.
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: controlUiBypass,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: true,
+        hasSharedAuth: false,
+        isLocalClient: false,
       }).kind,
     ).toBe("allow");
 

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -82,6 +82,9 @@ export function evaluateMissingDeviceIdentity(params: {
   if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
+  if (params.isControlUi && params.controlUiAuthPolicy.allowBypass && params.authOk) {
+    return { kind: "allow" };
+  }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {
     // Allow localhost Control UI connections when allowInsecureAuth is configured.
     // Localhost has no network interception risk, and browser SubtleCrypto


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI connections could still fail with `device-required` even when `gateway.controlUi.dangerouslyDisableDeviceAuth=true` if auth succeeded via a path not counted as `sharedAuthOk`.
- Why it matters: reverse-proxy/browser deployments can see false device-identity failures despite explicitly enabling break-glass device-auth bypass.
- What changed: missing-device evaluation now allows Control UI when bypass is enabled **and** authentication has already succeeded (`authOk=true`), plus regression coverage.
- What did NOT change (scope boundary): bypass still does not skip authentication; failed auth continues to be rejected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30092
- Related #

## User-visible / Behavior Changes

With `gateway.controlUi.dangerouslyDisableDeviceAuth=true`, authenticated Control UI sessions no longer fail with a false `device-required` error when device identity is unavailable.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): gateway websocket Control UI path
- Relevant config (redacted): `gateway.controlUi.dangerouslyDisableDeviceAuth=true`

### Steps

1. Connect as Control UI without usable device identity.
2. Ensure Control UI auth resolves successfully (`authOk=true`) and bypass flag is enabled.
3. Observe missing-device decision result.

### Expected

- Connection is allowed because auth already passed and device-auth bypass is explicitly enabled.

### Actual

- Before fix, some flows still returned `device-required`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- --run src/gateway/server/ws-connection/connect-policy.test.ts src/gateway/server.auth.test.ts`.
- Edge cases checked: strict Control UI path without bypass still rejects insecure/missing-device flows.
- What you did **not** verify: full LAN reverse-proxy deployment against Caddy.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/server/ws-connection/connect-policy.ts`, `src/gateway/server/ws-connection/connect-policy.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected Control UI `device-required` errors when bypass + successful auth are present.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: broadening bypass semantics could accidentally permit unauthenticated sessions.
  - Mitigation: new allow branch still requires `authOk=true`; failed auth remains blocked.
