### PR TITLE
fix(hooks): propagate sessionKey in after_tool_call context

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -427,7 +427,7 @@ export async function handleToolExecutionEnd(
       .runAfterToolCall(hookEvent, {
         toolName,
         agentId: undefined,
-        sessionKey: undefined,
+        sessionKey: ctx.params.sessionKey,
       })
       .catch((err) => {
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -132,7 +132,7 @@ export type EmbeddedPiSubscribeContext = {
  */
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
-  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult"
+  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult" | "sessionKey"
 >;
 
 export type ToolHandlerState = Pick<

--- a/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
@@ -114,7 +114,9 @@ describe("after_tool_call hook wiring", () => {
     const event = firstCall?.[0] as
       | { toolName?: string; params?: unknown; error?: unknown; durationMs?: unknown }
       | undefined;
-    const context = firstCall?.[1] as { toolName?: string } | undefined;
+    const context = firstCall?.[1] as
+      | { toolName?: string; agentId?: string; sessionKey?: string }
+      | undefined;
     expect(event).toBeDefined();
     expect(context).toBeDefined();
     if (!event || !context) {
@@ -125,6 +127,7 @@ describe("after_tool_call hook wiring", () => {
     expect(event.error).toBeUndefined();
     expect(typeof event.durationMs).toBe("number");
     expect(context.toolName).toBe("read");
+    expect(context.sessionKey).toBe("test-session");
   });
 
   it("includes error in after_tool_call event on tool failure", async () => {


### PR DESCRIPTION
## Summary

Fixes a bug where the `after_tool_call` plugin hook context was passing `sessionKey: undefined` even though the value is available on `ctx.params`. This prevented third-party plugins from accessing session-scoped context in their `after_tool_call` handlers.

- Adds `"sessionKey"` to the `ToolHandlerParams` Pick type so `ctx.params.sessionKey` is accessible
- Wires `ctx.params.sessionKey` into the `after_tool_call` hook context (replacing hardcoded `undefined`)
- Updates test to assert `sessionKey` propagation

**Follow-up:** #30527 threads `agentId` through the session params chain (addressing the remaining `agentId: undefined`).

## Motivation

Third-party plugins (e.g. [`openclaw-plimsoll-security`](https://www.npmjs.com/package/openclaw-plimsoll-security)) use `ctx.sessionKey` in `after_tool_call` hooks for per-session audit trails and security logging. Without this fix, `sessionKey` is always `undefined`, forcing plugins to fall back to hardcoded defaults.

## Test plan

- [x] Updated `wired-hooks-after-tool-call.test.ts` — asserts `context.sessionKey` equals the provided value
- [x] All 3 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

## Files changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-subscribe.handlers.types.ts` | Add `"sessionKey"` to `ToolHandlerParams` Pick |
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Wire `ctx.params.sessionKey` into hook context |
| `src/plugins/wired-hooks-after-tool-call.test.ts` | Assert sessionKey propagation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)