### PR TITLE
Feishu: honor configured default account for outbound resolution

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultFeishuAccountId, resolveFeishuAccount } from "./accounts.js";
+
+describe("resolveDefaultFeishuAccountId", () => {
+  it("prefers channels.feishu.defaultAccount when configured", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+            "router-d": { appId: "cli_router", appSecret: "secret_router" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("router-d");
+  });
+
+  it("falls back to literal default account id when present", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+            zeta: { appId: "cli_zeta", appSecret: "secret_zeta" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("default");
+  });
+});
+
+describe("resolveFeishuAccount", () => {
+  it("uses configured default account when accountId is omitted", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          accounts: {
+            default: { enabled: true },
+            "router-d": { appId: "cli_router", appSecret: "secret_router", enabled: true },
+          },
+        },
+      },
+    };
+
+    const account = resolveFeishuAccount({ cfg: cfg as never, accountId: undefined });
+    expect(account.accountId).toBe("router-d");
+    expect(account.configured).toBe(true);
+    expect(account.appId).toBe("cli_router");
+  });
+
+  it("keeps explicit accountId selection", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+            "router-d": { appId: "cli_router", appSecret: "secret_router" },
+          },
+        },
+      },
+    };
+
+    const account = resolveFeishuAccount({ cfg: cfg as never, accountId: "default" });
+    expect(account.accountId).toBe("default");
+    expect(account.appId).toBe("cli_default");
+  });
+});

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -35,6 +35,10 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
  * Resolve the default account ID.
  */
 export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
+  const preferred = (cfg.channels?.feishu as FeishuConfig | undefined)?.defaultAccount?.trim();
+  if (preferred) {
+    return preferred;
+  }
   const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
@@ -64,7 +68,7 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
   const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
 
   // Extract base config (exclude accounts field to avoid recursion)
-  const { accounts: _ignored, ...base } = feishuCfg ?? {};
+  const { accounts: _ignored, defaultAccount: _ignoredDefaultAccount, ...base } = feishuCfg ?? {};
 
   // Get account-specific overrides
   const account = resolveAccountConfig(cfg, accountId) ?? {};
@@ -104,7 +108,11 @@ export function resolveFeishuAccount(params: {
   cfg: ClawdbotConfig;
   accountId?: string | null;
 }): ResolvedFeishuAccount {
-  const accountId = normalizeAccountId(params.accountId);
+  const hasExplicitAccountId =
+    typeof params.accountId === "string" && params.accountId.trim() !== "";
+  const accountId = hasExplicitAccountId
+    ? normalizeAccountId(params.accountId)
+    : resolveDefaultFeishuAccountId(params.cfg);
   const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
 
   // Base enabled state (top-level)

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -79,6 +79,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       additionalProperties: false,
       properties: {
         enabled: { type: "boolean" },
+        defaultAccount: { type: "string" },
         appId: { type: "string" },
         appSecret: { type: "string" },
         encryptKey: { type: "string" },

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -191,6 +191,7 @@ export const FeishuAccountConfigSchema = z
 export const FeishuConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    defaultAccount: z.string().optional(),
     // Top-level credentials (backward compatible for single-account mode)
     appId: z.string().optional(),
     appSecret: z.string().optional(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when `accountId` is omitted, Feishu account resolution always normalized to literal `default`.
- Why it matters: outbound sends fail in multi-account setups where `channels.feishu.defaultAccount` points to another configured account.
- What changed: Feishu account resolution now respects `channels.feishu.defaultAccount`; Feishu config schemas now accept that field.
- What did NOT change (scope boundary): message routing and outbound target parsing behavior were not changed in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30045
- Related #21900

## User-visible / Behavior Changes

- Feishu outbound calls without explicit `accountId` now resolve to `channels.feishu.defaultAccount` when configured.
- Feishu config schema now recognizes `channels.feishu.defaultAccount`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted):
  - `channels.feishu.defaultAccount = "router-d"`
  - `channels.feishu.accounts.default` present but unconfigured
  - `channels.feishu.accounts.router-d` configured with app creds

### Steps

1. Run:
   `node --import tsx -e 'import { resolveFeishuAccount } from "./extensions/feishu/src/accounts.ts"; const cfg={channels:{feishu:{defaultAccount:"router-d",accounts:{default:{enabled:true},"router-d":{appId:"cli_router",appSecret:"sec",enabled:true}}}}}; const account=resolveFeishuAccount({cfg:cfg,accountId:undefined}); console.log(JSON.stringify({resolvedAccountId:account.accountId,configured:account.configured,appId:account.appId}));'`
2. Observe resolved account.
3. Run tests:
   - `pnpm vitest extensions/feishu/src/accounts.test.ts extensions/feishu/src/config-schema.test.ts --run`
   - `pnpm check`

### Expected

- Omitted `accountId` resolves to configured default account (`router-d`).

### Actual

- Before fix: resolved `default` account (often unconfigured).
- After fix: resolves configured `defaultAccount`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `resolveDefaultFeishuAccountId` prefers configured `defaultAccount`.
  - `resolveFeishuAccount` without `accountId` uses configured default and returns configured creds.
  - Explicit `accountId` still overrides default selection.
- Edge cases checked:
  - Legacy `default` account fallback remains intact when `defaultAccount` is not set.
- What you did **not** verify:
  - Live Feishu tenant delivery.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/accounts.ts`
  - `extensions/feishu/src/config-schema.ts`
  - `extensions/feishu/src/channel.ts`
- Known bad symptoms reviewers should watch for:
  - Omitted Feishu account selection regressing to literal `default`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Existing configs relying on implicit `default` selection could switch to configured `defaultAccount`.
  - Mitigation:
    - Behavior changes only when `defaultAccount` is explicitly set; legacy fallback remains unchanged.
