### PR TITLE
fix(telegram): continue partial streaming across 4096-char overflow

### DIFF
--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -239,6 +239,35 @@ describe("createTelegramDraftStream", () => {
       expect.stringContaining("telegram stream preview stopped (text length 127 > 100)"),
     );
   });
+
+  it("rotates to a new preview message when stream text exceeds maxChars after initial send", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockResolvedValueOnce({ message_id: 17 })
+      .mockResolvedValueOnce({ message_id: 42 });
+    const warn = vi.fn();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      maxChars: 20,
+      warn,
+    });
+
+    stream.update("12345678901234567890");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "12345678901234567890", undefined);
+
+    stream.update("12345678901234567890-ABCDE");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "-ABCDE", undefined);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("continuing in a new preview message"),
+    );
+
+    stream.update("12345678901234567890-ABCDEFGHIJ");
+    await stream.flush();
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 42, "-ABCDEFGHIJ");
+  });
 });
 
 describe("draft stream initial message debounce", () => {

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -57,6 +57,8 @@ export function createTelegramDraftStream(params: {
 
   const streamState = { stopped: false, final: false };
   let streamMessageId: number | undefined;
+  let sourcePrefixChars = 0;
+  let lastSentSourceText = "";
   let lastSentText = "";
   let lastSentParseMode: "HTML" | undefined;
   let generation = 0;
@@ -70,13 +72,31 @@ export function createTelegramDraftStream(params: {
     if (!trimmed) {
       return false;
     }
-    const rendered = params.renderText?.(trimmed) ?? { text: trimmed };
+    const sourceText = trimmed.slice(sourcePrefixChars);
+    if (!sourceText.trimEnd()) {
+      return false;
+    }
+    const rendered = params.renderText?.(sourceText) ?? { text: sourceText };
     const renderedText = rendered.text.trimEnd();
     const renderedParseMode = rendered.parseMode;
     if (!renderedText) {
       return false;
     }
     if (renderedText.length > maxChars) {
+      if (lastSentSourceText.length > 0) {
+        sourcePrefixChars += lastSentSourceText.length;
+        generation += 1;
+        streamMessageId = undefined;
+        lastSentSourceText = "";
+        lastSentText = "";
+        lastSentParseMode = undefined;
+        loop.resetPending();
+        loop.resetThrottleWindow();
+        params.warn?.(
+          `telegram stream preview exceeded ${maxChars} chars; continuing in a new preview message`,
+        );
+        return await sendOrEditStreamMessage(text);
+      }
       // Telegram text messages/edits cap at 4096 chars.
       // Stop streaming once we exceed the cap to avoid repeated API failures.
       streamState.stopped = true;
@@ -85,7 +105,11 @@ export function createTelegramDraftStream(params: {
       );
       return false;
     }
-    if (renderedText === lastSentText && renderedParseMode === lastSentParseMode) {
+    if (
+      sourceText === lastSentSourceText &&
+      renderedText === lastSentText &&
+      renderedParseMode === lastSentParseMode
+    ) {
       return true;
     }
     const sendGeneration = generation;
@@ -97,6 +121,7 @@ export function createTelegramDraftStream(params: {
       }
     }
 
+    lastSentSourceText = sourceText;
     lastSentText = renderedText;
     lastSentParseMode = renderedParseMode;
     try {
@@ -166,6 +191,8 @@ export function createTelegramDraftStream(params: {
   const forceNewMessage = () => {
     generation += 1;
     streamMessageId = undefined;
+    sourcePrefixChars = 0;
+    lastSentSourceText = "";
     lastSentText = "";
     lastSentParseMode = undefined;
     loop.resetPending();


### PR DESCRIPTION
## Summary
- keep Telegram `streaming: partial` active across long responses instead of stopping at 4096-char overflow
- when the current preview would exceed `maxChars`, rotate to a fresh preview message and continue streaming the remaining tail
- track already-delivered source prefix so subsequent updates keep editing the current active preview window
- add regression coverage for overflow rotation: first preview finalizes, second preview starts, then continues editing normally

## Testing
- `pnpm vitest src/telegram/draft-stream.test.ts`
- `pnpm exec oxfmt --check src/telegram/draft-stream.ts src/telegram/draft-stream.test.ts`
- `pnpm exec oxlint --type-aware src/telegram/draft-stream.ts src/telegram/draft-stream.test.ts`

Closes #30434
