### PR TITLE
fix(tui): prevent /model search rows from overflowing terminal width

### DIFF
--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -24,6 +24,11 @@ const ansiHighlightTheme: SearchableSelectListTheme = {
   matchHighlight: (t) => `\u001b[31m${t}\u001b[0m`,
 };
 
+const ansiColonTheme: SearchableSelectListTheme = {
+  ...ansiHighlightTheme,
+  description: (t) => `\u001b[38:5:245m${t}\u001b[0m`,
+};
+
 const testItems = [
   {
     value: "anthropic/claude-3-opus",
@@ -118,6 +123,31 @@ describe("SearchableSelectList", () => {
     typeInput(list, "provider");
 
     const width = 80;
+    const output = list.render(width);
+    for (const line of output) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it("keeps m-query rows within width when themed descriptions use colon ANSI codes", () => {
+    const items = [
+      { value: "minimax-cn/MiniMax-M2", label: "minimax-cn/MiniMax-M2", description: "MiniMax M2" },
+      {
+        value: "mistral/codestral-latest",
+        label: "mistral/codestral-latest",
+        description: "Codestral",
+      },
+      {
+        value: "mistral/devstral-medium-2507",
+        label: "mistral/devstral-medium-2507",
+        description: "Devstral Medium",
+      },
+    ];
+    const list = new SearchableSelectList(items, 8, ansiColonTheme);
+    list.setSelectedIndex(1); // force non-selected description rendering on first row
+
+    typeInput(list, "m");
+    const width = 64;
     const output = list.render(width);
     for (const line of output) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(width);


### PR DESCRIPTION
## Summary

- Problem: `/model` / `/models` search could render over-width lines (especially after typing `m`) and crash TUI with `Rendered line ... exceeds terminal width`.
- Why it matters: model switching becomes unstable for common provider prefixes (`mistral`, `minimax`, `moonshot`) and can terminate the session UI.
- What changed: expanded ANSI SGR splitting to support colon-form sequences, and added width clamping on rendered search/input/list/scroll lines before returning rows to TUI.
- What did NOT change (scope boundary): no model catalog ordering/filtering logic changes and no command routing changes outside searchable list rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30156
- Related #

## User-visible / Behavior Changes

- Typing `m` in `/model` search no longer produces over-width render lines that crash TUI.
- Search rows remain within terminal width even with ANSI-colored themes/descriptions.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (development), issue repro from Ubuntu
- Runtime/container: Node.js TUI runtime
- Model/provider: N/A
- Integration/channel (if any): TUI model selector
- Relevant config (redacted): default `/model` searchable list

### Steps

1. Open TUI and run `/model` (or `/models`).
2. Type `m` in the search input.
3. Verify all rendered rows remain within terminal width.

### Expected

- Search UI remains stable with no width-overflow crash.

### Actual

- Before fix: certain rows exceeded width and crashed TUI.
- After fix: rows are clamped and rendering stays within bounds.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- --run src/tui/components/searchable-select-list.test.ts`

## Human Verification (required)

- Verified scenarios: normal themes, ANSI-highlight themes, colon-form ANSI description themes, and `m` query rendering width bounds.
- Edge cases checked: empty/no-match rows and scroll info row also clamped.
- What you did **not** verify: full interactive manual TUI session on reporter’s exact terminal/font setup.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/tui/components/searchable-select-list.ts`.
- Known bad symptoms reviewers should watch for: overly aggressive truncation in highly styled themes.

## Risks and Mitigations

- Risk: clamping might trim styled suffix text in very narrow terminals.
  - Mitigation: clamping is width-safe by design and keeps the selector stable; tests cover ANSI-heavy rows to ensure non-crashing behavior.
