### PR TITLE
feat(feishu): add sheets range read tool

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -426,6 +426,71 @@ openclaw pairing list feishu
 
 > Note: Feishu does not support native command menus yet, so commands must be sent as text.
 
+## Tools
+
+You can enable tool usage via channel tools configuration. `sheets` defaults to `true`:
+
+```json5
+{
+  channels: {
+    feishu: {
+      tools: {
+        doc: true,
+        wiki: true,
+        drive: true,
+        sheets: true,
+      },
+    },
+  },
+}
+```
+
+Read a sheet range using `feishu_sheets_read_range`:
+
+```json
+{
+  "spreadsheet_token": "ss_xxx",
+  "sheet_id": "shxxxxxxxx",
+  "range": "A1:C10"
+}
+```
+
+If `range` is omitted, the tool resolves a best-effort range from sheet metadata:
+
+- uses `row_count` / `column_count` when metadata is available;
+- falls back to `A1:Z1000` when metadata is missing.
+
+Response:
+
+```json
+{
+  "spreadsheet_token": "ss_xxx",
+  "sheet_id": "shxxxxxxxx",
+  "requested_range": "A1:C10",
+  "resolved_range": "A1:C10",
+  "values": [
+    ["Name", "Score"],
+    ["Alice", 95]
+  ],
+  "value_range": {
+    "range": "A1:C10",
+    "major_dimension": "GRID",
+    "row_count": 2,
+    "column_count": 3
+  },
+  "sheet_meta": {
+    "title": "Budget",
+    "row_count": 1200,
+    "column_count": 12
+  },
+  "next_range_hint": "A11:C20"
+}
+```
+
+`include_markdown: true` adds a Markdown table preview to the output (keeps `values` unchanged).
+
+Wiki sheet pages (`obj_type = "sheet"`) return a hint from `feishu_wiki` pointing to `feishu_sheets_read_range`.
+
 ## Gateway management commands
 
 | Command                    | Description                   |

--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSheetsTools } from "./src/sheets.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -58,6 +59,7 @@ const plugin = {
     registerFeishuWikiTools(api);
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
+    registerFeishuSheetsTools(api);
     registerFeishuBitableTools(api);
   },
 };

--- a/extensions/feishu/skills/feishu-sheets/SKILL.md
+++ b/extensions/feishu/skills/feishu-sheets/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: feishu-sheets
+description: |
+  Feishu spreadsheet range read operations. Activate when users mention sheet links, A1 ranges, or data extraction tasks.
+---
+
+# Feishu Sheets Read Tool
+
+Tool: `feishu_sheets_read_range`
+
+## Required Parameters
+
+- `spreadsheet_token`: Spreadsheet token
+- `sheet_id`: Sheet ID inside the spreadsheet
+- `range` (optional): A1 range like `A1:C5`
+
+## Optional Parameters
+
+- `include_markdown`: Include a markdown preview under `markdown`
+
+## Read Behavior
+
+- If `range` is omitted, the tool tries to infer a read window from sheet metadata.
+- When metadata is unavailable, fallback range is `A1:Z1000`.
+- If the sheet is large, response may include `next_range_hint` for resumable reads.
+
+## Request Example
+
+```json
+{
+  "spreadsheet_token": "ssp_xxx",
+  "sheet_id": "sh_xxx",
+  "range": "A1:C10"
+}
+```
+
+## Success Response
+
+- `values`: 2D array
+- `value_range`: range metadata (`range`, `major_dimension`, `row_count`, `column_count`)
+- `sheet_meta`: sheet metadata (title, row/column caps)
+- `next_range_hint`: optional follow-up range suggestion
+
+## Configuration
+
+```yaml
+channels:
+  feishu:
+    tools:
+      sheets: true # default: true
+```
+
+## Permissions
+
+- `sheet:sheet` or `sheet:sheet:readonly`

--- a/extensions/feishu/skills/feishu-wiki/SKILL.md
+++ b/extensions/feishu/skills/feishu-wiki/SKILL.md
@@ -40,7 +40,8 @@ With parent:
 { "action": "get", "token": "ABC123def" }
 ```
 
-Returns: `node_token`, `obj_token`, `obj_type`, etc. Use `obj_token` with `feishu_doc` to read/write the document.
+Returns: `node_token`, `obj_token`, `obj_type`, etc. For `docx`, use `obj_token` with `feishu_doc`.
+For `sheet`, use `feishu_sheets_read_range` and pass `spreadsheet_token` from `obj_token`.
 
 ### Create Node
 
@@ -93,6 +94,11 @@ To edit a wiki page:
 1. Get node: `{ "action": "get", "token": "wiki_token" }` → returns `obj_token`
 2. Read doc: `feishu_doc { "action": "read", "doc_token": "obj_token" }`
 3. Write doc: `feishu_doc { "action": "write", "doc_token": "obj_token", "content": "..." }`
+
+For wiki sheets:
+
+1. Get node: `{ "action": "get", "token": "wiki_token" }` → returns `obj_token`
+2. Read sheet: `feishu_sheets_read_range { "spreadsheet_token": "obj_token", "sheet_id": "sh_xxx", "range": "A1:C20" }`
 
 ## Configuration
 

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -1,5 +1,7 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerFeishuChatTools } from "./chat.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 
@@ -7,9 +9,27 @@ vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
 }));
 
+function createConfig(tools?: { chat?: boolean }): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          main: {
+            appId: "app-id",
+            appSecret: "app-secret",
+            tools,
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
 describe("registerFeishuChatTools", () => {
   const chatGetMock = vi.hoisted(() => vi.fn());
   const chatMembersGetMock = vi.hoisted(() => vi.fn());
+  type ToolResult = { details: Record<string, unknown> };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -22,31 +42,20 @@ describe("registerFeishuChatTools", () => {
   });
 
   it("registers feishu_chat and handles info/members actions", async () => {
-    const registerTool = vi.fn();
-    registerFeishuChatTools({
-      config: {
-        channels: {
-          feishu: {
-            enabled: true,
-            appId: "app_id",
-            appSecret: "app_secret",
-            tools: { chat: true },
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
+    const { api, resolveTool } = createToolFactoryHarness(createConfig({ chat: true }));
+    registerFeishuChatTools(api);
+    const tool = resolveTool("feishu_chat", { agentAccountId: "main" });
 
-    expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.name).toBe("feishu_chat");
+    expect(tool.name).toBe("feishu_chat");
 
     chatGetMock.mockResolvedValueOnce({
       code: 0,
       data: { name: "group name", user_count: 3 },
     });
-    const infoResult = await tool.execute("tc_1", { action: "info", chat_id: "oc_1" });
+    const infoResult = (await tool.execute("tc_1", {
+      action: "info",
+      chat_id: "oc_1",
+    })) as ToolResult;
     expect(infoResult.details).toEqual(
       expect.objectContaining({ chat_id: "oc_1", name: "group name", user_count: 3 }),
     );
@@ -59,7 +68,10 @@ describe("registerFeishuChatTools", () => {
         items: [{ member_id: "ou_1", name: "member1", member_id_type: "open_id" }],
       },
     });
-    const membersResult = await tool.execute("tc_2", { action: "members", chat_id: "oc_1" });
+    const membersResult = (await tool.execute("tc_2", {
+      action: "members",
+      chat_id: "oc_1",
+    })) as ToolResult;
     expect(membersResult.details).toEqual(
       expect.objectContaining({
         chat_id: "oc_1",
@@ -69,21 +81,8 @@ describe("registerFeishuChatTools", () => {
   });
 
   it("skips registration when chat tool is disabled", () => {
-    const registerTool = vi.fn();
-    registerFeishuChatTools({
-      config: {
-        channels: {
-          feishu: {
-            enabled: true,
-            appId: "app_id",
-            appSecret: "app_secret",
-            tools: { chat: false },
-          },
-        },
-      } as any,
-      logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
-    } as any);
-    expect(registerTool).not.toHaveBeenCalled();
+    const { api, resolveTool } = createToolFactoryHarness(createConfig({ chat: false }));
+    registerFeishuChatTools(api);
+    expect(() => resolveTool("feishu_chat")).toThrow(/Tool not registered/);
   });
 });

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -2,8 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 function json(data: unknown) {
   return {
@@ -83,45 +82,51 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.chat) {
     api.logger.debug?.("feishu_chat: chat tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuChatExecuteParams = FeishuChatParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_chat",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuChatParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "members":
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  p.page_size,
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              return json(await getChatInfo(client, p.chat_id));
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_chat",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuChatExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "members":
+                return json(
+                  await getChatMembers(
+                    client,
+                    p.chat_id,
+                    p.page_size,
+                    p.page_token,
+                    p.member_id_type,
+                  ),
+                );
+              case "info":
+                return json(await getChatInfo(client, p.chat_id));
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_chat" },
   );

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -167,3 +167,15 @@ describe("FeishuConfigSchema defaultAccount", () => {
     }
   });
 });
+
+describe("FeishuConfigSchema tools", () => {
+  it("accepts tools.sheets override", () => {
+    const result = FeishuConfigSchema.parse({
+      tools: {
+        sheets: false,
+      },
+    });
+
+    expect(result.tools?.sheets).toBe(false);
+  });
+});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -86,6 +86,7 @@ const FeishuToolsConfigSchema = z
     chat: z.boolean().optional(), // Chat info + member query operations (default: true)
     wiki: z.boolean().optional(), // Knowledge base operations (default: true, requires doc)
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
+    sheets: z.boolean().optional(), // Spreadsheet read operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
   })

--- a/extensions/feishu/src/sheets.test.ts
+++ b/extensions/feishu/src/sheets.test.ts
@@ -1,0 +1,284 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { registerFeishuSheetsTools } from "./sheets.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const requestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+function createConfig(tools?: { sheets?: boolean }): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          main: {
+            appId: "app-id",
+            appSecret: "app-secret",
+            tools: tools,
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+describe("feishu_sheets_read_range", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      request: requestMock,
+    });
+  });
+
+  function getTool() {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuSheetsTools(api);
+    return resolveTool("feishu_sheets_read_range", { agentAccountId: "main" });
+  }
+
+  test("reads a known range", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "Budget",
+          row_count: 120,
+          column_count: 4,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          value_range: {
+            range: "A1:C5",
+            majorDimension: "GRID",
+            values: [
+              ["A", "B", "C"],
+              [1, 2, 3],
+            ],
+          },
+        },
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+      range: "A1:C5",
+    })) as { details: Record<string, unknown> };
+
+    expect(details.spreadsheet_token).toBe("ssp_xxx");
+    expect(details.sheet_id).toBe("sh_xxx");
+    expect(details.requested_range).toBe("A1:C5");
+    expect(details.resolved_range).toBe("A1:C5");
+    expect(details.values).toEqual([
+      ["A", "B", "C"],
+      [1, 2, 3],
+    ]);
+    expect(details.value_range).toMatchObject({
+      range: "A1:C5",
+      row_count: 5,
+      column_count: 3,
+      major_dimension: "GRID",
+    });
+    expect(details.sheet_meta).toMatchObject({
+      title: "Budget",
+      row_count: 120,
+      column_count: 4,
+    });
+    expect(details).not.toHaveProperty("markdown");
+
+    expect(requestMock).toHaveBeenNthCalledWith(1, {
+      method: "GET",
+      url: "/open-apis/sheets/v2/spreadsheets/ssp_xxx/sheets/sh_xxx",
+    });
+    expect(requestMock).toHaveBeenNthCalledWith(2, {
+      method: "GET",
+      url: "/open-apis/sheets/v2/spreadsheets/ssp_xxx/sheets/sh_xxx/values/A1%3AC5",
+    });
+  });
+
+  test("falls back to metadata range when range is omitted", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "EmptyRangeSheet",
+          row_count: 3,
+          column_count: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          value_range: {
+            values: [["x", "y"]],
+          },
+        },
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+    })) as { details: Record<string, unknown> };
+
+    expect(details.requested_range).toBeNull();
+    expect(details.resolved_range).toBe("A1:B3");
+    expect(details.value_range).toMatchObject({
+      range: "A1:B3",
+      row_count: 3,
+      column_count: 2,
+    });
+  });
+
+  test("treats blank range as omitted and falls back to metadata range", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "BlankRangeSheet",
+          row_count: 4,
+          column_count: 3,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          value_range: {
+            values: [["x", "y", "z"]],
+          },
+        },
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+      range: "   ",
+    })) as { details: Record<string, unknown> };
+
+    expect(details.requested_range).toBeNull();
+    expect(details.resolved_range).toBe("A1:C4");
+    expect(details.value_range).toMatchObject({
+      range: "A1:C4",
+      row_count: 4,
+      column_count: 3,
+    });
+  });
+
+  test("returns invalid_range error for bad range", async () => {
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+      range: "BAD",
+    })) as { details: Record<string, unknown> };
+
+    expect(requestMock).not.toHaveBeenCalled();
+
+    expect(details.code).toBe("invalid_range");
+    expect(details.error).toContain("Invalid A1 range");
+    expect(details).not.toHaveProperty("next_range_hint");
+  });
+
+  test("returns read_error with next_range_hint for oversized range", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "Large Sheet",
+          row_count: 1200,
+          column_count: 26,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 100,
+        msg: "Request too large",
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+      range: "A1:Z1000",
+    })) as { details: Record<string, unknown> };
+    expect(details.code).toBe("read_error");
+    expect(details.error).toContain("Failed to read sheet values");
+    expect(details.next_range_hint).toBe("A1:Z200");
+  });
+
+  test("returns read_error with next_range_hint when no range is provided and request is oversized", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "Large Sheet",
+          row_count: 1200,
+          column_count: 4,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 100,
+        msg: "Request too large",
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+    })) as { details: Record<string, unknown> };
+    expect(details.code).toBe("read_error");
+    expect(details.error).toContain("Failed to read sheet values");
+    expect(details.next_range_hint).toBe("A1:D200");
+  });
+
+  test("supports include_markdown output", async () => {
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          title: "Budget",
+          row_count: 5,
+          column_count: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          value_range: {
+            range: "A1:B2",
+            values: [
+              ["Name", "Score"],
+              ["Alice", 95],
+            ],
+          },
+        },
+      });
+
+    const tool = getTool();
+    const { details } = (await tool.execute("call", {
+      spreadsheet_token: "ssp_xxx",
+      sheet_id: "sh_xxx",
+      include_markdown: true,
+      range: "A1:B2",
+    })) as { details: Record<string, unknown> };
+    const markdown = details.markdown;
+
+    expect(typeof markdown).toBe("string");
+    expect(markdown).toContain("| C1 | C2 |");
+    expect(markdown).toContain("| --- | --- |");
+  });
+
+  test("does not register tool when sheets is disabled", () => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig({ sheets: false }));
+    registerFeishuSheetsTools(api);
+    expect(() => resolveTool("feishu_sheets_read_range")).toThrow(/Tool not registered/);
+  });
+});

--- a/extensions/feishu/src/sheets.ts
+++ b/extensions/feishu/src/sheets.ts
@@ -1,0 +1,559 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+
+// ============ Helpers =========
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+const ROW_FALLBACK_COUNT = 1000;
+const COLUMN_FALLBACK_COUNT = 26;
+const MAX_HINT_CHUNK_ROWS = 200;
+
+/**
+ * Error payload format used by Feishu Sheets tool.
+ */
+class FeishuSheetsError extends Error {
+  constructor(
+    public code: "invalid_range" | "sheet_meta_error" | "read_error" | "unknown",
+    message: string,
+    public details?: unknown,
+    public nextRangeHint?: string,
+  ) {
+    super(message);
+    this.name = "FeishuSheetsError";
+  }
+
+  toPayload() {
+    return {
+      error: this.message,
+      code: this.code,
+      ...(this.nextRangeHint ? { next_range_hint: this.nextRangeHint } : {}),
+      ...(this.details ? { details: this.details } : {}),
+    };
+  }
+}
+
+type RangeBounds = {
+  startColumnIndex: number;
+  endColumnIndex: number;
+  startRowIndex: number;
+  endRowIndex: number;
+};
+
+type SheetMeta = {
+  title?: string;
+  row_count?: number;
+  column_count?: number;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function cellToIndex(cell: string): [number, number] {
+  const match = /^([A-Za-z]+)(\d+)$/.exec(cell);
+  if (!match?.[1] || !match?.[2]) {
+    throw new FeishuSheetsError(
+      "invalid_range",
+      `Invalid A1 range cell: ${cell}. Expected values like A1, B2, AA12.`,
+    );
+  }
+
+  let columnIndex = 0;
+  for (const ch of match[1].toUpperCase()) {
+    const ord = ch.charCodeAt(0) - 64;
+    if (ord < 1 || ord > 26) {
+      throw new FeishuSheetsError("invalid_range", `Invalid column label: ${cell}`);
+    }
+    columnIndex = columnIndex * 26 + ord;
+  }
+
+  const rowIndex = Number.parseInt(match[2], 10);
+  if (!Number.isInteger(rowIndex) || rowIndex <= 0) {
+    throw new FeishuSheetsError("invalid_range", `Invalid row index: ${cell}`);
+  }
+
+  return [columnIndex, rowIndex];
+}
+
+function parseRange(range: string): RangeBounds {
+  const trimmed = range.trim();
+  const parts = trimmed.split(":");
+  if (parts.length > 2) {
+    throw new FeishuSheetsError(
+      "invalid_range",
+      `Invalid range format: ${range}. Expected A1 or A1:C5.`,
+    );
+  }
+  const startRaw = parts[0]?.trim();
+  const endRaw = parts[1]?.trim();
+
+  if (parts.length === 2 && endRaw === "") {
+    throw new FeishuSheetsError(
+      "invalid_range",
+      `Invalid range format: ${range}. Expected A1 or A1:C5.`,
+    );
+  }
+
+  if (!startRaw || startRaw.includes(":")) {
+    throw new FeishuSheetsError(
+      "invalid_range",
+      `Invalid range format: ${range}. Expected A1 or A1:C5.`,
+    );
+  }
+
+  const [startCol, startRow] = cellToIndex(startRaw);
+  const [endColRaw, endRowRaw] = endRaw ? cellToIndex(endRaw) : [startCol, startRow];
+  if (endColRaw < startCol || endRowRaw < startRow) {
+    throw new FeishuSheetsError(
+      "invalid_range",
+      `Invalid range format: ${range}. End cannot be before start.`,
+    );
+  }
+
+  return {
+    startColumnIndex: startCol,
+    endColumnIndex: endColRaw,
+    startRowIndex: startRow,
+    endRowIndex: endRowRaw,
+  };
+}
+
+function colToLabel(index: number): string {
+  let value = index;
+  let result = "";
+  while (value > 0) {
+    const rem = (value - 1) % 26;
+    result = String.fromCharCode(65 + rem) + result;
+    value = Math.floor((value - 1) / 26);
+  }
+  return result || "A";
+}
+
+function rangeToA1(range: RangeBounds): string {
+  return `${colToLabel(range.startColumnIndex)}${range.startRowIndex}:${colToLabel(range.endColumnIndex)}${range.endRowIndex}`;
+}
+
+function detectSheetMeta(raw: unknown): SheetMeta {
+  const root = asRecord(raw) ?? {};
+  const candidate =
+    asRecord(root.sheet) ?? asRecord(root.data) ?? asRecord(root.properties) ?? root;
+
+  const grid = asRecord(candidate.grid_properties) ?? asRecord(candidate.gridProperties) ?? {};
+
+  const title =
+    typeof candidate.title === "string"
+      ? candidate.title
+      : typeof candidate.name === "string"
+        ? candidate.name
+        : undefined;
+
+  const rowCountValue =
+    typeof candidate.row_count === "number"
+      ? candidate.row_count
+      : typeof candidate.rowCount === "number"
+        ? candidate.rowCount
+        : typeof grid.row_count === "number"
+          ? grid.row_count
+          : typeof grid.rowCount === "number"
+            ? grid.rowCount
+            : undefined;
+
+  const columnCountValue =
+    typeof candidate.column_count === "number"
+      ? candidate.column_count
+      : typeof candidate.columnCount === "number"
+        ? candidate.columnCount
+        : typeof grid.column_count === "number"
+          ? grid.column_count
+          : typeof grid.columnCount === "number"
+            ? grid.columnCount
+            : undefined;
+
+  return {
+    title,
+    row_count: rowCountValue,
+    column_count: columnCountValue,
+  };
+}
+
+function getRangeFromMeta(meta?: SheetMeta) {
+  const endRow =
+    typeof meta?.row_count === "number" && Number.isInteger(meta.row_count) && meta.row_count > 0
+      ? meta.row_count
+      : ROW_FALLBACK_COUNT;
+  const rawColCount =
+    typeof meta?.column_count === "number" &&
+    Number.isInteger(meta.column_count) &&
+    meta.column_count > 0
+      ? meta.column_count
+      : COLUMN_FALLBACK_COUNT;
+  const endCol = Math.min(rawColCount, 18278);
+
+  return {
+    startColumnIndex: 1,
+    startRowIndex: 1,
+    endColumnIndex: endCol,
+    endRowIndex: endRow,
+  };
+}
+
+function safeNextRangeHint(
+  current: RangeBounds,
+  nextStartRow: number,
+  columnEnd: number,
+  rowLimit?: number,
+) {
+  if (nextStartRow <= 0 || columnEnd <= 0) {
+    return undefined;
+  }
+
+  const chunk = current.endRowIndex - current.startRowIndex + 1;
+  const defaultEnd = nextStartRow + Math.max(1, chunk) - 1;
+
+  if (Number.isFinite(rowLimit ?? Infinity)) {
+    const limit = typeof rowLimit === "number" && rowLimit > 0 ? rowLimit : undefined;
+    const finalEnd = limit ? Math.min(limit, defaultEnd) : defaultEnd;
+    if (nextStartRow > finalEnd) {
+      return undefined;
+    }
+    return `${colToLabel(current.startColumnIndex)}${nextStartRow}:${colToLabel(columnEnd)}${finalEnd}`;
+  }
+
+  return `${colToLabel(current.startColumnIndex)}${nextStartRow}:${colToLabel(columnEnd)}${defaultEnd}`;
+}
+
+function parseValueRangeBounds(range: string): {
+  rowCount: number;
+  columnCount: number;
+} {
+  const parts = range.split(":");
+  if (parts.length === 1 && parts[0]) {
+    return { rowCount: 1, columnCount: 1 };
+  }
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return { rowCount: 0, columnCount: 0 };
+  }
+
+  const start = cellToIndex(parts[0]);
+  const end = cellToIndex(parts[1]);
+  return {
+    rowCount: Math.max(1, end[1] - start[1] + 1),
+    columnCount: Math.max(1, end[0] - start[0] + 1),
+  };
+}
+
+function normalizeCellValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "boolean") {
+    return value ? "TRUE" : "FALSE";
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "";
+  }
+  if (typeof value === "string") {
+    return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " <br> ");
+  }
+  return JSON.stringify(value);
+}
+
+function asMarkdownTable(values: unknown[][]): string {
+  const normalizedRows = values.map((row) =>
+    Array.isArray(row) ? row.map((cell) => normalizeCellValue(cell)) : [normalizeCellValue(row)],
+  );
+  const colCount =
+    normalizedRows.length === 0
+      ? 0
+      : Math.max(...normalizedRows.map((row) => (Array.isArray(row) ? row.length : 0)));
+
+  if (colCount === 0) {
+    return "";
+  }
+
+  const paddedRows = normalizedRows.map((row) =>
+    Array.from({ length: colCount }, (_, i) =>
+      Array.isArray(row) && row[i] !== undefined ? row[i] : "",
+    ),
+  );
+
+  const header = Array.from({ length: colCount }, (_, i) => `C${i + 1}`);
+  const headerRow = `| ${header.join(" | ")} |`;
+  const divider = `| ${header.map(() => "---").join(" | ")} |`;
+  const body = paddedRows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+
+  return `${headerRow}\n${divider}\n${body}`;
+}
+
+async function fetchSheetsJson(
+  client: Lark.Client,
+  spreadsheetToken: string,
+  sheetId: string,
+  extraPath: string,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fallback path for versions without typed helper
+  return (await (client as any).request({
+    method: "GET",
+    url: `/open-apis/sheets/v2/spreadsheets/${encodeURIComponent(spreadsheetToken)}/sheets/${encodeURIComponent(sheetId)}${extraPath}`,
+  })) as Record<string, unknown>;
+}
+
+async function getSheetMeta(
+  client: Lark.Client,
+  spreadsheetToken: string,
+  sheetId: string,
+): Promise<SheetMeta> {
+  const response = await fetchSheetsJson(client, spreadsheetToken, sheetId, "");
+  if (typeof response?.code !== "number" || response.code !== 0) {
+    throw new FeishuSheetsError(
+      "sheet_meta_error",
+      `Failed to read sheet metadata. code=${String(response?.code ?? "unknown")}, msg=${String(response?.msg ?? "unknown")}`,
+      response,
+    );
+  }
+
+  return detectSheetMeta(response.data ?? response);
+}
+
+async function readValues(
+  client: Lark.Client,
+  spreadsheetToken: string,
+  sheetId: string,
+  resolvedRange: string,
+) {
+  const response = await fetchSheetsJson(
+    client,
+    spreadsheetToken,
+    sheetId,
+    `/values/${encodeURIComponent(resolvedRange)}`,
+  );
+  if (typeof response?.code !== "number" || response.code !== 0) {
+    throw new FeishuSheetsError(
+      "read_error",
+      `Failed to read sheet values. code=${String(response?.code ?? "unknown")}, msg=${String(response?.msg ?? "unknown")}`,
+      response,
+    );
+  }
+
+  return response.data as Record<string, unknown>;
+}
+
+function normalizeValueRangeData(raw: Record<string, unknown> | undefined) {
+  const valueRange =
+    (asRecord(raw?.value_range) as Record<string, unknown> | undefined) ??
+    (asRecord(raw?.valueRange) as Record<string, unknown> | undefined) ??
+    asRecord(raw);
+
+  const values = Array.isArray(valueRange?.values) ? (valueRange.values as unknown[][]) : [];
+  const range =
+    typeof valueRange?.range === "string"
+      ? valueRange.range
+      : typeof valueRange?.valueRange === "string"
+        ? (valueRange.valueRange as string)
+        : "";
+
+  return {
+    range,
+    values,
+    majorDimension:
+      typeof valueRange?.majorDimension === "string"
+        ? valueRange.majorDimension
+        : typeof valueRange?.major_dimension === "string"
+          ? valueRange.major_dimension
+          : undefined,
+    revision: typeof valueRange?.revision === "number" ? valueRange.revision : undefined,
+  };
+}
+
+async function readSheetRange(params: {
+  client: Lark.Client;
+  spreadsheetToken: string;
+  sheetId: string;
+  requestedRange?: string;
+  includeMarkdown?: boolean;
+}) {
+  const normalizedRequestedRange = params.requestedRange?.trim();
+  const requestedRange =
+    normalizedRequestedRange && normalizedRequestedRange.length > 0
+      ? normalizedRequestedRange
+      : undefined;
+  const requestedBounds = requestedRange ? parseRange(requestedRange) : undefined;
+  const sheetMeta = await getSheetMeta(params.client, params.spreadsheetToken, params.sheetId);
+  const resolvedBounds = requestedBounds ?? getRangeFromMeta(sheetMeta);
+  const requestedRowsBounds = requestedBounds ?? resolvedBounds;
+  const resolvedRange = rangeToA1(resolvedBounds);
+  const requestedRows = requestedRowsBounds.endRowIndex - requestedRowsBounds.startRowIndex + 1;
+  const includeNextHint = requestedRange == null;
+
+  let resolved = {
+    spreadsheet_token: params.spreadsheetToken,
+    sheet_id: params.sheetId,
+    requested_range: requestedRange ?? null,
+    resolved_range: resolvedRange,
+  };
+
+  try {
+    const rawData = await readValues(
+      params.client,
+      params.spreadsheetToken,
+      params.sheetId,
+      resolvedRange,
+    );
+    const valueRange = normalizeValueRangeData(rawData);
+    const valueRangeRange = valueRange.range || resolvedRange;
+    const values = valueRange.values;
+    const responseBounds = parseValueRangeBounds(valueRangeRange);
+
+    const nextRangeHint =
+      includeNextHint &&
+      values.length >= Math.max(0, requestedRows) &&
+      responseBounds.rowCount === requestedRows
+        ? safeNextRangeHint(
+            requestedRowsBounds,
+            requestedRowsBounds.endRowIndex + 1,
+            requestedRowsBounds.endColumnIndex,
+            sheetMeta.row_count,
+          )
+        : undefined;
+
+    return {
+      ...resolved,
+      values,
+      value_range: {
+        range: valueRangeRange,
+        major_dimension: valueRange.majorDimension,
+        revision: valueRange.revision,
+        row_count: responseBounds.rowCount,
+        column_count: responseBounds.columnCount,
+      },
+      sheet_meta: sheetMeta,
+      ...(nextRangeHint ? { next_range_hint: nextRangeHint } : {}),
+      ...(params.includeMarkdown ? { markdown: asMarkdownTable(values) } : {}),
+    };
+  } catch (err) {
+    if (err instanceof FeishuSheetsError) {
+      const shouldChunkHint = requestedRangeExceedsLimit(requestedRowsBounds, MAX_HINT_CHUNK_ROWS);
+      const chunkEndRow = requestedRowsBounds.startRowIndex + MAX_HINT_CHUNK_ROWS - 1;
+      const fallbackHint = shouldChunkHint
+        ? safeNextRangeHint(
+            requestedRowsBounds,
+            requestedRowsBounds.startRowIndex,
+            requestedRowsBounds.endColumnIndex,
+            typeof sheetMeta.row_count === "number" && sheetMeta.row_count > 0
+              ? Math.min(sheetMeta.row_count, chunkEndRow)
+              : chunkEndRow,
+          )
+        : undefined;
+
+      throw new FeishuSheetsError(
+        err.code,
+        err.message,
+        err.details,
+        shouldChunkHint ? fallbackHint : err.nextRangeHint,
+      );
+    }
+
+    throw new FeishuSheetsError("unknown", `Unexpected sheet read failure: ${String(err)}`);
+  }
+}
+
+function requestedRangeExceedsLimit(range: RangeBounds, chunkRows: number): boolean {
+  const requestRows = range.endRowIndex - range.startRowIndex + 1;
+  return requestRows > chunkRows;
+}
+
+const FeishuSheetsReadRangeSchema = Type.Object({
+  spreadsheet_token: Type.String({
+    description: "Spreadsheet token (from URL path or token)",
+  }),
+  sheet_id: Type.String({ description: "Sheet ID in the spreadsheet" }),
+  range: Type.Optional(
+    Type.String({
+      description:
+        "Optional A1 range, for example A1:C5. If omitted, infer from sheet metadata, fallback A1:Z1000.",
+    }),
+  ),
+  include_markdown: Type.Optional(
+    Type.Boolean({ description: "Include a markdown preview under markdown field" }),
+  ),
+});
+
+type FeishuSheetsReadRangeParams = {
+  spreadsheet_token: string;
+  sheet_id: string;
+  range?: string;
+  include_markdown?: boolean;
+  accountId?: string;
+};
+
+// ============ Tool Registration ============
+
+export function registerFeishuSheetsTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_sheets: No config available, skipping sheets tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_sheets: No Feishu accounts configured, skipping sheets tools");
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.sheets) {
+    api.logger.debug?.("feishu_sheets: sheets tool disabled in config");
+    return;
+  }
+
+  const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
+    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+
+  api.registerTool(
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_sheets_read_range",
+        label: "Feishu Sheets Read Range",
+        description: "Read a spreadsheet range in A1 style from a sheet node.",
+        parameters: FeishuSheetsReadRangeSchema,
+        async execute(_toolCallId, rawParams) {
+          const params = rawParams as FeishuSheetsReadRangeParams;
+          try {
+            const client = getClient(params, defaultAccountId);
+            return json(
+              await readSheetRange({
+                client,
+                spreadsheetToken: params.spreadsheet_token,
+                sheetId: params.sheet_id,
+                requestedRange: params.range,
+                includeMarkdown: params.include_markdown,
+              }),
+            );
+          } catch (err) {
+            if (err instanceof FeishuSheetsError) {
+              return json(err.toPayload());
+            }
+            return json({
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        },
+      };
+    },
+    { name: "feishu_sheets_read_range" },
+  );
+
+  api.logger.info?.("feishu_sheets: Registered feishu_sheets_read_range tool");
+}

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -1,13 +1,32 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { registerFeishuBitableTools } from "./bitable.js";
+import { registerFeishuChatTools } from "./chat.js";
 import { registerFeishuDriveTools } from "./drive.js";
 import { registerFeishuPermTools } from "./perm.js";
+import { registerFeishuSheetsTools } from "./sheets.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 import { registerFeishuWikiTools } from "./wiki.js";
 
 const createFeishuClientMock = vi.fn((account: { appId?: string } | undefined) => ({
   __appId: account?.appId,
+  im: {
+    chat: { get: vi.fn(async () => ({ code: 0, data: {} })) },
+    chatMembers: { get: vi.fn(async () => ({ code: 0, data: { items: [] } })) },
+  },
+  request: vi.fn(async ({ url }: { url: string }) => {
+    if (url.includes("/values/")) {
+      return { code: 0, data: { value_range: { range: "A1:B2", values: [] } } };
+    }
+    return {
+      code: 0,
+      data: {
+        title: "Sheet",
+        row_count: 1200,
+        column_count: 26,
+      },
+    };
+  }),
 }));
 
 vi.mock("./client.js", () => ({
@@ -16,13 +35,17 @@ vi.mock("./client.js", () => ({
 
 function createConfig(params: {
   toolsA?: {
+    chat?: boolean;
     wiki?: boolean;
     drive?: boolean;
+    sheets?: boolean;
     perm?: boolean;
   };
   toolsB?: {
+    chat?: boolean;
     wiki?: boolean;
     drive?: boolean;
+    sheets?: boolean;
     perm?: boolean;
   };
   defaultAccount?: string;
@@ -122,6 +145,46 @@ describe("feishu tool account routing", () => {
     const tool = resolveTool("feishu_bitable_get_meta", { agentAccountId: "b" });
     await tool.execute("call-ctx", { url: "invalid-url" });
     await tool.execute("call-override", { url: "invalid-url", accountId: "a" });
+
+    expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
+    expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");
+  });
+
+  test("sheets tool routes to agentAccountId and allows explicit accountId override", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
+    registerFeishuSheetsTools(api);
+
+    const tool = resolveTool("feishu_sheets_read_range", { agentAccountId: "b" });
+    await tool.execute("call-ctx", {
+      spreadsheet_token: "ssp",
+      sheet_id: "sh1",
+      range: "BAD",
+    });
+    await tool.execute("call-override", {
+      spreadsheet_token: "ssp",
+      sheet_id: "sh1",
+      range: "BAD",
+      accountId: "a",
+    });
+
+    expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
+    expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");
+  });
+
+  test("chat tool routes to agentAccountId and allows explicit accountId override", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig({}));
+    registerFeishuChatTools(api);
+
+    const tool = resolveTool("feishu_chat", { agentAccountId: "b" });
+    await tool.execute("call-ctx", {
+      action: "info",
+      chat_id: "oc-chat",
+    });
+    await tool.execute("call-override", {
+      action: "info",
+      chat_id: "oc-chat",
+      accountId: "a",
+    });
 
     expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
     expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -54,6 +54,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     chat: false,
     wiki: false,
     drive: false,
+    sheets: false,
     perm: false,
     scopes: false,
   };
@@ -63,6 +64,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.chat = merged.chat || cfg.chat;
     merged.wiki = merged.wiki || cfg.wiki;
     merged.drive = merged.drive || cfg.drive;
+    merged.sheets = merged.sheets || cfg.sheets;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
   }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -10,6 +10,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   chat: true,
   wiki: true,
   drive: true,
+  sheets: true,
   perm: false,
   scopes: true,
 };

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -70,6 +70,7 @@ export type FeishuToolsConfig = {
   chat?: boolean;
   wiki?: boolean;
   drive?: boolean;
+  sheets?: boolean;
   perm?: boolean;
   scopes?: boolean;
 };

--- a/extensions/feishu/src/wiki.test.ts
+++ b/extensions/feishu/src/wiki.test.ts
@@ -1,0 +1,69 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, test, vi } from "vitest";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+import { registerFeishuWikiTools } from "./wiki.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const getNodeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: (account: { appId?: string } | undefined) => {
+    return createFeishuClientMock(account);
+  },
+}));
+
+describe("feishu_wiki", () => {
+  test("get returns sheet_read_hint for sheet nodes", async () => {
+    createFeishuClientMock.mockReturnValue({
+      wiki: {
+        space: {
+          getNode: getNodeMock,
+        },
+      },
+    });
+
+    getNodeMock.mockResolvedValue({
+      code: 0,
+      data: {
+        node: {
+          node_token: "node_1",
+          space_id: "space_1",
+          obj_token: "spreadsheet_1",
+          obj_type: "sheet",
+          title: "My sheet",
+          parent_node_token: "parent_1",
+          has_child: false,
+          creator: { name: "me" },
+          node_create_time: "2026-01-01",
+        },
+      },
+    });
+
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            main: {
+              appId: "app-id",
+              appSecret: "app-secret",
+            },
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"];
+
+    const { api, resolveTool } = createToolFactoryHarness(cfg);
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki");
+    const { details } = (await tool.execute("call", {
+      action: "get",
+      token: "node_1",
+    })) as { details: Record<string, unknown> };
+
+    expect(details.obj_type).toBe("sheet");
+    expect(details.obj_token).toBe("spreadsheet_1");
+    expect(details.sheet_read_hint).toContain("Use feishu_sheets_read_range");
+  });
+});

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -71,7 +71,7 @@ async function getNode(client: Lark.Client, token: string) {
   }
 
   const node = res.data?.node;
-  return {
+  const nodeData = {
     node_token: node?.node_token,
     space_id: node?.space_id,
     obj_token: node?.obj_token,
@@ -82,6 +82,18 @@ async function getNode(client: Lark.Client, token: string) {
     creator: node?.creator,
     create_time: node?.node_create_time,
   };
+
+  if (nodeData.obj_type === "sheet" && nodeData.obj_token) {
+    return {
+      ...nodeData,
+      sheet_read_hint:
+        "Sheet content is not in this tool output. " +
+        "Use feishu_sheets_read_range and pass spreadsheet_token from obj_token. " +
+        "If the sheet has multiple tabs, use the correct sheet_id from the sheet URL or API.",
+    };
+  }
+
+  return nodeData;
 }
 
 async function createNode(


### PR DESCRIPTION
Implements issue #29595 by adding a dedicated Feishu sheet range read tool.

## Summary
- Added `feishu_sheets_read_range` tool
  - Supports `spreadsheet_token`, `sheet_id`, optional `range`, optional `include_markdown`
  - Supports `agentAccountId` and `accountId` routing
  - Returns `spreadsheet_token`, `sheet_id`, `requested_range`, `resolved_range`, `values`, `value_range`, `sheet_meta`, and optional `next_range_hint`
- Added `tools.sheets` toggle (default enabled) in tool config and schema validation
- Added validation behavior for invalid/empty ranges with explicit error path
- Added fallback range inference from sheet metadata when `range` is empty (A1:Z1000 fallback)
- Added docs and skill docs for the new tool + usage examples
- Updated `feishu_wiki` sheet responses to include guidance to call `feishu_sheets_read_range`

## Testing
- `pnpm exec vitest run --config vitest.config.ts extensions/feishu/src/config-schema.test.ts extensions/feishu/src/tool-account-routing.test.ts extensions/feishu/src/sheets.test.ts extensions/feishu/src/wiki.test.ts`
