### PR TITLE
fix: harden file permissions for extensions dirs in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,18 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
 
 USER node
 COPY --chown=node:node . .
+
+# Harden file permissions: ensure extensions, .agent, and .agents directories
+# are not world-writable. Some build environments or volume mounts may produce
+# 777 permissions which causes OpenClaw to block plugins at runtime.
+# See: https://github.com/openclaw/openclaw/issues/30139
+USER root
+RUN find /app/extensions /app/.agent /app/.agents -type d -exec chmod 755 {} + 2>/dev/null; \
+    find /app/extensions /app/.agent /app/.agents -type f -exec chmod 644 {} + 2>/dev/null; \
+    chown -R node:node /app/extensions /app/.agent /app/.agents 2>/dev/null; \
+    true
+USER node
+
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
## Problem

The `/app/extensions`, `/app/.agent`, and `/app/.agents` directories ship with mode 777 (world-writable) in the Docker image under certain build environments. This causes OpenClaw to block all plugins at runtime:

```
WARN: blocked plugin candidate: world-writable path (/app/extensions/memory-core, mode=777)
```

Users have to manually run `chmod` on every container start as a workaround, which doesn't persist across restarts since permissions are baked into the image layer.

Reported in #30139.

## Solution

Add a permission hardening step in the Dockerfile after `COPY --chown=node:node . .`:

- Directories → `755`
- Files → `644`
- Ownership → `node:node`

This runs as root before switching back to the `node` user, ensuring consistent permissions regardless of the build environment.

## Changes

- `Dockerfile`: +12 lines (permission hardening block with inline comment)

## Testing

- Verified the Dockerfile syntax is valid
- The `find ... -exec chmod` commands are idempotent and safe (no-op if dirs don't exist, guarded by `2>/dev/null` and trailing `true`)
- No impact on non-Docker deployments

Closes #30139