### PR TITLE
fix(models): avoid false missing auth warning for SecretRef probe

### DIFF
--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+let mockStore: AuthProfileStore;
+let mockAllowedProfiles: string[];
+let resolvableProfiles: Set<string>;
+
+const resolveAuthProfileOrderMock = vi.fn(() => mockAllowedProfiles);
+const resolveApiKeyForProfileMock = vi.fn(
+  async (params: { profileId: string }): Promise<{ apiKey: string; provider: string } | null> => {
+    if (!resolvableProfiles.has(params.profileId)) {
+      return null;
+    }
+    return { apiKey: "sk-test", provider: "anthropic" };
+  },
+);
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => []),
+}));
+
+vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    ensureAuthProfileStore: () => mockStore,
+    listProfilesForProvider: (_store: AuthProfileStore, provider: string) =>
+      Object.entries(mockStore.profiles)
+        .filter(
+          ([, profile]) =>
+            typeof profile.provider === "string" && profile.provider.toLowerCase() === provider,
+        )
+        .map(([profileId]) => profileId),
+    resolveAuthProfileDisplayLabel: ({ profileId }: { profileId: string }) => profileId,
+    resolveAuthProfileOrder: resolveAuthProfileOrderMock,
+    resolveApiKeyForProfile: resolveApiKeyForProfileMock,
+  };
+});
+
+const { buildProbeTargets } = await import("./list.probe.js");
+
+describe("buildProbeTargets", () => {
+  beforeEach(() => {
+    mockStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          keyRef: { source: "exec", provider: "keychain", id: "anthropic-default" },
+        },
+      },
+      order: {
+        anthropic: ["anthropic:default"],
+      },
+    };
+    mockAllowedProfiles = [];
+    resolvableProfiles = new Set<string>();
+    resolveAuthProfileOrderMock.mockClear();
+    resolveApiKeyForProfileMock.mockClear();
+  });
+
+  it("keeps SecretRef profiles probeable when deferred credential resolution succeeds", async () => {
+    resolvableProfiles.add("anthropic:default");
+
+    const plan = await buildProbeTargets({
+      cfg: {} as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: ["anthropic/claude-sonnet-4-6"],
+      options: {
+        timeoutMs: 5000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    expect(plan.targets).toHaveLength(1);
+    expect(plan.targets[0]).toMatchObject({
+      provider: "anthropic",
+      profileId: "anthropic:default",
+      source: "profile",
+      mode: "api_key",
+    });
+    expect(plan.results).toEqual([]);
+    expect(resolveApiKeyForProfileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: "anthropic:default" }),
+    );
+  });
+
+  it("preserves missing-or-expired warning when deferred credential resolution fails", async () => {
+    const plan = await buildProbeTargets({
+      cfg: {} as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: ["anthropic/claude-sonnet-4-6"],
+      options: {
+        timeoutMs: 5000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    expect(plan.targets).toHaveLength(0);
+    expect(plan.results).toHaveLength(1);
+    expect(plan.results[0]).toMatchObject({
+      provider: "anthropic",
+      profileId: "anthropic:default",
+      status: "unknown",
+      error: "Auth profile credentials are missing or expired.",
+    });
+  });
+});

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -5,6 +5,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/ag
 import {
   ensureAuthProfileStore,
   listProfilesForProvider,
+  resolveApiKeyForProfile,
   resolveAuthProfileDisplayLabel,
   resolveAuthProfileOrder,
 } from "../../agents/auth-profiles.js";
@@ -139,7 +140,21 @@ function selectProbeModel(params: {
   return null;
 }
 
-function buildProbeTargets(params: {
+function canResolveDeferredProfileCredential(profile: {
+  type?: string;
+  keyRef?: unknown;
+  tokenRef?: unknown;
+}): boolean {
+  if (profile.type === "api_key") {
+    return profile.keyRef !== undefined;
+  }
+  if (profile.type === "token") {
+    return profile.tokenRef !== undefined;
+  }
+  return false;
+}
+
+export async function buildProbeTargets(params: {
   cfg: OpenClawConfig;
   providers: string[];
   modelCandidates: string[];
@@ -150,133 +165,165 @@ function buildProbeTargets(params: {
   const providerFilter = options.provider?.trim();
   const providerFilterKey = providerFilter ? normalizeProviderId(providerFilter) : null;
   const profileFilter = new Set((options.profileIds ?? []).map((id) => id.trim()).filter(Boolean));
+  const catalog = await loadModelCatalog({ config: cfg });
 
-  return loadModelCatalog({ config: cfg }).then((catalog) => {
-    const candidates = buildCandidateMap(modelCandidates);
-    const targets: AuthProbeTarget[] = [];
-    const results: AuthProbeResult[] = [];
+  const candidates = buildCandidateMap(modelCandidates);
+  const targets: AuthProbeTarget[] = [];
+  const results: AuthProbeResult[] = [];
 
-    for (const provider of providers) {
-      const providerKey = normalizeProviderId(provider);
-      if (providerFilterKey && providerKey !== providerFilterKey) {
-        continue;
-      }
+  for (const provider of providers) {
+    const providerKey = normalizeProviderId(provider);
+    if (providerFilterKey && providerKey !== providerFilterKey) {
+      continue;
+    }
 
-      const model = selectProbeModel({
-        provider: providerKey,
-        candidates,
-        catalog,
-      });
+    const model = selectProbeModel({
+      provider: providerKey,
+      candidates,
+      catalog,
+    });
 
-      const profileIds = listProfilesForProvider(store, providerKey);
-      const explicitOrder = (() => {
-        return (
-          findNormalizedProviderValue(store.order, providerKey) ??
-          findNormalizedProviderValue(cfg?.auth?.order, providerKey)
-        );
-      })();
-      const allowedProfiles =
-        explicitOrder && explicitOrder.length > 0
-          ? new Set(resolveAuthProfileOrder({ cfg, store, provider: providerKey }))
-          : null;
-      const filteredProfiles = profileFilter.size
-        ? profileIds.filter((id) => profileFilter.has(id))
-        : profileIds;
+    const profileIds = listProfilesForProvider(store, providerKey);
+    const explicitOrder = (() => {
+      return (
+        findNormalizedProviderValue(store.order, providerKey) ??
+        findNormalizedProviderValue(cfg?.auth?.order, providerKey)
+      );
+    })();
+    const allowedProfiles =
+      explicitOrder && explicitOrder.length > 0
+        ? new Set(resolveAuthProfileOrder({ cfg, store, provider: providerKey }))
+        : null;
+    const filteredProfiles = profileFilter.size
+      ? profileIds.filter((id) => profileFilter.has(id))
+      : profileIds;
 
-      if (filteredProfiles.length > 0) {
-        for (const profileId of filteredProfiles) {
-          const profile = store.profiles[profileId];
-          const mode = profile?.type;
-          const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
-          if (explicitOrder && !explicitOrder.includes(profileId)) {
-            results.push({
-              provider: providerKey,
-              model: model ? `${model.provider}/${model.model}` : undefined,
-              profileId,
-              label,
-              source: "profile",
-              mode,
-              status: "unknown",
-              error: "Excluded by auth.order for this provider.",
-            });
-            continue;
-          }
-          if (allowedProfiles && !allowedProfiles.has(profileId)) {
-            results.push({
-              provider: providerKey,
-              model: model ? `${model.provider}/${model.model}` : undefined,
-              profileId,
-              label,
-              source: "profile",
-              mode,
-              status: "unknown",
-              error: "Auth profile credentials are missing or expired.",
-            });
-            continue;
-          }
-          if (!model) {
-            results.push({
-              provider: providerKey,
-              model: undefined,
-              profileId,
-              label,
-              source: "profile",
-              mode,
-              status: "no_model",
-              error: "No model available for probe",
-            });
-            continue;
-          }
-          targets.push({
+    if (filteredProfiles.length > 0) {
+      for (const profileId of filteredProfiles) {
+        const profile = store.profiles[profileId];
+        const mode = profile?.type;
+        const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
+        if (explicitOrder && !explicitOrder.includes(profileId)) {
+          results.push({
             provider: providerKey,
-            model,
+            model: model ? `${model.provider}/${model.model}` : undefined,
             profileId,
             label,
             source: "profile",
             mode,
+            status: "unknown",
+            error: "Excluded by auth.order for this provider.",
           });
+          continue;
         }
-        continue;
-      }
-
-      if (profileFilter.size > 0) {
-        continue;
-      }
-
-      const envKey = resolveEnvApiKey(providerKey);
-      const customKey = getCustomProviderApiKey(cfg, providerKey);
-      if (!envKey && !customKey) {
-        continue;
-      }
-
-      const label = envKey ? "env" : "models.json";
-      const source = envKey ? "env" : "models.json";
-      const mode = envKey?.source.includes("OAUTH_TOKEN") ? "oauth" : "api_key";
-
-      if (!model) {
-        results.push({
+        if (allowedProfiles && !allowedProfiles.has(profileId)) {
+          const allowDeferredCredentialCheck =
+            profile && canResolveDeferredProfileCredential(profile);
+          if (allowDeferredCredentialCheck) {
+            try {
+              const resolved = await resolveApiKeyForProfile({ cfg, store, profileId });
+              if (resolved) {
+                if (!model) {
+                  results.push({
+                    provider: providerKey,
+                    model: undefined,
+                    profileId,
+                    label,
+                    source: "profile",
+                    mode,
+                    status: "no_model",
+                    error: "No model available for probe",
+                  });
+                } else {
+                  targets.push({
+                    provider: providerKey,
+                    model,
+                    profileId,
+                    label,
+                    source: "profile",
+                    mode,
+                  });
+                }
+                continue;
+              }
+            } catch {
+              // Keep legacy status message for unresolved/failed SecretRef lookups.
+            }
+          }
+          results.push({
+            provider: providerKey,
+            model: model ? `${model.provider}/${model.model}` : undefined,
+            profileId,
+            label,
+            source: "profile",
+            mode,
+            status: "unknown",
+            error: "Auth profile credentials are missing or expired.",
+          });
+          continue;
+        }
+        if (!model) {
+          results.push({
+            provider: providerKey,
+            model: undefined,
+            profileId,
+            label,
+            source: "profile",
+            mode,
+            status: "no_model",
+            error: "No model available for probe",
+          });
+          continue;
+        }
+        targets.push({
           provider: providerKey,
-          model: undefined,
+          model,
+          profileId,
           label,
-          source,
+          source: "profile",
           mode,
-          status: "no_model",
-          error: "No model available for probe",
         });
-        continue;
       }
+      continue;
+    }
 
-      targets.push({
+    if (profileFilter.size > 0) {
+      continue;
+    }
+
+    const envKey = resolveEnvApiKey(providerKey);
+    const customKey = getCustomProviderApiKey(cfg, providerKey);
+    if (!envKey && !customKey) {
+      continue;
+    }
+
+    const label = envKey ? "env" : "models.json";
+    const source = envKey ? "env" : "models.json";
+    const mode = envKey?.source.includes("OAUTH_TOKEN") ? "oauth" : "api_key";
+
+    if (!model) {
+      results.push({
         provider: providerKey,
-        model,
+        model: undefined,
         label,
         source,
         mode,
+        status: "no_model",
+        error: "No model available for probe",
       });
+      continue;
     }
 
-    return { targets, results };
-  });
+    targets.push({
+      provider: providerKey,
+      model,
+      label,
+      source,
+      mode,
+    });
+  }
+
+  return { targets, results };
 }
 
 async function probeTarget(params: {


### PR DESCRIPTION
## Summary
- fix `models status --probe` false negatives for `keyRef`/`tokenRef` auth profiles when explicit auth order exists
- when a profile is excluded by legacy `resolveAuthProfileOrder` filtering, attempt deferred credential resolution via `resolveApiKeyForProfile`
- if deferred resolution succeeds, include the profile in probe targets instead of emitting a premature "missing or expired" warning
- add regression tests for both success and failure paths of deferred SecretRef resolution

## Testing
- `pnpm vitest src/commands/models/list.probe.test.ts src/commands/models/list.probe.targets.test.ts`
- `pnpm exec oxfmt --check src/commands/models/list.probe.ts src/commands/models/list.probe.targets.test.ts`
- `pnpm exec oxlint --type-aware src/commands/models/list.probe.ts src/commands/models/list.probe.targets.test.ts`

Closes #30311
