### PR TITLE
Telegram: fix checkmark disappearing when switching back to default model (fix #30476)

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,9 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveDefaultAgentId,
+  resolveAgentEffectiveModelPrimary,
+} from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
@@ -319,11 +323,12 @@ export const registerTelegramHandlers = ({
         model: `${provider}/${model}`,
       };
     }
-    const modelCfg = cfg.agents?.defaults?.model;
+    // Use agent-aware resolution to get the default model (handles agent-specific overrides)
+    const defaultModel = resolveAgentEffectiveModelPrimary(cfg, route.agentId);
     return {
       agentId: route.agentId,
       sessionEntry: entry,
-      model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
+      model: defaultModel,
     };
   };
 


### PR DESCRIPTION
## Summary

Fixes issue #30476 where the `/models` menu checkmark disappears when switching back to the default (primary) model.

## Root Cause

In `resolveTelegramSessionState` (`src/telegram/bot-handlers.ts`), when determining the current model for the menu checkmark, the fallback code was using direct config access (`cfg.agents?.defaults?.model`) instead of the proper agent-aware resolution function.

When the user selects the default model via the menu:
1. The session model override is cleared (since it matches the default)
2. The runtime model fields (`entry.model`, `entry.modelProvider`) are also cleared
3. The fallback code should resolve the default model correctly, but was using a simplified approach that didn't handle all cases (like agent-specific model overrides)

## Fix

Use `resolveAgentEffectiveModelPrimary(cfg, route.agentId)` which properly handles:
- Global default models
- Agent-specific model overrides
- Both string and object format model configs

This ensures the checkmark correctly appears next to the currently active model, including when that model is the default primary.

## Changes

- `src/telegram/bot-handlers.ts`: Import and use `resolveAgentEffectiveModelPrimary` for default model resolution in `resolveTelegramSessionState`