### PR TITLE
fix(telegram): preserve reply context for external_reply + debounced batches

### DIFF
--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -27,7 +27,7 @@ describe("plugin-sdk root alias", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("loads legacy root exports lazily through the proxy", () => {
+  it("loads legacy root exports lazily through the proxy", { timeout: 240_000 }, () => {
     expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
     expect(typeof rootSdk.default).toBe("object");
     expect(rootSdk.default).toBe(rootSdk);

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -86,9 +86,13 @@ function hasInboundMedia(msg: Message): boolean {
   );
 }
 
-function hasReplyTargetMedia(msg: Message): boolean {
+function resolveReplyTargetMessage(msg: Message): Message | undefined {
   const externalReply = (msg as Message & { external_reply?: Message }).external_reply;
-  const replyTarget = msg.reply_to_message ?? externalReply;
+  return msg.reply_to_message ?? externalReply;
+}
+
+function hasReplyTargetMedia(msg: Message): boolean {
+  const replyTarget = resolveReplyTargetMessage(msg);
   return Boolean(replyTarget && hasInboundMedia(replyTarget));
 }
 
@@ -240,19 +244,20 @@ export const registerTelegramHandlers = ({
         return;
       }
       const first = entries[0];
-      const baseCtx = first.ctx;
+      const anchor = last;
       const syntheticMessage = buildSyntheticTextMessage({
-        base: first.msg,
+        base: anchor.msg,
         text: combinedText,
-        date: last.msg.date ?? first.msg.date,
+        date: anchor.msg.date ?? first.msg.date,
+        from: anchor.msg.from ?? first.msg.from,
       });
-      const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
-      const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      const replyMedia = await resolveReplyMediaForMessage(baseCtx, syntheticMessage);
+      const messageIdOverride = anchor.msg.message_id ? String(anchor.msg.message_id) : undefined;
+      const syntheticCtx = buildSyntheticContext(anchor.ctx, syntheticMessage);
+      const replyMedia = await resolveReplyMediaForMessage(anchor.ctx, anchor.msg);
       await processMessage(
         syntheticCtx,
         combinedMedia,
-        first.storeAllowFrom,
+        anchor.storeAllowFrom,
         messageIdOverride ? { messageIdOverride } : undefined,
         replyMedia,
       );
@@ -436,7 +441,7 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext,
     msg: Message,
   ): Promise<TelegramMediaRef[]> => {
-    const replyMessage = msg.reply_to_message;
+    const replyMessage = resolveReplyTargetMessage(msg);
     if (!replyMessage || !hasInboundMedia(replyMessage)) {
       return [];
     }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -245,15 +245,19 @@ export const registerTelegramHandlers = ({
       }
       const first = entries[0];
       const anchor = last;
+      const replyContextEntry = resolveReplyTargetMessage(anchor.msg) ? anchor : first;
       const syntheticMessage = buildSyntheticTextMessage({
-        base: anchor.msg,
+        base: replyContextEntry.msg,
         text: combinedText,
         date: anchor.msg.date ?? first.msg.date,
         from: anchor.msg.from ?? first.msg.from,
       });
       const messageIdOverride = anchor.msg.message_id ? String(anchor.msg.message_id) : undefined;
       const syntheticCtx = buildSyntheticContext(anchor.ctx, syntheticMessage);
-      const replyMedia = await resolveReplyMediaForMessage(anchor.ctx, anchor.msg);
+      const replyMedia = await resolveReplyMediaForMessage(
+        replyContextEntry.ctx,
+        replyContextEntry.msg,
+      );
       await processMessage(
         syntheticCtx,
         combinedMedia,

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -34,7 +34,11 @@ function mockTelegramDnsResolution() {
     async (hostname, params = {}) =>
       await resolvePinnedHostnameWithPolicy(hostname, {
         ...params,
-        lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+        lookupFn: async (hostname, family) => {
+          void hostname;
+          void family;
+          return [{ address: "93.184.216.34", family: 4 }];
+        },
       }),
   );
 }

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -6,6 +6,7 @@ import {
   listNativeCommandSpecsForConfig,
 } from "../auto-reply/commands-registry.js";
 import { normalizeTelegramCommandName } from "../config/telegram-custom-commands.js";
+import * as ssrf from "../infra/net/ssrf.js";
 import {
   answerCallbackQuerySpy,
   commandSpy,
@@ -26,6 +27,17 @@ import { createTelegramBot } from "./bot.js";
 
 const loadConfig = getLoadConfigMock();
 const readChannelAllowFromStore = getReadChannelAllowFromStoreMock();
+const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+
+function mockTelegramDnsResolution() {
+  return vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+    async (hostname, params = {}) =>
+      await resolvePinnedHostnameWithPolicy(hostname, {
+        ...params,
+        lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+      }),
+  );
+}
 
 function resolveSkillCommands(config: Parameters<typeof listNativeCommandSpecsForConfig>[0]) {
   void config;
@@ -558,6 +570,7 @@ describe("createTelegramBot", () => {
     replySpy.mockClear();
     getFileSpy.mockClear();
 
+    const resolvePinnedHostnameSpy = mockTelegramDnsResolution();
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
       async () =>
         new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
@@ -595,6 +608,55 @@ describe("createTelegramBot", () => {
       expect(payload.MediaPath).toBe(payload.MediaPaths?.[0]);
       expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1");
     } finally {
+      resolvePinnedHostnameSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("includes external reply media in inbound context for text replies", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    getFileSpy.mockClear();
+
+    const resolvePinnedHostnameSpy = mockTelegramDnsResolution();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "what is in this image?",
+          date: 1736380800,
+          external_reply: {
+            message_id: 9002,
+            photo: [{ file_id: "external-reply-photo-1" }],
+            from: { first_name: "Ada" },
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0][0] as {
+        MediaPath?: string;
+        MediaPaths?: string[];
+        ReplyToBody?: string;
+      };
+      expect(payload.ReplyToBody).toBe("<media:image>");
+      expect(payload.MediaPaths).toHaveLength(1);
+      expect(payload.MediaPath).toBe(payload.MediaPaths?.[0]);
+      expect(getFileSpy).toHaveBeenCalledWith("external-reply-photo-1");
+    } finally {
+      resolvePinnedHostnameSpy.mockRestore();
       fetchSpy.mockRestore();
     }
   });
@@ -662,6 +724,7 @@ describe("createTelegramBot", () => {
       },
     });
 
+    const resolvePinnedHostnameSpy = mockTelegramDnsResolution();
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
       async () =>
         new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
@@ -698,8 +761,8 @@ describe("createTelegramBot", () => {
           message_id: 102,
           from: { id: 42, first_name: "Ada" },
           reply_to_message: {
-            message_id: 9001,
-            photo: [{ file_id: "reply-photo-1" }],
+            message_id: 9002,
+            photo: [{ file_id: "reply-photo-2" }],
             from: { first_name: "Ada" },
           },
         },
@@ -729,8 +792,11 @@ describe("createTelegramBot", () => {
       });
 
       expect(getFileSpy).toHaveBeenCalledTimes(1);
-      expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1");
+      expect(getFileSpy).toHaveBeenCalledWith("reply-photo-2");
+      const payload = replySpy.mock.calls[0][0] as { ReplyToId?: string };
+      expect(payload.ReplyToId).toBe("9002");
     } finally {
+      resolvePinnedHostnameSpy.mockRestore();
       setTimeoutSpy.mockRestore();
       fetchSpy.mockRestore();
     }

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1,3 +1,4 @@
+import type { LookupAddress, LookupAllOptions, LookupOneOptions, LookupOptions } from "node:dns";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../test/helpers/envelope-timestamp.js";
 import { expectInboundContextContract } from "../../test/helpers/inbound-contract.js";
@@ -29,16 +30,37 @@ const loadConfig = getLoadConfigMock();
 const readChannelAllowFromStore = getReadChannelAllowFromStoreMock();
 const resolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
 
+function mockPinnedTelegramLookup(hostname: string): Promise<LookupAddress>;
+function mockPinnedTelegramLookup(hostname: string, family: number): Promise<LookupAddress>;
+function mockPinnedTelegramLookup(
+  hostname: string,
+  options: LookupOneOptions,
+): Promise<LookupAddress>;
+function mockPinnedTelegramLookup(
+  hostname: string,
+  options: LookupAllOptions,
+): Promise<LookupAddress[]>;
+function mockPinnedTelegramLookup(
+  hostname: string,
+  options: LookupOptions,
+): Promise<LookupAddress | LookupAddress[]>;
+function mockPinnedTelegramLookup(
+  hostname: string,
+  options?: number | LookupOneOptions | LookupAllOptions | LookupOptions,
+): Promise<LookupAddress | LookupAddress[]> {
+  void hostname;
+  if (typeof options === "object" && options?.all === true) {
+    return Promise.resolve([{ address: "93.184.216.34", family: 4 }]);
+  }
+  return Promise.resolve({ address: "93.184.216.34", family: 4 });
+}
+
 function mockTelegramDnsResolution() {
   return vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
     async (hostname, params = {}) =>
       await resolvePinnedHostnameWithPolicy(hostname, {
         ...params,
-        lookupFn: async (hostname, family) => {
-          void hostname;
-          void family;
-          return [{ address: "93.184.216.34", family: 4 }];
-        },
+        lookupFn: mockPinnedTelegramLookup,
       }),
   );
 }


### PR DESCRIPTION
Fixes reply context loss when:
- Telegram sends `external_reply`, and/or
- multiple messages are coalesced in the debounced handler.

Changes:
- Resolve reply target via a helper that supports both `reply_to_message` and `external_reply`.
- Use the last (anchor) message in a debounced batch for reply-media resolution + synthetic message base.

Tests:
- `pnpm test src/telegram/bot.test.ts --run`