### PR TITLE
fix(gemini-cli-auth): harden windows oauth credential discovery [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
+- Gemini CLI OAuth/Windows discovery: harden Gemini CLI credential extraction by handling quoted PATH entries and npm-prefix fallback install paths (including `%APPDATA%\\npm` layouts), and document `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_PROJECT_ID` fallback for Code Assist project discovery failures. (#30403)
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.
 - TUI/Session model status: clear stale runtime model identity when model overrides change so `/model` updates are reflected immediately in `sessions.patch` responses and `sessions.list` status surfaces. (#28619) Thanks @lejean2000.

--- a/extensions/google-gemini-cli-auth/README.md
+++ b/extensions/google-gemini-cli-auth/README.md
@@ -39,3 +39,9 @@ Override auto-detected credentials with:
 
 - `OPENCLAW_GEMINI_OAUTH_CLIENT_ID` / `GEMINI_CLI_OAUTH_CLIENT_ID`
 - `OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET` / `GEMINI_CLI_OAUTH_CLIENT_SECRET`
+
+If Google Code Assist project discovery fails (for example with `loadCodeAssist` 400 responses),
+set one of:
+
+- `GOOGLE_CLOUD_PROJECT`
+- `GOOGLE_CLOUD_PROJECT_ID`

--- a/extensions/google-gemini-cli-auth/oauth.test.ts
+++ b/extensions/google-gemini-cli-auth/oauth.test.ts
@@ -47,6 +47,10 @@ describe("extractGeminiCliCredentials", () => {
   `;
 
   let originalPath: string | undefined;
+  let originalNpmConfigPrefix: string | undefined;
+  let originalUpperNpmConfigPrefix: string | undefined;
+  let originalAppData: string | undefined;
+  let originalLocalAppData: string | undefined;
 
   function makeFakeLayout() {
     const binDir = join(rootDir, "fake", "bin");
@@ -147,10 +151,18 @@ describe("extractGeminiCliCredentials", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     originalPath = process.env.PATH;
+    originalNpmConfigPrefix = process.env.npm_config_prefix;
+    originalUpperNpmConfigPrefix = process.env.NPM_CONFIG_PREFIX;
+    originalAppData = process.env.APPDATA;
+    originalLocalAppData = process.env.LOCALAPPDATA;
   });
 
   afterEach(() => {
     process.env.PATH = originalPath;
+    process.env.npm_config_prefix = originalNpmConfigPrefix;
+    process.env.NPM_CONFIG_PREFIX = originalUpperNpmConfigPrefix;
+    process.env.APPDATA = originalAppData;
+    process.env.LOCALAPPDATA = originalLocalAppData;
   });
 
   it("returns null when gemini binary is not in PATH", async () => {
@@ -175,8 +187,55 @@ describe("extractGeminiCliCredentials", () => {
     });
   });
 
+  it("supports quoted PATH entries for gemini binary lookup", async () => {
+    const layout = installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
+    process.env.PATH = `"${layout.binDir}"`;
+
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    clearCredentialsCache();
+    const result = extractGeminiCliCredentials();
+
+    expect(result).toEqual({
+      clientId: FAKE_CLIENT_ID,
+      clientSecret: FAKE_CLIENT_SECRET,
+    });
+  });
+
   it("extracts credentials when PATH entry is an npm global shim", async () => {
     installNpmShimLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
+
+    const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
+    clearCredentialsCache();
+    const result = extractGeminiCliCredentials();
+
+    expect(result).toEqual({
+      clientId: FAKE_CLIENT_ID,
+      clientSecret: FAKE_CLIENT_SECRET,
+    });
+  });
+
+  it("falls back to npm prefix candidates when gemini binary lookup fails", async () => {
+    const npmPrefix = join(rootDir, "fake", "npm-prefix");
+    const oauth2Path = join(
+      npmPrefix,
+      "node_modules",
+      "@google",
+      "gemini-cli",
+      "node_modules",
+      "@google",
+      "gemini-cli-core",
+      "dist",
+      "src",
+      "code_assist",
+      "oauth2.js",
+    );
+    process.env.PATH = join(rootDir, "no-gemini-here");
+    process.env.npm_config_prefix = npmPrefix;
+
+    mockExistsSync.mockImplementation(
+      (p: string) => normalizePath(p) === normalizePath(oauth2Path),
+    );
+    mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
 
     const { extractGeminiCliCredentials, clearCredentialsCache } = await import("./oauth.js");
     clearCredentialsCache();

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -74,12 +74,11 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
 
   try {
     const geminiPath = findInPath("gemini");
-    if (!geminiPath) {
+    const resolvedPath = geminiPath ? realpathSync(geminiPath) : undefined;
+    const geminiCliDirs = resolveGeminiCliDirs({ geminiPath, resolvedPath });
+    if (geminiCliDirs.length === 0) {
       return null;
     }
-
-    const resolvedPath = realpathSync(geminiPath);
-    const geminiCliDirs = resolveGeminiCliDirs(geminiPath, resolvedPath);
 
     let content: string | null = null;
     for (const geminiCliDir of geminiCliDirs) {
@@ -136,15 +135,35 @@ export function extractGeminiCliCredentials(): { clientId: string; clientSecret:
   return null;
 }
 
-function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[] {
-  const binDir = dirname(geminiPath);
-  const candidates = [
-    dirname(dirname(resolvedPath)),
-    join(dirname(resolvedPath), "node_modules", "@google", "gemini-cli"),
-    join(binDir, "node_modules", "@google", "gemini-cli"),
-    join(dirname(binDir), "node_modules", "@google", "gemini-cli"),
-    join(dirname(binDir), "lib", "node_modules", "@google", "gemini-cli"),
-  ];
+function resolveGeminiCliDirs(params: { geminiPath?: string; resolvedPath?: string }): string[] {
+  const candidates: string[] = [];
+
+  if (params.geminiPath && params.resolvedPath) {
+    const binDir = dirname(params.geminiPath);
+    candidates.push(
+      dirname(dirname(params.resolvedPath)),
+      join(dirname(params.resolvedPath), "node_modules", "@google", "gemini-cli"),
+      join(binDir, "node_modules", "@google", "gemini-cli"),
+      join(dirname(binDir), "node_modules", "@google", "gemini-cli"),
+      join(dirname(binDir), "lib", "node_modules", "@google", "gemini-cli"),
+    );
+  }
+
+  const npmPrefixes = [
+    process.env.npm_config_prefix,
+    process.env.NPM_CONFIG_PREFIX,
+    process.env.APPDATA ? join(process.env.APPDATA, "npm") : undefined,
+    process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, "npm") : undefined,
+  ]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  for (const prefix of npmPrefixes) {
+    candidates.push(
+      join(prefix, "node_modules", "@google", "gemini-cli"),
+      join(prefix, "lib", "node_modules", "@google", "gemini-cli"),
+    );
+  }
 
   const deduped: string[] = [];
   const seen = new Set<string>();
@@ -161,8 +180,12 @@ function resolveGeminiCliDirs(geminiPath: string, resolvedPath: string): string[
 }
 
 function findInPath(name: string): string | null {
-  const exts = process.platform === "win32" ? [".cmd", ".bat", ".exe", ""] : [""];
-  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+  const exts = process.platform === "win32" ? [".cmd", ".bat", ".exe", ".ps1", ""] : [""];
+  const pathEntries = (process.env.PATH ?? "")
+    .split(delimiter)
+    .map((entry) => entry.trim().replace(/^"(.*)"$/u, "$1"))
+    .filter(Boolean);
+  for (const dir of pathEntries) {
     for (const ext of exts) {
       const p = join(dir, name + ext);
       if (existsSync(p)) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gemini CLI OAuth credential auto-discovery can fail on Windows/npm-global setups when PATH entries are quoted or binary lookup fails before probing install roots.
- Why it matters: users hit `client_secret is missing` token-exchange failures even with a valid global `@google/gemini-cli` install.
- What changed: hardened Gemini CLI credential extraction with quoted-PATH handling, npm-prefix/AppData candidate fallback scanning, and added regression tests for both paths.
- What did NOT change (scope boundary): no OAuth protocol/token exchange shape changes and no changes to Code Assist endpoint fallback ordering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30403
- Related #4585

## User-visible / Behavior Changes

- Gemini CLI OAuth credential extraction now tolerates quoted PATH entries and can recover from binary lookup misses by probing npm-prefix/AppData install roots.
- Plugin README now documents `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_PROJECT_ID` fallback env vars for Code Assist project discovery failures.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (with Windows-path style unit coverage)
- Runtime/container: Node + pnpm local dev
- Model/provider: `google-gemini-cli`
- Integration/channel (if any): OAuth plugin `google-gemini-cli-auth`
- Relevant config (redacted): env overrides + plugin defaults

### Steps

1. Simulate quoted PATH entry and npm-prefix install layouts in OAuth extraction tests.
2. Run credential extraction for each scenario.
3. Verify extracted `clientId/clientSecret` and fallback behavior.

### Expected

- Credentials are extracted for quoted PATH and npm-prefix fallback scenarios.

### Actual

- Before fix: these edge cases could return `null` and break token exchange (`client_secret is missing`).
- After fix: extraction succeeds in both scenarios.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added tests in `extensions/google-gemini-cli-auth/oauth.test.ts`:
  - quoted PATH entry lookup works.
  - npm prefix fallback works when gemini binary lookup fails.
- Local verification:
  - `pnpm oxfmt --check extensions/google-gemini-cli-auth/oauth.ts extensions/google-gemini-cli-auth/oauth.test.ts extensions/google-gemini-cli-auth/README.md CHANGELOG.md`
  - `pnpm vitest extensions/google-gemini-cli-auth/oauth.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Extractor recovers credentials from quoted PATH environments.
  - Extractor recovers credentials from npm-prefix fallback directories.
  - Existing OAuth tests still pass.
- Edge cases checked:
  - Binary-not-found path now still attempts install root candidates.
- What you did **not** verify:
  - End-to-end OAuth login on a real Windows host.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/google-gemini-cli-auth/oauth.ts`
  - `extensions/google-gemini-cli-auth/README.md`
- Known bad symptoms reviewers should watch for:
  - Unexpected credential extraction in environments with multiple Gemini CLI installs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Additional fallback path probing could pick an unintended install root in unusual multi-install setups.
  - Mitigation: candidate paths are narrowly scoped to known gemini-cli install layouts and deduped.

AI-assisted: yes (implemented and validated locally with human review).
