### PR TITLE
fix(process): share command queue runtime across duplicated bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
+- Process queue/Plugin SDK: persist command-lane runtime state on `globalThis` so duplicated bundles share lane concurrency limits (for example gateway + plugin-sdk), preventing `maxConcurrent` from silently falling back to per-bundle defaults. (#30501)
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.
 - TUI/Session model status: clear stale runtime model identity when model overrides change so `/model` updates are reflected immediately in `sessions.patch` responses and `sessions.list` status surfaces. (#28619) Thanks @lejean2000.

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -94,6 +94,46 @@ describe("command queue", () => {
     expect(getQueueSize()).toBe(0);
   });
 
+  it("shares lane concurrency across duplicate module instances", async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const moduleA = (await import(
+      /* @vite-ignore */ `./command-queue.js?dup-a-${suffix}`
+    )) as typeof import("./command-queue.js");
+    const moduleB = (await import(
+      /* @vite-ignore */ `./command-queue.js?dup-b-${suffix}`
+    )) as typeof import("./command-queue.js");
+
+    moduleA.resetAllLanes();
+    moduleB.resetAllLanes();
+
+    const lane = `cross-instance-${suffix}`;
+    moduleA.setCommandLaneConcurrency(lane, 2);
+
+    const firstDeferred = createDeferred();
+    const secondDeferred = createDeferred();
+    let firstStarted = false;
+    let secondStarted = false;
+
+    const first = moduleB.enqueueCommandInLane(lane, async () => {
+      firstStarted = true;
+      await firstDeferred.promise;
+    });
+    const second = moduleB.enqueueCommandInLane(lane, async () => {
+      secondStarted = true;
+      await secondDeferred.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(firstStarted).toBe(true);
+      expect(secondStarted).toBe(true);
+    });
+    expect(moduleB.getActiveTaskCount()).toBeGreaterThanOrEqual(2);
+
+    firstDeferred.resolve();
+    secondDeferred.resolve();
+    await Promise.all([first, second]);
+  });
+
   it("logs enqueue depth after push", async () => {
     const task = enqueueCommand(async () => {});
 

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -23,9 +23,6 @@ export class GatewayDrainingError extends Error {
   }
 }
 
-// Set while gateway is draining for restart; new enqueues are rejected.
-let gatewayDraining = false;
-
 // Minimal in-process queue to serialize command executions.
 // Default lane ("main") preserves the existing behavior. Additional lanes allow
 // low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
@@ -49,8 +46,34 @@ type LaneState = {
   generation: number;
 };
 
-const lanes = new Map<string, LaneState>();
-let nextTaskId = 1;
+type CommandQueueRuntimeState = {
+  // Set while gateway is draining for restart; new enqueues are rejected.
+  gatewayDraining: boolean;
+  lanes: Map<string, LaneState>;
+  nextTaskId: number;
+};
+
+const COMMAND_QUEUE_RUNTIME_STATE_KEY = "__openclawCommandQueueRuntimeStateV1__";
+
+function resolveCommandQueueRuntimeState(): CommandQueueRuntimeState {
+  const globalRuntime = globalThis as typeof globalThis & {
+    [COMMAND_QUEUE_RUNTIME_STATE_KEY]?: CommandQueueRuntimeState;
+  };
+  const existing = globalRuntime[COMMAND_QUEUE_RUNTIME_STATE_KEY];
+  if (existing) {
+    return existing;
+  }
+  const created: CommandQueueRuntimeState = {
+    gatewayDraining: false,
+    lanes: new Map<string, LaneState>(),
+    nextTaskId: 1,
+  };
+  globalRuntime[COMMAND_QUEUE_RUNTIME_STATE_KEY] = created;
+  return created;
+}
+
+const runtimeState = resolveCommandQueueRuntimeState();
+const lanes = runtimeState.lanes;
 
 function getLaneState(lane: string): LaneState {
   const existing = lanes.get(lane);
@@ -105,7 +128,7 @@ function drainLane(lane: string) {
           );
         }
         logLaneDequeue(lane, waitedMs, state.queue.length);
-        const taskId = nextTaskId++;
+        const taskId = runtimeState.nextTaskId++;
         const taskGeneration = state.generation;
         state.activeTaskIds.add(taskId);
         void (async () => {
@@ -148,7 +171,7 @@ function drainLane(lane: string) {
  * `GatewayDrainingError` instead of being silently killed on shutdown.
  */
 export function markGatewayDraining(): void {
-  gatewayDraining = true;
+  runtimeState.gatewayDraining = true;
 }
 
 export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
@@ -166,7 +189,7 @@ export function enqueueCommandInLane<T>(
     onWait?: (waitMs: number, queuedAhead: number) => void;
   },
 ): Promise<T> {
-  if (gatewayDraining) {
+  if (runtimeState.gatewayDraining) {
     return Promise.reject(new GatewayDrainingError());
   }
   const cleaned = lane.trim() || CommandLane.Main;
@@ -242,7 +265,7 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
  * `enqueueCommandInLane()` call (which may never come).
  */
 export function resetAllLanes(): void {
-  gatewayDraining = false;
+  runtimeState.gatewayDraining = false;
   const lanesToDrain: string[] = [];
   for (const state of lanes.values()) {
     state.generation += 1;


### PR DESCRIPTION
## Summary

- Problem: `command-queue` state lived in module-local variables, so duplicated bundles (gateway + plugin-sdk) could keep separate lane maps and separate `maxConcurrent` limits.
- Why it matters: concurrent chats could fall back to effectively serial execution in plugin contexts even when `agents.defaults.maxConcurrent` is higher.
- What changed: moved command-queue runtime state (`lanes`, `nextTaskId`, `gatewayDraining`) to a shared `globalThis` singleton, and added a regression test that loads duplicate module instances and verifies cross-instance concurrency propagation.
- What did NOT change (scope boundary): no queue algorithm changes, no lane policy changes, no new config knobs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30501
- Related #30509

## User-visible / Behavior Changes

- Duplicate in-process module instances now share lane concurrency state.
- `setCommandLaneConcurrency()` updates are consistently observed by code running through duplicated bundle instances.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): plugin-sdk lane usage path
- Relevant config (redacted): N/A

### Steps

1. Load `command-queue` through two distinct module instances.
2. Set lane concurrency (`2`) through instance A.
3. Enqueue two blocking tasks through instance B in the same lane.

### Expected

- Both tasks can start concurrently (shared lane state).

### Actual

- Verified by new regression test: both tasks start, active task count reaches `>= 2`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run locally:

- `pnpm vitest src/process/command-queue.test.ts`
- `pnpm oxfmt --check src/process/command-queue.ts src/process/command-queue.test.ts`
- `pnpm oxlint --type-aware src/process/command-queue.ts src/process/command-queue.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: duplicate module-instance concurrency propagation for same lane; existing queue tests remain green.
- Edge cases checked: shared `nextTaskId` and `gatewayDraining` now use the same runtime state object as `lanes` to avoid cross-instance ID/drain desync.
- What you did **not** verify: full Telegram live integration in a bundled production build.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/process/command-queue.ts`, `src/process/command-queue.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected lane cross-talk or stuck queue draining across modules.

## Risks and Mitigations

- Risk: global key collision on `globalThis`.
  - Mitigation: use a namespaced, versioned key and a narrow typed runtime state shape.
- Risk: hidden behavior change due shared runtime state.
  - Mitigation: targeted regression test covering cross-instance propagation plus existing queue suite.

AI-assisted: yes (implementation, tests, and PR drafting); human-reviewed and locally verified.
