### PR TITLE
fix(reply): sync responsePrefix model templates with runtime model

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -313,6 +313,38 @@ describe("runReplyAgent heartbeat followup guard", () => {
   });
 });
 
+describe("runReplyAgent model selection callback", () => {
+  it("updates onModelSelected with runtime model metadata", async () => {
+    const onModelSelected = vi.fn();
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {
+        agentMeta: {
+          provider: "google",
+          model: "gemini-3-flash-preview",
+        },
+      },
+    });
+
+    const { run } = createMinimalRun({
+      opts: { onModelSelected },
+    });
+    await run();
+
+    expect(onModelSelected).toHaveBeenCalledTimes(2);
+    expect(onModelSelected).toHaveBeenNthCalledWith(1, {
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+    });
+    expect(onModelSelected).toHaveBeenNthCalledWith(2, {
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      thinkLevel: "low",
+    });
+  });
+});
+
 describe("runReplyAgent typing (heartbeat)", () => {
   async function withTempStateDir<T>(fn: (stateDir: string) => Promise<T>): Promise<T> {
     return await withStateDirEnv(

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -440,6 +440,13 @@ export async function runReplyAgent(params: {
     const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
+    // Re-emit model selection with the resolved runtime model so downstream
+    // consumers (e.g. responsePrefix templates) track the actual model used.
+    opts?.onModelSelected?.({
+      provider: providerUsed,
+      model: modelUsed,
+      thinkLevel: followupRun.run.thinkLevel,
+    });
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const selectedProvider = followupRun.run.provider;
     const selectedModel = followupRun.run.model;

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -4,6 +4,7 @@ import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../token
 import type { ReplyPayload } from "../types.js";
 import { hasLineDirectives, parseLineDirectives } from "./line-directives.js";
 import {
+  hasTemplateVariables,
   resolveResponsePrefixTemplate,
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
@@ -76,10 +77,15 @@ export function normalizeReplyPayload(
     text = enrichedPayload.text;
   }
 
-  // Resolve template variables in responsePrefix if context is provided
-  const effectivePrefix = opts.responsePrefixContext
-    ? resolveResponsePrefixTemplate(opts.responsePrefix, opts.responsePrefixContext)
-    : opts.responsePrefix;
+  // Avoid leaking unresolved template variables (e.g. "{model}") into user-visible
+  // text when prefix context is not available yet.
+  const skipTemplatePrefix =
+    !opts.responsePrefixContext && hasTemplateVariables(opts.responsePrefix);
+  const effectivePrefix = skipTemplatePrefix
+    ? undefined
+    : opts.responsePrefixContext
+      ? resolveResponsePrefixTemplate(opts.responsePrefix, opts.responsePrefixContext)
+      : opts.responsePrefix;
 
   if (
     effectivePrefix &&

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -108,6 +108,25 @@ describe("normalizeReplyPayload", () => {
       expect(reasons, testCase.name).toEqual([testCase.reason]);
     }
   });
+
+  it("does not prepend unresolved template prefixes without context", () => {
+    const noContext = normalizeReplyPayload(
+      { text: "hello" },
+      {
+        responsePrefix: "[{model}]",
+      },
+    );
+    expect(noContext?.text).toBe("hello");
+
+    const withContext = normalizeReplyPayload(
+      { text: "hello" },
+      {
+        responsePrefix: "[{model}]",
+        responsePrefixContext: { model: "gpt-5.2" },
+      },
+    );
+    expect(withContext?.text).toBe("[gpt-5.2] hello");
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## Summary
- avoid injecting unresolved responsePrefix templates (like `{model}`) when model context is unavailable
- re-emit `onModelSelected` after run completion using runtime `provider/model` metadata
- add regression tests for both behaviors

## Why
`messages.responsePrefix` templates can become stale or literal when model context is not synchronized with runtime model usage. This change keeps template interpolation aligned with the actual model used and prevents leaking unresolved placeholders into user-facing replies.

## Testing
- pnpm vitest src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts
- pnpm oxfmt --check src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts
- pnpm oxlint --type-aware src/auto-reply/reply/normalize-reply.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts

Closes #30482
