### PR TITLE
fix(locks): reclaim stale session locks across reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/Lock recovery: mark session lock files stale when the stored Linux boot ID differs from the current boot, preventing PID reuse after hard reboot from blocking lock acquisition. (#29927)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -89,6 +89,67 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("reclaims fresh lock files when boot marker mismatches", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockPath = `${sessionFile}.lock`;
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          bootId: "old-boot",
+        }),
+        "utf8",
+      );
+
+      const lock = await acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: 500,
+        staleMs: 60_000,
+        bootId: "new-boot",
+      });
+      const raw = await fs.readFile(lockPath, "utf8");
+      const payload = JSON.parse(raw) as { pid: number; bootId?: string };
+
+      expect(payload.pid).toBe(process.pid);
+      expect(payload.bootId).toBe("new-boot");
+      await lock.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reclaim fresh lock files when boot marker matches", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockPath = `${sessionFile}.lock`;
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          bootId: "same-boot",
+        }),
+        "utf8",
+      );
+
+      await expect(
+        acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 50,
+          staleMs: 60_000,
+          bootId: "same-boot",
+        }),
+      ).rejects.toThrow(/session file locked/);
+      await expect(fs.access(lockPath)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not reclaim fresh malformed lock files during contention", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     try {
@@ -219,6 +280,39 @@ describe("acquireSessionWriteLock", () => {
       await expect(fs.access(staleDeadLock)).rejects.toThrow();
       await expect(fs.access(staleAliveLock)).rejects.toThrow();
       await expect(fs.access(freshAliveLock)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans fresh lock files from previous boots", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const sessionsDir = path.join(root, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const lockPath = path.join(sessionsDir, "prev-boot.jsonl.lock");
+
+    try {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          bootId: "boot-old",
+        }),
+        "utf8",
+      );
+
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs: 60_000,
+        removeStale: true,
+        bootId: "boot-new",
+      });
+
+      expect(result.cleaned).toHaveLength(1);
+      expect(path.basename(result.cleaned[0]?.lockPath ?? "")).toBe("prev-boot.jsonl.lock");
+      expect(result.cleaned[0]?.staleReasons).toContain("boot-id-mismatch");
+      await expect(fs.access(lockPath)).rejects.toThrow();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -7,6 +7,7 @@ import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 type LockFilePayload = {
   pid?: number;
   createdAt?: string;
+  bootId?: string;
 };
 
 type HeldLock = {
@@ -40,6 +41,9 @@ const DEFAULT_MAX_HOLD_MS = 5 * 60 * 1000;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
 const MAX_LOCK_HOLD_MS = 2_147_000_000;
+const LINUX_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
+
+let cachedBootId: string | null | undefined;
 
 type CleanupState = {
   registered: boolean;
@@ -100,6 +104,23 @@ function resolvePositiveMs(
     return fallback;
   }
   return value;
+}
+
+function resolveCurrentBootId(): string | null {
+  if (cachedBootId !== undefined) {
+    return cachedBootId;
+  }
+  if (process.platform !== "linux") {
+    cachedBootId = null;
+    return cachedBootId;
+  }
+  try {
+    const value = fsSync.readFileSync(LINUX_BOOT_ID_PATH, "utf8").trim();
+    cachedBootId = value.length > 0 ? value : null;
+  } catch {
+    cachedBootId = null;
+  }
+  return cachedBootId;
 }
 
 export function resolveSessionLockMaxHoldFromTimeout(params: {
@@ -276,6 +297,9 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
     if (typeof parsed.createdAt === "string") {
       payload.createdAt = parsed.createdAt;
     }
+    if (typeof parsed.bootId === "string") {
+      payload.bootId = parsed.bootId;
+    }
     return payload;
   } catch {
     return null;
@@ -286,10 +310,13 @@ function inspectLockPayload(
   payload: LockFilePayload | null,
   staleMs: number,
   nowMs: number,
+  currentBootId: string | null,
 ): LockInspectionDetails {
   const pid = typeof payload?.pid === "number" ? payload.pid : null;
   const pidAlive = pid !== null ? isPidAlive(pid) : false;
   const createdAt = typeof payload?.createdAt === "string" ? payload.createdAt : null;
+  const bootIdRaw = typeof payload?.bootId === "string" ? payload.bootId.trim() : "";
+  const bootId = bootIdRaw.length > 0 ? bootIdRaw : null;
   const createdAtMs = createdAt ? Date.parse(createdAt) : Number.NaN;
   const ageMs = Number.isFinite(createdAtMs) ? Math.max(0, nowMs - createdAtMs) : null;
 
@@ -303,6 +330,9 @@ function inspectLockPayload(
     staleReasons.push("invalid-createdAt");
   } else if (ageMs > staleMs) {
     staleReasons.push("too-old");
+  }
+  if (currentBootId && bootId && bootId !== currentBootId) {
+    staleReasons.push("boot-id-mismatch");
   }
 
   return {
@@ -351,6 +381,7 @@ export async function cleanStaleLockFiles(params: {
   staleMs?: number;
   removeStale?: boolean;
   nowMs?: number;
+  bootId?: string | null;
   log?: {
     warn?: (message: string) => void;
     info?: (message: string) => void;
@@ -360,6 +391,7 @@ export async function cleanStaleLockFiles(params: {
   const staleMs = resolvePositiveMs(params.staleMs, DEFAULT_STALE_MS);
   const removeStale = params.removeStale !== false;
   const nowMs = params.nowMs ?? Date.now();
+  const currentBootId = params.bootId === undefined ? resolveCurrentBootId() : params.bootId;
 
   let entries: fsSync.Dirent[] = [];
   try {
@@ -381,7 +413,7 @@ export async function cleanStaleLockFiles(params: {
   for (const entry of lockEntries) {
     const lockPath = path.join(sessionsDir, entry.name);
     const payload = await readLockPayload(lockPath);
-    const inspected = inspectLockPayload(payload, staleMs, nowMs);
+    const inspected = inspectLockPayload(payload, staleMs, nowMs, currentBootId);
     const lockInfo: SessionLockInspection = {
       lockPath,
       ...inspected,
@@ -409,6 +441,7 @@ export async function acquireSessionWriteLock(params: {
   staleMs?: number;
   maxHoldMs?: number;
   allowReentrant?: boolean;
+  bootId?: string | null;
 }): Promise<{
   release: () => Promise<void>;
 }> {
@@ -416,6 +449,7 @@ export async function acquireSessionWriteLock(params: {
   const timeoutMs = resolvePositiveMs(params.timeoutMs, 10_000, { allowInfinity: true });
   const staleMs = resolvePositiveMs(params.staleMs, DEFAULT_STALE_MS);
   const maxHoldMs = resolvePositiveMs(params.maxHoldMs, DEFAULT_MAX_HOLD_MS);
+  const currentBootId = params.bootId === undefined ? resolveCurrentBootId() : params.bootId;
   const sessionFile = path.resolve(params.sessionFile);
   const sessionDir = path.dirname(sessionFile);
   await fs.mkdir(sessionDir, { recursive: true });
@@ -447,7 +481,11 @@ export async function acquireSessionWriteLock(params: {
     try {
       handle = await fs.open(lockPath, "wx");
       const createdAt = new Date().toISOString();
-      await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt }, null, 2), "utf8");
+      const payload: LockFilePayload = { pid: process.pid, createdAt };
+      if (currentBootId) {
+        payload.bootId = currentBootId;
+      }
+      await handle.writeFile(JSON.stringify(payload, null, 2), "utf8");
       const createdHeld: HeldLock = {
         count: 1,
         handle,
@@ -480,7 +518,7 @@ export async function acquireSessionWriteLock(params: {
       }
       const payload = await readLockPayload(lockPath);
       const nowMs = Date.now();
-      const inspected = inspectLockPayload(payload, staleMs, nowMs);
+      const inspected = inspectLockPayload(payload, staleMs, nowMs, currentBootId);
       if (await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs)) {
         await fs.rm(lockPath, { force: true });
         continue;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: session lock files only validated `pid` liveness + age, so after hard reboot a reused PID could make a stale lock look active.
- Why it matters: affected sessions could fail for ~timeout windows with `session file locked` even though no real OpenClaw process held the lock.
- What changed: lock payloads now include Linux `bootId`; lock inspection marks locks stale on `boot-id-mismatch`; stale cleanup and lock acquisition reclaim those locks.
- What did NOT change (scope boundary): no scheduler/session routing logic changed, and non-Linux boot-id behavior remains unchanged.
- AI-assisted: yes (implemented with AI assistance, human-verified with targeted tests below).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29927
- Related #30521

## User-visible / Behavior Changes

- On Linux, stale session lock files from a previous boot are now reclaimed immediately when the stored boot ID differs from the current boot.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev) + Linux boot-id behavior covered by deterministic tests
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create a fresh lock file with live `pid`, fresh `createdAt`, and mismatched `bootId`.
2. Attempt `acquireSessionWriteLock` for the same session path.
3. Observe lock reclaimed and replaced with current payload.

### Expected

- Mismatched-boot lock is treated as stale and reclaimed.

### Actual

- Verified via new tests: lock is reclaimed on mismatch, and not reclaimed when boot ID matches.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest src/agents/session-write-lock.test.ts src/commands/doctor-session-locks.test.ts`

- `✓ src/agents/session-write-lock.test.ts (17 tests)`
- `✓ src/commands/doctor-session-locks.test.ts (2 tests)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: boot mismatch reclaim path in both acquisition and cleanup flows; matching-boot lock still blocks as expected.
- Edge cases checked: malformed/fresh lock behavior remained unchanged; stale cleanup still removes dead/old locks.
- What you did **not** verify: full gateway E2E reboot workflow on a real Linux host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d01660fb13`.
- Files/config to restore: `src/agents/session-write-lock.ts`, `src/agents/session-write-lock.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected lock reclamation on active sessions (not expected; guarded by boot mismatch + existing stale criteria).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Linux-only boot marker unavailable in constrained environments.
  - Mitigation: behavior gracefully falls back to existing pid/age logic when boot ID cannot be resolved.
