### PR TITLE
fix(auth): treat keyRef/tokenRef profiles as valid in auth order resolution

### DIFF
--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -58,9 +58,12 @@ export function resolveAuthProfileOrder(params: {
       }
     }
     if (cred.type === "api_key") {
-      return Boolean(cred.key?.trim());
+      return Boolean(cred.key?.trim() || cred.keyRef);
     }
     if (cred.type === "token") {
+      if (cred.tokenRef) {
+        return true;
+      }
       if (!cred.token?.trim()) {
         return false;
       }


### PR DESCRIPTION
## Summary

- **Problem:** `models status --probe` can report "Auth profile credentials are missing or expired" for profiles that use `keyRef`/`tokenRef` (especially with explicit `auth.order`), even though runtime secret resolution works.
- **Why it matters:** Operators get false negatives during auth health checks after migrating credentials to SecretRef-based providers (e.g. `source: exec`).
- **What changed:** Updated `resolveAuthProfileOrder` in `src/agents/auth-profiles/order.ts` so profiles backed by `keyRef` or `tokenRef` are treated as valid candidates (not dropped as empty plaintext credentials). Added regression tests in `src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts` for both `api_key + keyRef` and `token + tokenRef`.
- **What did NOT change:** Secret resolution protocol, provider execution logic, and probe runtime execution path remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30311

## User-visible / Behavior Changes

- `models status --probe` no longer prematurely marks SecretRef-backed auth profiles as "missing or expired" just because plaintext key/token fields are absent.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (validation semantics only)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS/Linux
- Runtime: CLI (`openclaw models status --probe`)
- Integration/channel: Auth profiles + SecretRef providers

### Steps

1. Configure auth profile using `keyRef`/`tokenRef` with explicit `auth.order`
2. Run `openclaw models status --probe`

### Expected

- Profile is considered eligible and actually probed

### Actual

- Before fix: profile can be pre-filtered as "missing or expired"
- After fix: profile remains in order candidates and is probed normally

## Evidence

Targeted tests passing:

```
✓ src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts (11 tests)
✓ src/commands/models/list.probe.test.ts (3 tests)
```

New regression assertions:
- keeps `api_key` profile with `keyRef` and no plaintext key
- keeps `token` profile with `tokenRef` even when token field is blank/expired

## Human Verification (required)

- Verified scenarios: explicit order + SecretRef-backed profile eligibility
- Edge cases checked: unchanged behavior for empty plaintext profiles without refs
- What I did **not** verify: end-to-end live probe against a real exec secret provider

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/auth-profiles/order.ts`
- Known bad symptoms: probe may regress to false "missing or expired" for SecretRef-backed profiles

## Risks and Mitigations

- Risk: potentially probing profiles that are still invalid at runtime.
- Mitigation: runtime probe already captures and reports real auth failures; this change only removes premature false-negative filtering for SecretRef-backed profiles.

