### PR TITLE
fix(cron): ignore channel resolution when delivery mode is none

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -108,6 +108,35 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("ignores channel=last when delivery mode is none", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "hello from cron" }]);
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "do it" }),
+          delivery: { mode: "none", channel: "last" },
+        },
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(false);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("announces the final payload text when delivery has an explicit target", async () => {
     await expectExplicitTelegramTargetAnnounce({
       payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -314,12 +314,18 @@ export async function runCronIsolatedAgentTurn(params: {
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
   const deliveryRequested = deliveryPlan.requested;
 
-  const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
-    channel: deliveryPlan.channel ?? "last",
-    to: deliveryPlan.to,
-    accountId: deliveryPlan.accountId,
-    sessionKey: params.job.sessionKey,
-  });
+  const resolvedDelivery: Awaited<ReturnType<typeof resolveDeliveryTarget>> = deliveryRequested
+    ? await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
+        channel: deliveryPlan.channel ?? "last",
+        to: deliveryPlan.to,
+        accountId: deliveryPlan.accountId,
+        sessionKey: params.job.sessionKey,
+      })
+    : {
+        ok: false,
+        mode: "implicit",
+        error: new Error("cron delivery disabled (delivery.mode=none)"),
+      };
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();


### PR DESCRIPTION
## Summary
- stop resolving delivery targets when cron delivery is not requested (`delivery.mode=none`)
- avoid implicit fallback to `channel="last"` for disabled delivery, which could previously trigger delivery-target errors
- add regression coverage for `delivery: { mode: "none", channel: "last" }`

Fixes #30393.

## Root cause
`runCronIsolatedAgentTurn` always called `resolveDeliveryTarget(...)` using `deliveryPlan.channel ?? "last"`, even when `delivery.mode` normalized to `none`.

## Testing
- `pnpm exec vitest run src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
- `pnpm exec oxlint src/cron/isolated-agent/run.ts src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
- `pnpm exec oxfmt --check src/cron/isolated-agent/run.ts src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
