### PR TITLE
Gateway: stabilize main session display name in sessions.list

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -671,6 +671,95 @@ describe("listSessionsFromStore search", () => {
     expect(result.sessions[0]?.displayName).toBe("Pinned Main");
   });
 
+  test("keeps bare main key title stable when displayName contains transient metadata", () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "sess-main-bare",
+        updatedAt: now,
+        displayName: "Heartbeat",
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Main Session");
+  });
+
+  test("keeps configured main key title stable when displayName contains transient metadata", () => {
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "work" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:ops:work": {
+        sessionId: "sess-main-work",
+        updatedAt: now,
+        displayName: "Heartbeat",
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Main Session");
+  });
+
+  test("does not rename non-default agent main sessions", () => {
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "work" },
+      agents: { list: [{ id: "ops", default: true }, { id: "dev" }] },
+    } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:dev:work": {
+        sessionId: "sess-dev-work",
+        updatedAt: now,
+        displayName: "Dev Main Session",
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Dev Main Session");
+  });
+
+  test("keeps main session origin label as fallback when label is missing", () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: now,
+        displayName: "Heartbeat",
+        origin: { label: "Primary Inbox", type: "channel" } as SessionEntry["origin"],
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Primary Inbox");
+  });
+
   test("filters sessions across display metadata and key fields", () => {
     const cases = [
       { search: "WORK PROJECT", expectedKey: "agent:main:work-project" },

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -630,6 +630,47 @@ describe("listSessionsFromStore search", () => {
     }
   });
 
+  test("keeps main session title stable when displayName contains transient metadata", () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: now,
+        displayName: "Heartbeat",
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Main Session");
+  });
+
+  test("keeps explicit main session label over transient displayName metadata", () => {
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: now,
+        displayName: "Heartbeat",
+        label: "Pinned Main",
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.displayName).toBe("Pinned Main");
+  });
+
   test("filters sessions across display metadata and key fields", () => {
     const cases = [
       { search: "WORK PROJECT", expectedKey: "agent:main:work-project" },

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -733,6 +733,7 @@ export function listSessionsFromStore(params: {
 }): SessionsListResult {
   const { cfg, storePath, store, opts } = params;
   const now = Date.now();
+  const canonicalMainSessionKey = resolveMainSessionKey(cfg);
 
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
@@ -790,6 +791,7 @@ export function listSessionsFromStore(params: {
       const total = resolveFreshSessionTotalTokens(entry);
       const totalTokensFresh =
         typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
+      const canonicalSessionKey = resolveSessionStoreKey({ cfg, sessionKey: key });
       const parsed = parseGroupKey(key);
       const parsedAgentSessionKey = parseAgentSessionKey(key);
       const channel = entry?.channel ?? parsed?.channel;
@@ -800,9 +802,9 @@ export function listSessionsFromStore(params: {
       const origin = entry?.origin;
       const originLabel = origin?.label;
       const sessionLabel = entry?.label?.trim();
-      const isMainSession = key.toLowerCase() === "main" || parsedAgentSessionKey?.rest === "main";
+      const isMainSession = canonicalSessionKey === canonicalMainSessionKey;
       const displayName = isMainSession
-        ? sessionLabel || "Main Session"
+        ? sessionLabel || originLabel || "Main Session"
         : (entry?.displayName ??
           (channel
             ? buildGroupDisplayName({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -791,6 +791,7 @@ export function listSessionsFromStore(params: {
       const totalTokensFresh =
         typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
       const parsed = parseGroupKey(key);
+      const parsedAgentSessionKey = parseAgentSessionKey(key);
       const channel = entry?.channel ?? parsed?.channel;
       const subject = entry?.subject;
       const groupChannel = entry?.groupChannel;
@@ -798,23 +799,27 @@ export function listSessionsFromStore(params: {
       const id = parsed?.id;
       const origin = entry?.origin;
       const originLabel = origin?.label;
-      const displayName =
-        entry?.displayName ??
-        (channel
-          ? buildGroupDisplayName({
-              provider: channel,
-              subject,
-              groupChannel,
-              space,
-              id,
-              key,
-            })
-          : undefined) ??
-        entry?.label ??
-        originLabel;
+      const sessionLabel = entry?.label?.trim();
+      const isMainSession = key.toLowerCase() === "main" || parsedAgentSessionKey?.rest === "main";
+      const displayName = isMainSession
+        ? sessionLabel || "Main Session"
+        : (entry?.displayName ??
+          (channel
+            ? buildGroupDisplayName({
+                provider: channel,
+                subject,
+                groupChannel,
+                space,
+                id,
+                key,
+              })
+            : undefined) ??
+          entry?.label ??
+          originLabel);
       const deliveryFields = normalizeSessionDeliveryFields(entry);
-      const parsedAgent = parseAgentSessionKey(key);
-      const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));
+      const sessionAgentId = normalizeAgentId(
+        parsedAgentSessionKey?.agentId ?? resolveDefaultAgentId(cfg),
+      );
       const resolvedModel = resolveSessionModelIdentityRef(cfg, entry, sessionAgentId);
       const modelProvider = resolvedModel.provider;
       const model = resolvedModel.model ?? DEFAULT_MODEL;


### PR DESCRIPTION
## Summary

Fixes Webchat session-title flicker for the main session by stabilizing `sessions.list` display naming.

When `agent:main:main` (or bare `main`) had transient `displayName` metadata like `Heartbeat`, clients would surface that value as the session title after refresh. This change now treats main sessions specially:
- keep explicit user label (`entry.label`) when present
- otherwise use stable fallback `Main Session`
- ignore transient `entry.displayName` for main sessions

Fixes #30350.

## Reproduction and verification

### Before fix
Added regression tests in `src/gateway/session-utils.test.ts`:
- `keeps main session title stable when displayName contains transient metadata`
- `keeps explicit main session label over transient displayName metadata`

Ran:

```bash
pnpm vitest run src/gateway/session-utils.test.ts -t "main session"
```

Both tests failed on `main` (received `Heartbeat`).

### After fix
Ran:

```bash
pnpm vitest run src/gateway/session-utils.test.ts -t "main session"
pnpm vitest run src/gateway/session-utils.test.ts
pnpm vitest run src/gateway/server.sessions.gateway-server-sessions-a.test.ts
```

All pass.
