### PR TITLE
fix(onboarding): separate OpenAI API key and Codex OAuth groups [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Onboarding/Auth choice grouping: split OpenAI API key (`openai`) and OpenAI Codex OAuth (`openai-codex`) into separate provider groups so setup no longer implies one credential path covers both auth providers. (#30533)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -80,4 +80,16 @@ describe("buildAuthChoiceOptions", () => {
     expect(chutesGroup).toBeDefined();
     expect(chutesGroup?.options.some((opt) => opt.value === "chutes")).toBe(true);
   });
+
+  it("separates OpenAI API key and OpenAI Codex OAuth groups", () => {
+    const { groups } = buildAuthChoiceGroups({
+      store: EMPTY_STORE,
+      includeSkip: false,
+    });
+    const openaiApiGroup = groups.find((group) => group.value === "openai-api-key");
+    const openaiCodexGroup = groups.find((group) => group.value === "openai-codex");
+
+    expect(openaiApiGroup?.options.map((opt) => opt.value)).toEqual(["openai-api-key"]);
+    expect(openaiCodexGroup?.options.map((opt) => opt.value)).toEqual(["openai-codex"]);
+  });
 });

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -24,10 +24,16 @@ const AUTH_CHOICE_GROUP_DEFS: {
   choices: AuthChoice[];
 }[] = [
   {
-    value: "openai",
-    label: "OpenAI",
-    hint: "Codex OAuth + API key",
-    choices: ["openai-codex", "openai-api-key"],
+    value: "openai-api-key",
+    label: "OpenAI API",
+    hint: "API key (provider: openai)",
+    choices: ["openai-api-key"],
+  },
+  {
+    value: "openai-codex",
+    label: "OpenAI Codex",
+    hint: "ChatGPT OAuth (provider: openai-codex)",
+    choices: ["openai-codex"],
   },
   {
     value: "anthropic",

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -53,6 +53,8 @@ export type AuthChoice =
   | "skip";
 export type AuthChoiceGroupId =
   | "openai"
+  | "openai-api-key"
+  | "openai-codex"
   | "anthropic"
   | "chutes"
   | "vllm"


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Onboarding grouped `openai-api-key` and `openai-codex` under one "OpenAI" bucket, which can imply one credential path covers both providers.
- Why it matters: `openai` (API key) and `openai-codex` (OAuth) are distinct auth providers; grouped presentation can lead to partial setup confusion.
- What changed: Split onboarding auth-choice groups into separate provider buckets: `OpenAI API` (`openai-api-key`) and `OpenAI Codex` (`openai-codex`) with explicit provider hints.
- What did NOT change (scope boundary): No auth backend logic changed; no token/OAuth storage changes; no model resolution behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30533
- Related #

## User-visible / Behavior Changes

- Grouped provider selection now shows separate entries for:
  - `OpenAI API` (API key, provider `openai`)
  - `OpenAI Codex` (ChatGPT OAuth, provider `openai-codex`)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Onboarding/auth choice prompt
- Relevant config (redacted): default auth-choice catalog

### Steps

1. Build grouped auth options from `buildAuthChoiceGroups(...)`.
2. Verify OpenAI API key and OpenAI Codex OAuth are emitted in separate groups.
3. Verify existing auth-choice tests still pass.

### Expected

- Distinct groups for API key vs Codex OAuth.
- Existing auth-choice behavior remains stable.

### Actual

- Matches expected in updated tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

- `pnpm vitest src/commands/auth-choice-options.test.ts`
- `pnpm vitest src/commands/auth-choice.test.ts`
- `pnpm oxfmt --check CHANGELOG.md src/commands/auth-choice-options.ts src/commands/auth-choice-options.test.ts src/commands/onboard-types.ts`
- `pnpm oxlint --type-aware src/commands/auth-choice-options.ts src/commands/auth-choice-options.test.ts src/commands/onboard-types.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Grouping now separates OpenAI API key and OpenAI Codex OAuth.
  - Each group maps to exactly one auth choice.
- Edge cases checked:
  - Existing grouped provider entries still build correctly.
  - Existing auth-choice suite remains green.
- What you did **not** verify:
  - Full interactive CLI walkthrough against live OAuth endpoints.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore:
  - `src/commands/auth-choice-options.ts`
  - `src/commands/onboard-types.ts`
  - `src/commands/auth-choice-options.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing OpenAI group entries in provider selection.
  - Auth choice prompt not rendering expected options.

## Risks and Mitigations

- Risk: Other code paths might assume a single `openai` group id.
  - Mitigation: Added new group ids while retaining existing `openai` type member for compatibility; covered grouping output with regression test.

---

AI-assisted: Yes (Codex).  
Testing degree: Fully tested for touched scope.
