### PR TITLE
fix(gateway): register OpenResponses runs for chat.abort [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenResponses/Abort parity: register `/v1/responses` in-flight runs in gateway abort tracking (with controller cleanup on completion/disconnect) so `chat.abort` can stop active `resp_*` runs instead of returning `aborted: false`. (#30558)
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
-import { agentCommand, getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+import {
+  agentCommand,
+  connectReq,
+  getFreePort,
+  installGatewayTestHooks,
+  rpcReq,
+} from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -511,6 +518,118 @@ describe("OpenResponses HTTP API (e2e)", () => {
       }
     } finally {
       // shared server
+    }
+  });
+
+  it("registers OpenResponses runs so chat.abort can stop in-flight requests", async () => {
+    const port = enabledPort;
+    const sessionKey = "agent:main:openresponses-abort-test";
+    let observedAbortSignal: AbortSignal | undefined;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const abortSignal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+      observedAbortSignal = abortSignal;
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("timeout waiting for chat.abort"));
+        }, 5_000);
+        const done = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+        if (abortSignal?.aborted) {
+          done();
+          return;
+        }
+        abortSignal?.addEventListener("abort", done, { once: true });
+      });
+      return {
+        payloads: [{ text: "aborted" }],
+        meta: { stopReason: "aborted", aborted: true },
+      };
+    }) as never);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, {
+      headers: { origin: `http://127.0.0.1:${port}` },
+    });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout waiting for ws open")), 10_000);
+      ws.once("open", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      ws.once("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+    const connectRes = await connectReq(ws, { token: "secret", device: null });
+    expect(connectRes.ok).toBe(true);
+    try {
+      const response = await postResponses(
+        port,
+        {
+          stream: true,
+          model: "openclaw",
+          input: "count forever",
+        },
+        { "x-openclaw-session-key": sessionKey },
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toBeTruthy();
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let streamBuffer = "";
+      let runId: string | undefined;
+      const deadline = Date.now() + 5_000;
+
+      while (!runId && Date.now() < deadline) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        streamBuffer += decoder.decode(chunk.value, { stream: true });
+        const parsedEvents = parseSseEvents(streamBuffer);
+        for (const event of parsedEvents) {
+          if (event.event !== "response.created") {
+            continue;
+          }
+          const parsed = JSON.parse(event.data) as {
+            response?: { id?: string };
+          };
+          const candidate = parsed.response?.id;
+          if (typeof candidate === "string" && candidate.startsWith("resp_")) {
+            runId = candidate;
+            break;
+          }
+        }
+      }
+
+      expect(runId).toMatch(/^resp_/);
+      const abortRes = await rpcReq<{
+        ok?: boolean;
+        aborted?: boolean;
+        runIds?: string[];
+      }>(ws, "chat.abort", { sessionKey, runId });
+      expect(abortRes.ok).toBe(true);
+      expect(abortRes.payload?.ok).toBe(true);
+      expect(abortRes.payload?.aborted).toBe(true);
+      expect(abortRes.payload?.runIds).toContain(runId);
+      expect(observedAbortSignal?.aborted).toBe(true);
+
+      // Drain stream to avoid open keepalive sockets in parallel test workers.
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        streamBuffer += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(streamBuffer).toContain("[DONE]");
+    } finally {
+      ws.close();
     }
   });
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ClientToolDefinition } from "../agents/pi-embedded-runner/run/params.js";
+import { resolveAgentTimeoutMs } from "../agents/timeout.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
 import type { ImageContent } from "../commands/agent/types.js";
@@ -32,6 +33,7 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
+import { resolveChatRunExpiresAtMs, type ChatAbortControllerEntry } from "./chat-abort.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
@@ -52,6 +54,7 @@ type OpenResponsesHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
 };
 
 const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
@@ -242,6 +245,7 @@ async function runResponsesAgentCommand(params: {
   sessionKey: string;
   runId: string;
   deps: ReturnType<typeof createDefaultDeps>;
+  abortSignal?: AbortSignal;
 }) {
   return agentCommand(
     {
@@ -255,6 +259,7 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: "webchat",
       bestEffortDeliver: false,
+      abortSignal: params.abortSignal,
     },
     defaultRuntime,
     params.deps,
@@ -444,6 +449,26 @@ export async function handleOpenResponsesHttpRequest(
   const responseId = `resp_${randomUUID()}`;
   const outputItemId = `msg_${randomUUID()}`;
   const deps = createDefaultDeps();
+  const runAbortController = new AbortController();
+  const timeoutMs = resolveAgentTimeoutMs({});
+  const startedAtMs = Date.now();
+  if (opts.chatAbortControllers) {
+    opts.chatAbortControllers.set(responseId, {
+      controller: runAbortController,
+      // OpenResponses is HTTP-first and does not register in websocket chatRunState.
+      // Keep sessionId scoped to runId for maintenance/cleanup compatibility.
+      sessionId: responseId,
+      sessionKey,
+      startedAtMs,
+      expiresAtMs: resolveChatRunExpiresAtMs({ now: startedAtMs, timeoutMs }),
+    });
+  }
+  const unregisterAbortController = () => {
+    const active = opts.chatAbortControllers?.get(responseId);
+    if (active?.controller === runAbortController) {
+      opts.chatAbortControllers?.delete(responseId);
+    }
+  };
   const streamParams =
     typeof payload.max_output_tokens === "number"
       ? { maxTokens: payload.max_output_tokens }
@@ -460,6 +485,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: runAbortController.signal,
       });
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
@@ -525,6 +551,8 @@ export async function handleOpenResponsesHttpRequest(
         error: { code: "api_error", message: "internal error" },
       });
       sendJson(res, 500, response);
+    } finally {
+      unregisterAbortController();
     }
     return true;
   }
@@ -555,6 +583,7 @@ export async function handleOpenResponsesHttpRequest(
     const usage = finalUsage;
 
     closed = true;
+    unregisterAbortController();
     unsubscribe();
 
     writeSseEvent(res, {
@@ -678,6 +707,8 @@ export async function handleOpenResponsesHttpRequest(
 
   req.on("close", () => {
     closed = true;
+    runAbortController.abort();
+    unregisterAbortController();
     unsubscribe();
   });
 
@@ -692,6 +723,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: runAbortController.signal,
       });
 
       finalUsage = extractUsageFromResult(result);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -32,6 +32,7 @@ import {
   type ResolvedGatewayAuth,
 } from "./auth.js";
 import { CANVAS_CAPABILITY_TTL_MS, normalizeCanvasScopedUrl } from "./canvas-capability.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -451,6 +452,7 @@ export function createHooksRequestHandler(
 export function createGatewayHttpServer(opts: {
   canvasHost: CanvasHostHandler | null;
   clients: Set<GatewayWsClient>;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
   controlUiEnabled: boolean;
   controlUiBasePath: string;
   controlUiRoot?: ControlUiRootState;
@@ -468,6 +470,7 @@ export function createGatewayHttpServer(opts: {
   const {
     canvasHost,
     clients,
+    chatAbortControllers,
     controlUiEnabled,
     controlUiBasePath,
     controlUiRoot,
@@ -555,6 +558,7 @@ export function createGatewayHttpServer(opts: {
             trustedProxies,
             allowRealIpFallback,
             rateLimiter,
+            chatAbortControllers,
           })
         ) {
           return;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -125,10 +125,12 @@ export async function createGatewayRuntimeState(params: {
   }
   const httpServers: HttpServer[] = [];
   const httpBindHosts: string[] = [];
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   for (const host of bindHosts) {
     const httpServer = createGatewayHttpServer({
       canvasHost,
       clients,
+      chatAbortControllers,
       controlUiEnabled: params.controlUiEnabled,
       controlUiBasePath: params.controlUiBasePath,
       controlUiRoot: params.controlUiRoot,
@@ -187,7 +189,6 @@ export async function createGatewayRuntimeState(params: {
   const chatDeltaSentAt = chatRunState.deltaSentAt;
   const addChatRun = chatRunRegistry.add;
   const removeChatRun = chatRunRegistry.remove;
-  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   const toolEventRecipients = createToolEventRecipientRegistry();
 
   return {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/v1/responses` runs were not registered in gateway `chatAbortControllers`, so `chat.abort` could not find active `resp_*` runs.
- Why it matters: users invoking OpenResponses HTTP API could not stop long-running requests, even though abort works for websocket `chat.send` runs.
- What changed: OpenResponses now registers an abort controller per `resp_*` run, passes the signal into `agentCommand`, and always unregisters on completion/disconnect.
- What did NOT change (scope boundary): no protocol/schema changes for `chat.abort`, no changes to OpenAI chat-completions endpoint behavior, no changes to session-key resolution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30558
- Related #30559

## User-visible / Behavior Changes

- `chat.abort` can now stop active OpenResponses HTTP runs (`resp_*`) when called with the matching `sessionKey` + `runId`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local contributor env)
- Runtime/container: Node + Vitest
- Model/provider: N/A (mocked `agentCommand` in tests)
- Integration/channel (if any): Gateway websocket (`chat.abort`) + HTTP `/v1/responses`
- Relevant config (redacted): gateway token auth enabled, OpenResponses enabled

### Steps

1. Start an OpenResponses streaming request and read `response.created` to capture `resp_*` id.
2. Call websocket RPC `chat.abort` with `{ sessionKey, runId }`.
3. Assert abort response and server-side abort signal state.

### Expected

- Abort returns `{ ok: true, aborted: true, runIds: [resp_*] }` and in-flight run aborts.

### Actual

- Before fix: run not tracked, abort did not stop OpenResponses run.
- After fix: run tracked and abort signal is triggered.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added regression test: `registers OpenResponses runs so chat.abort can stop in-flight requests` in `src/gateway/openresponses-http.test.ts`.
- Local verification commands:
  - `pnpm oxfmt --check src/gateway/openresponses-http.ts src/gateway/server-http.ts src/gateway/server-runtime-state.ts src/gateway/openresponses-http.test.ts`
  - `pnpm vitest src/gateway/openresponses-http.test.ts src/gateway/chat-abort.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts`
  - `pnpm oxlint --type-aware src/gateway/openresponses-http.ts src/gateway/server-http.ts src/gateway/server-runtime-state.ts src/gateway/openresponses-http.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: OpenResponses run is registered, `chat.abort` returns aborted true, abort signal reaches the running command, stream closes with `[DONE]`.
- Edge cases checked: controller cleanup on request completion and request close; no regressions in chat abort utility tests.
- What you did **not** verify: live channel-provider behavior with a real external model provider (test uses mocked `agentCommand`).

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/openresponses-http.ts`, `src/gateway/server-http.ts`, `src/gateway/server-runtime-state.ts`.
- Known bad symptoms reviewers should watch for: stale `chatAbortControllers` entries or OpenResponses runs not aborting.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: abort controller entry could be leaked if cleanup path is missed.
  - Mitigation: explicit unregister in non-stream `finally`, streaming finalize path, and request `close` handler + regression test.

AI-assisted: yes (implementation and test authoring with human verification).
