### PR TITLE
fix(plugins): allow bundled manifest hardlinks in pnpm installs

### DIFF
--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -17,7 +17,9 @@ export function resolveBundledPluginSources(params: {
     if (candidate.origin !== "bundled") {
       continue;
     }
-    const manifest = loadPluginManifest(candidate.rootDir);
+    const manifest = loadPluginManifest(candidate.rootDir, {
+      allowHardlinks: true,
+    });
     if (!manifest.ok) {
       continue;
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -167,7 +167,9 @@ export function loadPluginManifestRegistry(params: {
   const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
-    const manifestRes = loadPluginManifest(candidate.rootDir);
+    const manifestRes = loadPluginManifest(candidate.rootDir, {
+      allowHardlinks: candidate.origin === "bundled",
+    });
     if (!manifestRes.ok) {
       diagnostics.push({
         level: "error",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -25,6 +25,14 @@ export type PluginManifestLoadResult =
   | { ok: true; manifest: PluginManifest; manifestPath: string }
   | { ok: false; error: string; manifestPath: string };
 
+export type LoadPluginManifestOptions = {
+  /**
+   * Bundled plugins can be hardlinked under pnpm/node_modules stores.
+   * Keep hardlink rejection enabled by default and only relax it explicitly.
+   */
+  allowHardlinks?: boolean;
+};
+
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -42,12 +50,16 @@ export function resolvePluginManifestPath(rootDir: string): string {
   return path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
 }
 
-export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
+export function loadPluginManifest(
+  rootDir: string,
+  options?: LoadPluginManifestOptions,
+): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: rootDir,
     boundaryLabel: "plugin root",
+    rejectHardlinks: options?.allowHardlinks === true ? false : true,
   });
   if (!opened.ok) {
     if (opened.reason === "path") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled plugin manifests were rejected as `unsafe plugin manifest path` when installed through pnpm layouts that use hardlinks.
- Why it matters: bundled plugin registry loading failed, which cascaded into channel/plugin lookup failures (including feishu/memory slot failures).
- What changed: `loadPluginManifest` now supports explicit hardlink allowance; bundled plugin paths opt into this mode while non-bundled paths keep hardlink rejection.
- What did NOT change (scope boundary): symlink/path-boundary protection and hardlink rejection for workspace/global/config plugin roots remain intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30172
- Related #

## User-visible / Behavior Changes

Bundled plugins from pnpm/node_modules installs are now discovered/validated correctly instead of being dropped by false-positive manifest safety errors.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js + pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): plugin manifest registry/discovery
- Relevant config (redacted): bundled plugin candidates from package-managed install path

### Steps

1. Create a bundled plugin candidate whose manifest file is a hardlink (pnpm-style inode sharing).
2. Load plugin manifest registry.
3. Compare with workspace/global hardlink behavior.

### Expected

- Bundled hardlinked manifests are accepted.
- Non-bundled hardlink-escape manifests remain rejected.

### Actual

- Before fix, bundled hardlinked manifests were rejected as unsafe and skipped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- --run src/plugins/manifest-registry.test.ts src/plugins/bundled-sources.test.ts`.
- Edge cases checked: existing hardlink escape rejection test for workspace origin still passes.
- What you did **not** verify: full Windows pnpm E2E install run.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/plugins/manifest.ts`, `src/plugins/manifest-registry.ts`, `src/plugins/bundled-sources.ts`, `src/plugins/manifest-registry.test.ts`.
- Known bad symptoms reviewers should watch for: bundled plugins missing from registry on pnpm installs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: relaxing hardlink checks too broadly could reduce manifest path hardening.
  - Mitigation: hardlink allowance is opt-in and only enabled for `origin: bundled`; non-bundled paths keep strict rejection.
