### PR TITLE
fix(gateway): return 404 for /api/* routes instead of SPA fallback

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -374,4 +374,17 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+  it("returns 404 for /api/* routes instead of falling through to SPA", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end, handled } = runControlUiRequest({
+          url: "/api/sessions",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expectNotFoundResponse({ handled, res, end });
+      },
+    });
+  });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -285,6 +285,12 @@ export function handleControlUiHttpRequest(
   const url = new URL(urlRaw, "http://localhost");
   const basePath = normalizeControlUiBasePath(opts?.basePath);
   const pathname = url.pathname;
+  // API routes should return 404, not fall through to the SPA
+  // This prevents /api/* requests from being served as index.html
+  if (pathname.startsWith("/api/")) {
+    respondNotFound(res);
+    return true;
+  }
 
   if (!basePath) {
     if (pathname === "/ui" || pathname.startsWith("/ui/")) {


### PR DESCRIPTION
## Summary

This fixes issue #30295 where `/api/*` endpoints were returning the SPA HTML page instead of JSON responses.

## Root Cause

The control-ui request handler was falling through to serve the SPA index.html for unknown paths, including `/api/*` routes. This caused API requests to receive HTML instead of the expected 404 or JSON response.

## Fix

Added a check at the beginning of `handleControlUiHttpRequest` to return 404 for any path that starts with `/api/`, preventing API requests from falling through to the SPA router.

### Changes

- `src/gateway/control-ui.ts`: Add pathname check for `/api/` prefix
- `src/gateway/control-ui.http.test.ts`: Add test to verify `/api/*` routes return 404, not HTML

## Testing

- Test passes: `pnpm vitest run src/gateway/control-ui.http.test.ts`
- Format check passes: `pnpm format:check`

## Notes

The user expected `/api/sessions` to return JSON, but this endpoint doesn't actually exist. The fix ensures that any `/api/*` request now correctly returns 404 instead of HTML.