### PR TITLE
fix(reply): strip queued metadata echoes from collect replies

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -7,6 +7,7 @@ import {
   resolveResponsePrefixTemplate,
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
+import { stripInboundMetadata } from "./strip-inbound-meta.js";
 
 export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
 
@@ -19,6 +20,20 @@ export type NormalizeReplyOptions = {
   silentToken?: string;
   onSkip?: (reason: NormalizeReplySkipReason) => void;
 };
+
+const QUEUED_COLLECT_MARKER_RE = /(?:^|\n)(?:---\s*\n)?Queued #\d+\s*(?=\n|$)/g;
+
+function stripEchoedQueuedMetadata(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const withoutInboundMeta = stripInboundMetadata(text);
+  const withoutQueuedMarkers = withoutInboundMeta.replace(QUEUED_COLLECT_MARKER_RE, "\n");
+  return withoutQueuedMarkers
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\n+/, "")
+    .replace(/\n+$/, "");
+}
 
 export function normalizeReplyPayload(
   payload: ReplyPayload,
@@ -63,6 +78,7 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    text = stripEchoedQueuedMetadata(text);
   }
   if (!text?.trim() && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -108,6 +108,43 @@ describe("normalizeReplyPayload", () => {
       expect(reasons, testCase.name).toEqual([testCase.reason]);
     }
   });
+
+  it("strips echoed queued metadata blocks from collect-mode output", () => {
+    const payload = {
+      text: `---\nQueued #1\nConversation info (untrusted metadata):
+\`\`\`json
+{"message_id":"123"}
+\`\`\`
+
+Sender (untrusted metadata):
+\`\`\`json
+{"name":"alice"}
+\`\`\`
+
+---
+Queued #2
+Conversation info (untrusted metadata):
+\`\`\`json
+{"message_id":"456"}
+\`\`\`
+
+Final answer for the user.`,
+    };
+
+    const normalized = normalizeReplyPayload(payload);
+
+    expect(normalized?.text).toBe("Final answer for the user.");
+  });
+
+  it("keeps regular user-facing text that mentions queued items inline", () => {
+    const payload = {
+      text: "I already handled queued #1 and queued #2 tasks.",
+    };
+
+    const normalized = normalizeReplyPayload(payload);
+
+    expect(normalized?.text).toBe("I already handled queued #1 and queued #2 tasks.");
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## Summary
- strip collect-mode metadata echoes from outbound replies before channel delivery
- remove OpenClaw-injected metadata blocks (`Conversation info`, `Sender`, etc.) from assistant text via `stripInboundMetadata`
- remove collect queue markers (`Queued #N` with optional `---` separator) so metadata wrappers never leak to user channels
- add normalize-reply regressions for both stripping behavior and non-metadata inline text safety

## Testing
- `pnpm vitest src/auto-reply/reply/reply-utils.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/reply-utils.test.ts`
- `pnpm exec oxlint --type-aware src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/reply-utils.test.ts`

Closes #30405
