### PR TITLE
fix(ollama): use native stream for compat endpoints

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -7,6 +7,7 @@ import {
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   shouldInjectOllamaCompatNumCtx,
+  shouldUseOllamaNativeStream,
   wrapOllamaCompatNumCtx,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
@@ -330,6 +331,44 @@ describe("shouldInjectOllamaCompatNumCtx", () => {
           },
         },
         providerId: "ollama",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldUseOllamaNativeStream", () => {
+  it("uses native stream for explicit ollama api", () => {
+    expect(
+      shouldUseOllamaNativeStream({
+        model: {
+          provider: "ollama",
+          api: "ollama",
+          baseUrl: "http://127.0.0.1:11434",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("uses native stream for ollama-compatible openai-completions endpoints", () => {
+    expect(
+      shouldUseOllamaNativeStream({
+        model: {
+          provider: "my-ollama",
+          api: "openai-completions",
+          baseUrl: "http://remote-ollama-host:11434/v1",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps streamSimple for non-ollama openai-compatible endpoints", () => {
+    expect(
+      shouldUseOllamaNativeStream({
+        model: {
+          provider: "openai",
+          api: "openai-completions",
+          baseUrl: "https://api.openai.com/v1",
+        },
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary

- **Problem:** Remote Ollama endpoints configured via OpenAI-compatible `/v1` (`api: openai-completions`) can time out in long/slow generations.
- **Why it matters:** This blocks chat turns for self-hosted/remote Ollama users even when the backend is reachable and responsive.
- **What changed:** Reused existing Ollama compatibility detection and route those compatible OpenAI endpoints through native Ollama `/api/chat` streaming in the embedded runner; also skip OpenAI `num_ctx` payload wrapping on the native path.
- **What did NOT change:** Non-Ollama OpenAI-compatible providers continue using the existing `streamSimple` path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30305

## User-visible / Behavior Changes

- Ollama-compatible `openai-completions` model endpoints now run through native Ollama streaming in embedded runs.
- Timeout-prone OpenAI SDK path is avoided for those compatible Ollama endpoints.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same Ollama host, different API route handling)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS/Linux (code-level fix)
- Runtime: Node.js (OpenClaw embedded runner)
- Integration/channel: Embedded agent run with Ollama-compatible provider

### Steps

1. Configure an Ollama-compatible provider with `api: openai-completions` and base URL ending in `/v1`.
2. Run an embedded turn against a slow remote Ollama model.
3. Confirm runner selects native Ollama streaming path for compat endpoints.

### Expected

- Compatible Ollama endpoints use native `/api/chat` stream path.
- Turn no longer depends on OpenAI SDK stream behavior for that endpoint class.

### Actual

- Before fix: compat Ollama `openai-completions` path stayed on SDK stream path and could time out.
- After fix: compat Ollama path switches to native stream handling.

## Evidence

- Added tests in `src/agents/pi-embedded-runner/run/attempt.test.ts` for native stream selection behavior.
- Test command:
  - `pnpm test -- --run src/agents/pi-embedded-runner/run/attempt.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Explicit `api: ollama` keeps native stream path.
  - Ollama-compatible `openai-completions` endpoint now selects native stream path.
  - Non-Ollama OpenAI-compatible endpoints stay on `streamSimple`.
- Edge cases checked:
  - Existing `num_ctx` injection remains scoped to non-native OpenAI-compatible path.
- What I did **not** verify:
  - Full live remote Ollama end-to-end run in this CI-less local patch context.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/run/attempt.test.ts`
- Known bad symptoms:
  - Compatible Ollama OpenAI endpoints may again route through SDK path and re-introduce timeout behavior.

## Risks and Mitigations

- Risk: Misclassifying a non-Ollama endpoint as Ollama-compatible.
- Mitigation: Selection uses existing conservative compatibility detection plus explicit provider hints/known Ollama patterns; tests added for non-Ollama endpoint exclusion.

