### PR TITLE
fix(gateway): guard wizard against re-running when channels are configured

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1417,18 +1417,22 @@ public struct ConfigSchemaResponse: Codable, Sendable {
 public struct WizardStartParams: Codable, Sendable {
     public let mode: AnyCodable?
     public let workspace: String?
+    public let force: Bool?
 
     public init(
         mode: AnyCodable?,
-        workspace: String?)
+        workspace: String?,
+        force: Bool?)
     {
         self.mode = mode
         self.workspace = workspace
+        self.force = force
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case workspace
+        case force
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1417,18 +1417,22 @@ public struct ConfigSchemaResponse: Codable, Sendable {
 public struct WizardStartParams: Codable, Sendable {
     public let mode: AnyCodable?
     public let workspace: String?
+    public let force: Bool?
 
     public init(
         mode: AnyCodable?,
-        workspace: String?)
+        workspace: String?,
+        force: Bool?)
     {
         self.mode = mode
         self.workspace = workspace
+        self.force = force
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case workspace
+        case force
     }
 }
 

--- a/src/gateway/protocol/schema/wizard.ts
+++ b/src/gateway/protocol/schema/wizard.ts
@@ -12,6 +12,7 @@ export const WizardStartParamsSchema = Type.Object(
   {
     mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
     workspace: Type.Optional(Type.String()),
+    force: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { loadConfig } from "../../config/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { WizardSession } from "../../wizard/session.js";
 import {
@@ -12,6 +13,33 @@ import {
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+/**
+ * Check if the wizard has already been completed and channels are configured.
+ * Prevents accidental re-runs that could overwrite existing credentials (#30320).
+ */
+function hasCompletedWizardWithChannels(): boolean {
+  try {
+    const cfg = loadConfig();
+    const hasRun = Boolean(cfg.wizard?.lastRunAt);
+    if (!hasRun) {
+      return false;
+    }
+    // Check if any channel has credentials configured
+    const channels = cfg.channels;
+    if (!channels || typeof channels !== "object") {
+      return false;
+    }
+    for (const channel of Object.values(channels)) {
+      if (channel && typeof channel === "object" && "botToken" in channel && channel.botToken) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
 
 function readWizardStatus(session: WizardSession) {
   return {
@@ -41,6 +69,19 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const running = context.findRunningWizard();
     if (running) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "wizard already running"));
+      return;
+    }
+    // Guard: refuse to re-run the wizard if it has already completed and channels
+    // are configured, unless the caller explicitly passes `force: true` (#30320).
+    if (!params.force && hasCompletedWizardWithChannels()) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          "wizard already completed with configured channels; pass force=true to re-run",
+        ),
+      );
       return;
     }
     const sessionId = randomUUID();


### PR DESCRIPTION
## Problem

After a working setup (Telegram + Tailscale), the gateway can trigger an unsolicited wizard re-run that overwrites the working config — including `channels.telegram.botToken` — causing Telegram 401 Unauthorized errors.

The wizard can be triggered via the Control UI (`wizard.start` RPC), and combined with silent local pairing for scope-upgrade, this can happen without explicit user intent.

Fixes #30320

## Changes

- Added `force` parameter to `WizardStartParamsSchema` (optional boolean)
- Added `hasCompletedWizardWithChannels()` guard that checks if `wizard.lastRunAt` exists AND any channel has credentials (e.g. `botToken`)
- When the guard triggers, `wizard.start` returns an error: *"wizard already completed with configured channels; pass force=true to re-run"*
- Explicit `force: true` bypasses the guard for intentional re-runs

## Impact

- Prevents accidental credential overwrite from wizard re-runs
- No breaking change — existing callers without `force` still work for first-time setup
- Control UI can add `force: true` when user explicitly clicks "Re-run wizard"