### PR TITLE
fix(subagents): save long outputs to file instead of truncating

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,10 +151,8 @@
         "export CUSTOM_API_K[E]Y=\"your-key\"",
         "grep -q 'N[O]DE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache' ~/.bashrc \\|\\| cat >> ~/.bashrc <<'EOF'",
         "env: \\{ MISTRAL_API_K[E]Y: \"sk-\\.\\.\\.\" \\},",
-        "\"ap[i]Key\": \"xxxxx\"(,)?",
-        "ap[i]Key: \"A[I]za\\.\\.\\.\",",
-        "\"ap[i]Key\": \"(resolved|normalized|legacy)-key\"(,)?",
-        "sparkle:edSignature=\"[A-Za-z0-9+/=]+\""
+        "\"ap[i]Key\": \"xxxxx\",",
+        "ap[i]Key: \"A[I]za\\.\\.\\.\","
       ]
     },
     {
@@ -181,13 +179,27 @@
         "line_number": 15
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
+    "appcast.xml": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "71a4834e55f81fd17599b85a07ef64bf80b79b72",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "7afea670e53d801f1f881c99c40aa177e3395bfa",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "appcast.xml",
+        "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
+        "is_verified": false,
+        "line_number": 658
       }
     ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
@@ -206,22 +218,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1859
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -10990,15 +10986,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11367,84 +11354,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11463,31 +11372,6 @@
         "line_number": 157
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
     "src/agents/models-config.providers.nvidia.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11502,40 +11386,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 23
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11574,15 +11424,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11592,67 +11433,6 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
-        "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
-        "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
     "src/agents/tools/web-search.ts": [
       {
         "type": "Secret Keyword",
@@ -11660,63 +11440,6 @@
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
         "line_number": 291
-      }
-    ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
-        "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11771,15 +11494,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11787,50 +11501,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11842,31 +11512,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11874,52 +11519,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11936,96 +11535,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12053,15 +11562,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12388,15 +11888,6 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -12480,15 +11971,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12523,40 +12005,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12771,15 +12219,6 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12983,6 +12422,36 @@
         "hashed_secret": "564666dc1ca6e7318b2d5feeb1ce7b5bf717411e",
         "is_verified": false,
         "line_number": 60
+      }
+    ],
+    "test-fixtures/talk-config-contract.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "62836f14b86ed93da229b6b30b1556f322459d0f",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "260dd6b18b40c0ae7aeb1534a622b94d48a3a88d",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "fa3f8556220674269a6130b0eedd21dec9c033fb",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_verified": false,
+        "line_number": 85
       }
     ],
     "ui/src/i18n/locales/en.ts": [

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1493,7 +1493,18 @@ _Full output saved: \`${savedFilePath.replace(/.*\.openclaw\/workspace\//, "")}\
       directIdempotencyKey,
       signal: params.signal,
     });
-    didAnnounce = delivery.delivered;
+    // Cron delivery state should only be marked as delivered when we have a
+    // direct path result. Queue/steer means "accepted for later processing",
+    // not a confirmed channel send, and can otherwise produce false positives.
+    // (Preserves fix from #29716 / closes #29660)
+    if (
+      announceType === "cron job" &&
+      (delivery.path === "queued" || delivery.path === "steered")
+    ) {
+      didAnnounce = false;
+    } else {
+      didAnnounce = delivery.delivered;
+    }
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
       defaultRuntime.error?.(
         `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1420,8 +1420,11 @@ export async function runSubagentAnnounceFlow(params: {
     const cfg2 = loadConfig();
     const outputDir = resolveSubagentOutputDir(cfg2);
     const OUTPUT_THRESHOLD = 3_000;
+    // Only save to file when delivering to a human-facing channel. Subagent-to-subagent
+    // announces are internal (deliver: false) and have no channel size limit, so the
+    // parent orchestrator should always receive the full findings.
     const savedFilePath =
-      findings.length > OUTPUT_THRESHOLD
+      !requesterIsSubagent && findings.length > OUTPUT_THRESHOLD
         ? saveOutputToTempFile({
             findings,
             label: params.label ?? params.task?.slice(0, 40) ?? "agent",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1432,7 +1432,11 @@ export async function runSubagentAnnounceFlow(params: {
       ? `${findings.slice(0, 1_500)}
 …
 
-_Full output saved: \`${savedFilePath.replace(/.*\.openclaw\/workspace\//, "")}\`_`
+_Full output saved: \`${
+          savedFilePath.includes("/.openclaw/workspace/")
+            ? savedFilePath.replace(/.*\.openclaw\/workspace\//, "")
+            : savedFilePath
+        }\`_`
       : findings;
     const internalEvents: AgentInternalEvent[] = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
@@ -81,6 +83,36 @@ function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): n
 
 function isInternalAnnounceRequesterSession(sessionKey: string | undefined): boolean {
   return getSubagentDepthFromSessionStore(sessionKey) >= 1 || isCronSessionKey(sessionKey);
+}
+
+function resolveSubagentOutputDir(cfg: ReturnType<typeof loadConfig>): string {
+  const configured = (cfg.agents?.defaults?.subagents as Record<string, unknown> | undefined)
+    ?.outputDir;
+  if (typeof configured === "string" && configured.trim()) {
+    return configured.trim().replace(/^~/, process.env.HOME ?? homedir());
+  }
+  const home = process.env.HOME ?? homedir();
+  return `${home}/.openclaw/workspace/tmp/agent-output`;
+}
+
+function saveOutputToTempFile(params: {
+  findings: string;
+  label: string;
+  runId: string;
+  outputDir: string;
+}): string | undefined {
+  try {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const safeName = (params.label || "agent").replace(/[^a-z0-9-]/gi, "-").slice(0, 40);
+    const safeRunId = params.runId.replace(/[^a-z0-9]/gi, "-").slice(0, 8);
+    const filename = `${timestamp}-${safeName}-${safeRunId}.md`;
+    const filePath = join(params.outputDir, filename);
+    mkdirSync(params.outputDir, { recursive: true });
+    writeFileSync(filePath, params.findings, "utf8");
+    return filePath;
+  } catch {
+    return undefined;
+  }
 }
 
 function summarizeDeliveryError(error: unknown): string {
@@ -1384,6 +1416,24 @@ export async function runSubagentAnnounceFlow(params: {
       startedAt: params.startedAt,
       endedAt: params.endedAt,
     });
+    const cfg2 = loadConfig();
+    const outputDir = resolveSubagentOutputDir(cfg2);
+    const OUTPUT_THRESHOLD = 3_000;
+    const savedFilePath =
+      findings.length > OUTPUT_THRESHOLD
+        ? saveOutputToTempFile({
+            findings,
+            label: params.label ?? params.task?.slice(0, 40) ?? "agent",
+            runId: params.childRunId,
+            outputDir,
+          })
+        : undefined;
+    const findingsForContext = savedFilePath
+      ? `${findings.slice(0, 1_500)}
+…
+
+_Full output saved: \`${savedFilePath.replace(/.*\.openclaw\/workspace\//, "")}\`_`
+      : findings;
     const internalEvents: AgentInternalEvent[] = [
       {
         type: "task_completion",
@@ -1394,7 +1444,7 @@ export async function runSubagentAnnounceFlow(params: {
         taskLabel,
         status: outcome.status,
         statusLabel,
-        result: findings,
+        result: findingsForContext,
         statsLine,
         replyInstruction,
       },

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -281,6 +281,8 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /** Directory for saving long sub-agent output files. Supports ~ expansion. Defaults to ~/.openclaw/workspace/tmp/agent-output. */
+    outputDir?: string;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -186,6 +186,12 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        outputDir: z
+          .string()
+          .optional()
+          .describe(
+            "Directory for saving long sub-agent output files. Supports ~ expansion. Defaults to ~/.openclaw/workspace/tmp/agent-output.",
+          ),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Problem

When a sub-agent produces output longer than Telegram's 4096 char limit, the announce silently fails: the channel rejects the send, retries exhaust, and the user sees a failure with no indication the task actually succeeded.

Fixes #25110. Reproduced on Ubuntu 24.04, v2026.2.23-beta.1, Node 22.22.0.

## Approach

Instead of truncating (see #25190), save the output to a file and show a preview + path in the message. Full result stays accessible rather than losing the tail.

## Changes

**`resolveSubagentOutputDir(cfg)`** reads `agents.defaults.subagents.outputDir` or defaults to `~/.openclaw/workspace/tmp/agent-output`.

**`saveOutputToTempFile({ findings, label, runId, outputDir })`** writes findings to `{timestamp}-{label}-{runId}.md`. Returns `undefined` on write failure so announce flow is never blocked.

**`buildCompletionDeliveryMessage()`** now accepts `outputFilePath` instead of `announceType`. When a path is provided, shows a 1500-char preview with workspace-relative path:

```
…preview…

_Full output saved: `tmp/agent-output/2026-03-01T03-44-27-research-abc12345.md`_
```

Output under 3000 chars uses the existing truncation + `sessions_history` hint.

**`runSubagentAnnounceFlow()`** saves output when `findings.length > 3000`. `internalSummaryMessage` uses the truncated preview for context efficiency.

## Testing

All 67 existing announce tests pass. File-save is best-effort and message formatting changes are covered by existing format tests.
