### PR TITLE
fix(ui): expand agent files textarea and allow resize to grow panel

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2414,6 +2414,11 @@
   border-radius: var(--radius-lg);
   padding: 16px;
   background: var(--card);
+  overflow: auto;
+}
+
+.agent-files-editor .field textarea {
+  min-height: 400px;
 }
 
 .agent-file-header {


### PR DESCRIPTION
## Summary

- Fixes the Content textarea in Agent > Files being too small (160px) and resize handle having no visible effect

**Root cause:** The `.agent-files-editor` container had no `overflow` setting, so dragging the textarea resize handle couldn't expand the panel. The textarea also inherited the global minimum height of 160px which is too small for workspace files.

**Fix:**
- Add `overflow: auto` to `.agent-files-editor` so textarea resize expands the panel
- Set `min-height: 400px` for the textarea for a usable default height

## Changes

- `ui/src/styles/components.css`: Add overflow and scoped textarea min-height

## Test plan

- [ ] Open Control UI → Agents → Files tab
- [ ] Verify textarea has a usable default height (~400px)
- [ ] Drag the resize handle and verify the panel expands accordingly

Fixes #30189
Closes #30001