### PR TITLE
fix: use x-api-key header for Anthropic API authentication

### DIFF
--- a/src/infra/provider-usage.fetch.claude.test.ts
+++ b/src/infra/provider-usage.fetch.claude.test.ts
@@ -58,7 +58,7 @@ describe("fetchClaudeUsage", () => {
     const weekReset = "2026-01-12T00:00:00Z";
     const mockFetch = createProviderUsageFetch(async (_url, init) => {
       const headers = (init?.headers as Record<string, string> | undefined) ?? {};
-      expect(headers.Authorization).toBe("Bearer token");
+      expect(headers["x-api-key"]).toBe("token");
       expect(headers["anthropic-beta"]).toBe("oauth-2025-04-20");
 
       return makeResponse(200, {

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -121,7 +121,7 @@ export async function fetchClaudeUsage(
     "https://api.anthropic.com/api/oauth/usage",
     {
       headers: {
-        Authorization: `Bearer ${token}`,
+        "x-api-key": token,
         "User-Agent": "openclaw",
         Accept: "application/json",
         "anthropic-version": "2023-06-01",

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -271,7 +271,7 @@ describe("provider usage loading", () => {
         const mockFetch = createProviderUsageFetch(async (url, init) => {
           if (url.includes("api.anthropic.com/api/oauth/usage")) {
             const headers = (init?.headers ?? {}) as Record<string, string>;
-            expect(headers.Authorization).toBe("Bearer token-1");
+            expect(headers["x-api-key"]).toBe("token-1");
             return makeResponse(200, {
               five_hour: {
                 utilization: 20,


### PR DESCRIPTION
Fixes #30175

## Problem
The provider usage fetch for Anthropic was using `Authorization: Bearer <token>` header, but Anthropic's official API expects `x-api-key: <token>`.

## Change
- Changed `Authorization: Bearer ${token}` to `x-api-key: token` in `src/infra/provider-usage.fetch.claude.ts`

## Reference
- [Anthropic API Authentication Docs](https://docs.anthropic.com/en/api/getting-started#authentication)