### PR TITLE
fix(agents): keep manual model selection as primary candidate

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -990,6 +990,39 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5");
     });
 
+    it("tries the pinned primary model before fallback during cooldown", async () => {
+      const { dir } = await makeAuthStoreWithCooldown("anthropic", "rate_limit");
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("still cooling down"))
+        .mockResolvedValueOnce("sonnet success");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        run,
+        agentDir: dir,
+        pinPrimaryCandidate: true,
+      });
+
+      expect(result.result).toBe("sonnet success");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6");
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5");
+    });
+
     it("skips same-provider models on auth cooldown but still tries no-profile fallback providers", async () => {
       const { dir } = await makeAuthStoreWithCooldown("anthropic", "auth");
       const cfg = makeCfg({

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -322,6 +322,7 @@ function resolveCooldownDecision(params: {
   candidate: ModelCandidate;
   isPrimary: boolean;
   requestedModel: boolean;
+  pinPrimaryCandidate: boolean;
   hasFallbackCandidates: boolean;
   now: number;
   probeThrottleKey: string;
@@ -359,7 +360,7 @@ function resolveCooldownDecision(params: {
   // For same-provider fallbacks: only relax cooldown on rate_limit, which
   // is commonly model-scoped and can recover on a sibling model.
   const shouldAttemptDespiteCooldown =
-    (params.isPrimary && (!params.requestedModel || shouldProbe)) ||
+    (params.isPrimary && (params.pinPrimaryCandidate || !params.requestedModel || shouldProbe)) ||
     (!params.isPrimary && inferredReason === "rate_limit");
   if (!shouldAttemptDespiteCooldown) {
     return {
@@ -381,6 +382,11 @@ export async function runWithModelFallback<T>(params: {
   provider: string;
   model: string;
   agentDir?: string;
+  /**
+   * When true, always attempt the requested primary candidate for this run
+   * even if the provider is currently in cooldown, then continue fallback.
+   */
+  pinPrimaryCandidate?: boolean;
   /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
   fallbacksOverride?: string[];
   run: (provider: string, model: string) => Promise<T>;
@@ -421,6 +427,7 @@ export async function runWithModelFallback<T>(params: {
           candidate,
           isPrimary,
           requestedModel,
+          pinPrimaryCandidate: params.pinPrimaryCandidate === true,
           hasFallbackCandidates,
           now,
           probeThrottleKey,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -91,6 +91,7 @@ export async function runAgentTurnWithFallback(params: {
   resetSessionAfterCompactionFailure: (reason: string) => Promise<boolean>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
+  pinPrimaryCandidate?: boolean;
   sessionKey?: string;
   getActiveSessionEntry: () => SessionEntry | undefined;
   activeSessionStore?: Record<string, SessionEntry>;
@@ -182,6 +183,7 @@ export async function runAgentTurnWithFallback(params: {
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
+        pinPrimaryCandidate: params.pinPrimaryCandidate === true,
         run: (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -738,6 +738,43 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("pins the selected primary model when session has a model override", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      providerOverride: "google",
+      modelOverride: "gemini-3-flash-preview",
+    };
+    const sessionStore = { main: sessionEntry };
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const fallbackSpy = vi.spyOn(modelFallbackModule, "runWithModelFallback");
+    try {
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        runOverrides: {
+          provider: "google",
+          model: "gemini-3-flash-preview",
+        },
+      });
+      await run();
+      expect(fallbackSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "google",
+          model: "gemini-3-flash-preview",
+          pinPrimaryCandidate: true,
+        }),
+      );
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
   it("announces model fallback only once per active fallback state", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -381,6 +381,7 @@ export async function runReplyAgent(params: {
       resetSessionAfterCompactionFailure,
       resetSessionAfterRoleOrderingConflict,
       isHeartbeat,
+      pinPrimaryCandidate: Boolean(activeSessionEntry?.modelOverride?.trim()),
       sessionKey,
       getActiveSessionEntry: () => activeSessionEntry,
       activeSessionStore,


### PR DESCRIPTION
## Summary

- **Problem:** after users explicitly switch model via `/model`, provider cooldown logic can skip the selected primary candidate on later turns and start directly on fallback models.
- **Why it matters:** this looks like an unsolicited model switch and breaks user expectations that manual model selection remains authoritative.
- **What changed:** added a `pinPrimaryCandidate` path so sessions with explicit `modelOverride` always attempt the selected primary model first for the current turn, then continue normal fallback behavior if it fails.
- **What did NOT change:** fallback chains, cooldown checks, and non-manual/default model behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30483

## User-visible / Behavior Changes

- When a session has an explicit `/model` override, OpenClaw attempts that selected model first even under provider cooldown.
- If that attempt fails, standard fallback flow still runs in the same turn.
- This removes apparent cross-provider “auto switch” between turns for manually selected models.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js + pnpm
- Integration/channel: auto-reply agent runner / model fallback

### Steps

1. Set a manual model override in session (equivalent to `/model provider/model`).
2. Put provider profiles into cooldown (or mock cooldown state).
3. Run a turn and observe fallback candidate ordering.

### Expected

- Selected manual model is attempted first for that turn, then fallback candidates are tried.

### Actual

- Before fix: selected model could be skipped immediately under cooldown.
- After fix: selected model is attempted first when session override is present.

## Evidence

- Ran targeted tests:
  - `pnpm exec vitest run src/agents/model-fallback.test.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts`
- Result: `2 passed`, `83 passed` tests.
- Added regressions for:
  - pinned primary attempt under cooldown in `src/agents/model-fallback.test.ts`
  - auto-reply passing pin flag when `modelOverride` exists in `src/auto-reply/reply/agent-runner.runreplyagent.test.ts`

## Human Verification (required)

- Verified scenarios: cooldown + pinned override ordering; fallback continuation; runner wiring of pin flag.
- Edge cases checked: existing cooldown fallback behavior without pin remains intact.
- What I did **not** verify: live Telegram end-to-end reproduction against production provider cooldown windows.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/agents/model-fallback.ts`, `src/auto-reply/reply/agent-runner*.ts` and related tests.
- Known bad symptoms: selected model may again be skipped at turn start during cooldown.

## Risks and Mitigations

- Risk: temporary extra request load when pinned selected model is known-cooldown.
- Mitigation: pin applies only to sessions with explicit `modelOverride`; fallback and error handling remain unchanged.
