### PR TITLE
fix(gateway): prevent /api/* routes from returning SPA HTML when basePath is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Docs: https://docs.openclaw.ai
 - Web UI/Chat sessions: add a cron-session visibility toggle in the session selector, fix cron-key detection across `cron:*` and `agent:*:cron:*` formats, and localize the new control labels/tooltips. (#26976) Thanks @ianderrington.
 - Web UI/Cron jobs: add schedule-kind and last-run-status filters to the Jobs list, with reset control and client-side filtering over loaded results. (#9510) Thanks @guxu11.
 - Web UI/Control UI WebSocket defaults: include normalized `gateway.controlUi.basePath` (or inferred nested route base path) in the default `gatewayUrl` so first-load dashboard connections work behind path-based reverse proxies. (#30228) Thanks @gittb.
+- Gateway/Control UI API routing: when `gateway.controlUi.basePath` is unset (default), stop serving Control UI SPA HTML for `/api` and `/api/*` so API paths fall through to normal gateway handlers/404 responses instead of `index.html`. (#30333) Fixes #30295. thanks @Sid-Qin.
 - Cron/One-shot reliability: retry transient one-shot failures with bounded backoff and configurable retry policy before disabling. (#24435) Thanks .
 - Gateway/Cron auditability: add gateway info logs for successful cron create, update, and remove operations. (#25090) Thanks .
 - Cron/Schedule errors: notify users when a job is auto-disabled after repeated schedule computation failures. (#29098) Thanks .

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -326,6 +326,21 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("does not handle /api paths when basePath is empty", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        for (const apiPath of ["/api", "/api/sessions", "/api/channels/nostr"]) {
+          const { handled } = runControlUiRequest({
+            url: apiPath,
+            method: "GET",
+            rootPath: tmp,
+          });
+          expect(handled, `expected ${apiPath} to not be handled`).toBe(false);
+        }
+      },
+    });
+  });
+
   it("rejects absolute-path escape attempts under basePath routes", async () => {
     await withBasePathRootFixture({
       siblingDir: "ui-secrets",

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -292,6 +292,9 @@ export function handleControlUiHttpRequest(
       respondNotFound(res);
       return true;
     }
+    if (pathname === "/api" || pathname.startsWith("/api/")) {
+      return false;
+    }
   }
 
   if (basePath) {


### PR DESCRIPTION
## Summary

- **Problem:** When `gateway.controlUi.basePath` is unset (empty string, the default), all `/api/*` HTTP requests return the Control UI SPA `index.html` instead of JSON or a proper 404. This breaks the browser UI, curl-based API usage, and Discord integration.
- **Why it matters:** Any user running OpenClaw 2026.2.26 with the default configuration cannot use HTTP API endpoints — they receive HTML instead of JSON.
- **What changed:** `src/gateway/control-ui.ts` — added an early `return false` for `/api` and `/api/*` paths in the `!basePath` branch of `handleControlUiHttpRequest`, so these paths fall through to the gateway's normal handler chain and ultimately reach the 404 handler.
- **What did NOT change:** When `basePath` is set (e.g. `/webchat`), the existing guard at line 305 already excludes non-basePath paths. The SPA fallback for legitimate UI routes is unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30295

## User-visible / Behavior Changes

- `/api/*` HTTP requests now correctly return 404 (or the appropriate API response) instead of HTML when `basePath` is empty.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Control UI, curl, Discord

### Steps

1. Run OpenClaw with default config (no `gateway.controlUi.basePath` set)
2. `curl http://127.0.0.1:18789/api/sessions`

### Expected

- JSON response or `404 Not Found` (plain text)

### Actual

- Before fix: `200 OK` with HTML (`<!doctype html>...`)
- After fix: `404 Not Found` (plain text)

## Evidence

```
 ✓ src/gateway/control-ui.http.test.ts (13 tests) 17ms
   ✓ does not handle /api paths when basePath is empty
   ... (12 existing tests still pass)
```

## Human Verification (required)

- Verified scenarios: `/api`, `/api/sessions`, `/api/channels/nostr` all return `handled: false` when basePath is empty
- Edge cases checked: Existing SPA routes still served correctly; basePath-configured instances unaffected
- What I did **not** verify: End-to-end with a running gateway instance

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/gateway/control-ui.ts`
- Known bad symptoms: `/api/*` returns HTML again

## Risks and Mitigations

None — this restores the expected behavior where the Control UI handler only serves SPA content for UI paths.

