### PR TITLE
fix(errors): reduce false billing warnings for Anthropic HTTP 402

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -10,6 +10,12 @@ import {
 describe("failover-error", () => {
   it("infers failover reason from HTTP status", () => {
     expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "HTTP 402: request reached organization usage limit, try again later",
+      }),
+    ).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -157,15 +157,21 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const status = getStatusCode(err);
+  const message = getErrorMessage(err);
   if (status === 402) {
+    // Some providers (for example Anthropic Max plan tokens) can surface
+    // temporary usage/rate-limit failures as HTTP 402. Prefer explicit
+    // rate-limit semantics from the payload when available.
+    if (message && classifyFailoverReason(message) === "rate_limit") {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {
     return "rate_limit";
   }
   if (status === 401 || status === 403) {
-    const msg = getErrorMessage(err);
-    if (msg && isAuthPermanentErrorMessage(msg)) {
+    if (message && isAuthPermanentErrorMessage(message)) {
       return "auth_permanent";
     }
     return "auth";
@@ -188,7 +194,6 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
     return "timeout";
   }
 
-  const message = getErrorMessage(err);
   if (!message) {
     return null;
   }

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -84,6 +84,13 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("uses a non-billing warning for ambiguous Anthropic HTTP 402 errors", () => {
+    const msg = makeAssistantError("HTTP 402 Payment Required");
+    const result = formatAssistantErrorText(msg, { provider: "Anthropic" });
+    expect(result).toContain("Anthropic returned HTTP 402");
+    expect(result).toContain("temporary Claude Max usage limit");
+    expect(result).not.toContain("run out of credits");
+  });
   it("returns a friendly billing message for insufficient credits", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -23,6 +23,8 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
+const ANTHROPIC_AMBIGUOUS_402_USER_MESSAGE =
+  "⚠️ Anthropic returned HTTP 402 (Payment Required). This can be a temporary Claude Max usage limit, not only depleted credits. Please retry later, and if it persists check your Anthropic usage and billing limits.";
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
@@ -32,6 +34,29 @@ function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
     return OVERLOADED_ERROR_USER_MESSAGE;
   }
   return undefined;
+}
+
+function isAnthropicAmbiguous402Error(raw: string, provider?: string): boolean {
+  const providerNormalized = provider?.trim().toLowerCase();
+  if (!providerNormalized || providerNormalized !== "anthropic") {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  if (!BILLING_ERROR_HARD_402_RE.test(lower)) {
+    return false;
+  }
+  // Keep explicit billing errors as billing.
+  if (
+    lower.includes("credit balance") ||
+    lower.includes("insufficient credit") ||
+    lower.includes("insufficient credits") ||
+    lower.includes("insufficient balance") ||
+    lower.includes("billing hard limit") ||
+    (lower.includes("billing") && lower.includes("disabled"))
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isReasoningConstraintErrorMessage(raw: string): boolean {
@@ -532,6 +557,10 @@ export function formatAssistantErrorText(
 
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
+  }
+
+  if (isAnthropicAmbiguous402Error(raw, opts?.provider)) {
+    return ANTHROPIC_AMBIGUOUS_402_USER_MESSAGE;
   }
 
   if (isBillingErrorMessage(raw)) {


### PR DESCRIPTION
## Summary
- avoid hard-mapping all HTTP 402 failures to `billing` when the payload text clearly indicates rate limiting
- add an Anthropic-specific warning copy for ambiguous `HTTP 402 Payment Required` errors (common with Claude Max usage windows)
- keep explicit credit/balance billing failures mapped to the existing billing guidance
- add regression tests for both failover reason inference and user-facing error text

## Why
Issue #30484 reports false billing warnings when Anthropic Max plan usage limits surface as HTTP 402. This patch reduces false-positive billing messaging while preserving real billing error handling.

## Testing
- pnpm vitest src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
- pnpm oxfmt --check src/agents/failover-error.ts src/agents/failover-error.test.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
- pnpm oxlint --type-aware src/agents/failover-error.ts src/agents/failover-error.test.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts

Closes #30484
