### PR TITLE
fix(cron): wire bashElevated into isolated agentTurn runs

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -1,6 +1,7 @@
 import "./isolated-agent.mocks.js";
 import fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
 import type { CliDeps } from "../cli/deps.js";
 import {
@@ -108,6 +109,58 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("passes cron-event bashElevated defaults into embedded runs", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, {
+        lastProvider: "webchat",
+        lastTo: "",
+      });
+      const cfg = makeCfg(home, storePath);
+      cfg.tools = {
+        elevated: {
+          enabled: true,
+          allowFrom: { "cron-event": ["*"] },
+        },
+      };
+      cfg.agents = {
+        ...cfg.agents,
+        defaults: {
+          ...cfg.agents?.defaults,
+          elevatedDefault: "ask",
+        },
+      };
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "hello from cron" }]);
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg,
+        deps,
+        job: {
+          ...makeJob({ kind: "agentTurn", message: "do it" }),
+          delivery: { mode: "none", channel: "last" },
+        },
+        message: "do it",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0] as
+        | {
+            bashElevated?: {
+              enabled?: boolean;
+              allowed?: boolean;
+              defaultLevel?: string;
+            };
+          }
+        | undefined;
+      expect(call?.bashElevated).toEqual({
+        enabled: true,
+        allowed: true,
+        defaultLevel: "ask",
+      });
+    });
+  });
   it("announces the final payload text when delivery has an explicit target", async () => {
     await expectExplicitTelegramTargetAnnounce({
       payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -25,6 +25,7 @@ import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
+import { resolveElevatedPermissions } from "../../auto-reply/reply/reply-elevated.js";
 import {
   normalizeThinkLevel,
   normalizeVerboseLevel,
@@ -313,13 +314,25 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentPayload = params.job.payload.kind === "agentTurn" ? params.job.payload : null;
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
   const deliveryRequested = deliveryPlan.requested;
-
   const resolvedDelivery = await resolveDeliveryTarget(cfgWithAgentDefaults, agentId, {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
     accountId: deliveryPlan.accountId,
     sessionKey: params.job.sessionKey,
   });
+  const elevated = resolveElevatedPermissions({
+    cfg: cfgWithAgentDefaults,
+    agentId,
+    ctx: {
+      Provider: "cron-event",
+      AccountId: resolvedDelivery.accountId,
+      From: resolvedDelivery.to,
+      To: resolvedDelivery.to,
+      SessionKey: agentSessionKey,
+    },
+    provider: "cron-event",
+  });
+  const elevatedDefault = agentCfg?.elevatedDefault ?? "off";
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
@@ -471,6 +484,11 @@ export async function runCronIsolatedAgentTurn(params: {
           // be blocked by a target it cannot satisfy (#27898).
           requireExplicitMessageTarget: deliveryRequested && resolvedDelivery.ok,
           disableMessageTool: deliveryRequested || deliveryPlan.mode === "none",
+          bashElevated: {
+            enabled: elevated.enabled,
+            allowed: elevated.allowed,
+            defaultLevel: elevatedDefault,
+          },
           abortSignal,
         });
       },


### PR DESCRIPTION
## Summary
- resolve elevated permissions for isolated cron `agentTurn` runs using a cron-event context
- pass `bashElevated` into `runEmbeddedPiAgent` for cron isolated runs
- add regression coverage asserting `bashElevated` is propagated to embedded runs

Fixes #30379.

## Why
Previously cron isolated runs omitted `bashElevated` entirely, so exec tool elevated gates always treated elevated mode as disabled.

## Testing
- `pnpm exec vitest run src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
- `pnpm exec oxlint src/cron/isolated-agent/run.ts src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
- `pnpm exec oxfmt --check src/cron/isolated-agent/run.ts src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
