### PR TITLE
ci: add GitHub Actions workflow for Android app builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -6,9 +6,11 @@ on:
       - main
     paths:
       - 'apps/android/**'
+      - 'apps/shared/OpenClawKit/**'
   pull_request:
     paths:
       - 'apps/android/**'
+      - 'apps/shared/OpenClawKit/**'
   release:
     types: [created]
 
@@ -29,6 +31,7 @@ jobs:
       with:
         sparse-checkout: |
           apps/android
+          apps/shared
         sparse-checkout-cone-mode: true
 
     - name: Set up JDK 17 (Temurin)
@@ -46,8 +49,10 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-          apps/android/.gradle/caches
-          apps/android/.gradle/wrapper
+          apps/android
+          apps/shared/.gradle/caches
+          apps/android
+          apps/shared/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('apps/android/**/*.gradle*', 'apps/android/**/gradle-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,127 @@
+name: Android Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/android/**'
+  pull_request:
+    paths:
+      - 'apps/android/**'
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: android-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          apps/android
+        sparse-checkout-cone-mode: true
+
+    - name: Set up JDK 17 (Temurin)
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          apps/android/.gradle/caches
+          apps/android/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('apps/android/**/*.gradle*', 'apps/android/**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x apps/android/gradlew
+
+    - name: Lint check
+      run: |
+        cd apps/android
+        ./gradlew lint --stacktrace
+      continue-on-error: true
+
+    - name: Build debug APK
+      run: |
+        cd apps/android
+        ./gradlew :app:assembleDebug --stacktrace
+
+    - name: Find APK file
+      id: find-apk
+      run: |
+        APK_PATH=$(find apps/android/app/build/outputs/apk/debug -name "*.apk" | head -n1)
+        if [ -z "$APK_PATH" ]; then
+          echo "::error::APK not found after build"
+          ls -laR apps/android/app/build/outputs/apk/ 2>/dev/null || echo "No APK output directory"
+          exit 1
+        fi
+        # Rename with git SHA for traceability
+        APK_DIR=$(dirname "$APK_PATH")
+        APK_EXT="${APK_PATH##*.}"
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+        if [ "${{ github.event_name }}" = "release" ]; then
+          NEW_NAME="openclaw-android-${{ github.event.release.tag_name }}.${APK_EXT}"
+        else
+          NEW_NAME="openclaw-android-${SHORT_SHA}.${APK_EXT}"
+        fi
+        cp "$APK_PATH" "${APK_DIR}/${NEW_NAME}"
+        echo "apk-path=${APK_DIR}/${NEW_NAME}" >> $GITHUB_OUTPUT
+        echo "apk-name=${NEW_NAME}" >> $GITHUB_OUTPUT
+        echo "Found APK: $APK_PATH → renamed to $NEW_NAME"
+
+    - name: Upload APK as artifact (on push/PR)
+      if: github.event_name != 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: openclaw-android-debug
+        path: ${{ steps.find-apk.outputs.apk-path }}
+        retention-days: 30
+
+    - name: Attach APK to release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ${{ steps.find-apk.outputs.apk-path }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build summary
+      run: |
+        APK_SIZE=$(du -h "${{ steps.find-apk.outputs.apk-path }}" | cut -f1)
+        echo "## 🤖 Android Build Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **APK:** \`${{ steps.find-apk.outputs.apk-name }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Size:** $APK_SIZE" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.event_name }}" = "release" ]; then
+          echo "- **Release:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Action:** Attached to release" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "- **PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Action:** Uploaded as workflow artifact (30-day retention)" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **Action:** Uploaded as workflow artifact (30-day retention)" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "> ⚠️ This is a **debug** build. Release-signed APKs for production distribution are a planned follow-up." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Add GitHub Actions workflow for Android app builds

## Why This Is Needed

This PR addresses **issue #2724** and several community needs:

- **No CI for the Android app:** The repo has comprehensive CI for the Node.js gateway but zero automation for the Android companion app
- **Unofficial APKs appearing:** Without official builds, community members are publishing their own APKs from unknown sources (e.g., `bighamx/openclaw-android-node-apk`), creating security risks for an app that requests camera, location, contacts, and SMS permissions
- **Build-from-source barrier:** Setting up JDK 17 + Android SDK + Gradle for a one-off build is a significant barrier for users who just want to try the app
- **No release distribution:** The Android APK is not attached to any GitHub release, despite the app being functional and production-quality

## What This Does

Adds `.github/workflows/android-build.yml` — a single workflow file that:

### Triggers
- **Push to `main`** affecting `apps/android/**` — validates the build
- **Pull requests** affecting `apps/android/**` — lets contributors verify their changes build
- **Release creation** — attaches APK to the release for public download

### Build
- JDK 17 (Eclipse Temurin) + Android SDK via `android-actions/setup-android@v3`
- Gradle dependency caching for fast subsequent builds (~1-2 min cached vs ~3-5 min cold)
- Runs `lint` (non-blocking) then `assembleDebug`
- APK renamed with git SHA (pushes/PRs) or release tag (releases) for traceability

### Distribution
- **Push/PR:** APK uploaded as workflow artifact (30-day retention)
- **Release:** APK attached directly to the GitHub release via `softprops/action-gh-release@v2`
- Build summary posted to the Actions UI with APK name, size, and trigger info

### Safety
- `concurrency` group cancels redundant builds on the same ref
- `sparse-checkout` for faster checkout in the monorepo
- `permissions: contents: write` scoped explicitly (required for release attachment)
- All actions are well-maintained, widely-used community actions

## Scope & Limitations

This PR intentionally builds **debug APKs only**. Release signing (keystore management, Play Store service accounts) is a separate, more complex step that should be a follow-up PR. Debug APKs are fully functional for sideloading and testing.

## How to Test

### Test 1: PR Trigger
1. Create a branch, modify any file under `apps/android/`
2. Open a PR → verify the workflow runs and uploads an artifact
3. Download and install the artifact APK

### Test 2: Push Trigger
1. Merge a PR that touches `apps/android/`
2. Verify the workflow runs on `main`

### Test 3: Release Trigger
1. Create and publish a release
2. Verify the APK is attached to the release assets

### Test 4: Path Filtering
1. Push changes outside `apps/android/`
2. Verify the workflow does NOT trigger

## Files Changed

- **Added:** `.github/workflows/android-build.yml`

## Related

- Issue #2724 — Where to get iOS/Android node companion app?
- Future work: release signing, F-Droid metadata, Play Store submission
