### PR TITLE
fix(web-fetch): pass SSRF policy to fetchWithSsrFGuard for fake-ip DNS environments

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -2,7 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { stringEnum } from "../schema/typebox.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
@@ -79,6 +79,27 @@ function resolveFetchConfig(cfg?: OpenClawConfig): WebFetchConfig {
     return undefined;
   }
   return fetch as WebFetchConfig;
+}
+
+/**
+ * Resolve SSRF policy from fetch config.
+ * When `allowPrivateNetwork` is set in `tools.web.fetch`, pass it through
+ * so that `fetchWithSsrFGuard` allows private/special-use IP addresses.
+ * This is needed for environments using fake-ip DNS (e.g., Mihomo/Clash)
+ * where all domains resolve to `198.18.x.x` (RFC 2544 benchmark range).
+ */
+function resolveSsrfPolicy(fetch?: WebFetchConfig): SsrFPolicy | undefined {
+  if (!fetch || typeof fetch !== "object") {
+    return undefined;
+  }
+  const allowPrivate =
+    "allowPrivateNetwork" in fetch && typeof fetch.allowPrivateNetwork === "boolean"
+      ? fetch.allowPrivateNetwork
+      : false;
+  if (!allowPrivate) {
+    return undefined;
+  }
+  return { allowPrivateNetwork: true };
 }
 
 function resolveFetchEnabled(params: { fetch?: WebFetchConfig; sandboxed?: boolean }): boolean {
@@ -378,6 +399,7 @@ async function runWebFetch(params: {
   firecrawlProxy: "auto" | "basic" | "stealth";
   firecrawlStoreInCache: boolean;
   firecrawlTimeoutSeconds: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
@@ -413,6 +435,7 @@ async function runWebFetch(params: {
           "Accept-Language": "en-US,en;q=0.9",
         },
       },
+      policy: params.ssrfPolicy,
     });
     res = result.response;
     finalUrl = result.finalUrl;
@@ -681,6 +704,7 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        ssrfPolicy: resolveSsrfPolicy(fetch),
       });
       return jsonResult(result);
     },


### PR DESCRIPTION
## Summary

Fix `web_fetch` blocking all requests with "resolves to private/internal/special-use IP address" when running behind Mihomo/Clash in fake-ip DNS mode.

Closes #29669

## Root Cause

`runWebFetch()` calls `fetchWithSsrFGuard()` **without a `policy` parameter**, so the SSRF guard uses strict defaults that block all special-use IP ranges — including the RFC 2544 benchmark range (`198.18.0.0/15`) used by Mihomo/Clash fake-ip DNS.

Meanwhile, other consumers like media fetching already pass `SsrFPolicy` through to the guard, which is why `web_search`, `browser`, and `curl` all work fine on the same host.

Call chain:
```
runWebFetch()
  → fetchWithSsrFGuard({ url, ... })          // ← no policy!
    → resolvePinnedHostname(hostname)           // strict mode
      → assertAllowedResolvedAddressesOrThrow() // blocks 198.18.x.x
```

## Fix

1. Add `resolveSsrfPolicy()` function that reads `allowPrivateNetwork` from the `tools.web.fetch` config section
2. Thread `ssrfPolicy` parameter through `runWebFetch` to `fetchWithSsrFGuard`
3. Users can now set `tools.web.fetch.allowPrivateNetwork: true` in `openclaw.json` to allow fake-ip DNS environments

```json
{
  "tools": {
    "web": {
      "fetch": {
        "allowPrivateNetwork": true
      }
    }
  }
}
```

This is consistent with how media fetching and other internal consumers already pass `SsrFPolicy` through to the guard.

## Changes

- **`src/agents/tools/web-fetch.ts`** (+25/-1)
  - Import `SsrFPolicy` type
  - Add `resolveSsrfPolicy()` to read config
  - Add `ssrfPolicy` to `runWebFetch` params
  - Pass `policy: params.ssrfPolicy` to `fetchWithSsrFGuard()`
  - Wire up in tool `execute` call

## Testing

```
✓ src/agents/tools/web-fetch.ssrf.test.ts (5 tests) 139ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

All 5 existing SSRF tests pass. The fix is additive — when no `allowPrivateNetwork` config is set, behavior is identical to before (strict SSRF blocking).