### PR TITLE
Fix TUI crash when model search starts with 'm'

### DIFF
--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -286,9 +286,9 @@ export class SearchableSelectList implements Component {
           const highlightedDesc = this.highlightMatch(truncatedDesc, query);
           const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
           const line = `${prefix}${valueText}${spacing}${descText}`;
-    const finalLine = isSelected ? this.theme.selectedText(line) : line;
-    // Ensure the final line does not exceed terminal width
-    return truncateToWidth(finalLine, width, "");
+          const finalLine = isSelected ? this.theme.selectedText(line) : line;
+          // Ensure the final line does not exceed terminal width
+          return truncateToWidth(finalLine, width, "");
         }
       }
     }

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -286,7 +286,9 @@ export class SearchableSelectList implements Component {
           const highlightedDesc = this.highlightMatch(truncatedDesc, query);
           const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
           const line = `${prefix}${valueText}${spacing}${descText}`;
-          return isSelected ? this.theme.selectedText(line) : line;
+    const finalLine = isSelected ? this.theme.selectedText(line) : line;
+    // Ensure the final line does not exceed terminal width
+    return truncateToWidth(finalLine, width, "");
         }
       }
     }
@@ -295,7 +297,9 @@ export class SearchableSelectList implements Component {
     const truncatedValue = truncateToWidth(displayValue, maxWidth, "");
     const valueText = this.highlightMatch(truncatedValue, query);
     const line = `${prefix}${valueText}`;
-    return isSelected ? this.theme.selectedText(line) : line;
+    const finalLine = isSelected ? this.theme.selectedText(line) : line;
+    // Ensure the final line does not exceed terminal width
+    return truncateToWidth(finalLine, width, "");
   }
 
   private getDescriptionLayout(


### PR DESCRIPTION
Fixes the TUI crash that occurs when searching for models starting with the letter 'm'.

The crash was caused by rendered lines exceeding the terminal width. Added truncateToWidth() calls after applying theme styling to ensure final rendered lines never exceed terminal width.

Fixes #30156