### PR TITLE
Agents: reject nodes screen_record durations above 60s

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayTool: vi.fn(),
+}));
+
+vi.mock("./gateway.js", async () => {
+  return {
+    callGatewayTool: (...args: unknown[]) => gatewayMocks.callGatewayTool(...args),
+    readGatewayCallOptions: (params: Record<string, unknown>) => ({
+      gatewayUrl: typeof params.gatewayUrl === "string" ? params.gatewayUrl : undefined,
+      gatewayToken: typeof params.gatewayToken === "string" ? params.gatewayToken : undefined,
+      timeoutMs: typeof params.timeoutMs === "number" ? params.timeoutMs : undefined,
+    }),
+  };
+});
+
+import { createNodesTool } from "./nodes-tool.js";
+
+describe("nodes tool screen_record duration limits", () => {
+  beforeEach(() => {
+    gatewayMocks.callGatewayTool.mockReset();
+  });
+
+  it("rejects durationMs values above the node runtime limit before calling the gateway", async () => {
+    const tool = createNodesTool();
+
+    await expect(
+      tool.execute("call-screen-record-too-long-ms", {
+        action: "screen_record",
+        node: "ios-node",
+        durationMs: 3_600_000,
+      }),
+    ).rejects.toThrow("screen_record durationMs must be at most 60000");
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects parsed duration strings above the node runtime limit before calling the gateway", async () => {
+    const tool = createNodesTool();
+
+    await expect(
+      tool.execute("call-screen-record-too-long-duration", {
+        action: "screen_record",
+        node: "ios-node",
+        duration: "1h",
+      }),
+    ).rejects.toThrow("screen_record durationMs must be at most 60000");
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the `nodes` agent tool accepted arbitrarily large `screen_record` durations and forwarded them straight to `node.invoke`.
- Why it matters: node runtimes clamp screen recording to 60s, so a request like `duration: "1h"` is invalid at the tool boundary and can waste time on a request that should fail immediately.
- What changed: `screen_record` now validates the requested duration before node resolution and rejects anything above 60,000 ms.
- What did NOT change (scope boundary): this PR does not change node runtime clamping, camera clip behavior, CLI `nodes screen record`, or any gateway policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29831
- Related #29831

## User-visible / Behavior Changes

`nodes` tool calls with `action: "screen_record"` now fail fast when `durationMs > 60000` (including parsed strings like `duration: "1h"`) instead of forwarding the overlong request to the gateway.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  The tool now rejects a previously accepted invalid `screen_record` duration at the agent-tool boundary. The change is narrowly scoped to `screen_record` and backed by a regression test covering both numeric and string durations.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): agent `nodes` tool
- Relevant config (redacted): none

### Steps

1. On `upstream/main`, run `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29831-nodes-screen-record.test.ts --reporter=verbose` with a harness that calls `createNodesTool().execute({ action: "screen_record", node: "ios-node", duration: "1h" })` and asserts the forwarded `node.invoke` params.
2. Observe the failing assertion: the tool forwards `durationMs: 3600000` to `node.invoke` instead of stopping at the existing 60s node-runtime limit.
3. On this branch, run `pnpm exec vitest run src/agents/tools/nodes-tool.test.ts --reporter=verbose`.

### Expected

- The `nodes` tool should reject overlong `screen_record` requests before any gateway call.

### Actual

- Before this patch, the tool resolved the node and forwarded the unbounded duration directly to `node.invoke`.
- After this patch, the tool throws `screen_record durationMs must be at most 60000` and does not call the gateway.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the pre-fix failure locally with a focused Vitest harness; added `src/agents/tools/nodes-tool.test.ts`; confirmed both `durationMs: 3600000` and `duration: "1h"` now fail before any gateway call.
- Edge cases checked: validated both the numeric and parsed-string entry paths because the bug existed in both.
- What you did **not** verify: live node recording on a device, because the bug is resolved before any device or gateway interaction.

Verification commands:

- `pnpm exec vitest run src/agents/tools/nodes-tool.test.ts --reporter=verbose`
- `pnpm check` currently stops on the existing unrelated `src/gateway/server-cron.ts(197)` type error present on current `upstream/main`; this PR does not touch that file.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `64fdf43ab8`.
- Files/config to restore: `src/agents/tools/nodes-tool.ts` and `src/agents/tools/nodes-tool.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate `screen_record` requests above 60s will now fail immediately instead of reaching the gateway.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: callers that relied on downstream node-runtime clamping for `screen_record` values above 60s will now get an explicit tool error.
  - Mitigation: this matches the existing node-runtime limit and keeps the behavior deterministic at the earliest boundary, with regression coverage for both supported duration inputs.

