### PR TITLE
fix(terminal): use explicit foreground color in CLI note boxes

### DIFF
--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -1,6 +1,7 @@
 import { note as clackNote } from "@clack/prompts";
 import { visibleWidth } from "./ansi.js";
 import { stylePromptTitle } from "./prompt-style.js";
+import { isRich, theme } from "./theme.js";
 
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
@@ -130,5 +131,7 @@ export function wrapNoteMessage(
 }
 
 export function note(message: string, title?: string) {
-  clackNote(wrapNoteMessage(message), stylePromptTitle(title));
+  clackNote(wrapNoteMessage(message), stylePromptTitle(title), {
+    format: (line) => (isRich() ? theme.muted(line) : line),
+  });
 }


### PR DESCRIPTION
## Summary

- **Problem:** CLI styled boxes (notes, provider info) have invisible text in web-based terminals (xterm.js, Dokploy). The box borders render correctly but content text is black-on-black.
- **Why it matters:** All users accessing OpenClaw CLI through web-based terminals (Dokploy, ttyd, Wetty, any xterm.js-based UI) cannot read note box content without `NO_COLOR=1` workaround.
- **What changed:** `src/terminal/note.ts` — pass a custom `format` callback to `@clack/prompts` `note()` that uses the theme `muted` hex color (`#8B7F77`) instead of the default ANSI `dim` attribute.
- **What did NOT change:** Box borders, title styling, intro/outro styling, non-note CLI output, `NO_COLOR` behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #3989

## User-visible / Behavior Changes

- Note box content text now uses an explicit foreground color (`#8B7F77`) instead of ANSI `dim`, making it readable in web-based terminals while remaining visually subdued in native terminals.
- When `NO_COLOR` is set, content is rendered without any styling (same as before).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any (issue is terminal-dependent)
- Runtime: Node.js
- Integration/channel: CLI (TUI, doctor, onboarding)

### Steps

1. Open OpenClaw CLI in a web-based terminal (xterm.js / Dokploy)
2. Run any command that outputs a styled box (e.g., `openclaw doctor`)

### Expected

- Box content text is readable with sufficient contrast

### Actual

- Before fix: Content invisible (ANSI `dim` renders as black on dark background)
- After fix: Content uses `#8B7F77` hex color, readable in both native and web terminals

## Evidence

```diff
// src/terminal/note.ts
 export function note(message: string, title?: string) {
-  clackNote(wrapNoteMessage(message), stylePromptTitle(title));
+  clackNote(wrapNoteMessage(message), stylePromptTitle(title), {
+    format: (line) => (isRich() ? theme.muted(line) : line),
+  });
 }
```

The `theme.muted` function uses `chalk.hex('#8B7F77')` which emits a 24-bit ANSI color code that web terminals handle correctly, unlike the `dim` attribute (`ESC[2m`) which many web terminals render as near-invisible.

## Human Verification (required)

- Verified scenarios: `note()` call in `doctor`, `configure`, onboarding flows
- Edge cases checked: `NO_COLOR=1` produces unstyled text; `FORCE_COLOR` overrides `NO_COLOR`; native terminals (iTerm2, Terminal.app) show muted gray text
- What I did **not** verify: Actual Dokploy environment (verified logic against xterm.js dim behavior docs)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit
- Files/config to restore: `src/terminal/note.ts`
- Known bad symptoms: Note box text color wrong

## Risks and Mitigations

- Risk: `#8B7F77` may have lower contrast than `dim` on some very light terminal themes → Mitigated by using the same muted color already used elsewhere in the CLI palette

