### PR TITLE
fix(discord): route outbound REST by account proxy token

### DIFF
--- a/src/discord/monitor/provider.rest-proxy.test.ts
+++ b/src/discord/monitor/provider.rest-proxy.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetDiscordRestProxyFetchRouterForTest,
+  registerDiscordRestProxyFetch,
+  resolveDiscordRestFetch,
+} from "./rest-fetch.js";
 
 const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
   undiciFetchMock: vi.fn(),
@@ -24,6 +28,11 @@ vi.mock("undici", () => {
 });
 
 describe("resolveDiscordRestFetch", () => {
+  afterEach(() => {
+    __resetDiscordRestProxyFetchRouterForTest();
+    vi.unstubAllGlobals();
+  });
+
   it("uses undici proxy fetch when a proxy URL is configured", async () => {
     const runtime = {
       log: vi.fn(),
@@ -58,5 +67,45 @@ describe("resolveDiscordRestFetch", () => {
     expect(fetcher).toBe(fetch);
     expect(runtime.error).toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("routes discord REST requests through token-bound proxy fetch", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+    const fallbackFetch = vi.fn(async () => new Response("fallback", { status: 200 }));
+    vi.stubGlobal("fetch", fallbackFetch as unknown as typeof fetch);
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("proxied", { status: 200 }));
+    proxyAgentSpy.mockClear();
+
+    registerDiscordRestProxyFetch({
+      token: "bot-token-123",
+      proxyUrl: "http://proxy.test:8080",
+      runtime,
+    });
+
+    await fetch("https://discord.com/api/v10/channels/1/messages", {
+      headers: { Authorization: "Bot bot-token-123" },
+    });
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(undiciFetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/1/messages",
+      expect.objectContaining({
+        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+      }),
+    );
+    expect(fallbackFetch).not.toHaveBeenCalled();
+
+    await fetch("https://discord.com/api/v10/channels/1/messages", {
+      headers: { Authorization: "Bot other-token" },
+    });
+    expect(fallbackFetch).toHaveBeenCalledTimes(1);
+
+    await fetch("https://example.com", {
+      headers: { Authorization: "Bot bot-token-123" },
+    });
+    expect(fallbackFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/discord/monitor/provider.test.ts
+++ b/src/discord/monitor/provider.test.ts
@@ -225,6 +225,7 @@ vi.mock("./provider.lifecycle.js", () => ({
 
 vi.mock("./rest-fetch.js", () => ({
   resolveDiscordRestFetch: () => async () => undefined,
+  registerDiscordRestProxyFetch: vi.fn(),
 }));
 
 vi.mock("./thread-bindings.js", () => ({

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -70,7 +70,7 @@ import {
 import { resolveDiscordPresenceUpdate } from "./presence.js";
 import { resolveDiscordAllowlistConfig } from "./provider.allowlist.js";
 import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
-import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import { registerDiscordRestProxyFetch, resolveDiscordRestFetch } from "./rest-fetch.js";
 import {
   createNoopThreadBindingManager,
   createThreadBindingManager,
@@ -266,6 +266,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const discordAccountThreadBindings =
     cfg.channels?.discord?.accounts?.[account.accountId]?.threadBindings;
   const discordRestFetch = resolveDiscordRestFetch(rawDiscordCfg.proxy, runtime);
+  registerDiscordRestProxyFetch({
+    token,
+    proxyUrl: rawDiscordCfg.proxy,
+    runtime,
+  });
   const dmConfig = rawDiscordCfg.dm;
   let guildEntries = rawDiscordCfg.guilds;
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);

--- a/src/discord/monitor/rest-fetch.ts
+++ b/src/discord/monitor/rest-fetch.ts
@@ -3,13 +3,129 @@ import { danger } from "../../globals.js";
 import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
-export function resolveDiscordRestFetch(
+type ProxyFetchRouterState = {
+  installed: boolean;
+  originalFetch: typeof fetch;
+  byAuthorization: Map<string, typeof fetch>;
+};
+
+let proxyFetchRouterState: ProxyFetchRouterState | null = null;
+
+const normalizeAuthorization = (value: string): string => value.trim();
+
+const readHeaderValue = (headers: HeadersInit | undefined, name: string): string | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined;
+  }
+  if (Array.isArray(headers)) {
+    const found = headers.find(([key]) => key.toLowerCase() === name.toLowerCase());
+    return typeof found?.[1] === "string" ? found[1] : undefined;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== name.toLowerCase()) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      return typeof value[0] === "string" ? value[0] : undefined;
+    }
+    return typeof value === "string" ? value : undefined;
+  }
+  return undefined;
+};
+
+const resolveRequestAuthorization = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): string | undefined => {
+  const initAuth = readHeaderValue(init?.headers, "authorization");
+  if (initAuth?.trim()) {
+    return normalizeAuthorization(initAuth);
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    const requestAuth = input.headers.get("authorization");
+    if (requestAuth?.trim()) {
+      return normalizeAuthorization(requestAuth);
+    }
+  }
+  return undefined;
+};
+
+const resolveFetchUrl = (input: RequestInfo | URL): string | undefined => {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.url;
+  }
+  return undefined;
+};
+
+const isDiscordRestUrl = (input: RequestInfo | URL): boolean => {
+  const raw = resolveFetchUrl(input);
+  if (!raw) {
+    return false;
+  }
+  try {
+    const url = new URL(raw);
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "discord.com" ||
+      host.endsWith(".discord.com") ||
+      host === "discordapp.com" ||
+      host.endsWith(".discordapp.com")
+    );
+  } catch {
+    return false;
+  }
+};
+
+const getProxyFetchRouterState = (): ProxyFetchRouterState => {
+  if (!proxyFetchRouterState) {
+    proxyFetchRouterState = {
+      installed: false,
+      originalFetch: fetch,
+      byAuthorization: new Map<string, typeof fetch>(),
+    };
+  }
+  return proxyFetchRouterState;
+};
+
+const ensureProxyFetchRouterInstalled = () => {
+  const state = getProxyFetchRouterState();
+  if (state.installed) {
+    return;
+  }
+  const routedFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (!isDiscordRestUrl(input)) {
+      return state.originalFetch(input, init);
+    }
+    const authorization = resolveRequestAuthorization(input, init);
+    if (authorization) {
+      const proxiedFetch = state.byAuthorization.get(authorization);
+      if (proxiedFetch) {
+        return proxiedFetch(input, init);
+      }
+    }
+    return state.originalFetch(input, init);
+  }) as typeof fetch;
+  state.originalFetch = fetch;
+  state.installed = true;
+  globalThis.fetch = routedFetch;
+};
+
+const createDiscordRestProxyFetch = (
   proxyUrl: string | undefined,
   runtime: RuntimeEnv,
-): typeof fetch {
+): typeof fetch | null => {
   const proxy = proxyUrl?.trim();
   if (!proxy) {
-    return fetch;
+    return null;
   }
   try {
     const agent = new ProxyAgent(proxy);
@@ -22,6 +138,45 @@ export function resolveDiscordRestFetch(
     return wrapFetchWithAbortSignal(fetcher);
   } catch (err) {
     runtime.error?.(danger(`discord: invalid rest proxy: ${String(err)}`));
-    return fetch;
+    return null;
   }
+};
+
+export function resolveDiscordRestFetch(
+  proxyUrl: string | undefined,
+  runtime: RuntimeEnv,
+): typeof fetch {
+  return createDiscordRestProxyFetch(proxyUrl, runtime) ?? fetch;
+}
+
+export function registerDiscordRestProxyFetch(params: {
+  token: string;
+  proxyUrl: string | undefined;
+  runtime: RuntimeEnv;
+}) {
+  const token = params.token.trim();
+  if (!token) {
+    return;
+  }
+  const authorization = normalizeAuthorization(`Bot ${token}`);
+  const state = getProxyFetchRouterState();
+  const proxyFetch = createDiscordRestProxyFetch(params.proxyUrl, params.runtime);
+  if (!proxyFetch) {
+    state.byAuthorization.delete(authorization);
+    return;
+  }
+  ensureProxyFetchRouterInstalled();
+  state.byAuthorization.set(authorization, proxyFetch);
+}
+
+export function __resetDiscordRestProxyFetchRouterForTest() {
+  if (!proxyFetchRouterState) {
+    return;
+  }
+  if (proxyFetchRouterState.installed) {
+    globalThis.fetch = proxyFetchRouterState.originalFetch;
+  }
+  proxyFetchRouterState.byAuthorization.clear();
+  proxyFetchRouterState.installed = false;
+  proxyFetchRouterState = null;
 }


### PR DESCRIPTION
## Summary

- Problem: `channels.discord.proxy` only affected gateway metadata/WebSocket paths, while outbound REST sends still used the default global `fetch` and failed behind regional proxies.
- Why it matters: Discord bots in restricted networks could receive events but could not send replies (`fetch failed`), breaking two-way communication.
- What changed: added a token-bound Discord REST fetch router, registered it during provider startup, and routed Discord REST requests for matching bot authorization headers through the configured proxy fetch.
- What did NOT change (scope boundary): no changes to Discord command/reply semantics, no proxy behavior changes for non-Discord domains, and no global provider routing changes outside Discord.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30244
- Related #

## User-visible / Behavior Changes

- When `channels.discord.proxy` is configured, outbound Discord REST sends now follow the same proxy path as gateway connection/bootstrap flows.
- Proxy routing is scoped to Discord hosts and matching bot authorization headers, so unrelated outbound requests are unaffected.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development), issue repro from restricted-network deployments
- Runtime/container: Node.js monorepo test runtime
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.proxy: "http://proxy.test:8080"`

### Steps

1. Configure Discord with `channels.discord.proxy` and start monitor/provider.
2. Send a message requiring outbound Discord REST reply.
3. Verify REST request path uses proxy dispatcher for matching bot authorization.

### Expected

- Outbound Discord REST sends succeed via configured proxy.

### Actual

- Before fix: REST sends bypassed proxy and failed in restricted networks.
- After fix: REST sends route through configured proxy for matching Discord bot requests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- --run src/discord/monitor/provider.rest-proxy.test.ts src/discord/monitor/provider.proxy.test.ts src/discord/monitor/provider.test.ts`

## Human Verification (required)

- Verified scenarios: proxy fetch creation, token-bound routing, Discord-host-only routing, provider startup registration path.
- Edge cases checked: invalid proxy fallback behavior, non-matching authorization header falls back to default fetch, non-Discord URLs remain untouched.
- What you did **not** verify: live Discord delivery in a real restricted-region network.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit or remove proxy config to return to default fetch behavior.
- Files/config to restore: `src/discord/monitor/rest-fetch.ts`, `src/discord/monitor/provider.ts`.
- Known bad symptoms reviewers should watch for: unexpected REST routing for non-Discord hosts (guarded by domain checks).

## Risks and Mitigations

- Risk: global fetch router affects unrelated traffic.
  - Mitigation: strict Discord-host guard + exact authorization-token routing + fallback to original fetch when no route matches.
