### PR TITLE
fix(frontmatter): handle unquoted colons in YAML frontmatter values

### DIFF
--- a/src/markdown/frontmatter.test.ts
+++ b/src/markdown/frontmatter.test.ts
@@ -72,4 +72,48 @@ metadata:
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toEqual({});
   });
+
+  it("handles description with unquoted colon (auto-quoting)", () => {
+    const content = `---
+name: test-skill
+description: Generate images using API. IMPORTANT: Must use anime style
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("test-skill");
+    expect(result.description).toContain("IMPORTANT");
+    expect(result.description).toContain("anime style");
+  });
+
+  it("handles multiple colons in description", () => {
+    const content = `---
+name: multi-colon
+description: Step 1: do this. Step 2: do that. Step 3: done
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.name).toBe("multi-colon");
+    expect(result.description).toContain("Step 1");
+    expect(result.description).toContain("Step 3");
+  });
+
+  it("preserves already-quoted values with colons", () => {
+    const content = `---
+name: quoted-skill
+description: "Has colon: inside quotes"
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.description).toBe("Has colon: inside quotes");
+  });
+
+  it("does not auto-quote values without colons", () => {
+    const content = `---
+name: normal-skill
+description: Simple description without extra colons
+---
+`;
+    const result = parseFrontmatterBlock(content);
+    expect(result.description).toBe("Simple description without extra colons");
+  });
 });

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -51,7 +51,14 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatter | null {
       result[key] = coerced;
     }
     return result;
-  } catch {
+  } catch (err) {
+    // Log a hint so users can diagnose silent skill-loading failures.
+    // Common cause: unquoted colons in description fields.
+    const hint = String(err).includes("Nested mappings")
+      ? " (hint: quote values containing colons)"
+      : "";
+    // eslint-disable-next-line no-console
+    console.warn(`[frontmatter] YAML parse failed${hint}: ${String(err).split("\n")[0]}`);
     return null;
   }
 }
@@ -130,6 +137,44 @@ function parseLineFrontmatter(block: string): ParsedFrontmatter {
   return frontmatter;
 }
 
+/**
+ * Auto-quote unquoted YAML values that contain colons, which would
+ * otherwise cause "Nested mappings" parse errors.
+ *
+ * Before: `description: Use API. IMPORTANT: anime only`
+ * After:  `description: "Use API. IMPORTANT: anime only"`
+ */
+function autoQuoteColonValues(block: string): string {
+  return block
+    .split("\n")
+    .map((line) => {
+      // Match top-level key: value lines (not indented, not already quoted)
+      const m = line.match(/^([\w-]+):\s+(.+)$/);
+      if (!m) {
+        return line;
+      }
+      const value = m[2];
+      // Skip if already quoted or is a YAML block scalar indicator
+      if (
+        value.startsWith('"') ||
+        value.startsWith("'") ||
+        value === "|" ||
+        value === ">" ||
+        value === "|-" ||
+        value === ">-"
+      ) {
+        return line;
+      }
+      // Only quote if value contains an additional colon (the problematic case)
+      if (value.includes(":")) {
+        const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+        return `${m[1]}: "${escaped}"`;
+      }
+      return line;
+    })
+    .join("\n");
+}
+
 export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   if (!normalized.startsWith("---")) {
@@ -142,7 +187,15 @@ export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   const block = normalized.slice(4, endIndex);
 
   const lineParsed = parseLineFrontmatter(block);
-  const yamlParsed = parseYamlFrontmatter(block);
+
+  // Try YAML parse; if it fails, retry with auto-quoted colon values
+  let yamlParsed = parseYamlFrontmatter(block);
+  if (yamlParsed === null) {
+    const quoted = autoQuoteColonValues(block);
+    if (quoted !== block) {
+      yamlParsed = parseYamlFrontmatter(quoted);
+    }
+  }
   if (yamlParsed === null) {
     return lineParsed;
   }


### PR DESCRIPTION
## Summary

Fix SKILL.md files with unquoted colons in description fields silently failing to load, making skills invisible in `openclaw skills` CLI with no error message.

Closes #29981

## Root Cause

When a SKILL.md frontmatter contains an unquoted colon in a value field:

```yaml
---
name: test-skill
description: Generate images using API. IMPORTANT: Must use anime style
---
```

The YAML parser interprets `IMPORTANT:` as a nested mapping key, throwing a "Nested mappings are not allowed in compact mappings" error. The `catch` block silently returned `null` with **no logging**, so users had no way to know why their skill disappeared.

## Fix

Three-layer approach:

### 1. Auto-quote fallback (`autoQuoteColonValues`)
When YAML parsing fails, automatically wrap values containing colons in double quotes and retry:
- `description: A. IMPORTANT: B` → `description: "A. IMPORTANT: B"`
- Only applied as fallback (never changes valid YAML)
- Properly escapes backslashes and quotes in values
- Skips already-quoted values and YAML block scalar indicators (`|`, `>`, `|-`, `>-`)

### 2. Diagnostic logging
When YAML parsing fails, log a warning with actionable hint:
```
[frontmatter] YAML parse failed (hint: quote values containing colons): YAMLParseError: Nested mappings...
```

### 3. Tests
4 new tests covering:
- Single colon in description (the reported bug)
- Multiple colons in description
- Already-quoted values with colons (no change)
- Normal values without colons (no change)

## Changes

- **`src/markdown/frontmatter.ts`** (+58 lines)
  - `autoQuoteColonValues()` function
  - Retry logic in `parseFrontmatterBlock()`
  - `console.warn` with hint in `parseYamlFrontmatter()`

- **`src/markdown/frontmatter.test.ts`** (+44 lines)
  - 4 new test cases

## Testing

```
✓ src/markdown/frontmatter.test.ts (9 tests) 33ms
Test Files  1 passed (1)
     Tests  9 passed (9)
```

All 5 existing tests continue to pass. Codex (gpt-5.3-codex) review confirmed the auto-quoting fallback is safe — it only triggers when YAML parsing already failed, so it cannot break valid YAML documents.

## Backward Compatibility

✅ Fully backward compatible:
- Auto-quoting only runs as fallback when YAML parsing fails
- Valid YAML documents are never modified
- The `lineParsed` fallback still works as before
- New warning log helps users diagnose issues without changing behavior