### PR TITLE
fix(hooks): emit gateway:startup after plugin services load to prevent race

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -139,17 +139,6 @@ export async function startGatewaySidecars(params: {
     );
   }
 
-  if (params.cfg.hooks?.internal?.enabled) {
-    setTimeout(() => {
-      const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
-        cfg: params.cfg,
-        deps: params.deps,
-        workspaceDir: params.defaultWorkspaceDir,
-      });
-      void triggerInternalHook(hookEvent);
-    }, 250);
-  }
-
   let pluginServices: PluginServicesHandle | null = null;
   try {
     pluginServices = await startPluginServices({
@@ -159,6 +148,17 @@ export async function startGatewaySidecars(params: {
     });
   } catch (err) {
     params.log.warn(`plugin services failed to start: ${String(err)}`);
+  }
+
+  // Emit the gateway:startup hook event AFTER plugin services (which load hooks)
+  // have started, so that hooks like boot-md are already registered (#30257).
+  if (params.cfg.hooks?.internal?.enabled) {
+    const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+      cfg: params.cfg,
+      deps: params.deps,
+      workspaceDir: params.defaultWorkspaceDir,
+    });
+    void triggerInternalHook(hookEvent);
   }
 
   if (params.cfg.acp?.enabled) {


### PR DESCRIPTION
## Problem
The `boot-md` hook registers for the `gateway:startup` event, but the hook loader completes registration after the startup event has already been emitted. The hook never fires.

The root cause: `server-startup.ts` emits `gateway:startup` via `setTimeout(250)` before `startPluginServices()` (which loads hooks) has completed.

Fixes #30257

## Changes
- Moved `gateway:startup` hook event emission to after `startPluginServices()` completes
- Removed the `setTimeout(250)` hack — the event now fires synchronously after plugins/hooks are loaded
- This ensures all hooks (including `boot-md`) are registered before the startup event is emitted

## Impact
- `boot-md` and other `gateway:startup` hooks will now fire reliably
- No behavioral change for setups without hooks