### PR TITLE
fix(ui): make cron Edit Job panel scrollable on desktop

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -608,6 +608,9 @@
 .cron-workspace-form {
   position: sticky;
   top: 74px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .cron-form {


### PR DESCRIPTION
## Summary

- Fixes the sticky Edit Job panel on the Cron page being non-scrollable when form content exceeds viewport height

**Root cause:** `.cron-workspace-form` only had `position: sticky; top: 74px;` with no `max-height` or `overflow-y`, so content below the fold was unreachable.

**Fix:** Add `max-height: calc(100vh - 90px)`, `overflow-y: auto`, and `overscroll-behavior: contain`.

## Changes

- `ui/src/styles/components.css`: Add scroll properties to `.cron-workspace-form`

## Test plan

- [ ] Open Control UI → Cron → Edit a job with many fields
- [ ] Verify the right panel scrolls independently on desktop
- [ ] Verify mobile layout (< 1100px) is unaffected

Fixes #30155