### PR TITLE
fix(discord): decouple message listener from agent run to prevent cross-session drops

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -126,7 +126,11 @@ export class DiscordMessageListener extends MessageCreateListener {
   }
 
   async handle(data: DiscordMessageEvent, client: Client) {
-    await runDiscordListenerWithSlowLog({
+    // Fire-and-forget: decouple event dispatch from agent run processing so
+    // one long-running session does not block Carbon's EventQueue listener
+    // timeout (30s) for events destined to other sessions.  Errors and slow-
+    // listener warnings are still handled inside runDiscordListenerWithSlowLog.
+    void runDiscordListenerWithSlowLog({
       logger: this.logger,
       listener: this.constructor.name,
       event: this.type,


### PR DESCRIPTION
## Summary

- **Problem:** When a Discord bot has an active agent run (LLM inference + tool calls) on session A, incoming `MESSAGE_CREATE` events for session B (different channel/thread) are silently dropped after Carbon's 30-second `EventQueue` listener timeout.
- **Why it matters:** Multi-channel Discord setups become unreliable — forum threads, DMs, and other channels miss messages whenever any session has a long-running agent turn.
- **What changed:** `src/discord/monitor/listeners.ts` — `DiscordMessageListener.handle()` now fires-and-forgets the handler instead of awaiting the full agent run pipeline. The handler still runs in background with full error handling and slow-listener logging.
- **What did NOT change:** Handler logic, preflight, dispatch, debouncing, error handling, slow-listener warnings. Only the await/void semantics of the listener method changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30006

## User-visible / Behavior Changes

- Discord bots with multiple channels/threads no longer silently drop messages for one session when another session has a long-running agent run.
- The `[EventQueue] Listener DiscordMessageListener timed out` log no longer appears for normal agent runs (since the listener returns immediately).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (any)
- Runtime: Node.js 22+
- Integration/channel: Discord (multi-channel bot)

### Steps

1. Configure a single Discord bot with multiple channels (DM + forum threads, `requireMention: false`)
2. Start a conversation in DM that triggers tool calls (run >30 seconds)
3. While the DM run is active, send a message in a forum thread

### Expected

- Forum thread message is dispatched independently

### Actual

- Before fix: Forum message dropped after 30s EventQueue listener timeout
- After fix: Forum message dispatched immediately, processed in parallel

## Evidence

```diff
// src/discord/monitor/listeners.ts — DiscordMessageListener.handle()
   async handle(data: DiscordMessageEvent, client: Client) {
-    await runDiscordListenerWithSlowLog({
+    void runDiscordListenerWithSlowLog({
       logger: this.logger,
       listener: this.constructor.name,
       event: this.type,
       run: () => this.handler(data, client),
       onError: (err) => { ... },
     });
   }
```

**Root cause chain:**
1. `DiscordMessageListener.handle()` awaits full handler
2. Handler awaits `debouncer.enqueue()` → `processDiscordMessage()` → `dispatchInboundMessage()` → full agent run
3. Carbon `EventQueue.processListener()` uses `Promise.race([handle(), 30s timeout])`
4. Agent run >30s → timeout fires → event logged as timed out
5. Cross-session events get caught in this timeout

**Fix:** `void` instead of `await` makes `handle()` return immediately. The handler runs in background with identical error handling. Carbon's EventQueue processes the next event without waiting.

## Human Verification (required)

- Verified scenarios: Traced full code path from EventQueue → listener → handler → dispatch
- Edge cases checked: Error handling preserved (onError callback); slow-listener logging preserved (runs in finally block); debouncer still works per-key (channel+author)
- What I did **not** verify: Live multi-channel Discord bot (verified via code analysis only)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit (change `void` back to `await`)
- Files/config to restore: `src/discord/monitor/listeners.ts`
- Known bad symptoms: If backpressure is needed, rapid message floods could overwhelm the system (mitigated by Carbon's maxQueueSize: 10000)

## Risks and Mitigations

- **Risk:** Loss of backpressure — the EventQueue no longer waits for the handler to complete before accepting new events. **Mitigation:** Carbon's `maxQueueSize` (10000) provides a safety valve. The agent runner has its own per-session concurrency controls. In practice, Discord's rate limits and the debouncer prevent message floods.
- **Risk:** Unobserved promise rejections if the handler throws after `void`. **Mitigation:** `runDiscordListenerWithSlowLog` has full try/catch with `onError` callback — errors are logged, never thrown.

