### PR TITLE
fix(bootstrap): skip [MISSING] marker for BOOTSTRAP.md after onboarding deletion

### DIFF
--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -35,6 +35,48 @@ describe("buildBootstrapContextFiles", () => {
       },
     ]);
   });
+  it("skips [MISSING] marker for BOOTSTRAP.md (intentionally deleted after onboarding)", () => {
+    const files = [
+      makeFile({
+        name: "BOOTSTRAP.md",
+        path: "/tmp/BOOTSTRAP.md",
+        missing: true,
+        content: undefined,
+      }),
+    ];
+    expect(buildBootstrapContextFiles(files)).toEqual([]);
+  });
+  it("still injects [MISSING] for other files when BOOTSTRAP.md is also missing", () => {
+    const files = [
+      makeFile({
+        name: "BOOTSTRAP.md",
+        path: "/tmp/BOOTSTRAP.md",
+        missing: true,
+        content: undefined,
+      }),
+      makeFile({ name: "AGENTS.md", path: "/tmp/AGENTS.md", missing: true, content: undefined }),
+    ];
+    expect(buildBootstrapContextFiles(files)).toEqual([
+      {
+        path: "/tmp/AGENTS.md",
+        content: "[MISSING] Expected at: /tmp/AGENTS.md",
+      },
+    ]);
+  });
+  it("includes BOOTSTRAP.md content when present (not missing)", () => {
+    const files = [
+      makeFile({
+        name: "BOOTSTRAP.md",
+        path: "/tmp/BOOTSTRAP.md",
+        missing: false,
+        content: "# Welcome\nFollow these steps...",
+      }),
+    ];
+    const result = buildBootstrapContextFiles(files);
+    expect(result).toEqual([
+      { path: "/tmp/BOOTSTRAP.md", content: "# Welcome\nFollow these steps..." },
+    ]);
+  });
   it("skips empty or whitespace-only content", () => {
     const files = [makeFile({ content: "   \n  " })];
     expect(buildBootstrapContextFiles(files)).toEqual([]);

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { truncateUtf16Safe } from "../../utils.js";
-import type { WorkspaceBootstrapFile } from "../workspace.js";
+import { DEFAULT_BOOTSTRAP_FILENAME, type WorkspaceBootstrapFile } from "../workspace.js";
 import type { EmbeddedContextFile } from "./types.js";
 
 type ContentBlockWithSignature = {
@@ -218,6 +218,12 @@ export function buildBootstrapContextFiles(
       continue;
     }
     if (file.missing) {
+      // BOOTSTRAP.md is intentionally deleted after initial setup ("Follow it, figure
+      // out who you are, then delete it"). Skip the [MISSING] marker so users who have
+      // completed onboarding don't see noisy context injections every session.
+      if (file.name === DEFAULT_BOOTSTRAP_FILENAME) {
+        continue;
+      }
       const missingText = `[MISSING] Expected at: ${pathValue}`;
       const cappedMissingText = clampToBudget(missingText, remainingTotalChars);
       if (!cappedMissingText) {


### PR DESCRIPTION
## Problem

`BOOTSTRAP.md` is designed to be deleted after initial setup — the default `AGENTS.md` template instructs:

> "If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out who you are, then delete it."

However, when `BOOTSTRAP.md` is missing, a `[MISSING] Expected at: /path/to/BOOTSTRAP.md` marker is injected into every session context. This means **every user who has completed onboarding sees a noisy, unnecessary marker in every session**.

## Impact

- ~98 characters / ~25 tokens of context noise per session
- Affects all main sessions for every user who followed the documented onboarding flow
- Sub-agent/cron sessions are unaffected (`BOOTSTRAP.md` is not in `MINIMAL_BOOTSTRAP_ALLOWLIST`)

## Fix

Skip the `[MISSING]` marker specifically for `BOOTSTRAP.md` when it is absent, using the existing `DEFAULT_BOOTSTRAP_FILENAME` constant. All other files retain their `[MISSING]` markers as before.

## Tests

Added 3 test cases:
1. `BOOTSTRAP.md` missing → no `[MISSING]` marker (skipped)
2. `BOOTSTRAP.md` + `AGENTS.md` both missing → only `AGENTS.md` gets `[MISSING]`
3. `BOOTSTRAP.md` present → content included normally

All 16 tests pass.

## Future consideration

A more general approach would be to add an `optional` flag to the bootstrap file definition, so any file marked `optional: true` would skip the `[MISSING]` marker when absent. This would avoid hardcoding specific filenames in the rendering logic. Kept this PR minimal and focused on the immediate issue.