### PR TITLE
docs: expand CLI reference for agent, health, logs, tui, dns

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -7,18 +7,74 @@ title: "agent"
 
 # `openclaw agent`
 
-Run an agent turn via the Gateway (use `--local` for embedded).
-Use `--agent <id>` to target a configured agent directly.
+Run a single agent turn via the Gateway. Use `--local` to run the embedded agent directly (requires model provider API keys in your shell environment).
+
+Use `--agent <id>` to target a specific configured agent, or `--to` to route by recipient number.
 
 Related:
 
 - Agent send tool: [Agent send](/tools/agent-send)
+- Managing agents: [`openclaw agents`](/cli/agents)
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-m, --message <text>` | **(Required)** Message body for the agent |
+| `-t, --to <number>` | Recipient number in E.164 format, used to derive the session key |
+| `--session-id <id>` | Target an explicit session id instead of routing by recipient |
+| `--agent <id>` | Agent id to use (overrides routing bindings) |
+| `--thinking <level>` | Thinking level: `off` \| `minimal` \| `low` \| `medium` \| `high` |
+| `--verbose <on\|off>` | Persist agent verbose level for the session |
+| `--channel <channel>` | Delivery channel (omit to use the main session channel) |
+| `--reply-to <target>` | Delivery target override (separate from session routing) |
+| `--reply-channel <channel>` | Delivery channel override (separate from routing) |
+| `--reply-account <id>` | Delivery account id override |
+| `--deliver` | Send the agent's reply back to the selected channel |
+| `--local` | Run the embedded agent locally instead of via Gateway |
+| `--json` | Output result as JSON |
+| `--timeout <seconds>` | Agent command timeout (default: `600` or config value) |
 
 ## Examples
 
+Start a new session by recipient number:
+
 ```bash
-openclaw agent --to +15555550123 --message "status update" --deliver
+openclaw agent --to +15555550123 --message "status update"
+```
+
+Target a specific agent:
+
+```bash
 openclaw agent --agent ops --message "Summarize logs"
+```
+
+Target an existing session with extended thinking:
+
+```bash
 openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium
+```
+
+Enable verbose logging and get JSON output:
+
+```bash
+openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json
+```
+
+Deliver the reply back to the session channel:
+
+```bash
+openclaw agent --to +15555550123 --message "Summon reply" --deliver
+```
+
+Deliver the reply to a different channel and target:
+
+```bash
 openclaw agent --agent ops --message "Generate report" --deliver --reply-channel slack --reply-to "#reports"
+```
+
+Run with the local embedded agent (no Gateway required):
+
+```bash
+openclaw agent --local --message "Hello"
 ```

--- a/docs/cli/dns.md
+++ b/docs/cli/dns.md
@@ -2,22 +2,95 @@
 summary: "CLI reference for `openclaw dns` (wide-area discovery helpers)"
 read_when:
   - You want wide-area discovery (DNS-SD) via Tailscale + CoreDNS
-  - You’re setting up split DNS for a custom discovery domain (example: openclaw.internal)
+  - You're setting up split DNS for a custom discovery domain (example: openclaw.internal)
 title: "dns"
 ---
 
 # `openclaw dns`
 
-DNS helpers for wide-area discovery (Tailscale + CoreDNS). Currently focused on macOS + Homebrew CoreDNS.
+DNS helpers for wide-area discovery (Tailscale + CoreDNS). Configures unicast DNS-SD so OpenClaw gateways can be discovered across a tailnet, not just on the local LAN.
+
+Currently focused on macOS + Homebrew CoreDNS.
 
 Related:
 
 - Gateway discovery: [Discovery](/gateway/discovery)
+- Wide-area Bonjour: [Bonjour](/gateway/bonjour)
 - Wide-area discovery config: [Configuration](/gateway/configuration)
 
-## Setup
+## Subcommands
+
+### `dns setup`
+
+Set up CoreDNS to serve your discovery domain for Wide-Area Bonjour (unicast DNS-SD).
+
+Without `--apply`, the command prints the recommended config and Tailscale admin steps without making any changes. Add `--apply` to actually install and configure CoreDNS.
 
 ```bash
 openclaw dns setup
 openclaw dns setup --apply
+openclaw dns setup --domain openclaw.internal --apply
 ```
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--domain <domain>` | Wide-area discovery domain (e.g. `openclaw.internal`). Falls back to `discovery.wideArea.domain` in config. |
+| `--apply` | Install/update CoreDNS config and (re)start the service. Requires sudo on macOS. |
+
+## Setup walkthrough
+
+**1. Dry run — see what will be configured:**
+
+```bash
+openclaw dns setup --domain openclaw.internal
+```
+
+This prints:
+- The discovery domain and zone file path
+- Your Tailscale IPs
+- The recommended `~/.openclaw/openclaw.json` snippet
+- Tailscale admin steps (add a split-DNS nameserver)
+
+**2. Apply — install CoreDNS and write configs:**
+
+```bash
+openclaw dns setup --domain openclaw.internal --apply
+```
+
+This will (with sudo where needed):
+- Install CoreDNS via Homebrew if not already installed
+- Write a CoreDNS server block for your discovery domain
+- Bootstrap the DNS zone file
+- Restart the CoreDNS service
+
+**3. Enable wide-area discovery in your Gateway config:**
+
+```json
+{
+  "gateway": { "bind": "auto" },
+  "discovery": {
+    "wideArea": {
+      "enabled": true,
+      "domain": "openclaw.internal"
+    }
+  }
+}
+```
+
+Then restart the Gateway. It will write DNS-SD records into the zone file automatically.
+
+**4. Add a split-DNS nameserver in the Tailscale admin console:**
+
+- Go to **DNS → Nameservers → Add nameserver**
+- Set the nameserver IP to this machine's Tailscale IPv4 address
+- Restrict it to your domain (e.g. `openclaw.internal`)
+
+Once done, other machines on your tailnet can discover this Gateway via `openclaw gateway discover`.
+
+## Notes
+
+- `dns setup --apply` is macOS-only and requires Homebrew.
+- The zone file is managed by the Gateway once wide-area discovery is enabled — do not edit it manually, as the Gateway overwrites it on restart.
+- If your Tailscale IP changes, rerun `openclaw dns setup --apply` to update the CoreDNS bind address.

--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -1,21 +1,59 @@
 ---
 summary: "CLI reference for `openclaw health` (gateway health endpoint via RPC)"
 read_when:
-  - You want to quickly check the running Gateway’s health
+  - You want to quickly check the running Gateway's health
 title: "health"
 ---
 
 # `openclaw health`
 
-Fetch health from the running Gateway.
+Fetch health from the running Gateway over RPC.
+
+Use this as a quick liveness check. For deeper diagnostics, see [`openclaw doctor`](/cli/doctor) or [`openclaw status`](/cli/status).
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output JSON instead of human-readable text |
+| `--timeout <ms>` | Connection timeout in milliseconds (default: `10000`) |
+| `--verbose` | Verbose logging |
+| `--debug` | Alias for `--verbose` |
+
+## Examples
+
+Basic health check:
 
 ```bash
 openclaw health
+```
+
+JSON output (useful for scripting):
+
+```bash
 openclaw health --json
+```
+
+Verbose output (shows per-account probe timings when multiple accounts are configured):
+
+```bash
 openclaw health --verbose
 ```
 
-Notes:
+Tighten the timeout for fast failure in scripts:
+
+```bash
+openclaw health --timeout 3000 --json
+```
+
+## Notes
 
 - `--verbose` runs live probes and prints per-account timings when multiple accounts are configured.
-- Output includes per-agent session stores when multiple agents are configured.
+- Output includes per-agent session store info when multiple agents are configured.
+- If the Gateway is not running or not reachable, the command exits with a non-zero status. Run `openclaw doctor` to diagnose connectivity issues.
+
+## Related
+
+- Deep diagnostics: [`openclaw doctor`](/cli/doctor)
+- Channel health and session summary: [`openclaw status`](/cli/status)
+- Gateway management: [`openclaw gateway`](/cli/gateway)

--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -8,21 +8,94 @@ title: "logs"
 
 # `openclaw logs`
 
-Tail Gateway file logs over RPC (works in remote mode).
+Tail Gateway file logs over RPC. Works in remote mode — no SSH required.
 
 Related:
 
 - Logging overview: [Logging](/logging)
 
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--limit <n>` | Max log lines to return (default: `200`) |
+| `--max-bytes <n>` | Max bytes to read from the log file (default: `250000`) |
+| `--follow` | Follow log output (poll continuously) |
+| `--interval <ms>` | Polling interval when using `--follow` (default: `1000`) |
+| `--json` | Emit parsed JSON log lines instead of formatted text |
+| `--plain` | Plain text output — no ANSI styling |
+| `--no-color` | Disable ANSI colors (also respects `NO_COLOR=1`) |
+| `--local-time` | Display timestamps in local timezone instead of UTC |
+| `--url <url>` | Gateway WebSocket URL override |
+| `--token <token>` | Gateway token (if required) |
+| `--timeout <ms>` | RPC connection timeout |
+
 ## Examples
+
+Tail the last 200 log lines:
 
 ```bash
 openclaw logs
+```
+
+Follow logs continuously (like `tail -f`):
+
+```bash
 openclaw logs --follow
-openclaw logs --json
-openclaw logs --limit 500
-openclaw logs --local-time
+```
+
+Follow with timestamps in your local timezone:
+
+```bash
 openclaw logs --follow --local-time
 ```
 
-Use `--local-time` to render timestamps in your local timezone.
+Fetch more lines:
+
+```bash
+openclaw logs --limit 500
+```
+
+Emit JSON for piping into tools like `jq`:
+
+```bash
+openclaw logs --json | jq 'select(.level == "error")'
+```
+
+Faster polling when following:
+
+```bash
+openclaw logs --follow --interval 500
+```
+
+## JSON output format
+
+When `--json` is used, each line is a JSON object. The first line is a `meta` event:
+
+```json
+{"type":"meta","file":"/path/to/gateway.log","cursor":12345,"size":67890}
+```
+
+Subsequent lines are either parsed log events:
+
+```json
+{"type":"log","time":"2026-03-01T10:00:00.000Z","level":"info","module":"gateway","message":"started"}
+```
+
+Or raw lines that could not be parsed:
+
+```json
+{"type":"raw","raw":"some unparsed log line"}
+```
+
+If the log was truncated, a notice is emitted:
+
+```json
+{"type":"notice","message":"Log tail truncated (increase --max-bytes)."}
+```
+
+## Notes
+
+- Logs are fetched from the Gateway's log file via RPC — this works even when accessing a remote Gateway.
+- If the log file rotates while following, a `{"type":"notice","message":"Log cursor reset (file rotated)."}` event is emitted and tailing resumes from the new file.
+- If the Gateway is unreachable, the command exits with a non-zero status and prints a hint to run `openclaw doctor`.

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -10,14 +10,67 @@ title: "tui"
 
 Open the terminal UI connected to the Gateway.
 
+`openclaw tui` gives you a full interactive chat interface in your terminal — useful when you want to talk to the agent without a messaging app, or when working over SSH.
+
 Related:
 
 - TUI guide: [TUI](/web/tui)
+- Web dashboard: [`openclaw dashboard`](/cli/dashboard)
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | Gateway WebSocket URL (defaults to `gateway.remote.url` when configured) |
+| `--token <token>` | Gateway token (if required) |
+| `--password <password>` | Gateway password (if required) |
+| `--session <key>` | Session key to connect to (default: `"main"`, or `"global"` when scope is global) |
+| `--deliver` | Deliver assistant replies to the session channel |
+| `--thinking <level>` | Thinking level override for this session |
+| `--message <text>` | Send an initial message immediately after connecting |
+| `--timeout-ms <ms>` | Agent timeout in milliseconds (defaults to `agents.defaults.timeoutSeconds`) |
+| `--history-limit <n>` | Number of history entries to load on connect (default: `200`) |
 
 ## Examples
 
+Open the TUI with defaults:
+
 ```bash
 openclaw tui
-openclaw tui --url ws://127.0.0.1:18789 --token <token>
+```
+
+Connect to a remote Gateway:
+
+```bash
+openclaw tui --url ws://gateway-host:18789 --token <token>
+```
+
+Connect to a specific session:
+
+```bash
+openclaw tui --session work
+```
+
+Open and send an initial message automatically:
+
+```bash
+openclaw tui --message "good morning, summarize overnight alerts"
+```
+
+Open with extended thinking enabled:
+
+```bash
+openclaw tui --thinking high
+```
+
+Deliver replies back to the session's messaging channel:
+
+```bash
 openclaw tui --session main --deliver
 ```
+
+## Notes
+
+- When `--url` is set, credentials are not read from config — pass `--token` or `--password` explicitly.
+- `--session` accepts any configured session key. Use `openclaw sessions` to list active sessions.
+- `--thinking` overrides the model's default thinking level for this TUI session only; it does not persist to config.


### PR DESCRIPTION
## Summary

- **Problem:** Five CLI reference pages (`agent`, `health`, `logs`, `tui`, `dns`) were stubs — 15–25 lines each with only a handful of examples and no flag documentation.
- **Why it matters:** Users running these commands for the first time have to fall back to `--help` to discover flags; docs should answer the question without a terminal.
- **What changed:** Added a complete flags table, annotated examples, and a Notes section to each of the five pages. JSON output format documented for `logs`. Full step-by-step walkthrough added for `dns setup`.
- **What did NOT change:** No code, config, or behaviour changes — docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related: none (proactive doc improvement)

## User-visible / Behavior Changes

None — documentation only.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Flags cross-checked against source: `src/cli/program/register.agent.ts`, `src/cli/program/register.status-health-sessions.ts`, `src/cli/logs-cli.ts`, `src/cli/tui-cli.ts`, `src/cli/dns-cli.ts`

## Evidence

- [x] Flags cross-checked against Commander option definitions in source

## Human Verification (required)

- Verified scenarios: all flags match the Commander option definitions in source
- Edge cases checked: `--local` for agent, log rotation behaviour for logs, `--apply` dry-run distinction for dns
- What I did not verify: live runtime output format (no running Gateway available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

Docs-only; revert is a single `git revert`.

## Risks and Mitigations

- Risk: a flag description may become stale if the CLI changes.
  - Mitigation: descriptions are sourced directly from the Commander option strings in source, minimising drift.