### PR TITLE
Fix Control UI crash on browsers without Array.prototype.toSorted

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -173,7 +173,7 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  ).slice().sort((a, b) => a.localeCompare(b));
   const cronModelSuggestions = Array.from(
     new Set(
       [
@@ -188,7 +188,7 @@ export function renderApp(state: AppViewState) {
           .filter(Boolean),
       ].filter(Boolean),
     ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  ).slice().sort((a, b) => a.localeCompare(b));
   const selectedDeliveryChannel =
     state.cronForm.deliveryChannel && state.cronForm.deliveryChannel.trim()
       ? state.cronForm.deliveryChannel.trim()


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI 在不支持 `Array.prototype.toSorted` 的浏览器（例如 Win7 上的旧版 Chrome）中报错 `TypeError: Array.from(...).toSorted is not a function`，导致页面空白。
- Why it matters: 这些环境依然有真实用户使用，会直接打不开 Dashboard / Web UI，影响远程管理和排障。
- What changed: 在 `ui/src/ui/app-render.ts` 中，将两个 `Array.from(...).toSorted(...)` 替换为 `Array.from(...).slice().sort(...)`，保持返回新数组且不修改原数组。
- What did NOT change (scope boundary): 未修改排序逻辑、未更改任何后端逻辑、配置、CI 或其它 UI 组件，仅影响 cron 配置相关的本地排序实现。

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

（如没有关联 issue，可以先留空或写 `None`）

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Control UI 在不支持 `Array.prototype.toSorted` 的浏览器中不再白屏，cron 相关下拉建议（agents/models）依旧按相同规则排序。
- 对支持 `toSorted` 的现代浏览器行为无变化：仍然返回排序后的新数组，原始数组保持不变。

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) **No**
- Secrets/tokens handling changed? (`Yes/No`) **No**
- New/changed network calls? (`Yes/No`) **No**
- Command/tool execution surface changed? (`Yes/No`) **No**
- Data access scope changed? (`Yes/No`) **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 7（客户端浏览器），Gateway 运行在 Linux 服务器（官方 Docker 镜像）
- Runtime/container: `ghcr.io/openclaw/openclaw:main`（Docker）
- Model/provider: N/A（UI-only）
- Integration/channel (if any): Web Control UI / WebChat
- Relevant config (redacted):
  - `gateway.controlUi.enabled: true`
  - 通过浏览器访问远程 Gateway 控制台

### Steps

1. 在服务器上启动 Gateway（Docker），确保 Control UI 可访问。
2. 在 Windows 7 上使用不支持 `Array.prototype.toSorted` 的浏览器（旧版 Chrome）打开 Control UI。
3. 打开 DevTools Console，刷新页面并访问 cron 配置视图。

### Expected

- Control UI 正常渲染，cron 相关表单和下拉建议可见。
- 控制台无致命 JS 报错。

### Actual

- 页面保持空白。
- 控制台持续输出：`TypeError: Array.from(...).toSorted is not a function`，堆栈指向 `ui/src/ui/app-render.ts` 中两处 `toSorted` 调用。

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after（控制台错误截图 / 文本）
- [ ] Trace/log snippets
- [x] Screenshot/recording（Win7 上白屏 + 修复后正常界面）
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - 在 Windows 7 + 旧版 Chrome 上，应用此变更后 Control UI 能正常加载，cron 相关下拉建议显示并按预期排序。
  - 在现代浏览器（最新版 Chrome / Firefox）上，Control UI 行为与变更前一致，相关建议列表仍然按相同规则排序，原始数组未被修改。
- Edge cases checked:
  - cron jobs 为空/只包含少量项时，`slice().sort` 不会抛异常，结果与预期一致。
- What you did **not** verify:
  - 未跑完整 test suite，仅依赖 CI + 人工 UI 验证。
  - 未对非 UI 子系统（gateway/skills/auth 等）做额外回归。

## Compatibility / Migration

- Backward compatible? (`Yes/No`) **Yes**
- Config/env changes? (`Yes/No`) **No**
- Migration needed? (`Yes/No`) **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - 回滚 `ui/src/ui/app-render.ts` 中两处 `slice().sort` 到原来的 `toSorted` 实现（或直接 revert 该 commit）。
- Files/config to restore:
  - `ui/src/ui/app-render.ts`
- Known bad symptoms reviewers should watch for:
  - Control UI 再次在旧浏览器中白屏。
  - cron 相关下拉建议顺序异常或列表为空。

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - 若后续在其它 UI 代码中又引入 `Array.prototype.toSorted`，旧浏览器仍可能出现类似问题。
  - Mitigation:
    - 后续可以在 UI 层统一增加一个小的 `toSorted` polyfill helper，或在 lint 规则中禁止直接使用原生 `toSorted`。