### PR TITLE
Config: accept agents.list params cacheRetention

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -116,6 +116,26 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.list params.cacheRetention", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            params: {
+              cacheRetention: "short",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.list?.[0]?.params?.cacheRetention).toBe("short");
+    }
+  });
+
   it("rejects relative iMessage attachment roots", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -703,6 +703,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `agents.list[].params` was defined in the config types but missing from `AgentEntrySchema`, so validation rejected entries like `params.cacheRetention`.
- Why it matters: per-agent model params are a documented/configured surface, and rejecting them blocks valid agent-specific Anthropic cache retention settings.
- What changed: added `params` to `AgentEntrySchema` and added a schema regression test covering `agents.list[].params.cacheRetention`.
- What did NOT change (scope boundary): this PR does not change defaults behavior, model param semantics, or `agents.defaults.models[*].params` handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29902
- Related #29902

## User-visible / Behavior Changes

Configs using `agents.list[].params`, including `params.cacheRetention`, now validate successfully and preserve the configured values.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): config validation
- Relevant config (redacted): none

### Steps

1. On `upstream/main`, run `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29902-agent-params.test.ts --reporter=verbose` with a harness that expects `validateConfigObject({ agents: { list: [{ id: "my-agent", params: { cacheRetention: "short" } }] } })` to succeed.
2. Observe the failure: `res.ok` is `false` because `AgentEntrySchema` rejects the `params` key.
3. On this branch, run `pnpm exec vitest run src/config/config.schema-regressions.test.ts --reporter=verbose`.

### Expected

- `agents.list[].params.cacheRetention` should be accepted and preserved in the validated config.

### Actual

- Before this patch, validation failed at `agents.list.0` with `Unrecognized key: "params"`.
- After this patch, validation succeeds and preserves `params.cacheRetention`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the rejection on a clean branch with a focused Vitest harness; added an in-repo regression test proving `validateConfigObject` now accepts and preserves `agents.list[].params.cacheRetention`.
- Edge cases checked: confirmed the validated config still includes the configured `cacheRetention` value rather than merely ignoring the field.
- What you did **not** verify: any runtime model behavior downstream of validation, because this bug is limited to schema acceptance.

Verification commands:

- `pnpm exec vitest run src/config/config.schema-regressions.test.ts --reporter=verbose`
- `pnpm exec vitest run --config /tmp/openclaw-repros/vitest.config.cjs /tmp/openclaw-repros/29902-agent-params.test.ts --reporter=verbose`
- `pnpm check` currently stops on the existing unrelated `src/gateway/server-cron.ts(197)` type error present on current `upstream/main`; this PR does not touch that file.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e87f7ad909`.
- Files/config to restore: `src/config/zod-schema.agent-runtime.ts` and `src/config/config.schema-regressions.test.ts`.
- Known bad symptoms reviewers should watch for: agent entries unexpectedly accepting malformed `params` structures beyond a string-keyed record.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `agents.list[].params` now accepts any JSON-like value shape because the type is intentionally `Record<string, unknown>`.
  - Mitigation: this matches the existing `AgentConfig` type and existing `agents.defaults.models[*].params` contract; the PR only restores schema parity with those existing interfaces.

