### PR TITLE
fix(feishu): remove message content from system event to prevent duplicate display

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { FeishuMessageEvent } from "./bot.js";
+import { parseFeishuMessageEvent } from "./bot.js";
+
+// --- Helpers ---
+
+function makeEvent(overrides?: Partial<FeishuMessageEvent>): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: {
+        open_id: "ou_test_sender",
+        user_id: "user_test",
+      },
+      sender_type: "user",
+    },
+    message: {
+      message_id: "om_test_msg_001",
+      chat_id: "oc_test_group",
+      chat_type: "group",
+      message_type: "text",
+      content: JSON.stringify({ text: "Hello world" }),
+      ...overrides?.message,
+    },
+    ...overrides,
+  } as FeishuMessageEvent;
+}
+
+// --- Tests ---
+
+describe("parseFeishuMessageEvent", () => {
+  it("parses a simple text message", () => {
+    const event = makeEvent();
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.chatId).toBe("oc_test_group");
+    expect(ctx.messageId).toBe("om_test_msg_001");
+    expect(ctx.senderId).toBe("user_test");
+    expect(ctx.senderOpenId).toBe("ou_test_sender");
+    expect(ctx.chatType).toBe("group");
+    expect(ctx.content).toBe("Hello world");
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("parses a DM text message", () => {
+    const event = makeEvent({
+      message: {
+        message_id: "om_dm_001",
+        chat_id: "oc_dm_chat",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "DM message" }),
+      },
+    });
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.chatType).toBe("p2p");
+    expect(ctx.content).toBe("DM message");
+  });
+
+  it("detects bot mention", () => {
+    const botOpenId = "ou_bot_123";
+    const event = makeEvent({
+      message: {
+        message_id: "om_mention_001",
+        chat_id: "oc_group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@Bot hello" }),
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: botOpenId },
+            name: "Bot",
+            tenant_key: "t1",
+          },
+        ],
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event, botOpenId);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("strips bot mention from content", () => {
+    const botOpenId = "ou_bot_123";
+    const event = makeEvent({
+      message: {
+        message_id: "om_strip_001",
+        chat_id: "oc_group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@Bot please help me" }),
+        mentions: [
+          {
+            key: "@_user_1",
+            id: { open_id: botOpenId },
+            name: "Bot",
+            tenant_key: "t1",
+          },
+        ],
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event, botOpenId);
+    expect(ctx.content).not.toContain("@Bot");
+    expect(ctx.content).toContain("help me");
+  });
+
+  it("preserves rootId and parentId", () => {
+    const event = makeEvent({
+      message: {
+        message_id: "om_reply_001",
+        chat_id: "oc_group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply" }),
+        root_id: "om_root_001",
+        parent_id: "om_parent_001",
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event);
+    expect(ctx.rootId).toBe("om_root_001");
+    expect(ctx.parentId).toBe("om_parent_001");
+  });
+
+  it("handles missing user_id gracefully", () => {
+    const event = makeEvent();
+    event.sender.sender_id.user_id = undefined;
+    const ctx = parseFeishuMessageEvent(event);
+    // Falls back to open_id
+    expect(ctx.senderId).toBe("ou_test_sender");
+  });
+
+  it("handles post (rich text) message type", () => {
+    const postContent = JSON.stringify({
+      title: "Test Post",
+      content: [[{ tag: "text", text: "Hello from post" }]],
+    });
+
+    const event = makeEvent({
+      message: {
+        message_id: "om_post_001",
+        chat_id: "oc_group",
+        chat_type: "group",
+        message_type: "post",
+        content: postContent,
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event);
+    expect(ctx.content).toContain("Test Post");
+    expect(ctx.content).toContain("Hello from post");
+  });
+
+  it("handles invalid JSON content gracefully", () => {
+    const event = makeEvent({
+      message: {
+        message_id: "om_bad_001",
+        chat_id: "oc_group",
+        chat_type: "group",
+        message_type: "text",
+        content: "not valid json",
+      },
+    });
+
+    const ctx = parseFeishuMessageEvent(event);
+    // Should not throw, returns raw content
+    expect(ctx.content).toBe("not valid json");
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -657,12 +657,17 @@ export async function handleFeishuMessage(params: {
       },
     });
 
-    const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
       ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
 
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+    // Only include a notification label (no message content preview).
+    // The full message is delivered via the inbound context below;
+    // including a truncated preview here caused the same message to
+    // appear twice in webchat (once truncated, once complete).
+    // Append messageId so consecutive messages stay unique for the
+    // system-event text-based dedupe in system-events.ts.
+    core.system.enqueueSystemEvent(`${inboundLabel} [${ctx.messageId}]`, {
       sessionKey: route.sessionKey,
       contextKey: `feishu:message:${ctx.chatId}:${ctx.messageId}`,
     });


### PR DESCRIPTION
## Summary

Fix Feishu group messages appearing twice in webchat — first truncated, then complete.

Closes #30308

## Root Cause

When a Feishu group message was received, the message content was delivered to the agent **twice**:

1. **`enqueueSystemEvent()`** — injected a 160-char truncated preview as a `[System Message]`
2. **Normal inbound context** — delivered the full message as a `user:` message

In webchat this displayed as:
```
system: ...this is a prompt..(cut here)
user: this is a prompt, it's very long and not cut.
```

The same message appeared twice — first truncated, then complete — confusing users.

## Fix

Remove the message content preview from `enqueueSystemEvent()`, keeping it as a **pure notification label** (e.g., `Feishu[default] message in group oc_xxx [om_msg_id]`).

Key design decision: **append `messageId` to the label text** so consecutive messages remain unique for the text-based dedupe in `system-events.ts`. Without this, consecutive messages from the same group would have identical text and collapse into a single event (identified during Codex gpt-5.3-codex code review).

This aligns with how other channels use `enqueueSystemEvent`:
- **Telegram**: only for reactions (`"Telegram reaction added: 👍 by Ada"`)
- **Signal**: only for non-message events
- **WhatsApp**: only for connection status

None of them include message content in system events.

## Changes

- **`extensions/feishu/src/bot.ts`** (2 lines changed)
  - Remove `preview` variable (160-char truncated content)
  - Change `enqueueSystemEvent` text from `${inboundLabel}: ${preview}` to `${inboundLabel} [${ctx.messageId}]`

- **`extensions/feishu/src/bot.test.ts`** (new, 171 lines)
  - First unit test suite for the Feishu extension
  - 8 tests covering `parseFeishuMessageEvent()`:
    - Simple text message parsing
    - DM message parsing
    - Bot mention detection
    - Bot mention stripping from content
    - rootId/parentId preservation
    - Missing user_id fallback
    - Post (rich text) message handling
    - Invalid JSON content graceful handling

## Testing

```
✓ extensions/feishu/src/bot.test.ts (8 tests) 13ms
Test Files  1 passed (1)
     Tests  8 passed (8)
```

## Backward Compatibility

✅ Fully backward compatible:
- System events still fire for every inbound message (logging/routing unaffected)
- The only change is the event text content (no message preview, just notification label)
- `contextKey` unchanged — no impact on event routing or deduplication logic