### PR TITLE
fix(telegram): use group allowlist for native command auth in groups

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -253,19 +253,21 @@ async function resolveTelegramCommandAuth(params: {
     }
   }
 
-  const dmAllow = normalizeDmAllowFromWithStore({
-    allowFrom: allowFrom,
-    storeAllowFrom: isGroup ? [] : storeAllowFrom,
-    dmPolicy: telegramCfg.dmPolicy ?? "pairing",
-  });
+  const allow = isGroup
+    ? effectiveGroupAllow
+    : normalizeDmAllowFromWithStore({
+        allowFrom: allowFrom,
+        storeAllowFrom,
+        dmPolicy: telegramCfg.dmPolicy ?? "pairing",
+      });
   const senderAllowed = isSenderAllowed({
-    allow: dmAllow,
+    allow,
     senderId,
     senderUsername,
   });
   const commandAuthorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
-    authorizers: [{ configured: dmAllow.hasEntries, allowed: senderAllowed }],
+    authorizers: [{ configured: allow.hasEntries, allowed: senderAllowed }],
     modeWhenAccessGroupsOff: "configured",
   });
   if (requireAuth && !commandAuthorized) {


### PR DESCRIPTION
## Summary

- Fixes native Telegram slash commands in groups rejecting authorized senders because the auth check used the DM allowlist instead of the group allowlist

**Root cause:** `resolveTelegramCommandAuth` always used `normalizeDmAllowFromWithStore` (DM allowlist) for the final sender authorization, even in group contexts. Users in `groupAllowFrom` but not in `allowFrom` were rejected.

**Fix:** Use `effectiveGroupAllow` (already resolved from `groupAllowFrom` and per-group/topic overrides) for group contexts. Keep DM allowlist logic only for direct messages.

## Changes

- `src/telegram/bot-native-commands.ts`: Branch auth logic based on `isGroup` — use `effectiveGroupAllow` for groups, `normalizeDmAllowFromWithStore` for DMs

## Test plan

- [ ] Configure a Telegram group with `groupAllowFrom: [userId]` but no top-level `allowFrom`
- [ ] Send a native slash command (e.g. `/status`) in the group
- [ ] Verify the command is authorized (no "not authorized" rejection)
- [ ] Verify DM commands still work with the DM allowlist

Fixes #30234