### PR TITLE
fix(infra): add persistent session secret utility for gateway wrappers

### DIFF
--- a/src/infra/session-secret.test.ts
+++ b/src/infra/session-secret.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("loadOrCreateSessionSecret", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("generates a secret and persists it to disk", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-secret-test-"));
+    vi.stubEnv("OPENCLAW_CONFIG_DIR", tmpDir);
+
+    // Re-import to pick up env change
+    const { loadOrCreateSessionSecret } = await import("./session-secret.js");
+    const secret1 = loadOrCreateSessionSecret();
+    expect(secret1).toBeTruthy();
+    expect(secret1.length).toBeGreaterThanOrEqual(32);
+
+    // File should exist
+    const filePath = path.join(tmpDir, ".session-secret");
+    expect(fs.existsSync(filePath)).toBe(true);
+    const fileContent = fs.readFileSync(filePath, "utf-8").trim();
+    expect(fileContent).toBe(secret1);
+  });
+
+  it("returns the same secret on subsequent calls", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-secret-test-"));
+    vi.stubEnv("OPENCLAW_CONFIG_DIR", tmpDir);
+
+    const { loadOrCreateSessionSecret } = await import("./session-secret.js");
+    const _secret1 = loadOrCreateSessionSecret();
+
+    // Write a known secret to the file
+    const knownSecret = "a".repeat(64);
+    fs.writeFileSync(path.join(tmpDir, ".session-secret"), knownSecret);
+
+    const secret2 = loadOrCreateSessionSecret();
+    expect(secret2).toBe(knownSecret);
+  });
+});

--- a/src/infra/session-secret.ts
+++ b/src/infra/session-secret.ts
@@ -1,0 +1,52 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve the path to a persisted session secret file.
+ * Defaults to `~/.openclaw/.session-secret` but respects
+ * the `OPENCLAW_CONFIG_DIR` environment variable.
+ */
+function resolveSecretPath(): string {
+  const configDir =
+    process.env.OPENCLAW_CONFIG_DIR?.trim() ||
+    path.join(process.env.HOME ?? process.env.USERPROFILE ?? "/tmp", ".openclaw");
+  return path.join(configDir, ".session-secret");
+}
+
+/**
+ * Load or generate a persistent session secret that survives process restarts.
+ *
+ * On first call, generates a random 32-byte hex secret and writes it to disk.
+ * On subsequent calls (including after container restart), reads the persisted
+ * secret from disk.
+ *
+ * This is intended for use by gateway wrappers (e.g. Hostinger) that need a
+ * stable express-session secret across restarts (#29955).
+ */
+export function loadOrCreateSessionSecret(): string {
+  const secretPath = resolveSecretPath();
+
+  // Try to read existing secret
+  try {
+    const existing = fs.readFileSync(secretPath, "utf-8").trim();
+    if (existing.length >= 32) {
+      return existing;
+    }
+  } catch {
+    // File doesn't exist or can't be read; generate a new one.
+  }
+
+  // Generate and persist
+  const secret = crypto.randomBytes(32).toString("hex");
+  try {
+    const dir = path.dirname(secretPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(secretPath, secret, { encoding: "utf-8", mode: 0o600 });
+  } catch {
+    // If we can't persist, still return the generated secret for this session.
+    // The next restart will generate a new one (same as current broken behavior).
+  }
+
+  return secret;
+}


### PR DESCRIPTION
## Problem

Gateway wrappers (e.g. Hostinger HVPS) that use express-session regenerate the session secret on every container restart using `crypto.randomBytes(32)`. This invalidates all browser sessions and causes an infinite login loop — the UI becomes permanently inaccessible after any restart.

Fixes #29955

## Changes

- Added `src/infra/session-secret.ts` with `loadOrCreateSessionSecret()` utility
- On first call: generates a random 32-byte hex secret and persists it to `~/.openclaw/.session-secret` (mode 0600)
- On subsequent calls: reads the persisted secret from disk
- Respects `OPENCLAW_CONFIG_DIR` environment variable for custom config locations
- Graceful fallback: if disk write fails, still returns a generated secret (same as current behavior)
- Added test coverage for generation, persistence, and reload scenarios

## Usage

Gateway wrappers can replace:
```js
const secret = crypto.randomBytes(32).toString('hex');
```
With:
```js
import { loadOrCreateSessionSecret } from './infra/session-secret.js';
const secret = loadOrCreateSessionSecret();
```