### PR TITLE
fix(subagents): strip leaked function-call wire text in announces

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -537,6 +537,15 @@ describe("stripDowngradedToolCallText", () => {
         expected: "Intro.",
       },
       {
+        name: "strips leaked assistant function-call wire blocks",
+        text: `+#+#+#+#+#+assistant to=functions.subagents.commentary json
+{"action":"list","recentMinutes":20}
+assistant to=functions.sessions_list.commentary
+{"kinds":["subagent"],"limit":20}
+Final result for user.`,
+        expected: "Final result for user.",
+      },
+      {
         name: "no markers",
         text: "Just a normal response with no markers.",
         expected: "Just a normal response with no markers.",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -43,7 +43,10 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+  const hasDowngradedMarkers =
+    /\[Tool (?:Call|Result)/i.test(text) || /\[Historical context/i.test(text);
+  const hasFunctionCallLeak = /assistant\s+to=functions\.[\w.-]+/i.test(text);
+  if (!hasDowngradedMarkers && !hasFunctionCallLeak) {
     return text;
   }
 
@@ -194,6 +197,61 @@ export function stripDowngradedToolCallText(text: string): string {
 
   // Remove [Historical context: ...] markers (self-contained within brackets).
   cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
+
+  const stripFunctionCallLeakLines = (input: string): string => {
+    const lines = input.split(/\r?\n/);
+    const kept: string[] = [];
+    let skipPayload = false;
+    const functionCallLeakLineRe = /assistant\s+to=functions\.[\w.-]+/i;
+
+    const looksLikeFunctionPayloadLine = (line: string): boolean => {
+      if (!line) {
+        return false;
+      }
+      if (/^json\b/i.test(line)) {
+        return true;
+      }
+      if (/^```(?:json)?$/i.test(line) || line === "```") {
+        return true;
+      }
+      if (line.startsWith("{") || line.startsWith("[") || line === "}" || line === "]") {
+        return true;
+      }
+      if (/^["'\w-]+\s*:/.test(line)) {
+        return true;
+      }
+      const isJsonishCharsOnly = /^[\]{}(),:"'A-Za-z0-9_.+\-/]+$/.test(line);
+      const hasJsonPunctuation =
+        line.includes("{") ||
+        line.includes("}") ||
+        line.includes("[") ||
+        line.includes("]") ||
+        line.includes(":");
+      if (isJsonishCharsOnly && hasJsonPunctuation) {
+        return true;
+      }
+      return false;
+    };
+
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (functionCallLeakLineRe.test(rawLine)) {
+        skipPayload = true;
+        continue;
+      }
+      if (skipPayload && looksLikeFunctionPayloadLine(line)) {
+        continue;
+      }
+      if (skipPayload) {
+        skipPayload = false;
+      }
+      kept.push(rawLine);
+    }
+
+    return kept.join("\n");
+  };
+
+  cleaned = stripFunctionCallLeakLines(cleaned);
 
   return cleaned.trim();
 }

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -230,6 +230,28 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("Keep this internal context private");
   });
 
+  it("sanitizes leaked assistant function-call wire text before announce delivery", async () => {
+    readLatestAssistantReplyMock.mockResolvedValueOnce(
+      `assistant to=functions.subagents.commentary json
+{"action":"list","recentMinutes":20}
+Done summary for the user.`,
+    );
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-wire-leak",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+    });
+
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+    const msg = call?.params?.message as string;
+    expect(msg).toContain("Done summary for the user.");
+    expect(msg).not.toContain("assistant to=functions.");
+    expect(msg).not.toContain('{"action":"list","recentMinutes":20}');
+  });
+
   it("includes success status when outcome is ok", async () => {
     // Use waitForCompletion: false so it uses the provided outcome instead of calling agent.wait
     await runSubagentAnnounceFlow({

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -294,14 +294,23 @@ function extractSubagentOutputText(message: unknown): string {
   return "";
 }
 
+function sanitizeSubagentReplyText(reply: string | undefined): string | undefined {
+  if (typeof reply !== "string") {
+    return reply;
+  }
+  const sanitized = sanitizeTextContent(reply).trim();
+  return sanitized ? sanitized : undefined;
+}
+
 async function readLatestSubagentOutput(sessionKey: string): Promise<string | undefined> {
   try {
     const latestAssistant = await readLatestAssistantReply({
       sessionKey,
       limit: 50,
     });
-    if (latestAssistant?.trim()) {
-      return latestAssistant;
+    const sanitizedLatest = sanitizeSubagentReplyText(latestAssistant);
+    if (sanitizedLatest) {
+      return sanitizedLatest;
     }
   } catch {
     // Best-effort: fall back to richer history parsing below.
@@ -315,7 +324,7 @@ async function readLatestSubagentOutput(sessionKey: string): Promise<string | un
     const msg = messages[i];
     const text = extractSubagentOutputText(msg);
     if (text) {
-      return text;
+      return sanitizeSubagentReplyText(text);
     }
   }
   return undefined;
@@ -1089,7 +1098,7 @@ export async function runSubagentAnnounceFlow(params: {
         : undefined;
     })();
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
-    let reply = params.roundOneReply;
+    let reply = sanitizeSubagentReplyText(params.roundOneReply);
     let outcome: SubagentRunOutcome | undefined = params.outcome;
     // Lifecycle "end" can arrive before auto-compaction retries finish. If the
     // subagent is still active, wait for the embedded run to fully settle.
@@ -1138,18 +1147,20 @@ export async function runSubagentAnnounceFlow(params: {
           outcome = { status: "timeout" };
         }
       }
-      reply = await readLatestSubagentOutput(params.childSessionKey);
+      reply = sanitizeSubagentReplyText(await readLatestSubagentOutput(params.childSessionKey));
     }
 
     if (!reply) {
-      reply = await readLatestSubagentOutput(params.childSessionKey);
+      reply = sanitizeSubagentReplyText(await readLatestSubagentOutput(params.childSessionKey));
     }
 
     if (!reply?.trim()) {
-      reply = await readLatestSubagentOutputWithRetry({
-        sessionKey: params.childSessionKey,
-        maxWaitMs: params.timeoutMs,
-      });
+      reply = sanitizeSubagentReplyText(
+        await readLatestSubagentOutputWithRetry({
+          sessionKey: params.childSessionKey,
+          maxWaitMs: params.timeoutMs,
+        }),
+      );
     }
 
     if (
@@ -1192,11 +1203,13 @@ export async function runSubagentAnnounceFlow(params: {
 
     if (requesterDepth >= 1 && reply?.trim()) {
       const minReplyChangeWaitMs = FAST_TEST_MODE ? FAST_TEST_REPLY_CHANGE_WAIT_MS : 250;
-      reply = await waitForSubagentOutputChange({
-        sessionKey: params.childSessionKey,
-        baselineReply: reply,
-        maxWaitMs: Math.max(minReplyChangeWaitMs, Math.min(params.timeoutMs, 2_000)),
-      });
+      reply = sanitizeSubagentReplyText(
+        await waitForSubagentOutputChange({
+          sessionKey: params.childSessionKey,
+          baselineReply: reply,
+          maxWaitMs: Math.max(minReplyChangeWaitMs, Math.min(params.timeoutMs, 2_000)),
+        }),
+      );
     }
 
     // Build status label


### PR DESCRIPTION
## Summary
- sanitize leaked `assistant to=functions.*` wire-format fragments from user-facing text paths
- apply this sanitization in `stripDowngradedToolCallText` so function-call leak lines and adjacent JSON payload lines are removed
- ensure subagent announce flow sanitizes `readLatestAssistantReply` and round-one replies before composing delivery messages
- add regressions for both text sanitizer behavior and subagent announce delivery output

## Testing
- `pnpm vitest src/agents/pi-embedded-utils.test.ts src/agents/subagent-announce.format.test.ts`
- `pnpm exec oxfmt --check src/agents/pi-embedded-utils.ts src/agents/pi-embedded-utils.test.ts src/agents/subagent-announce.ts src/agents/subagent-announce.format.test.ts`
- `pnpm exec oxlint --type-aware src/agents/pi-embedded-utils.ts src/agents/pi-embedded-utils.test.ts src/agents/subagent-announce.ts src/agents/subagent-announce.format.test.ts`

Closes #30441
