### PR TITLE
fix(gateway): make start idempotent when already running [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/CLI start idempotency: exit `0` (with an informational message) when `openclaw gateway` hits a `GatewayLockError` that indicates an already-running gateway, so repeated start/ensure invocations do not fail automation loops. (#30532)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -99,8 +99,8 @@ async function runGatewayCommand(args: string[]) {
   await program.parseAsync(args, { from: "user" });
 }
 
-async function expectGatewayExit(args: string[]) {
-  await expect(runGatewayCommand(args)).rejects.toThrow("__exit__:1");
+async function expectGatewayExit(args: string[], code = 1) {
+  await expect(runGatewayCommand(args)).rejects.toThrow(`__exit__:${code}`);
 }
 
 describe("gateway-cli coverage", () => {
@@ -209,13 +209,28 @@ describe("gateway-cli coverage", () => {
     }
   });
 
-  it("prints stop hints on GatewayLockError when service is loaded", async () => {
+  it("treats already-running GatewayLockError as idempotent success", async () => {
     resetRuntimeCapture();
     serviceIsLoaded.mockResolvedValue(true);
 
     const { GatewayLockError } = await import("../infra/gateway-lock.js");
     startGatewayServer.mockRejectedValueOnce(
-      new GatewayLockError("another gateway instance is already listening"),
+      new GatewayLockError("gateway already running (pid 4321); lock timeout after 5000ms"),
+    );
+    await expectGatewayExit(["gateway", "--token", "test-token", "--allow-unconfigured"], 0);
+
+    expect(startGatewayServer).toHaveBeenCalled();
+    expect(runtimeLogs.join("\n")).toContain("Gateway already running:");
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("prints stop hints on non-idempotent GatewayLockError when service is loaded", async () => {
+    resetRuntimeCapture();
+    serviceIsLoaded.mockResolvedValue(true);
+
+    const { GatewayLockError } = await import("../infra/gateway-lock.js");
+    startGatewayServer.mockRejectedValueOnce(
+      new GatewayLockError("failed to acquire gateway lock at /tmp/openclaw-gateway.lock"),
     );
     await expectGatewayExit(["gateway", "--token", "test-token", "--allow-unconfigured"]);
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -113,6 +113,11 @@ function formatModeErrorList<T extends string>(modes: readonly T[]): string {
   return `${quoted.slice(0, -1).join(", ")}, or ${quoted[quoted.length - 1]}`;
 }
 
+function isGatewayAlreadyRunningLockError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes("gateway already running") || normalized.includes("already listening");
+}
+
 function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): GatewayRunOpts {
   const resolved: GatewayRunOpts = { ...opts };
 
@@ -365,6 +370,11 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       (err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
     ) {
       const errMessage = describeUnknownError(err);
+      if (isGatewayAlreadyRunningLockError(errMessage)) {
+        defaultRuntime.log(`Gateway already running: ${errMessage}`);
+        defaultRuntime.exit(0);
+        return;
+      }
       defaultRuntime.error(
         `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
       );


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway` exits with code `1` on `GatewayLockError` even when the gateway is already running.
- Why it matters: Automation/boot flows that call gateway start as an "ensure running" step treat this as failure and can loop/retry unnecessarily.
- What changed: Added an idempotency path for `GatewayLockError` messages indicating an already-running/listening gateway, logging informational output and exiting `0`.
- What did NOT change (scope boundary): Non-idempotent lock/start errors still fail with exit `1`, diagnostics, and stop hints.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30532
- Related #

## User-visible / Behavior Changes

- `openclaw gateway` now returns exit `0` when startup fails only because another gateway instance is already running/listening.
- Existing hard-failure path for other lock errors remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway CLI
- Relevant config (redacted): default gateway CLI test harness

### Steps

1. Mock gateway startup to throw `GatewayLockError("gateway already running ...")`.
2. Run `gateway` CLI command path.
3. Assert exit code is `0` and output is informational (no error logs).
4. Mock non-idempotent `GatewayLockError` and assert existing failure behavior remains.

### Expected

- Already-running lock error exits successfully (`0`).
- Non-idempotent lock error still exits with failure (`1`) + stop hint.

### Actual

- Matches expected with updated test coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

- `pnpm vitest src/cli/gateway-cli.coverage.test.ts`
- `pnpm vitest src/cli/gateway-cli/run.option-collisions.test.ts`
- `pnpm oxfmt --check CHANGELOG.md src/cli/gateway-cli/run.ts src/cli/gateway-cli.coverage.test.ts`
- `pnpm oxlint --type-aware src/cli/gateway-cli/run.ts src/cli/gateway-cli.coverage.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `GatewayLockError` containing `gateway already running` now exits with code `0` and logs an informational message.
  - Non-idempotent `GatewayLockError` still reports failure with stop guidance.
- Edge cases checked:
  - Generic lock error string is still treated as failure.
  - Existing CLI coverage tests remain green.
- What you did **not** verify:
  - Live systemd-managed restart loop in a production-like host environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore:
  - `src/cli/gateway-cli/run.ts`
  - `src/cli/gateway-cli.coverage.test.ts`
- Known bad symptoms reviewers should watch for:
  - Lock errors that should fail now silently pass.
  - Gateway command returns `0` for non-idempotent startup failures.

## Risks and Mitigations

- Risk: Over-broad message matching could classify a real failure as idempotent success.
  - Mitigation: Matching is restricted to explicit already-running/listening phrases; non-matching lock errors preserve existing failure path and diagnostics.

---

AI-assisted: Yes (Codex).  
Testing degree: Fully tested for touched scope.
