### PR TITLE
fix: propagate explicit provider apiKey/baseUrl changes to per-agent models.json

### DIFF
--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -163,11 +163,19 @@ export async function ensureOpenClawModelsJson(
             })
           | undefined;
         if (existing) {
+          // Only preserve agent-local apiKey/baseUrl when the global config
+          // does not explicitly set them. When the user updates these fields in
+          // openclaw.json (explicit providers), those values must propagate to
+          // every agent; otherwise stale credentials remain stuck in the
+          // per-agent models.json forever.
+          const explicitEntry = explicitProviders[key] as
+            | ({ apiKey?: string; baseUrl?: string } & Record<string, unknown>)
+            | undefined;
           const preserved: Record<string, unknown> = {};
-          if (typeof existing.apiKey === "string" && existing.apiKey) {
+          if (typeof existing.apiKey === "string" && existing.apiKey && !explicitEntry?.apiKey) {
             preserved.apiKey = existing.apiKey;
           }
-          if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+          if (typeof existing.baseUrl === "string" && existing.baseUrl && !explicitEntry?.baseUrl) {
             preserved.baseUrl = existing.baseUrl;
           }
           mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

Fixes #30395

- When `models.mode` is `"merge"` (default), the per-agent `models.json` merge logic now correctly propagates `apiKey` and `baseUrl` changes from the global `openclaw.json` config to all agent directories.
- Previously, once an agent's `models.json` was written, stale `apiKey`/`baseUrl` values were preserved indefinitely, even after the user updated the global config. This caused silent authentication failures (HTTP 401) in multi-agent setups.
- Agent-local `apiKey`/`baseUrl` values are still preserved when the provider was only implicitly discovered (e.g. from environment variables), maintaining backward compatibility for that use case.

## Changes

- **`src/agents/models-config.ts`**: In the merge-mode branch of `ensureOpenClawModelsJson()`, check whether the global config (`explicitProviders`) has `apiKey`/`baseUrl` set for the provider. If so, use the global values instead of preserving stale agent-local ones. Only preserve agent-local values when the provider is implicitly discovered.
- **`src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`**: Updated the existing test to verify the new correct behavior (explicit config values propagate), and added a new test verifying that implicitly-discovered provider credentials are still preserved.

## Test plan

- [x] Existing `models-config` tests pass (8/8)
- [x] New test: explicit config `apiKey`/`baseUrl` overrides stale agent-local values
- [x] New test: implicitly-discovered provider `apiKey`/`baseUrl` are preserved when no explicit config is set
- [x] Lint and format pass (`pnpm lint`, `pnpm format:fix`)

