### PR TITLE
fix(ui): prevent agent skills panel from clearing when clicking the resolved default agent

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -562,7 +562,7 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onSelectAgent: (agentId) => {
-                  if (state.agentsSelectedId === agentId) {
+                  if (state.agentsSelectedId === agentId || resolvedAgentId === agentId) {
                     return;
                   }
                   state.agentsSelectedId = agentId;


### PR DESCRIPTION
## Summary

- **Problem:** In the WebChat agents tab, the skills panel shows 0 skills after clicking anywhere on the page (Edge browser). Chrome is not affected.
- **Why it matters:** Users on Edge cannot view agent skills — the panel clears on any click and may not recover.
- **What changed:** `ui/src/ui/app-render.ts` — added `resolvedAgentId` to the `onSelectAgent` guard so clicking the already-displayed agent (resolved from `defaultId` or first entry) is treated as a no-op.
- **What did NOT change:** Agent selection logic, skills loading, skills rendering, tab navigation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29726

## User-visible / Behavior Changes

- Clicking the currently-displayed agent in the sidebar no longer clears and reloads the skills panel. This prevents the flash-to-empty behavior that was permanent on Edge.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime: Node.js
- Integration/channel: WebChat (Edge browser)

### Steps

1. Open WebChat in Edge browser
2. Navigate to Agents tab → Skills panel
3. Skills load correctly after page refresh
4. Click anywhere on the page (e.g., on the already-selected agent row)

### Expected

- Skills remain visible

### Actual

- Before fix: Skills panel shows 0 (data cleared, async reload may fail on Edge)
- After fix: Skills remain visible (no unnecessary clear/reload)

## Evidence

```diff
// ui/src/ui/app-render.ts — onSelectAgent handler
 onSelectAgent: (agentId) => {
-  if (state.agentsSelectedId === agentId) {
+  if (state.agentsSelectedId === agentId || resolvedAgentId === agentId) {
     return;
   }
```

**Root cause:** `state.agentsSelectedId` starts as `null` after page load. The displayed agent is resolved from `agentsList.defaultId ?? agents[0]?.id`. When the user clicks that agent row, the guard `null === agentId` evaluates to `false`, so `onSelectAgent` proceeds to:
1. Clear `agentSkillsReport` and `agentSkillsAgentId`
2. Fire async `loadAgentSkills(state, agentId)` to reload

On Chrome, the reload succeeds quickly. On Edge, the WebSocket connection may be in a transitional state after focus change, causing `loadAgentSkills` to return early (`!state.connected`), leaving the panel at 0.

The fix adds `resolvedAgentId === agentId` to the guard, treating clicks on the already-resolved agent as a no-op regardless of `agentsSelectedId` initialization state.

## Human Verification (required)

- Verified scenarios: Traced `onSelectAgent` flow with `agentsSelectedId=null` and `resolvedAgentId="main"`; confirmed guard bypass leading to skills clear
- Edge cases checked: Selecting a different agent still clears and reloads correctly; initial load with `agentsSelectedId=null` works; `resolvedAgentId` fallback chain verified
- What I did **not** verify: Live Edge browser (verified via code analysis)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `ui/src/ui/app-render.ts`
- Known bad symptoms: Clicking on an agent that's already displayed might not refresh its data (non-issue since the data is already loaded)

## Risks and Mitigations

- **Risk:** If `resolvedAgentId` somehow points to a different agent than the one displayed, clicking that agent would be incorrectly blocked. **Mitigation:** `resolvedAgentId` uses the same fallback chain as `selectedId` in the agents view (`agentsSelectedId ?? defaultId ?? agents[0]?.id`), so they always agree.

