### PR TITLE
Status: use persisted session levels when runtime overrides are missing

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -185,6 +185,28 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("elevated");
   });
 
+  it("uses persisted session levels when runtime overrides are absent", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-5" },
+      sessionEntry: {
+        sessionId: "levels-1",
+        updatedAt: 0,
+        thinkingLevel: "high",
+        verboseLevel: "full",
+        reasoningLevel: "stream",
+        elevatedLevel: "ask",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(text).toContain("Think: high");
+    expect(text).toContain("verbose:full");
+    expect(text).toContain("Reasoning: stream");
+    expect(text).toContain("elevated:ask");
+  });
+
   it("includes media understanding decisions when present", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -48,7 +48,16 @@ import {
 import type { CommandCategory } from "./commands-registry.types.js";
 import { resolveActiveFallbackState } from "./fallback-state.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
+import {
+  normalizeElevatedLevel,
+  normalizeReasoningLevel,
+  normalizeThinkLevel,
+  normalizeVerboseLevel,
+  type ElevatedLevel,
+  type ReasoningLevel,
+  type ThinkLevel,
+  type VerboseLevel,
+} from "./thinking.js";
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
 type AgentConfig = Partial<AgentDefaults> & {
@@ -506,12 +515,21 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel =
+    args.resolvedThink ??
+    normalizeThinkLevel(args.sessionEntry?.thinkingLevel) ??
+    args.agent?.thinkingDefault ??
+    "off";
+  const verboseLevel =
+    args.resolvedVerbose ??
+    normalizeVerboseLevel(args.sessionEntry?.verboseLevel) ??
+    args.agent?.verboseDefault ??
+    "off";
+  const reasoningLevel =
+    args.resolvedReasoning ?? normalizeReasoningLevel(args.sessionEntry?.reasoningLevel) ?? "off";
   const elevatedLevel =
     args.resolvedElevated ??
-    args.sessionEntry?.elevatedLevel ??
+    normalizeElevatedLevel(args.sessionEntry?.elevatedLevel) ??
     args.agent?.elevatedDefault ??
     "on";
 


### PR DESCRIPTION
## Summary
- make `/status` and `session_status` prefer persisted session-level flags when no runtime override is present
- normalize persisted `thinkingLevel`, `verboseLevel`, `reasoningLevel`, and `elevatedLevel` before rendering
- add regression coverage for persisted level rendering

## Validation
- `pnpm vitest src/auto-reply/status.test.ts src/agents/tools/browser-tool.test.ts`
- `pnpm check`

Fixes #30126
