### PR TITLE
fix(tui): prevent crash when model search starts with "m"

### DIFF
--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -1,5 +1,6 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
 import { describe, expect, it } from "vitest";
-import { stripAnsi, visibleWidth } from "../../terminal/ansi.js";
+import { stripAnsi } from "../../terminal/ansi.js";
 import { SearchableSelectList, type SearchableSelectListTheme } from "./searchable-select-list.js";
 
 const mockTheme: SearchableSelectListTheme = {

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -7,8 +7,9 @@ import {
   type SelectItem,
   type SelectListTheme,
   truncateToWidth,
+  visibleWidth,
 } from "@mariozechner/pi-tui";
-import { stripAnsi, visibleWidth } from "../../terminal/ansi.js";
+import { stripAnsi } from "../../terminal/ansi.js";
 import { findWordBoundaryIndex, fuzzyFilterLower } from "./fuzzy-filter.js";
 
 const ANSI_ESCAPE = String.fromCharCode(27);
@@ -255,7 +256,13 @@ export class SearchableSelectList implements Component {
       lines.push(this.theme.scrollInfo(`  ${scrollInfo}`));
     }
 
-    return lines;
+    // Defensive: ensure no line exceeds the declared render width.
+    // The pi-tui framework crashes if a component returns lines wider than
+    // the width passed to render(). Guard against any width-calculation drift
+    // between ANSI-heavy content and the framework's own visibleWidth().
+    return lines.map((line) =>
+      visibleWidth(line) > width ? truncateToWidth(line, width, "") : line,
+    );
   }
 
   private renderItemLine(


### PR DESCRIPTION
Fixes #30156

## Summary

Typing "m" in the TUI model search crashes with "Rendered line exceeds terminal width".

## Root Cause

SearchableSelectList used a local visibleWidth (code-point counting after SGR strip) for its internal width math, but pi-tui validates lines with its own visibleWidth (grapheme segmentation + eastAsianWidth). When the two disagree on ANSI-heavy highlighted text, the component returns lines the framework considers wider than the declared render width, triggering the crash.

## Fix

1. **Import visibleWidth from pi-tui** instead of the local implementation, ensuring width calculations are consistent with the framework.
2. **Add a defensive truncation pass** at the end of render -- every returned line is clamped to the declared width via truncateToWidth, preventing crashes even in edge cases.

## Testing

All 19 existing searchable-select-list tests pass. Test file also updated to use pi-tui visibleWidth for consistency.