### PR TITLE
fix(tui): reload history for finalized external final events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -338,6 +338,51 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(loadHistory).toHaveBeenCalledTimes(1);
   });
 
+  it("reloads history when a finalized run receives another final with no payload", () => {
+    const { state, loadHistory, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-reused",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "first pass" }] },
+    });
+    loadHistory.mockClear();
+
+    handleChatEvent({
+      runId: "run-reused",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps suppressing duplicate assistant final payloads for finalized runs", () => {
+    const { state, loadHistory, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-dup",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+    });
+    loadHistory.mockClear();
+
+    handleChatEvent({
+      runId: "run-dup",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "duplicate" }] },
+    });
+
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
   function createConcurrentRunHarness(localContent = "partial") {
     const { state, chatLog, setActivityStatus, loadHistory, handleChatEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -146,6 +146,20 @@ export function createEventHandlers(context: EventHandlerContext) {
     void loadHistory?.();
   };
 
+  const shouldReloadHistoryForFinalEvent = (message: unknown): boolean => {
+    if (!message || typeof message !== "object") {
+      return true;
+    }
+    const role =
+      typeof (message as Record<string, unknown>).role === "string"
+        ? ((message as Record<string, unknown>).role as string).toLowerCase()
+        : "";
+    if (role && role !== "assistant") {
+      return true;
+    }
+    return false;
+  };
+
   const handleChatEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") {
       return;
@@ -160,6 +174,10 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       if (evt.state === "final") {
+        if (shouldReloadHistoryForFinalEvent(evt.message)) {
+          maybeRefreshHistoryForRun(evt.runId);
+          tui.requestRender();
+        }
         return;
       }
     }


### PR DESCRIPTION
## Summary
- fix TUI chat-event dedupe path for finalized run IDs
- when a finalized run receives another `chat.final` without an assistant payload (or with a non-assistant role), trigger `loadHistory()` so external announces render immediately
- keep suppressing duplicate assistant payload finals for finalized runs to avoid duplicate renders

## Why
- addresses #30409 where sub-agent completion announce messages only appeared after the next user action in TUI
- this mirrors existing webchat behavior that reloads history on terminal finals lacking assistant content

## Tests
- `pnpm vitest src/tui/tui-event-handlers.test.ts`
- `pnpm oxfmt --check src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
- `pnpm oxlint --type-aware src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
