### PR TITLE
fix(tui): clamp model search rows to terminal width [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
+- TUI/Model search: clamp searchable select-list rows to terminal width so `/model` and `/models` single-letter searches (for example `m`) cannot trigger render width overflow crashes. (#30156)
 
 ## 2026.2.26
 

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { stripAnsi, visibleWidth } from "../../terminal/ansi.js";
+import { searchableSelectListTheme } from "../theme/theme.js";
 import { SearchableSelectList, type SearchableSelectListTheme } from "./searchable-select-list.js";
 
 const mockTheme: SearchableSelectListTheme = {
@@ -116,6 +117,40 @@ describe("SearchableSelectList", () => {
     list.setSelectedIndex(1); // make first row non-selected so description styling is applied
 
     typeInput(list, "provider");
+
+    const width = 80;
+    const output = list.render(width);
+    for (const line of output) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it("keeps /model search rows within width for single-letter queries", () => {
+    const items = [
+      {
+        value: "minimax-cn/MiniMax-M2",
+        label: "minimax-cn/MiniMax-M2",
+        description: "MiniMax M2",
+      },
+      {
+        value: "mistral/codestral-latest",
+        label: "mistral/codestral-latest",
+        description: "Codestral",
+      },
+      {
+        value: "mistral/devstral-medium-latest",
+        label: "mistral/devstral-medium-latest",
+        description: "Devstral Medium",
+      },
+      {
+        value: "moonshot/moonshot-v1-8k",
+        label: "moonshot/moonshot-v1-8k",
+        description: "Moonshot",
+      },
+    ];
+    const list = new SearchableSelectList(items, 12, searchableSelectListTheme);
+
+    typeInput(list, "m");
 
     const width = 80;
     const output = list.render(width);

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -59,6 +59,13 @@ export class SearchableSelectList implements Component {
     return regex;
   }
 
+  private constrainLineWidth(line: string, width: number): string {
+    if (width <= 0) {
+      return "";
+    }
+    return visibleWidth(line) > width ? truncateToWidth(line, width, "") : line;
+  }
+
   private updateFilter() {
     const query = this.searchInput.getValue().trim();
 
@@ -218,14 +225,14 @@ export class SearchableSelectList implements Component {
     const inputWidth = Math.max(1, width - visibleWidth(prompt));
     const inputLines = this.searchInput.render(inputWidth);
     const inputText = inputLines[0] ?? "";
-    lines.push(`${prompt}${this.theme.searchInput(inputText)}`);
+    lines.push(this.constrainLineWidth(`${prompt}${this.theme.searchInput(inputText)}`, width));
     lines.push(""); // Spacer
 
     const query = this.searchInput.getValue().trim();
 
     // If no items match filter, show message
     if (this.filteredItems.length === 0) {
-      lines.push(this.theme.noMatch("  No matches"));
+      lines.push(this.constrainLineWidth(this.theme.noMatch("  No matches"), width));
       return lines;
     }
 
@@ -246,13 +253,15 @@ export class SearchableSelectList implements Component {
         continue;
       }
       const isSelected = i === this.selectedIndex;
-      lines.push(this.renderItemLine(item, isSelected, width, query));
+      lines.push(
+        this.constrainLineWidth(this.renderItemLine(item, isSelected, width, query), width),
+      );
     }
 
     // Show scroll indicator if needed
     if (this.filteredItems.length > this.maxVisible) {
       const scrollInfo = `${this.selectedIndex + 1}/${this.filteredItems.length}`;
-      lines.push(this.theme.scrollInfo(`  ${scrollInfo}`));
+      lines.push(this.constrainLineWidth(this.theme.scrollInfo(`  ${scrollInfo}`), width));
     }
 
     return lines;
@@ -286,7 +295,8 @@ export class SearchableSelectList implements Component {
           const highlightedDesc = this.highlightMatch(truncatedDesc, query);
           const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
           const line = `${prefix}${valueText}${spacing}${descText}`;
-          return isSelected ? this.theme.selectedText(line) : line;
+          const styled = isSelected ? this.theme.selectedText(line) : line;
+          return this.constrainLineWidth(styled, width);
         }
       }
     }
@@ -295,7 +305,8 @@ export class SearchableSelectList implements Component {
     const truncatedValue = truncateToWidth(displayValue, maxWidth, "");
     const valueText = this.highlightMatch(truncatedValue, query);
     const line = `${prefix}${valueText}`;
-    return isSelected ? this.theme.selectedText(line) : line;
+    const styled = isSelected ? this.theme.selectedText(line) : line;
+    return this.constrainLineWidth(styled, width);
   }
 
   private getDescriptionLayout(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/model` and `/models` searchable list rendering could exceed terminal width and crash TUI (`Rendered line ... exceeds terminal width`) on certain queries (notably single-letter `m`).
- Why it matters: It blocks model selection in TUI and can terminate active interactive sessions.
- What changed: Added a final width clamp (`constrainLineWidth`) in searchable select-list rendering paths (input/no-match/items/scroll-info), plus regression test coverage for single-letter `m` query on model-like items.
- What did NOT change (scope boundary): Did not change fuzzy ranking behavior or keybinding semantics (`j/k`, arrows, etc.).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30156
- Related #N/A

## User-visible / Behavior Changes

- TUI model-selection searchable list no longer crashes from width overflow in narrow/long-row highlight scenarios.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: macOS (local verification), issue originally reported on Ubuntu
- Runtime/container: local Node/pnpm test runtime
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open searchable select list (e.g., `/model` flow).
2. Type single-letter query such as `m` with model entries that include descriptions.
3. Verify rendered lines remain within terminal width.

### Expected

- No render overflow crash; every rendered line width is <= terminal width.

### Actual

- Regression tests pass and enforce width constraints for this scenario.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test commands run locally:

- `pnpm vitest src/tui/components/searchable-select-list.test.ts`
- `pnpm oxfmt --check src/tui/components/searchable-select-list.ts src/tui/components/searchable-select-list.test.ts CHANGELOG.md`
- `pnpm oxlint --type-aware src/tui/components/searchable-select-list.ts src/tui/components/searchable-select-list.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: render output lines are clamped in all key searchable list output paths (input line, no-match line, item rows, scroll info); width assertions hold for single-letter `m` query with model-like rows.
- Edge cases checked: narrow width handling via clamping path, highlighted rows with themed output.
- What you did **not** verify: full interactive `/model` flow on Ubuntu terminal emulator from the report environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/tui/components/searchable-select-list.ts`.
- Known bad symptoms reviewers should watch for: unexpected truncation artifacts in searchable rows.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Additional truncation could hide some trailing text in extreme-width rows.
  - Mitigation: clamp only applies when visible width exceeds terminal width, preserving prior behavior when rows already fit.

AI-assisted: Yes (implementation and tests authored with AI assistance).
