### PR TITLE
fix(logging): expand tilde in logging.file config path

### DIFF
--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -79,3 +79,26 @@ describe("OPENCLAW_LOG_LEVEL", () => {
     expect(warnings[0]).toContain('Ignoring invalid OPENCLAW_LOG_LEVEL="nope"');
   });
 });
+
+describe("logging.file tilde expansion", () => {
+  beforeEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  it("expands ~ in logging.file to the home directory", () => {
+    setLoggerOverride({
+      level: "info",
+      file: "~/.openclaw/logs/gateway.log",
+    });
+
+    const settings = getResolvedLoggerSettings();
+    expect(settings.file).toBe(path.join(os.homedir(), ".openclaw", "logs", "gateway.log"));
+    expect(settings.file).not.toContain("~");
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
@@ -74,7 +75,7 @@ function resolveSettings(): ResolvedSettings {
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const envLevel = resolveEnvLogLevelOverride();
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = expandHomePrefix(cfg?.file ?? defaultRollingPathForToday());
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }


### PR DESCRIPTION
## Summary

- **Problem:** Gateway crashes with `ENOENT` when `logging.file` is set to a tilde-prefixed path (e.g. `~/.openclaw/logs/gateway.log`)
- **Why it matters:** Gateway enters a crash loop under launchd; can be triggered by the embedded agent running `openclaw config set`
- **What changed:** Call `expandHomePrefix()` on the resolved file path in `resolveSettings()` so `~` is expanded before `fs.mkdirSync()`
- **What did NOT change (scope boundary):** No changes to config parsing, `readLoggingConfig()`, or `normalizeConfigPaths()` pipeline

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30401

## User-visible / Behavior Changes

`logging.file` config values starting with `~` now correctly resolve to the user's home directory instead of causing a crash.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (reported on macOS)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `logging.file: "~/.openclaw/logs/gateway.log"`

### Steps

1. `openclaw config set logging.file '"~/.openclaw/logs/gateway.log"' --json`
2. `openclaw gateway run`
3. Gateway crashes with `ENOENT: no such file or directory, mkdir '~/.openclaw/logs'`

### Expected

- Gateway starts normally, log file created at `$HOME/.openclaw/logs/gateway.log`

### Actual

- Gateway crashes on startup

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added test in `src/logging/logger-env.test.ts` that verifies `~/.openclaw/logs/gateway.log` resolves to `os.homedir() + /.openclaw/logs/gateway.log`.

## Human Verification (required)

- Verified scenarios: Test confirms tilde expansion works via `getResolvedLoggerSettings()`
- Edge cases checked: Non-tilde paths are unaffected (`expandHomePrefix` is a no-op for paths not starting with `~`)
- What you did **not** verify: Full gateway startup end-to-end with tilde config (no local gateway instance)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line change in `src/logging/logger.ts`
- Files/config to restore: `src/logging/logger.ts`
- Known bad symptoms reviewers should watch for: Unexpected log file paths

## Risks and Mitigations

None — `expandHomePrefix()` is the established utility already used by `normalizeConfigPaths()`, and is a no-op for paths that don't start with `~`.

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Fully tested
- [x] I understand what this code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)