### PR TITLE
fix(cron): allow message tool in agentTurn when delivery mode is none

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -470,7 +470,7 @@ export async function runCronIsolatedAgentTurn(params: {
           // was successfully resolved. When resolution fails the agent should not
           // be blocked by a target it cannot satisfy (#27898).
           requireExplicitMessageTarget: deliveryRequested && resolvedDelivery.ok,
-          disableMessageTool: deliveryRequested || deliveryPlan.mode === "none",
+          disableMessageTool: deliveryRequested,
           abortSignal,
         });
       },


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs with `payload.kind: "agentTurn"` and `delivery.mode: "none"` cannot execute tool calls (specifically the message tool) even when the agent prompt explicitly instructs it to send messages. The message tool is unconditionally disabled whenever `delivery.mode` is `"none"`.
- **Why it matters:** Users who set `delivery.mode: "none"` intend to bypass the built-in cron delivery mechanism, not to prevent the agent from sending messages autonomously via tools. This blocks a valid use case: scheduling an agent to proactively send messages to specific Telegram/Discord targets.
- **What changed:** `src/cron/isolated-agent/run.ts` — removed the `|| deliveryPlan.mode === "none"` condition from `disableMessageTool`. The message tool is now only disabled when an active delivery mechanism (announce/webhook) is configured, preventing double-sends while still allowing tool-based messaging when delivery is off.
- **What did NOT change:** The `requireExplicitMessageTarget` logic, delivery dispatch flow, CLI runner tool policy, and announce/webhook delivery paths are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30052

## User-visible / Behavior Changes

- Cron `agentTurn` jobs with `delivery.mode: "none"` can now use the message tool to send messages directly (e.g. to Telegram targets), as instructed by the prompt.

## Security Impact (required)

- New permissions/capabilities? `No` — the message tool was already available in other cron contexts; this restores it for `delivery.mode: "none"`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — message tool was already gated by other controls (requireExplicitMessageTarget, channel auth)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js
- Integration/channel: Telegram (or any channel with message tool)

### Steps

1. Create a cron job: `payload.kind: "agentTurn"`, `delivery: { "mode": "none" }`, prompt: "Use the message tool to send 'Test' to Telegram target ID 123"
2. Wait for scheduled time

### Expected

- Agent executes the message tool call and sends the Telegram message

### Actual

- Before fix: Agent cannot call message tool; returns text response only; `delivered: false`
- After fix: Agent can call message tool and send the message directly

## Evidence

```
Before: disableMessageTool: deliveryRequested || deliveryPlan.mode === "none"
After:  disableMessageTool: deliveryRequested

When delivery.mode === "none":
  deliveryRequested = false (from resolveCronDeliveryPlan)
  Before: disableMessageTool = false || true = true  ← BUG
  After:  disableMessageTool = false                  ← FIXED
```

Existing delivery tests pass:
```
 ✓ src/cron/delivery.test.ts (5 tests) 2ms
 ✓ src/cron/service.delivery-plan.test.ts (3 tests) 19ms
```

## Human Verification (required)

- Verified scenarios: `delivery.mode: "none"` → message tool enabled; `delivery.mode: "announce"` → message tool still disabled (prevents double-send)
- Edge cases checked: No delivery field at all → `deliveryRequested` is false → message tool enabled (same as "none")
- What I did **not** verify: End-to-end cron job execution with live Telegram delivery

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: Agent sends duplicate messages (if delivery mechanism is also active — but this only changes behavior when delivery is `"none"`)

## Risks and Mitigations

- Risk: Agent sends unwanted messages when `delivery.mode: "none"` — mitigated by the fact that the user explicitly prompts the agent to use the message tool; the tool also requires valid channel auth.

