### PR TITLE
fix: deliver steered user replies swallowed by HEARTBEAT_OK discard

### DIFF
--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -230,6 +230,32 @@ describe("runHeartbeatOnce ack handling", () => {
       expectedCalls: 1,
       expectedText: "History check complete",
     },
+    {
+      title: "delivers steered user reply when HEARTBEAT_OK is followed by paragraph break",
+      replyText: "HEARTBEAT_OK\n\nThe answer is 42.",
+      messages: { queue: { mode: "steer" } },
+      expectedCalls: 1,
+      expectedText: "The answer is 42.",
+    },
+    {
+      title: "delivers steered user reply with responsePrefix",
+      replyText: "[openclaw] HEARTBEAT_OK\n\nHere is your answer.",
+      messages: { responsePrefix: "[openclaw]", queue: { mode: "steer" } },
+      expectedCalls: 1,
+      expectedText: "[openclaw] Here is your answer.",
+    },
+    {
+      title: "does not double responsePrefix when model reply already includes it",
+      replyText: "[openclaw] HEARTBEAT_OK\n\n[openclaw] Here is your answer.",
+      messages: { responsePrefix: "[openclaw]", queue: { mode: "steer" } },
+      expectedCalls: 1,
+      expectedText: "[openclaw] Here is your answer.",
+    },
+    {
+      title: "does not recover paragraph-break replies when queue mode is not steer",
+      replyText: "HEARTBEAT_OK\n\nAll clear.",
+      expectedCalls: 0,
+    },
   ])("$title", async ({ replyText, messages, expectedCalls, expectedText }) => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const sendTelegram = await runTelegramHeartbeatWithDefaults({
@@ -244,6 +270,45 @@ describe("runHeartbeatOnce ack handling", () => {
       if (expectedText) {
         expect(sendTelegram).toHaveBeenCalledWith(TELEGRAM_GROUP, expectedText, expect.any(Object));
       }
+    });
+  });
+
+  it("delivers recovered steered reply even when it matches lastHeartbeatText (dedupe bypass)", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const steeredAnswer = "The answer is 42.";
+      const cfg = createHeartbeatConfig({
+        tmpDir,
+        storePath,
+        heartbeat: { every: "5m", target: "telegram" },
+        channels: {
+          telegram: {
+            token: "test-token",
+            allowFrom: ["*"],
+            heartbeat: { showOk: false },
+          },
+        },
+        messages: { queue: { mode: "steer" } },
+      });
+
+      // Seed store with lastHeartbeatText matching the steered answer so the
+      // dedupe gate would normally suppress it as a duplicate.
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+        lastHeartbeatText: steeredAnswer,
+        lastHeartbeatSentAt: Date.now() - 60_000, // 1 minute ago, within 24h window
+      } as never);
+
+      replySpy.mockResolvedValue({ text: `HEARTBEAT_OK\n\n${steeredAnswer}` });
+      const sendTelegram = createMessageSendSpy();
+      await runHeartbeatOnce({
+        cfg,
+        deps: makeTelegramDeps({ sendTelegram }),
+      });
+
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(TELEGRAM_GROUP, steeredAnswer, expect.any(Object));
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -17,6 +17,7 @@ import {
   stripHeartbeatToken,
 } from "../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";
+import { resolveQueueSettings } from "../auto-reply/reply/queue/settings.js";
 import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
@@ -791,6 +792,49 @@ export async function runHeartbeatOnce(opts: {
       normalized.text = execFallbackText;
       normalized.shouldSkip = false;
     }
+    // When steer-mode injects a user message into a heartbeat run, the model
+    // replies with HEARTBEAT_OK followed by the real answer in a single payload.
+    // normalizeHeartbeatReply strips the token with mode "heartbeat" which marks
+    // shouldSkip=true when the remaining text is under maxAckChars.  This is
+    // correct for single-line acks ("HEARTBEAT_OK — all clear") but wrong when
+    // the reply contains a separate paragraph with a genuine user-facing answer.
+    //
+    // Detect steered replies: only attempt recovery when the effective queue
+    // mode (resolved via resolveQueueSettings, which checks global, per-channel,
+    // and session-level overrides) is "steer" or "steer-backlog" — otherwise no
+    // user message could have been injected.  If the raw text has a paragraph
+    // break (\n\n) after the HEARTBEAT_OK token, the content below it is a
+    // user-facing response.  Re-strip with mode "message" (no length threshold)
+    // and deliver.
+    let recoveredFromSteer = false;
+    const effectiveQueueMode = resolveQueueSettings({
+      cfg,
+      channel: delivery.channel !== "none" ? delivery.channel : undefined,
+      sessionEntry: entry,
+    }).mode;
+    const isSteerConfigured =
+      effectiveQueueMode === "steer" || effectiveQueueMode === "steer-backlog";
+    if (normalized.shouldSkip && isSteerConfigured) {
+      const rawText = typeof replyPayload.text === "string" ? replyPayload.text : "";
+      const prefixStripped = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
+      const tokenIdx = prefixStripped.toLowerCase().indexOf(HEARTBEAT_TOKEN.toLowerCase());
+      if (tokenIdx !== -1) {
+        const afterToken = prefixStripped.slice(tokenIdx + HEARTBEAT_TOKEN.length);
+        if (afterToken.includes("\n\n")) {
+          const messageStripped = stripHeartbeatToken(prefixStripped, { mode: "message" });
+          if (messageStripped.didStrip && messageStripped.text.trim()) {
+            const recoveredText = messageStripped.text.trim();
+            const alreadyPrefixed = responsePrefix && recoveredText.startsWith(responsePrefix);
+            normalized.text =
+              responsePrefix && !alreadyPrefixed
+                ? `${responsePrefix} ${recoveredText}`
+                : recoveredText;
+            normalized.shouldSkip = false;
+            recoveredFromSteer = true;
+          }
+        }
+      }
+    }
     const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
@@ -822,8 +866,12 @@ export async function runHeartbeatOnce(opts: {
       typeof entry?.lastHeartbeatText === "string" ? entry.lastHeartbeatText : "";
     const prevHeartbeatAt =
       typeof entry?.lastHeartbeatSentAt === "number" ? entry.lastHeartbeatSentAt : undefined;
+    // Recovered steered replies are user-facing answers, not heartbeat alerts —
+    // they must bypass the dedupe gate to avoid dropping legitimate responses
+    // that happen to match a recently sent heartbeat text.
     const isDuplicateMain =
       !shouldSkipMain &&
+      !recoveredFromSteer &&
       !mediaUrls.length &&
       Boolean(prevHeartbeatText.trim()) &&
       normalized.text.trim() === prevHeartbeatText.trim() &&


### PR DESCRIPTION
## Summary

- **Problem:** When `messages.queue.mode` is `steer`, user messages injected into an active heartbeat run produce a combined response (`HEARTBEAT_OK\n\nThe actual answer`). `normalizeHeartbeatReply` strips the token with `mode: "heartbeat"`, which marks `shouldSkip=true` when remaining text is under `maxAckChars` — suppressing the user's actual answer.
- **Why it matters:** The user sends a message, the model answers correctly, but the answer is silently discarded. The user never receives their reply.
- **What changed:** After `shouldSkip=true`, detect paragraph-break (`\n\n`) after the `HEARTBEAT_OK` token when steer mode is active. If found, re-strip with `mode: "message"` (no length threshold) and deliver the user-facing content. Recovered replies bypass the heartbeat dedupe gate.
- **What did NOT change:** Non-steer heartbeat suppression is untouched. Pure acks (`"HEARTBEAT_OK"`, `"HEARTBEAT_OK — all clear"`) are still suppressed. No changes to queue mode resolution, probe mechanism, or heartbeat scheduling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30197

## User-visible / Behavior Changes

- User messages sent during a heartbeat run (with steer mode) now receive their replies instead of being silently discarded.
- No config changes required.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.6 (Apple Silicon)
- Runtime/container: Node.js v25.6.1
- Model/provider: Any (issue is in heartbeat reply processing, not model-specific)
- Integration/channel: Telegram (also reproducible on Discord)
- Relevant config: `messages.queue.mode: "steer"`

### Steps

1. Set `messages.queue.mode` to `steer`
2. Wait for a heartbeat run to start
3. Send a user message during the active heartbeat run
4. Observe the model responds with `HEARTBEAT_OK\n\n<answer>` but the answer is never delivered

### Expected

- User receives their answer (the content after `HEARTBEAT_OK\n\n`)

### Actual

- `normalizeHeartbeatReply` marks the entire response as `shouldSkip=true` and the answer is discarded

## Evidence

- [x] Failing test/log before + passing after

5 new test cases in `heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`:
- Steered reply without responsePrefix → delivers stripped answer
- Steered reply with responsePrefix → delivers with prefix
- Steered reply where model already includes responsePrefix → no double prefix
- Steered reply matching `lastHeartbeatText` → still delivered (dedupe bypass)
- Paragraph-break reply without steer mode → suppressed (no false positive)

All 57 existing heartbeat-runner tests pass (no regressions).

## Human Verification (required)

- Verified scenarios: All 62 heartbeat-runner tests pass (57 existing + 5 new). Full `pnpm test` suite green. Verified locally with OpenClaw gateway + Telegram + steer mode enabled.
- Edge cases checked: (1) No double responsePrefix when model already includes it, (2) Dedupe bypass for recovered steered replies, (3) Paragraph-break replies without steer mode still suppressed (conservative — no false positives), (4) Steer gate uses `resolveQueueSettings` covering global, per-channel, and session-level overrides
- What you did **not** verify: Inline per-message `/queue steer` directives during heartbeat runs (these resolve in the user reply path, not the heartbeat runner — documented in design notes below).

## Compatibility / Migration

- Backward compatible? `Yes` — behavior only changes when `steer` mode is active and a paragraph break is detected. All other paths unchanged.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. Alternatively, set `messages.queue.mode` to a non-steer value to avoid the code path entirely.
- Files/config to restore: None.
- Known bad symptoms: If the `\n\n` heuristic false-positives, a pure heartbeat ack could be promoted to a delivered message. In practice, pure acks are single-line and don't contain paragraph breaks.

## Risks and Mitigations

- Risk: `\n\n` heuristic could false-positive on a multi-line heartbeat ack that isn't a steered reply.
  - Mitigation: Gated on steer mode being active (via `resolveQueueSettings`). Without steer, no user message could have been injected, so paragraph breaks are left suppressed. Additionally, pure heartbeat acks in practice are single-line.
- Risk: Inline per-message `/queue steer` directives won't trigger recovery.
  - Mitigation: Consistent with how the heartbeat pipeline resolves all config — it reads from its own context, not from the triggering user message. Session-level or config-level steer mode is the supported path.

### Design notes

- The steer gate uses `resolveQueueSettings` with the delivery channel and session entry, covering global, per-channel, and session-level queue mode settings. It does not cover inline per-message directives (`perMessageQueueMode`) — these resolve in `get-reply-run.ts`, not the heartbeat runner.
- The `\n\n` heuristic is intentionally conservative: false negatives (a steered reply without a paragraph break gets suppressed) are safer than false positives.
- Recovery follows the same escape-hatch pattern as the existing `hasExecCompletion` check.

> **Note:** This PR was AI-assisted. All code has been reviewed, understood, and tested locally. Prompts and review logs available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)