### PR TITLE
fix(ui): make cron edit panel scrollable when content exceeds viewport

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -608,6 +608,8 @@
 .cron-workspace-form {
   position: sticky;
   top: 74px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
 }
 
 .cron-form {


### PR DESCRIPTION
## Problem

On the Cron page, the right-side Edit Job panel becomes non-scrollable when the form content exceeds viewport height. The panel is `position: sticky` but has no local scroll container.

Fixes #30155

## Changes

- Added `max-height: calc(100vh - 90px)` and `overflow-y: auto` to `.cron-workspace-form` in `ui/src/styles/components.css`
- The panel now scrolls independently when content is longer than the viewport while remaining sticky

## Impact

- CSS-only change, no JavaScript modifications
- Only affects the desktop cron edit panel (mobile layout is already `position: static`)