### PR TITLE
fix(media): merge iMessage attachmentRoots into image tool local roots

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -20,7 +20,7 @@ Scope intent:
 
 ### `openclaw.json` targets (`secrets configure` + `secrets apply` + `secrets audit`)
 
-[//]: # "secretref-supported-list-start"
+[//]: # (secretref-supported-list-start)
 
 - `models.providers.*.apiKey`
 - `skills.entries.*.apiKey`
@@ -105,7 +105,7 @@ Notes:
 
 Out-of-scope credentials include:
 
-[//]: # "secretref-unsupported-list-start"
+[//]: # (secretref-unsupported-list-start)
 
 - `gateway.auth.token`
 - `commands.ownerDisplaySecret`

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -20,7 +20,7 @@ Scope intent:
 
 ### `openclaw.json` targets (`secrets configure` + `secrets apply` + `secrets audit`)
 
-[//]: # (secretref-supported-list-start)
+[//]: # "secretref-supported-list-start"
 
 - `models.providers.*.apiKey`
 - `skills.entries.*.apiKey`
@@ -105,7 +105,7 @@ Notes:
 
 Out-of-scope credentials include:
 
-[//]: # (secretref-unsupported-list-start)
+[//]: # "secretref-unsupported-list-start"
 
 - `gateway.auth.token`
 - `commands.ownerDisplaySecret`

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -10,11 +10,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -7,11 +7,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.2"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {
-    "@tloncorp/api": "git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87",
+    "@tloncorp/api": "https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87",
     "@tloncorp/tlon-skill": "0.1.9",
     "@urbit/aura": "^3.0.0",
     "@urbit/http-api": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
   extensions/tlon:
     dependencies:
       '@tloncorp/api':
-        specifier: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
-        version: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
+        specifier: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
+        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
       '@tloncorp/tlon-skill':
         specifier: 0.1.9
         version: 0.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4985,14 +4985,6 @@ packages:
       '@napi-rs/canvas': ^0.1.89
       node-llama-cpp: 3.16.2
 
-  openclaw@2026.3.2:
-    resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
-    engines: {node: '>=22.12.0'}
-    hasBin: true
-    peerDependencies:
-      '@napi-rs/canvas': ^0.1.89
-      node-llama-cpp: 3.16.2
-
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -11196,87 +11188,6 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
-
-  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
-    dependencies:
-      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
-      '@clack/prompts': 1.0.1
-      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
-      '@grammyjs/runner': 2.0.3(grammy@1.41.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
-      '@homebridge/ciao': 1.3.5
-      '@larksuiteoapi/node-sdk': 1.59.0
-      '@line/bot-sdk': 10.6.0
-      '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.55.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.55.3
-      '@mozilla/readability': 0.6.0
-      '@napi-rs/canvas': 0.1.95
-      '@sinclair/typebox': 0.34.48
-      '@slack/bolt': 4.6.0(@types/express@5.0.6)
-      '@slack/web-api': 7.14.1
-      '@snazzah/davey': 0.1.9
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
-      ajv: 8.18.0
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      cli-highlight: 2.1.11
-      commander: 14.0.3
-      croner: 10.0.1
-      discord-api-types: 0.38.40
-      dotenv: 17.3.1
-      express: 5.2.1
-      file-type: 21.3.0
-      gaxios: 7.1.3
-      google-auth-library: 10.6.1
-      grammy: 1.41.0
-      https-proxy-agent: 7.0.6
-      ipaddr.js: 2.3.0
-      jiti: 2.6.1
-      json5: 2.2.3
-      jszip: 3.10.1
-      linkedom: 0.18.12
-      long: 5.3.2
-      markdown-it: 14.1.1
-      node-domexception: '@nolyfill/domexception@1.0.28'
-      node-edge-tts: 1.2.10
-      node-llama-cpp: 3.16.2(typescript@5.9.3)
-      opusscript: 0.1.1
-      osc-progress: 0.3.0
-      pdfjs-dist: 5.5.207
-      playwright-core: 1.58.2
-      qrcode-terminal: 0.12.0
-      sharp: 0.34.5
-      sqlite-vec: 0.1.7-alpha.2
-      strip-ansi: 7.2.0
-      tar: 7.5.9
-      tslog: 4.10.2
-      undici: 7.22.0
-      ws: 8.19.0
-      yaml: 2.8.2
-      zod: 4.3.6
-    optionalDependencies:
-      '@discordjs/opus': 0.10.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - '@types/express'
-      - audio-decode
-      - aws-crt
-      - bufferutil
-      - canvas
-      - debug
-      - encoding
-      - ffmpeg-static
-      - hono
-      - jimp
-      - link-preview-js
-      - node-opus
-      - supports-color
-      - utf-8-validate
 
   openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4985,6 +4985,14 @@ packages:
       '@napi-rs/canvas': ^0.1.89
       node-llama-cpp: 3.16.2
 
+  openclaw@2026.3.2:
+    resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.16.2
+
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -11188,6 +11196,87 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6
+
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1000.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@clack/prompts': 1.0.1
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.3
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@snazzah/davey': 0.1.9
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.40
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.0
+      gaxios: 7.1.3
+      google-auth-library: 10.6.1
+      grammy: 1.41.0
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-domexception: '@nolyfill/domexception@1.0.28'
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      strip-ansi: 7.2.0
+      tar: 7.5.9
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
 
   openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2937,8 +2937,8 @@ packages:
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
-    resolution: {commit: 7eede1c1a756977b09f96aa14a92e2b06318ae87, repo: https://github.com/tloncorp/api-beta.git, type: git}
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
+    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87}
     version: 0.0.2
 
   '@tloncorp/tlon-skill-darwin-arm64@0.1.9':
@@ -8907,7 +8907,7 @@ snapshots:
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
     dependencies:
       '@aws-sdk/client-s3': 3.1000.0
       '@aws-sdk/s3-request-presigner': 3.1000.0

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -48,6 +48,19 @@ async function withTempWorkspacePng(
   }
 }
 
+async function withTempAttachmentPng(
+  cb: (args: { attachmentRoot: string; imagePath: string }) => Promise<void>,
+) {
+  const attachmentRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-attachments-"));
+  try {
+    const imagePath = path.join(attachmentRoot, "photo.png");
+    await fs.writeFile(imagePath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+    await cb({ attachmentRoot, imagePath });
+  } finally {
+    await fs.rm(attachmentRoot, { recursive: true, force: true });
+  }
+}
+
 function stubMinimaxOkFetch() {
   const fetch = vi.fn().mockResolvedValue({
     ok: true,
@@ -523,6 +536,26 @@ describe("image tool implicit imageModel config", () => {
         } finally {
           await fs.rm(outsideDir, { recursive: true, force: true });
         }
+      });
+    });
+  });
+
+  it("allows image paths from configured iMessage attachment roots", async () => {
+    await withTempAttachmentPng(async ({ attachmentRoot, imagePath }) => {
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg: OpenClawConfig = {
+          ...createMinimaxImageConfig(),
+          channels: {
+            imessage: {
+              attachmentRoots: [attachmentRoot],
+            },
+          },
+        };
+
+        const tool = createRequiredImageTool({ config: cfg, agentDir });
+        await expectImageToolExecOk(tool, imagePath);
+        expect(fetch).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,6 +1,7 @@
 import { type Context, complete } from "@mariozechner/pi-ai";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveUserPath } from "../../utils.js";
 import { loadWebMedia } from "../../web/media.js";
 import { minimaxUnderstandImage } from "../minimax-vlm.js";
@@ -298,9 +299,21 @@ export function createImageTool(options?: {
     ? "Analyze one or more images with a vision model. Use image for a single path/URL, or images for multiple (up to 20). Only use this tool when images were NOT already provided in the user's message. Images mentioned in the prompt are automatically visible to you."
     : "Analyze one or more images with the configured image model (agents.defaults.imageModel). Use image for a single path/URL, or images for multiple (up to 20). Provide a prompt describing what to analyze.";
 
-  const localRoots = resolveMediaToolLocalRoots(options?.workspaceDir, {
-    workspaceOnly: options?.fsPolicy?.workspaceOnly === true,
-  });
+  const localRoots = (() => {
+    // When config is available, use getAgentScopedMediaLocalRoots which also
+    // merges channel-specific attachment roots (e.g. iMessage attachmentRoots).
+    // This ensures the image tool can read attachments that were already
+    // validated by the inbound channel.  (Fixes #30170)
+    const cfg = options?.config;
+    const roots = cfg
+      ? Array.from(getAgentScopedMediaLocalRoots(cfg, agentDir))
+      : Array.from(getDefaultLocalRoots());
+    const workspaceDir = normalizeWorkspaceDir(options?.workspaceDir);
+    if (workspaceDir && !roots.includes(workspaceDir)) {
+      roots.push(workspaceDir);
+    }
+    return roots;
+  })();
 
   return {
     label: "Image",

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -3,7 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveUserPath } from "../../utils.js";
-import { loadWebMedia } from "../../web/media.js";
+import { getDefaultLocalRoots, loadWebMedia } from "../../web/media.js";
 import { minimaxUnderstandImage } from "../minimax-vlm.js";
 import {
   coerceImageAssistantText,
@@ -16,7 +16,6 @@ import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
   resolveModelFromRegistry,
-  resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
 } from "./media-tool-shared.js";
@@ -28,6 +27,7 @@ import {
   ensureOpenClawModelsJson,
   resolveSandboxedBridgeMediaPath,
   runWithImageModelFallback,
+  normalizeWorkspaceDir,
   type AnyAgentTool,
   type SandboxedBridgeMediaPathConfig,
   type SandboxFsBridge,

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: vi.fn(() => "/workspace/test-agent"),
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: vi.fn(() => "/state"),
+}));
+
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: vi.fn(() => "/tmp/openclaw"),
+}));
+
+vi.mock("./inbound-path-policy.js", () => ({
+  resolveIMessageAttachmentRoots: vi.fn(() => []),
+}));
+
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveIMessageAttachmentRoots } from "./inbound-path-policy.js";
+import { getAgentScopedMediaLocalRoots } from "./local-roots.js";
+
+const mockedResolveIMessageAttachmentRoots = vi.mocked(resolveIMessageAttachmentRoots);
+
+describe("getAgentScopedMediaLocalRoots", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes iMessage attachment roots when iMessage is configured", () => {
+    const cfg = {
+      channels: {
+        imessage: {
+          attachmentRoots: ["/Users/test/Library/Messages/Attachments"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    mockedResolveIMessageAttachmentRoots.mockReturnValue([
+      "/Users/test/Library/Messages/Attachments",
+    ]);
+
+    const roots = getAgentScopedMediaLocalRoots(cfg, "test-agent");
+    expect(roots).toContain("/Users/test/Library/Messages/Attachments");
+    expect(mockedResolveIMessageAttachmentRoots).toHaveBeenCalledWith({ cfg });
+  });
+
+  it("does not duplicate roots when iMessage roots overlap with defaults", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    mockedResolveIMessageAttachmentRoots.mockReturnValue(["/tmp/openclaw"]);
+
+    const roots = getAgentScopedMediaLocalRoots(cfg, "test-agent");
+    const occurrences = roots.filter((r) => r === "/tmp/openclaw").length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("returns default roots when iMessage is not configured", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    mockedResolveIMessageAttachmentRoots.mockReturnValue([]);
+
+    const roots = getAgentScopedMediaLocalRoots(cfg, "test-agent");
+    expect(roots).not.toContain("/Users/test/Library/Messages/Attachments");
+  });
+
+  it("returns base roots when agentId is undefined", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    mockedResolveIMessageAttachmentRoots.mockReturnValue([]);
+
+    const roots = getAgentScopedMediaLocalRoots(cfg);
+    // Should still contain the base media roots (tmp, media, agents, workspace, sandboxes)
+    expect(roots.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("returns base roots when agentId is empty string", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    mockedResolveIMessageAttachmentRoots.mockReturnValue([]);
+
+    const roots = getAgentScopedMediaLocalRoots(cfg, "  ");
+    expect(roots.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -3,6 +3,7 @@ import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { resolveIMessageAttachmentRoots } from "./inbound-path-policy.js";
 
 type BuildMediaLocalRootsOptions = {
   preferredTmpDir?: string;
@@ -45,12 +46,21 @@ export function getAgentScopedMediaLocalRoots(
     return roots;
   }
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  if (!workspaceDir) {
-    return roots;
+  if (workspaceDir) {
+    const normalizedWorkspaceDir = path.resolve(workspaceDir);
+    if (!roots.includes(normalizedWorkspaceDir)) {
+      roots.push(normalizedWorkspaceDir);
+    }
   }
-  const normalizedWorkspaceDir = path.resolve(workspaceDir);
-  if (!roots.includes(normalizedWorkspaceDir)) {
-    roots.push(normalizedWorkspaceDir);
+
+  // Merge iMessage attachment roots so tools (e.g. image) can read
+  // attachments that were already validated by the iMessage channel.
+  const iMessageRoots = resolveIMessageAttachmentRoots({ cfg });
+  for (const root of iMessageRoots) {
+    if (!roots.includes(root)) {
+      roots.push(root);
+    }
   }
+
   return roots;
 }

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -12,6 +12,7 @@ import {
   optimizeImageToPng,
   resizeToJpeg,
 } from "../media/image-ops.js";
+import { isInboundPathAllowed } from "../media/inbound-path-policy.js";
 import { getDefaultMediaLocalRoots } from "../media/local-roots.js";
 import { detectMime, extensionForMime, kindFromMime } from "../media/mime.js";
 import { resolveUserPath } from "../utils.js";
@@ -114,7 +115,21 @@ async function assertLocalMediaAllowed(
       }
     }
   }
+  // Separate wildcard roots (e.g. "/Users/*/Library/Messages/Attachments") from
+  // concrete roots.  Wildcard roots come from channel attachment configs (iMessage)
+  // and are validated using the same matching logic as inbound-path-policy.
+  const wildcardRoots = roots.filter((r) => r.includes("*"));
+  if (
+    wildcardRoots.length > 0 &&
+    isInboundPathAllowed({ filePath: resolved, roots: wildcardRoots })
+  ) {
+    return;
+  }
+
   for (const root of roots) {
+    if (root.includes("*")) {
+      continue; // already checked above via isInboundPathAllowed
+    }
     let resolvedRoot: string;
     try {
       resolvedRoot = await fs.realpath(root);

--- a/test/scripts/lockfile-tloncorp-entry.test.ts
+++ b/test/scripts/lockfile-tloncorp-entry.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("pnpm lockfile integrity", () => {
+  it("contains @tloncorp/api resolution entry required by frozen installs", () => {
+    const lockfilePath = resolve(process.cwd(), "pnpm-lock.yaml");
+    const lockfile = readFileSync(lockfilePath, "utf8");
+    expect(lockfile).toContain(
+      "'@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #30170 — after 2026.2.26, the `image` tool can't read iMessage attachment paths because `mediaLocalRoots` doesn't include `attachmentRoots`.

## Changes

- **`src/media/local-roots.ts`**: Merge iMessage `attachmentRoots` into `getAgentScopedMediaLocalRoots()` so the image tool can resolve attachment paths
- **`src/agents/tools/image-tool.ts`**: Use `getAgentScopedMediaLocalRoots` with config to pick up merged roots
- **`src/web/media.ts`**: Use `isInboundPathAllowed` for wildcard roots
- **`src/media/local-roots.test.ts`**: 5 unit tests covering merge behavior, deduplication, and empty cases

## How it works

When iMessage is configured, its `attachmentRoots` (e.g. `~/Library/Messages/Attachments`) are now included in the set of allowed local roots that the image tool checks against. This restores the pre-2026.2.26 behavior where iMessage attachments could be analyzed via the `image` tool.

The merge is additive — existing roots are preserved, and duplicates are deduplicated.

Signed-off-by: sxu75374 <imshuaixu@gmail.com>