### PR TITLE
fix(tui): preserve pre-tool streamed text on final render

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -246,6 +246,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (evt.stream === "tool") {
+      streamAssembler.noteToolBoundary(evt.runId);
       const verbose = state.sessionInfo.verboseLevel ?? "off";
       const allowToolEvents = verbose !== "off";
       const allowToolOutput = verbose === "full";

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -107,6 +107,32 @@ describe("TuiStreamAssembler", () => {
     expect(second).toBeNull();
   });
 
+  it("keeps streamed delta text when tool boundary is marked out-of-band", () => {
+    const assembler = new TuiStreamAssembler();
+    const first = assembler.ingestDelta("run-delta-tool-event", TEXT_ONLY_TWO_BLOCKS, false);
+    expect(first).toBe("Draft line 1\nDraft line 2");
+    assembler.noteToolBoundary("run-delta-tool-event");
+
+    const second = assembler.ingestDelta(
+      "run-delta-tool-event",
+      messageWithContent([text("Draft line 2")]),
+      false,
+    );
+    expect(second).toBeNull();
+  });
+
+  it("preserves streamed text when out-of-band tool boundary drops prefix on final", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta("run-final-tool-event", TEXT_ONLY_TWO_BLOCKS, false);
+    assembler.noteToolBoundary("run-final-tool-event");
+    const finalText = assembler.finalize(
+      "run-final-tool-event",
+      messageWithContent([text("Draft line 2")]),
+      false,
+    );
+    expect(finalText).toBe("Draft line 1\nDraft line 2");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();


### PR DESCRIPTION
## Summary

- Problem: TUI final rendering could drop text that appeared before tool calls, especially when tool boundaries were represented by out-of-band agent tool events.
- Why it matters: users lose important context in scrollback after streaming completes, making conversation history misleading and harder to follow.
- What changed: added run-level tool-boundary tracking in stream assembly, wired tool events to mark that boundary, and updated finalize/delta merge logic to preserve streamed prefix/suffix text when final payload is a boundary-drop subset.
- What did NOT change (scope boundary): no changes to tool execution, chat event protocol, or message persistence; only TUI render/assembly behavior was adjusted.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30145
- Related #

## User-visible / Behavior Changes

- TUI now preserves assistant text that appeared before tool calls when final payloads drop boundary blocks.
- Out-of-band tool events (without inline `tool_use` block in the final message content) now correctly keep streamed text continuity.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development), issue repro from Ubuntu TUI report
- Runtime/container: Node.js TUI runtime
- Model/provider: N/A
- Integration/channel (if any): TUI
- Relevant config (redacted): default TUI with tool events enabled

### Steps

1. Stream an assistant response that includes pre-tool text and then a tool event/call.
2. Emit a final message payload missing boundary text blocks.
3. Inspect finalized assistant text in TUI scrollback.

### Expected

- Finalized TUI output keeps pre-tool and post-tool text continuity.

### Actual

- Before fix: pre-tool text could disappear after finalization.
- After fix: boundary-dropped final payloads keep streamed text intact.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- --run src/tui/tui-stream-assembler.test.ts src/tui/tui-event-handlers.test.ts`

## Human Verification (required)

- Verified scenarios: inline tool boundary subset cases, out-of-band tool-boundary marking, finalize and delta behavior.
- Edge cases checked: unchanged deltas, empty final payload fallback, non-boundary replacement text still prefers final payload.
- What you did **not** verify: interactive manual TUI run against a live model session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/tui/tui-stream-assembler.ts`, `src/tui/tui-event-handlers.ts`.
- Known bad symptoms reviewers should watch for: duplicated final text or stale streamed text in non-boundary replacement cases.

## Risks and Mitigations

- Risk: boundary-preservation could keep stale streamed text when final payload should replace it.
  - Mitigation: subset detection remains strict; non-subset replacements continue to prefer final payload, covered by new/updated tests.
