### PR TITLE
fix: ownerAllowFrom wildcard should grant tool-level owner access

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -341,7 +341,7 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwner = Boolean(matchedSender);
+  const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner


### PR DESCRIPTION
## Problem

`commands.ownerAllowFrom: ["*"]` correctly grants command access (`isOwnerForCommands = true`) but does NOT set `senderIsOwner = true`. This causes owner-only tools (`cron`, `gateway`, `whatsapp_login`) to be silently stripped from the tool list via `applyOwnerOnlyToolPolicy()`.

## Root Cause

In `command-auth.ts`, the `ownerAllowAll` flag (derived from `"*"` in the allowlist) is used for `isOwnerForCommands` but not for `senderIsOwner`. When the allowlist is `["*"]`, the explicit owners list is empty after filtering, so `matchedSender` is always `undefined` and `senderIsOwner` is always `false`.

## Fix

One-line change (line 344):

```typescript
// Before:
const senderIsOwner = Boolean(matchedSender);

// After:
const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
```

## Impact

Any deployment using `ownerAllowFrom: ["*"]` will now correctly grant owner-level tool access. This is important for:
- Single-user containers where the owner ID is unknown at config time
- Team setups where all members should have full tool access
- Managed hosting platforms that provision containers dynamically

Fixes #30226