### PR TITLE
fix(discord): strip echoed inbound metadata from model output

### DIFF
--- a/src/auto-reply/reply/normalize-reply.test.ts
+++ b/src/auto-reply/reply/normalize-reply.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { normalizeReplyPayload } from "./normalize-reply.js";
+
+const CONV_BLOCK = `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "message_id": "msg-abc",
+  "chat_id": "12345",
+  "channel": "discord"
+}
+\`\`\``;
+
+const SENDER_BLOCK = `Sender (untrusted metadata):
+\`\`\`json
+{
+  "label": "Alice",
+  "name": "Alice"
+}
+\`\`\``;
+
+describe("normalizeReplyPayload", () => {
+  it("strips echoed Conversation info metadata from model output", () => {
+    const result = normalizeReplyPayload({
+      text: `${CONV_BLOCK}\n\nHere is your answer!`,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Here is your answer!");
+  });
+
+  it("strips multiple echoed metadata blocks from model output", () => {
+    const result = normalizeReplyPayload({
+      text: `${CONV_BLOCK}\n\n${SENDER_BLOCK}\n\nHere is your answer!`,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Here is your answer!");
+  });
+
+  it("passes through normal text without metadata unchanged", () => {
+    const result = normalizeReplyPayload({ text: "Hello, world!" });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Hello, world!");
+  });
+
+  it("returns null for empty text with no media", () => {
+    expect(normalizeReplyPayload({ text: "" })).toBeNull();
+  });
+
+  it("returns null when model output is only metadata (no actual content)", () => {
+    expect(normalizeReplyPayload({ text: CONV_BLOCK })).toBeNull();
+  });
+
+  it("returns null when model output is only multiple metadata blocks", () => {
+    expect(normalizeReplyPayload({ text: `${CONV_BLOCK}\n\n${SENDER_BLOCK}` })).toBeNull();
+  });
+
+  it("does not strip sentinel text that lacks a fenced JSON block", () => {
+    const text = 'The "Conversation info (untrusted metadata):" header is used for context.';
+    const result = normalizeReplyPayload({ text });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("Conversation info");
+  });
+});

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -7,6 +7,7 @@ import {
   resolveResponsePrefixTemplate,
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
+import { stripInboundMetadata } from "./strip-inbound-meta.js";
 
 export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
 
@@ -63,6 +64,8 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    // Strip any inbound metadata blocks the model may have echoed back (#30405).
+    text = stripInboundMetadata(text);
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");


### PR DESCRIPTION
## Problem

When the model receives inbound context (Conversation info, Sender metadata, etc.), it sometimes echoes these JSON metadata blocks verbatim into its response. This raw metadata then appears in Discord messages, confusing users.

Fixes #30405

## Changes

- Created `strip-inbound-meta.ts` module that identifies and removes all OpenClaw-injected metadata blocks from model output text
  - Recognizes all sentinel headers: Conversation info, Sender info, Thread starter, Replied message, Forwarded message context, Chat history
  - Handles fenced JSON blocks following each sentinel
  - Fast-path regex check to avoid unnecessary processing when no metadata is present
  - Also strips trailing `Untrusted context` suffix blocks
- Integrated `stripInboundMetadata()` into `normalize-reply.ts` output pipeline, running after text sanitization

## Testing

- Added `normalize-reply.test.ts` covering metadata stripping for single blocks, multiple blocks, mixed content, and passthrough for clean text