### PR TITLE
fix(hooks): thread agentId into after_tool_call hook context

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1186,6 +1186,7 @@ export async function runEmbeddedAttempt(
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
         sessionKey: params.sessionKey ?? params.sessionId,
+        agentId: sessionAgentId,
       });
 
       const {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -427,7 +427,7 @@ export async function handleToolExecutionEnd(
       .runAfterToolCall(hookEvent, {
         toolName,
         agentId: undefined,
-        sessionKey: undefined,
+        sessionKey: ctx.params.sessionKey,
       })
       .catch((err) => {
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -426,7 +426,7 @@ export async function handleToolExecutionEnd(
     void hookRunnerAfter
       .runAfterToolCall(hookEvent, {
         toolName,
-        agentId: undefined,
+        agentId: ctx.params.agentId,
         sessionKey: ctx.params.sessionKey,
       })
       .catch((err) => {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -132,7 +132,7 @@ export type EmbeddedPiSubscribeContext = {
  */
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
-  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult"
+  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult" | "sessionKey"
 >;
 
 export type ToolHandlerState = Pick<

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -132,7 +132,7 @@ export type EmbeddedPiSubscribeContext = {
  */
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
-  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult" | "sessionKey"
+  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult" | "sessionKey" | "agentId"
 >;
 
 export type ToolHandlerState = Pick<

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -31,6 +31,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   enforceFinalTag?: boolean;
   config?: OpenClawConfig;
   sessionKey?: string;
+  /** Agent identity for hook context — resolved from session config in attempt.ts. */
+  agentId?: string;
 };
 
 export type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";

--- a/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
@@ -114,7 +114,9 @@ describe("after_tool_call hook wiring", () => {
     const event = firstCall?.[0] as
       | { toolName?: string; params?: unknown; error?: unknown; durationMs?: unknown }
       | undefined;
-    const context = firstCall?.[1] as { toolName?: string } | undefined;
+    const context = firstCall?.[1] as
+      | { toolName?: string; agentId?: string; sessionKey?: string }
+      | undefined;
     expect(event).toBeDefined();
     expect(context).toBeDefined();
     if (!event || !context) {
@@ -125,6 +127,7 @@ describe("after_tool_call hook wiring", () => {
     expect(event.error).toBeUndefined();
     expect(typeof event.durationMs).toBe("number");
     expect(context.toolName).toBe("read");
+    expect(context.sessionKey).toBe("test-session");
   });
 
   it("includes error in after_tool_call event on tool failure", async () => {

--- a/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.e2e.test.ts
@@ -127,6 +127,7 @@ describe("after_tool_call hook wiring", () => {
     expect(event.error).toBeUndefined();
     expect(typeof event.durationMs).toBe("number");
     expect(context.toolName).toBe("read");
+    expect(context.agentId).toBe("main");
     expect(context.sessionKey).toBe("test-session");
   });
 
@@ -166,6 +167,10 @@ describe("after_tool_call hook wiring", () => {
       throw new Error("missing hook call payload");
     }
     expect(event.error).toBeDefined();
+
+    // agentId should be undefined when not provided
+    const context = firstCall?.[1] as { agentId?: string } | undefined;
+    expect(context?.agentId).toBeUndefined();
   });
 
   it("does not call runAfterToolCall when no hooks registered", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #30511 — threads `agentId` through the session params chain so the `after_tool_call` hook context receives the resolved agent identity instead of `undefined`.

- Adds `agentId?: string` to `SubscribeEmbeddedPiSessionParams`
- Adds `"agentId"` to the `ToolHandlerParams` Pick type
- Passes `sessionAgentId` (resolved in `attempt.ts` via `resolveSessionAgentIds()`) at the `subscribeEmbeddedPiSession()` call site
- Wires `ctx.params.agentId` into the `after_tool_call` hook context (replacing hardcoded `undefined`)

## Motivation

Third-party plugins (e.g. [`openclaw-plimsoll-security`](https://www.npmjs.com/package/openclaw-plimsoll-security)) use `ctx.agentId` in both `before_tool_call` and `after_tool_call` hooks for agent-scoped audit trails and per-agent security policies. Without this fix, `agentId` is always `undefined` in the hook context, forcing plugins to fall back to `sessionKey` or a hardcoded default.

## Test plan

- [x] Updated `wired-hooks-after-tool-call.test.ts` — asserts `context.agentId` equals the provided value
- [x] Added assertion that `agentId` is `undefined` when not provided (no-agentId path)
- [x] All 3 existing tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

## Files changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-subscribe.types.ts` | Add `agentId?: string` field |
| `src/agents/pi-embedded-subscribe.handlers.types.ts` | Add `"agentId"` to `ToolHandlerParams` Pick |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Pass `agentId: sessionAgentId` to `subscribeEmbeddedPiSession()` |
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Wire `ctx.params.agentId` into hook context |
| `src/plugins/wired-hooks-after-tool-call.test.ts` | Assert agentId propagation |

Depends on #30511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)