### PR TITLE
fix(discord): support applied_tags for forum thread creation

### DIFF
--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -363,13 +363,17 @@ export async function handleDiscordMessagingAction(
         typeof autoArchiveMinutesRaw === "number" && Number.isFinite(autoArchiveMinutesRaw)
           ? autoArchiveMinutesRaw
           : undefined;
+      const appliedTags = readStringArrayParam(params, "appliedTags");
+      const payload = {
+        name,
+        messageId,
+        autoArchiveMinutes,
+        content,
+        appliedTags: appliedTags ?? undefined,
+      };
       const thread = accountId
-        ? await createThreadDiscord(
-            channelId,
-            { name, messageId, autoArchiveMinutes, content },
-            { accountId },
-          )
-        : await createThreadDiscord(channelId, { name, messageId, autoArchiveMinutes, content });
+        ? await createThreadDiscord(channelId, payload, { accountId })
+        : await createThreadDiscord(channelId, payload);
       return jsonResult({ ok: true, thread });
     }
     case "threadList": {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -311,6 +311,7 @@ function buildThreadSchema() {
   return {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTags: Type.Optional(Type.Array(Type.String())),
   };
 }
 

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -230,6 +230,7 @@ export async function handleDiscordMessageAction(
     const autoArchiveMinutes = readNumberParam(params, "autoArchiveMin", {
       integer: true,
     });
+    const appliedTags = readStringArrayParam(params, "appliedTags");
     return await handleDiscordAction(
       {
         action: "threadCreate",
@@ -239,6 +240,7 @@ export async function handleDiscordMessageAction(
         messageId,
         content,
         autoArchiveMinutes,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
       actionOptions,

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -124,6 +124,9 @@ export async function createThreadDiscord(
   if (isForumLike) {
     const starterContent = payload.content?.trim() ? payload.content : payload.name;
     body.message = { content: starterContent };
+    if (payload.appliedTags?.length) {
+      body.applied_tags = payload.appliedTags;
+    }
   }
   // When creating a standalone thread (no messageId) in a non-forum channel,
   // default to public thread (type 11). Discord defaults to private (type 12)

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -74,6 +74,8 @@ export type DiscordThreadCreate = {
   content?: string;
   /** Discord thread type (default: PublicThread for standalone threads). */
   type?: number;
+  /** Tag IDs to apply when creating a forum/media thread (Discord `applied_tags`). */
+  appliedTags?: string[];
 };
 
 export type DiscordThreadList = {


### PR DESCRIPTION
## Summary

- Forum channels that require tags fail with `A tag is required to create a forum post in this channel` because there was no way to pass tag IDs during thread creation.
- Added `appliedTags` parameter (string array of tag IDs) to the `thread-create` action, passed as Discord API's `applied_tags` field on forum/media thread creation requests.
- Tag IDs are already discoverable via `channel-list` which returns `available_tags`.

Closes #30309

## Change Type

- [x] Feature

## Scope

- [x] Integrations

## Files Changed

- `src/discord/send.types.ts` — added `appliedTags?: string[]` to `DiscordThreadCreate`
- `src/discord/send.messages.ts` — pass `applied_tags` in request body for forum/media threads
- `src/agents/tools/message-tool.ts` — added `appliedTags` to thread schema
- `src/channels/plugins/actions/discord/handle-action.ts` — read and forward `appliedTags` param
- `src/agents/tools/discord-actions-messaging.ts` — read and forward `appliedTags` param
- `src/discord/send.creates-thread.test.ts` — added tests for forum tag passing and non-forum exclusion

## Test plan

- [x] New unit tests verify `applied_tags` is included in forum thread creation body
- [x] New unit test verifies `applied_tags` is omitted for non-forum channels
- [x] All 24 existing thread tests continue to pass