### PR TITLE
fix(secrets): include stderr and stdin-hint in exec provider error for exit code 2

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -545,8 +545,16 @@ async function resolveExecRefs(params: {
     );
   }
   if (result.code !== 0) {
+    const stderrSnippet = result.stderr?.trim().slice(0, 512);
+    const hint =
+      result.code === 2
+        ? " Exit code 2 typically means the command received invalid arguments or does not read stdin. " +
+          "OpenClaw sends a JSON batch request via stdin; if the command does not support this, " +
+          "wrap it in a script that reads stdin and invokes the command per-ID (see docs/gateway/secrets.md)."
+        : "";
     throw new Error(
-      `Exec provider "${params.providerName}" exited with code ${String(result.code)}.`,
+      `Exec provider "${params.providerName}" exited with code ${String(result.code)}.${hint}` +
+        (stderrSnippet ? ` stderr: ${stderrSnippet}` : ""),
     );
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** When an exec secret provider exits with a non-zero code (e.g. Vault CLI exiting with code 2 because it doesn't read stdin), the error message is opaque: `Exec provider "vault_local" exited with code 2`. No stderr output, no hint about what went wrong.
- **Why it matters:** Users configuring HashiCorp Vault CLI (or similar tools that don't support stdin batch mode) see a cryptic error with no guidance. The issue reporter spent significant time debugging before realizing the CLI doesn't support stdin.
- **What changed:** `src/secrets/resolve.ts` — the non-zero exit code error now includes: (1) stderr output (first 512 bytes) for all exit codes, and (2) a specific hint for exit code 2 explaining that the command may not support stdin batch mode and suggesting a wrapper script.
- **What did NOT change:** The exec provider's batch protocol, configuration schema, and normal success path are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29723

## User-visible / Behavior Changes

- Error messages for exec provider failures now include stderr output and (for exit code 2) a hint about stdin/batch mode.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — only error message formatting
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js
- Integration/channel: Secrets / exec provider

### Steps

1. Configure exec provider with a command that exits with code 2 (e.g. Vault CLI)
2. Start gateway

### Expected

- Clear error message with stderr and hint about stdin support

### Actual

- Before fix: `Exec provider "vault_local" exited with code 2.`
- After fix: `Exec provider "vault_local" exited with code 2. Exit code 2 typically means the command received invalid arguments or does not read stdin. OpenClaw sends a JSON batch request via stdin; if the command does not support this, wrap it in a script that reads stdin and invokes the command per-ID (see docs/gateway/secrets.md). stderr: <actual stderr output>`

## Evidence

```
 ✓ src/secrets/resolve.test.ts (16 tests) 4655ms
   ✓ includes stderr and stdin hint when exec provider exits with code 2
   ✓ includes stderr for non-2 exit codes without the stdin hint
   ... (14 existing tests still pass)
```

## Human Verification (required)

- Verified scenarios: Exit code 2 with stderr, exit code 1 with stderr (no stdin hint), all existing exec provider tests
- Edge cases checked: Empty stderr (no "stderr:" suffix added)
- What I did **not** verify: End-to-end with HashiCorp Vault CLI

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/secrets/resolve.ts`
- Known bad symptoms: Error messages revert to opaque format

## Risks and Mitigations

None — this only changes error message formatting for failure paths.

