### PR TITLE
fix(docker): harden file permissions for extensions dirs in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,16 @@ RUN pnpm build
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
-# Expose the CLI binary without requiring npm global writes as non-root.
+# Harden file permissions for plugin/extension directories.
+# Some build environments produce world-writable (777) paths, which
+# causes OpenClaw to block plugins at runtime with "world-writable path".
 USER root
+RUN find /app/extensions /app/.agent /app/.agents -type d -exec chmod 755 {} + 2>/dev/null; \
+    find /app/extensions /app/.agent /app/.agents -type f -exec chmod 644 {} + 2>/dev/null; \
+    chown -R node:node /app/extensions /app/.agent /app/.agents 2>/dev/null; \
+    true
+
+# Expose the CLI binary without requiring npm global writes as non-root.
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 


### PR DESCRIPTION
## Summary

- Fixes Docker image shipping with world-writable (777) permissions on extension directories, causing OpenClaw to block all plugins at runtime

**Root cause:** Some build environments produce mode 777 for `/app/extensions`, `/app/.agent`, and `/app/.agents`. OpenClaw's security check rejects world-writable plugin paths with `blocked plugin candidate: world-writable path`.

**Fix:** Add a permission hardening step in the Dockerfile after `COPY --chown=node:node . .`:
- Directories → `755`
- Files → `644`
- Ownership → `node:node`

The commands are idempotent and safe (no-op if dirs don't exist, guarded by trailing `true`).

## Changes

- `Dockerfile`: Add permission hardening block before CLI binary symlink

## Test plan

- [ ] Build Docker image: `docker build -t openclaw-test .`
- [ ] Verify `/app/extensions` has mode 755 (not 777)
- [ ] Verify plugins load without "world-writable path" warnings
- [ ] Verify non-Docker deployments are unaffected

Fixes #30230
Closes #30139