### PR TITLE
fix(agents): resolve tilde paths for fs tool calls

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -6,6 +6,7 @@ import { createEditTool, createReadTool, createWriteTool } from "@mariozechner/p
 import { SafeOpenError, openFileWithinRoot, writeFileWithinRoot } from "../infra/fs-safe.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
+import { resolveUserPath } from "../utils.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -423,6 +424,10 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   if ("file_path" in normalized && !("path" in normalized)) {
     normalized.path = normalized.file_path;
     delete normalized.file_path;
+  }
+  const normalizedPath = normalized.path;
+  if (typeof normalizedPath === "string" && normalizedPath.trim().startsWith("~")) {
+    normalized.path = resolveUserPath(normalizedPath);
   }
   // old_string → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createOpenClawCodingTools } from "./pi-tools.js";
 
 describe("FS tools with workspaceOnly=false", () => {
@@ -17,6 +17,7 @@ describe("FS tools with workspaceOnly=false", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -143,6 +144,44 @@ describe("FS tools with workspaceOnly=false", () => {
     expect(hasError).toBe(false);
     const content = await fs.readFile(outsideRelativeFile, "utf-8");
     expect(content).toBe("new relative content");
+  });
+
+  it("should allow edit outside workspace via ~ path when workspaceOnly=false", async () => {
+    const fakeHome = path.join(tmpDir, "fake-home");
+    const tildeFile = path.join(
+      fakeHome,
+      ".npm-global/lib/node_modules/openclaw/skills/gog/SKILL.md",
+    );
+    await fs.mkdir(path.dirname(tildeFile), { recursive: true });
+    await fs.writeFile(tildeFile, "old tilde content", "utf-8");
+    vi.stubEnv("OPENCLAW_HOME", fakeHome);
+
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: {
+        tools: {
+          fs: {
+            workspaceOnly: false,
+          },
+        },
+      },
+    });
+
+    const editTool = tools.find((t) => t.name === "edit");
+    expect(editTool).toBeDefined();
+
+    const result = await editTool!.execute("test-call-2c", {
+      path: "~/.npm-global/lib/node_modules/openclaw/skills/gog/SKILL.md",
+      oldText: "old tilde content",
+      newText: "new tilde content",
+    });
+
+    const hasError = result.content.some(
+      (c) => c.type === "text" && c.text.toLowerCase().includes("error"),
+    );
+    expect(hasError).toBe(false);
+    const content = await fs.readFile(tildeFile, "utf-8");
+    expect(content).toBe("new tilde content");
   });
 
   it("should allow read outside workspace when workspaceOnly=false", async () => {


### PR DESCRIPTION
## Summary
- normalize `path` params for fs tools by expanding `~` to the effective home directory
- fix edit/read/write calls that passed `~/*` paths and were treated as literal unresolved paths
- add regression coverage for editing a file outside workspace via `~` when `tools.fs.workspaceOnly=false`

Closes #30335

## Testing
- pnpm exec vitest run src/agents/pi-tools.workspace-only-false.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
- pnpm exec oxlint src/agents/pi-tools.read.ts src/agents/pi-tools.workspace-only-false.test.ts
- pnpm exec oxfmt --check src/agents/pi-tools.read.ts src/agents/pi-tools.workspace-only-false.test.ts
