### PR TITLE
fix: idempotent gateway start, tilde path expansion, ufw PATH detection

### DIFF
--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -70,7 +70,7 @@ If the user grants read-only permission, run the OS-appropriate checks by defaul
    - Linux: `ss -ltnup` (or `ss -ltnp` if `-u` unsupported).
    - macOS: `lsof -nP -iTCP -sTCP:LISTEN`.
 3. Firewall status:
-   - Linux: `ufw status`, `firewall-cmd --state`, `nft list ruleset` (pick what is installed).
+   - Linux: try `ufw status` first; if not found, try `/usr/sbin/ufw status` or `/sbin/ufw status` (ufw often lives outside `$PATH` for non-root users). Also try `firewall-cmd --state`, `nft list ruleset` (pick what is installed). Check `/etc/ufw/ufw.conf` for ENABLED state if ufw binary is found but status requires sudo.
    - macOS: `/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate` and `pfctl -s info`.
 4. Backups (macOS): `tmutil status` (if Time Machine is used).
 

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -434,6 +435,16 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
     normalized.newText = normalized.new_string;
     delete normalized.new_string;
   }
+  // Expand tilde prefix in file path parameters.
+  // Some models emit paths like "~/Documents/file.txt" — Node's path.resolve()
+  // treats "~" as a literal directory name, causing misleading "File not found" errors.
+  if (typeof normalized.path === "string" && normalized.path.startsWith("~/")) {
+    const home = os.homedir();
+    if (home) {
+      normalized.path = normalized.path.replace(/^~(?=[\\/])/, home);
+    }
+  }
+
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
   normalizeTextLikeParam(normalized, "content");

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -364,23 +364,26 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       err instanceof GatewayLockError ||
       (err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
     ) {
-      // Idempotent: if the gateway is already running, the desired state is
-      // achieved — exit 0 with an informational message instead of failing.
-      // This prevents automation loops from retrying endlessly when
-      // `openclaw gateway` is called to verify/ensure the gateway is up.
       const errMessage = describeUnknownError(err);
-      try {
-        const diagnostics = await inspectPortUsage(port);
-        if (diagnostics.status === "busy") {
-          // Gateway is genuinely running → idempotent success
-          defaultRuntime.log(`Gateway is already running (${errMessage.replace(/;.*$/, "")})`);
-          defaultRuntime.exit(0);
-          return;
+      // Only treat lock-contention (timeout) as idempotent — not other lock
+      // failures like EACCES or other filesystem errors.  The timeout path
+      // produces messages containing "lock timeout", so we use that as the
+      // discriminant.  See PR #30569 review.
+      const isLockContention = /lock timeout/i.test(errMessage);
+      if (isLockContention) {
+        try {
+          const diagnostics = await inspectPortUsage(port);
+          if (diagnostics.status === "busy") {
+            // Gateway is genuinely running → idempotent success
+            defaultRuntime.log(`Gateway is already running (${errMessage.replace(/;.*$/, "")})`);
+            defaultRuntime.exit(0);
+            return;
+          }
+        } catch {
+          // ignore diagnostics failures — fall through to error path
         }
-      } catch {
-        // ignore diagnostics failures — fall through to error path
       }
-      // Port is free but lock exists → stale lock or race condition → error
+      // Lock error but gateway is not confirmed running → real failure
       defaultRuntime.error(
         `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
       );

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -15,7 +15,7 @@ import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setVerbose } from "../../globals.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
-import { formatPortDiagnostics, inspectPortUsage } from "../../infra/ports.js";
+import { inspectPortUsage } from "../../infra/ports.js";
 import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logging/console.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -364,20 +364,26 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       err instanceof GatewayLockError ||
       (err && typeof err === "object" && (err as { name?: string }).name === "GatewayLockError")
     ) {
+      // Idempotent: if the gateway is already running, the desired state is
+      // achieved — exit 0 with an informational message instead of failing.
+      // This prevents automation loops from retrying endlessly when
+      // `openclaw gateway` is called to verify/ensure the gateway is up.
       const errMessage = describeUnknownError(err);
-      defaultRuntime.error(
-        `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
-      );
       try {
         const diagnostics = await inspectPortUsage(port);
         if (diagnostics.status === "busy") {
-          for (const line of formatPortDiagnostics(diagnostics)) {
-            defaultRuntime.error(line);
-          }
+          // Gateway is genuinely running → idempotent success
+          defaultRuntime.log(`Gateway is already running (${errMessage.replace(/;.*$/, "")})`);
+          defaultRuntime.exit(0);
+          return;
         }
       } catch {
-        // ignore diagnostics failures
+        // ignore diagnostics failures — fall through to error path
       }
+      // Port is free but lock exists → stale lock or race condition → error
+      defaultRuntime.error(
+        `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
+      );
       await maybeExplainGatewayServiceStop();
       defaultRuntime.exit(1);
       return;

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -182,7 +182,12 @@ describe("tilde expansion in file tools", () => {
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");
-      expect(result).toBe(`${fakeHome}/file.txt`);
+      // On Windows the resolved HOME acquires a drive letter and separators
+      // may be mixed (forward + back-slash), so normalise both sides before
+      // comparing.
+      expect(path.normalize(result)).toBe(
+        path.normalize(path.resolve(fakeHome) + "/file.txt"),
+      );
     } finally {
       process.env.HOME = originalHome;
     }


### PR DESCRIPTION
## Summary

Three small independent fixes, bundled for convenience.

### Fix 1: Gateway idempotent start (#30532)

When `openclaw gateway` is called while the gateway is already running, the CLI now:
- Checks if the port is actually busy (gateway genuinely running)
- If yes: exits **0** with `Gateway is already running (pid ...)`
- If no (stale lock): falls through to the existing error path

**Why**: Automation agents (e.g. boot-run scripts) call `openclaw gateway` to verify the gateway is up. Exit code 1 causes infinite retry loops that burn LLM API credits.

### Fix 2: Tilde path expansion in edit tool (#30335)

Expands `~/...` paths to `$HOME/...` in `normalizeToolParams` before paths hit `path.resolve()`. Without this, `~` is treated as a literal directory name, causing misleading "File not found" errors.

### Fix 3: UFW PATH detection in healthcheck skill (#30361)

Updated the healthcheck skill instructions to include fallback paths (`/usr/sbin/ufw`, `/sbin/ufw`) when the binary isn't on `$PATH`, plus `/etc/ufw/ufw.conf` as a backup status check.

## Testing

- Existing cron schedule tests pass (12/12)
- Gateway run-loop tests pass (8/8)
- No new test files (fixes are defensive guards)
