### PR TITLE
fix(cron): allow delivery mode none for main-session systemEvent jobs

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -41,7 +41,12 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
 }
 
 function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">) {
-  if (job.delivery && job.sessionTarget !== "isolated") {
+  // delivery: { mode: "none" } is a no-op — skip validation so main-session
+  // systemEvent jobs can include it without triggering the isolated-only guard.
+  if (!job.delivery || job.delivery.mode === "none") {
+    return;
+  }
+  if (job.sessionTarget !== "isolated") {
     throw new Error('cron delivery config is only supported for sessionTarget="isolated"');
   }
 }


### PR DESCRIPTION
## Summary

Fix cron job creation failing with `cron delivery config is only supported for sessionTarget="isolated"` when the AI agent includes `delivery: { mode: "none" }` on a `sessionTarget="main"` systemEvent job.

Closes #27431

## Root Cause

`assertDeliverySupport()` in `src/cron/service/jobs.ts` checks for the **presence** of `job.delivery` but does not distinguish `mode: "none"` (a no-op) from actual delivery modes like `"announce"` or `"webhook"`.

The cron tool guidance in `cron-tool.ts` documents `delivery.mode` as a valid field including `"none"`, so the AI agent legitimately generates `delivery: { mode: "none" }` for main-session reminders. This creates an inconsistency between what the tool guidance says and what runtime validation accepts.

## Fix

Return early from `assertDeliverySupport()` when `delivery.mode` is `"none"`, since no-op delivery requires no isolated session support.

## Changes

- **`src/cron/service/jobs.ts`** (+6/-1) — early return for `mode: "none"`

## Testing

```
Test Files  20 passed (20)
     Tests  86 passed (86)
```

All 86 existing cron tests pass.
