### PR TITLE
feat(skills): allow per-skill model overrides for slash skills

### DIFF
--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -51,6 +51,8 @@ export type SkillCommandDispatchSpec = {
 export type SkillCommandSpec = {
   name: string;
   skillName: string;
+  /** Resolved config key for skills.entries (frontmatter skillKey or skill name). */
+  skillKey?: string;
   description: string;
   /** Optional deterministic dispatch behavior for this command. */
   dispatch?: SkillCommandDispatchSpec;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -16,6 +16,7 @@ import { normalizeSkillFilter } from "./filter.js";
 import {
   parseFrontmatter,
   resolveOpenClawMetadata,
+  resolveSkillKey,
   resolveSkillInvocationPolicy,
 } from "./frontmatter.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
@@ -679,6 +680,7 @@ export function buildWorkspaceSkillCommandSpecs(
   const specs: SkillCommandSpec[] = [];
   for (const entry of userInvocable) {
     const rawName = entry.skill.name;
+    const skillKey = resolveSkillKey(entry.skill, entry);
     const base = sanitizeSkillCommandName(rawName);
     if (base !== rawName) {
       debugSkillCommandOnce(
@@ -752,6 +754,7 @@ export function buildWorkspaceSkillCommandSpecs(
     specs.push({
       name: unique,
       skillName: rawName,
+      skillKey,
       description,
       ...(dispatch ? { dispatch } : {}),
     });

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -221,4 +221,110 @@ describe("handleInlineActions", () => {
     expect(sessionStore["s:main"]?.abortCutoffTimestamp).toBeUndefined();
     expect(handleCommandsMock).toHaveBeenCalledTimes(1);
   });
+
+  it("applies per-skill model override when invoking a skill command", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValue({ shouldContinue: true, reply: undefined });
+
+    const ctx = buildTestCtx({
+      Body: "/demo summarize this",
+      CommandBody: "/demo summarize this",
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/demo summarize this",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          abortKey: "sender-1",
+        },
+        overrides: {
+          cfg: {
+            skills: {
+              entries: {
+                "demo-skill": {
+                  model: "google/gemini-3-flash-preview",
+                },
+              },
+            },
+          },
+          allowTextCommands: true,
+          skillCommands: [
+            {
+              name: "demo",
+              skillName: "demo-skill",
+              skillKey: "demo-skill",
+              description: "Demo skill",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("continue");
+    if (result.kind === "continue") {
+      expect(result.directives.hasModelDirective).toBe(true);
+      expect(result.directives.rawModelDirective).toBe("google/gemini-3-flash-preview");
+    }
+    expect(ctx.Body).toContain('Use the "demo-skill" skill for this request.');
+  });
+
+  it("does not override explicit /model directives when a skill has model config", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValue({ shouldContinue: true, reply: undefined });
+
+    const ctx = buildTestCtx({
+      Body: "/demo summarize this",
+      CommandBody: "/demo summarize this",
+    });
+
+    const explicitDirectives = {
+      ...clearInlineDirectives("/demo summarize this"),
+      hasModelDirective: true,
+      rawModelDirective: "openai/gpt-4o",
+    };
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/demo summarize this",
+        command: {
+          isAuthorizedSender: true,
+          senderId: "sender-1",
+          abortKey: "sender-1",
+        },
+        overrides: {
+          cfg: {
+            skills: {
+              entries: {
+                "demo-skill": {
+                  model: "google/gemini-3-flash-preview",
+                },
+              },
+            },
+          },
+          allowTextCommands: true,
+          directives: explicitDirectives,
+          skillCommands: [
+            {
+              name: "demo",
+              skillName: "demo-skill",
+              skillKey: "demo-skill",
+              description: "Demo skill",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("continue");
+    if (result.kind === "continue") {
+      expect(result.directives.hasModelDirective).toBe(true);
+      expect(result.directives.rawModelDirective).toBe("openai/gpt-4o");
+    }
+  });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -53,6 +53,22 @@ function resolveSlashCommandName(commandBodyNormalized: string): string | null {
   return name ? name : null;
 }
 
+function resolveSkillModelOverride(params: {
+  cfg: OpenClawConfig;
+  command: SkillCommandSpec;
+}): string | undefined {
+  const key = params.command.skillKey?.trim() || params.command.skillName.trim();
+  if (!key) {
+    return undefined;
+  }
+  const override = params.cfg.skills?.entries?.[key]?.model;
+  if (typeof override !== "string") {
+    return undefined;
+  }
+  const trimmed = override.trim();
+  return trimmed || undefined;
+}
+
 export type InlineActionResult =
   | { kind: "reply"; reply: ReplyPayload | ReplyPayload[] | undefined }
   | {
@@ -246,6 +262,19 @@ export async function handleInlineActions(params: {
     sessionCtx.BodyForAgent = rewrittenBody;
     sessionCtx.BodyStripped = rewrittenBody;
     cleanedBody = rewrittenBody;
+    if (!directives.hasModelDirective) {
+      const skillModelOverride = resolveSkillModelOverride({
+        cfg,
+        command: skillInvocation.command,
+      });
+      if (skillModelOverride) {
+        directives = {
+          ...directives,
+          hasModelDirective: true,
+          rawModelDirective: skillModelOverride,
+        };
+      }
+    }
   }
 
   const sendInlineReply = async (reply?: ReplyPayload) => {

--- a/src/config/config.skills-entries-config.test.ts
+++ b/src/config/config.skills-entries-config.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest";
 import { OpenClawSchema } from "./zod-schema.js";
 
 describe("skills entries config schema", () => {
+  it("accepts per-skill model overrides", () => {
+    const res = OpenClawSchema.safeParse({
+      skills: {
+        entries: {
+          "custom-skill": {
+            enabled: true,
+            model: "google/gemini-3-flash-preview",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
   it("accepts custom fields under config", () => {
     const res = OpenClawSchema.safeParse({
       skills: {

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -2,6 +2,7 @@ import type { SecretInput } from "./types.secrets.js";
 
 export type SkillConfig = {
   enabled?: boolean;
+  model?: string;
   apiKey?: SecretInput;
   env?: Record<string, string>;
   config?: Record<string, unknown>;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -727,6 +727,7 @@ export const OpenClawSchema = z
             z
               .object({
                 enabled: z.boolean().optional(),
+                model: z.string().optional(),
                 apiKey: SecretInputSchema.optional().register(sensitive),
                 env: z.record(z.string(), z.string()).optional(),
                 config: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
## Summary
- add optional `skills.entries.<skill>.model` support to config schema/types
- thread the resolved skill entry key into generated slash skill commands
- apply per-skill model override when invoking a slash skill command (unless user already set `/model`)
- add regression tests for schema acceptance and inline-action model selection behavior

## Testing
- pnpm vitest src/config/config.skills-entries-config.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/skill-commands.test.ts
- pnpm oxfmt --check src/config/types.skills.ts src/config/zod-schema.ts src/agents/skills/types.ts src/agents/skills/workspace.ts src/auto-reply/reply/get-reply-inline-actions.ts src/config/config.skills-entries-config.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
- pnpm oxlint --type-aware src/config/types.skills.ts src/config/zod-schema.ts src/agents/skills/types.ts src/agents/skills/workspace.ts src/auto-reply/reply/get-reply-inline-actions.ts src/config/config.skills-entries-config.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts

Closes #30465
