### PR TITLE
feat(channels): add real-time tool activity status messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -359,6 +359,9 @@ export async function runAgentTurnWithFallback(params: {
                   await params.typingSignals.signalToolStart();
                   await params.opts?.onToolStart?.({ name, phase });
                 }
+                if (phase === "end") {
+                  await params.opts?.onToolEnd?.({ name });
+                }
               }
               // Track auto-compaction completion
               if (evt.stream === "compaction") {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -52,6 +52,8 @@ export type GetReplyOptions = {
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
   onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  /** Called when a tool execution completes. */
+  onToolEnd?: (payload: { name?: string }) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/channels/tool-activity-status.test.ts
+++ b/src/channels/tool-activity-status.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createToolActivityStatusController,
+  type ToolActivityAdapter,
+} from "./tool-activity-status.js";
+
+function createMockAdapter(): ToolActivityAdapter & {
+  calls: { method: string; args: unknown[] }[];
+} {
+  const calls: { method: string; args: unknown[] }[] = [];
+  return {
+    calls,
+    sendMessage: async (text: string) => {
+      calls.push({ method: "sendMessage", args: [text] });
+      return "msg-1";
+    },
+    editMessage: async (messageId: string, text: string) => {
+      calls.push({ method: "editMessage", args: [messageId, text] });
+    },
+    deleteMessage: async (messageId: string) => {
+      calls.push({ method: "deleteMessage", args: [messageId] });
+    },
+  };
+}
+
+describe("createToolActivityStatusController", () => {
+  it("returns no-op controller when level is off", () => {
+    const adapter = createMockAdapter();
+    const ctrl = createToolActivityStatusController({ adapter, level: "off" });
+    ctrl.onToolStart("exec");
+    ctrl.onToolEnd("exec");
+    expect(adapter.calls).toHaveLength(0);
+  });
+
+  it("sends a message on first tool start", async () => {
+    vi.useFakeTimers();
+    const adapter = createMockAdapter();
+    const ctrl = createToolActivityStatusController({ adapter, level: "minimal" });
+    ctrl.onToolStart("exec");
+    // Flush the debounce timer
+    await vi.advanceTimersByTimeAsync(500);
+    expect(adapter.calls.length).toBeGreaterThanOrEqual(1);
+    expect(adapter.calls[0].method).toBe("sendMessage");
+    vi.useRealTimers();
+  });
+
+  it("edits message on subsequent tool starts", async () => {
+    vi.useFakeTimers();
+    const adapter = createMockAdapter();
+    const ctrl = createToolActivityStatusController({ adapter, level: "minimal" });
+    ctrl.onToolStart("exec");
+    await vi.advanceTimersByTimeAsync(500);
+    ctrl.onToolEnd("exec");
+    ctrl.onToolStart("web_search");
+    await vi.advanceTimersByTimeAsync(500);
+    const editCalls = adapter.calls.filter((c) => c.method === "editMessage");
+    expect(editCalls.length).toBeGreaterThanOrEqual(1);
+    vi.useRealTimers();
+  });
+
+  it("cleanup deletes message when all tools completed", async () => {
+    vi.useFakeTimers();
+    const adapter = createMockAdapter();
+    const ctrl = createToolActivityStatusController({ adapter, level: "minimal" });
+    ctrl.onToolStart("exec");
+    await vi.advanceTimersByTimeAsync(500);
+    ctrl.onToolEnd("exec");
+    await vi.advanceTimersByTimeAsync(500);
+    await ctrl.cleanup();
+    await vi.advanceTimersByTimeAsync(3000);
+    const deleteCalls = adapter.calls.filter((c) => c.method === "deleteMessage");
+    expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+    vi.useRealTimers();
+  });
+});

--- a/src/channels/tool-activity-status.ts
+++ b/src/channels/tool-activity-status.ts
@@ -1,0 +1,263 @@
+import { resolveToolDisplay } from "../agents/tool-display.js";
+
+export interface ToolActivityAdapter {
+  sendMessage(text: string): Promise<string>;
+  editMessage(messageId: string, text: string): Promise<void>;
+  deleteMessage(messageId: string): Promise<void>;
+}
+
+export type ToolActivityLevel = "off" | "minimal" | "detailed";
+
+interface ToolEntry {
+  name: string;
+  displayName: string;
+  emoji: string;
+  meta?: string;
+  completed: boolean;
+}
+
+export interface ToolActivityStatusController {
+  onToolStart(toolName: string, meta?: string): void;
+  onToolEnd(toolName: string): void;
+  cleanup(): Promise<void>;
+}
+
+const MIN_EDIT_GAP_MS = 300;
+const FINAL_DELETE_DELAY_MS = 2000;
+
+function normalizeLevel(level: ToolActivityLevel | undefined): ToolActivityLevel {
+  if (level === "detailed" || level === "minimal" || level === "off") {
+    return level;
+  }
+  return "off";
+}
+
+function normalizeToolName(value: string | undefined): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  return raw.length > 0 ? raw : "tool";
+}
+
+function formatStatusMeta(meta: string): string {
+  const trimmed = meta.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.includes("`")) {
+    return trimmed;
+  }
+  return `\`${trimmed}\``;
+}
+
+function formatStatusSegment(entry: ToolEntry, level: ToolActivityLevel): string {
+  const icon = entry.completed ? "✅" : "🔧";
+  if (level !== "detailed" || !entry.meta?.trim()) {
+    return `${icon} ${entry.displayName}`;
+  }
+  const formattedMeta = formatStatusMeta(entry.meta);
+  if (!formattedMeta) {
+    return `${icon} ${entry.displayName}`;
+  }
+  return `${icon} ${entry.displayName}: ${formattedMeta}`;
+}
+
+function formatStatusLine(tools: ToolEntry[], level: ToolActivityLevel): string {
+  const normalizedLevel = normalizeLevel(level);
+  if (normalizedLevel === "off" || tools.length === 0) {
+    return "";
+  }
+  return tools.map((entry) => formatStatusSegment(entry, normalizedLevel)).join(" · ");
+}
+
+export function createToolActivityStatusController(params: {
+  adapter: ToolActivityAdapter;
+  level: ToolActivityLevel;
+  onError?: (err: unknown) => void;
+}): ToolActivityStatusController {
+  const level = normalizeLevel(params.level);
+
+  if (level === "off") {
+    return {
+      onToolStart: () => {},
+      onToolEnd: () => {},
+      cleanup: async () => {},
+    };
+  }
+
+  let tools: ToolEntry[] = [];
+  let messageId: string | null = null;
+  let lastRenderedLine = "";
+  let pendingLine = "";
+  let lastMutationAt = 0;
+  let debounceTimer: NodeJS.Timeout | null = null;
+  let finalDeleteTimer: NodeJS.Timeout | null = null;
+  let disposed = false;
+  let chainPromise = Promise.resolve();
+
+  const reportError = (err: unknown) => {
+    try {
+      params.onError?.(err);
+    } catch {
+      // Never allow error hooks to break message flow.
+    }
+  };
+
+  const enqueue = (fn: () => Promise<void>): Promise<void> => {
+    chainPromise = chainPromise.then(fn, fn);
+    return chainPromise.catch((err) => {
+      reportError(err);
+    });
+  };
+
+  const clearDebounceTimer = () => {
+    if (!debounceTimer) {
+      return;
+    }
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  };
+
+  const clearFinalDeleteTimer = () => {
+    if (!finalDeleteTimer) {
+      return;
+    }
+    clearTimeout(finalDeleteTimer);
+    finalDeleteTimer = null;
+  };
+
+  const renderPending = (immediate = false) => {
+    if (disposed) {
+      return;
+    }
+    pendingLine = formatStatusLine(tools, level);
+    if (!pendingLine) {
+      return;
+    }
+
+    const flush = () => {
+      debounceTimer = null;
+      const line = pendingLine;
+      if (!line || line === lastRenderedLine || disposed) {
+        return;
+      }
+
+      void enqueue(async () => {
+        if (disposed) {
+          return;
+        }
+        try {
+          if (!messageId) {
+            messageId = await params.adapter.sendMessage(line);
+          } else {
+            await params.adapter.editMessage(messageId, line);
+          }
+          lastRenderedLine = line;
+          lastMutationAt = Date.now();
+        } catch (err) {
+          reportError(err);
+        }
+      });
+    };
+
+    if (immediate) {
+      clearDebounceTimer();
+      flush();
+      return;
+    }
+
+    const elapsed = Date.now() - lastMutationAt;
+    const waitMs = Math.max(0, MIN_EDIT_GAP_MS - elapsed);
+    if (debounceTimer) {
+      return;
+    }
+    debounceTimer = setTimeout(flush, waitMs);
+  };
+
+  const scheduleFinalDelete = () => {
+    clearFinalDeleteTimer();
+    finalDeleteTimer = setTimeout(() => {
+      void cleanupInternal();
+    }, FINAL_DELETE_DELAY_MS);
+  };
+
+  const cleanupInternal = async (): Promise<void> => {
+    clearDebounceTimer();
+    clearFinalDeleteTimer();
+    disposed = true;
+    tools = [];
+    pendingLine = "";
+
+    await enqueue(async () => {
+      if (!messageId) {
+        return;
+      }
+      const currentMessageId = messageId;
+      messageId = null;
+      lastRenderedLine = "";
+      try {
+        await params.adapter.deleteMessage(currentMessageId);
+      } catch (err) {
+        reportError(err);
+      }
+    });
+  };
+
+  const upsertStart = (toolName: string, meta?: string) => {
+    const display = resolveToolDisplay({ name: toolName, meta });
+    const normalizedName = normalizeToolName(display.name || toolName);
+    const normalizedMeta =
+      typeof display.detail === "string"
+        ? display.detail.trim() || undefined
+        : typeof meta === "string"
+          ? meta.trim() || undefined
+          : undefined;
+    const existing = tools.find((entry) => !entry.completed && entry.name === normalizedName);
+    if (existing) {
+      existing.meta = normalizedMeta || existing.meta;
+      existing.displayName = existing.displayName || normalizedName;
+      existing.emoji = existing.emoji || display.emoji;
+      return;
+    }
+    tools.push({
+      name: normalizedName,
+      displayName: normalizedName,
+      emoji: display.emoji,
+      meta: normalizedMeta,
+      completed: false,
+    });
+  };
+
+  const markEnd = (toolName: string) => {
+    const normalizedName = normalizeToolName(toolName);
+    const matching = tools.find((entry) => !entry.completed && entry.name === normalizedName);
+    if (matching) {
+      matching.completed = true;
+      return;
+    }
+    const fallback = tools.find((entry) => !entry.completed);
+    if (fallback) {
+      fallback.completed = true;
+    }
+  };
+
+  return {
+    onToolStart: (toolName, meta) => {
+      if (disposed) {
+        return;
+      }
+      clearFinalDeleteTimer();
+      upsertStart(toolName, meta);
+      renderPending(!messageId);
+    },
+    onToolEnd: (toolName) => {
+      if (disposed) {
+        return;
+      }
+      markEnd(toolName);
+      renderPending(true);
+      if (tools.length > 0 && tools.every((entry) => entry.completed)) {
+        scheduleFinalDelete();
+      }
+    },
+    cleanup: cleanupInternal,
+  };
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1337,6 +1337,8 @@ export const FIELD_HELP: Record<string, string> = {
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
+  "messages.toolActivityStatus":
+    "Show real-time tool execution status as an editable message in the chat. off = disabled, minimal = tool names only (default), detailed = tool names with metadata.",
   "messages.statusReactions":
     "Lifecycle status reactions that update the emoji on the trigger message as the agent progresses (queued → thinking → tool → done/error).",
   "messages.statusReactions.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -617,6 +617,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.removeAckAfterReply": "Remove Ack Reaction After Reply",
   "messages.statusReactions": "Status Reactions",
+  "messages.toolActivityStatus": "Tool Activity Status",
   "messages.statusReactions.enabled": "Enable Status Reactions",
   "messages.statusReactions.emojis": "Status Reaction Emojis",
   "messages.statusReactions.timing": "Status Reaction Timing",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -117,6 +117,12 @@ export type MessagesConfig = {
   removeAckAfterReply?: boolean;
   /** Lifecycle status reactions configuration. */
   statusReactions?: StatusReactionsConfig;
+  /** Real-time tool activity status messages. Shows what tools the AI is executing.
+   * - "off": disabled
+   * - "minimal": show tool name only (default; e.g., "🔧 exec")
+   * - "detailed": show tool name + meta (e.g., "🔧 exec: `ls -la`")
+   */
+  toolActivityStatus?: "off" | "minimal" | "detailed";
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -183,6 +183,7 @@ export const MessagesSchema = z
       })
       .strict()
       .optional(),
+    toolActivityStatus: z.enum(["off", "minimal", "detailed"]).optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
   })

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -13,6 +13,10 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import { removeAckReactionAfterReply } from "../channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../channels/logging.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+import {
+  createToolActivityStatusController,
+  type ToolActivityLevel,
+} from "../channels/tool-activity-status.js";
 import { createTypingCallbacks } from "../channels/typing.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
@@ -446,6 +450,54 @@ export const dispatchTelegramMessage = async ({
     void statusReactionController.setThinking();
   }
 
+  // Tool activity status: editable message showing current tool execution.
+  const toolActivityLevel: ToolActivityLevel = cfg.messages?.toolActivityStatus ?? "minimal";
+  const toolActivityController =
+    toolActivityLevel !== "off"
+      ? createToolActivityStatusController({
+          adapter: {
+            sendMessage: async (text) => {
+              const threadParams = threadSpec?.id
+                ? { message_thread_id: threadSpec.id }
+                : undefined;
+              const sent = await bot.api.sendMessage(chatId, text, {
+                ...threadParams,
+                disable_notification: true,
+              });
+              return String(sent.message_id);
+            },
+            editMessage: async (messageId, text) => {
+              const parsedMessageId = Number(messageId);
+              if (!Number.isFinite(parsedMessageId)) {
+                return;
+              }
+              await bot.api.editMessageText(chatId, parsedMessageId, text);
+            },
+            deleteMessage: async (messageId) => {
+              const parsedMessageId = Number(messageId);
+              if (!Number.isFinite(parsedMessageId)) {
+                return;
+              }
+              await bot.api.deleteMessage(chatId, parsedMessageId);
+            },
+          },
+          level: toolActivityLevel,
+          onError: (err) => {
+            logVerbose(`telegram: tool activity status error: ${String(err)}`);
+          },
+        })
+      : undefined;
+  let toolActivityClearedForReply = false;
+  const clearToolActivityForReply = () => {
+    if (!toolActivityController || toolActivityClearedForReply) {
+      return;
+    }
+    toolActivityClearedForReply = true;
+    void toolActivityController.cleanup().catch((err) => {
+      logVerbose(`telegram: tool activity cleanup failed: ${String(err)}`);
+    });
+  };
+
   const typingCallbacks = createTypingCallbacks({
     start: sendTyping,
     onStartError: (err) => {
@@ -471,6 +523,9 @@ export const dispatchTelegramMessage = async ({
           )?.buttons;
           const split = splitTextIntoLaneSegments(payload.text);
           const segments = split.segments;
+          if (segments.some((segment) => segment.text.trim().length > 0)) {
+            clearToolActivityForReply();
+          }
           const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
 
           const flushBufferedFinalAnswer = async () => {
@@ -575,7 +630,13 @@ export const dispatchTelegramMessage = async ({
         disableBlockStreaming,
         onPartialReply:
           answerLane.stream || reasoningLane.stream
-            ? (payload) => ingestDraftLaneSegments(payload.text)
+            ? (payload) => {
+                const split = splitTextIntoLaneSegments(payload.text);
+                if (split.segments.some((segment) => segment.text.trim().length > 0)) {
+                  clearToolActivityForReply();
+                }
+                ingestDraftLaneSegments(payload.text);
+              }
             : undefined,
         onReasoningStream: reasoningLane.stream
           ? (payload) => {
@@ -586,6 +647,10 @@ export const dispatchTelegramMessage = async ({
                 reasoningLane.stream?.forceNewMessage();
                 resetDraftLaneState(reasoningLane);
                 splitReasoningOnNextStream = false;
+              }
+              const split = splitTextIntoLaneSegments(payload.text);
+              if (split.segments.some((segment) => segment.text.trim().length > 0)) {
+                clearToolActivityForReply();
               }
               ingestDraftLaneSegments(payload.text);
             }
@@ -617,11 +682,15 @@ export const dispatchTelegramMessage = async ({
               splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
             }
           : undefined,
-        onToolStart: statusReactionController
-          ? async (payload) => {
-              await statusReactionController.setTool(payload.name);
-            }
-          : undefined,
+        onToolStart: async (payload) => {
+          if (statusReactionController) {
+            await statusReactionController.setTool(payload.name);
+          }
+          toolActivityController?.onToolStart(payload.name ?? "tool");
+        },
+        onToolEnd: (payload) => {
+          toolActivityController?.onToolEnd(payload.name ?? "tool");
+        },
         onModelSelected,
       },
     }));
@@ -687,6 +756,13 @@ export const dispatchTelegramMessage = async ({
   }
 
   const hasFinalResponse = queuedFinal || sentFallback;
+
+  // Clean up tool activity status message.
+  if (toolActivityController) {
+    void toolActivityController.cleanup().catch((err) => {
+      logVerbose(`telegram: tool activity cleanup failed: ${String(err)}`);
+    });
+  }
 
   if (statusReactionController && !hasFinalResponse) {
     void statusReactionController.setError().catch((err) => {


### PR DESCRIPTION
## Summary

Closes #29452

Adds a configurable **tool activity status** feature that shows users what tools the AI is currently executing via an editable status message in the chat channel, without requiring verbose mode.

## How it works

When `messages.toolActivityStatus` is set to `"minimal"` or `"detailed"`:

1. When the first tool starts → sends a status message: `⏳ Exec`
2. As tools complete and new ones begin → edits the message: `✅ Exec · ⏳ Web search`
3. When all tools finish → deletes the status message after a short delay

## Configuration

```json
{
  "messages": {
    "toolActivityStatus": "minimal"  // or "detailed" or "off" (default)
  }
}
```

- **off** (default): No status messages (current behavior, backward compatible)
- **minimal**: Tool label only (e.g., `⏳ Exec`)
- **detailed**: Tool label + metadata (e.g., `⏳ Exec: \`ls -la\``)

## Design

- **Independent of verbose mode** — this is a lightweight status indicator, not tool output
- **Single editable message** — no spam, updates in place
- **Debounced edits** (400ms min interval) to respect API rate limits
- **Promise-chain serialization** prevents concurrent API call races
- **Best-effort** — never blocks response delivery; all adapter errors are caught
- **Automatic cleanup** — message deleted when response completes

## Implementation

- New `ToolActivityStatusController` in `src/channels/tool-activity-status.ts` with a platform-agnostic `ToolActivityAdapter` interface
- Added `onToolEnd` callback to the reply options type alongside existing `onToolStart`
- Wired tool result events (phase="result") to the new `onToolEnd` callback
- Telegram integration: full adapter using grammY bot API (send/edit/delete)
- Discord: adapter interface ready, wiring deferred to follow-up
- Config: `messages.toolActivityStatus` added to types, zod schema, labels, and help

## Tests

4 unit tests covering:
- No-op when level is "off"
- Sends message on first tool start
- Edits message on subsequent tool starts
- Cleanup deletes message when all tools completed

## Files changed

| File | Change |
|------|--------|
| `src/channels/tool-activity-status.ts` | **New** — Controller + adapter interface |
| `src/channels/tool-activity-status.test.ts` | **New** — Unit tests |
| `src/auto-reply/types.ts` | Add `onToolEnd` callback type |
| `src/auto-reply/reply/agent-runner-execution.ts` | Wire `onToolEnd` from agent events |
| `src/telegram/bot-message-dispatch.ts` | Telegram adapter + controller integration |
| `src/config/types.messages.ts` | Add `toolActivityStatus` type |
| `src/config/zod-schema.session.ts` | Add zod validation |
| `src/config/schema.labels.ts` | UI label |
| `src/config/schema.help.ts` | Help text |