### PR TITLE
fix(telegram): keep /models checkmark when default model uses alias

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,11 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentEffectiveModelPrimary,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../agents/model-selection.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
@@ -319,11 +325,25 @@ export const registerTelegramHandlers = ({
         model: `${provider}/${model}`,
       };
     }
-    const modelCfg = cfg.agents?.defaults?.model;
+    const rawDefaultModel = resolveAgentEffectiveModelPrimary(cfg, route.agentId);
+    const defaultAliasIndex = buildModelAliasIndex({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    const resolvedDefaultModelRef = (rawDefaultModel
+      ? resolveModelRefFromString({
+          raw: rawDefaultModel,
+          defaultProvider: DEFAULT_PROVIDER,
+          aliasIndex: defaultAliasIndex,
+        })?.ref
+      : undefined) ?? {
+      provider: DEFAULT_PROVIDER,
+      model: DEFAULT_MODEL,
+    };
     return {
       agentId: route.agentId,
       sessionEntry: entry,
-      model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
+      model: `${resolvedDefaultModelRef.provider}/${resolvedDefaultModelRef.model}`,
     };
   };
 

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -279,6 +279,65 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("marks the default model in model-list callbacks when default is configured via alias", async () => {
+    onSpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: {
+            primary: "flash3",
+          },
+          models: {
+            "google/gemini-3-flash-preview": {
+              alias: "flash3",
+            },
+          },
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-models-default-alias",
+        data: "mdl_list_google_1",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 14,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    const [, , , params] = editMessageTextSpy.mock.calls[0] ?? [];
+    const inlineKeyboard = (
+      params as
+        | {
+            reply_markup?: {
+              inline_keyboard?: Array<Array<{ text?: string; callback_data?: string }>>;
+            };
+          }
+        | undefined
+    )?.reply_markup?.inline_keyboard;
+    const firstModelButtonText = inlineKeyboard?.[0]?.[0]?.text ?? "";
+    expect(firstModelButtonText).toContain("gemini-3-flash-preview");
+    expect(firstModelButtonText).toContain("✓");
+  });
+
   it("blocks pagination callbacks when allowlist rejects sender", async () => {
     onSpy.mockClear();
     editMessageTextSpy.mockClear();


### PR DESCRIPTION
## Summary\n- fix Telegram model-list callback current-model resolution to canonical  defaults\n- resolve fallback defaults using agent-aware model config + alias parsing instead of raw primary string\n- add regression test covering alias-configured default model in  callbacks\n\n## Why\nWhen session override is cleared (switching back to default), the callback path could end up with a non-canonical or missing current model string, so the menu stopped showing the active checkmark.\n\n## Testing\n- 
 RUN  v4.0.18 /Users/liuxiaopai/Documents/GitHub/openclaw-improve

 ✓ src/telegram/model-buttons.test.ts (14 tests) 5ms
 ✓ src/telegram/bot.test.ts (41 tests) 158ms

 Test Files  2 passed (2)
      Tests  55 passed (55)
   Start at  16:44:48
   Duration  5.03s (transform 3.28s, setup 291ms, import 4.67s, tests 163ms, environment 0ms)\n- Checking formatting...

All matched files use the correct format.
Finished in 23ms on 2 files using 8 threads.\n- Found 0 warnings and 0 errors.
Finished in 1.1s on 2 files with 136 rules using 8 threads.\n\nCloses #30476