### PR TITLE
fix(reply): deduplicate text payloads when TTS adds media to final reply

### DIFF
--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -41,9 +41,14 @@ export function createBlockReplyPayloadKey(payload: ReplyPayload): string {
     : payload.mediaUrl
       ? [payload.mediaUrl]
       : [];
+  // When the payload contains text, exclude media from the key so that
+  // final payloads enriched with TTS audio are still recognised as duplicates
+  // of the text-only block that was already streamed (#30316).
+  // Media-only payloads (no text) still include the media list to avoid
+  // collapsing distinct media sends.
   return JSON.stringify({
     text,
-    mediaList,
+    mediaList: text ? [] : mediaList,
     replyToId: payload.replyToId ?? null,
   });
 }


### PR DESCRIPTION
## Problem

Messages sent to Telegram appear as duplicates — both text and audio get sent twice. This happens when block streaming sends text during processing, and then the final reply (with TTS audio added) sends the same text again.

The root cause: `createBlockReplyPayloadKey()` includes `mediaList` in the dedup key. When TTS processing adds a `mediaUrl` to the final reply payload, the key differs from the block-streamed key (which had no media), so deduplication fails.

Fixes #30316

## Changes

- Modified `createBlockReplyPayloadKey()` to exclude media from the key when the payload contains text
- Text-bearing payloads are now deduped purely by text content + replyToId, regardless of whether TTS later adds audio
- Media-only payloads (no text) still include media in the key to avoid collapsing distinct media sends

## How it works

Before:
- Block streams: key = `{text:"hello", mediaList:[], replyToId:null}`
- Final + TTS: key = `{text:"hello", mediaList:["audio.ogg"], replyToId:null}`
- Different keys → text sent twice ❌

After:
- Block streams: key = `{text:"hello", mediaList:[], replyToId:null}`  
- Final + TTS: key = `{text:"hello", mediaList:[], replyToId:null}`
- Same keys → deduplicated ✅