### PR TITLE
fix(security): detect Linux UFW without relying on PATH

### DIFF
--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { collectLinuxUfwFindings } from "./audit-extra.js";
+
+const FILE_STAT = {
+  ok: true,
+  isSymlink: false,
+  isDir: false,
+  mode: 0o755,
+  uid: 0,
+  gid: 0,
+} as const;
+
+const MISSING_STAT = {
+  ok: false,
+  isSymlink: false,
+  isDir: false,
+  mode: null,
+  uid: null,
+  gid: null,
+  error: "ENOENT",
+} as const;
+
+describe("collectLinuxUfwFindings", () => {
+  it("returns no findings on non-linux platforms", async () => {
+    const findings = await collectLinuxUfwFindings({
+      platform: "darwin",
+      statFn: async () => FILE_STAT,
+      readFileFn: async () => "ENABLED=yes\n",
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("reports enabled ufw when binary is detected but not on PATH", async () => {
+    const findings = await collectLinuxUfwFindings({
+      platform: "linux",
+      env: { PATH: "/usr/bin:/bin" },
+      ufwBinaryCandidates: ["/usr/sbin/ufw"],
+      ufwConfigPath: "/etc/ufw/ufw.conf",
+      statFn: async () => FILE_STAT,
+      readFileFn: async () => "ENABLED=yes\n",
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "host.firewall.ufw.enabled_not_on_path",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("reports enabled ufw when binary directory is already on PATH", async () => {
+    const findings = await collectLinuxUfwFindings({
+      platform: "linux",
+      env: { PATH: "/usr/sbin:/usr/bin:/bin" },
+      ufwBinaryCandidates: ["/usr/sbin/ufw"],
+      statFn: async () => FILE_STAT,
+      readFileFn: async () => "ENABLED=yes\n",
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "host.firewall.ufw.enabled",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("warns when config says enabled but ufw binary cannot be found", async () => {
+    const findings = await collectLinuxUfwFindings({
+      platform: "linux",
+      env: { PATH: "/usr/bin:/bin" },
+      ufwBinaryCandidates: ["/usr/sbin/ufw", "/sbin/ufw"],
+      statFn: async () => MISSING_STAT,
+      readFileFn: async () => "ENABLED=yes\n",
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "host.firewall.ufw.config_enabled_binary_missing",
+          severity: "warn",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -29,6 +29,7 @@ export {
 
 // Async collectors
 export {
+  collectLinuxUfwFindings,
   collectSandboxBrowserHashLabelFindings,
   collectIncludeFilePermFindings,
   collectInstalledSkillsCodeSafetyFindings,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -26,6 +26,7 @@ import {
   collectHooksHardeningFindings,
   collectIncludeFilePermFindings,
   collectInstalledSkillsCodeSafetyFindings,
+  collectLinuxUfwFindings,
   collectLikelyMultiUserSetupFindings,
   collectSandboxBrowserHashLabelFindings,
   collectMinimalProfileOverrideFindings,
@@ -978,6 +979,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     findings.push(
       ...(await collectStateDeepFilesystemFindings({ cfg, env, stateDir, platform, execIcacls })),
     );
+    findings.push(...(await collectLinuxUfwFindings({ env, platform })));
     findings.push(
       ...(await collectSandboxBrowserHashLabelFindings({
         execDockerRawFn: opts.execDockerRawFn,


### PR DESCRIPTION
## Summary
- add a Linux UFW audit collector that checks common sbin binary locations (`/usr/sbin/ufw`, `/sbin/ufw`, `/usr/local/sbin/ufw`)
- parse `/etc/ufw/ufw.conf` (`ENABLED=yes|no`) to report firewall state even when `ufw` is not invocable from user PATH
- emit explicit findings for enabled-but-not-on-PATH and config-enabled-but-binary-missing cases, with remediation guidance and regression tests

## Test plan
- [x] `pnpm exec vitest run --config vitest.unit.config.ts src/security/audit-extra.async.test.ts src/security/audit.test.ts`

Fixes #30361