### PR TITLE
UI: extract magic numbers in GatewayBrowserClient reconnect logic into named constants (#30402)

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -91,6 +91,15 @@ export type GatewayBrowserClientOptions = {
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
 
+/** Initial backoff delay (ms) before first reconnect attempt. */
+const INITIAL_BACKOFF_MS = 800;
+/** Maximum backoff delay (ms) between reconnect attempts. */
+const MAX_BACKOFF_MS = 15_000;
+/** Multiplier applied to backoff after each failed reconnect. */
+const BACKOFF_MULTIPLIER = 1.7;
+/** Delay (ms) before sending connect after WebSocket open. */
+const CONNECT_QUEUE_DELAY_MS = 750;
+
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
   private pending = new Map<string, Pending>();
@@ -99,7 +108,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
-  private backoffMs = 800;
+  private backoffMs = INITIAL_BACKOFF_MS;
   private pendingConnectError: GatewayErrorInfo | undefined;
 
   constructor(private opts: GatewayBrowserClientOptions) {}
@@ -147,7 +156,7 @@ export class GatewayBrowserClient {
       return;
     }
     const delay = this.backoffMs;
-    this.backoffMs = Math.min(this.backoffMs * 1.7, 15_000);
+    this.backoffMs = Math.min(this.backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
     window.setTimeout(() => this.connect(), delay);
   }
 
@@ -257,7 +266,7 @@ export class GatewayBrowserClient {
             scopes: hello.auth.scopes ?? [],
           });
         }
-        this.backoffMs = 800;
+        this.backoffMs = INITIAL_BACKOFF_MS;
         this.opts.onHello?.(hello);
       })
       .catch((err: unknown) => {
@@ -355,6 +364,6 @@ export class GatewayBrowserClient {
     }
     this.connectTimer = window.setTimeout(() => {
       void this.sendConnect();
-    }, 750);
+    }, CONNECT_QUEUE_DELAY_MS);
   }
 }


### PR DESCRIPTION
…o named constants (#30402)

## Summary

- **Problem:** `GatewayBrowserClient` uses raw magic numbers (800, 1.7, 15_000, 750) for WebSocket reconnect logic, with no names or comments.
- **Why it matters:** Magic numbers make the logic harder to read, tune, and maintain, and increase the risk of mistakes.
- **What changed:** Replaced these values with named constants (`INITIAL_BACKOFF_MS`, `MAX_BACKOFF_MS`, `BACKOFF_MULTIPLIER`, `CONNECT_QUEUE_DELAY_MS`) and added JSDoc comments.
- **What did NOT change (scope boundary):** Reconnect behavior, timing, and backoff logic are unchanged; only code structure was improved.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30402
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Browser
- Model/provider: N/A
- Integration/channel (if any): Web control UI
- Relevant config (redacted): N/A

### Steps

1. Open `ui/src/ui/gateway.ts`
2. Confirm all reconnect-related values use named constants
3. Run `pnpm build` and `pnpm check`; both pass

### Expected

- Build and checks pass
- Reconnect behavior unchanged from before

### Actual

- Matches expected

## Evidence

- [x] No new failing tests; behavior unchanged; existing tests still pass
- [x] Code diff shows constant extraction and replacement

## Human Verification (required)

- **Verified scenarios:** Constants defined correctly, all usages updated, JSDoc added
- **Edge cases checked:** Numeric values unchanged; behavior equivalent
- **What you did NOT verify:** No long-running real-world reconnect validation

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert <commit>`
- Files/config to restore: `ui/src/ui/gateway.ts`
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None.
