### PR TITLE
feat(config): add per-provider HTTP proxy support for model providers

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -59,6 +59,7 @@ import {
   emitAgentEvent,
   registerAgentRunContext,
 } from "../infra/agent-events.js";
+import { installProviderProxyDispatcher } from "../infra/net/provider-proxy-dispatcher.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -234,6 +235,8 @@ export async function agentCommand(
   }
 
   const cfg = loadConfig();
+  installProviderProxyDispatcher(cfg.models);
+
   const agentIdOverrideRaw = opts.agentId?.trim();
   const agentIdOverride = agentIdOverrideRaw ? normalizeAgentId(agentIdOverrideRaw) : undefined;
   if (agentIdOverride) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -649,6 +649,8 @@ export const FIELD_HELP: Record<string, string> = {
     "When true, credentials are sent via the HTTP Authorization header even if alternate auth is possible. Use this only when your provider or proxy explicitly requires Authorization forwarding.",
   "models.providers.*.models":
     "Declared model list for a provider including identifiers, metadata, and optional compatibility/cost hints. Keep IDs exact to provider catalog values so selection and fallback resolve correctly.",
+  "models.providers.*.proxy":
+    'Per-provider HTTP proxy override. Set to "direct" to bypass all proxies and connect directly, a proxy URL (e.g. "http://127.0.0.1:7890") to route through a specific proxy, or omit to use the system proxy from HTTP_PROXY/HTTPS_PROXY environment variables.',
   "models.bedrockDiscovery":
     "Automatic AWS Bedrock model discovery settings used to synthesize provider model entries from account visibility. Keep discovery scoped and refresh intervals conservative to reduce API churn.",
   "models.bedrockDiscovery.enabled":

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -56,6 +56,8 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  /** Per-provider HTTP proxy. "direct" bypasses all proxies; a URL routes through that proxy; omit to use system env proxy. */
+  proxy?: string;
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -236,6 +236,7 @@ export const ModelProviderSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
+    proxy: z.string().optional(),
   })
   .strict();
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -32,6 +32,7 @@ import { createExecApprovalForwarder } from "../infra/exec-approval-forwarder.js
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
+import { installProviderProxyDispatcher } from "../infra/net/provider-proxy-dispatcher.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import {
@@ -369,6 +370,9 @@ export async function startGatewayServer(
       activate: true,
     })
   ).config;
+
+  installProviderProxyDispatcher(cfgAtStart.models);
+
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();

--- a/src/infra/net/provider-proxy-dispatcher.test.ts
+++ b/src/infra/net/provider-proxy-dispatcher.test.ts
@@ -1,0 +1,163 @@
+import type { Dispatcher } from "undici";
+import { describe, expect, it, vi } from "vitest";
+import type { ModelsConfig } from "../../config/types.models.js";
+import { buildProviderProxyRouter, ProviderProxyRouter } from "./provider-proxy-dispatcher.js";
+
+vi.mock("../../logger.js", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+function minimalProvider(baseUrl: string, proxy?: string) {
+  return {
+    baseUrl,
+    proxy,
+    models: [
+      {
+        id: "m",
+        name: "m",
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
+describe("buildProviderProxyRouter", () => {
+  it("returns undefined when no providers exist", () => {
+    expect(buildProviderProxyRouter(undefined)).toBeUndefined();
+    expect(buildProviderProxyRouter({})).toBeUndefined();
+    expect(buildProviderProxyRouter({ providers: {} })).toBeUndefined();
+  });
+
+  it("returns undefined when no provider has a proxy field", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        openai: minimalProvider("https://api.openai.com/v1"),
+      },
+    };
+    expect(buildProviderProxyRouter(cfg)).toBeUndefined();
+  });
+
+  it('returns undefined when all providers use proxy: "env"', () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        openai: minimalProvider("https://api.openai.com/v1", "env"),
+      },
+    };
+    expect(buildProviderProxyRouter(cfg)).toBeUndefined();
+  });
+
+  it('builds a router when a provider has proxy: "direct"', () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        local: minimalProvider("http://localhost:11434", "direct"),
+      },
+    };
+    const router = buildProviderProxyRouter(cfg);
+    expect(router).toBeInstanceOf(ProviderProxyRouter);
+  });
+
+  it("builds a router when a provider has a proxy URL", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        custom: minimalProvider("https://api.example.com", "http://127.0.0.1:7890"),
+      },
+    };
+    const router = buildProviderProxyRouter(cfg);
+    expect(router).toBeInstanceOf(ProviderProxyRouter);
+  });
+
+  it("skips providers with unparseable baseUrl", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        bad: minimalProvider("not-a-url", "direct"),
+      },
+    };
+    expect(buildProviderProxyRouter(cfg)).toBeUndefined();
+  });
+});
+
+describe("ProviderProxyRouter.dispatch", () => {
+  function makeMockDispatcher() {
+    const dispatchFn = vi.fn().mockReturnValue(true);
+    const dispatcher = {
+      dispatch: dispatchFn,
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Dispatcher;
+    return { dispatcher, dispatchFn };
+  }
+
+  it("routes to the matched hostname dispatcher", () => {
+    const direct = makeMockDispatcher();
+    const fb = makeMockDispatcher();
+    const map = new Map<string, Dispatcher>([["api.pucode.com", direct.dispatcher]]);
+    const router = new ProviderProxyRouter(map, fb.dispatcher, [direct.dispatcher]);
+
+    const handler = {} as Dispatcher.DispatchHandler;
+    router.dispatch(
+      { origin: "https://api.pucode.com", path: "/v1/messages", method: "POST" },
+      handler,
+    );
+
+    expect(direct.dispatchFn).toHaveBeenCalledTimes(1);
+    expect(fb.dispatchFn).not.toHaveBeenCalled();
+  });
+
+  it("falls back for unmatched hostnames", () => {
+    const direct = makeMockDispatcher();
+    const fb = makeMockDispatcher();
+    const map = new Map<string, Dispatcher>([["api.pucode.com", direct.dispatcher]]);
+    const router = new ProviderProxyRouter(map, fb.dispatcher, [direct.dispatcher]);
+
+    const handler = {} as Dispatcher.DispatchHandler;
+    router.dispatch(
+      { origin: "https://api.openai.com", path: "/v1/chat", method: "POST" },
+      handler,
+    );
+
+    expect(direct.dispatchFn).not.toHaveBeenCalled();
+    expect(fb.dispatchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back when origin is missing", () => {
+    const direct = makeMockDispatcher();
+    const fb = makeMockDispatcher();
+    const map = new Map<string, Dispatcher>([["example.com", direct.dispatcher]]);
+    const router = new ProviderProxyRouter(map, fb.dispatcher, [direct.dispatcher]);
+
+    const handler = {} as Dispatcher.DispatchHandler;
+    router.dispatch(
+      { path: "/v1/messages", method: "POST" } as Dispatcher.DispatchOptions,
+      handler,
+    );
+
+    expect(fb.dispatchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses dispatchers for the same proxy URL across different providers", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        a: minimalProvider("https://api-a.example.com", "http://127.0.0.1:7890"),
+        b: minimalProvider("https://api-b.example.com", "http://127.0.0.1:7890"),
+      },
+    };
+    const router = buildProviderProxyRouter(cfg);
+    expect(router).toBeInstanceOf(ProviderProxyRouter);
+  });
+
+  it("handles mixed proxy/direct/env providers", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        proxied: minimalProvider("https://api.pucode.com", "http://127.0.0.1:12334"),
+        direct: minimalProvider("http://localhost:11434", "direct"),
+        default: minimalProvider("https://api.openai.com/v1"),
+      },
+    };
+    const router = buildProviderProxyRouter(cfg);
+    expect(router).toBeInstanceOf(ProviderProxyRouter);
+  });
+});

--- a/src/infra/net/provider-proxy-dispatcher.test.ts
+++ b/src/infra/net/provider-proxy-dispatcher.test.ts
@@ -160,4 +160,41 @@ describe("ProviderProxyRouter.dispatch", () => {
     const router = buildProviderProxyRouter(cfg);
     expect(router).toBeInstanceOf(ProviderProxyRouter);
   });
+
+  it("routes by host (hostname:port), not hostname alone", () => {
+    const directLocal = makeMockDispatcher();
+    const proxiedLocal = makeMockDispatcher();
+    const fb = makeMockDispatcher();
+    const map = new Map<string, Dispatcher>([
+      ["localhost:11434", directLocal.dispatcher],
+      ["localhost:8080", proxiedLocal.dispatcher],
+    ]);
+    const router = new ProviderProxyRouter(map, fb.dispatcher, [
+      directLocal.dispatcher,
+      proxiedLocal.dispatcher,
+    ]);
+
+    const handler = {} as Dispatcher.DispatchHandler;
+
+    router.dispatch(
+      { origin: "http://localhost:11434", path: "/api/generate", method: "POST" },
+      handler,
+    );
+    expect(directLocal.dispatchFn).toHaveBeenCalledTimes(1);
+    expect(proxiedLocal.dispatchFn).not.toHaveBeenCalled();
+
+    router.dispatch({ origin: "http://localhost:8080", path: "/v1/chat", method: "POST" }, handler);
+    expect(proxiedLocal.dispatchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes same hostname with different ports via buildProviderProxyRouter", () => {
+    const cfg: ModelsConfig = {
+      providers: {
+        ollama: minimalProvider("http://localhost:11434", "direct"),
+        localProxy: minimalProvider("http://localhost:8080", "http://127.0.0.1:7890"),
+      },
+    };
+    const router = buildProviderProxyRouter(cfg);
+    expect(router).toBeInstanceOf(ProviderProxyRouter);
+  });
 });

--- a/src/infra/net/provider-proxy-dispatcher.ts
+++ b/src/infra/net/provider-proxy-dispatcher.ts
@@ -1,0 +1,153 @@
+import { Agent, EnvHttpProxyAgent, ProxyAgent, setGlobalDispatcher, type Dispatcher } from "undici";
+import type { ModelsConfig } from "../../config/types.models.js";
+import { logDebug, logInfo } from "../../logger.js";
+
+const PROXY_DIRECT = "direct";
+const PROXY_ENV = "env";
+
+/**
+ * Routing dispatcher that directs HTTP requests based on destination hostname.
+ *
+ * - Providers with `proxy: "direct"` bypass all proxies.
+ * - Providers with `proxy: "<url>"` route through the specified proxy.
+ * - Everything else falls back to the system env proxy (EnvHttpProxyAgent).
+ */
+export class ProviderProxyRouter extends Agent {
+  readonly #hostnameMap: Map<string, Dispatcher>;
+  readonly #ownedDispatchers: Dispatcher[];
+  readonly #fallback: Dispatcher;
+
+  constructor(hostnameMap: Map<string, Dispatcher>, fallback: Dispatcher, owned: Dispatcher[]) {
+    super();
+    this.#hostnameMap = hostnameMap;
+    this.#fallback = fallback;
+    this.#ownedDispatchers = owned;
+  }
+
+  dispatch(opts: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandler): boolean {
+    const origin = opts.origin;
+    if (origin) {
+      const hostname = extractHostname(typeof origin === "string" ? origin : origin.toString());
+      const target = hostname ? this.#hostnameMap.get(hostname) : undefined;
+      if (target) {
+        return target.dispatch(opts, handler);
+      }
+    }
+    return this.#fallback.dispatch(opts, handler);
+  }
+
+  async close(): Promise<void> {
+    const errors: unknown[] = [];
+    for (const d of this.#ownedDispatchers) {
+      try {
+        await d.close();
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+    try {
+      await this.#fallback.close();
+    } catch (err) {
+      errors.push(err);
+    }
+    await super.close();
+  }
+}
+
+function extractHostname(origin: string): string | undefined {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build a {@link ProviderProxyRouter} from the models config.
+ *
+ * Returns `undefined` when no provider declares a custom `proxy` value,
+ * meaning the default `EnvHttpProxyAgent` behaviour is sufficient.
+ */
+export function buildProviderProxyRouter(
+  modelsConfig: ModelsConfig | undefined,
+): ProviderProxyRouter | undefined {
+  const providers = modelsConfig?.providers;
+  if (!providers) {
+    return undefined;
+  }
+
+  const hostnameToProxy = new Map<string, string>();
+  for (const [providerId, providerCfg] of Object.entries(providers)) {
+    if (!providerCfg) {
+      continue;
+    }
+    const proxy = providerCfg.proxy?.trim();
+    if (!proxy || proxy === PROXY_ENV) {
+      continue;
+    }
+
+    const hostname = extractHostname(providerCfg.baseUrl);
+    if (!hostname) {
+      logDebug(
+        `[provider-proxy] skipping provider "${providerId}": cannot extract hostname from baseUrl "${providerCfg.baseUrl}"`,
+      );
+      continue;
+    }
+
+    const existing = hostnameToProxy.get(hostname);
+    if (existing && existing !== proxy) {
+      logDebug(
+        `[provider-proxy] hostname "${hostname}" has conflicting proxy values ("${existing}" vs "${proxy}"); last writer wins`,
+      );
+    }
+    hostnameToProxy.set(hostname, proxy);
+  }
+
+  if (hostnameToProxy.size === 0) {
+    return undefined;
+  }
+
+  const hostnameMap = new Map<string, Dispatcher>();
+  const owned: Dispatcher[] = [];
+  // Cache dispatchers by proxy URL so multiple hostnames sharing the same proxy reuse a single agent.
+  const proxyAgentCache = new Map<string, Dispatcher>();
+
+  let directAgent: Agent | undefined;
+
+  for (const [hostname, proxy] of hostnameToProxy) {
+    if (proxy === PROXY_DIRECT) {
+      if (!directAgent) {
+        directAgent = new Agent();
+        owned.push(directAgent);
+      }
+      hostnameMap.set(hostname, directAgent);
+      logInfo(`[provider-proxy] ${hostname} → direct (no proxy)`);
+    } else {
+      let agent = proxyAgentCache.get(proxy);
+      if (!agent) {
+        agent = new ProxyAgent(proxy);
+        proxyAgentCache.set(proxy, agent);
+        owned.push(agent);
+      }
+      hostnameMap.set(hostname, agent);
+      logInfo(`[provider-proxy] ${hostname} → ${proxy}`);
+    }
+  }
+
+  const fallback = new EnvHttpProxyAgent();
+  return new ProviderProxyRouter(hostnameMap, fallback, owned);
+}
+
+/**
+ * Build a routing dispatcher from config and install it as the global undici
+ * dispatcher, replacing pi-ai's default `EnvHttpProxyAgent`.
+ *
+ * No-op when no provider declares a custom `proxy` value.
+ */
+export function installProviderProxyDispatcher(modelsConfig: ModelsConfig | undefined): void {
+  const router = buildProviderProxyRouter(modelsConfig);
+  if (router) {
+    setGlobalDispatcher(router);
+    logInfo("[provider-proxy] custom routing dispatcher installed");
+  }
+}

--- a/src/infra/net/provider-proxy-dispatcher.ts
+++ b/src/infra/net/provider-proxy-dispatcher.ts
@@ -13,13 +13,13 @@ const PROXY_ENV = "env";
  * - Everything else falls back to the system env proxy (EnvHttpProxyAgent).
  */
 export class ProviderProxyRouter extends Agent {
-  readonly #hostnameMap: Map<string, Dispatcher>;
+  readonly #hostMap: Map<string, Dispatcher>;
   readonly #ownedDispatchers: Dispatcher[];
   readonly #fallback: Dispatcher;
 
-  constructor(hostnameMap: Map<string, Dispatcher>, fallback: Dispatcher, owned: Dispatcher[]) {
+  constructor(hostMap: Map<string, Dispatcher>, fallback: Dispatcher, owned: Dispatcher[]) {
     super();
-    this.#hostnameMap = hostnameMap;
+    this.#hostMap = hostMap;
     this.#fallback = fallback;
     this.#ownedDispatchers = owned;
   }
@@ -27,8 +27,8 @@ export class ProviderProxyRouter extends Agent {
   dispatch(opts: Dispatcher.DispatchOptions, handler: Dispatcher.DispatchHandler): boolean {
     const origin = opts.origin;
     if (origin) {
-      const hostname = extractHostname(typeof origin === "string" ? origin : origin.toString());
-      const target = hostname ? this.#hostnameMap.get(hostname) : undefined;
+      const host = extractHost(typeof origin === "string" ? origin : origin.toString());
+      const target = host ? this.#hostMap.get(host) : undefined;
       if (target) {
         return target.dispatch(opts, handler);
       }
@@ -57,9 +57,10 @@ export class ProviderProxyRouter extends Agent {
   }
 }
 
-function extractHostname(origin: string): string | undefined {
+function extractHost(origin: string): string | undefined {
   try {
-    return new URL(origin).hostname;
+    const url = new URL(origin);
+    return url.host; // hostname:port (port omitted when default for the protocol)
   } catch {
     return undefined;
   }
@@ -79,7 +80,7 @@ export function buildProviderProxyRouter(
     return undefined;
   }
 
-  const hostnameToProxy = new Map<string, string>();
+  const hostToProxy = new Map<string, string>();
   for (const [providerId, providerCfg] of Object.entries(providers)) {
     if (!providerCfg) {
       continue;
@@ -89,42 +90,41 @@ export function buildProviderProxyRouter(
       continue;
     }
 
-    const hostname = extractHostname(providerCfg.baseUrl);
-    if (!hostname) {
+    const host = extractHost(providerCfg.baseUrl);
+    if (!host) {
       logDebug(
-        `[provider-proxy] skipping provider "${providerId}": cannot extract hostname from baseUrl "${providerCfg.baseUrl}"`,
+        `[provider-proxy] skipping provider "${providerId}": cannot extract host from baseUrl "${providerCfg.baseUrl}"`,
       );
       continue;
     }
 
-    const existing = hostnameToProxy.get(hostname);
+    const existing = hostToProxy.get(host);
     if (existing && existing !== proxy) {
       logDebug(
-        `[provider-proxy] hostname "${hostname}" has conflicting proxy values ("${existing}" vs "${proxy}"); last writer wins`,
+        `[provider-proxy] host "${host}" has conflicting proxy values ("${existing}" vs "${proxy}"); last writer wins`,
       );
     }
-    hostnameToProxy.set(hostname, proxy);
+    hostToProxy.set(host, proxy);
   }
 
-  if (hostnameToProxy.size === 0) {
+  if (hostToProxy.size === 0) {
     return undefined;
   }
 
-  const hostnameMap = new Map<string, Dispatcher>();
+  const hostMap = new Map<string, Dispatcher>();
   const owned: Dispatcher[] = [];
-  // Cache dispatchers by proxy URL so multiple hostnames sharing the same proxy reuse a single agent.
   const proxyAgentCache = new Map<string, Dispatcher>();
 
   let directAgent: Agent | undefined;
 
-  for (const [hostname, proxy] of hostnameToProxy) {
+  for (const [host, proxy] of hostToProxy) {
     if (proxy === PROXY_DIRECT) {
       if (!directAgent) {
         directAgent = new Agent();
         owned.push(directAgent);
       }
-      hostnameMap.set(hostname, directAgent);
-      logInfo(`[provider-proxy] ${hostname} → direct (no proxy)`);
+      hostMap.set(host, directAgent);
+      logInfo(`[provider-proxy] ${host} → direct (no proxy)`);
     } else {
       let agent = proxyAgentCache.get(proxy);
       if (!agent) {
@@ -132,13 +132,13 @@ export function buildProviderProxyRouter(
         proxyAgentCache.set(proxy, agent);
         owned.push(agent);
       }
-      hostnameMap.set(hostname, agent);
-      logInfo(`[provider-proxy] ${hostname} → ${proxy}`);
+      hostMap.set(host, agent);
+      logInfo(`[provider-proxy] ${host} → ${proxy}`);
     }
   }
 
   const fallback = new EnvHttpProxyAgent();
-  return new ProviderProxyRouter(hostnameMap, fallback, owned);
+  return new ProviderProxyRouter(hostMap, fallback, owned);
 }
 
 /**

--- a/src/infra/net/provider-proxy-dispatcher.ts
+++ b/src/infra/net/provider-proxy-dispatcher.ts
@@ -50,6 +50,9 @@ export class ProviderProxyRouter extends Agent {
     } catch (err) {
       errors.push(err);
     }
+    if (errors.length > 0) {
+      logDebug(`[provider-proxy] errors during close: ${errors.map(String).join(", ")}`);
+    }
     await super.close();
   }
 }

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -4,12 +4,18 @@ import { resetTelegramFetchStateForTests, resolveTelegramFetch } from "./fetch.j
 
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
+const getGlobalDispatcher = vi.hoisted(() => vi.fn().mockReturnValue({}));
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
 const AgentCtor = vi.hoisted(() =>
   vi.fn(function MockAgent(this: { options: unknown }, options: unknown) {
     this.options = options;
   }),
 );
+const MockProviderProxyRouter = vi.hoisted(() => class MockProviderProxyRouter {});
+
+vi.mock("../infra/net/provider-proxy-dispatcher.js", () => ({
+  ProviderProxyRouter: MockProviderProxyRouter,
+}));
 
 vi.mock("node:net", async () => {
   const actual = await vi.importActual<typeof import("node:net")>("node:net");
@@ -29,6 +35,7 @@ vi.mock("node:dns", async () => {
 
 vi.mock("undici", () => ({
   Agent: AgentCtor,
+  getGlobalDispatcher,
   setGlobalDispatcher,
 }));
 
@@ -38,6 +45,7 @@ afterEach(() => {
   resetTelegramFetchStateForTests();
   setDefaultAutoSelectFamily.mockReset();
   setDefaultResultOrder.mockReset();
+  getGlobalDispatcher.mockReset().mockReturnValue({});
   setGlobalDispatcher.mockReset();
   AgentCtor.mockClear();
   vi.unstubAllEnvs();
@@ -186,5 +194,13 @@ describe("resolveTelegramFetch", () => {
         autoSelectFamilyAttemptTimeout: 300,
       },
     });
+  });
+
+  it("skips setGlobalDispatcher when ProviderProxyRouter is active", async () => {
+    getGlobalDispatcher.mockReturnValue(new MockProviderProxyRouter());
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -1,8 +1,9 @@
 import * as dns from "node:dns";
 import * as net from "node:net";
-import { Agent, setGlobalDispatcher } from "undici";
+import { Agent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 import type { TelegramNetworkConfig } from "../config/types.telegram.js";
 import { resolveFetch } from "../infra/fetch.js";
+import { ProviderProxyRouter } from "../infra/net/provider-proxy-dispatcher.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
@@ -45,16 +46,25 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
     try {
-      setGlobalDispatcher(
-        new Agent({
-          connect: {
-            autoSelectFamily: autoSelectDecision.value,
-            autoSelectFamilyAttemptTimeout: 300,
-          },
-        }),
-      );
-      appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-      log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
+      // Skip if a ProviderProxyRouter is already installed — overwriting it
+      // would break per-provider proxy routing.
+      if (getGlobalDispatcher() instanceof ProviderProxyRouter) {
+        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+        log.info(
+          `skipping global dispatcher replacement (ProviderProxyRouter active); autoSelectFamily=${autoSelectDecision.value}`,
+        );
+      } else {
+        setGlobalDispatcher(
+          new Agent({
+            connect: {
+              autoSelectFamily: autoSelectDecision.value,
+              autoSelectFamilyAttemptTimeout: 300,
+            },
+          }),
+        );
+        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+        log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
+      }
     } catch {
       // ignore if setGlobalDispatcher is unavailable
     }


### PR DESCRIPTION
## Summary

- Add optional `proxy` field to model provider configuration for per-provider HTTP proxy routing
- Support three proxy modes: explicit proxy URL, `"direct"` (bypass all proxies), and omit/`"env"` (use system `HTTP_PROXY`/`HTTPS_PROXY`)
- Implement `ProviderProxyRouter` — a custom `undici` dispatcher that routes requests to the correct proxy based on destination hostname

Closes #30368

## Motivation

In network environments where system-level proxies (`HTTP_PROXY`/`HTTPS_PROXY`) block certain model provider APIs, users have no way to configure per-provider proxy routing. This PR enables fine-grained proxy control per provider.

## Changes

- **`src/config/types.models.ts`**: Add `proxy?: string` to `ModelProviderConfig`
- **`src/config/zod-schema.core.ts`**: Add `proxy` field to `ModelProviderSchema`
- **`src/config/schema.help.ts`**: Add help text for the new `proxy` config field
- **`src/infra/net/provider-proxy-dispatcher.ts`**: New `ProviderProxyRouter` class that extends `undici.Agent` and routes dispatches by hostname → per-provider dispatcher (`ProxyAgent` / `Agent` / `EnvHttpProxyAgent`)
- **`src/infra/net/provider-proxy-dispatcher.test.ts`**: 11 unit tests covering all routing scenarios
- **`src/gateway/server.impl.ts`**: Install the proxy dispatcher at gateway startup
- **`src/commands/agent.ts`**: Install the proxy dispatcher at CLI agent startup

## Example Configuration

```json
{
  "models": {
    "providers": {
      "my_api": {
        "baseUrl": "https://api.example.com/",
        "apiKey": "sk-xxx",
        "proxy": "http://127.0.0.1:7890",
        "models": [...]
      },
      "local_ollama": {
        "baseUrl": "http://localhost:11434",
        "proxy": "direct",
        "models": [...]
      }
    }
  }
}
```

## Test plan

- [x] 11 unit tests for `buildProviderProxyRouter` and `ProviderProxyRouter.dispatch`
- [ ] Manual test: configure a provider with `proxy: "http://..."` and verify requests route through the proxy
- [ ] Manual test: configure a provider with `proxy: "direct"` and verify requests bypass system proxy
- [ ] Manual test: provider without `proxy` field uses system env proxy as before

Made with [Cursor](https://cursor.com)