### PR TITLE
fix(exec): append /usr/sbin and /sbin to PATH fallback on Linux

### DIFF
--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -60,6 +60,16 @@ function resolveExecutablePath(rawExecutable: string, cwd?: string, env?: NodeJS
   }
   const envPath = env?.PATH ?? env?.Path ?? process.env.PATH ?? process.env.Path ?? "";
   const entries = envPath.split(path.delimiter).filter(Boolean);
+  // On Linux, common system binaries (ufw, iptables, etc.) live in /usr/sbin
+  // or /sbin which may not be in the user's PATH. Append them as fallbacks so
+  // security audit and other system checks can locate these tools (#30361).
+  if (process.platform === "linux") {
+    for (const sbin of ["/usr/sbin", "/sbin"]) {
+      if (!entries.includes(sbin)) {
+        entries.push(sbin);
+      }
+    }
+  }
   const hasExtension = process.platform === "win32" && path.extname(expanded).length > 0;
   const extensions =
     process.platform === "win32"


### PR DESCRIPTION
## Problem

`openclaw security audit` reports "UFW not found" even when UFW is installed at `/usr/sbin/ufw`. The issue is that `/usr/sbin` and `/sbin` are not in the user's $PATH on many Linux distributions (especially when running as a non-root user or in container environments).

Fixes #30361

## Changes

- In `resolveCommand()` (`src/infra/exec-command-resolution.ts`), append `/usr/sbin` and `/sbin` as fallback PATH entries on Linux when they're not already present
- This allows system administration tools (ufw, iptables, ss, etc.) to be found during security audits without requiring users to modify their PATH

## Impact

- Linux only (guarded by `process.platform === 'linux'`)
- Fallback entries are appended (not prepended), so user PATH entries always take priority
- No change on macOS/Windows