### PR TITLE
fix(tui): sanitize OSC control sequences to prevent /compact terminal crash

### DIFF
--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -1,12 +1,10 @@
-const ANSI_SGR_PATTERN = "\\x1b\\[[0-9;]*m";
-// OSC-8 hyperlinks: ESC ] 8 ; ; url ST ... ESC ] 8 ; ; ST
-const OSC8_PATTERN = "\\x1b\\]8;;.*?\\x1b\\\\|\\x1b\\]8;;\\x1b\\\\";
-
-const ANSI_REGEX = new RegExp(ANSI_SGR_PATTERN, "g");
-const OSC8_REGEX = new RegExp(OSC8_PATTERN, "g");
+const ANSI_CSI_PATTERN = "\\x1b\\[[0-?]*[ -/]*[@-~]";
+// Generic OSC sequence: ESC ] ... BEL or ESC \\
+const ANSI_OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)";
+const ANSI_REGEX = new RegExp(`${ANSI_CSI_PATTERN}|${ANSI_OSC_PATTERN}`, "g");
 
 export function stripAnsi(input: string): string {
-  return input.replace(OSC8_REGEX, "").replace(ANSI_REGEX, "");
+  return input.replace(ANSI_REGEX, "");
 }
 
 export function visibleWidth(input: string): number {

--- a/src/tui/components/assistant-message.ts
+++ b/src/tui/components/assistant-message.ts
@@ -1,5 +1,6 @@
 import { Container, Spacer } from "@mariozechner/pi-tui";
 import { markdownTheme, theme } from "../theme/theme.js";
+import { sanitizeRenderableText } from "../tui-formatters.js";
 import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
 
 export class AssistantMessageComponent extends Container {
@@ -7,7 +8,7 @@ export class AssistantMessageComponent extends Container {
 
   constructor(text: string) {
     super();
-    this.body = new HyperlinkMarkdown(text, 1, 0, markdownTheme, {
+    this.body = new HyperlinkMarkdown(sanitizeRenderableText(text), 1, 0, markdownTheme, {
       // Keep assistant body text in terminal default foreground so contrast
       // follows the user's terminal theme (dark or light).
       color: (line) => theme.assistantText(line),
@@ -17,6 +18,6 @@ export class AssistantMessageComponent extends Container {
   }
 
   setText(text: string) {
-    this.body.setText(text);
+    this.body.setText(sanitizeRenderableText(text));
   }
 }

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -41,4 +41,21 @@ describe("ChatLog", () => {
 
     expect(chatLog.children.length).toBe(20);
   });
+
+  it("sanitizes OSC sequences from system/user/assistant messages", () => {
+    const chatLog = new ChatLog(40);
+    const osc7 = "\x1b]7;file://example-host/tmp\x07";
+
+    chatLog.addSystem(`system-${osc7}-line`);
+    chatLog.addUser(`user-${osc7}-line`);
+    chatLog.startAssistant(`assistant-${osc7}-stream`, "run-osc");
+    chatLog.finalizeAssistant(`assistant-${osc7}-final`, "run-osc");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toContain("\x1b]7;");
+    expect(rendered).not.toContain("file://example-host/tmp");
+    expect(rendered).toContain("system--line");
+    expect(rendered).toContain("user--line");
+    expect(rendered).toContain("assistant--final");
+  });
 });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -1,6 +1,7 @@
 import type { Component } from "@mariozechner/pi-tui";
 import { Container, Spacer, Text } from "@mariozechner/pi-tui";
 import { theme } from "../theme/theme.js";
+import { sanitizeRenderableText } from "../tui-formatters.js";
 import { AssistantMessageComponent } from "./assistant-message.js";
 import { ToolExecutionComponent } from "./tool-execution.js";
 import { UserMessageComponent } from "./user-message.js";
@@ -52,12 +53,13 @@ export class ChatLog extends Container {
   }
 
   addSystem(text: string) {
+    const sanitized = sanitizeRenderableText(text);
     this.append(new Spacer(1));
-    this.append(new Text(theme.system(text), 1, 0));
+    this.append(new Text(theme.system(sanitized), 1, 0));
   }
 
   addUser(text: string) {
-    this.append(new UserMessageComponent(text));
+    this.append(new UserMessageComponent(sanitizeRenderableText(text)));
   }
 
   private resolveRunId(runId?: string) {
@@ -65,7 +67,7 @@ export class ChatLog extends Container {
   }
 
   startAssistant(text: string, runId?: string) {
-    const component = new AssistantMessageComponent(text);
+    const component = new AssistantMessageComponent(sanitizeRenderableText(text));
     this.streamingRuns.set(this.resolveRunId(runId), component);
     this.append(component);
     return component;
@@ -78,18 +80,19 @@ export class ChatLog extends Container {
       this.startAssistant(text, runId);
       return;
     }
-    existing.setText(text);
+    existing.setText(sanitizeRenderableText(text));
   }
 
   finalizeAssistant(text: string, runId?: string) {
+    const sanitized = sanitizeRenderableText(text);
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);
     if (existing) {
-      existing.setText(text);
+      existing.setText(sanitized);
       this.streamingRuns.delete(effectiveRunId);
       return;
     }
-    this.append(new AssistantMessageComponent(text));
+    this.append(new AssistantMessageComponent(sanitized));
   }
 
   dropAssistant(runId?: string) {

--- a/src/tui/components/user-message.ts
+++ b/src/tui/components/user-message.ts
@@ -1,9 +1,10 @@
 import { theme } from "../theme/theme.js";
+import { sanitizeRenderableText } from "../tui-formatters.js";
 import { MarkdownMessageComponent } from "./markdown-message.js";
 
 export class UserMessageComponent extends MarkdownMessageComponent {
   constructor(text: string) {
-    super(text, 1, {
+    super(sanitizeRenderableText(text), 1, {
       bgColor: (line) => theme.userBg(line),
       color: (line) => theme.userText(line),
     });

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -1,10 +1,10 @@
 // Regex patterns for ANSI escape sequences (constructed from strings to
 // satisfy the no-control-regex lint rule).
 const SGR_PATTERN = "\\x1b\\[[0-9;]*m";
-const OSC8_PATTERN = "\\x1b\\]8;;.*?(?:\\x07|\\x1b\\\\)";
-const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC8_PATTERN}`, "g");
+const OSC_PATTERN = "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)";
+const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC_PATTERN}`, "g");
 const SGR_START_RE = new RegExp(`^${SGR_PATTERN}`);
-const OSC8_START_RE = new RegExp(`^${OSC8_PATTERN}`);
+const OSC_START_RE = new RegExp(`^${OSC_PATTERN}`);
 
 /** Wrap text with an OSC 8 terminal hyperlink. */
 export function wrapOsc8(url: string, text: string): string {
@@ -175,8 +175,8 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
         continue;
       }
 
-      // Existing OSC 8 sequence (pass through)
-      const osc = line.slice(i).match(OSC8_START_RE);
+      // Existing OSC sequence (pass through)
+      const osc = line.slice(i).match(OSC_START_RE);
       if (osc) {
         result += osc[0];
         i += osc[0].length;

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -87,6 +87,15 @@ describe("extractTextFromMessage", () => {
     expect(text).toBe("Hello redworld");
   });
 
+  it("strips OSC control sequences from string content", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      content: "before\x1b]7;file://example-host/tmp\x07after",
+    });
+
+    expect(text).toBe("beforeafter");
+  });
+
   it("redacts heavily corrupted binary-like lines", () => {
     const text = extractTextFromMessage({
       role: "assistant",
@@ -268,5 +277,13 @@ describe("sanitizeRenderableText", () => {
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
+  });
+
+  it("removes generic OSC control sequences while preserving visible text", () => {
+    const input =
+      "x\x1b]7;file://example-host/tmp\x07y\x1b]8;;https://example.com\x07link\x1b]8;;\x07";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe("xylink");
   });
 });


### PR DESCRIPTION
## Summary
- sanitize system/user/assistant text at the TUI render boundary so control sequences cannot leak into terminal output
- extend ANSI stripping and OSC hyperlink parsing to handle generic OSC payloads (including OSC 7 cwd reports)
- add regression tests covering OSC-sequence sanitization in formatter and chat-log rendering paths

## Test plan
- [x] `pnpm exec vitest run --config vitest.unit.config.ts src/tui/tui-formatters.test.ts src/tui/components/chat-log.test.ts src/tui/osc8-hyperlinks.test.ts`
- [x] `pnpm exec vitest run --config vitest.unit.config.ts src/tui/components/searchable-select-list.test.ts src/tui/osc8-hyperlinks.test.ts`

Fixes #30421