### PR TITLE
fix(plugin-sdk): expose waitForAbortSignal for extension imports

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -8,11 +8,11 @@ import {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   setAccountEnabledInConfigSection,
+  waitForAbortSignal,
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import * as sdk from "./index.js";
 
 describe("plugin-sdk exports", () => {
+  it("exports waitForAbortSignal helper", async () => {
+    expect(typeof sdk.waitForAbortSignal).toBe("function");
+    await expect(sdk.waitForAbortSignal(undefined)).resolves.toBeUndefined();
+  });
+
   it("does not expose runtime modules", () => {
     const forbidden = [
       "chunkMarkdownText",

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -303,6 +303,7 @@ export { fetchWithBearerAuthScopeFallback } from "./fetch-auth.js";
 export type { ScopeTokenProvider } from "./fetch-auth.js";
 export { rawDataToString } from "../infra/ws.js";
 export { isWSLSync, isWSL2Sync, isWSLEnv } from "../infra/wsl.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export { isTruthyEnvValue } from "../infra/env.js";
 export { resolveToolsBySender } from "../config/group-policy.js";
 export {


### PR DESCRIPTION
## Summary
- export `waitForAbortSignal` from `openclaw/plugin-sdk`
- update nextcloud-talk to import `waitForAbortSignal` from the SDK instead of a repo-internal relative `src/infra` path
- add plugin-sdk export coverage to prevent regressions in packaged extension builds

## Test plan
- [x] `pnpm exec vitest run src/plugin-sdk/index.test.ts extensions/nextcloud-talk/src`

Fixes #30057