### PR TITLE
fix(subagents): trigger immediate parent turn after direct delivery

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -389,7 +389,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     const rawMessage = call?.params?.message;
     const msg = typeof rawMessage === "string" ? rawMessage : "";
@@ -471,7 +471,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(3);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry completion direct send on permanent channel errors", async () => {
@@ -834,7 +834,7 @@ describe("subagent announce formatting", () => {
 
       expect(didAnnounce).toBe(true);
       expect(sendSpy).toHaveBeenCalledTimes(1);
-      expect(agentSpy).not.toHaveBeenCalled();
+      expect(agentSpy).toHaveBeenCalledTimes(1);
       const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
       expect(call?.params?.channel).toBe("discord");
       expect(call?.params?.to).toBe("channel:12345");
@@ -876,7 +876,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
     const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
     expect(call?.params?.channel).toBe("telegram");
     expect(call?.params?.to).toBe("123");
@@ -1217,10 +1217,6 @@ describe("subagent announce formatting", () => {
         sessionId: "requester-session-direct-route",
       },
     };
-    agentSpy.mockImplementationOnce(async () => {
-      throw new Error("agent fallback should not run when direct route exists");
-    });
-
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:worker",
       childRunId: "run-completion-explicit-route",
@@ -1233,7 +1229,7 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(agentSpy).toHaveBeenCalledTimes(0);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
     expect(sendSpy.mock.calls[0]?.[0]).toMatchObject({
       method: "send",
       params: {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1422,7 +1422,7 @@ export async function runSubagentAnnounceFlow(params: {
         params: {
           sessionKey: resolveRequesterStoreKey(cfg, targetRequesterSessionKey),
           message: silentTrigger,
-          deliver: Boolean(silentChannel && silentTo),
+          deliver: false,
           channel: silentChannel,
           to: silentTo,
           accountId: silentOrigin?.accountId,


### PR DESCRIPTION
## Problem

When a sub-agent completes and its result is sent directly to the user's channel, the requester session never sees it until the user sends another message. The result sits unprocessed.

Related: #22099, #27317

## Context

PR #25437 attempted a similar fix but was closed Feb 26 as superseded by commit `4258a3307`. That commit improved announce routing but doesn't address this specific gap: after a successful direct channel send, the requester session still isn't woken up.

## Approach

After direct-channel delivery confirms success, fire a lightweight `method:agent` call into the requester session with `SILENT_REPLY_TOKEN`. Atlas processes the result without producing a duplicate user-visible message.

## Key guard: `hadDirectSendRoute`

`sendSubagentAnnounceDirectly` returns `path: "direct"` for two different cases:

- Real channel send via `method:send` (should trigger)
- Internal requester-session injection via `method:agent` (fallback when no direct route exists — already wakes the requester, no trigger needed)

A naive `path === "direct"` check would fire the silent trigger even on the internal fallback, causing a duplicate turn. Fix: require `completionResolution.origin?.channel` and `completionResolution.origin?.to` to both be present — a real send route always has both; the internal fallback doesn't.

## Full guard set

```typescript
const isSilentTriggerCandidate =
  delivery.delivered &&
  delivery.path === "direct" &&
  hadDirectSendRoute &&          // real channel send, not internal fallback
  !requesterIsSubagent &&
  expectsCompletionMessage &&
  announceType !== "cron job" &&
  params.spawnMode !== "session" &&
  findings.trim().length > 0 &&
  findings !== "(no output)";
```

Plus an active-sibling check: trigger only fires when no other descendant runs are still active (conservative default: assumes siblings exist, calls `countActiveDescendantRuns` only when the candidate check passes).

## Testing

67 existing announce tests pass. 5 assertions updated from `not.toHaveBeenCalled()` to `toHaveBeenCalledTimes(1)` to reflect that the silent trigger now fires after direct delivery.
