### PR TITLE
fix(gateway): surface real connect handshake errors instead of generic close reason

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -23,6 +23,7 @@ class MockWebSocket {
   private closeHandlers: WsEventHandlers["close"][] = [];
   private errorHandlers: WsEventHandlers["error"][] = [];
   readonly sent: string[] = [];
+  closed: { code: number; reason: string } | null = null;
 
   constructor(_url: string, _options?: unknown) {
     wsInstances.push(this);
@@ -51,7 +52,12 @@ class MockWebSocket {
     }
   }
 
-  close(_code?: number, _reason?: string): void {}
+  close(code?: number, reason?: string): void {
+    this.closed = {
+      code: typeof code === "number" ? code : 1000,
+      reason: typeof reason === "string" ? reason : "",
+    };
+  }
 
   send(data: string): void {
     this.sent.push(data);
@@ -349,6 +355,40 @@ describe("GatewayClient connect auth payload", () => {
     );
   }
 
+  function emitConnectResponse(
+    ws: MockWebSocket,
+    params: {
+      ok: boolean;
+      errorMessage?: string;
+      errorCode?: string;
+      payload?: unknown;
+    },
+  ) {
+    const raw = ws.sent.find((frame) => frame.includes('"method":"connect"'));
+    if (!raw) {
+      throw new Error("missing connect frame");
+    }
+    const parsed = JSON.parse(raw) as { id?: string };
+    if (!parsed.id) {
+      throw new Error("missing connect request id");
+    }
+    ws.emitMessage(
+      JSON.stringify({
+        type: "res",
+        id: parsed.id,
+        ok: params.ok,
+        ...(params.ok
+          ? { payload: params.payload ?? {} }
+          : {
+              error: {
+                code: params.errorCode ?? "INVALID_REQUEST",
+                message: params.errorMessage ?? "request failed",
+              },
+            }),
+      }),
+    );
+  }
+
   it("uses explicit shared token and does not inject stored device token", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });
     const client = new GatewayClient({
@@ -402,6 +442,53 @@ describe("GatewayClient connect auth payload", () => {
       token: "explicit-device-token",
       deviceToken: "explicit-device-token",
     });
+    client.stop();
+  });
+
+  it("preserves connect handshake error detail in close reason", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+    emitConnectResponse(ws, {
+      ok: false,
+      errorMessage: "provide gateway auth token",
+    });
+    await vi.waitFor(() => {
+      expect(ws.closed).not.toBeNull();
+    });
+
+    expect(ws.closed).toEqual({
+      code: 1008,
+      reason: "provide gateway auth token",
+    });
+    client.stop();
+  });
+
+  it("sanitizes and truncates connect close reason", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+    emitConnectResponse(ws, {
+      ok: false,
+      errorMessage: `bad\treason ${"x".repeat(200)}`,
+    });
+    await vi.waitFor(() => {
+      expect(ws.closed).not.toBeNull();
+    });
+
+    expect(ws.closed?.code).toBe(1008);
+    expect(ws.closed?.reason.includes("\t")).toBe(false);
+    expect((ws.closed?.reason.length ?? 0) <= 120).toBe(true);
     client.stop();
   });
 });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -78,6 +78,37 @@ export const GATEWAY_CLOSE_CODE_HINTS: Readonly<Record<number, string>> = {
   1012: "service restart",
 };
 
+const CONNECT_FAILED_CLOSE_REASON_MAX_LEN = 120;
+
+function replaceControlChars(value: string): string {
+  let cleaned = "";
+  for (const char of value) {
+    const codePoint = char.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+    ) {
+      cleaned += " ";
+      continue;
+    }
+    cleaned += char;
+  }
+  return cleaned;
+}
+
+function sanitizeConnectFailureCloseReason(err: unknown): string {
+  const rawValue =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "connect failed";
+  const normalized = replaceControlChars(rawValue).replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "connect failed";
+  }
+  if (normalized.length <= CONNECT_FAILED_CLOSE_REASON_MAX_LEN) {
+    return normalized;
+  }
+  return `${normalized.slice(0, CONNECT_FAILED_CLOSE_REASON_MAX_LEN - 1).trimEnd()}…`;
+}
+
 export function describeGatewayCloseCode(code: number): string | undefined {
   return GATEWAY_CLOSE_CODE_HINTS[code];
 }
@@ -345,7 +376,7 @@ export class GatewayClient {
         } else {
           logError(msg);
         }
-        this.ws?.close(1008, "connect failed");
+        this.ws?.close(1008, sanitizeConnectFailureCloseReason(err));
       });
   }
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -90,6 +90,36 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+const WS_CLOSE_REASON_MAX_LEN = 120;
+
+function replaceControlChars(value: string): string {
+  let cleaned = "";
+  for (const char of value) {
+    const codePoint = char.codePointAt(0);
+    if (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+    ) {
+      cleaned += " ";
+      continue;
+    }
+    cleaned += char;
+  }
+  return cleaned;
+}
+
+function sanitizeConnectFailureCloseReason(err: unknown): string {
+  const rawValue =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "connect failed";
+  const raw = replaceControlChars(rawValue).replace(/\s+/g, " ").trim();
+  if (!raw) {
+    return "connect failed";
+  }
+  if (raw.length <= WS_CLOSE_REASON_MAX_LEN) {
+    return raw;
+  }
+  return `${raw.slice(0, WS_CLOSE_REASON_MAX_LEN - 1).trimEnd()}…`;
+}
 
 export class GatewayBrowserClient {
   private ws: WebSocket | null = null;
@@ -273,7 +303,8 @@ export class GatewayBrowserClient {
         if (canFallbackToShared && deviceIdentity) {
           clearDeviceAuthToken({ deviceId: deviceIdentity.deviceId, role });
         }
-        this.ws?.close(CONNECT_FAILED_CLOSE_CODE, "connect failed");
+        const closeReason = sanitizeConnectFailureCloseReason(err);
+        this.ws?.close(CONNECT_FAILED_CLOSE_CODE, closeReason);
       });
   }
 


### PR DESCRIPTION
## Summary
- preserve connect handshake failure details in WebSocket close reasons instead of always using generic `connect failed`
- apply the same close-reason sanitization/truncation logic in both gateway clients:
  - Node client (`src/gateway/client.ts`)
  - Control UI browser client (`ui/src/ui/gateway.ts`)
- add regression tests for Node client close-reason behavior:
  - keeps server-provided auth error detail
  - strips control chars and truncates overlong reasons

## Why
Issues #30469 and #30458 report webchat connections closing with code 4008 and reason `connect failed`, which masks the actual handshake/auth failure and makes diagnosis look like auth was skipped.

With this patch, close reasons preserve meaningful server-side handshake errors (for example missing token), while still remaining safe and bounded for WebSocket close frames.

## Testing
- pnpm vitest src/gateway/client.test.ts
- pnpm vitest ui/src/ui/views/agents-utils.test.ts ui/src/ui/views/usage-render-details.test.ts ui/src/ui/controllers/agents.test.ts
- pnpm oxfmt --check src/gateway/client.ts src/gateway/client.test.ts ui/src/ui/gateway.ts
- pnpm oxlint --type-aware src/gateway/client.ts src/gateway/client.test.ts ui/src/ui/gateway.ts

Closes #30469
Ref #30458
