### PR TITLE
fix(browser): extend start timeout for openclaw profiles [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
+- Browser/OpenClaw profile startup: increase `browser action=start` client timeout from 15s to 40s to cover first-run profile bootstrap/startup latency and avoid false "Can't reach the OpenClaw browser control service" timeouts on valid launches. (#30570)
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.
 - TUI/Session model status: clear stale runtime model identity when model overrides change so `/model` updates are reflected immediately in `sessions.patch` responses and `sessions.list` status surfaces. (#28619) Thanks @lejean2000.

--- a/src/browser/client.test.ts
+++ b/src/browser/client.test.ts
@@ -8,7 +8,13 @@ import {
   browserPdfSave,
   browserScreenshotAction,
 } from "./client-actions.js";
-import { browserOpenTab, browserSnapshot, browserStatus, browserTabs } from "./client.js";
+import {
+  browserOpenTab,
+  browserSnapshot,
+  browserStart,
+  browserStatus,
+  browserTabs,
+} from "./client.js";
 
 describe("browser client", () => {
   function stubSnapshotFetch(calls: string[]) {
@@ -50,6 +56,36 @@ describe("browser client", () => {
   it("adds useful timeout messaging for abort-like failures", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("aborted")));
     await expect(browserStatus("http://127.0.0.1:18791")).rejects.toThrow(/timed out/i);
+  });
+
+  it("uses an extended timeout budget for browser start", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_url: string, init?: RequestInit) => {
+          return new Promise((_, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              return;
+            }
+            if (signal.aborted) {
+              reject(new Error("aborted"));
+              return;
+            }
+            signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+          });
+        }),
+      );
+
+      const startPromise = browserStart("http://127.0.0.1:18791");
+      const startRejected = expect(startPromise).rejects.toThrow(/timed out after 40000ms/i);
+      await vi.advanceTimersByTimeAsync(40_000);
+
+      await startRejected;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("surfaces non-2xx responses with body text", async () => {

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -1,5 +1,7 @@
 import { fetchBrowserJson } from "./client-fetch.js";
 
+const BROWSER_START_TIMEOUT_MS = 40_000;
+
 export type BrowserStatus = {
   enabled: boolean;
   profile?: string;
@@ -122,7 +124,7 @@ export async function browserStart(baseUrl?: string, opts?: { profile?: string }
   const q = buildProfileQuery(opts?.profile);
   await fetchBrowserJson(withBaseUrl(baseUrl, `/start${q}`), {
     method: "POST",
-    timeoutMs: 15000,
+    timeoutMs: BROWSER_START_TIMEOUT_MS,
   });
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `browser action=start` used a 15s client timeout, which is shorter than first-run openclaw profile bootstrap + launch paths in some environments.
- Why it matters: valid browser startups can be reported as control-service failures (`timed out after 15000ms`) even though startup is still in progress.
- What changed: increased browser start client timeout budget to 40s and added regression coverage for the timeout behavior.
- What did NOT change (scope boundary): no changes to browser launch internals, CDP probing logic, or profile persistence behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30570
- Related #30467

## User-visible / Behavior Changes

- `browser action=start` now waits up to 40 seconds before returning timeout errors, reducing false negatives during slower first-run profile startup.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): Browser tool (`openclaw` profile)
- Relevant config (redacted): `browser.profiles.<name>.driver=openclaw`

### Steps

1. Call browser start API path through browser client.
2. Simulate a hanging fetch that only ends on abort.
3. Advance fake timers to timeout boundary.

### Expected

- Start timeout budget should be 40s for browser start path.

### Actual

- Before fix: timed out after 15s.
- After fix: timed out after 40s.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added/updated tests in `src/browser/client.test.ts`:
  - verifies `browserStart()` timeout error triggers at 40000ms.
- Local verification:
  - `pnpm oxfmt --check src/browser/client.ts src/browser/client.test.ts CHANGELOG.md`
  - `pnpm oxlint --type-aware src/browser/client.ts src/browser/client.test.ts`
  - `pnpm vitest src/browser/client.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Browser start timeout message now reports `40000ms` budget.
  - Existing browser client tests continue passing.
- Edge cases checked:
  - Timeout rejection remains wrapped with existing operator/model guidance.
- What you did **not** verify:
  - Full live browser launch timing on every platform.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/browser/client.ts`
- Known bad symptoms reviewers should watch for:
  - Browser start calls waiting unexpectedly long in cases where immediate failure is preferred.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Longer timeout can delay surfaced failures on genuinely broken starts.
  - Mitigation: scoped only to start action; stop/status and other calls keep existing shorter budgets.

AI-assisted: yes (implemented and validated locally with human review).
