### PR TITLE
feat(feishu): extend sendText auto-detection to support document and media files

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -11,11 +11,25 @@ import { sendMessageFeishu } from "./send.js";
  */
 const AUTO_SEND_EXTENSIONS = new Set([
   // Images
-  ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".ico",
+  ".tiff",
   // Documents
-  ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
   // Audio/Video
-  ".opus", ".mp4",
+  ".opus",
+  ".mp4",
 ]);
 
 function normalizePossibleLocalFilePath(text: string | undefined): string | null {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -5,7 +5,20 @@ import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
 
-function normalizePossibleLocalImagePath(text: string | undefined): string | null {
+/**
+ * Supported file extensions for auto-detecting local file paths in plain text.
+ * Includes images and common document/media types supported by Feishu upload API.
+ */
+const AUTO_SEND_EXTENSIONS = new Set([
+  // Images
+  ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff",
+  // Documents
+  ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+  // Audio/Video
+  ".opus", ".mp4",
+]);
+
+function normalizePossibleLocalFilePath(text: string | undefined): string | null {
   const raw = text?.trim();
   if (!raw) return null;
 
@@ -18,10 +31,7 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   if (/^(https?:\/\/|data:|file:\/\/)/i.test(raw)) return null;
 
   const ext = path.extname(raw).toLowerCase();
-  const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
-    ext,
-  );
-  if (!isImageExt) return null;
+  if (!AUTO_SEND_EXTENSIONS.has(ext)) return null;
 
   if (!path.isAbsolute(raw)) return null;
   if (!fs.existsSync(raw)) return null;
@@ -47,7 +57,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
-    const localImagePath = normalizePossibleLocalImagePath(text);
+    const localImagePath = normalizePossibleLocalFilePath(text);
     if (localImagePath) {
       try {
         const result = await sendMediaFeishu({
@@ -58,7 +68,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { channel: "feishu", ...result };
       } catch (err) {
-        console.error(`[feishu] local image path auto-send failed:`, err);
+        console.error(`[feishu] local file path auto-send failed:`, err);
         // fall through to plain text as last resort
       }
     }


### PR DESCRIPTION
## Summary

Previously, the `sendText` shim in the Feishu outbound adapter only auto-detected **local image paths** (`.jpg`, `.png`, `.gif`, etc.) and uploaded them as Feishu media messages. This meant that when the AI agent returned a local file path (e.g. a PDF resume at `/home/user/resume/resume.pdf`) as plain text, it would be sent as a **raw path string** instead of being uploaded as a file — leaking internal filesystem paths to the end user.

## Changes

- Renames `normalizePossibleLocalImagePath` → `normalizePossibleLocalFilePath`
- Expands supported extensions to include:
  - **Documents**: `.pdf`, `.doc`, `.docx`, `.xls`, `.xlsx`, `.ppt`, `.pptx`
  - **Audio/Video**: `.opus`, `.mp4`
- Uses a `Set` for O(1) extension lookup instead of `Array.includes`

## Motivation

When using the Feishu channel, the AI agent often needs to send local files (e.g. generated PDFs, exported spreadsheets) to the user. Without this change, the agent's only option is to use the `message` tool with the `media` parameter explicitly — but in practice the agent frequently falls back to returning the file path as plain text. This auto-detection shim catches those cases and transparently uploads the file via `sendMediaFeishu`, providing a seamless experience.

## Testing

Tested manually with PDF files on a local OpenClaw deployment with the Feishu channel configured. Files are correctly uploaded and delivered as Feishu file messages instead of plain text paths.