### PR TITLE
fix: surface provider/model context in LLM timeout errors

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -113,8 +113,22 @@ describe("formatAssistantErrorText", () => {
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
   });
 
-  it("returns a friendly message for empty stream chunk errors", () => {
+  it("returns a friendly message for timeout errors without provider context", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
+    expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
+  });
+
+  it("includes provider and model in timeout message when opts are provided", () => {
+    const msg = makeAssistantError("request timed out");
+    const result = formatAssistantErrorText(msg, {
+      provider: "anthropic",
+      model: "claude-sonnet-4",
+    });
+    expect(result).toBe("LLM request timed out (anthropic/claude-sonnet-4).");
+  });
+
+  it("omits provider context in timeout message when opts are absent", () => {
+    const msg = makeAssistantError("request timed out");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -531,7 +531,8 @@ export function formatAssistantErrorText(
   }
 
   if (isTimeoutErrorMessage(raw)) {
-    return "LLM request timed out.";
+    const context = opts?.provider && opts?.model ? ` (${opts.provider}/${opts.model})` : "";
+    return `LLM request timed out${context}.`;
   }
 
   if (isBillingErrorMessage(raw)) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -306,7 +306,31 @@ describe("overflow compaction in run loop", () => {
     const result = await runEmbeddedPiAgent(baseParams);
 
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("timed out");
+    expect(result.payloads?.[0]?.text).toContain("Request timed out.");
+    expect(result.payloads?.[0]?.text).toContain("agents.defaults.timeoutSeconds");
+  });
+
+  it("includes provider, model and timeout seconds in the timeout payload", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        aborted: true,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        assistantTexts: [],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...baseParams,
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+      timeoutMs: 900_000,
+    });
+
+    const text = result.payloads?.[0]?.text ?? "";
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(text).toContain("anthropic/");
+    expect(text).toContain("900s");
   });
 
   it("sets promptTokens from the latest model call usage, not accumulated attempt usage", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1091,11 +1091,16 @@ export async function runEmbeddedPiAgent(
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
           if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
+            const timeoutSeconds = Math.round(params.timeoutMs / 1000);
+            const providerDetail =
+              agentMeta.provider && agentMeta.model
+                ? `The LLM provider (${agentMeta.provider}/${agentMeta.model}) did not respond within ${timeoutSeconds}s.`
+                : `No response was received within ${timeoutSeconds}s.`;
             return {
               payloads: [
                 {
                   text:
-                    "Request timed out before a response was generated. " +
+                    `Request timed out. ${providerDetail} ` +
                     "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
                   isError: true,
                 },


### PR DESCRIPTION
## Summary

- **Problem:** LLM provider timeouts show a generic `"Request timed out before a response was generated."` with no indication of which provider/model failed or how long it waited.
- **Why it matters:** Operators and users cannot diagnose whether the issue is a provider outage, a too-short timeout config, or a specific model problem.
- **What changed:** Timeout error messages now include the provider name, model ID, and elapsed timeout in seconds (e.g. `"Request timed out. The LLM provider (anthropic/claude-sonnet-4) did not respond within 900s."`). The [formatAssistantErrorText](cci:1://file:///home/akram/openclaw/src/agents/pi-embedded-helpers/errors.ts:461:0-550:1) helper also threads provider/model into assistant-level timeout strings.
- **What did NOT change:** No new hook, no plugin API change, no config schema change. The Discord 30s slow-listener WARN log is intentionally left as-is (it is never user-facing).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #30262

## User-visible / Behavior Changes

Timeout error messages sent to Discord/Telegram now include the provider, model, and timeout seconds. No config or default changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Darwin 25.2.0 per issue)
- Runtime/container: Node.js
- Model/provider: anthropic/claude-sonnet-4 (originally observed), reproducible with any provider
- Integration/channel: Discord
- Relevant config: `agents.defaults.timeoutSeconds: 900`

### Steps

1. Configure a model with a short `timeoutSeconds` (e.g. 10s) against a slow provider
2. Send a message that triggers an LLM call
3. Wait for timeout

### Expected

`Request timed out. The LLM provider (anthropic/claude-sonnet-4) did not respond within 10s. Please try again, or increase agents.defaults.timeoutSeconds in your config.`

### Actual (before fix)

`Request timed out before a response was generated. Please try again, or increase agents.defaults.timeoutSeconds in your config.`

## Evidence

- [x] Failing test/log before + passing after


New tests added:
- `includes provider, model and timeout seconds in the timeout payload`
- `includes provider and model in timeout message when opts are provided`
- `omits provider context in timeout message when opts are absent`

## Human Verification (required)

- Verified scenarios: timeout path with and without provider/model set; graceful fallback when agentMeta has no provider/model
- Edge cases checked: `timeoutMs` is typed `number` (non-optional) — no undefined risk
- What I did not verify: live end-to-end against a real provider (requires live credentials)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: `git revert 5dcd126a6`
- Files to restore: [src/agents/pi-embedded-runner/run.ts](cci:7://file:///home/akram/openclaw/src/agents/pi-embedded-runner/run.ts:0:0-0:0), [src/agents/pi-embedded-helpers/errors.ts](cci:7://file:///home/akram/openclaw/src/agents/pi-embedded-helpers/errors.ts:0:0-0:0)
- Bad symptoms: timeout messages missing or malformed in Discord/Telegram

## Risks and Mitigations

- Risk: `agentMeta.provider` or `agentMeta.model` is empty string (falsy)
  - Mitigation: Both are guarded with `&&` — falls back to `"No response was received within Xs."` 
