### PR TITLE
fix: reorder system prompt sections to maximize Anthropic prefix caching

### DIFF
--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -135,11 +135,7 @@ export function buildSystemPromptReport(params: {
   tools: AgentTool[];
 }): SessionSystemPromptReport {
   const systemPrompt = params.systemPrompt.trim();
-  const projectContext = extractBetween(
-    systemPrompt,
-    "\n# Project Context\n",
-    "\n## Silent Replies\n",
-  );
+  const projectContext = extractBetween(systemPrompt, "\n# Project Context\n", "\n## Runtime\n");
   const projectContextChars = projectContext.text.length;
   const toolListText = extractToolListText(systemPrompt);
   const toolListChars = toolListText.length;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -636,6 +636,119 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Reactions");
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
+
+  it("places stable sections before dynamic sections for prompt caching", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      extraSystemPrompt: "Group chat context here",
+      contextFiles: [{ path: "AGENTS.md", content: "Agent instructions" }],
+      reactionGuidance: { level: "minimal", channel: "Telegram" },
+      reasoningTagHint: true,
+      runtimeInfo: {
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v22",
+        model: "anthropic/claude",
+      },
+    });
+
+    // Stable sections must appear before dynamic sections to maximize the
+    // cacheable prefix for Anthropic prompt caching (prefix-based).
+    const reactionsIdx = prompt.indexOf("## Reactions");
+    const reasoningIdx = prompt.indexOf("## Reasoning Format");
+    const silentIdx = prompt.indexOf("## Silent Replies");
+    const heartbeatsIdx = prompt.indexOf("## Heartbeats");
+    const groupChatIdx = prompt.indexOf("## Group Chat Context");
+    const projectCtxIdx = prompt.indexOf("# Project Context");
+    const runtimeIdx = prompt.indexOf("## Runtime");
+
+    // All sections must be present.
+    expect(reactionsIdx, "Reactions section missing").toBeGreaterThan(-1);
+    expect(reasoningIdx, "Reasoning Format section missing").toBeGreaterThan(-1);
+    expect(silentIdx, "Silent Replies section missing").toBeGreaterThan(-1);
+    expect(heartbeatsIdx, "Heartbeats section missing").toBeGreaterThan(-1);
+    expect(groupChatIdx, "Group Chat Context section missing").toBeGreaterThan(-1);
+    expect(projectCtxIdx, "Project Context section missing").toBeGreaterThan(-1);
+    expect(runtimeIdx, "Runtime section missing").toBeGreaterThan(-1);
+
+    // Stable sections come before dynamic sections.
+    expect(reactionsIdx, "Reactions must precede Group Chat").toBeLessThan(groupChatIdx);
+    expect(reasoningIdx, "Reasoning must precede Group Chat").toBeLessThan(groupChatIdx);
+    expect(silentIdx, "Silent Replies must precede Group Chat").toBeLessThan(groupChatIdx);
+    expect(heartbeatsIdx, "Heartbeats must precede Group Chat").toBeLessThan(groupChatIdx);
+
+    // Dynamic section ordering: extraSystemPrompt → contextFiles → Runtime
+    expect(groupChatIdx, "Group Chat must precede Project Context").toBeLessThan(projectCtxIdx);
+    expect(projectCtxIdx, "Project Context must precede Runtime").toBeLessThan(runtimeIdx);
+  });
+
+  it("maintains ordering invariant when optional stable sections are absent", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      extraSystemPrompt: "Group context",
+      contextFiles: [{ path: "AGENTS.md", content: "Instructions" }],
+      // No reactionGuidance, no reasoningTagHint — these stable sections are absent
+      runtimeInfo: {
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v22",
+        model: "anthropic/claude",
+      },
+    });
+
+    // Even without optional stable sections, dynamic sections stay at the end.
+    const silentIdx = prompt.indexOf("## Silent Replies");
+    const heartbeatsIdx = prompt.indexOf("## Heartbeats");
+    const groupChatIdx = prompt.indexOf("## Group Chat Context");
+    const projectCtxIdx = prompt.indexOf("# Project Context");
+    const runtimeIdx = prompt.indexOf("## Runtime");
+
+    expect(silentIdx, "Silent Replies section missing").toBeGreaterThan(-1);
+    expect(heartbeatsIdx, "Heartbeats section missing").toBeGreaterThan(-1);
+    expect(groupChatIdx, "Group Chat Context section missing").toBeGreaterThan(-1);
+    expect(projectCtxIdx, "Project Context section missing").toBeGreaterThan(-1);
+    expect(runtimeIdx, "Runtime section missing").toBeGreaterThan(-1);
+
+    expect(heartbeatsIdx, "Heartbeats must precede Group Chat").toBeLessThan(groupChatIdx);
+    expect(groupChatIdx, "Group Chat must precede Project Context").toBeLessThan(projectCtxIdx);
+    expect(projectCtxIdx, "Project Context must precede Runtime").toBeLessThan(runtimeIdx);
+  });
+
+  it("maintains ordering invariant in minimal mode (subagents)", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      extraSystemPrompt: "Subagent context",
+      contextFiles: [{ path: "AGENTS.md", content: "Instructions" }],
+      runtimeInfo: {
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v22",
+        model: "anthropic/claude",
+      },
+    });
+
+    // In minimal mode, Silent Replies and Heartbeats are skipped.
+    // Dynamic sections must still appear at the end.
+    expect(prompt).not.toContain("## Silent Replies");
+    expect(prompt).not.toContain("## Heartbeats");
+
+    const subagentCtxIdx = prompt.indexOf("## Subagent Context");
+    const projectCtxIdx = prompt.indexOf("# Project Context");
+    const runtimeIdx = prompt.indexOf("## Runtime");
+
+    expect(subagentCtxIdx, "Subagent Context section missing").toBeGreaterThan(-1);
+    expect(projectCtxIdx, "Project Context section missing").toBeGreaterThan(-1);
+    expect(runtimeIdx, "Runtime section missing").toBeGreaterThan(-1);
+
+    expect(subagentCtxIdx, "Subagent Context must precede Project Context").toBeLessThan(
+      projectCtxIdx,
+    );
+    expect(projectCtxIdx, "Project Context must precede Runtime").toBeLessThan(runtimeIdx);
+  });
 });
 
 describe("buildSubagentSystemPrompt", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -569,12 +569,9 @@ export function buildAgentSystemPrompt(params: {
     ...buildVoiceSection({ isMinimal, ttsHint: params.ttsHint }),
   ];
 
-  if (extraSystemPrompt) {
-    // Use "Subagent Context" header for minimal mode (subagents), otherwise "Group Chat Context"
-    const contextHeader =
-      promptMode === "minimal" ? "## Subagent Context" : "## Group Chat Context";
-    lines.push(contextHeader, extraSystemPrompt, "");
-  }
+  // --- Stable sections (cacheable prefix) ---
+  // Session-stable sections placed before dynamic content to maximize the prefix that
+  // can be cached. See https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
   if (params.reactionGuidance) {
     const { level, channel } = params.reactionGuidance;
     const guidanceText =
@@ -600,28 +597,6 @@ export function buildAgentSystemPrompt(params: {
   }
   if (reasoningHint) {
     lines.push("## Reasoning Format", reasoningHint, "");
-  }
-
-  const contextFiles = params.contextFiles ?? [];
-  const validContextFiles = contextFiles.filter(
-    (file) => typeof file.path === "string" && file.path.trim().length > 0,
-  );
-  if (validContextFiles.length > 0) {
-    const hasSoulFile = validContextFiles.some((file) => {
-      const normalizedPath = file.path.trim().replace(/\\/g, "/");
-      const baseName = normalizedPath.split("/").pop() ?? normalizedPath;
-      return baseName.toLowerCase() === "soul.md";
-    });
-    lines.push("# Project Context", "", "The following project context files have been loaded:");
-    if (hasSoulFile) {
-      lines.push(
-        "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
-      );
-    }
-    lines.push("");
-    for (const file of validContextFiles) {
-      lines.push(`## ${file.path}`, "", file.content, "");
-    }
   }
 
   // Skip silent replies for subagent/none modes
@@ -653,6 +628,38 @@ export function buildAgentSystemPrompt(params: {
       'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
       "",
     );
+  }
+
+  // --- Dynamic sections (cache-volatile, placed at end) ---
+  // extraSystemPrompt, contextFiles, and Runtime may change between requests.
+  // Placing them after stable sections maximizes the cacheable prefix.
+  if (extraSystemPrompt) {
+    // Use "Subagent Context" header for minimal mode (subagents), otherwise "Group Chat Context"
+    const contextHeader =
+      promptMode === "minimal" ? "## Subagent Context" : "## Group Chat Context";
+    lines.push(contextHeader, extraSystemPrompt, "");
+  }
+
+  const contextFiles = params.contextFiles ?? [];
+  const validContextFiles = contextFiles.filter(
+    (file) => typeof file.path === "string" && file.path.trim().length > 0,
+  );
+  if (validContextFiles.length > 0) {
+    const hasSoulFile = validContextFiles.some((file) => {
+      const normalizedPath = file.path.trim().replace(/\\/g, "/");
+      const baseName = normalizedPath.split("/").pop() ?? normalizedPath;
+      return baseName.toLowerCase() === "soul.md";
+    });
+    lines.push("# Project Context", "", "The following project context files have been loaded:");
+    if (hasSoulFile) {
+      lines.push(
+        "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+      );
+    }
+    lines.push("");
+    for (const file of validContextFiles) {
+      lines.push(`## ${file.path}`, "", file.content, "");
+    }
   }
 
   lines.push(


### PR DESCRIPTION
## Summary

Reorders sections in `buildAgentSystemPrompt()` so session-stable content (behavioral rules, reactions, reasoning format, silent replies, heartbeats) precedes per-request-dynamic content (SOUL.md, group chat context, runtime model info). This maximizes the cacheable prefix length for Anthropic's prefix-based prompt caching.

**Before:** dynamic sections (extraSystemPrompt, contextFiles/SOUL.md) interleaved with stable sections
**After:** all stable sections first, then all dynamic sections grouped at the end

## Changes

- **`system-prompt.ts`** — Reorder sections so stable content precedes dynamic content. Added brief comments documenting cache rationale.
- **`system-prompt.test.ts`** — 3 new ordering invariant tests verifying stable-before-dynamic section order is maintained.
- **`system-prompt-report.ts`** — Fix `extractBetween` end marker (`## Silent Replies` → `## Runtime`) to match new section order. Without this fix, the `/context` diagnostic command would return corrupted output after the reorder.

## Notes

- Pure section reorder — no logic changes, no new dependencies
- The cache benefit is incremental (more prefix bytes cacheable per request), not architectural. A future multi-breakpoint `cache_control` approach would be more robust, but this reorder is a safe first step.
- The `system-prompt-report.ts` parser fix is critical: `extractBetween()` uses section header markers, and the reorder changes their relative positions.

## Testing

- All 50 existing tests pass
- 3 new tests verify section ordering invariants

Fixes #26750