### PR TITLE
fix(usage): handle OpenRouter numeric usage.cost values

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -82,11 +82,21 @@ const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | unde
     return undefined;
   }
   const record = usageRaw as Record<string, unknown>;
-  const cost = record.cost as Record<string, unknown> | undefined;
-  if (!cost) {
+  const rawCost = record.cost;
+  if (rawCost === undefined || rawCost === null) {
     return undefined;
   }
 
+  // OpenRouter sends cost as a flat number; normalize to object form.
+  if (typeof rawCost === "number") {
+    const total = toFiniteNumber(rawCost);
+    if (total === undefined || total < 0) {
+      return undefined;
+    }
+    return { total };
+  }
+
+  const cost = rawCost as Record<string, unknown>;
   const total = toFiniteNumber(cost.total);
   if (total === undefined || total < 0) {
     return undefined;


### PR DESCRIPTION
## Summary

- Handles OpenRouter's flat numeric `usage.cost` format (e.g. `0.0045`) in addition to the existing object format `{total, input, output}`

**Root cause:** `extractCostBreakdown()` assumed `cost` is always an object, but OpenRouter sends it as a plain number. This caused `cost.total` to be `undefined`, resulting in silent $0 cost tracking for all OpenRouter requests.

**Fix:** Add an early type check — when `cost` is a number, wrap it as `{ total: cost }`. The existing object path remains unchanged.

## Changes

- `src/infra/session-cost-usage.ts`: Handle both numeric and object `usage.cost` formats

## Test plan

- [ ] Send a request through OpenRouter and verify cost is tracked correctly
- [ ] Verify existing object-based cost tracking (e.g. from other providers) still works

Fixes #30249
Closes #30204