### PR TITLE
feat(docs): support dark mode for Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left)](https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left)
+<p align="center">
+  <a href="https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left">
+    <picture>
+     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&theme=dark&legend=top-left" />
+     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left" />
+     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left" />
+    </picture>
+  </a>
+</p>
 
 ## Everything we built so far
 


### PR DESCRIPTION
## Summary

Replaces the Star History chart's plain Markdown image with an HTML `<picture>` element, so the chart automatically switches between light and dark variants based on the viewer's system theme.

## Changes

`README.md` — `## Star History` section only.

**Before:**
```markdown
[![Star History Chart](https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left)](https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left)
```

**After:**
```html
<p align="center">
  <a href="https://www.star-history.com/#openclaw/openclaw&type=date&legend=top-left">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&theme=dark&legend=top-left" />
      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left" />
      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=openclaw/openclaw&type=date&legend=top-left" />
    </picture>
  </a>
</p>
```

## How it works

- `(prefers-color-scheme: dark)` → uses `&theme=dark` variant from star-history.com API
- `(prefers-color-scheme: light)` → uses the default (light) variant
- The `<img>` fallback ensures compatibility with renderers that don't support `<picture>`
- GitHub's Markdown renderer fully supports `<picture>` and `prefers-color-scheme`, so this works natively in the README

## Testing

- [x] Viewed README on GitHub in light mode — chart renders correctly
- [x] Viewed README on GitHub in dark mode — dark-themed chart renders correctly
- [x] No other sections of README were modified

## Notes

This is a docs-only change with zero functional impact. No scripts, no config, no code paths affected.