### PR TITLE
fix(prompt): enforce tool-first behavior for tool-backed tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Tool-use guidance: strengthen system prompt instructions to call available tools (for example `cron`) instead of replying that the assistant lacks capability when an action is tool-backed. (#30512)
 - Cron/Delivery: disable the agent messaging tool when `delivery.mode` is `"none"` so cron output is not sent to Telegram or other channels. (#21808)
 - Feishu/Reply media attachments: send Feishu reply `mediaUrl`/`mediaUrls` payloads as attachments alongside text/streamed replies in the reply dispatcher, including legacy fallback when `mediaUrls` is empty. (#28959)
 - Feishu/Reaction notifications: add `channels.feishu.reactionNotifications` (`off | own | all`, default `own`) so operators can disable reaction ingress or allow all verified reaction events (not only bot-authored message reactions). (#28529)

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -224,6 +224,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
     );
+    expect(prompt).toContain(
+      "If a relevant tool is available, do not claim you cannot perform the action; call the tool and only ask for missing parameters.",
+    );
   });
 
   it("lists available tools when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -459,6 +459,7 @@ export function buildAgentSystemPrompt(params: {
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
     "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
+    "If a relevant tool is available, do not claim you cannot perform the action; call the tool and only ask for missing parameters.",
     "",
     ...safetySection,
     "## OpenClaw CLI Quick Reference",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: in #30512, Mistral runs can reply with “I can’t schedule this” even when tool-backed scheduling (`cron`) is available.
- Why it matters: users get a false capability denial and no cron job is created.
- What changed: strengthened system prompt Tool Call Style guidance to explicitly require tool usage for tool-backed actions and avoid “cannot do this” replies when tools are available.
- What did NOT change (scope boundary): no provider API wiring/tool schemas/retry logic changed; this is prompt-policy guidance only.
- AI-assisted: yes (AI-assisted implementation + human-run tests below).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30512
- Related #30525

## User-visible / Behavior Changes

- Agents are now explicitly instructed to call available tools for tool-backed tasks (such as scheduling via `cron`) instead of stating they lack capability.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node.js + Vitest
- Model/provider: prompt-level behavior (provider-agnostic instruction)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build agent system prompt with default/full mode.
2. Verify Tool Call Style section includes tool-first/no-false-denial guidance.
3. Run system-prompt unit tests.

### Expected

- Prompt contains explicit instruction to call available tools instead of claiming inability.

### Actual

- Verified in unit test + snapshot assertions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest src/agents/system-prompt.test.ts`
- `✓ src/agents/system-prompt.test.ts (41 tests)`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new Tool Call Style rule is present; existing prompt sections remain intact.
- Edge cases checked: minimal mode tests remain green; no regressions in existing system-prompt assertions.
- What you did **not** verify: live end-to-end Mistral API behavior in a running gateway session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8cff96d7c0`.
- Files/config to restore: `src/agents/system-prompt.ts`, `src/agents/system-prompt.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: over-eager tool usage in cases where no matching tool exists (guarded by wording: “if a relevant tool is available”).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: prompt-level fix may not fully resolve all provider/model-specific tool-call failures.
  - Mitigation: scoped as a low-risk first fix; does not block future provider-level handling if needed.
