### PR TITLE
fix(reply): avoid swallowing equal-timestamp follow-ups after /stop

### DIFF
--- a/src/auto-reply/reply/abort-cutoff.ts
+++ b/src/auto-reply/reply/abort-cutoff.ts
@@ -117,7 +117,9 @@ export function shouldSkipMessageByAbortCutoff(params: {
     typeof params.timestamp === "number" &&
     Number.isFinite(params.timestamp)
   ) {
-    return params.timestamp <= params.cutoffTimestamp;
+    // Timestamp-only channels can share second-level precision across distinct messages.
+    // Treat strictly older messages as stale and allow equal timestamps through.
+    return params.timestamp < params.cutoffTimestamp;
   }
   return false;
 }

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -276,7 +276,7 @@ describe("abort detection", () => {
         cutoffTimestamp: 2000,
         timestamp: 2000,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldSkipMessageByAbortCutoff({
         cutoffTimestamp: 2000,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -221,4 +221,41 @@ describe("handleInlineActions", () => {
     expect(sessionStore["s:main"]?.abortCutoffTimestamp).toBeUndefined();
     expect(handleCommandsMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not skip equal-timestamp messages when cutoff only has timestamp", async () => {
+    const typing = createTypingController();
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-3",
+      updatedAt: Date.now(),
+      abortCutoffTimestamp: 2000,
+      abortedLastRun: true,
+    };
+    const sessionStore = { "s:main": sessionEntry };
+    handleCommandsMock.mockResolvedValue({ shouldContinue: false, reply: { text: "ok" } });
+    const ctx = buildTestCtx({
+      Body: "follow-up",
+      CommandBody: "follow-up",
+      Timestamp: 2000,
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "follow-up",
+        command: {
+          rawBodyNormalized: "follow-up",
+          commandBodyNormalized: "follow-up",
+        },
+        overrides: {
+          sessionEntry,
+          sessionStore,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "ok" } });
+    expect(sessionStore["s:main"]?.abortCutoffTimestamp).toBeUndefined();
+    expect(handleCommandsMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- adjust timestamp-based abort-cutoff filtering to skip only strictly older messages (`< cutoff`) instead of equal timestamps
- keep message-id based stale filtering unchanged (`<=` for numeric/identical message IDs)
- add regression coverage for equal-timestamp handling in both cutoff unit tests and inline action flow

## Why
Issue #30487 reports follow-up messages getting silently dropped after a terminated run. On channels that rely on timestamp-only cutoff fallback (no reliable message ID), distinct messages can share the same second-level timestamp and were previously dropped as stale. This patch prevents those false drops while preserving stale message filtering for truly older messages.

## Testing
- pnpm vitest src/auto-reply/reply/abort.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
- pnpm oxfmt --check src/auto-reply/reply/abort-cutoff.ts src/auto-reply/reply/abort.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
- pnpm oxlint --type-aware src/auto-reply/reply/abort-cutoff.ts src/auto-reply/reply/abort.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts

Ref #30487
