### PR TITLE
Feishu: fallback to create send when reply target is withdrawn

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
+const resolveMarkdownTableModeMock = vi.hoisted(() => vi.fn(() => "preserve"));
+const convertMarkdownTablesMock = vi.hoisted(() => vi.fn((text: string) => text));
+
+vi.mock("./send-target.js", () => ({
+  resolveFeishuSendTarget: resolveFeishuSendTargetMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      text: {
+        resolveMarkdownTableMode: resolveMarkdownTableModeMock,
+        convertMarkdownTables: convertMarkdownTablesMock,
+      },
+    },
+  }),
+}));
+
+import { sendCardFeishu, sendMessageFeishu } from "./send.js";
+
+describe("Feishu reply fallback for withdrawn/deleted targets", () => {
+  const replyMock = vi.fn();
+  const createMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeishuSendTargetMock.mockReturnValue({
+      client: {
+        im: {
+          message: {
+            reply: replyMock,
+            create: createMock,
+          },
+        },
+      },
+      receiveId: "ou_target",
+      receiveIdType: "open_id",
+    });
+  });
+
+  it("falls back to create for withdrawn post replies", async () => {
+    replyMock.mockResolvedValue({
+      code: 230011,
+      msg: "The message was withdrawn.",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_new" },
+    });
+
+    const result = await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe("om_new");
+  });
+
+  it("falls back to create for withdrawn card replies", async () => {
+    replyMock.mockResolvedValue({
+      code: 231003,
+      msg: "The message is not found",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_card_new" },
+    });
+
+    const result = await sendCardFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      card: { schema: "2.0" },
+      replyToMessageId: "om_parent",
+    });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe("om_card_new");
+  });
+
+  it("still throws for non-withdrawn reply failures", async () => {
+    replyMock.mockResolvedValue({
+      code: 999999,
+      msg: "unknown failure",
+    });
+
+    await expect(
+      sendMessageFeishu({
+        cfg: {} as never,
+        to: "user:ou_target",
+        text: "hello",
+        replyToMessageId: "om_parent",
+      }),
+    ).rejects.toThrow("Feishu reply failed");
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -8,6 +8,16 @@ import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
+const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
+
+function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
+  if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
+    return true;
+  }
+  const msg = response.msg?.toLowerCase() ?? "";
+  return msg.includes("withdrawn") || msg.includes("not found");
+}
+
 export type FeishuMessageInfo = {
   messageId: string;
   chatId: string;
@@ -167,6 +177,18 @@ export async function sendMessageFeishu(
         ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
+    if (shouldFallbackFromReplyTarget(response)) {
+      const fallback = await client.im.message.create({
+        params: { receive_id_type: receiveIdType },
+        data: {
+          receive_id: receiveId,
+          content,
+          msg_type: msgType,
+        },
+      });
+      assertFeishuMessageApiSuccess(fallback, "Feishu send failed");
+      return toFeishuSendResult(fallback, receiveId);
+    }
     assertFeishuMessageApiSuccess(response, "Feishu reply failed");
     return toFeishuSendResult(response, receiveId);
   }
@@ -207,6 +229,18 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
         ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
+    if (shouldFallbackFromReplyTarget(response)) {
+      const fallback = await client.im.message.create({
+        params: { receive_id_type: receiveIdType },
+        data: {
+          receive_id: receiveId,
+          content,
+          msg_type: "interactive",
+        },
+      });
+      assertFeishuMessageApiSuccess(fallback, "Feishu card send failed");
+      return toFeishuSendResult(fallback, receiveId);
+    }
     assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
     return toFeishuSendResult(response, receiveId);
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu reply sends fail hard when parent message is withdrawn/deleted (`230011` / `231003`), causing replies to be dropped.
- Why it matters: users receive no response even though agent output was produced.
- What changed: reply sends for post/interactive messages now detect withdrawn/not-found reply target errors and fall back to normal `message.create` send.
- What did NOT change (scope boundary): generic retry/backoff policy and typing-indicator behavior were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27103
- Related #28660

## User-visible / Behavior Changes

- If reply target message has been withdrawn/deleted, Feishu replies now fall back to a normal send so the user still receives the response.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): N/A

### Steps

1. Simulate Feishu reply API returning withdrawn/not-found response codes.
2. Call Feishu send path with `replyToMessageId`.
3. Verify fallback create send is attempted.
4. Run tests:
   - `pnpm vitest extensions/feishu/src/send.reply-fallback.test.ts --run`
   - `pnpm check`

### Expected

- Withdrawn/not-found reply target should not drop response; send should fall back to normal create API.

### Actual

- Before fix: reply path threw and stopped.
- After fix: reply path falls back to create and returns successful send result.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - post reply fallback on `230011`.
  - card reply fallback on `231003`.
  - non-withdrawn reply failures still throw (no over-broad fallback).
- Edge cases checked:
  - fallback uses same receive target and msg_type payload.
- What you did **not** verify:
  - Live Feishu API calls in a real tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/send.ts`
  - `extensions/feishu/src/send.reply-fallback.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected fallback sends on unrelated reply errors.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Message-based heuristic could match unrelated error messages in non-English locales.
  - Mitigation:
    - Primary trigger uses known Feishu error codes (`230011`, `231003`); message-text check is secondary.
