### PR TITLE
docs(community): add SerpApi search provider plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **SerpApi Search** — SerpApi search provider with vertical search routing (News, Scholar, Images, Shopping, Maps, Jobs, Finance, Patents, YouTube, and alternative engines).
+  npm: `openclaw-serpapi-search`
+  repo: `https://github.com/xiaoyaner0201/openclaw-serpapi-search`
+  install: `openclaw plugins install openclaw-serpapi-search`


### PR DESCRIPTION
## Summary

Add [openclaw-serpapi-search](https://github.com/xiaoyaner0201/openclaw-serpapi-search) to the community plugins page.

## Plugin Details

- **npm**: `openclaw-serpapi-search` ([npmjs](https://www.npmjs.com/package/openclaw-serpapi-search))
- **repo**: https://github.com/xiaoyaner0201/openclaw-serpapi-search
- **install**: `openclaw plugins install openclaw-serpapi-search`

### Features
- 20+ search verticals via SerpApi (News, Scholar, Images, Shopping, Maps, Jobs, Finance, Patents, YouTube)
- Alternative engines (Bing, Baidu, Yandex, Naver, DuckDuckGo)
- Zero extra LLM calls — model selects vertical via `engine` parameter
- Freshness filtering for Google engines
- Uses the built-in `registerSearchProvider` API

### Context

This was originally submitted as PR #28764 which modified core OpenClaw code. Per maintainer feedback, it has been restructured as a standalone third-party plugin using the existing plugin API.