### PR TITLE
fix: handle OpenRouter numeric usage.cost in cost tracking

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -82,7 +82,12 @@ const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | unde
     return undefined;
   }
   const record = usageRaw as Record<string, unknown>;
-  const cost = record.cost as Record<string, unknown> | undefined;
+  const costRaw = record.cost;
+  if (typeof costRaw === "number") {
+    const total = toFiniteNumber(costRaw);
+    return total !== undefined && total >= 0 ? { total } : undefined;
+  }
+  const cost = costRaw as Record<string, unknown> | undefined;
   if (!cost) {
     return undefined;
   }


### PR DESCRIPTION
## Problem

OpenRouter returns `usage.cost` as a flat number (e.g. `0.0045`), but `extractCostBreakdown()` expects it to be an object with `{total, input, output}`. This causes `cost.total` to be `undefined`, resulting in **silent \$0 cost tracking for all OpenRouter requests**.

## Fix

Add an early check for numeric `cost` values in `extractCostBreakdown()`. When `cost` is a number, wrap it directly as `{ total: cost }`. The existing object-based path remains unchanged.

## Changes

- `src/infra/session-cost-usage.ts`: Handle both `number` and `object` formats for `usage.cost`

Closes #30204