### PR TITLE
docs: add plimsoll-security (financial guard) to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **Plimsoll Financial Guard** — Financial security guard for any agent that handles money (crypto, stocks, purchases, banking). Five deterministic engines: loop detection, spend-rate limits, credential exfiltration defense (credit cards, SSNs, API keys, crypto keys), high-value confirmation gates, and amount anomaly detection. Zero dependencies, fail-closed.
+  npm: `openclaw-plimsoll-security`
+  repo: `https://github.com/scoootscooob/openclaw-plimsoll-security`
+  install: `openclaw plugins install openclaw-plimsoll-security`


### PR DESCRIPTION
## Summary

- Add `openclaw-plimsoll-security` to the community plugins page (`docs/plugins/community.md`)
- Financial security guard for any OpenClaw agent that handles money — crypto, stocks, purchases, banking
- Five deterministic engines + SHA-256 hash-chained audit trail, zero dependencies, fail-closed
- 121 tests, MIT licensed

**npm**: https://www.npmjs.com/package/openclaw-plimsoll-security
**repo**: https://github.com/scoootscooob/openclaw-plimsoll-security

## Why this plugin

Multiple community discussions have asked for deterministic security gates for financial tool calls (#26348, #4981, #3387). This plugin addresses that gap — it hooks into `before_tool_call` to block hallucination retry loops, spend-rate abuse, credential exfiltration (credit cards, SSNs, ETH keys, mnemonics, API keys), unauthorized large transactions, and anomalous spending patterns.

Also see PR #30511 — a small bug fix for the `after_tool_call` hook context (propagating `agentId`/`sessionKey`), found while building this plugin.

## Checklist

- [x] Plugin published on npm (`openclaw-plimsoll-security@2.2.0`)
- [x] Source code on GitHub (public repo)
- [x] README with setup/usage docs
- [x] Issue tracker enabled
- [x] 121 automated tests
- [x] Zero runtime dependencies

<!-- greptile_comment -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)