### PR TITLE
feat(telegram): add pin/unpin message actions [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
+- Telegram/Message actions: add Telegram `pin` and `unpin` channel actions with message-action adapter routing, per-account `actions.pins` gating, and regression coverage for action mapping and send helpers. (#30518)
 
 ## 2026.2.26
 

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -13,6 +13,8 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const pinMessageTelegram = vi.fn(async () => ({ ok: true }));
+const unpinMessageTelegram = vi.fn(async () => ({ ok: true }));
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -24,6 +26,10 @@ vi.mock("../../telegram/send.js", () => ({
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
     deleteMessageTelegram(...args),
+  pinMessageTelegram: (...args: Parameters<typeof pinMessageTelegram>) =>
+    pinMessageTelegram(...args),
+  unpinMessageTelegram: (...args: Parameters<typeof unpinMessageTelegram>) =>
+    unpinMessageTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -67,6 +73,8 @@ describe("handleTelegramAction", () => {
     sendMessageTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    pinMessageTelegram.mockClear();
+    unpinMessageTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -415,6 +423,62 @@ describe("handleTelegramAction", () => {
         cfg,
       ),
     ).rejects.toThrow(/Telegram deleteMessage is disabled/);
+  });
+
+  it("pins a message", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+    await handleTelegramAction(
+      {
+        action: "pinMessage",
+        chatId: "123",
+        messageId: 456,
+      },
+      cfg,
+    );
+    expect(pinMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      expect.objectContaining({ token: "tok" }),
+    );
+  });
+
+  it("unpins a message", async () => {
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+    await handleTelegramAction(
+      {
+        action: "unpinMessage",
+        chatId: "123",
+        messageId: 456,
+      },
+      cfg,
+    );
+    expect(unpinMessageTelegram).toHaveBeenCalledWith(
+      "123",
+      456,
+      expect.objectContaining({ token: "tok" }),
+    );
+  });
+
+  it("respects pins gating", async () => {
+    const cfg = {
+      channels: {
+        telegram: { botToken: "tok", actions: { pins: false } },
+      },
+    } as OpenClawConfig;
+    await expect(
+      handleTelegramAction(
+        {
+          action: "pinMessage",
+          chatId: "123",
+          messageId: 456,
+        },
+        cfg,
+      ),
+    ).rejects.toThrow(/Telegram pins are disabled/);
   });
 
   it("throws on missing bot token for sendMessage", async () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -11,9 +11,11 @@ import {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editMessageTelegram,
+  pinMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
+  unpinMessageTelegram,
 } from "../../telegram/send.js";
 import { getCacheStats, searchStickers } from "../../telegram/sticker-cache.js";
 import { resolveTelegramToken } from "../../telegram/token.js";
@@ -310,6 +312,38 @@ export async function handleTelegramAction(
       messageId: result.messageId,
       chatId: result.chatId,
     });
+  }
+
+  if (action === "pinMessage" || action === "unpinMessage") {
+    if (!isActionEnabled("pins")) {
+      throw new Error("Telegram pins are disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const messageId = readNumberParam(params, "messageId", {
+      required: true,
+      integer: true,
+    });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    if (action === "pinMessage") {
+      await pinMessageTelegram(chatId ?? "", messageId ?? 0, {
+        token,
+        accountId: accountId ?? undefined,
+        silent: typeof params.silent === "boolean" ? params.silent : undefined,
+      });
+    } else {
+      await unpinMessageTelegram(chatId ?? "", messageId ?? 0, {
+        token,
+        accountId: accountId ?? undefined,
+      });
+    }
+    return jsonResult({ ok: true });
   }
 
   if (action === "sendSticker") {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -460,6 +460,7 @@ describe("telegramMessageActions", () => {
         name: "default config",
         cfg: telegramCfg(),
         expectSticker: false,
+        expectPins: true,
       },
       {
         name: "per-account sticker enabled",
@@ -473,6 +474,7 @@ describe("telegramMessageActions", () => {
           },
         } as OpenClawConfig,
         expectSticker: true,
+        expectPins: true,
       },
       {
         name: "all accounts omit sticker",
@@ -487,6 +489,20 @@ describe("telegramMessageActions", () => {
           },
         } as OpenClawConfig,
         expectSticker: false,
+        expectPins: true,
+      },
+      {
+        name: "pins disabled globally",
+        cfg: {
+          channels: {
+            telegram: {
+              botToken: "tok",
+              actions: { pins: false },
+            },
+          },
+        } as OpenClawConfig,
+        expectSticker: false,
+        expectPins: false,
       },
     ] as const;
 
@@ -498,6 +514,13 @@ describe("telegramMessageActions", () => {
       } else {
         expect(actions, testCase.name).not.toContain("sticker");
         expect(actions, testCase.name).not.toContain("sticker-search");
+      }
+      if (testCase.expectPins) {
+        expect(actions, testCase.name).toContain("pin");
+        expect(actions, testCase.name).toContain("unpin");
+      } else {
+        expect(actions, testCase.name).not.toContain("pin");
+        expect(actions, testCase.name).not.toContain("unpin");
       }
     }
   });
@@ -566,6 +589,37 @@ describe("telegramMessageActions", () => {
           name: "Build Updates",
           iconColor: undefined,
           iconCustomEmojiId: undefined,
+          accountId: undefined,
+        },
+      },
+      {
+        name: "pin maps to pinMessage",
+        action: "pin" as const,
+        params: {
+          channelId: "123",
+          messageId: 42,
+          silent: true,
+        },
+        expectedPayload: {
+          action: "pinMessage",
+          chatId: "123",
+          messageId: 42,
+          silent: true,
+          accountId: undefined,
+        },
+      },
+      {
+        name: "unpin maps to unpinMessage",
+        action: "unpin" as const,
+        params: {
+          chatId: "123",
+          messageId: 42,
+        },
+        expectedPayload: {
+          action: "unpinMessage",
+          chatId: "123",
+          messageId: 42,
+          silent: undefined,
           accountId: undefined,
         },
       },

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -86,6 +86,10 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("editMessage")) {
       actions.add("edit");
     }
+    if (isEnabled("pins")) {
+      actions.add("pin");
+      actions.add("unpin");
+    }
     if (isEnabled("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
@@ -167,6 +171,22 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           messageId,
           content: message,
           buttons,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "pin" || action === "unpin") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageId = readTelegramMessageIdParam(params);
+      return await handleTelegramAction(
+        {
+          action: action === "pin" ? "pinMessage" : "unpinMessage",
+          chatId,
+          messageId,
+          silent: typeof params.silent === "boolean" ? params.silent : undefined,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -16,6 +16,8 @@ export type TelegramActionConfig = {
   sendMessage?: boolean;
   deleteMessage?: boolean;
   editMessage?: boolean;
+  /** Enable pin and unpin actions. */
+  pins?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
   /** Enable forum topic creation. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -205,6 +205,7 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        pins: z.boolean().optional(),
         sticker: z.boolean().optional(),
       })
       .strict()

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -15,10 +15,12 @@ const {
   buildInlineKeyboard,
   createForumTopicTelegram,
   editMessageTelegram,
+  pinMessageTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
   sendPollTelegram,
   sendStickerTelegram,
+  unpinMessageTelegram,
 } = await importTelegramSendModule();
 
 async function expectChatNotFoundWithChatId(
@@ -1205,6 +1207,53 @@ describe("reactMessageTelegram", () => {
         resolvedChatId: "-100123",
       }),
     );
+  });
+});
+
+describe("pin/unpin message actions", () => {
+  it("pins a message", async () => {
+    const pinChatMessage = vi.fn().mockResolvedValue(true);
+    const api = { pinChatMessage } as unknown as {
+      pinChatMessage: typeof pinChatMessage;
+    };
+
+    await pinMessageTelegram("123", 456, {
+      token: "tok",
+      api,
+    });
+
+    expect(pinChatMessage).toHaveBeenCalledWith("123", 456, undefined);
+  });
+
+  it("forwards disable_notification when pinning silently", async () => {
+    const pinChatMessage = vi.fn().mockResolvedValue(true);
+    const api = { pinChatMessage } as unknown as {
+      pinChatMessage: typeof pinChatMessage;
+    };
+
+    await pinMessageTelegram("123", 456, {
+      token: "tok",
+      api,
+      silent: true,
+    });
+
+    expect(pinChatMessage).toHaveBeenCalledWith("123", 456, {
+      disable_notification: true,
+    });
+  });
+
+  it("unpins a message", async () => {
+    const unpinChatMessage = vi.fn().mockResolvedValue(true);
+    const api = { unpinChatMessage } as unknown as {
+      unpinChatMessage: typeof unpinChatMessage;
+    };
+
+    await unpinMessageTelegram("123", 456, {
+      token: "tok",
+      api,
+    });
+
+    expect(unpinChatMessage).toHaveBeenCalledWith("123", 456);
   });
 });
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -829,6 +829,86 @@ export async function deleteMessageTelegram(
   return { ok: true };
 }
 
+type TelegramPinOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  /** Send pin notification silently. */
+  silent?: boolean;
+};
+
+export async function pinMessageTelegram(
+  chatIdInput: string | number,
+  messageIdInput: string | number,
+  opts: TelegramPinOpts = {},
+): Promise<{ ok: true }> {
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const rawTarget = String(chatIdInput);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: rawTarget,
+    persistTarget: rawTarget,
+    verbose: opts.verbose,
+  });
+  const messageId = normalizeMessageId(messageIdInput);
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  await requestWithDiag(
+    () =>
+      api.pinChatMessage(
+        chatId,
+        messageId,
+        opts.silent === true ? { disable_notification: true } : undefined,
+      ),
+    "pinMessage",
+  );
+  logVerbose(`[telegram] Pinned message ${messageId} in chat ${chatId}`);
+  return { ok: true };
+}
+
+type TelegramUnpinOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+};
+
+export async function unpinMessageTelegram(
+  chatIdInput: string | number,
+  messageIdInput?: string | number,
+  opts: TelegramUnpinOpts = {},
+): Promise<{ ok: true }> {
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const rawTarget = String(chatIdInput);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: rawTarget,
+    persistTarget: rawTarget,
+    verbose: opts.verbose,
+  });
+  const messageId = messageIdInput === undefined ? undefined : normalizeMessageId(messageIdInput);
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  await requestWithDiag(() => api.unpinChatMessage(chatId, messageId), "unpinMessage");
+  logVerbose(`[telegram] Unpinned message ${messageId ?? "(latest)"} in chat ${chatId}`);
+  return { ok: true };
+}
+
 type TelegramEditOpts = {
   token?: string;
   accountId?: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram message actions supported send/react/edit/delete/sticker/topic-create but did not expose pin/unpin actions.
- Why it matters: Agents maintaining pinned dashboards/messages in Telegram required manual intervention.
- What changed: Added Telegram `pin`/`unpin` channel actions, action routing to `pinMessage`/`unpinMessage`, send-layer helpers (`pinMessageTelegram`/`unpinMessageTelegram`), config gate key `channels.telegram.actions.pins`, and regression coverage.
- What did NOT change (scope boundary): Did not add list-pins for Telegram, and did not alter existing behavior for other Telegram actions.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30518
- Related #N/A

## User-visible / Behavior Changes

- Telegram channel action adapter now advertises `pin` and `unpin` when Telegram account/action gating allows it.
- Telegram message actions now route `pin`/`unpin` to Telegram Bot API `pinChatMessage`/`unpinChatMessage`.
- New Telegram action gate config key: `channels.telegram.actions.pins` (default enabled).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Adds two outbound Telegram Bot API operations (pin/unpin) behind existing authenticated bot token flows and per-action gating (`actions.pins`), with focused tests for routing and gating behavior.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm test runtime
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.botToken`, optional `channels.telegram.actions.pins`

### Steps

1. Enable Telegram with bot token in config.
2. Invoke channel message action `pin` (or `unpin`) with `chatId` + `messageId`.
3. Run regression tests and lint/format checks.

### Expected

- `pin` maps to `pinMessage` and calls Telegram pin API.
- `unpin` maps to `unpinMessage` and calls Telegram unpin API.
- `actions.pins: false` blocks pin/unpin actions.

### Actual

- Matches expected behavior in adapter tests, telegram-actions tests, and send-layer tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test commands run locally:

- `pnpm vitest src/agents/tools/telegram-actions.test.ts src/channels/plugins/actions/actions.test.ts src/telegram/send.test.ts`
- `pnpm oxfmt --check src/config/types.telegram.ts src/config/zod-schema.providers-core.ts src/telegram/send.ts src/agents/tools/telegram-actions.ts src/channels/plugins/actions/telegram.ts src/agents/tools/telegram-actions.test.ts src/channels/plugins/actions/actions.test.ts src/telegram/send.test.ts CHANGELOG.md`
- `pnpm oxlint --type-aware src/agents/tools/telegram-actions.ts src/channels/plugins/actions/telegram.ts src/telegram/send.ts src/agents/tools/telegram-actions.test.ts src/channels/plugins/actions/actions.test.ts src/telegram/send.test.ts src/config/types.telegram.ts src/config/zod-schema.providers-core.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: adapter action list includes/excludes pin/unpin based on config gate; adapter correctly maps `pin`/`unpin`; action handler calls pin/unpin send helpers; send helpers call expected Telegram API methods including silent pin option.
- Edge cases checked: global `actions.pins=false` gate rejection, silent pin option forwarding.
- What you did **not** verify: live Telegram network call against a real bot/chat in this local run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - Optional: set `channels.telegram.actions.pins: false` to disable these actions.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `channels.telegram.actions.pins: false` or revert this PR.
- Files/config to restore: Telegram action adapter and telegram action/send helpers touched in this PR.
- Known bad symptoms reviewers should watch for: unexpected pin/unpin availability when gating should disable.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Pin/unpin actions exposed where operators do not want them.
  - Mitigation: Explicit `channels.telegram.actions.pins` gate (top-level/per-account) with test coverage.
- Risk: Mapping regression between adapter and telegram-actions payload.
  - Mitigation: Added adapter mapping tests and telegram-actions unit tests for pin/unpin.

AI-assisted: Yes (implementation and tests authored with AI assistance).
