### PR TITLE
feat(discord): add typing action support [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/Message actions: add `message(action="typing")` support so agents can trigger Discord typing indicators in target channels before sending responses. (#30529)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -20,6 +20,7 @@ import {
   sendMessageDiscord,
   sendPollDiscord,
   sendStickerDiscord,
+  sendTypingDiscord,
   sendVoiceMessageDiscord,
   unpinMessageDiscord,
 } from "../../discord/send.js";
@@ -168,6 +169,16 @@ export async function handleDiscordMessagingAction(
         { ...(accountId ? { accountId } : {}), content },
       );
       return jsonResult({ ok: true });
+    }
+    case "typing": {
+      if (!isActionEnabled("messages")) {
+        throw new Error("Discord message sends are disabled.");
+      }
+      const channelId = resolveChannelId();
+      const result = accountId
+        ? await sendTypingDiscord(channelId, { accountId })
+        : await sendTypingDiscord(channelId);
+      return jsonResult(result);
     }
     case "permissions": {
       if (!isActionEnabled("permissions")) {

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -12,6 +12,7 @@ const messagingActions = new Set([
   "reactions",
   "sticker",
   "poll",
+  "typing",
   "permissions",
   "fetchMessage",
   "readMessages",

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -195,6 +195,7 @@ describe("discord message actions", () => {
     const cfg = { channels: { discord: { token: "d0" } } } as OpenClawConfig;
     const actions = discordMessageActions.listActions?.({ cfg }) ?? [];
 
+    expect(actions).toContain("typing");
     expect(actions).toContain("emoji-upload");
     expect(actions).toContain("sticker-upload");
     expect(actions).toContain("channel-create");
@@ -322,6 +323,19 @@ describe("handleDiscordMessageAction", () => {
         to: "channel:123",
         question: "Ready?",
         answers: ["Yes", "No"],
+      },
+    },
+    {
+      name: "forwards typing action",
+      input: {
+        action: "typing" as const,
+        params: { to: "channel:123" },
+        accountId: "ops",
+      },
+      expected: {
+        action: "typing",
+        accountId: "ops",
+        channelId: "123",
       },
     },
     {

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -31,6 +31,7 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
       actions.add("read");
       actions.add("edit");
       actions.add("delete");
+      actions.add("typing");
     }
     if (isEnabled("pins")) {
       actions.add("pin");

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -115,6 +115,18 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "typing") {
+    return await handleDiscordAction(
+      {
+        action: "typing",
+        accountId: accountId ?? undefined,
+        channelId: resolveChannelId(),
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
   if (action === "react") {
     const messageId = readStringParam(params, "messageId", { required: true });
     const emoji = readStringParam(params, "emoji", { allowEmpty: true });

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -2,6 +2,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "send",
   "broadcast",
   "poll",
+  "typing",
   "react",
   "reactions",
   "read",

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -36,6 +36,15 @@ export async function readMessagesDiscord(
   return (await rest.get(Routes.channelMessages(channelId), params)) as APIMessage[];
 }
 
+export async function sendTypingDiscord(
+  channelId: string,
+  opts: DiscordReactOpts = {},
+): Promise<{ ok: true }> {
+  const rest = resolveDiscordRest(opts);
+  await rest.post(Routes.channelTyping(channelId));
+  return { ok: true };
+}
+
 export async function fetchMessageDiscord(
   channelId: string,
   messageId: string,

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -12,6 +12,7 @@ import {
   removeReactionDiscord,
   searchMessagesDiscord,
   sendMessageDiscord,
+  sendTypingDiscord,
   unpinMessageDiscord,
 } from "./send.js";
 import { makeDiscordRest } from "./send.test-harness.js";
@@ -481,6 +482,19 @@ describe("readMessagesDiscord", () => {
     const call = getMock.mock.calls[0];
     const options = call?.[1] as Record<string, unknown>;
     expect(options).toEqual({ limit: 5, before: "10" });
+  });
+});
+
+describe("sendTypingDiscord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("triggers typing in the requested channel", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({});
+    await sendTypingDiscord("chan1", { rest, token: "t" });
+    expect(postMock).toHaveBeenCalledWith(Routes.channelTyping("chan1"));
   });
 });
 

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -35,6 +35,7 @@ export {
   pinMessageDiscord,
   readMessagesDiscord,
   searchMessagesDiscord,
+  sendTypingDiscord,
   unpinMessageDiscord,
 } from "./send.messages.js";
 export {

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -7,6 +7,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     send: "to",
     broadcast: "none",
     poll: "to",
+    typing: "to",
     react: "to",
     reactions: "to",
     read: "to",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord messaging actions did not support a `typing` action, so callers could not trigger typing indicators through the unified message-action pipeline.
- Why it matters: Integrations that rely on typing indicators for UX parity (or rate-friendly “I am preparing a response” feedback) had no first-class path.
- What changed: Added `typing` end-to-end for Discord action routing (`message action names` -> `outbound spec` -> `channel plugin action mapping` -> `discord action handler` -> `discord send API`), and added regression tests.
- What did NOT change (scope boundary): No behavior changes to existing send/edit/react/pin actions; no new permissions model; no non-Discord channel behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30529
- Related #

## User-visible / Behavior Changes

- Discord action payloads can now use `action: "typing"` with target channel/account routing.
- Discord plugin action list now includes `typing` when `messages` action-gate is enabled.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - Adds a single Discord REST call to `Routes.channelTyping(channelId)` behind existing `messages` action gate.
  - Reuses existing account/channel resolution and auth path; no new token surfaces.
  - Covered by focused tests for action forwarding and REST route invocation.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): default Discord messaging action-gate enabled

### Steps

1. Invoke Discord message action handler with `action: "typing"`, channel target, and optional account id.
2. Verify routing passes through channel plugin action mapping to Discord action tool.
3. Verify Discord send layer calls `POST /channels/{channelId}/typing`.

### Expected

- `typing` action is accepted and forwarded consistently.
- Send layer posts to Discord typing endpoint and returns `{ ok: true }`.

### Actual

- Matches expected in focused tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification run:

- `pnpm vitest src/channels/plugins/actions/actions.test.ts`
- `pnpm vitest src/discord/send.sends-basic-channel-messages.test.ts`
- `pnpm oxfmt --check <touched-files>`
- `pnpm oxlint --type-aware <touched-files>`

Note on full-suite baseline in this local env:

- `pnpm test` currently has unrelated existing failures in other areas (SSRF-guard-sensitive tests and optional extension dependency tests), not in files touched by this PR.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `typing` appears in Discord plugin action list under `messages` gate.
  - `typing` action is forwarded with correct `channelId/accountId` payload.
  - Discord send API posts to `Routes.channelTyping` and returns success.
- Edge cases checked:
  - With and without `accountId` override.
  - Existing actions remain untouched in routing path.
- What you did **not** verify:
  - Live Discord end-to-end against production guilds (validated via unit/integration tests only in this PR).

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR/commit.
- Files/config to restore:
  - `src/agents/tools/discord-actions-messaging.ts`
  - `src/channels/plugins/actions/discord/handle-action.ts`
  - `src/discord/send.messages.ts`
  - `src/channels/plugins/message-action-names.ts`
  - `src/infra/outbound/message-action-spec.ts`
- Known bad symptoms reviewers should watch for:
  - `typing` action rejected unexpectedly.
  - Discord action routing resolves action but does not hit typing endpoint.

## Risks and Mitigations

- Risk: `typing` action wiring could regress action-routing for Discord plugin paths.
  - Mitigation: Added assertions at plugin action list + forwarding layer + send layer route call.

---

AI-assisted: Yes (Codex).  
Testing degree: Fully tested for touched scope (targeted tests + formatting/lint/type-aware checks).
