### PR TITLE
fix: wrap session key in inline code in usage footer (Slack emoji parsing)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -605,7 +605,7 @@ export async function runReplyAgent(params: {
         costConfig,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {
-        formatted = `${formatted} · session ${sessionKey}`;
+        formatted = `${formatted} · session \`${sessionKey}\``;
       }
       if (formatted) {
         responseUsageLine = formatted;


### PR DESCRIPTION
## Problem

When the usage footer is rendered in Slack, session keys like `agent:main:slack:direct:u045c0gtsmb` contain colon-delimited segments that Slack auto-parses as emoji shortcodes (`:main:`, `:slack:`, `:direct:`). These render as grey placeholder boxes when no matching emoji exists.

## Fix

Wrap the session key in backticks (inline code) in the usage footer. Slack does not parse emoji shortcodes inside code spans, so the session key renders as plain monospace text.

**Before:** `Usage: 3 in / 1.8k out · session agent [grey box] slack [grey box] u045c0gtsmb`
**After:** `Usage: 3 in / 1.8k out · session ` + "`agent:main:slack:direct:u045c0gtsmb`" + "`

This also improves readability on other platforms by visually distinguishing the session key from surrounding text.

## Changes

- `src/auto-reply/reply/agent-runner.ts`: Wrap `sessionKey` in backtick escapes in the `full` usage footer line

Fixes #30258