### PR TITLE
fix: treat HTTP 402 with rate limit message as rate_limit not billing

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -87,6 +87,26 @@ describe("failover-error", () => {
     );
   });
 
+  // Issue #30484: HTTP 402 from Anthropic Max plan can indicate rate limit, not billing error
+  it("HTTP 402 with rate limit message returns rate_limit (not billing)", () => {
+    expect(resolveFailoverReasonFromError({ status: 402, message: "rate limit exceeded" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "too many requests" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "429 rate limit" })).toBe(
+      "rate_limit",
+    );
+    expect(resolveFailoverReasonFromError({ status: 402, message: "quota exceeded" })).toBe(
+      "rate_limit",
+    );
+    // Pure billing 402 should still return billing
+    expect(resolveFailoverReasonFromError({ status: 402, message: "payment required" })).toBe(
+      "billing",
+    );
+  });
+
   it("resolveFailoverStatus maps auth_permanent to 403", () => {
     expect(resolveFailoverStatus("auth_permanent")).toBe(403);
   });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,6 +1,7 @@
 import {
   classifyFailoverReason,
   isAuthPermanentErrorMessage,
+  isRateLimitErrorMessage,
   type FailoverReason,
 } from "./pi-embedded-helpers.js";
 
@@ -160,6 +161,12 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
 
   const status = getStatusCode(err);
   if (status === 402) {
+    // HTTP 402 can mean either billing error OR rate limit (e.g., Anthropic Max plan).
+    // Check the error message to differentiate.
+    const msg = getErrorMessage(err);
+    if (msg && isRateLimitErrorMessage(msg)) {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {


### PR DESCRIPTION
## Summary

Fixes #30484

Anthropic Max plan returns HTTP 402 for both billing errors and rate limits, but OpenClaw was treating all 402s as billing errors. This caused misleading "your API key has run out of credits" warnings for users who actually just hit rate limits.

## Problem

When using OpenClaw with a Claude Max plan ($100/mo subscription), hitting the plan's rate limits causes Anthropic's API to return HTTP 402 (payment required) instead of HTTP 429 (rate limited).

OpenClaw correctly interprets 402 as a billing error and posts a warning to the channel:

> ⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance.

This is misleading for Max plan users who have active credits and valid billing. The actual issue is a temporary rate limit, not insufficient funds.

## Solution

Modified `resolveFailoverReasonFromError` in `failover-error.ts` to check if HTTP 402 error messages contain rate limit keywords before classifying as a billing error.

If the message contains rate limit indicators (like "rate limit", "too many requests", "quota exceeded", "resource exhausted"), it's now classified as `rate_limit` instead of `billing`.

## Changes

- `src/agents/failover-error.ts`: Added rate limit message check for HTTP 402 errors
- `src/agents/failover-error.test.ts`: Added test case for HTTP 402 with rate limit message

## Test Plan

- Added new test case "HTTP 402 with rate limit message returns rate_limit (not billing)"
- All 14 tests in `failover-error.test.ts` pass