### PR TITLE
fix(agents): update merged models credentials from explicit config

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -134,7 +134,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("uses explicit config apiKey/baseUrl for matching providers in merge mode", async () => {
     await withTempHome(async () => {
       const agentDir = resolveOpenClawAgentDir();
       await fs.mkdir(agentDir, { recursive: true });
@@ -164,6 +164,59 @@ describe("models-config", () => {
             custom: {
               baseUrl: "https://config.example/v1",
               apiKey: "CONFIG_KEY",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("preserves non-empty agent apiKey/baseUrl when explicit config omits them", async () => {
+    await withTempHome(async () => {
+      const agentDir = resolveOpenClawAgentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://agent.example/v1",
+                apiKey: "AGENT_KEY",
+                api: "openai-responses",
+                models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
               api: "openai-responses",
               models: [
                 {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -101,6 +101,14 @@ function mergeProviders(params: {
   return out;
 }
 
+function hasExplicitNonEmptyProviderValue(
+  provider: ProviderConfig | undefined,
+  key: "apiKey" | "baseUrl",
+): boolean {
+  const value = provider?.[key];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 async function readJson(pathname: string): Promise<unknown> {
   try {
     const raw = await fs.readFile(pathname, "utf8");
@@ -118,6 +126,14 @@ export async function ensureOpenClawModelsJson(
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveOpenClawAgentDir();
 
   const explicitProviders = cfg.models?.providers ?? {};
+  const explicitProviderEntries: Record<string, ProviderConfig> = {};
+  for (const [rawKey, entry] of Object.entries(explicitProviders)) {
+    const providerKey = rawKey.trim();
+    if (!providerKey) {
+      continue;
+    }
+    explicitProviderEntries[providerKey] = entry;
+  }
   const implicitProviders = await resolveImplicitProviders({ agentDir, explicitProviders });
   const providers: Record<string, ProviderConfig> = mergeProviders({
     implicit: implicitProviders,
@@ -156,6 +172,7 @@ export async function ensureOpenClawModelsJson(
         mergedProviders[key] = entry;
       }
       for (const [key, newEntry] of Object.entries(providers)) {
+        const explicitProvider = explicitProviderEntries[key];
         const existing = existingProviders[key] as
           | (NonNullable<ModelsConfig["providers"]>[string] & {
               apiKey?: string;
@@ -164,10 +181,18 @@ export async function ensureOpenClawModelsJson(
           | undefined;
         if (existing) {
           const preserved: Record<string, unknown> = {};
-          if (typeof existing.apiKey === "string" && existing.apiKey) {
+          if (
+            !hasExplicitNonEmptyProviderValue(explicitProvider, "apiKey") &&
+            typeof existing.apiKey === "string" &&
+            existing.apiKey
+          ) {
             preserved.apiKey = existing.apiKey;
           }
-          if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+          if (
+            !hasExplicitNonEmptyProviderValue(explicitProvider, "baseUrl") &&
+            typeof existing.baseUrl === "string" &&
+            existing.baseUrl
+          ) {
             preserved.baseUrl = existing.baseUrl;
           }
           mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary
- update `ensureOpenClawModelsJson()` merge behavior so explicit global provider `apiKey`/`baseUrl` override stale per-agent values
- keep preserving existing agent-local credentials only when explicit global config omits those fields
- extend merge-mode tests to cover both explicit override and omission-preserve cases

Closes #30395

## Testing
- pnpm exec vitest run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
- pnpm exec vitest run src/agents/models-config*.test.ts
- pnpm exec oxlint src/agents/models-config.ts src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
- pnpm exec oxfmt --check src/agents/models-config.ts src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
