### PR TITLE
fix(usage): show Weekly instead of Day for codex secondary window

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -79,4 +79,27 @@ describe("fetchCodexUsage", () => {
       { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
     ]);
   });
+
+  it("infers weekly label from reset_at when limit_window_seconds is absent", async () => {
+    const futureResetSec = Math.floor(Date.now() / 1000) + 5 * 24 * 3600;
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 5,
+            reset_at: Math.floor(Date.now() / 1000) + 3600,
+          },
+          secondary_window: {
+            used_percent: 14,
+            reset_at: futureResetSec,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows[1]?.label).toBe("Week");
+    expect(result.windows[1]?.usedPercent).toBe(14);
+  });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -64,7 +64,17 @@ export async function fetchCodexUsage(
 
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
-    const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
+    let windowHours: number;
+    if (sw.limit_window_seconds && sw.limit_window_seconds > 0) {
+      windowHours = Math.round(sw.limit_window_seconds / 3600);
+    } else if (sw.reset_at) {
+      // When limit_window_seconds is absent, infer from reset_at distance.
+      // A reset > 48h away almost certainly belongs to a weekly window.
+      const remainingSec = sw.reset_at - Math.floor(Date.now() / 1000);
+      windowHours = remainingSec > 48 * 3600 ? 168 : 24;
+    } else {
+      windowHours = 24;
+    }
     const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,


### PR DESCRIPTION
## Summary

- `models status --probe` displays "Day X% left" for openai-codex secondary usage window even when the reset time is 5+ days away, making it look like a daily limit when it's actually weekly
- Root cause: when OpenAI omits `limit_window_seconds` from the API response, the fallback defaults to `86400` (24h), producing "Day" regardless of the actual window
- Fix: when `limit_window_seconds` is absent, infer window scope from `reset_at` distance — a reset > 48h away indicates a weekly window

Closes #29783

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Files Changed

- `src/infra/provider-usage.fetch.codex.ts` — infer window label from `reset_at` when `limit_window_seconds` is absent
- `src/infra/provider-usage.fetch.codex.test.ts` — added test for weekly inference from `reset_at`

## Test plan

- [x] All 71 provider-usage tests pass
- [x] New test verifies "Week" label when `limit_window_seconds` is absent but `reset_at` is 5 days away
- [x] Existing test for explicit `limit_window_seconds: 604800` still passes