### PR TITLE
fix(discord): allowlist Discord CDN hostnames in SSRF policy for media downloads

### DIFF
--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -5,6 +5,20 @@ import { logVerbose } from "../../globals.js";
 import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
 
+/**
+ * SSRF policy for Discord CDN/media downloads.
+ *
+ * Discord attachment URLs point to cdn.discordapp.com and media.discordapp.net.
+ * On networks using proxy tools with fake-ip mode (e.g. Surge, Clash), these
+ * hostnames may resolve to RFC 2544 benchmark addresses (198.18.0.0/15) which
+ * are blocked by default SSRF protection.  Explicitly allowlisting Discord
+ * media hostnames ensures attachments can be downloaded regardless of local DNS
+ * resolution behavior.
+ */
+const DISCORD_MEDIA_SSRF_POLICY = {
+  hostnameAllowlist: ["cdn.discordapp.com", "media.discordapp.net"],
+};
+
 export type DiscordMediaInfo = {
   path: string;
   contentType?: string;
@@ -228,6 +242,7 @@ async function appendResolvedMediaFromAttachments(params: {
         filePathHint: attachment.filename ?? attachment.url,
         maxBytes: params.maxBytes,
         fetchImpl: params.fetchImpl,
+        ssrfPolicy: DISCORD_MEDIA_SSRF_POLICY,
       });
       const saved = await saveMediaBuffer(
         fetched.buffer,
@@ -320,6 +335,7 @@ async function appendResolvedMediaFromStickers(params: {
           filePathHint: candidate.fileName,
           maxBytes: params.maxBytes,
           fetchImpl: params.fetchImpl,
+          ssrfPolicy: DISCORD_MEDIA_SSRF_POLICY,
         });
         const saved = await saveMediaBuffer(
           fetched.buffer,


### PR DESCRIPTION
## Problem

Discord attachment downloads (images, PDFs, voice messages, stickers) fail silently on networks using proxy tools with **fake-ip mode** (Surge, Clash, etc.).

These tools resolve `cdn.discordapp.com` and `media.discordapp.net` to RFC 2544 benchmark addresses (`198.18.0.0/15`), which are blocked by the default SSRF protection in `fetchRemoteMedia()`.

**Gateway error log:**
```
[security] blocked URL fetch (url-fetch) target=https://cdn.discordapp.com/attachments/.../-_wentong.pdf
reason=Blocked: resolves to private/internal/special-use IP address
```

**Impact:** No attachments are downloaded to `media/inbound/`, so the agent never sees any file content — not just PDFs, but also images, voice messages, and stickers sent via Discord.

## Root Cause

`appendResolvedMediaFromAttachments()` and `appendResolvedMediaFromStickers()` in `message-utils.ts` call `fetchRemoteMedia()` without specifying an `ssrfPolicy`. The default policy blocks all private/special-use IP ranges, including `198.18.0.0/15`.

## Fix

Add a `hostnameAllowlist` for Discord CDN domains (`cdn.discordapp.com`, `media.discordapp.net`) to the SSRF policy passed to `fetchRemoteMedia()` in both the attachment and sticker download paths.

This is a minimal, targeted change — only Discord media downloads are affected, and only the two known Discord CDN hostnames are allowlisted.

## Changes

- `src/discord/monitor/message-utils.ts`: Add `DISCORD_MEDIA_SSRF_POLICY` constant and pass it to both `fetchRemoteMedia()` call sites.
