### PR TITLE
fix: make gateway command idempotent when already running

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -365,6 +365,23 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       (err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
     ) {
       const errMessage = describeUnknownError(err);
+      const isAlreadyRunning = errMessage.includes("already running");
+      if (isAlreadyRunning) {
+        // Idempotent behavior: gateway already running is a success state
+        defaultRuntime.log(`Gateway is already running and healthy.`);
+        try {
+          const diagnostics = await inspectPortUsage(port);
+          if (diagnostics.status === "busy") {
+            for (const line of formatPortDiagnostics(diagnostics)) {
+              defaultRuntime.log(line);
+            }
+          }
+        } catch {
+          // ignore diagnostics failures
+        }
+        defaultRuntime.exit(0);
+        return;
+      }
       defaultRuntime.error(
         `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
       );


### PR DESCRIPTION
## Summary

Fixes #30532

When `openclaw gateway` (or `openclaw gateway run`) is called while the gateway is already running, it now exits with **code 0** instead of code 1.

## Problem

Previously:
- Exit code 1 with error message `gateway already running`
- Agents interpret this as failure and retry
- This caused retry loops that burned API credits

## Solution

Now:
- Exit code 0 with informational message `Gateway is already running and healthy.`
- Gateway already running = goal state achieved = success

## Impact

This prevents the agent retry loop described in the issue where:
1. Gateway restart fires `gateway:startup` boot run
2. Boot run agent calls `openclaw gateway` to verify gateway is running
3. Command returned exit 1 → agent loops and retries
4. Each retry burns API credits

## Test Plan

```bash
# Start gateway
openclaw gateway run &

# While running, call again
openclaw gateway
# Expected: exit 0, message "Gateway is already running and healthy."

# Verify exit code
echo $?  # Should be 0
```

## Checklist

- [x] Code changes are minimal and focused
- [x] Maintains backward compatibility (only changes exit code for already-running case)
- [x] Follows project coding style