### PR TITLE
fix(ui): keep main session title stable after chat refresh

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -24,6 +24,13 @@ describe("parseSessionKey", () => {
     });
   });
 
+  it("identifies main session for any agent main-key pattern", () => {
+    expect(parseSessionKey("agent:ops:main")).toEqual({
+      prefix: "",
+      fallbackName: "Main Session",
+    });
+  });
+
   it("identifies subagent sessions", () => {
     expect(parseSessionKey("agent:main:subagent:18abfefe-1fa6-43cb-8ba8-ebdc9b43e253")).toEqual({
       prefix: "Subagent:",
@@ -135,6 +142,21 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:main", row({ key: "agent:main:main" }))).toBe(
       "Main Session",
     );
+  });
+
+  it("keeps main session display stable when row label is transient", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:main:main",
+        row({ key: "agent:main:main", label: "Heartbeat", displayName: "Heartbeat" }),
+      ),
+    ).toBe("Main Session");
+    expect(
+      resolveSessionDisplayName(
+        "agent:ops:main",
+        row({ key: "agent:ops:main", label: "Heartbeat" }),
+      ),
+    ).toBe("Main Session");
   });
 
   it("returns parsed fallback when displayName matches key", () => {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -282,7 +282,7 @@ function capitalize(s: string): string {
  */
 export function parseSessionKey(key: string): SessionKeyInfo {
   // ── Main session ─────────────────────────────────
-  if (key === "main" || key === "agent:main:main") {
+  if (key === "main" || /^agent:[^:]+:main$/.test(key)) {
     return { prefix: "", fallbackName: "Main Session" };
   }
 
@@ -331,6 +331,7 @@ export function resolveSessionDisplayName(
   const label = row?.label?.trim() || "";
   const displayName = row?.displayName?.trim() || "";
   const { prefix, fallbackName } = parseSessionKey(key);
+  const isMainSession = fallbackName === "Main Session";
 
   const applyTypedPrefix = (name: string): string => {
     if (!prefix) {
@@ -339,6 +340,12 @@ export function resolveSessionDisplayName(
     const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\s*`, "i");
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
+
+  // Keep main-session naming stable in chat controls. Backend metadata can
+  // briefly surface internal transient labels (e.g. "Heartbeat").
+  if (isMainSession) {
+    return fallbackName;
+  }
 
   if (label && label !== key) {
     return applyTypedPrefix(label);


### PR DESCRIPTION
## Summary

- **Problem:** In Webchat, the active main session title can briefly flicker to internal labels like `Heartbeat` after clicking "Refresh Chat Data".
- **Why it matters:** Users see unstable/misleading session identity in chat controls and may think they switched sessions or lost context.
- **What changed:** Updated `resolveSessionDisplayName` in `ui/src/ui/app-render.helpers.ts` to keep main-session display names stable (`Main Session`) and expanded main-key parsing to include `agent:<id>:main` keys. Added regression coverage in `ui/src/ui/app-render.helpers.node.test.ts`.
- **What did NOT change:** No backend session data behavior, no session switching logic, and no message/history loading flow changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30350

## User-visible / Behavior Changes

- Main chat session now consistently displays as `Main Session` in chat controls, instead of transient internal labels.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Control UI Webchat
- Integration/channel: Chat page session selector/controls

### Steps

1. Open Webchat on the main session
2. Click the in-chat "Refresh Chat Data" button repeatedly
3. Observe main session display name in chat controls

### Expected

- Main session display name remains stable (`Main Session`)

### Actual

- Before fix: Name can flicker to transient internal labels (e.g. `Heartbeat`)
- After fix: Name remains stable as `Main Session`

## Evidence

- Code change: main-session display now bypasses transient `label/displayName` metadata
- Added regression tests for:
  - `agent:<id>:main` recognized as main session key
  - transient labels (`Heartbeat`) ignored for main session display

## Human Verification (required)

- Verified scenarios: main key parsing; display resolution for main-session keys with transient labels
- Edge cases checked: `main`, `agent:main:main`, `agent:ops:main`
- What I did **not** verify: Browser e2e in this environment (UI browser test dependencies unavailable)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`
- Known bad symptoms: Main session title may flicker to transient internal labels again

## Risks and Mitigations

- Risk: Users who intentionally relied on backend-provided main-session labels in chat controls will now always see `Main Session`.
- Mitigation: This behavior is intentionally constrained to main-session keys to eliminate misleading flicker from internal metadata.

