### PR TITLE
fix(agents): treat Anthropic 402 throttling as rate limit

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -84,6 +84,13 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("treats 402 request-window throttling as rate limit instead of billing", () => {
+    const msg = makeAssistantError(
+      "HTTP 402: request limit reached in your 5-hour window, please try again later",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe("⚠️ API rate limit reached. Please try again later.");
+  });
   it("returns a friendly billing message for insufficient credits", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -98,6 +98,7 @@ describe("isBillingErrorMessage", () => {
       "Use a 402 stainless bolt",
       "Book a 402 room",
       "There is a 402 near me",
+      "HTTP 402: request limit reached in your 5-hour window, please try again later",
     ];
     for (const sample of falsePositives) {
       expect(isBillingErrorMessage(sample)).toBe(false);
@@ -467,6 +468,11 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("Missing scopes: model.request")).toBe("auth");
     expect(classifyFailoverReason("429 too many requests")).toBe("rate_limit");
     expect(classifyFailoverReason("resource has been exhausted")).toBe("rate_limit");
+    expect(
+      classifyFailoverReason(
+        "HTTP 402: request limit reached in your 5-hour window, please try again later",
+      ),
+    ).toBe("rate_limit");
     expect(
       classifyFailoverReason("model_cooldown: All credentials for model gpt-5 are cooling down"),
     ).toBe("rate_limit");

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -66,6 +66,13 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text, { errorContext: true })).toContain("billing error");
   });
 
+  it("rewrites 402 request-window throttling as rate limit with errorContext", () => {
+    const text = "HTTP 402: request limit reached in your 5-hour window, please try again later";
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toBe(
+      "⚠️ API rate limit reached. Please try again later.",
+    );
+  });
+
   it("sanitizes raw API error payloads", () => {
     const raw = '{"type":"error","error":{"message":"Something exploded","type":"server_error"}}';
     expect(sanitizeUserFacingText(raw, { errorContext: true })).toBe(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -25,7 +25,7 @@ const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
-  if (isRateLimitErrorMessage(raw)) {
+  if (isRateLimitErrorMessage(raw) || isRateLimit402Error(raw)) {
     return RATE_LIMIT_ERROR_USER_MESSAGE;
   }
   if (isOverloadedErrorMessage(raw)) {
@@ -163,6 +163,8 @@ const BILLING_ERROR_HEAD_RE =
   /^(?:error[:\s-]+)?billing(?:\s+error)?(?:[:\s-]+|$)|^(?:error[:\s-]+)?(?:credit balance|insufficient credits?|payment required|http\s*402\b)/i;
 const BILLING_ERROR_HARD_402_RE =
   /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|^\s*402\s+payment/i;
+const RATE_LIMIT_402_HINT_RE =
+  /rate[_\s-]?limit|too many requests|request(?:s)?(?:\s+\w+){0,4}\s+limit|quota|throttl|usage limit|message limit|retry(?:ing)? after|try again later|resource(?:\s+has\s+been)? exhausted|tpm|tokens per minute|rpm|rpd|\b(?:5|five)[-\s]?hour\b.*window|window.*(?:limit|exceed)/i;
 const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
 const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
@@ -577,6 +579,11 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       );
     }
 
+    const transientCopy = formatRateLimitOrOverloadedErrorCopy(trimmed);
+    if (transientCopy) {
+      return transientCopy;
+    }
+
     if (isBillingErrorMessage(trimmed)) {
       return BILLING_ERROR_USER_MESSAGE;
     }
@@ -715,6 +722,22 @@ export function isTimeoutErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.timeout);
 }
 
+function isRateLimit402Error(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  if (!BILLING_ERROR_HARD_402_RE.test(lower)) {
+    return false;
+  }
+  if (isRateLimitErrorMessage(lower) || isOverloadedErrorMessage(lower)) {
+    return true;
+  }
+  const parsed = parseApiErrorInfo(raw);
+  const searchable = [lower, parsed?.type, parsed?.message].filter(Boolean).join(" ");
+  return RATE_LIMIT_402_HINT_RE.test(searchable);
+}
+
 /**
  * Maximum character length for a string to be considered a billing error message.
  * Real API billing errors are short, structured messages (typically under 300 chars).
@@ -725,6 +748,10 @@ const BILLING_ERROR_MAX_LENGTH = 512;
 export function isBillingErrorMessage(raw: string): boolean {
   const value = raw.toLowerCase();
   if (!value) {
+    return false;
+  }
+  // Anthropic Max can return HTTP 402 for temporary usage throttling.
+  if (isRateLimit402Error(raw)) {
     return false;
   }
   // Real billing error messages from APIs are short structured payloads.
@@ -896,7 +923,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isJsonApiInternalServerError(raw)) {
     return "timeout";
   }
-  if (isRateLimitErrorMessage(raw)) {
+  if (isRateLimitErrorMessage(raw) || isRateLimit402Error(raw)) {
     return "rate_limit";
   }
   if (isOverloadedErrorMessage(raw)) {


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic Max can return HTTP 402 for temporary request-window throttling, which OpenClaw currently treats as billing exhaustion.
- **Why it matters:** Users see a false “insufficient balance” warning and lose retry/failover behavior for a transient limit condition.
- **What changed:** Added a targeted 402+rate-limit classifier, routed those errors to rate-limit copy/failover, and added regression tests for billing classification, failover reasoning, and user-facing formatting.
- **What did NOT change:** Real billing failures (credit balance / payment required) are still classified and surfaced as billing errors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30484

## User-visible / Behavior Changes

- Anthropic 402 payloads that include request-window/rate-limit signals now show: `⚠️ API rate limit reached. Please try again later.`
- These payloads now classify as `rate_limit` failover reasons (instead of `billing`).
- Plain billing 402/payment-required/credit-balance errors remain unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: Anthropic provider error-classification path

### Steps

1. Trigger error text containing `HTTP 402` + request-window/rate-limit hints (e.g., 5-hour window limit).
2. Observe formatted error copy and failover classification.

### Expected

- 402 throttling is treated as retryable rate limit, not billing exhaustion.

### Actual

- Before fix: surfaced as billing error (`run out of credits / insufficient balance`).
- After fix: surfaced as rate-limit warning and classified as `rate_limit`.

## Evidence

- Ran targeted tests:
  - `pnpm exec vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Result: `3 passed`, `122 passed` tests.

## Human Verification (required)

- Verified scenarios: 402+throttling hint classification, formatted error copy, sanitize path behavior.
- Edge cases checked: plain numeric 402 mentions; real billing 402 patterns; failover reason mapping.
- What I did **not** verify: live Anthropic Max account traffic against real API limits.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts` and related tests.
- Known bad symptoms: billing warning may reappear for Anthropic 402 throttling events.

## Risks and Mitigations

- Risk: heuristic over-matching for unusual 402 payloads.
- Mitigation: guard requires explicit 402 markers plus rate-limit/request-window hints; existing billing-specific tests remain passing.
