### PR TITLE
fix(web): honor proxy env vars for WhatsApp websocket

### DIFF
--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -21,6 +21,33 @@ async function emitCredsUpdateAndReadSaveCreds() {
   return saveCreds;
 }
 
+const proxyEnvKeys = [
+  "OPENCLAW_WHATSAPP_PROXY",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "ALL_PROXY",
+  "https_proxy",
+  "http_proxy",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+] as const;
+
+function snapshotProxyEnv() {
+  return Object.fromEntries(proxyEnvKeys.map((k) => [k, process.env[k]]));
+}
+
+function restoreProxyEnv(snapshot: Record<string, string | undefined>) {
+  for (const key of proxyEnvKeys) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
 function mockCredsJsonSpies(readContents: string) {
   const credsSuffix = path.join(".openclaw", "credentials", "whatsapp", "default", "creds.json");
   const copySpy = vi.spyOn(fsSync, "copyFileSync").mockImplementation(() => {});
@@ -86,7 +113,7 @@ describe("web session", () => {
   });
 
   it("passes proxy agent when OPENCLAW_WHATSAPP_PROXY is set", async () => {
-    const prev = process.env.OPENCLAW_WHATSAPP_PROXY;
+    const prev = snapshotProxyEnv();
     process.env.OPENCLAW_WHATSAPP_PROXY = "http://127.0.0.1:7899";
     try {
       await createWaSocket(false, false);
@@ -94,26 +121,13 @@ describe("web session", () => {
       const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
       expect(passed?.agent).toBeTruthy();
     } finally {
-      if (prev === undefined) {
-        delete process.env.OPENCLAW_WHATSAPP_PROXY;
-      } else {
-        process.env.OPENCLAW_WHATSAPP_PROXY = prev;
-      }
+      restoreProxyEnv(prev);
     }
   });
 
   it("passes proxy agent when lowercase proxy env is set", async () => {
-    const keys = [
-      "OPENCLAW_WHATSAPP_PROXY",
-      "HTTPS_PROXY",
-      "HTTP_PROXY",
-      "ALL_PROXY",
-      "https_proxy",
-      "http_proxy",
-      "all_proxy",
-    ] as const;
-    const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
-    for (const key of keys) {
+    const prev = snapshotProxyEnv();
+    for (const key of proxyEnvKeys) {
       delete process.env[key];
     }
     process.env.https_proxy = "http://127.0.0.1:7899";
@@ -123,14 +137,40 @@ describe("web session", () => {
       const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
       expect(passed?.agent).toBeTruthy();
     } finally {
-      for (const key of keys) {
-        const value = prev[key];
-        if (value === undefined) {
-          delete process.env[key];
-        } else {
-          process.env[key] = value;
-        }
-      }
+      restoreProxyEnv(prev);
+    }
+  });
+
+  it("does not pass proxy agent when NO_PROXY excludes web.whatsapp.com", async () => {
+    const prev = snapshotProxyEnv();
+    for (const key of proxyEnvKeys) {
+      delete process.env[key];
+    }
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7899";
+    process.env.NO_PROXY = "localhost,web.whatsapp.com";
+    try {
+      await createWaSocket(false, false);
+      const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+      const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
+      expect(passed?.agent).toBeFalsy();
+    } finally {
+      restoreProxyEnv(prev);
+    }
+  });
+
+  it("ignores invalid proxy env without throwing", async () => {
+    const prev = snapshotProxyEnv();
+    for (const key of proxyEnvKeys) {
+      delete process.env[key];
+    }
+    process.env.OPENCLAW_WHATSAPP_PROXY = "bad-proxy";
+    try {
+      await expect(createWaSocket(false, false)).resolves.toBeTruthy();
+      const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+      const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
+      expect(passed?.agent).toBeFalsy();
+    } finally {
+      restoreProxyEnv(prev);
     }
   });
 

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -102,6 +102,38 @@ describe("web session", () => {
     }
   });
 
+  it("passes proxy agent when lowercase proxy env is set", async () => {
+    const keys = [
+      "OPENCLAW_WHATSAPP_PROXY",
+      "HTTPS_PROXY",
+      "HTTP_PROXY",
+      "ALL_PROXY",
+      "https_proxy",
+      "http_proxy",
+      "all_proxy",
+    ] as const;
+    const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    for (const key of keys) {
+      delete process.env[key];
+    }
+    process.env.https_proxy = "http://127.0.0.1:7899";
+    try {
+      await createWaSocket(false, false);
+      const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+      const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
+      expect(passed?.agent).toBeTruthy();
+    } finally {
+      for (const key of keys) {
+        const value = prev[key];
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
   it("waits for connection open", async () => {
     const ev = new EventEmitter();
     const promise = waitForWaConnection({ ev } as unknown as ReturnType<

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -85,6 +85,23 @@ describe("web session", () => {
     expect(saveCreds).toHaveBeenCalled();
   });
 
+  it("passes proxy agent when OPENCLAW_WHATSAPP_PROXY is set", async () => {
+    const prev = process.env.OPENCLAW_WHATSAPP_PROXY;
+    process.env.OPENCLAW_WHATSAPP_PROXY = "http://127.0.0.1:7899";
+    try {
+      await createWaSocket(false, false);
+      const makeWASocket = baileys.makeWASocket as ReturnType<typeof vi.fn>;
+      const passed = makeWASocket.mock.calls.at(-1)?.[0] as { agent?: unknown } | undefined;
+      expect(passed?.agent).toBeTruthy();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.OPENCLAW_WHATSAPP_PROXY;
+      } else {
+        process.env.OPENCLAW_WHATSAPP_PROXY = prev;
+      }
+    }
+  });
+
   it("waits for connection open", async () => {
     const ev = new EventEmitter();
     const promise = waitForWaConnection({ ev } as unknown as ReturnType<

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -110,7 +110,10 @@ export async function createWaSocket(
     process.env.OPENCLAW_WHATSAPP_PROXY ??
     process.env.HTTPS_PROXY ??
     process.env.HTTP_PROXY ??
-    process.env.ALL_PROXY;
+    process.env.ALL_PROXY ??
+    process.env.https_proxy ??
+    process.env.http_proxy ??
+    process.env.all_proxy;
   const sock = makeWASocket({
     auth: {
       creds: state.creds,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -33,6 +33,63 @@ export {
 } from "./auth-store.js";
 
 let credsSaveQueue: Promise<void> = Promise.resolve();
+
+const WA_PROXY_TARGET_HOST = "web.whatsapp.com";
+
+function resolveWaProxyUrlFromEnv(): string | undefined {
+  return (
+    process.env.OPENCLAW_WHATSAPP_PROXY ??
+    process.env.HTTPS_PROXY ??
+    process.env.HTTP_PROXY ??
+    process.env.ALL_PROXY ??
+    process.env.https_proxy ??
+    process.env.http_proxy ??
+    process.env.all_proxy
+  );
+}
+
+function resolveNoProxyFromEnv(): string | undefined {
+  return process.env.NO_PROXY ?? process.env.no_proxy;
+}
+
+function noProxyTokenMatchesHost(token: string, host: string): boolean {
+  const normalizedHost = host.toLowerCase();
+  let normalizedToken = token.trim().toLowerCase();
+  if (!normalizedToken) {
+    return false;
+  }
+  if (normalizedToken === "*") {
+    return true;
+  }
+  if (normalizedToken.includes("/")) {
+    return false;
+  }
+  if (normalizedToken.startsWith("*.")) {
+    normalizedToken = normalizedToken.slice(2);
+  }
+  if (normalizedToken.startsWith(".")) {
+    normalizedToken = normalizedToken.slice(1);
+  }
+  const colonIdx = normalizedToken.lastIndexOf(":");
+  if (colonIdx > 0 && !normalizedToken.includes("]")) {
+    normalizedToken = normalizedToken.slice(0, colonIdx);
+  }
+  if (!normalizedToken) {
+    return false;
+  }
+  return normalizedHost === normalizedToken || normalizedHost.endsWith(`.${normalizedToken}`);
+}
+
+function shouldBypassWaProxy(noProxyRaw: string | undefined): boolean {
+  if (!noProxyRaw) {
+    return false;
+  }
+  return noProxyRaw
+    .split(",")
+    .map((token) => token.trim())
+    .some((token) => noProxyTokenMatchesHost(token, WA_PROXY_TARGET_HOST));
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
@@ -106,21 +163,27 @@ export async function createWaSocket(
   maybeRestoreCredsFromBackup(authDir);
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
-  const proxyUrl =
-    process.env.OPENCLAW_WHATSAPP_PROXY ??
-    process.env.HTTPS_PROXY ??
-    process.env.HTTP_PROXY ??
-    process.env.ALL_PROXY ??
-    process.env.https_proxy ??
-    process.env.http_proxy ??
-    process.env.all_proxy;
+  const proxyUrl = resolveWaProxyUrlFromEnv();
+  const noProxyRaw = resolveNoProxyFromEnv();
+  const bypassProxy = shouldBypassWaProxy(noProxyRaw);
+  let proxyAgent: HttpsProxyAgent<string> | undefined;
+  if (proxyUrl && !bypassProxy) {
+    try {
+      proxyAgent = new HttpsProxyAgent(proxyUrl);
+    } catch (err) {
+      sessionLogger.warn(
+        { error: String(err) },
+        "invalid WhatsApp proxy URL; continuing without proxy",
+      );
+    }
+  }
   const sock = makeWASocket({
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),
     },
     version,
-    ...(proxyUrl ? { agent: new HttpsProxyAgent(proxyUrl) } : {}),
+    ...(proxyAgent ? { agent: proxyAgent } : {}),
     logger,
     printQRInTerminal: false,
     browser: ["openclaw", "cli", VERSION],

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -7,6 +7,7 @@ import {
   makeWASocket,
   useMultiFileAuthState,
 } from "@whiskeysockets/baileys";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import qrcode from "qrcode-terminal";
 import { formatCliCommand } from "../cli/command-format.js";
 import { danger, success } from "../globals.js";
@@ -105,12 +106,18 @@ export async function createWaSocket(
   maybeRestoreCredsFromBackup(authDir);
   const { state, saveCreds } = await useMultiFileAuthState(authDir);
   const { version } = await fetchLatestBaileysVersion();
+  const proxyUrl =
+    process.env.OPENCLAW_WHATSAPP_PROXY ??
+    process.env.HTTPS_PROXY ??
+    process.env.HTTP_PROXY ??
+    process.env.ALL_PROXY;
   const sock = makeWASocket({
     auth: {
       creds: state.creds,
       keys: makeCacheableSignalKeyStore(state.keys, logger),
     },
     version,
+    ...(proxyUrl ? { agent: new HttpsProxyAgent(proxyUrl) } : {}),
     logger,
     printQRInTerminal: false,
     browser: ["openclaw", "cli", VERSION],


### PR DESCRIPTION
## Summary
- add proxy support when creating WhatsApp socket in src/web/session.ts
- use OPENCLAW_WHATSAPP_PROXY first, then fallback to HTTPS_PROXY / HTTP_PROXY / ALL_PROXY
- add unit test to verify an agent is passed to makeWASocket when proxy env is set

## Why
Users in restricted networks can load QR but fail on WhatsApp websocket handshake unless proxy is explicitly applied to the socket layer.

## Validation
- corepack pnpm exec vitest run --config vitest.unit.config.ts src/web/session.test.ts
- corepack pnpm exec oxfmt --check src/web/session.ts src/web/session.test.ts
- corepack pnpm exec oxlint --type-aware src/web/session.ts src/web/session.test.ts

Fixes #30303