### PR TITLE
fix(discord): recover stalled websocket reconnects after close (#30514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Gateway reconnect watchdog: add a close-event reconnect stall guard in Discord gateway lifecycle so stale websocket closes that never recover trigger a forced reconnect instead of leaving Discord monitors in a zombie connected state. (#30514)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import type { Client } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -51,6 +52,8 @@ describe("runDiscordGatewayLifecycle", () => {
     stop?: () => Promise<void>;
     isDisallowedIntentsError?: (err: unknown) => boolean;
     pendingGatewayErrors?: unknown[];
+    withGateway?: boolean;
+    gatewayConnected?: boolean;
   }) => {
     const start = vi.fn(params?.start ?? (async () => undefined));
     const stop = vi.fn(params?.stop ?? (async () => undefined));
@@ -64,15 +67,30 @@ describe("runDiscordGatewayLifecycle", () => {
       error: runtimeError,
       exit: runtimeExit,
     };
+    const gatewayEmitter = params?.withGateway ? new EventEmitter() : undefined;
+    const gateway =
+      params?.withGateway && gatewayEmitter
+        ? ({
+            emitter: gatewayEmitter,
+            disconnect: vi.fn(),
+            connect: vi.fn(),
+            isConnected: params?.gatewayConnected ?? true,
+            options: { reconnect: { maxAttempts: 50 } },
+          } as const)
+        : undefined;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(gatewayEmitter);
     return {
       start,
       stop,
       threadStop,
+      runtimeLog,
       runtimeError,
       releaseEarlyGatewayErrorGuard,
+      gateway,
+      gatewayEmitter,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
-        client: { getPlugin: vi.fn(() => undefined) } as unknown as Client,
+        client: { getPlugin: vi.fn(() => gateway) } as unknown as Client,
         runtime,
         isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
         voiceManager: null,
@@ -202,5 +220,89 @@ describe("runDiscordGatewayLifecycle", () => {
       waitCalls: 0,
       releaseEarlyGatewayErrorGuard,
     });
+  });
+
+  it("forces reconnect when the gateway closes and stays disconnected", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      let resolveWait: (() => void) | undefined;
+      waitForDiscordGatewayStopMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWait = resolve;
+          }),
+      );
+      const {
+        lifecycleParams,
+        start,
+        stop,
+        threadStop,
+        runtimeLog,
+        gateway,
+        gatewayEmitter,
+        releaseEarlyGatewayErrorGuard,
+      } = createLifecycleHarness({
+        withGateway: true,
+        gatewayConnected: false,
+      });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      gatewayEmitter?.emit("debug", "WebSocket connection closed with code 1006");
+      await vi.advanceTimersByTimeAsync(15000);
+
+      expect(gateway?.disconnect).toHaveBeenCalledTimes(1);
+      expect(gateway?.connect).toHaveBeenCalledTimes(1);
+      expect(gateway?.connect).toHaveBeenCalledWith(false);
+      expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("no reconnect within"));
+
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 1,
+        releaseEarlyGatewayErrorGuard,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels forced reconnect when the gateway reopens before timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      let resolveWait: (() => void) | undefined;
+      waitForDiscordGatewayStopMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWait = resolve;
+          }),
+      );
+      const { lifecycleParams, gateway, gatewayEmitter } = createLifecycleHarness({
+        withGateway: true,
+        gatewayConnected: false,
+      });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      gatewayEmitter?.emit("debug", "WebSocket connection closed with code 1006");
+      await vi.advanceTimersByTimeAsync(5000);
+      if (gateway) {
+        gateway.isConnected = true;
+      }
+      gatewayEmitter?.emit("debug", "WebSocket connection opened");
+      await vi.advanceTimersByTimeAsync(15000);
+
+      expect(gateway?.disconnect).not.toHaveBeenCalled();
+      expect(gateway?.connect).not.toHaveBeenCalled();
+
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -25,6 +25,8 @@ export async function runDiscordGatewayLifecycle(params: {
   pendingGatewayErrors?: unknown[];
   releaseEarlyGatewayErrorGuard?: () => void;
 }) {
+  const HELLO_TIMEOUT_MS = 30000;
+  const RECONNECT_STALL_TIMEOUT_MS = 15000;
   const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
   if (gateway) {
     registerGateway(params.accountId, gateway);
@@ -35,7 +37,25 @@ export async function runDiscordGatewayLifecycle(params: {
     runtime: params.runtime,
   });
 
+  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let reconnectTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let isShuttingDown = false;
+  const clearHelloTimeout = () => {
+    if (helloTimeoutId) {
+      clearTimeout(helloTimeoutId);
+      helloTimeoutId = undefined;
+    }
+  };
+  const clearReconnectTimeout = () => {
+    if (reconnectTimeoutId) {
+      clearTimeout(reconnectTimeoutId);
+      reconnectTimeoutId = undefined;
+    }
+  };
   const onAbort = () => {
+    isShuttingDown = true;
+    clearHelloTimeout();
+    clearReconnectTimeout();
     if (!gateway) {
       return;
     }
@@ -50,28 +70,53 @@ export async function runDiscordGatewayLifecycle(params: {
     params.abortSignal?.addEventListener("abort", onAbort, { once: true });
   }
 
-  const HELLO_TIMEOUT_MS = 30000;
-  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
-    if (!message.includes("WebSocket connection opened")) {
+    if (message.includes("WebSocket connection opened")) {
+      clearReconnectTimeout();
+      clearHelloTimeout();
+      helloTimeoutId = setTimeout(() => {
+        if (!gateway || isShuttingDown) {
+          helloTimeoutId = undefined;
+          return;
+        }
+        if (!gateway.isConnected) {
+          params.runtime.log?.(
+            danger(
+              `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+            ),
+          );
+          gateway.disconnect();
+          gateway.connect(false);
+        }
+        helloTimeoutId = undefined;
+      }, HELLO_TIMEOUT_MS);
       return;
     }
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
+    if (!message.includes("WebSocket connection closed")) {
+      return;
     }
-    helloTimeoutId = setTimeout(() => {
-      if (!gateway?.isConnected) {
+    clearHelloTimeout();
+    if (isShuttingDown) {
+      return;
+    }
+    clearReconnectTimeout();
+    reconnectTimeoutId = setTimeout(() => {
+      if (!gateway || isShuttingDown) {
+        reconnectTimeoutId = undefined;
+        return;
+      }
+      if (!gateway.isConnected) {
         params.runtime.log?.(
           danger(
-            `connection stalled: no HELLO received within ${HELLO_TIMEOUT_MS}ms, forcing reconnect`,
+            `connection stalled: no reconnect within ${RECONNECT_STALL_TIMEOUT_MS}ms after close, forcing reconnect`,
           ),
         );
-        gateway?.disconnect();
-        gateway?.connect(false);
+        gateway.disconnect();
+        gateway.connect(false);
       }
-      helloTimeoutId = undefined;
-    }, HELLO_TIMEOUT_MS);
+      reconnectTimeoutId = undefined;
+    }, RECONNECT_STALL_TIMEOUT_MS);
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
 
@@ -137,9 +182,8 @@ export async function runDiscordGatewayLifecycle(params: {
     params.releaseEarlyGatewayErrorGuard?.();
     unregisterGateway(params.accountId);
     stopGatewayLogging();
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-    }
+    clearHelloTimeout();
+    clearReconnectTimeout();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
     params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord monitor can enter a zombie state after websocket close events where no further inbound messages arrive and no reconnect succeeds.
- Why it matters: Bot appears online/healthy but silently stops processing Discord traffic until manual restart.
- What changed: Added a reconnect watchdog in Discord lifecycle that listens for `WebSocket connection closed` debug events and forces reconnect if no recovery occurs within 15s; existing HELLO timeout guard remains in place.
- What did NOT change (scope boundary): No protocol-level changes, no Carbon gateway patching, no config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30514
- Related #30469

## User-visible / Behavior Changes

- Discord channel monitors now self-heal when websocket close/reconnect gets stuck: after close, if no reconnect recovery is observed within 15 seconds, OpenClaw forces a reconnect attempt.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.1
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): Discord monitor
- Relevant config (redacted): default Discord gateway monitor with reconnect enabled

### Steps

1. Start Discord monitor lifecycle with gateway plugin attached.
2. Emit `WebSocket connection closed` debug event and keep gateway disconnected.
3. Advance timers beyond reconnect stall timeout.

### Expected

- Lifecycle triggers a forced reconnect attempt without requiring gateway restart.

### Actual

- Verified with new unit tests: disconnect/connect are triggered after stall timeout.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run locally:

- `pnpm vitest src/discord/monitor/provider.lifecycle.test.ts`
- `pnpm vitest src/discord/monitor/provider.test.ts`
- `pnpm oxfmt --check src/discord/monitor/provider.lifecycle.ts src/discord/monitor/provider.lifecycle.test.ts CHANGELOG.md`
- `pnpm oxlint --type-aware src/discord/monitor/provider.lifecycle.ts src/discord/monitor/provider.lifecycle.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: forced reconnect on stalled close event; no forced reconnect when socket reopens before watchdog timeout.
- Edge cases checked: cleanup of watchdog/HELLO timers on abort and lifecycle teardown to avoid reconnect attempts during intentional shutdown.
- What you did **not** verify: live Discord outage simulation against real gateway infra.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/discord/monitor/provider.lifecycle.ts`, `src/discord/monitor/provider.lifecycle.test.ts`.
- Known bad symptoms reviewers should watch for: excessive reconnect churn in unstable networks.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: forced reconnect could fire during prolonged instability and increase reconnect frequency.
  - Mitigation: watchdog triggers only after explicit close signal plus 15s no-recovery window, and cancels immediately on reopened connection.

AI-assisted: yes (Codex). Tests and behavior were manually reviewed and verified.
