### PR TITLE
fix(config): migrate legacy model/provider/control-ui keys

### DIFF
--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -104,3 +104,63 @@ describe("legacy migrate mention routing", () => {
     ).toBeUndefined();
   });
 });
+
+describe("legacy migrate model/provider layout", () => {
+  it("migrates defaultModel, providers, and legacy top-level model map", () => {
+    const res = migrateLegacyConfig({
+      defaultModel: "xai/grok-4-fast",
+      providers: {
+        ollama: {
+          url: "http://10.0.0.50:11434",
+          models: ["qwen:7b", "qwen3:8b"],
+        },
+      },
+      models: {
+        "ollama/qwen:7b": {
+          provider: "ollama",
+          model: "qwen:7b",
+          url: "http://10.0.0.50:11434",
+        },
+      },
+    });
+
+    expect(res.config).not.toBeNull();
+    expect(res.changes).toContain("Moved defaultModel → agents.defaults.model.primary.");
+    expect(res.changes).toContain("Moved providers → models.providers.");
+    expect(res.changes).toContain(
+      "Moved legacy models.<provider/model> entries → agents.defaults.models.",
+    );
+
+    expect(res.config?.agents?.defaults?.model).toEqual({
+      primary: "xai/grok-4-fast",
+      fallbacks: [],
+    });
+    expect(res.config?.agents?.defaults?.models).toMatchObject({
+      "ollama/qwen:7b": {},
+      "ollama/qwen3:8b": {},
+    });
+    expect(res.config?.models?.providers?.ollama?.baseUrl).toBe("http://10.0.0.50:11434");
+    expect(res.config?.models?.providers?.ollama?.models.map((item) => item.id)).toEqual([
+      "qwen:7b",
+      "qwen3:8b",
+    ]);
+  });
+});
+
+describe("legacy migrate controlUi", () => {
+  it("moves top-level controlUi into gateway.controlUi", () => {
+    const res = migrateLegacyConfig({
+      controlUi: {
+        enabled: true,
+        allowInsecureAuth: true,
+      },
+    });
+
+    expect(res.config).not.toBeNull();
+    expect(res.changes).toContain("Moved controlUi → gateway.controlUi.");
+    expect(res.config?.gateway?.controlUi).toMatchObject({
+      enabled: true,
+      allowInsecureAuth: true,
+    });
+  });
+});

--- a/src/config/legacy.migrations.part-2.ts
+++ b/src/config/legacy.migrations.part-2.ts
@@ -35,7 +35,291 @@ function applyLegacyAudioTranscriptionModel(params: {
   params.changes.push(params.alreadySetMessage);
 }
 
+function readTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function readLegacyModelIds(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const ids = new Set<string>();
+  for (const item of value) {
+    const direct = readTrimmedString(item);
+    if (direct) {
+      ids.add(direct);
+      continue;
+    }
+    const record = getRecord(item);
+    const id = readTrimmedString(record?.id) ?? readTrimmedString(record?.model);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+function normalizeLegacyAuthMode(value: unknown): string | undefined {
+  const normalized = readTrimmedString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "api_key") {
+    return "api-key";
+  }
+  if (
+    normalized === "api-key" ||
+    normalized === "aws-sdk" ||
+    normalized === "oauth" ||
+    normalized === "token"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function readStringMap(value: unknown): Record<string, string> | undefined {
+  const record = getRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  const entries = Object.entries(record).filter(([, item]) => typeof item === "string");
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+function ensureAgentsDefaults(raw: Record<string, unknown>): Record<string, unknown> {
+  const agents = ensureRecord(raw, "agents");
+  return ensureRecord(agents, "defaults");
+}
+
+function ensureModelsRoot(raw: Record<string, unknown>): Record<string, unknown> {
+  return ensureRecord(raw, "models");
+}
+
+function ensureModelsProviders(raw: Record<string, unknown>): Record<string, unknown> {
+  const models = ensureModelsRoot(raw);
+  return ensureRecord(models, "providers");
+}
+
+function ensureModelAllowlist(raw: Record<string, unknown>): Record<string, unknown> {
+  const defaults = ensureAgentsDefaults(raw);
+  return ensureRecord(defaults, "models");
+}
+
+function ensureAllowlistModelEntry(
+  allowlist: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const existing = getRecord(allowlist[key]);
+  if (existing) {
+    return existing;
+  }
+  const created: Record<string, unknown> = {};
+  allowlist[key] = created;
+  return created;
+}
+
+function appendProviderModels(providerEntry: Record<string, unknown>, modelIds: string[]) {
+  const models = Array.isArray(providerEntry.models) ? [...providerEntry.models] : [];
+  const seen = new Set<string>();
+  for (const item of models) {
+    const record = getRecord(item);
+    const id = readTrimmedString(record?.id);
+    if (id) {
+      seen.add(id);
+    }
+  }
+  for (const modelId of modelIds) {
+    if (seen.has(modelId)) {
+      continue;
+    }
+    models.push({ id: modelId, name: modelId });
+    seen.add(modelId);
+  }
+  providerEntry.models = models;
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_PART_2: LegacyConfigMigration[] = [
+  {
+    id: "legacy.model-config-v1",
+    describe:
+      "Migrate legacy top-level defaultModel/providers/models map into agents.defaults/models.providers",
+    apply: (raw, changes) => {
+      const legacyDefaultModel = readTrimmedString(raw.defaultModel);
+      if (raw.defaultModel !== undefined) {
+        const defaults = ensureAgentsDefaults(raw);
+        const current = defaults.model;
+        const currentRecord = getRecord(current);
+        if (legacyDefaultModel) {
+          if (typeof current === "string") {
+            if (!readTrimmedString(current)) {
+              defaults.model = legacyDefaultModel;
+            }
+          } else if (currentRecord) {
+            if (!readTrimmedString(currentRecord.primary)) {
+              currentRecord.primary = legacyDefaultModel;
+              defaults.model = currentRecord;
+            }
+          } else if (current === undefined) {
+            defaults.model = { primary: legacyDefaultModel, fallbacks: [] };
+          }
+          changes.push("Moved defaultModel → agents.defaults.model.primary.");
+        } else {
+          changes.push("Removed defaultModel (invalid value).");
+        }
+        delete raw.defaultModel;
+      }
+
+      const legacyProviders = getRecord(raw.providers);
+      if (legacyProviders) {
+        const providers = ensureModelsProviders(raw);
+        const allowlist = ensureModelAllowlist(raw);
+        for (const [providerIdRaw, providerValue] of Object.entries(legacyProviders)) {
+          const providerId = readTrimmedString(providerIdRaw);
+          const providerLegacy = getRecord(providerValue);
+          if (!providerId || !providerLegacy) {
+            continue;
+          }
+          const modelIds = readLegacyModelIds(providerLegacy.models);
+          const existingProvider = getRecord(providers[providerId]) ?? {};
+          const baseUrl =
+            readTrimmedString(existingProvider.baseUrl) ??
+            readTrimmedString(providerLegacy.baseUrl) ??
+            readTrimmedString(providerLegacy.url);
+          if (baseUrl) {
+            existingProvider.baseUrl = baseUrl;
+            const auth = normalizeLegacyAuthMode(existingProvider.auth ?? providerLegacy.auth);
+            if (auth) {
+              existingProvider.auth = auth;
+            }
+            const api = readTrimmedString(existingProvider.api ?? providerLegacy.api);
+            if (api) {
+              existingProvider.api = api;
+            }
+            if (existingProvider.apiKey === undefined && providerLegacy.apiKey !== undefined) {
+              existingProvider.apiKey = providerLegacy.apiKey;
+            }
+            if (
+              existingProvider.authHeader === undefined &&
+              typeof providerLegacy.authHeader === "boolean"
+            ) {
+              existingProvider.authHeader = providerLegacy.authHeader;
+            }
+            if (
+              existingProvider.injectNumCtxForOpenAICompat === undefined &&
+              typeof providerLegacy.injectNumCtxForOpenAICompat === "boolean"
+            ) {
+              existingProvider.injectNumCtxForOpenAICompat =
+                providerLegacy.injectNumCtxForOpenAICompat;
+            }
+            const headers =
+              readStringMap(existingProvider.headers) ?? readStringMap(providerLegacy.headers);
+            if (headers) {
+              existingProvider.headers = headers;
+            }
+            appendProviderModels(existingProvider, modelIds);
+            providers[providerId] = existingProvider;
+          }
+          for (const modelId of modelIds) {
+            ensureAllowlistModelEntry(allowlist, `${providerId}/${modelId}`);
+          }
+        }
+        delete raw.providers;
+        changes.push("Moved providers → models.providers.");
+      }
+
+      const modelsRoot = getRecord(raw.models);
+      if (modelsRoot) {
+        const legacyModelKeys = Object.keys(modelsRoot).filter((key) => key.includes("/"));
+        if (legacyModelKeys.length > 0) {
+          const allowlist = ensureModelAllowlist(raw);
+          const providers = ensureModelsProviders(raw);
+          for (const modelKeyRaw of legacyModelKeys) {
+            const modelKey = modelKeyRaw.trim();
+            if (!modelKey) {
+              delete modelsRoot[modelKeyRaw];
+              continue;
+            }
+            const slash = modelKey.indexOf("/");
+            if (slash <= 0 || slash >= modelKey.length - 1) {
+              delete modelsRoot[modelKeyRaw];
+              continue;
+            }
+            const providerFromKey = modelKey.slice(0, slash).trim();
+            const modelFromKey = modelKey.slice(slash + 1).trim();
+            if (!providerFromKey || !modelFromKey) {
+              delete modelsRoot[modelKeyRaw];
+              continue;
+            }
+
+            const legacyEntry = getRecord(modelsRoot[modelKeyRaw]);
+            const providerId = readTrimmedString(legacyEntry?.provider) ?? providerFromKey;
+            const modelId = readTrimmedString(legacyEntry?.model) ?? modelFromKey;
+            const allowEntry = ensureAllowlistModelEntry(allowlist, `${providerId}/${modelId}`);
+            const alias = readTrimmedString(legacyEntry?.alias);
+            if (alias && !readTrimmedString(allowEntry.alias)) {
+              allowEntry.alias = alias;
+            }
+            if (allowEntry.streaming === undefined && typeof legacyEntry?.streaming === "boolean") {
+              allowEntry.streaming = legacyEntry.streaming;
+            }
+            const params = getRecord(legacyEntry?.params);
+            if (params && !getRecord(allowEntry.params)) {
+              allowEntry.params = params;
+            }
+
+            const baseUrl =
+              readTrimmedString(legacyEntry?.baseUrl) ?? readTrimmedString(legacyEntry?.url);
+            if (baseUrl) {
+              const providerEntry = getRecord(providers[providerId]) ?? {};
+              if (!readTrimmedString(providerEntry.baseUrl)) {
+                providerEntry.baseUrl = baseUrl;
+              }
+              appendProviderModels(providerEntry, [modelId]);
+              providers[providerId] = providerEntry;
+            }
+
+            delete modelsRoot[modelKeyRaw];
+          }
+          changes.push("Moved legacy models.<provider/model> entries → agents.defaults.models.");
+        }
+
+        if (Object.keys(modelsRoot).length === 0) {
+          delete raw.models;
+        } else {
+          raw.models = modelsRoot;
+        }
+      }
+    },
+  },
+  {
+    id: "controlUi->gateway.controlUi",
+    describe: "Move top-level controlUi to gateway.controlUi",
+    apply: (raw, changes) => {
+      const legacyControlUi = getRecord(raw.controlUi);
+      if (!legacyControlUi) {
+        return;
+      }
+      const gateway = ensureRecord(raw, "gateway");
+      const controlUi = ensureRecord(gateway, "controlUi");
+      const hadEntries = Object.keys(controlUi).length > 0;
+      mergeMissing(controlUi, legacyControlUi);
+      gateway.controlUi = controlUi;
+      delete raw.controlUi;
+      changes.push(
+        hadEntries
+          ? "Merged controlUi → gateway.controlUi."
+          : "Moved controlUi → gateway.controlUi.",
+      );
+    },
+  },
   {
     id: "agent.model-config-v2",
     describe:

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -17,6 +17,13 @@ function hasLegacyThreadBindingTtlInAccounts(value: unknown): boolean {
   );
 }
 
+function hasLegacyTopLevelModelMap(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.keys(value).some((key) => key.includes("/"));
+}
+
 export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
   {
     path: ["whatsapp"],
@@ -119,6 +126,24 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     path: ["agent"],
     message:
       "agent.* was moved; use agents.defaults (and tools.* for tool/elevated/exec settings) instead (auto-migrated on load).",
+  },
+  {
+    path: ["defaultModel"],
+    message: "defaultModel was moved to agents.defaults.model.primary (auto-migrated on load).",
+  },
+  {
+    path: ["providers"],
+    message: "providers was moved to models.providers (auto-migrated on load).",
+  },
+  {
+    path: ["models"],
+    message:
+      "legacy models.<provider/model> map was moved to agents.defaults.models (auto-migrated on load).",
+    match: (value) => hasLegacyTopLevelModelMap(value),
+  },
+  {
+    path: ["controlUi"],
+    message: "controlUi was moved to gateway.controlUi (auto-migrated on load).",
   },
   {
     path: ["memorySearch"],


### PR DESCRIPTION
## Summary

- **Problem:** Legacy top-level config keys (`defaultModel`, `providers`, `models.<provider/model>`, `controlUi`) were not migrated, causing invalid/ignored config after upgrade and user-facing breakage (`model not allowed`, wrong provider fallback, dashboard 404 scenarios).
- **Why it matters:** Users upgrading from older layouts can lose model/provider routing and control-ui behavior even when their intent/config values are correct.
- **What changed:** Added legacy migrations to move old keys into modern schema paths, normalize provider auth/url fields, synthesize provider model entries, and preserve model allowlist semantics; added regression tests for both model/provider migration and `controlUi` migration.
- **What did NOT change:** Runtime model execution/fallback algorithms and gateway HTTP routing behavior were not modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30003
- Closes #30168
- Closes #29525

## User-visible / Behavior Changes

- Legacy `defaultModel` now auto-migrates to `agents.defaults.model.primary`.
- Legacy top-level `providers` now auto-migrates to `models.providers`.
- Legacy top-level `models` maps keyed by `provider/model` now auto-migrate into `agents.defaults.models` allowlist entries (and provider model entries when URL/baseUrl is present).
- Legacy top-level `controlUi` now auto-migrates to `gateway.controlUi`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node + pnpm + Vitest
- Integration/channel: config migration path at startup

### Steps

1. Provide legacy config with top-level `defaultModel/providers/models/controlUi` keys.
2. Run legacy migration + validation path.
3. Confirm output config contains modern keys and remains valid.

### Expected

- Legacy keys are migrated to modern schema paths and behavior remains intact.

### Actual

- Before fix: legacy layouts could be ignored/rejected, leading to model/provider mismatch and dashboard misconfiguration.
- After fix: migrations preserve intent and pass validation.

## Evidence

- `pnpm exec vitest run src/config/legacy-migrate.test.ts`
- `pnpm exec vitest run src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts`

## Human Verification (required)

- Verified scenarios:
  - legacy `defaultModel/providers/models` migration
  - legacy `controlUi` migration
- Edge cases checked:
  - `auth` normalization from `api_key` -> `api-key`
  - model ID dedupe while synthesizing provider model lists
- What I did **not** verify:
  - full end-to-end remote deployment reproduction on affected user environments

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (auto-migration only)
- Migration needed? `No` (automatic)

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit
- Files/config to restore: `src/config/legacy.migrations.part-2.ts`, `src/config/legacy.rules.ts`, `src/config/legacy-migrate.test.ts`
- Known bad symptoms: legacy keys no longer auto-migrated

## Risks and Mitigations

- Risk: over-migrating malformed legacy provider payloads.
- Mitigation: migration only maps recognized/typed fields and keeps strict schema validation in place.
