### PR TITLE
fix(skills): preserve description containing colons in SKILL.md frontmatter

### DIFF
--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -68,6 +68,17 @@ metadata:
     expect(parsed.openclaw?.events).toEqual(["command:new"]);
   });
 
+  it("preserves description containing mid-string colons", () => {
+    const content = `---
+name: anime-skill
+description: Use anime style IMPORTANT: Must be kawaii
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("anime-skill");
+    expect(result.description).toBe("Use anime style IMPORTANT: Must be kawaii");
+  });
+
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -91,6 +91,18 @@ description: |
     expect(result.description).toBe("{json-ish text here}");
   });
 
+  it("preserves YAML block scalars with chomping indicators starting with {", () => {
+    const content = `---
+name: chomp-test
+description: |-
+  {json-ish text here}
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("chomp-test");
+    expect(result.description).toBe("{json-ish text here}");
+  });
+
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -79,6 +79,18 @@ description: Use anime style IMPORTANT: Must be kawaii
     expect(result.description).toBe("Use anime style IMPORTANT: Must be kawaii");
   });
 
+  it("preserves YAML block scalars starting with {", () => {
+    const content = `---
+name: block-test
+description: |
+  {json-ish text here}
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("block-test");
+    expect(result.description).toBe("{json-ish text here}");
+  });
+
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});

--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -103,6 +103,21 @@ description: |-
     expect(result.description).toBe("{json-ish text here}");
   });
 
+  it("preserves nested YAML mappings as JSON objects", () => {
+    const content = `---
+name: nested-test
+metadata:
+  openclaw:
+    events:
+      - command:new
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("nested-test");
+    const parsed = JSON.parse(result.metadata ?? "");
+    expect(parsed.openclaw?.events).toEqual(["command:new"]);
+  });
+
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -155,13 +155,13 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
       merged[key] !== undefined &&
       merged[key].startsWith("{") &&
       !value.includes("\n") &&
-      value !== "|" &&
-      value !== ">"
+      !/^[|>][+-]?\d*$/.test(value)
     ) {
       // YAML misinterpreted an unquoted colon as a nested key and produced
       // a JSON object; prefer the line-parsed plain string instead.
-      // Skip when the line-parsed value is a block scalar indicator (| or >)
-      // since YAML correctly handled those.
+      // Skip when the line-parsed value is a block scalar indicator
+      // (|, >, |-, |+, >-, >+, |2, >2-, etc.) since YAML correctly
+      // handled those.
       merged[key] = value;
     }
   }

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -151,6 +151,10 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   for (const [key, value] of Object.entries(lineParsed)) {
     if (value.startsWith("{") || value.startsWith("[")) {
       merged[key] = value;
+    } else if (merged[key] !== undefined && merged[key].startsWith("{") && !value.includes("\n")) {
+      // YAML misinterpreted an unquoted colon as a nested key and produced
+      // a JSON object; prefer the line-parsed plain string instead.
+      merged[key] = value;
     }
   }
   return merged;

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -155,13 +155,14 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
       merged[key] !== undefined &&
       merged[key].startsWith("{") &&
       !value.includes("\n") &&
-      !/^[|>][+-]?\d*$/.test(value)
+      !/^[|>][+-]?\d*$/.test(value) &&
+      value.includes(":")
     ) {
       // YAML misinterpreted an unquoted colon as a nested key and produced
       // a JSON object; prefer the line-parsed plain string instead.
-      // Skip when the line-parsed value is a block scalar indicator
-      // (|, >, |-, |+, >-, >+, |2, >2-, etc.) since YAML correctly
-      // handled those.
+      // Only applies when the line-parsed value itself contains a colon
+      // (the symptom of the YAML mis-parse). This avoids overwriting
+      // legitimate YAML-parsed objects (e.g. nested mappings).
       merged[key] = value;
     }
   }

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -151,9 +151,17 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   for (const [key, value] of Object.entries(lineParsed)) {
     if (value.startsWith("{") || value.startsWith("[")) {
       merged[key] = value;
-    } else if (merged[key] !== undefined && merged[key].startsWith("{") && !value.includes("\n")) {
+    } else if (
+      merged[key] !== undefined &&
+      merged[key].startsWith("{") &&
+      !value.includes("\n") &&
+      value !== "|" &&
+      value !== ">"
+    ) {
       // YAML misinterpreted an unquoted colon as a nested key and produced
       // a JSON object; prefer the line-parsed plain string instead.
+      // Skip when the line-parsed value is a block scalar indicator (| or >)
+      // since YAML correctly handled those.
       merged[key] = value;
     }
   }


### PR DESCRIPTION
## Summary

- Fixes SKILL.md `description` fields containing unquoted colons being corrupted by YAML parsing

**Root cause:** When a description like `Use anime style IMPORTANT: Must be kawaii` is parsed, YAML interprets the second colon as a nested key and produces a JSON object. `coerceFrontmatterValue` then stringifies this, corrupting the description and making the skill absent from `openclaw skills` output.

**Fix:** After merging YAML and line-parsed values, prefer the line-parsed plain string when YAML produced a JSON object but the line parser has a non-empty single-line value. The single-line guard ensures multi-line YAML blocks are not affected.

## Changes

- `src/markdown/frontmatter.ts`: Add fallback to line-parsed value when YAML produces unexpected JSON
- `src/markdown/frontmatter.test.ts`: Add test case for description with mid-string colons

## Test plan

- [x] All 6 frontmatter tests pass (including new test)
- [ ] Create a SKILL.md with `description: Use anime style IMPORTANT: Must be kawaii`
- [ ] Verify the skill appears correctly in `openclaw skills` output

Fixes #30187
Closes #29981