### PR TITLE
fix(line): detect M4A audio files by ftyp brand instead of falling through to video/mp4

### DIFF
--- a/src/line/download.test.ts
+++ b/src/line/download.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { detectContentType } from "./download.js";
+
+/**
+ * Helper to build a minimal ftyp box buffer.
+ * Real MPEG-4 files start with a 4-byte size, then "ftyp", then the brand.
+ */
+function makeFtypBuffer(brand: string): Buffer {
+  // size (4 bytes) + "ftyp" (4 bytes) + brand (4 bytes) = 12 bytes minimum
+  const buf = Buffer.alloc(12);
+  buf.writeUInt32BE(12, 0); // box size
+  buf.write("ftyp", 4, 4, "ascii"); // box type
+  buf.write(brand, 8, 4, "ascii"); // major brand
+  return buf;
+}
+
+describe("detectContentType", () => {
+  it("detects M4A audio (iTunes AAC brand)", () => {
+    const buf = makeFtypBuffer("M4A ");
+    expect(detectContentType(buf)).toBe("audio/mp4");
+  });
+
+  it("detects M4B audio (audiobook brand)", () => {
+    const buf = makeFtypBuffer("M4B ");
+    expect(detectContentType(buf)).toBe("audio/mp4");
+  });
+
+  it("detects F4A audio (Adobe audio brand)", () => {
+    const buf = makeFtypBuffer("F4A ");
+    expect(detectContentType(buf)).toBe("audio/mp4");
+  });
+
+  it("detects MP4 video (isom brand)", () => {
+    const buf = makeFtypBuffer("isom");
+    expect(detectContentType(buf)).toBe("video/mp4");
+  });
+
+  it("detects MP4 video (mp42 brand)", () => {
+    const buf = makeFtypBuffer("mp42");
+    expect(detectContentType(buf)).toBe("video/mp4");
+  });
+
+  it("detects JPEG", () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    expect(detectContentType(buf)).toBe("image/jpeg");
+  });
+
+  it("detects PNG", () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectContentType(buf)).toBe("image/png");
+  });
+
+  it("returns octet-stream for unknown content", () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    expect(detectContentType(buf)).toBe("application/octet-stream");
+  });
+
+  it("returns octet-stream for empty buffer", () => {
+    const buf = Buffer.alloc(0);
+    expect(detectContentType(buf)).toBe("application/octet-stream");
+  });
+});

--- a/src/line/download.ts
+++ b/src/line/download.ts
@@ -55,7 +55,7 @@ export async function downloadLineMedia(
   };
 }
 
-function detectContentType(buffer: Buffer): string {
+export function detectContentType(buffer: Buffer): string {
   // Check magic bytes
   if (buffer.length >= 2) {
     // JPEG
@@ -83,15 +83,22 @@ function detectContentType(buffer: Buffer): string {
     ) {
       return "image/webp";
     }
-    // MP4
-    if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
-      return "video/mp4";
-    }
-    // M4A/AAC
-    if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
-      if (buffer[4] === 0x66 && buffer[5] === 0x74 && buffer[6] === 0x79 && buffer[7] === 0x70) {
+    // MPEG-4 container (ftyp box at bytes 4-7)
+    // Both MP4 video and M4A audio share the same ftyp magic bytes,
+    // so we must check the brand string at bytes 8-11 to distinguish them.
+    if (
+      buffer.length >= 12 &&
+      buffer[4] === 0x66 &&
+      buffer[5] === 0x74 &&
+      buffer[6] === 0x79 &&
+      buffer[7] === 0x70
+    ) {
+      const brand = buffer.toString("ascii", 8, 12);
+      // M4A audio brands: M4A (iTunes AAC), M4B (audiobook), F4A (Adobe audio)
+      if (brand === "M4A " || brand === "M4B " || brand === "F4A ") {
         return "audio/mp4";
       }
+      return "video/mp4";
     }
   }
 


### PR DESCRIPTION
## Summary

Fix LINE voice messages (M4A/AAC-LC) not being transcribed because `detectContentType()` classifies them as `video/mp4` instead of `audio/mp4`.

Closes #29751

## Root Cause

The MP4 detection at bytes 4-7 (`ftyp` magic) fires for **all** MPEG-4 containers, including M4A audio files. The M4A-specific check below it was **dead code** — it checked the same bytes 4-7 but was unreachable because the MP4 branch always matched first:

```ts
// MP4 — matches ALL ftyp containers (including M4A)
if (buffer[4] === 0x66 && buffer[5] === 0x74 && ...) {
  return "video/mp4";  // ← M4A files hit this and stop
}
// M4A/AAC — DEAD CODE, never reached
if (buffer[0] === 0x00 && buffer[1] === 0x00 && buffer[2] === 0x00) {
  if (buffer[4] === 0x66 && ...) {
    return "audio/mp4";  // ← never executes
  }
}
```

Since `isAudioAttachment()` checks for `audio/*` content types, M4A voice messages were silently skipped by the transcription pipeline.

## Fix

After matching the `ftyp` magic bytes, read the **major brand** string at bytes 8-11 to distinguish audio containers from video:

```ts
const brand = buffer.toString("ascii", 8, 12);
if (brand === "M4A " || brand === "M4B " || brand === "F4A ") {
  return "audio/mp4";
}
return "video/mp4";
```

Recognized audio brands:
- `M4A ` — iTunes AAC audio
- `M4B ` — Audiobook
- `F4A ` — Adobe Flash audio

All other ftyp brands (e.g., `isom`, `mp42`, `mp41`, `MSNV`) default to `video/mp4`.

## Changes

- **`src/line/download.ts`** — Replace two-check dead-code pattern with single ftyp+brand detection; export `detectContentType` for testing
- **`src/line/download.test.ts`** (new) — 9 tests covering M4A, M4B, F4A, MP4 (isom/mp42), JPEG, PNG, unknown content, and empty buffer

## Testing

```
✓ src/line/download.test.ts (9 tests) 11ms
Test Files  1 passed (1)
     Tests  9 passed (9)
```