### PR TITLE
fix(auth): add google-vertex ADC passthrough for sub-agents

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -333,4 +333,89 @@ describe("getApiKeyForModel", () => {
       },
     );
   });
+
+  it("google-vertex: falls back to google-adc mode when no API key is configured", async () => {
+    await withEnvAsync(
+      {
+        GOOGLE_API_KEY: undefined,
+        GOOGLE_APPLICATION_CREDENTIALS: undefined,
+        GOOGLE_CLOUD_PROJECT: undefined,
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "google-vertex",
+          store: { version: 1, profiles: {} },
+        });
+        expect(resolved.mode).toBe("google-adc");
+        expect(resolved.apiKey).toBeUndefined();
+        expect(resolved.source).toContain("google-adc");
+      },
+    );
+  });
+
+  it("google-vertex: reports GOOGLE_APPLICATION_CREDENTIALS as source when set", async () => {
+    await withEnvAsync(
+      {
+        GOOGLE_API_KEY: undefined,
+        GOOGLE_APPLICATION_CREDENTIALS: "/path/to/sa.json",
+        GOOGLE_CLOUD_PROJECT: undefined,
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "google-vertex",
+          store: { version: 1, profiles: {} },
+        });
+        expect(resolved.mode).toBe("google-adc");
+        expect(resolved.apiKey).toBeUndefined();
+        expect(resolved.source).toContain("GOOGLE_APPLICATION_CREDENTIALS");
+      },
+    );
+  });
+
+  it("google-vertex: reports GOOGLE_CLOUD_PROJECT as source when credentials env is absent", async () => {
+    await withEnvAsync(
+      {
+        GOOGLE_API_KEY: undefined,
+        GOOGLE_APPLICATION_CREDENTIALS: undefined,
+        GOOGLE_CLOUD_PROJECT: "my-project",
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "google-vertex",
+          store: { version: 1, profiles: {} },
+        });
+        expect(resolved.mode).toBe("google-adc");
+        expect(resolved.source).toContain("GOOGLE_CLOUD_PROJECT");
+      },
+    );
+  });
+
+  it("google-vertex: explicit auth: 'google-adc' config override triggers ADC mode", async () => {
+    await withEnvAsync(
+      {
+        GOOGLE_API_KEY: undefined,
+        GOOGLE_APPLICATION_CREDENTIALS: undefined,
+        GOOGLE_CLOUD_PROJECT: undefined,
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "google-vertex",
+          store: { version: 1, profiles: {} },
+          cfg: {
+            models: {
+              providers: {
+                "google-vertex": {
+                  baseUrl: "https://us-central1-aiplatform.googleapis.com",
+                  auth: "google-adc",
+                  models: [],
+                },
+              },
+            },
+          } as never,
+        });
+        expect(resolved.mode).toBe("google-adc");
+        expect(resolved.apiKey).toBeUndefined();
+      },
+    );
+  });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -25,6 +25,9 @@ const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
 const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
 const AWS_PROFILE_ENV = "AWS_PROFILE";
 
+const GOOGLE_APPLICATION_CREDENTIALS_ENV = "GOOGLE_APPLICATION_CREDENTIALS";
+const GOOGLE_CLOUD_PROJECT_ENV = "GOOGLE_CLOUD_PROJECT";
+
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
@@ -61,7 +64,13 @@ function resolveProviderAuthOverride(
 ): ModelProviderAuthMode | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   const auth = entry?.auth;
-  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token") {
+  if (
+    auth === "api-key" ||
+    auth === "aws-sdk" ||
+    auth === "google-adc" ||
+    auth === "oauth" ||
+    auth === "token"
+  ) {
     return auth;
   }
   return undefined;
@@ -88,6 +97,31 @@ export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): s
     return AWS_PROFILE_ENV;
   }
   return undefined;
+}
+
+function resolveGoogleAdcAuthInfo(): { mode: "google-adc"; source: string } {
+  const applied = new Set(getShellEnvAppliedKeys());
+  if (process.env[GOOGLE_APPLICATION_CREDENTIALS_ENV]?.trim()) {
+    return {
+      mode: "google-adc",
+      source: resolveEnvSourceLabel({
+        applied,
+        envVars: [GOOGLE_APPLICATION_CREDENTIALS_ENV],
+        label: GOOGLE_APPLICATION_CREDENTIALS_ENV,
+      }),
+    };
+  }
+  if (process.env[GOOGLE_CLOUD_PROJECT_ENV]?.trim()) {
+    return {
+      mode: "google-adc",
+      source: resolveEnvSourceLabel({
+        applied,
+        envVars: [GOOGLE_CLOUD_PROJECT_ENV],
+        label: GOOGLE_CLOUD_PROJECT_ENV,
+      }),
+    };
+  }
+  return { mode: "google-adc", source: "google-adc default chain" };
 }
 
 function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
@@ -129,7 +163,7 @@ export type ResolvedProviderAuth = {
   apiKey?: string;
   profileId?: string;
   source: string;
-  mode: "api-key" | "oauth" | "token" | "aws-sdk";
+  mode: "api-key" | "oauth" | "token" | "aws-sdk" | "google-adc";
 };
 
 export async function resolveApiKeyForProvider(params: {
@@ -165,6 +199,9 @@ export async function resolveApiKeyForProvider(params: {
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
     return resolveAwsSdkAuthInfo();
+  }
+  if (authOverride === "google-adc") {
+    return resolveGoogleAdcAuthInfo();
   }
 
   const order = resolveAuthProfileOrder({
@@ -211,6 +248,10 @@ export async function resolveApiKeyForProvider(params: {
   if (authOverride === undefined && normalized === "amazon-bedrock") {
     return resolveAwsSdkAuthInfo();
   }
+  // google-vertex uses ADC when no explicit API key is configured — same pattern as amazon-bedrock
+  if (authOverride === undefined && normalized === "google-vertex") {
+    return resolveGoogleAdcAuthInfo();
+  }
 
   if (provider === "openai") {
     const hasCodex = listProfilesForProvider(store, "openai-codex").length > 0;
@@ -233,7 +274,14 @@ export async function resolveApiKeyForProvider(params: {
 }
 
 export type EnvApiKeyResult = { apiKey: string; source: string };
-export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" | "unknown";
+export type ModelAuthMode =
+  | "api-key"
+  | "oauth"
+  | "token"
+  | "mixed"
+  | "aws-sdk"
+  | "google-adc"
+  | "unknown";
 
 export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   const normalized = normalizeProviderId(provider);
@@ -344,6 +392,9 @@ export function resolveModelAuthMode(
   if (authOverride === "aws-sdk") {
     return "aws-sdk";
   }
+  if (authOverride === "google-adc") {
+    return "google-adc";
+  }
 
   const authStore = store ?? ensureAuthProfileStore();
   const profiles = listProfilesForProvider(authStore, resolved);
@@ -372,6 +423,9 @@ export function resolveModelAuthMode(
 
   if (authOverride === undefined && normalizeProviderId(resolved) === "amazon-bedrock") {
     return "aws-sdk";
+  }
+  if (authOverride === undefined && normalizeProviderId(resolved) === "google-vertex") {
+    return "google-adc";
   }
 
   const envKey = resolveEnvApiKey(resolved);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -293,7 +293,7 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "google-adc") {
         throw new Error(
           `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -427,7 +427,7 @@ export async function runEmbeddedPiAgent(
         apiKeyInfo = await resolveApiKeyForCandidate(candidate);
         const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
         if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
+          if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "google-adc") {
             throw new Error(
               `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
             );

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -365,7 +365,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "memory.backend": ['"builtin"', '"qmd"'],
   "memory.qmd.searchMode": ['"query"', '"search"', '"vsearch"'],
   "models.mode": ['"merge"', '"replace"'],
-  "models.providers.*.auth": ['"api-key"', '"token"', '"oauth"', '"aws-sdk"'],
+  "models.providers.*.auth": ['"api-key"', '"token"', '"oauth"', '"aws-sdk"', '"google-adc"'],
   "gateway.reload.mode": ['"off"', '"restart"', '"hot"', '"hybrid"'],
   "approvals.exec.mode": ['"session"', '"targets"', '"both"'],
   "bindings[].match.peer.kind": ['"direct"', '"group"', '"channel"', '"dm"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -600,7 +600,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.apiKey":
     "Provider credential used for API-key based authentication when the provider requires direct key auth. Use secret/env substitution and avoid storing real keys in committed config files.",
   "models.providers.*.auth":
-    'Selects provider auth style: "api-key" for API key auth, "token" for bearer token auth, "oauth" for OAuth credentials, and "aws-sdk" for AWS credential resolution. Match this to your provider requirements.',
+    'Selects provider auth style: "api-key" for API key auth, "token" for bearer token auth, "oauth" for OAuth credentials, "aws-sdk" for AWS credential resolution, and "google-adc" for Google Application Default Credentials. Match this to your provider requirements.',
   "models.providers.*.api":
     "Provider API adapter selection controlling request/response compatibility handling for model calls. Use the adapter that matches your upstream provider protocol to avoid feature mismatch.",
   "models.providers.*.headers":

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -21,7 +21,7 @@ export type ModelCompatConfig = {
   requiresMistralToolIds?: boolean;
 };
 
-export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";
+export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "google-adc" | "oauth" | "token";
 
 export type ModelDefinitionConfig = {
   id: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -60,7 +60,13 @@ export const ModelProviderSchema = z
     baseUrl: z.string().min(1),
     apiKey: z.string().optional().register(sensitive),
     auth: z
-      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
+      .union([
+        z.literal("api-key"),
+        z.literal("aws-sdk"),
+        z.literal("google-adc"),
+        z.literal("oauth"),
+        z.literal("token"),
+      ])
       .optional(),
     api: ModelApiSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
## Summary

- **Problem:** `resolveApiKeyForProvider` requires an API key for every provider, but Google Vertex AI uses Application Default Credentials (ADC) via the `@google/genai` SDK — not an API key. Sub-agents using `google-vertex` hit `No API key found for provider "google-vertex"` before the SDK can handle ADC auth.
- **Why it matters:** Sub-agents cannot use Vertex AI at all when ADC is the intended auth mechanism (e.g. service account via `GOOGLE_APPLICATION_CREDENTIALS`).
- **What changed:** Added a `"google-adc"` auth mode mirroring the existing `"aws-sdk"` / `amazon-bedrock` pattern. `google-vertex` now falls back to ADC when no explicit API key is found; users can also set `auth: "google-adc"` explicitly in their provider config. The no-apiKey guard in both pi-embedded runners now permits `google-adc` mode.
- **What did NOT change:** All other providers are unaffected. The `amazon-bedrock` / `aws-sdk` path is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #30253

## User-visible / Behavior Changes

- Sub-agents using `google-vertex` with Application Default Credentials no longer throw `No API key found`. Auth falls through to the Google SDK's ADC chain automatically.
- New explicit config option: `models.providers.<name>.auth: "google-adc"` to force ADC mode for any custom Vertex-compatible provider entry.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — no secrets are stored; ADC credentials are managed entirely by the Google SDK / gcloud toolchain outside of OpenClaw.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node 22 / Bun
- Model/provider: google-vertex (Vertex AI service account ADC)
- Relevant config: `GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json`, `GOOGLE_CLOUD_PROJECT=my-project`

### Steps

1. Configure a sub-agent with `google-vertex` and no `GOOGLE_API_KEY` set.
2. Spawn the sub-agent via `sessions_spawn`.
3. **Before:** throws `No API key found for provider "google-vertex"`.
4. **After:** sub-agent initialises and authenticates via ADC.

### Expected

- Sub-agent starts and routes requests through the Google SDK ADC chain.

### Actual (before fix)

- Auth gate throws before the SDK is invoked.

## Evidence

- [x] Failing test/log before + passing after — 4 new tests in `src/agents/model-auth.profiles.test.ts` covering: default-chain ADC fallback, `GOOGLE_APPLICATION_CREDENTIALS` source label, `GOOGLE_CLOUD_PROJECT` source label, and explicit `auth: "google-adc"` config override. All 19 tests in the file pass.

## Human Verification (required)

- Verified scenarios: type-check (`pnpm tsgo` on touched files), lint (`pnpm lint` — 0 warnings/errors), all 19 profile auth tests pass.
- Edge cases checked: `google-vertex` with an explicit API key still works (resolves via `resolveEnvApiKey` before the ADC fallback); explicit `auth: "google-adc"` config override triggers ADC mode immediately without falling through the key-lookup chain.
- What you did **not** verify: live Vertex AI end-to-end with a real service account.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — ADC fallback is automatic; no config change required for existing Vertex users.
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `google-vertex` fallback block added in `src/agents/model-auth.ts` and the mode-guard additions in the two pi-embedded runner files.
- Files/config to restore: `src/agents/model-auth.ts`, `src/agents/pi-embedded-runner/run.ts`, `src/agents/pi-embedded-runner/compact.ts`.
- Known bad symptoms: sub-agents for non-Vertex providers unexpectedly skipping key validation (would not happen — fallback is guarded by `normalized === "google-vertex"`).

## Risks and Mitigations

- Risk: ADC fallback triggers for a user who misconfigured `google-vertex` and has no credentials at all — the Google SDK will throw its own auth error rather than OpenClaw's "No API key" message.
  - Mitigation: The error from the SDK is descriptive enough; no silent failure. The existing behaviour for all other providers is unchanged.

Made with [Cursor](https://cursor.com)