### PR TITLE
fix(ui): add Array.prototype.toSorted polyfill for older browsers

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,2 +1,3 @@
+import "./polyfills.ts";
 import "./styles.css";
 import "./ui/app.ts";

--- a/ui/src/polyfills.ts
+++ b/ui/src/polyfills.ts
@@ -1,0 +1,14 @@
+/**
+ * Polyfills for older browsers that lack newer Array/TypedArray methods.
+ * Must be imported before any application code.
+ */
+
+if (!Array.prototype.toSorted) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.toSorted = function <T>(this: T[], compareFn?: (a: T, b: T) => number): T[] {
+    // oxlint-disable-next-line unicorn/prefer-array-flat-map
+    const copy = this.slice();
+    copy.sort(compareFn); // oxlint-ignore unicorn/require-array-sort-compare
+    return copy;
+  };
+}


### PR DESCRIPTION
## Summary

The Control UI uses `Array.prototype.toSorted()` in ~20 places across the codebase. Browsers without native support (e.g. older Chrome on Windows 7) fail with a blank page and `TypeError: Array.from(...).toSorted is not a function`.

## Changes

- Add `ui/src/polyfills.ts` with a lightweight `Array.prototype.toSorted` polyfill
- Import polyfill at the top of `ui/src/main.ts` before any application code

This approach avoids modifying all ~20 call sites while ensuring compatibility with older browsers.

Fixes #30467