### PR TITLE
refactor(ui): extract reconnect timing constants in GatewayBrowserClient

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -90,6 +90,12 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+// Reconnect tuning: conservative initial retry with bounded exponential backoff.
+const RECONNECT_INITIAL_BACKOFF_MS = 800;
+const RECONNECT_BACKOFF_MULTIPLIER = 1.7;
+const RECONNECT_MAX_BACKOFF_MS = 15_000;
+// Delay a little after socket open so challenge/connect sequencing stays stable.
+const CONNECT_QUEUE_DELAY_MS = 750;
 
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
@@ -99,7 +105,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
-  private backoffMs = 800;
+  private backoffMs = RECONNECT_INITIAL_BACKOFF_MS;
   private pendingConnectError: GatewayErrorInfo | undefined;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
@@ -147,7 +153,10 @@ export class GatewayBrowserClient {
       return;
     }
     const delay = this.backoffMs;
-    this.backoffMs = Math.min(this.backoffMs * 1.7, 15_000);
+    this.backoffMs = Math.min(
+      this.backoffMs * RECONNECT_BACKOFF_MULTIPLIER,
+      RECONNECT_MAX_BACKOFF_MS,
+    );
     window.setTimeout(() => this.connect(), delay);
   }
 
@@ -257,7 +266,7 @@ export class GatewayBrowserClient {
             scopes: hello.auth.scopes ?? [],
           });
         }
-        this.backoffMs = 800;
+        this.backoffMs = RECONNECT_INITIAL_BACKOFF_MS;
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
@@ -355,6 +364,6 @@ export class GatewayBrowserClient {
     }
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, 750);
+    }, CONNECT_QUEUE_DELAY_MS);
   }
 }


### PR DESCRIPTION
## Summary
- extract reconnect/backoff magic numbers in `ui/src/ui/gateway.ts` into named constants
- replace inline values in backoff initialization/reset, exponential growth cap, and connect queue delay
- add short comments explaining reconnect tuning intent

Fixes #30402.

## Testing
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app-gateway.node.test.ts`
- `pnpm exec oxlint ui/src/ui/gateway.ts`
- `pnpm exec oxfmt --check ui/src/ui/gateway.ts`

## Notes
- `pnpm --dir ui test` currently reports existing unrelated failures in cron/config-form view suites on upstream `main`; this PR does not touch those areas.
