### PR TITLE
Feishu tools: prefer configured defaultAccount for tool execution

### DIFF
--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -25,11 +25,13 @@ function createConfig(params: {
     drive?: boolean;
     perm?: boolean;
   };
+  defaultAccount?: string;
 }): OpenClawPluginApi["config"] {
   return {
     channels: {
       feishu: {
         enabled: true,
+        defaultAccount: params.defaultAccount,
         accounts: {
           a: {
             appId: "app-a",
@@ -62,6 +64,22 @@ describe("feishu tool account routing", () => {
     registerFeishuWikiTools(api);
 
     const tool = resolveTool("feishu_wiki", { agentAccountId: "b" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
+  test("wiki tool prefers configured defaultAccount over inherited default account context", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -12,6 +12,15 @@ function normalizeOptionalAccountId(value: string | undefined): string | undefin
   return trimmed ? trimmed : undefined;
 }
 
+function readConfiguredDefaultAccountId(config: OpenClawPluginApi["config"]): string | undefined {
+  const value = (config?.channels?.feishu as { defaultAccount?: unknown } | undefined)
+    ?.defaultAccount;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return normalizeOptionalAccountId(value);
+}
+
 export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
@@ -24,6 +33,7 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
+      readConfiguredDefaultAccountId(params.api.config) ??
       normalizeOptionalAccountId(params.defaultAccountId),
   });
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu tool account resolution preferred inherited/default context account IDs even when `channels.feishu.defaultAccount` was explicitly configured.
- Why it matters: doc/wiki/drive/perm tools could execute against the wrong app credentials/scopes in multi-account setups.
- What changed: Feishu tool account selection now prefers explicit tool `accountId`, then configured `channels.feishu.defaultAccount`, then inherited context fallback.
- What did NOT change (scope boundary): channel runtime routing, message dispatch, and non-tool account selection paths were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21900
- Related #30045

## User-visible / Behavior Changes

- Feishu doc/wiki/drive/perm/bitable tool calls now honor configured `channels.feishu.defaultAccount` when no explicit `accountId` is passed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu tools
- Relevant config (redacted):
  - `channels.feishu.defaultAccount = "main"`
  - accounts: `alpha`, `main`

### Steps

1. Run:
   `node --import tsx -e 'import { resolveFeishuToolAccount } from "./extensions/feishu/src/tool-account.ts"; const api={config:{channels:{feishu:{defaultAccount:"main",accounts:{alpha:{appId:"cli_alpha",appSecret:"alpha"},main:{appId:"cli_main",appSecret:"main"}}}}}}; const account=resolveFeishuToolAccount({api,defaultAccountId:"alpha"}); console.log(JSON.stringify({resolvedAccountId:account.accountId,appId:account.appId}));'`
2. Run regression tests:
   - `pnpm vitest extensions/feishu/src/tool-account-routing.test.ts --run`
   - `pnpm check`

### Expected

- With no explicit tool `accountId`, configured `defaultAccount` is selected.

### Actual

- Before fix: inherited context default (`alpha`) was selected.
- After fix: configured default (`main`) is selected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Configured default account overrides inherited default context for tool execution.
  - Explicit tool `accountId` still overrides everything else.
  - Existing tool-account routing tests continue to pass.
- Edge cases checked:
  - Missing/empty `defaultAccount` still falls back to inherited context.
- What you did **not** verify:
  - Live Feishu API calls with real app scopes.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/tool-account.ts`
  - `extensions/feishu/src/tool-account-routing.test.ts`
  - `extensions/feishu/src/accounts.ts`
- Known bad symptoms reviewers should watch for:
  - Feishu tools resolving to unexpected account IDs in multi-account setups.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Changing account precedence could affect existing setups relying on inherited default context.
  - Mitigation:
    - Explicit `accountId` remains highest priority; only configured defaultAccount precedence changed.
