### PR TITLE
perf(agents): compact nested tool schema metadata

### DIFF
--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -112,6 +112,11 @@ describe("pi tool definition adapter", () => {
           },
           { description: "Payload description" },
         ),
+        title: Type.String({ title: "Field title", description: "Field description meta" }),
+        description: Type.String({
+          title: "Description field title",
+          description: "Description field meta",
+        }),
       },
       { title: "Top title", description: "Top level description" },
     );
@@ -144,6 +149,12 @@ describe("pi tool definition adapter", () => {
             },
           },
         },
+        title: {
+          type: "string",
+        },
+        description: {
+          type: "string",
+        },
       },
     });
     const compactedSchemaJson = JSON.stringify(def?.parameters);
@@ -151,7 +162,14 @@ describe("pi tool definition adapter", () => {
     expect(compactedSchemaJson).not.toContain("Action description");
     expect(compactedSchemaJson).not.toContain("Message title");
     expect(compactedSchemaJson).not.toContain("Message description");
-    expect(compactedSchemaJson).not.toContain('"title"');
+    expect(compactedSchemaJson).not.toContain("Field title");
+    expect(compactedSchemaJson).not.toContain("Field description meta");
+    const compactedParameters = def?.parameters as Record<string, unknown>;
+    expect(compactedParameters).not.toHaveProperty("title");
+    expect(compactedParameters).toHaveProperty("properties.title.type", "string");
+    expect(compactedParameters).toHaveProperty("properties.description.type", "string");
+    expect(compactedParameters).not.toHaveProperty("properties.title.title");
+    expect(compactedParameters).not.toHaveProperty("properties.description.title");
     expect(JSON.parse(JSON.stringify(parameters))).toEqual(originalParameters);
   });
 
@@ -172,6 +190,16 @@ describe("pi tool definition adapter", () => {
                 title: "Query title",
                 description: "Query description",
               },
+              title: {
+                type: "string",
+                title: "Client field title",
+                description: "Client field title description",
+              },
+              description: {
+                type: "string",
+                title: "Client description field title",
+                description: "Client description field description",
+              },
             },
             required: ["query"],
           },
@@ -186,6 +214,12 @@ describe("pi tool definition adapter", () => {
       description: "Client top description",
       properties: {
         query: {
+          type: "string",
+        },
+        title: {
+          type: "string",
+        },
+        description: {
           type: "string",
         },
       },

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -215,6 +215,19 @@ describe("pi tool definition adapter", () => {
                   },
                 ],
               },
+              tupleArg: {
+                type: "array",
+                items: [
+                  {
+                    type: "string",
+                    description: "Tuple first entry",
+                  },
+                  {
+                    type: "number",
+                    description: "Tuple second entry",
+                  },
+                ],
+              },
             },
             required: ["query"],
           },
@@ -247,6 +260,17 @@ describe("pi tool definition adapter", () => {
             {
               title: "Keep example title",
               description: "Keep example description",
+            },
+          ],
+        },
+        tupleArg: {
+          type: "array",
+          items: [
+            {
+              type: "string",
+            },
+            {
+              type: "number",
             },
           ],
         },

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -1,7 +1,8 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
-import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
+import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -96,5 +97,99 @@ describe("pi tool definition adapter", () => {
     });
     expect(result.content[0]).toMatchObject({ type: "text" });
     expect((result.content[0] as { text?: string }).text).toContain('"count"');
+  });
+
+  it("compacts nested tool parameter schema metadata without mutating the source schema", () => {
+    const parameters = Type.Object(
+      {
+        action: Type.Union([Type.Literal("send"), Type.Literal("edit")], {
+          title: "Action title",
+          description: "Action description",
+        }),
+        payload: Type.Object(
+          {
+            message: Type.String({ title: "Message title", description: "Message description" }),
+          },
+          { description: "Payload description" },
+        ),
+      },
+      { title: "Top title", description: "Top level description" },
+    );
+    const originalParameters = JSON.parse(JSON.stringify(parameters));
+    const tool = {
+      name: "compact_me",
+      label: "compact_me",
+      description: "test compact tool",
+      parameters,
+      execute: (async () => ({ details: { ok: true } })) as unknown as AgentTool["execute"],
+    } satisfies AgentTool;
+
+    const [def] = toToolDefinitions([tool]);
+    expect(def).toBeDefined();
+    expect(def?.parameters).toMatchObject({
+      type: "object",
+      description: "Top level description",
+      properties: {
+        action: {
+          anyOf: [
+            { const: "send", type: "string" },
+            { const: "edit", type: "string" },
+          ],
+        },
+        payload: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+            },
+          },
+        },
+      },
+    });
+    const compactedSchemaJson = JSON.stringify(def?.parameters);
+    expect(compactedSchemaJson).not.toContain("Action title");
+    expect(compactedSchemaJson).not.toContain("Action description");
+    expect(compactedSchemaJson).not.toContain("Message title");
+    expect(compactedSchemaJson).not.toContain("Message description");
+    expect(compactedSchemaJson).not.toContain('"title"');
+    expect(JSON.parse(JSON.stringify(parameters))).toEqual(originalParameters);
+  });
+
+  it("compacts nested client tool schemas before exposing definitions", () => {
+    const clientTools: ClientToolDefinition[] = [
+      {
+        type: "function",
+        function: {
+          name: "client_compact_me",
+          description: "client tool",
+          parameters: {
+            type: "object",
+            title: "Client top title",
+            description: "Client top description",
+            properties: {
+              query: {
+                type: "string",
+                title: "Query title",
+                description: "Query description",
+              },
+            },
+            required: ["query"],
+          },
+        },
+      },
+    ];
+
+    const [tool] = toClientToolDefinitions(clientTools);
+    expect(tool).toBeDefined();
+    expect(tool?.parameters).toEqual({
+      type: "object",
+      description: "Client top description",
+      properties: {
+        query: {
+          type: "string",
+        },
+      },
+      required: ["query"],
+    });
   });
 });

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -200,6 +200,21 @@ describe("pi tool definition adapter", () => {
                 title: "Client description field title",
                 description: "Client description field description",
               },
+              payload: {
+                type: "object",
+                title: "Payload title",
+                description: "Payload description",
+                default: {
+                  title: "Keep default title",
+                  description: "Keep default description",
+                },
+                examples: [
+                  {
+                    title: "Keep example title",
+                    description: "Keep example description",
+                  },
+                ],
+              },
             },
             required: ["query"],
           },
@@ -221,6 +236,19 @@ describe("pi tool definition adapter", () => {
         },
         description: {
           type: "string",
+        },
+        payload: {
+          type: "object",
+          default: {
+            title: "Keep default title",
+            description: "Keep default description",
+          },
+          examples: [
+            {
+              title: "Keep example title",
+              description: "Keep example description",
+            },
+          ],
         },
       },
       required: ["query"],

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -41,10 +41,17 @@ type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteA
 function compactToolParametersSchema(
   schema: ToolDefinition["parameters"],
 ): ToolDefinition["parameters"] {
+  const schemaKeyMapKeywords = new Set([
+    "properties",
+    "patternProperties",
+    "$defs",
+    "definitions",
+    "dependentSchemas",
+  ]);
   const seen = new WeakMap<object, unknown>();
-  const compact = (value: unknown, depth: number): unknown => {
+  const compact = (value: unknown, depth: number, inSchemaKeyMap = false): unknown => {
     if (Array.isArray(value)) {
-      return value.map((entry) => compact(entry, depth + 1));
+      return value.map((entry) => compact(entry, depth + 1, false));
     }
     if (!value || typeof value !== "object") {
       return value;
@@ -56,17 +63,17 @@ function compactToolParametersSchema(
     const output: Record<string, unknown> = {};
     seen.set(value, output);
     for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      if (key === "title") {
+      if (!inSchemaKeyMap && key === "title") {
         continue;
       }
-      if (key === "description" && depth > 0) {
+      if (!inSchemaKeyMap && key === "description" && depth > 0) {
         continue;
       }
-      output[key] = compact(entry, depth + 1);
+      output[key] = compact(entry, depth + 1, schemaKeyMapKeywords.has(key));
     }
     return output;
   };
-  return compact(schema, 0) as ToolDefinition["parameters"];
+  return compact(schema, 0, false) as ToolDefinition["parameters"];
 }
 
 function isAbortSignal(value: unknown): value is AbortSignal {

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -64,6 +64,9 @@ function compactToolParametersSchema(
   const schemaArrayKeywords = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
   const seen = new WeakMap<object, unknown>();
   const compactSchema = (value: unknown, depth: number): unknown => {
+    if (Array.isArray(value)) {
+      return value.map((entry) => compactSchema(entry, depth + 1));
+    }
     if (!value || typeof value !== "object") {
       return value;
     }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -48,11 +48,22 @@ function compactToolParametersSchema(
     "definitions",
     "dependentSchemas",
   ]);
+  const schemaNodeKeywords = new Set([
+    "items",
+    "additionalItems",
+    "contains",
+    "not",
+    "if",
+    "then",
+    "else",
+    "propertyNames",
+    "additionalProperties",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+  ]);
+  const schemaArrayKeywords = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
   const seen = new WeakMap<object, unknown>();
-  const compact = (value: unknown, depth: number, inSchemaKeyMap = false): unknown => {
-    if (Array.isArray(value)) {
-      return value.map((entry) => compact(entry, depth + 1, false));
-    }
+  const compactSchema = (value: unknown, depth: number): unknown => {
     if (!value || typeof value !== "object") {
       return value;
     }
@@ -63,17 +74,47 @@ function compactToolParametersSchema(
     const output: Record<string, unknown> = {};
     seen.set(value, output);
     for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      if (!inSchemaKeyMap && key === "title") {
+      if (key === "title") {
         continue;
       }
-      if (!inSchemaKeyMap && key === "description" && depth > 0) {
+      if (key === "description" && depth > 0) {
         continue;
       }
-      output[key] = compact(entry, depth + 1, schemaKeyMapKeywords.has(key));
+      if (schemaKeyMapKeywords.has(key)) {
+        output[key] = compactSchemaKeyMap(entry, depth + 1);
+        continue;
+      }
+      if (schemaArrayKeywords.has(key)) {
+        output[key] = Array.isArray(entry)
+          ? entry.map((child) => compactSchema(child, depth + 1))
+          : entry;
+        continue;
+      }
+      if (schemaNodeKeywords.has(key)) {
+        output[key] = compactSchema(entry, depth + 1);
+        continue;
+      }
+      // Preserve non-schema payload values as-is (e.g. default/examples objects).
+      output[key] = entry;
     }
     return output;
   };
-  return compact(schema, 0, false) as ToolDefinition["parameters"];
+  const compactSchemaKeyMap = (value: unknown, depth: number): unknown => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return value;
+    }
+    const cached = seen.get(value);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const output: Record<string, unknown> = {};
+    seen.set(value, output);
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      output[key] = compactSchema(entry, depth + 1);
+    }
+    return output;
+  };
+  return compactSchema(schema, 0) as ToolDefinition["parameters"];
 }
 
 function isAbortSignal(value: unknown): value is AbortSignal {

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -38,6 +38,37 @@ type ToolExecuteArgs = ToolDefinition["execute"] extends (...args: infer P) => u
   : ToolExecuteArgsCurrent;
 type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteArgsCurrent;
 
+function compactToolParametersSchema(
+  schema: ToolDefinition["parameters"],
+): ToolDefinition["parameters"] {
+  const seen = new WeakMap<object, unknown>();
+  const compact = (value: unknown, depth: number): unknown => {
+    if (Array.isArray(value)) {
+      return value.map((entry) => compact(entry, depth + 1));
+    }
+    if (!value || typeof value !== "object") {
+      return value;
+    }
+    const cached = seen.get(value);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const output: Record<string, unknown> = {};
+    seen.set(value, output);
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "title") {
+        continue;
+      }
+      if (key === "description" && depth > 0) {
+        continue;
+      }
+      output[key] = compact(entry, depth + 1);
+    }
+    return output;
+  };
+  return compact(schema, 0) as ToolDefinition["parameters"];
+}
+
 function isAbortSignal(value: unknown): value is AbortSignal {
   return typeof value === "object" && value !== null && "aborted" in value;
 }
@@ -145,7 +176,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       name,
       label: tool.label ?? name,
       description: tool.description ?? "",
-      parameters: tool.parameters,
+      parameters: compactToolParametersSchema(tool.parameters),
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         let executeParams = params;
@@ -255,7 +286,7 @@ export function toClientToolDefinitions(
       name: func.name,
       label: func.name,
       description: func.description ?? "",
-      parameters: func.parameters as ToolDefinition["parameters"],
+      parameters: compactToolParametersSchema(func.parameters as ToolDefinition["parameters"]),
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
         const outcome = await runBeforeToolCallHook({


### PR DESCRIPTION
## Summary
- compact outgoing tool parameter schemas in `pi-tool-definition-adapter` before they are sent to model providers
- remove nested schema metadata (`description` below root and all `title` keys) while preserving root-level schema description
- apply the same compaction to both built-in tools and client-hosted tools (`toToolDefinitions` and `toClientToolDefinitions`)
- keep compaction non-mutating via clone-on-walk behavior

## Why
Tool parameter schema metadata is injected on every run. Stripping redundant nested descriptions/titles lowers fixed prompt overhead for all users without changing tool runtime behavior.

A quick measurement on current default tools (19 tools) shows:
- before: 19,528 schema chars
- after: 14,414 schema chars
- savings: 5,114 chars (~26.19%, about 1,279 tokens at ~4 chars/token)

Largest single reduction in that sample:
- `message`: 8,919 -> 6,813 chars (2,106 chars saved)

## Validation
- `pnpm vitest run src/agents/pi-tool-definition-adapter.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tools.before-tool-call.integration.test.ts`
- `pnpm check`

## Notes
- Related context: #14785 #28397 #26948 #30004
