### PR TITLE
fix(config): add firecrawl, readability, and allowPrivateNetwork to web fetch schema

### DIFF
--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -188,6 +188,18 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const ToolsWebFetchFirecrawlSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    apiKey: z.string().optional(),
+    baseUrl: z.string().optional(),
+    onlyMainContent: z.boolean().optional(),
+    maxAgeMs: z.number().nonnegative().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -197,6 +209,9 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    allowPrivateNetwork: z.boolean().optional(),
+    firecrawl: ToolsWebFetchFirecrawlSchema,
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Fix `openclaw doctor` rejecting valid `tools.web.fetch.firecrawl` config with "Unrecognized key: firecrawl", despite the field being documented and functional at runtime.

Closes #27833

## Root Cause

`ToolsWebFetchSchema` in `zod-schema.agent-runtime.ts` uses `.strict()` validation (rejects unknown keys) but was missing several fields that are:
1. Documented at [docs.openclaw.ai/tools/firecrawl](https://docs.openclaw.ai/tools/firecrawl)
2. Defined in the TypeScript types (`config/types.tools.ts`)
3. Listed in the config schema descriptions (`config/schema.ts`)
4. Consumed at runtime (`agents/tools/web-fetch.ts`)

## Fix

Add the missing fields to `ToolsWebFetchSchema`:

### `firecrawl` (new sub-schema `ToolsWebFetchFirecrawlSchema`)
- `enabled` (boolean) — enable/disable Firecrawl fallback
- `apiKey` (string) — API key (fallback: `FIRECRAWL_API_KEY` env)
- `baseUrl` (string) — custom endpoint URL
- `onlyMainContent` (boolean) — return only main content
- `maxAgeMs` (number) — cache max age in ms
- `timeoutSeconds` (number) — request timeout

### Other missing fields
- `readability` (boolean) — controls readability extraction
- `allowPrivateNetwork` (boolean) — SSRF guard bypass for fake-ip DNS environments

## Testing

```
Test Files  45 passed (45)
     Tests  305 passed (305)
```

All 305 existing config validation tests pass. The fix is additive — existing configs without firecrawl are unaffected.