### PR TITLE
feat(telegram): send native location pins [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
+- Telegram/Location sends: route `message(action=send, location="lat,lng")` through Telegram native `sendLocation`, including coordinate validation, action-adapter routing, and regression coverage. (#30394)
 
 ## 2026.2.26
 

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -8,6 +8,10 @@ const sendMessageTelegram = vi.fn(async () => ({
   messageId: "789",
   chatId: "123",
 }));
+const sendLocationTelegram = vi.fn(async () => ({
+  messageId: "321",
+  chatId: "123",
+}));
 const sendStickerTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
@@ -20,6 +24,8 @@ vi.mock("../../telegram/send.js", () => ({
     reactMessageTelegram(...args),
   sendMessageTelegram: (...args: Parameters<typeof sendMessageTelegram>) =>
     sendMessageTelegram(...args),
+  sendLocationTelegram: (...args: Parameters<typeof sendLocationTelegram>) =>
+    sendLocationTelegram(...args),
   sendStickerTelegram: (...args: Parameters<typeof sendStickerTelegram>) =>
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
@@ -65,6 +71,7 @@ describe("handleTelegramAction", () => {
     envSnapshot = captureEnv(["TELEGRAM_BOT_TOKEN"]);
     reactMessageTelegram.mockClear();
     sendMessageTelegram.mockClear();
+    sendLocationTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
@@ -279,6 +286,56 @@ describe("handleTelegramAction", () => {
       type: "text",
       text: expect.stringContaining('"ok": true'),
     });
+  });
+
+  it("sends a native location pin", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendLocation",
+        to: "@testchannel",
+        location: "37.7749,-122.4194",
+      },
+      telegramConfig(),
+    );
+
+    expect(sendLocationTelegram).toHaveBeenCalledWith(
+      "@testchannel",
+      37.7749,
+      -122.4194,
+      expect.objectContaining({ token: "tok" }),
+    );
+  });
+
+  it("sends optional text after location when content is provided", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendLocation",
+        to: "@testchannel",
+        location: "37.7749,-122.4194",
+        content: "Meet me here",
+      },
+      telegramConfig(),
+    );
+
+    expect(sendLocationTelegram).toHaveBeenCalled();
+    expect(sendMessageTelegram).toHaveBeenCalledWith(
+      "@testchannel",
+      "Meet me here",
+      expect.objectContaining({ token: "tok" }),
+    );
+  });
+
+  it("rejects invalid location strings", async () => {
+    await expect(
+      handleTelegramAction(
+        {
+          action: "sendLocation",
+          to: "@testchannel",
+          location: "invalid-location",
+        },
+        telegramConfig(),
+      ),
+    ).rejects.toThrow(/location must be in "latitude,longitude" format/i);
   });
 
   it("forwards trusted mediaLocalRoots into sendMessageTelegram", async () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -12,6 +12,7 @@ import {
   deleteMessageTelegram,
   editMessageTelegram,
   reactMessageTelegram,
+  sendLocationTelegram,
   sendMessageTelegram,
   sendStickerTelegram,
 } from "../../telegram/send.js";
@@ -26,6 +27,7 @@ import {
 } from "./common.js";
 
 const TELEGRAM_BUTTON_STYLES: readonly TelegramButtonStyle[] = ["danger", "success", "primary"];
+const TELEGRAM_COORDS_RE = /^\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*,\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*$/;
 
 export function readTelegramButtons(
   params: Record<string, unknown>,
@@ -80,6 +82,24 @@ export function readTelegramButtons(
   });
   const filtered = rows.filter((row) => row.length > 0);
   return filtered.length > 0 ? filtered : undefined;
+}
+
+function parseTelegramLocation(input: string): { latitude: number; longitude: number } {
+  const match = TELEGRAM_COORDS_RE.exec(input);
+  if (!match) {
+    throw new Error(
+      'location must be in "latitude,longitude" format (example: "37.7749,-122.4194").',
+    );
+  }
+  const latitude = Number.parseFloat(match[1] ?? "");
+  const longitude = Number.parseFloat(match[2] ?? "");
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
+    throw new Error("location latitude must be between -90 and 90.");
+  }
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
+    throw new Error("location longitude must be between -180 and 180.");
+  }
+  return { latitude, longitude };
 }
 
 export async function handleTelegramAction(
@@ -240,6 +260,53 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+    });
+  }
+
+  if (action === "sendLocation") {
+    if (!isActionEnabled("sendMessage")) {
+      throw new Error("Telegram sendMessage is disabled.");
+    }
+    const to = readStringParam(params, "to", { required: true });
+    const location = readStringParam(params, "location", { required: true });
+    const content = readStringParam(params, "content", {
+      allowEmpty: true,
+    });
+    const replyToMessageId = readNumberParam(params, "replyToMessageId", {
+      integer: true,
+    });
+    const messageThreadId = readNumberParam(params, "messageThreadId", {
+      integer: true,
+    });
+    const { latitude, longitude } = parseTelegramLocation(location);
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const result = await sendLocationTelegram(to, latitude, longitude, {
+      token,
+      accountId: accountId ?? undefined,
+      replyToMessageId: replyToMessageId ?? undefined,
+      messageThreadId: messageThreadId ?? undefined,
+      silent: typeof params.silent === "boolean" ? params.silent : undefined,
+    });
+    if (content?.trim()) {
+      await sendMessageTelegram(to, content, {
+        token,
+        accountId: accountId ?? undefined,
+        replyToMessageId: replyToMessageId ?? undefined,
+        messageThreadId: messageThreadId ?? undefined,
+        silent: typeof params.silent === "boolean" ? params.silent : undefined,
+      });
+    }
+    return jsonResult({
+      ok: true,
+      messageId: result.messageId,
+      chatId: result.chatId,
+      latitude,
+      longitude,
     });
   }
 

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -521,6 +521,23 @@ describe("telegramMessageActions", () => {
         }),
       },
       {
+        name: "location send maps to sendLocation",
+        action: "send" as const,
+        params: {
+          to: "123",
+          location: "37.7749,-122.4194",
+          message: "Meet me here",
+          silent: true,
+        },
+        expectedPayload: expect.objectContaining({
+          action: "sendLocation",
+          to: "123",
+          location: "37.7749,-122.4194",
+          content: "Meet me here",
+          silent: true,
+        }),
+      },
+      {
         name: "silent send forwards silent flag",
         action: "send" as const,
         params: {
@@ -625,6 +642,30 @@ describe("telegramMessageActions", () => {
         accountId: undefined,
       }),
     ).rejects.toThrow();
+
+    expect(handleTelegramAction).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed location and media sends before reaching telegram-actions", async () => {
+    const cfg = telegramCfg();
+    const handleAction = telegramMessageActions.handleAction;
+    if (!handleAction) {
+      throw new Error("telegram handleAction unavailable");
+    }
+
+    await expect(
+      handleAction({
+        channel: "telegram",
+        action: "send",
+        params: {
+          to: "123",
+          location: "37.7749,-122.4194",
+          media: "https://example.com/map.png",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/location sends do not support media/i);
 
     expect(handleTelegramAction).not.toHaveBeenCalled();
   });

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -20,7 +20,11 @@ const providerId = "telegram";
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
   const mediaUrl = readStringParam(params, "media", { trim: false });
-  const message = readStringParam(params, "message", { required: !mediaUrl, allowEmpty: true });
+  const location = readStringParam(params, "location");
+  const message = readStringParam(params, "message", {
+    required: !mediaUrl && !location,
+    allowEmpty: true,
+  });
   const caption = readStringParam(params, "caption", { allowEmpty: true });
   const content = message || caption || "";
   const replyTo = readStringParam(params, "replyTo");
@@ -33,6 +37,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     to,
     content,
     mediaUrl: mediaUrl ?? undefined,
+    location: location ?? undefined,
     replyToMessageId: replyTo ?? undefined,
     messageThreadId: threadId ?? undefined,
     buttons,
@@ -110,6 +115,27 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
   handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, toolContext }) => {
     if (action === "send") {
       const sendParams = readTelegramSendParams(params);
+      if (sendParams.location && sendParams.mediaUrl) {
+        throw new Error(
+          "Telegram location sends do not support media in the same action. Send location and media separately.",
+        );
+      }
+      if (sendParams.location) {
+        return await handleTelegramAction(
+          {
+            action: "sendLocation",
+            to: sendParams.to,
+            location: sendParams.location,
+            content: sendParams.content,
+            replyToMessageId: sendParams.replyToMessageId,
+            messageThreadId: sendParams.messageThreadId,
+            silent: sendParams.silent,
+            accountId: accountId ?? undefined,
+          },
+          cfg,
+          { mediaLocalRoots },
+        );
+      }
       return await handleTelegramAction(
         {
           action: "sendMessage",

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -16,6 +16,7 @@ const {
   createForumTopicTelegram,
   editMessageTelegram,
   reactMessageTelegram,
+  sendLocationTelegram,
   sendMessageTelegram,
   sendPollTelegram,
   sendStickerTelegram,
@@ -1204,6 +1205,61 @@ describe("reactMessageTelegram", () => {
         rawTarget: "@mychannel",
         resolvedChatId: "-100123",
       }),
+    );
+  });
+});
+
+describe("sendLocationTelegram", () => {
+  it("sends a native location pin", async () => {
+    const sendLocation = vi.fn().mockResolvedValue({
+      message_id: 91,
+      chat: { id: "123" },
+    });
+    const api = { sendLocation } as unknown as {
+      sendLocation: typeof sendLocation;
+    };
+
+    const result = await sendLocationTelegram("123", 37.7749, -122.4194, {
+      token: "tok",
+      api,
+    });
+
+    expect(sendLocation).toHaveBeenCalledWith("123", 37.7749, -122.4194, undefined);
+    expect(result).toEqual({
+      messageId: "91",
+      chatId: "123",
+    });
+  });
+
+  it("forwards silent and thread options", async () => {
+    const sendLocation = vi.fn().mockResolvedValue({
+      message_id: 92,
+      chat: { id: "-1001" },
+    });
+    const api = { sendLocation } as unknown as {
+      sendLocation: typeof sendLocation;
+    };
+
+    await sendLocationTelegram("telegram:group:-1001:topic:271", 37.7749, -122.4194, {
+      token: "tok",
+      api,
+      silent: true,
+      replyToMessageId: 7,
+    });
+
+    expect(sendLocation).toHaveBeenCalledWith("-1001", 37.7749, -122.4194, {
+      message_thread_id: 271,
+      reply_to_message_id: 7,
+      disable_notification: true,
+    });
+  });
+
+  it("validates coordinate range", async () => {
+    await expect(sendLocationTelegram("123", 120, 20, { token: "tok" })).rejects.toThrow(
+      /latitude must be between -90 and 90/i,
+    );
+    await expect(sendLocationTelegram("123", 20, 200, { token: "tok" })).rejects.toThrow(
+      /longitude must be between -180 and 180/i,
     );
   });
 });

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1141,6 +1141,96 @@ export async function sendPollTelegram(
   return { messageId: String(messageId), chatId: resolvedChatId, pollId };
 }
 
+type TelegramLocationOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  /** Message ID to reply to (for threading). */
+  replyToMessageId?: number;
+  /** Forum topic thread ID (for forum supergroups). */
+  messageThreadId?: number;
+  /** Send message silently (no notification). Defaults to false. */
+  silent?: boolean;
+};
+
+/**
+ * Send a native Telegram location pin.
+ * @param to - Chat ID or username (e.g. "123456789" or "@username")
+ * @param latitude - Latitude in range [-90, 90]
+ * @param longitude - Longitude in range [-180, 180]
+ * @param opts - Optional configuration
+ */
+export async function sendLocationTelegram(
+  to: string,
+  latitude: number,
+  longitude: number,
+  opts: TelegramLocationOpts = {},
+): Promise<TelegramSendResult> {
+  if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
+    throw new Error("Telegram latitude must be between -90 and 90");
+  }
+  if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
+    throw new Error("Telegram longitude must be between -180 and 180");
+  }
+
+  const { cfg, account, api } = resolveTelegramApiContext(opts);
+  const target = parseTelegramTarget(to);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: to,
+    verbose: opts.verbose,
+  });
+
+  const threadParams = buildTelegramThreadReplyParams({
+    targetMessageThreadId: target.messageThreadId,
+    messageThreadId: opts.messageThreadId,
+    chatType: target.chatType,
+    replyToMessageId: opts.replyToMessageId,
+  });
+  const locationParams = {
+    ...(Object.keys(threadParams).length > 0 ? threadParams : {}),
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+  };
+
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+  });
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag,
+    chatId,
+    input: to,
+  });
+
+  const result = await withTelegramThreadFallback(
+    Object.keys(locationParams).length > 0 ? locationParams : undefined,
+    "location",
+    opts.verbose,
+    async (effectiveParams, label) =>
+      requestWithChatNotFound(
+        () => api.sendLocation(chatId, latitude, longitude, effectiveParams),
+        label,
+      ),
+  );
+
+  const messageId = resolveTelegramMessageIdOrThrow(result, "location send");
+  const resolvedChatId = String(result?.chat?.id ?? chatId);
+  recordSentMessage(chatId, messageId);
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+  return { messageId: String(messageId), chatId: resolvedChatId };
+}
+
 // ---------------------------------------------------------------------------
 // Forum topic creation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `message(action=send, location="lat,lng")` on Telegram did not route to native Telegram location pins.
- Why it matters: Users received non-native behavior and lost interactive map pin UX.
- What changed: Added Telegram native `sendLocation` send helper, mapped Telegram `send` actions with `location` to a new internal `sendLocation` action, added coordinate validation and optional text follow-up behavior, and added regression tests.
- What did NOT change (scope boundary): Did not add venue/live-location support and did not modify non-Telegram channel behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30394
- Related #N/A

## User-visible / Behavior Changes

- Telegram now routes `message(action=send, location="lat,lng")` to native Telegram `sendLocation`.
- Coordinates are validated (`latitude` in `[-90, 90]`, `longitude` in `[-180, 180]`).
- If `message`/`caption` is also provided with location, Telegram sends a text follow-up after the location pin.
- Sending `location` and `media` together in one Telegram `send` action is now rejected with a clear error.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Adds Telegram `sendLocation` outbound API call path behind existing token auth and existing action routing; includes coordinate validation plus adapter/action/send-layer tests.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm test runtime
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.botToken`

### Steps

1. Configure Telegram bot token.
2. Invoke message tool: `action=send`, `to=<chat>`, `location="37.7749,-122.4194"`.
3. Run regression tests and lint/format checks.

### Expected

- Adapter routes to internal Telegram `sendLocation` action.
- Native `api.sendLocation` is called with validated coordinates.
- Invalid coordinates are rejected.

### Actual

- Matches expected behavior in unit tests across adapter, action handler, and send helper layers.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test commands run locally:

- `pnpm vitest src/channels/plugins/actions/actions.test.ts src/agents/tools/telegram-actions.test.ts src/telegram/send.test.ts`
- `pnpm oxfmt --check src/channels/plugins/actions/telegram.ts src/agents/tools/telegram-actions.ts src/telegram/send.ts src/channels/plugins/actions/actions.test.ts src/agents/tools/telegram-actions.test.ts src/telegram/send.test.ts CHANGELOG.md`
- `pnpm oxlint --type-aware src/channels/plugins/actions/telegram.ts src/agents/tools/telegram-actions.ts src/telegram/send.ts src/channels/plugins/actions/actions.test.ts src/agents/tools/telegram-actions.test.ts src/telegram/send.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: location send routes to `sendLocation`; coordinate validation errors; silent/thread options on location sends; optional follow-up text behavior; mixed location+media rejection.
- Edge cases checked: malformed coordinate string; out-of-range latitude/longitude.
- What you did **not** verify: live Telegram bot/network integration against a real chat in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR (or avoid passing `location` in Telegram send action).
- Files/config to restore: Telegram action adapter (`src/channels/plugins/actions/telegram.ts`) and Telegram send/action helpers (`src/telegram/send.ts`, `src/agents/tools/telegram-actions.ts`).
- Known bad symptoms reviewers should watch for: Telegram send action unexpectedly rejecting payloads when both `location` and `media` are provided.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Input ambiguity from free-form location strings.
  - Mitigation: strict `lat,lng` parser + explicit validation errors.
- Risk: Unexpected behavior when callers include both media and location.
  - Mitigation: explicit adapter-level guard with clear error and regression test.

AI-assisted: Yes (implementation and tests authored with AI assistance).
