### PR TITLE
Feishu: normalize provider-prefixed targets

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveReceiveIdType } from "./targets.js";
+import { looksLikeFeishuId, normalizeFeishuTarget, resolveReceiveIdType } from "./targets.js";
 
 describe("resolveReceiveIdType", () => {
   it("resolves chat IDs by oc_ prefix", () => {
@@ -12,5 +12,30 @@ describe("resolveReceiveIdType", () => {
 
   it("defaults unprefixed IDs to user_id", () => {
     expect(resolveReceiveIdType("u_123")).toBe("user_id");
+  });
+});
+
+describe("normalizeFeishuTarget", () => {
+  it("strips provider and user prefixes", () => {
+    expect(normalizeFeishuTarget("feishu:user:ou_123")).toBe("ou_123");
+    expect(normalizeFeishuTarget("lark:user:ou_123")).toBe("ou_123");
+  });
+
+  it("strips provider and chat prefixes", () => {
+    expect(normalizeFeishuTarget("feishu:chat:oc_123")).toBe("oc_123");
+  });
+
+  it("accepts provider-prefixed raw ids", () => {
+    expect(normalizeFeishuTarget("feishu:ou_123")).toBe("ou_123");
+  });
+});
+
+describe("looksLikeFeishuId", () => {
+  it("accepts provider-prefixed user targets", () => {
+    expect(looksLikeFeishuId("feishu:user:ou_123")).toBe(true);
+  });
+
+  it("accepts provider-prefixed chat targets", () => {
+    expect(looksLikeFeishuId("lark:chat:oc_123")).toBe(true);
   });
 });

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -4,6 +4,10 @@ const CHAT_ID_PREFIX = "oc_";
 const OPEN_ID_PREFIX = "ou_";
 const USER_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 
+function stripProviderPrefix(raw: string): string {
+  return raw.replace(/^(feishu|lark):/i, "").trim();
+}
+
 export function detectIdType(id: string): FeishuIdType | null {
   const trimmed = id.trim();
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {
@@ -24,18 +28,19 @@ export function normalizeFeishuTarget(raw: string): string | null {
     return null;
   }
 
-  const lowered = trimmed.toLowerCase();
+  const withoutProvider = stripProviderPrefix(trimmed);
+  const lowered = withoutProvider.toLowerCase();
   if (lowered.startsWith("chat:")) {
-    return trimmed.slice("chat:".length).trim() || null;
+    return withoutProvider.slice("chat:".length).trim() || null;
   }
   if (lowered.startsWith("user:")) {
-    return trimmed.slice("user:".length).trim() || null;
+    return withoutProvider.slice("user:".length).trim() || null;
   }
   if (lowered.startsWith("open_id:")) {
-    return trimmed.slice("open_id:".length).trim() || null;
+    return withoutProvider.slice("open_id:".length).trim() || null;
   }
 
-  return trimmed;
+  return withoutProvider;
 }
 
 export function formatFeishuTarget(id: string, type?: FeishuIdType): string {
@@ -61,7 +66,7 @@ export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_
 }
 
 export function looksLikeFeishuId(raw: string): boolean {
-  const trimmed = raw.trim();
+  const trimmed = stripProviderPrefix(raw.trim());
   if (!trimmed) {
     return false;
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu target normalization did not handle provider-prefixed targets like `feishu:user:ou_xxx`.
- Why it matters: outbound sends from generic/message paths could pass invalid receive IDs and fail delivery.
- What changed: `normalizeFeishuTarget` and `looksLikeFeishuId` now strip optional `feishu:`/`lark:` prefixes before parsing target forms.
- What did NOT change (scope boundary): receive-id type inference and message send APIs were not refactored.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30324
- Related #30314

## User-visible / Behavior Changes

- Feishu targets now accept provider-prefixed forms:
  - `feishu:user:...`
  - `feishu:chat:...`
  - `lark:user:...`
  - `feishu:ou_xxx`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): N/A

### Steps

1. Run:
   `node --import tsx -e 'import { normalizeFeishuTarget, looksLikeFeishuId } from "./extensions/feishu/src/targets.ts"; console.log(normalizeFeishuTarget("feishu:user:ou_abc")); console.log(looksLikeFeishuId("feishu:user:ou_abc"));'`
2. Observe current outputs.
3. Run `pnpm vitest extensions/feishu/src/targets.test.ts --run`.

### Expected

- `normalizeFeishuTarget("feishu:user:ou_abc")` returns `ou_abc`
- `looksLikeFeishuId("feishu:user:ou_abc")` returns `true`

### Actual

- Before fix: returned `feishu:user:ou_abc` and `false`
- After fix: returns `ou_abc` and `true`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Provider-prefixed user/chat/open_id targets normalize correctly.
  - Non-prefixed targets keep existing behavior.
- Edge cases checked:
  - `lark:` prefix and raw provider-prefixed IDs (`feishu:ou_...`).
- What you did **not** verify:
  - Live Feishu API delivery against a real tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/targets.ts`
  - `extensions/feishu/src/targets.test.ts`
- Known bad symptoms reviewers should watch for:
  - Feishu provider-prefixed targets rejected or sent as raw text IDs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Over-normalizing non-Feishu prefixes.
  - Mitigation:
    - Prefix stripping is scoped to `feishu:` and `lark:` only.
