### PR TITLE
security: add X-Content-Type-Options nosniff header to media route

### DIFF
--- a/changelog/fragments/pr-30356.md
+++ b/changelog/fragments/pr-30356.md
@@ -1,0 +1,1 @@
+- Security/Media route: add `X-Content-Type-Options: nosniff` header regression assertions for successful and not-found media responses (#30356) (thanks @13otKmdr)

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -71,6 +71,9 @@ describe("exec PATH login shell merge", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["PATH", "SHELL"]);
+    if (!isWin && !process.env.SHELL) {
+      process.env.SHELL = "/bin/sh";
+    }
   });
 
   afterEach(() => {

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -71,9 +71,6 @@ describe("exec PATH login shell merge", () => {
 
   beforeEach(() => {
     envSnapshot = captureEnv(["PATH", "SHELL"]);
-    if (!isWin && !process.env.SHELL) {
-      process.env.SHELL = "/bin/sh";
-    }
   });
 
   afterEach(() => {

--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -61,6 +61,7 @@ describe("media server", () => {
     const file = await writeMediaFile("file1", "hello");
     const res = await fetch(mediaUrl("file1"));
     expect(res.status).toBe(200);
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     expect(await res.text()).toBe("hello");
     await waitForFileRemoval(file);
   });
@@ -113,6 +114,7 @@ describe("media server", () => {
   it("returns not found for missing media IDs", async () => {
     const res = await fetch(mediaUrl("missing-file"));
     expect(res.status).toBe(404);
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     expect(await res.text()).toBe("not found");
   });
 

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -1,6 +1,6 @@
+import fs from "node:fs/promises";
 import type { Server } from "node:http";
 import express, { type Express } from "express";
-import fs from "node:fs/promises";
 import { danger } from "../globals.js";
 import { SafeOpenError, readFileWithinRoot } from "../infra/fs-safe.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs/promises";
 import type { Server } from "node:http";
 import express, { type Express } from "express";
+import fs from "node:fs/promises";
 import { danger } from "../globals.js";
 import { SafeOpenError, readFileWithinRoot } from "../infra/fs-safe.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
@@ -33,6 +33,7 @@ export function attachMediaRoutes(
   const mediaDir = getMediaDir();
 
   app.get("/media/:id", async (req, res) => {
+    res.setHeader("X-Content-Type-Options", "nosniff");
     const id = req.params.id;
     if (!isValidMediaId(id)) {
       res.status(400).send("invalid path");


### PR DESCRIPTION
## Summary

- Adds `X-Content-Type-Options: nosniff` header to the `/media/:id` Express route in the media server
- Prevents browsers from MIME-sniffing the response content-type, which can lead to XSS via content-type confusion attacks

## Test plan

- [ ] Verify `curl -I http://localhost:<port>/media/<id>` response includes `X-Content-Type-Options: nosniff`
- [ ] Existing media route tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)