### PR TITLE
fix(logging): expand tilde in logging.file config path

### DIFF
--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -24,6 +24,7 @@ describe("OPENCLAW_LOG_LEVEL", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     if (originalEnv === undefined) {
       delete process.env.OPENCLAW_LOG_LEVEL;
     } else {
@@ -77,5 +78,15 @@ describe("OPENCLAW_LOG_LEVEL", () => {
       .filter((line) => line.includes("OPENCLAW_LOG_LEVEL"));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('Ignoring invalid OPENCLAW_LOG_LEVEL="nope"');
+  });
+
+  it("expands tilde-prefixed logging file paths from effective home", () => {
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+    setLoggerOverride({
+      level: "info",
+      file: "~/.openclaw/logs/gateway.log",
+    });
+
+    expect(getResolvedLoggerSettings().file).toBe("/srv/openclaw-home/.openclaw/logs/gateway.log");
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
 import type { ConsoleStyle } from "./console.js";
@@ -74,7 +75,7 @@ function resolveSettings(): ResolvedSettings {
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const envLevel = resolveEnvLogLevelOverride();
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = expandHomePrefix(cfg?.file ?? defaultRollingPathForToday());
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }


### PR DESCRIPTION
## Summary
- expand `logging.file` via `expandHomePrefix` when resolving logger settings
- prevent startup crashes when config uses tilde-prefixed paths like `~/.openclaw/logs/gateway.log`
- add a regression test covering tilde expansion through effective home resolution

Closes #30401

## Testing
- pnpm exec vitest run src/logging/logger-env.test.ts
- pnpm exec vitest run src/logging/*.test.ts
- pnpm exec oxlint src/logging/logger.ts src/logging/logger-env.test.ts
- pnpm exec oxfmt --check src/logging/logger.ts src/logging/logger-env.test.ts
