### PR TITLE
fix: LaunchAgent plist not updated during openclaw update

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -276,7 +276,7 @@ async function runPackageInstallUpdate(params: {
     DEFAULT_PACKAGE_NAME;
 
   const beforeVersion = pkgRoot ? await readPackageVersion(pkgRoot) : null;
-  if (pkgRoot) {
+  if (effectivePkgRoot) {
     await cleanupGlobalRenameDirs({
       globalRoot: path.dirname(pkgRoot),
       packageName,
@@ -291,11 +291,17 @@ async function runPackageInstallUpdate(params: {
   });
 
   const steps = [updateStep];
+
+  // Re-resolve pkgRoot after update to handle npm moving the package during update
+  // This ensures we use the correct path for the updated installation
+  // See: https://github.com/openclaw/openclaw/issues/13258
+  const updatedPkgRoot = await resolveGlobalPackageRoot(manager, runCommand, params.timeoutMs);
+  const effectivePkgRoot = updatedPkgRoot ?? pkgRoot;
   let afterVersion = beforeVersion;
 
-  if (pkgRoot) {
-    afterVersion = await readPackageVersion(pkgRoot);
-    const entryPath = path.join(pkgRoot, "dist", "entry.js");
+  if (effectivePkgRoot) {
+    afterVersion = await readPackageVersion(effectivePkgRoot);
+    const entryPath = path.join(effectivePkgRoot, "dist", "entry.js");
     if (await pathExists(entryPath)) {
       const doctorStep = await runUpdateStep({
         name: `${CLI_NAME} doctor`,
@@ -311,7 +317,7 @@ async function runPackageInstallUpdate(params: {
   return {
     status: failedStep ? "error" : "ok",
     mode: manager,
-    root: pkgRoot ?? params.root,
+    root: effectivePkgRoot ?? params.root,
     reason: failedStep ? failedStep.name : undefined,
     before: { version: beforeVersion },
     after: { version: afterVersion },


### PR DESCRIPTION
## Problem

When running "openclaw update" with npm global installation, the LaunchAgent plist was not being updated to point to the new installation path. This caused the Gateway service to enter a crash-loop because the plist still referenced the old (temporary) installation path.

Fixes #13258

## Root Cause

In "runPackageInstallUpdate", the package root (pkgRoot) was resolved **before** running npm update, but npm may move the package to a different location during update. The old path was then used for:
1. The return value (result.root)
2. The doctor step entry point
3. The LaunchAgent plist refresh

## Solution

Re-resolve the global package root after npm update completes, ensuring we use the correct path for all subsequent operations.

## Changes

- Added re-resolution of pkgRoot after npm update
- Use effectivePkgRoot (newly resolved or fallback to original) for all operations
- Added comment referencing the issue for future maintainers

## Testing

- [ ] Install older version: npm i -g openclaw@older
- [ ] Install Gateway service: openclaw gateway install
- [ ] Check plist path: cat ~/Library/LaunchAgents/ai.openclaw.gateway.plist
- [ ] Run update: openclaw update
- [ ] Verify plist is updated with new path
- [ ] Verify Gateway service starts correctly