### PR TITLE
test(gateway): add regression for header-based agent model override

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -167,6 +167,14 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       {
         await expectAgentSessionKeyMatch({
+          body: { model: "gpt-4", messages: [{ role: "user", content: "hi" }] },
+          headers: { "x-openclaw-agent-id": "beta" },
+          matcher: /^agent:beta:/,
+        });
+      }
+
+      {
+        await expectAgentSessionKeyMatch({
           body: {
             model: "openclaw:beta",
             messages: [{ role: "user", content: "hi" }],


### PR DESCRIPTION
## Summary
- add a regression test for header-based agent routing precedence
- verify the request body `model` is ignored when an explicit `x-openclaw-agent-id` header is provided
- keep existing behavior unchanged while preventing future regressions

Closes #30381

## Testing
- pnpm exec vitest run src/gateway/openai-http.test.ts
- pnpm exec oxlint src/gateway/openai-http.test.ts
- pnpm exec oxfmt --check src/gateway/openai-http.test.ts
