### PR TITLE
fix(docker): normalize plugin directory perms [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor group allowlist diagnostics: align `groupPolicy: "allowlist"` warnings with per-channel runtime semantics by excluding Google Chat sender-list checks and by warning when no-fallback channels (for example iMessage) omit `groupAllowFrom`, with regression coverage. (#28477) Thanks @tonydehnke.
 - Onboarding/Custom providers: use Azure OpenAI-specific verification auth/payload shape (`api-key`, deployment-path chat completions payload) when probing Azure endpoints so valid Azure custom-provider setup no longer fails preflight. (#29421) Thanks @kunalk16.
 - Feishu/Docx editing tools: add `feishu_doc` positional insert, table row/column operations, table-cell merge, and color-text updates; switch markdown write/append/insert to Descendant API insertion with large-document batching; and harden image uploads for data URI/base64/local-path inputs with strict validation and routing-safe upload metadata. (#29411) Thanks @Elarwei001.
+- Docker/Image permissions: normalize `/app/extensions`, `/app/.agent`, and `/app/.agents` to directory mode `755` and file mode `644` during image build so plugin discovery does not block world-writable paths from inherited source modes. (#30139)
 
 ## 2026.2.26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,14 @@ RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
 
 USER node
 COPY --chown=node:node . .
+# Normalize plugin/agent state permissions inside image layers.
+# Prevent world-writable paths (e.g. mode 777) from being blocked by plugin path safety checks.
+RUN for dir in /app/extensions /app/.agent /app/.agents; do \
+      if [ -d "$dir" ]; then \
+        find "$dir" -type d -exec chmod 755 {} +; \
+        find "$dir" -type f -exec chmod 644 {} +; \
+      fi; \
+    done
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -20,4 +20,11 @@ describe("Dockerfile", () => {
     );
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
+
+  it("normalizes plugin and agent state permissions in image layers", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain("for dir in /app/extensions /app/.agent /app/.agents");
+    expect(dockerfile).toContain('find "$dir" -type d -exec chmod 755 {} +');
+    expect(dockerfile).toContain('find "$dir" -type f -exec chmod 644 {} +');
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Docker image could preserve world-writable (`777`) modes for `/app/extensions` and agent-state directories, causing plugin discovery to block candidates as unsafe.
- Why it matters: Plugins may be silently blocked in container deployments even when plugin content is correct.
- What changed: Added a Docker build-step that normalizes `/app/extensions`, `/app/.agent`, and `/app/.agents` to `755` directories and `644` files; added Dockerfile regression test assertions.
- What did NOT change (scope boundary): Did not change runtime plugin safety policy, ownership checks, or non-container path permissions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #30139
- Related #N/A

## User-visible / Behavior Changes

- Container builds now normalize plugin/agent directory permissions during image build, reducing false plugin blocks caused by inherited world-writable source modes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm tests; Dockerfile static validation
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build Docker image from repo root Dockerfile.
2. Inspect permissions under `/app/extensions`, `/app/.agent`, `/app/.agents` in the built layer.
3. Run Dockerfile regression tests.

### Expected

- Directories use `755`, files use `644` in those paths.
- Dockerfile tests assert normalization commands exist.

### Actual

- Dockerfile now includes explicit permission normalization step and tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test commands run locally:

- `pnpm vitest src/dockerfile.test.ts`
- `pnpm oxfmt --check src/dockerfile.test.ts CHANGELOG.md`
- `pnpm oxlint --type-aware src/dockerfile.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Dockerfile now applies directory/file mode normalization on targeted paths; regression test asserts exact commands are present.
- Edge cases checked: missing directories are safely skipped via `if [ -d "$dir" ]` guard.
- What you did **not** verify: full multi-platform Docker runtime validation on all orchestrators.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `Dockerfile`, `src/dockerfile.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected permission errors during image build if filesystem semantics differ.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Overly strict file mode normalization could affect uncommon executable files inside `/app/extensions`.
  - Mitigation: Scope is limited to plugin/agent state paths and mirrors reported expected secure defaults; can be reverted quickly if a specific executable extension path requires an exception.

AI-assisted: Yes (implementation and tests authored with AI assistance).
