### PR TITLE
docs(browser): add browser automation best-practices playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Docs/Browser: add a browser automation best-practices playbook with explicit arming workflows for upload/download/dialog actions, iframe-scoped snapshot patterns, and dynamic-wait + extraction recipes. (#30502)
+
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -529,6 +529,64 @@ When an action fails (e.g. “not visible”, “strict mode violation”, “co
    - reproduce the issue
    - `openclaw browser trace stop` (prints `TRACE:<path>`)
 
+## Browser automation best practices
+
+Use this checklist for reliable browser runs:
+
+1. Start each interaction cycle with a fresh snapshot.
+2. Use refs from that snapshot immediately (`click`/`type`/`drag`), then snapshot again after navigation or major DOM changes.
+3. Prefer role snapshots (`--interactive`) for action-heavy flows; refs are more stable than guessing selectors.
+4. Pair actions with explicit waits (`--url`, `--load`, `--fn`, selector/text wait) before the next step.
+5. Treat `upload`, `download`, and `dialog` as two-step flows: arm first, trigger second.
+
+### Common task patterns
+
+Form fill + submit:
+
+```bash
+openclaw browser snapshot --interactive
+openclaw browser type e12 "Ada Lovelace"
+openclaw browser click e18
+openclaw browser wait --url "**/success" --load networkidle
+```
+
+File upload (arm, then trigger):
+
+```bash
+openclaw browser upload /tmp/openclaw/uploads/report.pdf --ref e22
+openclaw browser click e22
+```
+
+File download (arm, then trigger):
+
+```bash
+openclaw browser download e31 report.pdf
+openclaw browser click e31
+openclaw browser waitfordownload report.pdf
+```
+
+Dialogs (arm, then trigger):
+
+```bash
+openclaw browser dialog --accept
+openclaw browser click e41
+```
+
+iFrame flow (no manual frame switching API required):
+
+```bash
+openclaw browser snapshot --frame "iframe#checkout" --interactive
+openclaw browser click e12
+```
+
+Dynamic content wait + extract:
+
+```bash
+openclaw browser wait --text "Ready" --timeout-ms 15000
+openclaw browser snapshot --interactive
+openclaw browser evaluate --fn "() => document.body.innerText.slice(0, 2000)"
+```
+
 ## JSON output
 
 `--json` is for scripting and structured tooling.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: browser docs are comprehensive but users still miss the practical sequencing rules (snapshot lifecycle + arming workflow) during real automation runs.
- Why it matters: upload/download/dialog actions are order-sensitive; missing "arm first, trigger second" patterns causes avoidable failures.
- What changed: added a dedicated **Browser automation best practices** section in `docs/tools/browser.md` with a reliability checklist and copy/paste task patterns (forms, upload, download, dialogs, iframe, dynamic waits).
- What did NOT change (scope boundary): no runtime/browser code paths, no API/CLI behavior changes, docs only.
- AI-assisted: yes (Codex). Testing degree: lightly tested (docs formatting + link/command consistency review).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30502
- Related #30521

## User-visible / Behavior Changes

- Browser docs now include a task-oriented best-practices playbook with explicit arming and wait sequencing patterns.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: docs-only change
- Model/provider: N/A
- Integration/channel (if any): browser docs
- Relevant config (redacted): N/A

### Steps

1. Open `docs/tools/browser.md`.
2. Navigate to `## Browser automation best practices`.
3. Validate flow guidance against existing browser CLI commands and sections.

### Expected

- Users can follow concise, correct task patterns for snapshot cycles, arming flows, iframe targeting, and dynamic waits.

### Actual

- Section added with practical examples and command ordering guidance.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification command:

- `pnpm oxfmt --check docs/tools/browser.md CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed each added command against existing documented CLI command set and semantics in the same doc.
- Edge cases checked: explicitly documented arming-first patterns for upload/download/dialog to reduce common sequencing failures.
- What you did **not** verify: runtime browser automation behavior (no code/runtime changes in this PR).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `docs/tools/browser.md`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: duplicated or conflicting browser command guidance.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: examples could drift from CLI behavior over time.
  - Mitigation: examples were aligned with currently documented commands and grouped near existing browser reference sections for easier maintenance.
