### PR TITLE
fix(edit): expand tilde in file paths and improve outside-workspace error

### DIFF
--- a/src/agents/pi-tools.read.tilde-expansion.test.ts
+++ b/src/agents/pi-tools.read.tilde-expansion.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type CapturedEditOperations = {
+  readFile: (absolutePath: string) => Promise<Buffer>;
+  writeFile: (absolutePath: string, content: string) => Promise<void>;
+  access: (absolutePath: string) => Promise<void>;
+};
+
+const mocks = vi.hoisted(() => ({
+  operations: undefined as CapturedEditOperations | undefined,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createEditTool: (_cwd: string, options?: { operations?: CapturedEditOperations }) => {
+      mocks.operations = options?.operations;
+      return {
+        name: "edit",
+        description: "test edit tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({
+          content: [{ type: "text" as const, text: "ok" }],
+        }),
+      };
+    },
+  };
+});
+
+const { createHostWorkspaceEditTool, expandTilde } = await import("./pi-tools.read.js");
+
+describe("expandTilde", () => {
+  it("expands bare ~ to homedir", () => {
+    expect(expandTilde("~")).toBe(os.homedir());
+  });
+
+  it("expands ~/ prefix to homedir", () => {
+    expect(expandTilde("~/foo/bar.txt")).toBe(path.join(os.homedir(), "foo/bar.txt"));
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    expect(expandTilde("/usr/local/bin")).toBe("/usr/local/bin");
+  });
+
+  it("leaves relative paths unchanged", () => {
+    expect(expandTilde("foo/bar")).toBe("foo/bar");
+  });
+
+  it("does not expand ~user form (only bare ~)", () => {
+    expect(expandTilde("~otheruser/file")).toBe("~otheruser/file");
+  });
+});
+
+describe("createHostWorkspaceEditTool tilde expansion", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    mocks.operations = undefined;
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "tilde path outside workspace yields EACCES, not ENOENT",
+    async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tilde-test-"));
+      const workspaceDir = path.join(tmpDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true });
+      expect(mocks.operations).toBeDefined();
+
+      // ~/.npm-global/lib/foo.txt is outside the workspace; should get EACCES
+      await expect(mocks.operations!.access("~/.npm-global/lib/foo.txt")).rejects.toMatchObject({
+        code: "EACCES",
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "tilde path inside workspace resolves correctly",
+    async () => {
+      // Create workspace under the real homedir so ~/... can resolve inside it
+      const home = os.homedir();
+      tmpDir = await fs.mkdtemp(path.join(home, ".openclaw-tilde-test-"));
+      const testFile = path.join(tmpDir, "hello.txt");
+      await fs.writeFile(testFile, "world", "utf8");
+
+      createHostWorkspaceEditTool(tmpDir, { workspaceOnly: true });
+      expect(mocks.operations).toBeDefined();
+
+      // Build a ~/... path that points inside the workspace
+      const relative = path.relative(home, testFile);
+      const tildePath = `~/${relative}`;
+
+      const buf = await mocks.operations!.readFile(tildePath);
+      expect(buf.toString("utf8")).toBe("world");
+    },
+  );
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -764,11 +765,11 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     // When workspaceOnly is false, allow writes anywhere on the host
     return {
       mkdir: async (dir: string) => {
-        const resolved = path.resolve(dir);
+        const resolved = path.resolve(expandTilde(dir));
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandTilde(absolutePath));
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
@@ -803,17 +804,17 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     // When workspaceOnly is false, allow edits anywhere on the host
     return {
       readFile: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandTilde(absolutePath));
         return await fs.readFile(resolved);
       },
       writeFile: async (absolutePath: string, content: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandTilde(absolutePath));
         const dir = path.dirname(resolved);
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(resolved, content, "utf-8");
       },
       access: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandTilde(absolutePath));
         await fs.access(resolved);
       },
     } as const;
@@ -843,8 +844,8 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
       });
     },
     access: async (absolutePath: string) => {
-      const relative = toRelativePathInRoot(root, absolutePath);
       try {
+        const relative = toRelativePathInRoot(root, absolutePath);
         const opened = await openFileWithinRoot({
           rootDir: root,
           relativePath: relative,
@@ -863,22 +864,33 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
   } as const;
 }
 
+/** Expand leading `~` or `~/` to the user's home directory. */
+export function expandTilde(filePath: string): string {
+  if (filePath === "~") {
+    return os.homedir();
+  }
+  if (filePath.startsWith("~/") || filePath.startsWith("~\\")) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
 function toRelativePathInRoot(
   root: string,
   candidate: string,
   options?: { allowRoot?: boolean },
 ): string {
   const rootResolved = path.resolve(root);
-  const resolved = path.resolve(candidate);
+  const resolved = path.resolve(expandTilde(candidate));
   const relative = path.relative(rootResolved, resolved);
   if (relative === "" || relative === ".") {
     if (options?.allowRoot) {
       return "";
     }
-    throw new Error(`Path escapes workspace root: ${candidate}`);
+    throw new SafeOpenError("outside-workspace", `Path is outside workspace root: ${candidate}`);
   }
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new Error(`Path escapes workspace root: ${candidate}`);
+    throw new SafeOpenError("outside-workspace", `Path is outside workspace root: ${candidate}`);
   }
   return relative;
 }


### PR DESCRIPTION
## Problem

The `edit` tool reports "File not found" when given paths containing tilde (`~`), e.g. `~/.npm-global/lib/node_modules/openclaw/skills/gog/SKILL.md`. The actual issue is that `path.resolve()` does not expand `~` — it treats it as a literal directory name, resolving to something like `/workspace/~/...` which doesn't exist.

Additionally, when `workspaceOnly=true` and the resolved path is outside the workspace, the error says "file not found" instead of the more accurate "outside workspace" or "access denied".

Fixes #30335

## Changes

- Added `expandTilde()` utility that replaces leading `~/` with `os.homedir()`
- Applied `expandTilde()` to all path resolution in `createHostEditOperations` and `createHostWriteOperations` (both workspaceOnly=true and false paths)
- Updated `toRelativePathInRoot` to expand tilde before resolving
- Moved the `try` block in the workspaceOnly `access` handler to properly catch path escape errors

## Testing

- Added `pi-tools.read.tilde-expansion.test.ts` covering tilde expansion for home dir, trailing paths, and passthrough for non-tilde paths