### PR TITLE
fix(ui): replace Array.toSorted() with slice().sort() for browser compatibility

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -477,17 +477,15 @@ export function renderApp(state: AppViewState) {
                     // Shift-click: select range from last selected to this session
                     // Sort sessions same way as displayed (by tokens or cost descending)
                     const isTokenMode = state.usageChartMode === "tokens";
-                    const sortedSessions = [...(state.usageResult?.sessions ?? [])].toSorted(
-                      (a, b) => {
-                        const valA = isTokenMode
-                          ? (a.usage?.totalTokens ?? 0)
-                          : (a.usage?.totalCost ?? 0);
-                        const valB = isTokenMode
-                          ? (b.usage?.totalTokens ?? 0)
-                          : (b.usage?.totalCost ?? 0);
-                        return valB - valA;
-                      },
-                    );
+                    const sortedSessions = [...(state.usageResult?.sessions ?? [])].sort((a, b) => {
+                      const valA = isTokenMode
+                        ? (a.usage?.totalTokens ?? 0)
+                        : (a.usage?.totalCost ?? 0);
+                      const valB = isTokenMode
+                        ? (b.usage?.totalTokens ?? 0)
+                        : (b.usage?.totalCost ?? 0);
+                      return valB - valA;
+                    });
                     const allKeys = sortedSessions.map((s) => s.key);
                     const lastSelected =
                       state.usageSelectedSessions[state.usageSelectedSessions.length - 1];

--- a/ui/src/ui/device-auth.ts
+++ b/ui/src/ui/device-auth.ts
@@ -28,7 +28,7 @@ function normalizeScopes(scopes: string[] | undefined): string[] {
       out.add(trimmed);
     }
   }
-  return [...out].toSorted();
+  return [...out].slice().sort();
 }
 
 function readStore(): DeviceAuthStore | null {

--- a/ui/src/ui/usage-helpers.ts
+++ b/ui/src/ui/usage-helpers.ts
@@ -305,7 +305,9 @@ export function parseToolSummary(content: string) {
     }
     nonToolLines.push(line);
   }
-  const sortedTools = Array.from(toolCounts.entries()).toSorted((a, b) => b[1] - a[1]);
+  const sortedTools = Array.from(toolCounts.entries())
+    .slice()
+    .sort((a, b) => b[1] - a[1]);
   const totalCalls = sortedTools.reduce((sum, [, count]) => sum + count, 0);
   const summary =
     sortedTools.length > 0

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -43,7 +43,8 @@ export function renderChannels(props: ChannelsProps) {
       enabled: channelEnabled(key, props),
       order: index,
     }))
-    .toSorted((a, b) => {
+    .slice()
+    .sort((a, b) => {
       if (a.enabled !== b.enabled) {
         return a.enabled ? -1 : 1;
       }

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -487,7 +487,7 @@ function renderObject(params: {
   const entries = Object.entries(props);
 
   // Sort by hint order
-  const sorted = entries.toSorted((a, b) => {
+  const sorted = entries.slice().sort((a, b) => {
     const orderA = hintForPath([...path, a[0]], hints)?.order ?? 0;
     const orderB = hintForPath([...path, b[0]], hints)?.order ?? 0;
     if (orderA !== orderB) {

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -371,14 +371,16 @@ export function renderConfigForm(props: ConfigFormProps) {
   const activeSection = props.activeSection;
   const activeSubsection = props.activeSubsection ?? null;
 
-  const entries = Object.entries(properties).toSorted((a, b) => {
-    const orderA = hintForPath([a[0]], props.uiHints)?.order ?? 50;
-    const orderB = hintForPath([b[0]], props.uiHints)?.order ?? 50;
-    if (orderA !== orderB) {
-      return orderA - orderB;
-    }
-    return a[0].localeCompare(b[0]);
-  });
+  const entries = Object.entries(properties)
+    .slice()
+    .sort((a, b) => {
+      const orderA = hintForPath([a[0]], props.uiHints)?.order ?? 50;
+      const orderB = hintForPath([b[0]], props.uiHints)?.order ?? 50;
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
+      return a[0].localeCompare(b[0]);
+    });
 
   const filteredEntries = entries.filter(([key, node]) => {
     if (activeSection && key !== activeSection) {

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -59,7 +59,7 @@ export function renderCron(props: CronProps) {
   const selectedJob =
     props.runsJobId == null ? undefined : props.jobs.find((job) => job.id === props.runsJobId);
   const selectedRunTitle = selectedJob?.name ?? props.runsJobId ?? "(select a job)";
-  const orderedRuns = props.runs.toSorted((a, b) => b.ts - a.ts);
+  const orderedRuns = props.runs.slice().sort((a, b) => b.ts - a.ts);
   return html`
     <section class="grid grid-cols-2">
       <div class="card">

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -2268,7 +2268,8 @@ function buildPeakErrorHours(sessions: UsageSessionEntry[], timeZone: "local" | 
       };
     })
     .filter((entry) => entry.msgs > 0 && entry.errors > 0)
-    .toSorted((a, b) => b.rate - a.rate)
+    .slice()
+    .sort((a, b) => b.rate - a.rate)
     .slice(0, 5)
     .map((entry) => ({
       label: formatHourLabel(entry.hour),
@@ -2759,20 +2760,23 @@ const buildAggregatesFromSessions = (
       uniqueTools: toolMap.size,
       tools: Array.from(toolMap.entries())
         .map(([name, count]) => ({ name, count }))
-        .toSorted((a, b) => b.count - a.count),
+        .slice()
+        .sort((a, b) => b.count - a.count),
     },
-    byModel: Array.from(modelMap.values()).toSorted(
-      (a, b) => b.totals.totalCost - a.totals.totalCost,
-    ),
-    byProvider: Array.from(providerMap.values()).toSorted(
-      (a, b) => b.totals.totalCost - a.totals.totalCost,
-    ),
+    byModel: Array.from(modelMap.values())
+      .slice()
+      .sort((a, b) => b.totals.totalCost - a.totals.totalCost),
+    byProvider: Array.from(providerMap.values())
+      .slice()
+      .sort((a, b) => b.totals.totalCost - a.totals.totalCost),
     byAgent: Array.from(agentMap.entries())
       .map(([agentId, totals]) => ({ agentId, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+      .slice()
+      .sort((a, b) => b.totals.totalCost - a.totals.totalCost),
     byChannel: Array.from(channelMap.entries())
       .map(([channel, totals]) => ({ channel, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+      .slice()
+      .sort((a, b) => b.totals.totalCost - a.totals.totalCost),
     latency:
       latencyTotals.count > 0
         ? {
@@ -2792,11 +2796,14 @@ const buildAggregatesFromSessions = (
         maxMs: entry.max,
         p95Ms: entry.p95Max,
       }))
-      .toSorted((a, b) => a.date.localeCompare(b.date)),
-    modelDaily: Array.from(modelDailyMap.values()).toSorted(
-      (a, b) => a.date.localeCompare(b.date) || b.cost - a.cost,
-    ),
-    daily: Array.from(dailyMap.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
+      .slice()
+      .sort((a, b) => a.date.localeCompare(b.date)),
+    modelDaily: Array.from(modelDailyMap.values())
+      .slice()
+      .sort((a, b) => a.date.localeCompare(b.date) || b.cost - a.cost),
+    daily: Array.from(dailyMap.values())
+      .slice()
+      .sort((a, b) => a.date.localeCompare(b.date)),
   };
 };
 
@@ -2842,7 +2849,8 @@ const buildUsageInsightStats = (
       messages: day.messages,
       rate: day.errors / day.messages,
     }))
-    .toSorted((a, b) => b.rate - a.rate || b.errors - a.errors)[0];
+    .slice()
+    .sort((a, b) => b.rate - a.rate || b.errors - a.errors)[0];
 
   return {
     durationSumMs,
@@ -3487,7 +3495,8 @@ function renderUsageInsights(
         rate,
       };
     })
-    .toSorted((a, b) => b.rate - a.rate)
+    .slice()
+    .sort((a, b) => b.rate - a.rate)
     .slice(0, 5)
     .map(({ rate: _rate, ...rest }) => rest);
 
@@ -3696,7 +3705,7 @@ function renderSessionsCard(
     return isTokenMode ? (usage.totalTokens ?? 0) : (usage.totalCost ?? 0);
   };
 
-  const sortedSessions = [...sessions].toSorted((a, b) => {
+  const sortedSessions = [...sessions].slice().sort((a, b) => {
     switch (sessionSort) {
       case "recent":
         return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
@@ -4328,13 +4337,15 @@ function renderContextPanel(
     }
   }
 
-  const skillsList = contextWeight.skills.entries.toSorted((a, b) => b.blockChars - a.blockChars);
-  const toolsList = contextWeight.tools.entries.toSorted(
-    (a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars),
-  );
-  const filesList = contextWeight.injectedWorkspaceFiles.toSorted(
-    (a, b) => b.injectedChars - a.injectedChars,
-  );
+  const skillsList = contextWeight.skills.entries
+    .slice()
+    .sort((a, b) => b.blockChars - a.blockChars);
+  const toolsList = contextWeight.tools.entries
+    .slice()
+    .sort((a, b) => b.summaryChars + b.schemaChars - (a.summaryChars + a.schemaChars));
+  const filesList = contextWeight.injectedWorkspaceFiles
+    .slice()
+    .sort((a, b) => b.injectedChars - a.injectedChars);
   const defaultLimit = 4;
   const showAll = expanded;
   const skillsTop = showAll ? skillsList : skillsList.slice(0, defaultLimit);
@@ -4500,7 +4511,9 @@ function renderSessionLogsCompact(
   });
   const toolOptions = Array.from(
     new Set(entries.flatMap((entry) => entry.toolInfo.tools.map(([name]) => name))),
-  ).toSorted((a, b) => a.localeCompare(b));
+  )
+    .slice()
+    .sort((a, b) => a.localeCompare(b));
   const filteredEntries = entries.filter((entry) => {
     if (filters.roles.length > 0 && !filters.roles.includes(entry.log.role)) {
       return false;
@@ -4692,7 +4705,7 @@ export function renderUsage(props: UsageProps) {
   // (intentionally no global Clear button in the header; chips + query clear handle this)
 
   // Sort sessions by tokens or cost depending on mode
-  const sortedSessions = [...props.sessions].toSorted((a, b) => {
+  const sortedSessions = [...props.sessions].slice().sort((a, b) => {
     const valA = isTokenMode ? (a.usage?.totalTokens ?? 0) : (a.usage?.totalCost ?? 0);
     const valB = isTokenMode ? (b.usage?.totalTokens ?? 0) : (b.usage?.totalCost ?? 0);
     return valB - valA;


### PR DESCRIPTION
## Summary

Fix Control UI rendering a blank page on older browsers that lack ES2023 `Array.prototype.toSorted()` support.

Closes #30467

## Root Cause

The Control UI uses `Array.prototype.toSorted()` (ES2023) in 8 files across 24 call sites. Older Chrome-based browsers (e.g., Chrome on Windows 7, still widely used in China) throw `TypeError: Array.from(...).toSorted is not a function`, which crashes the entire UI rendering.

## Fix

Replace all 24 occurrences of `.toSorted(compareFn)` with `.slice().sort(compareFn)`, which produces identical non-mutating sort behavior and is supported in all browsers back to ES5.

- `.toSorted()` → `.slice().sort()` (returns new sorted array, does not mutate original)
- Semantically identical — both create a copy, then sort it

## Changes

| File | Replacements |
|------|-------------|
| `ui/src/ui/app-render.ts` | 1 |
| `ui/src/ui/device-auth.ts` | 1 |
| `ui/src/ui/usage-helpers.ts` | 1 |
| `ui/src/ui/views/channels.ts` | 1 |
| `ui/src/ui/views/config-form.render.ts` | 1 |
| `ui/src/ui/views/config-form.node.ts` | 1 |
| `ui/src/ui/views/cron.ts` | 1 |
| `ui/src/ui/views/usage.ts` | 17 |
| **Total** | **24** |

## Backward Compatibility

Fully backward compatible. `.slice().sort()` behaves identically to `.toSorted()` and works in all modern and legacy browsers.
