### PR TITLE
fix(telegram): avoid overriding undici dispatcher when proxy env is set

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -179,6 +179,23 @@ describe("resolveTelegramFetch", () => {
     expect(AgentCtor).not.toHaveBeenCalled();
   });
 
+  it("applies global dispatcher after proxy env is removed", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+
+    clearProxyEnv();
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    expect(AgentCtor).toHaveBeenCalledWith({
+      connect: {
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 300,
+      },
+    });
+  });
+
   it("sets global dispatcher only once across repeated equal decisions", async () => {
     clearProxyEnv();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -50,6 +50,15 @@ afterEach(() => {
 });
 
 describe("resolveTelegramFetch", () => {
+  function clearProxyEnv(): void {
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("ALL_PROXY", "");
+    vi.stubEnv("all_proxy", "");
+  }
+
   it("returns wrapped global fetch when available", async () => {
     const fetchMock = vi.fn(async () => ({}));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -148,6 +157,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("replaces global undici dispatcher with autoSelectFamily-enabled agent", async () => {
+    clearProxyEnv();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
 
@@ -160,7 +170,17 @@ describe("resolveTelegramFetch", () => {
     });
   });
 
+  it("does not replace global dispatcher when proxy env is configured", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
+    resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(AgentCtor).not.toHaveBeenCalled();
+  });
+
   it("sets global dispatcher only once across repeated equal decisions", async () => {
+    clearProxyEnv();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
@@ -169,6 +189,7 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("updates global dispatcher when autoSelectFamily decision changes", async () => {
+    clearProxyEnv();
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: true } });
     resolveTelegramFetch(undefined, { network: { autoSelectFamily: false } });

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -14,6 +14,18 @@ let appliedDnsResultOrder: string | null = null;
 let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 
+function hasProxyEnvConfigured(): boolean {
+  const env = process.env ?? {};
+  const keys = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"];
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
 // Many networks have IPv6 configured but not routed, causing "Network is unreachable" errors.
 // See: https://github.com/nodejs/node/issues/54359
@@ -44,19 +56,25 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== null &&
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
-    try {
-      setGlobalDispatcher(
-        new Agent({
-          connect: {
-            autoSelectFamily: autoSelectDecision.value,
-            autoSelectFamilyAttemptTimeout: 300,
-          },
-        }),
+    if (hasProxyEnvConfigured()) {
+      log.info(
+        "skip global undici dispatcher autoSelectFamily override because proxy env is configured",
       );
-      appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-      log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
-    } catch {
-      // ignore if setGlobalDispatcher is unavailable
+    } else {
+      try {
+        setGlobalDispatcher(
+          new Agent({
+            connect: {
+              autoSelectFamily: autoSelectDecision.value,
+              autoSelectFamilyAttemptTimeout: 300,
+            },
+          }),
+        );
+        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+        log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
+      } catch {
+        // ignore if setGlobalDispatcher is unavailable
+      }
     }
   }
 

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -12,6 +12,7 @@ import {
 let appliedAutoSelectFamily: boolean | null = null;
 let appliedDnsResultOrder: string | null = null;
 let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
+let skippedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 
 function hasProxyEnvConfigured(): boolean {
@@ -57,9 +58,12 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
     if (hasProxyEnvConfigured()) {
-      log.info(
-        "skip global undici dispatcher autoSelectFamily override because proxy env is configured",
-      );
+      if (skippedGlobalDispatcherAutoSelectFamily !== autoSelectDecision.value) {
+        log.info(
+          "skip global undici dispatcher autoSelectFamily override because proxy env is configured",
+        );
+        skippedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+      }
     } else {
       try {
         setGlobalDispatcher(
@@ -71,6 +75,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
           }),
         );
         appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+        skippedGlobalDispatcherAutoSelectFamily = null;
         log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
       } catch {
         // ignore if setGlobalDispatcher is unavailable
@@ -116,4 +121,5 @@ export function resetTelegramFetchStateForTests(): void {
   appliedAutoSelectFamily = null;
   appliedDnsResultOrder = null;
   appliedGlobalDispatcherAutoSelectFamily = null;
+  skippedGlobalDispatcherAutoSelectFamily = null;
 }


### PR DESCRIPTION
## Summary

  In proxy-enabled environments, Telegram startup currently overrides the global undici dispatcher to apply `autoSelectFamily`.
  This can unintentionally bypass or conflict with existing proxy dispatcher settings and lead to request failures like `fetch failed` in embedded runs.

  This PR changes Telegram network workaround behavior:

  - Detect proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, including lowercase variants).
  - If proxy env is configured, skip `setGlobalDispatcher(new Agent(...))`.
  - Keep existing `autoSelectFamily` and DNS result-order handling.
  - Add tests to ensure dispatcher override is skipped when proxy env is present.

  ## Why

  When users rely on a proxy, replacing the global dispatcher in Telegram path can break other request paths that depend on proxy-aware dispatch behavior.

  ## Changes

  - `src/telegram/fetch.ts`
    - Added proxy-env detection.
    - Guarded global dispatcher override behind proxy check.
  - `src/telegram/fetch.test.ts`
    - Added test coverage for proxy-env behavior.
    - Kept existing dispatcher behavior tests for non-proxy cases.

  ## Verification

  - `pnpm build` 
  - `pnpm vitest run src/telegram/fetch.test.ts`  (12 passed)
  - Local gateway runtime check with copied real config:
    - Telegram startup log shows:
      - `skip global undici dispatcher autoSelectFamily override because proxy env is configured`
    - `chat.send` run completed with `isError=false` 

  ## Impact

  - Proxy setups: safer behavior, avoids clobbering global proxy dispatcher.
  - Non-proxy setups: existing workaround remains unchanged.