### PR TITLE
fix(gateway): surface clean channel exits in runtime diagnostics [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Startup diagnostics: record and surface an explicit runtime error when a channel `startAccount` exits cleanly without throwing (instead of silently entering restart backoff), so crash-loop diagnostics are visible in logs/status output. (#21840)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -153,6 +153,23 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("records an explicit error when a channel exits without throwing", async () => {
+    const startAccount = vi.fn(async () => {});
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    vi.runAllTicks();
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.lastError).toBe("channel exited unexpectedly without error");
+  });
+
   it("marks enabled/configured when account descriptors omit them", () => {
     installTestRegistry(
       createTestPlugin({

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -200,10 +200,24 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           getStatus: () => getRuntime(channelId, id),
           setStatus: (next) => setRuntime(channelId, id, next),
         });
+        let exitedWithError = false;
         const trackedPromise = Promise.resolve(task)
           .catch((err) => {
+            exitedWithError = true;
             const message = formatErrorMessage(err);
             setRuntime(channelId, id, { accountId: id, lastError: message });
+            log.error?.(`[${id}] channel exited: ${message}`);
+          })
+          .then(() => {
+            if (exitedWithError || abort.signal.aborted || manuallyStopped.has(rKey)) {
+              return;
+            }
+            const runtime = getRuntime(channelId, id);
+            const message =
+              runtime.lastError?.trim() || "channel exited unexpectedly without error";
+            if (!runtime.lastError) {
+              setRuntime(channelId, id, { accountId: id, lastError: message });
+            }
             log.error?.(`[${id}] channel exited: ${message}`);
           })
           .finally(() => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when a channel `startAccount` task exits cleanly (no throw), the gateway immediately enters restart backoff without persisting/logging an exit reason.
- Why it matters: operators see repeated `auto-restart` lines but no actionable root-cause context, matching the silent crash-loop pattern reported in #21840.
- What changed: `server-channels` now records a synthetic runtime error (`channel exited unexpectedly without error`) and logs `channel exited: ...` for clean, unexpected exits.
- What changed: added regression coverage to assert `lastError` is populated for clean exits.
- What did NOT change (scope boundary): restart/backoff policy, thrown-error handling, and manual-stop behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21840
- Related #18975

## User-visible / Behavior Changes

- Channel runtime snapshots/logs now include an explicit error for unexpected clean exits, instead of only showing restart attempts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm + vitest
- Model/provider: N/A
- Integration/channel (if any): channel manager lifecycle (gateway)
- Relevant config (redacted): N/A (plugin test harness)

### Steps

1. Start channel manager with a plugin whose `startAccount` resolves immediately.
2. Allow lifecycle microtasks to flush.
3. Inspect runtime snapshot and logs.

### Expected

- `lastError` is set to an explicit message.
- Exit is logged as `channel exited: ...`.

### Actual

- `lastError` is now set to `channel exited unexpectedly without error`.
- Exit is logged and restart behavior remains intact.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression test:
- `src/gateway/server-channels.test.ts` → `records an explicit error when a channel exits without throwing`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Immediate clean exit now persists a diagnostic `lastError`.
  - Existing crash-loop retry behavior still works.
- Edge cases checked:
  - Manual stop path remains covered by existing test (`does not auto-restart after manual stop during backoff`).
  - Thrown-error path unchanged (existing catch path still sets/logs formatter output).
- What you did **not** verify:
  - Full end-to-end Google Chat live deployment with real webhook infra.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `aedf55b169`.
- Files/config to restore:
  - `src/gateway/server-channels.ts`
  - `src/gateway/server-channels.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - Unexpected extra error logs during intentional short-lived channel lifecycles.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Channels intentionally designed to return quickly could now emit an explicit exit error message.
  - Mitigation:
    - Guarded to skip manual stop and aborted shutdown paths; retry/backoff behavior unchanged, and message is diagnostic-only.
