### PR TITLE
Onboarding: honor explicit plugin defaultChoice on dev channel

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -30,6 +30,7 @@ export type ChannelPluginCatalogEntry = {
     npmSpec: string;
     localPath?: string;
     defaultChoice?: "npm" | "local";
+    explicitDefaultChoice?: boolean;
   };
 };
 
@@ -183,10 +184,12 @@ function resolveInstallInfo(params: {
     localPath = path.relative(params.workspaceDir, params.packageDir) || undefined;
   }
   const defaultChoice = params.manifest.install?.defaultChoice ?? (localPath ? "local" : "npm");
+  const explicitDefaultChoice = params.manifest.install?.defaultChoice !== undefined;
   return {
     npmSpec,
     ...(localPath ? { localPath } : {}),
     ...(defaultChoice ? { defaultChoice } : {}),
+    ...(explicitDefaultChoice ? { explicitDefaultChoice: true } : {}),
   };
 }
 

--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -163,6 +163,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       install: {
         ...baseEntry.install,
         defaultChoice: "npm",
+        explicitDefaultChoice: true,
       },
     };
 
@@ -172,6 +173,41 @@ describe("ensureOnboardingPluginInstalled", () => {
         entry: entryWithNpmDefault,
       }),
     ).toBe("npm");
+  });
+
+  it("keeps beta/stable npm default for implicit local catalog defaults", async () => {
+    const entryWithImplicitLocalDefault: ChannelPluginCatalogEntry = {
+      ...baseEntry,
+      install: {
+        ...baseEntry.install,
+        defaultChoice: "local",
+      },
+    };
+
+    expect(
+      await runInitialValueForEntry({
+        channel: "beta",
+        entry: entryWithImplicitLocalDefault,
+      }),
+    ).toBe("npm");
+  });
+
+  it("respects explicit local manifest defaults on beta/stable channels", async () => {
+    const entryWithExplicitLocalDefault: ChannelPluginCatalogEntry = {
+      ...baseEntry,
+      install: {
+        ...baseEntry.install,
+        defaultChoice: "local",
+        explicitDefaultChoice: true,
+      },
+    };
+
+    expect(
+      await runInitialValueForEntry({
+        channel: "beta",
+        entry: entryWithExplicitLocalDefault,
+      }),
+    ).toBe("local");
   });
 
   it("falls back to local path after npm install failure", async () => {

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -109,18 +109,19 @@ function resolveInstallDefaultChoice(params: {
   localPath?: string | null;
 }): InstallChoice {
   const { cfg, entry, localPath } = params;
+  const entryDefault = entry.install.defaultChoice;
+  if (entryDefault === "npm") {
+    return "npm";
+  }
+  if (entryDefault === "local") {
+    return localPath ? "local" : "npm";
+  }
+
   const updateChannel = cfg.update?.channel;
   if (updateChannel === "dev") {
     return localPath ? "local" : "npm";
   }
   if (updateChannel === "stable" || updateChannel === "beta") {
-    return "npm";
-  }
-  const entryDefault = entry.install.defaultChoice;
-  if (entryDefault === "local") {
-    return localPath ? "local" : "npm";
-  }
-  if (entryDefault === "npm") {
     return "npm";
   }
   return localPath ? "local" : "npm";

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -110,11 +110,14 @@ function resolveInstallDefaultChoice(params: {
 }): InstallChoice {
   const { cfg, entry, localPath } = params;
   const entryDefault = entry.install.defaultChoice;
-  if (entryDefault === "npm") {
-    return "npm";
-  }
-  if (entryDefault === "local") {
-    return localPath ? "local" : "npm";
+  const hasExplicitEntryDefault = entry.install.explicitDefaultChoice === true;
+  if (hasExplicitEntryDefault) {
+    if (entryDefault === "npm") {
+      return "npm";
+    }
+    if (entryDefault === "local") {
+      return localPath ? "local" : "npm";
+    }
   }
 
   const updateChannel = cfg.update?.channel;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: onboarding default install choice forced `local` on `update.channel=dev` even when plugin manifest explicitly set `install.defaultChoice: "npm"`.
- Why it matters: official Feishu plugin onboarding could prefer local workspace load paths and trigger duplicate plugin-loading/conflicting behavior.
- What changed: `resolveInstallDefaultChoice` now honors explicit manifest `defaultChoice` first, then falls back to channel-based defaults.
- What did NOT change (scope boundary): install execution path, fallback behavior, and prompt UX are unchanged beyond default preselection logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30321
- Related #29632

## User-visible / Behavior Changes

- On dev channel, plugins that explicitly declare `install.defaultChoice: "npm"` are now preselected as npm installs instead of local path installs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu onboarding plugin install flow
- Relevant config (redacted):
  - `update.channel = "dev"`
  - channel plugin manifest with `install.defaultChoice = "npm"`

### Steps

1. Run:
   `pnpm vitest src/commands/onboarding/plugin-install.test.ts --run`
2. Observe the test `respects entry defaultChoice=npm even on dev channel`.
3. Run `pnpm check`.

### Expected

- Explicit manifest default `npm` remains `npm` regardless of dev channel mode.

### Actual

- Before fix: initial selection was `local` on dev.
- After fix: initial selection is `npm`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Existing onboarding install tests still pass.
  - New regression test fails before fix and passes after fix.
- Edge cases checked:
  - `defaultChoice: "local"` still falls back to npm when local path is unavailable.
- What you did **not** verify:
  - Interactive CLI flow against a live end-user environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/commands/onboarding/plugin-install.ts`
  - `src/commands/onboarding/plugin-install.test.ts`
- Known bad symptoms reviewers should watch for:
  - Onboarding preselecting wrong install source for explicit manifest defaults.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some dev workflows may have relied on channel-level dev override despite explicit manifest default.
  - Mitigation:
    - Behavior changes only when manifest explicitly sets `defaultChoice`; implicit/default cases remain unchanged.
