### PR TITLE
fix(whatsapp): clear stale auth after logged-out disconnects

### DIFF
--- a/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
+++ b/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
@@ -274,6 +274,45 @@ describe("web auto-reply", () => {
     }
   });
 
+  it("reports cleanup failure when logged-out auth removal returns false", async () => {
+    const logoutSpy = vi.spyOn(webSession, "logoutWeb").mockResolvedValue(false);
+    try {
+      const closeResolvers: Array<(reason?: unknown) => void> = [];
+      const sleep = vi.fn(async () => {});
+      const listenerFactory = vi.fn(async () => {
+        const onClose = new Promise<unknown>((res) => {
+          closeResolvers.push(res);
+        });
+        return { close: vi.fn(), onClose };
+      });
+      const { runtime, run } = startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+      });
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      closeResolvers.shift()?.({
+        status: 401,
+        isLoggedOut: true,
+        error: { output: { statusCode: 401 } },
+      });
+      await run;
+
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("failed to clear cached web session"),
+      );
+    } finally {
+      logoutSpy.mockRestore();
+    }
+  });
+
   it("forces reconnect when watchdog closes without onClose", async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
+++ b/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
@@ -9,6 +9,7 @@ import {
   setLoadConfigMock,
 } from "./auto-reply.test-harness.js";
 import type { WebInboundMessage } from "./inbound.js";
+import * as webSession from "./session.js";
 
 installWebAutoReplyTestHomeHooks();
 
@@ -193,6 +194,45 @@ describe("web auto-reply", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("status 440"));
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("session conflict"));
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Stopping web monitoring"));
+  });
+
+  it("clears cached auth when close reason is logged out", async () => {
+    const logoutSpy = vi.spyOn(webSession, "logoutWeb").mockResolvedValue(true);
+    try {
+      const closeResolvers: Array<(reason?: unknown) => void> = [];
+      const sleep = vi.fn(async () => {});
+      const listenerFactory = vi.fn(async () => {
+        const onClose = new Promise<unknown>((res) => {
+          closeResolvers.push(res);
+        });
+        return { close: vi.fn(), onClose };
+      });
+      const { runtime, run } = startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+      });
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      closeResolvers.shift()?.({
+        status: 401,
+        isLoggedOut: true,
+        error: { output: { statusCode: 401 } },
+      });
+      await run;
+
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("Cleared cached web session"),
+      );
+    } finally {
+      logoutSpy.mockRestore();
+    }
   });
 
   it("forces reconnect when watchdog closes without onClose", async () => {

--- a/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
+++ b/src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts
@@ -235,6 +235,45 @@ describe("web auto-reply", () => {
     }
   });
 
+  it("reports cleanup failure when logged-out auth removal throws", async () => {
+    const logoutSpy = vi.spyOn(webSession, "logoutWeb").mockRejectedValue(new Error("EPERM"));
+    try {
+      const closeResolvers: Array<(reason?: unknown) => void> = [];
+      const sleep = vi.fn(async () => {});
+      const listenerFactory = vi.fn(async () => {
+        const onClose = new Promise<unknown>((res) => {
+          closeResolvers.push(res);
+        });
+        return { close: vi.fn(), onClose };
+      });
+      const { runtime, run } = startMonitorWebChannel({
+        monitorWebChannelFn: monitorWebChannel as never,
+        listenerFactory,
+        sleep,
+        reconnect: { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
+      });
+
+      await Promise.resolve();
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+
+      closeResolvers.shift()?.({
+        status: 401,
+        isLoggedOut: true,
+        error: { output: { statusCode: 401 } },
+      });
+      await run;
+
+      expect(listenerFactory).toHaveBeenCalledTimes(1);
+      expect(sleep).not.toHaveBeenCalled();
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("failed to clear cached web session"),
+      );
+    } finally {
+      logoutSpy.mockRestore();
+    }
+  });
+
   it("forces reconnect when watchdog closes without onClose", async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -403,12 +403,12 @@ export async function monitorWebChannel(
     if (loggedOut) {
       let clearedCachedAuth = false;
       try {
-        await logoutWeb({
+        const cleared = await logoutWeb({
           authDir: account.authDir,
           isLegacyAuthDir: account.isLegacyAuthDir,
           runtime,
         });
-        clearedCachedAuth = true;
+        clearedCachedAuth = cleared;
       } catch (err) {
         reconnectLogger.warn(
           {

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -401,12 +401,14 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
+      let clearedCachedAuth = false;
       try {
         await logoutWeb({
           authDir: account.authDir,
           isLegacyAuthDir: account.isLegacyAuthDir,
           runtime,
         });
+        clearedCachedAuth = true;
       } catch (err) {
         reconnectLogger.warn(
           {
@@ -416,9 +418,16 @@ export async function monitorWebChannel(
           "web reconnect: failed to clear cached auth after logged-out disconnect",
         );
       }
-      runtime.error(
-        `WhatsApp session logged out. Cleared cached web session. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
-      );
+      const relinkCommand = formatCliCommand("openclaw channels login --channel web");
+      if (clearedCachedAuth) {
+        runtime.error(
+          `WhatsApp session logged out. Cleared cached web session. Run \`${relinkCommand}\` to relink.`,
+        );
+      } else {
+        runtime.error(
+          `WhatsApp session logged out, but failed to clear cached web session. Fix filesystem permissions, then run \`${relinkCommand}\` to relink.`,
+        );
+      }
       await closeListener();
       break;
     }

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -22,7 +22,7 @@ import {
   resolveReconnectPolicy,
   sleepWithAbort,
 } from "../reconnect.js";
-import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
+import { formatError, getWebAuthAgeMs, logoutWeb, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
@@ -401,8 +401,13 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
+      await logoutWeb({
+        authDir: account.authDir,
+        isLegacyAuthDir: account.isLegacyAuthDir,
+        runtime,
+      });
       runtime.error(
-        `WhatsApp session logged out. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
+        `WhatsApp session logged out. Cleared cached web session. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
       );
       await closeListener();
       break;

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -401,11 +401,21 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
-      await logoutWeb({
-        authDir: account.authDir,
-        isLegacyAuthDir: account.isLegacyAuthDir,
-        runtime,
-      });
+      try {
+        await logoutWeb({
+          authDir: account.authDir,
+          isLegacyAuthDir: account.isLegacyAuthDir,
+          runtime,
+        });
+      } catch (err) {
+        reconnectLogger.warn(
+          {
+            connectionId,
+            error: formatError(err),
+          },
+          "web reconnect: failed to clear cached auth after logged-out disconnect",
+        );
+      }
       runtime.error(
         `WhatsApp session logged out. Cleared cached web session. Run \`${formatCliCommand("openclaw channels login --channel web")}\` to relink.`,
       );

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -14,11 +14,28 @@ vi.mock("./session.js", () => {
   );
   const waitForWaConnection = vi.fn();
   const formatError = vi.fn((err: unknown) => `formatted:${String(err)}`);
-  const getStatusCode = vi.fn(
-    (err: unknown) =>
-      (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-      (err as { status?: number })?.status,
-  );
+  const getStatusCode = vi.fn((err: unknown) => {
+    const queue: unknown[] = [err];
+    const seen = new Set<unknown>();
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || typeof current !== "object" || seen.has(current)) {
+        continue;
+      }
+      seen.add(current);
+      const outputStatus = (current as { output?: { statusCode?: unknown } })?.output?.statusCode;
+      if (typeof outputStatus === "number") {
+        return outputStatus;
+      }
+      const status = (current as { status?: unknown })?.status;
+      if (typeof status === "number") {
+        return status;
+      }
+      queue.push((current as { error?: unknown })?.error);
+      queue.push((current as { lastDisconnect?: { error?: unknown } })?.lastDisconnect?.error);
+    }
+    return undefined;
+  });
   const webAuthExists = vi.fn(async () => false);
   const readWebSelfId = vi.fn(() => ({ e164: null, jid: null }));
   const logoutWeb = vi.fn(async () => true);
@@ -59,5 +76,20 @@ describe("login-qr", () => {
     expect(result.connected).toBe(true);
     expect(createWaSocketMock).toHaveBeenCalledTimes(2);
     expect(logoutWebMock).not.toHaveBeenCalled();
+  });
+
+  it("clears creds when login fails with nested logged-out status", async () => {
+    waitForWaConnectionMock.mockRejectedValueOnce({
+      error: { output: { statusCode: 401 } },
+    });
+
+    const start = await startWebLoginWithQr({ timeoutMs: 5000 });
+    expect(start.qrDataUrl).toBe("data:image/png;base64,base64");
+
+    const result = await waitForWebLogin({ timeoutMs: 5000 });
+
+    expect(result.connected).toBe(false);
+    expect(result.message).toContain("logged out");
+    expect(logoutWebMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/login-qr.test.ts
+++ b/src/web/login-qr.test.ts
@@ -27,6 +27,10 @@ vi.mock("./session.js", () => {
       if (typeof outputStatus === "number") {
         return outputStatus;
       }
+      const statusCode = (current as { statusCode?: unknown })?.statusCode;
+      if (typeof statusCode === "number") {
+        return statusCode;
+      }
       const status = (current as { status?: unknown })?.status;
       if (typeof status === "number") {
         return status;

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
 
-const { createWaSocket, formatError, logWebSelfId, waitForWaConnection } =
+const { createWaSocket, formatError, getStatusCode, logWebSelfId, waitForWaConnection } =
   await import("./session.js");
 const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
 
@@ -151,6 +151,26 @@ describe("web session", () => {
     expect(formatError(err)).toContain("status=408");
     expect(formatError(err)).toContain("Request Time-out");
     expect(formatError(err)).toContain("QR refs attempts ended");
+  });
+
+  it("getStatusCode resolves nested disconnect wrappers", () => {
+    expect(
+      getStatusCode({
+        error: {
+          output: { statusCode: 401 },
+        },
+      }),
+    ).toBe(401);
+
+    expect(
+      getStatusCode({
+        lastDisconnect: {
+          error: {
+            output: { statusCode: 440 },
+          },
+        },
+      }),
+    ).toBe(440);
   });
 
   it("does not clobber creds backup when creds.json is corrupted", async () => {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -184,10 +184,45 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 }
 
 export function getStatusCode(err: unknown) {
-  return (
-    (err as { output?: { statusCode?: number } })?.output?.statusCode ??
-    (err as { status?: number })?.status
-  );
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+
+  // Baileys can wrap disconnect errors as:
+  // - { output: { statusCode } }
+  // - { error: { output: { statusCode } } }
+  // - { lastDisconnect: { error: { output: { statusCode } } } }
+  // Traverse these known wrappers to avoid missing logged-out/device-removed cases.
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    const outputStatus = (current as { output?: { statusCode?: unknown } })?.output?.statusCode;
+    if (typeof outputStatus === "number") {
+      return outputStatus;
+    }
+
+    const statusCode = (current as { statusCode?: unknown })?.statusCode;
+    if (typeof statusCode === "number") {
+      return statusCode;
+    }
+
+    const status = (current as { status?: unknown })?.status;
+    if (typeof status === "number") {
+      return status;
+    }
+
+    queue.push((current as { error?: unknown })?.error);
+    queue.push((current as { lastDisconnect?: { error?: unknown } })?.lastDisconnect?.error);
+  }
+
+  return undefined;
 }
 
 function safeStringify(value: unknown, limit = 800): string {


### PR DESCRIPTION
## Summary
Fixes #4686.

This PR addresses a relink dead-end where WhatsApp could end up in a "Linked: Yes / Connected: No" state after `device_removed`/logged-out disconnects, and subsequent login attempts would stall or fail without clearing stale credentials.

## Related PR evaluation
I checked related attempts before patching:
- #8409: closed/unmerged; added pairing-code flow but did not land.
- #13696: open; focuses on CLI `--code` pairing flow and does not fix logged-out stale-credential cleanup path.

## Root cause
1. `getStatusCode` only read top-level `output.statusCode`/`status` and missed nested disconnect wrappers (for example `{ error: { output: { statusCode: 401 } } }` and `{ lastDisconnect: { error: ... } }`).
2. `waitForWebLogin` relies on that status code to detect `DisconnectReason.loggedOut`; when status extraction failed, it skipped `logoutWeb`, leaving stale creds behind.
3. `monitorWebChannel` stopped on logged-out disconnect but also kept stale creds, preserving the bad "linked but disconnected" state.

## Remedy
- Hardened `getStatusCode` to traverse known nested disconnect wrappers.
- In `monitorWebChannel`, clear cached auth (`logoutWeb`) when a logged-out close reason is observed before stopping.
- Added regression coverage for both login and monitor flows.

## Tests
Passed:
- `pnpm exec vitest run --config vitest.unit.config.ts src/web/session.test.ts src/web/login-qr.test.ts src/web/auto-reply.web-auto-reply.reconnects-after-connection-close.test.ts`
- `pnpm format:check`
- `pnpm check`
