### PR TITLE
fix(qmd): include archived session transcripts in file listing

### DIFF
--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -111,8 +111,10 @@ describe("listSessionFilesForAgent", () => {
       "abc.jsonl",
       "abc.jsonl.reset.2026-02-16T22-26-33.000Z",
       "abc.jsonl.deleted.2026-02-16T22-26-33.000Z",
+      "abc.jsonl.bak.2026-02-16T22-26-33.000Z",
       "abc.jsonl.lock",
       "sessions.json",
+      "sessions.json.bak.123456",
       "notes.txt",
     ];
     for (const f of files) {
@@ -125,8 +127,10 @@ describe("listSessionFilesForAgent", () => {
     expect(names).toContain("abc.jsonl");
     expect(names).toContain("abc.jsonl.reset.2026-02-16T22-26-33.000Z");
     expect(names).toContain("abc.jsonl.deleted.2026-02-16T22-26-33.000Z");
+    expect(names).toContain("abc.jsonl.bak.2026-02-16T22-26-33.000Z");
     expect(names).not.toContain("abc.jsonl.lock");
     expect(names).not.toContain("sessions.json");
+    expect(names).not.toContain("sessions.json.bak.123456");
     expect(names).not.toContain("notes.txt");
   });
 });

--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildSessionEntry } from "./session-files.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSessionEntry, listSessionFilesForAgent } from "./session-files.js";
 
 describe("buildSessionEntry", () => {
   let tmpDir: string;
@@ -83,5 +83,50 @@ describe("buildSessionEntry", () => {
     const entry = await buildSessionEntry(filePath);
     expect(entry).not.toBeNull();
     expect(entry!.lineMap).toEqual([3, 5]);
+  });
+});
+
+vi.mock("../config/sessions/paths.js", () => ({
+  resolveSessionTranscriptsDirForAgent: (_agentId: string) => {
+    // Overridden per test via __mockDir
+    return (globalThis as Record<string, unknown>).__mockSessionDir as string;
+  },
+}));
+
+describe("listSessionFilesForAgent", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-list-test-"));
+    (globalThis as Record<string, unknown>).__mockSessionDir = tmpDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    delete (globalThis as Record<string, unknown>).__mockSessionDir;
+  });
+
+  it("includes primary, reset, and deleted session files but excludes lock files", async () => {
+    const files = [
+      "abc.jsonl",
+      "abc.jsonl.reset.2026-02-16T22-26-33.000Z",
+      "abc.jsonl.deleted.2026-02-16T22-26-33.000Z",
+      "abc.jsonl.lock",
+      "sessions.json",
+      "notes.txt",
+    ];
+    for (const f of files) {
+      await fs.writeFile(path.join(tmpDir, f), "");
+    }
+
+    const result = await listSessionFilesForAgent("test-agent");
+    const names = result.map((p) => path.basename(p));
+
+    expect(names).toContain("abc.jsonl");
+    expect(names).toContain("abc.jsonl.reset.2026-02-16T22-26-33.000Z");
+    expect(names).toContain("abc.jsonl.deleted.2026-02-16T22-26-33.000Z");
+    expect(names).not.toContain("abc.jsonl.lock");
+    expect(names).not.toContain("sessions.json");
+    expect(names).not.toContain("notes.txt");
   });
 });

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -1,9 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  isSessionArchiveArtifactName,
-  isPrimarySessionTranscriptFileName,
-} from "../config/sessions/artifacts.js";
+import { isPrimarySessionTranscriptFileName } from "../config/sessions/artifacts.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -22,6 +19,13 @@ export type SessionFileEntry = {
   lineMap: number[];
 };
 
+/** Matches JSONL transcript archives only (e.g. foo.jsonl.reset.*, foo.jsonl.deleted.*). */
+const JSONL_ARCHIVE_RE = /\.jsonl\.(reset|deleted|bak)\.\d{4}-\d{2}-\d{2}T/;
+
+function isJsonlArchiveTranscript(name: string): boolean {
+  return JSONL_ARCHIVE_RE.test(name);
+}
+
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
   const dir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
@@ -29,9 +33,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter(
-        (name) => isPrimarySessionTranscriptFileName(name) || isSessionArchiveArtifactName(name),
-      )
+      .filter((name) => isPrimarySessionTranscriptFileName(name) || isJsonlArchiveTranscript(name))
       .map((name) => path.join(dir, name));
   } catch {
     return [];

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -25,7 +25,7 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter((name) => name.endsWith(".jsonl"))
+      .filter((name) => name.endsWith(".jsonl") || name.includes(".jsonl."))
       .map((name) => path.join(dir, name));
   } catch {
     return [];

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  isSessionArchiveArtifactName,
+  isPrimarySessionTranscriptFileName,
+} from "../config/sessions/artifacts.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -25,7 +29,9 @@ export async function listSessionFilesForAgent(agentId: string): Promise<string[
     return entries
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
-      .filter((name) => name.endsWith(".jsonl") || name.includes(".jsonl."))
+      .filter(
+        (name) => isPrimarySessionTranscriptFileName(name) || isSessionArchiveArtifactName(name),
+      )
       .map((name) => path.join(dir, name));
   } catch {
     return [];


### PR DESCRIPTION
## Summary

- Fixes `listSessionFilesForAgent()` excluding reset and deleted session transcripts from QMD indexing

**Root cause:** The file filter used `.endsWith(".jsonl")` which excluded archived files with suffixes like `.jsonl.reset.2026-02-16T22-26-33.000Z` and `.jsonl.deleted.2026-02-16T22-26-33.000Z`. On setups with daily session resets, most conversation history became unsearchable via `memory_search`.

**Fix:** Broaden the filter to also match filenames containing `.jsonl.` so archived transcripts are included.

## Changes

- `src/memory/session-files.ts`: Update filter to include `.jsonl.*` archived files

## Test plan

- [x] Existing tests pass (`session-files.test.ts` — 3/3, `artifacts.test.ts` — 3/3)
- [ ] Configure `session.reset.mode: "daily"` and verify archived sessions appear in `memory_search` results after reset

Fixes #30220