### PR TITLE
fix(telegram): prevent duplicate equivalent payload sends per turn

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -525,6 +525,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("dedupes equivalent media finals within one dispatch turn", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Voice summary",
+          mediaUrl: "file:///tmp/voice.opus",
+          audioAsVoice: false,
+        },
+        { kind: "final" },
+      );
+      await dispatcherOptions.deliver(
+        {
+          text: "Voice summary",
+          mediaUrl: "file:///tmp/voice.opus",
+          audioAsVoice: true,
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "off" });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({ text: "Voice summary", mediaUrl: "file:///tmp/voice.opus" }),
+        ],
+      }),
+    );
+  });
+
   it("keeps streamed preview visible when final text regresses after a tool warning", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -394,6 +394,23 @@ export const dispatchTelegramMessage = async ({
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
   };
+  const buildDeliveredPayloadKey = (payload: ReplyPayload): string | null => {
+    const text = typeof payload.text === "string" ? payload.text.trim() : "";
+    const mediaList = payload.mediaUrls?.length
+      ? payload.mediaUrls
+      : payload.mediaUrl
+        ? [payload.mediaUrl]
+        : [];
+    if (!text && mediaList.length === 0) {
+      return null;
+    }
+    return JSON.stringify({
+      text,
+      mediaList,
+      replyToId: payload.replyToId ?? null,
+    });
+  };
+  const deliveredPayloadKeys = new Set<string>();
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {
       return payload;
@@ -401,12 +418,21 @@ export const dispatchTelegramMessage = async ({
     return { ...payload, text };
   };
   const sendPayload = async (payload: ReplyPayload) => {
+    const payloadKey = buildDeliveredPayloadKey(payload);
+    if (payloadKey && deliveredPayloadKeys.has(payloadKey)) {
+      logVerbose("telegram: skipping duplicate payload delivery within the same dispatch turn");
+      deliveryState.markDelivered();
+      return true;
+    }
     const result = await deliverReplies({
       ...deliveryBaseOptions,
       replies: [payload],
       onVoiceRecording: sendRecordVoice,
     });
     if (result.delivered) {
+      if (payloadKey) {
+        deliveredPayloadKeys.add(payloadKey);
+      }
       deliveryState.markDelivered();
     }
     return result.delivered;


### PR DESCRIPTION
## Summary
- add per-dispatch payload deduplication in Telegram reply delivery so semantically identical text/media payloads are only sent once
- use a normalized dedupe key (text + media list + reply target) to guard duplicate sends even when `audioAsVoice` differs for the same attachment
- keep delivery accounting consistent by marking deduped repeats as already delivered

## Test plan
- [x] `pnpm exec vitest run src/telegram/bot-message-dispatch.test.ts`
- [x] added regression case: `dedupes equivalent media finals within one dispatch turn`

Fixes #30316