### PR TITLE
usage: fix misleading 'Day' label for long Codex reset windows

### DIFF
--- a/src/infra/provider-usage.fetch.codex.test.ts
+++ b/src/infra/provider-usage.fetch.codex.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProviderUsageFetch, makeResponse } from "../test-utils/provider-usage-fetch.js";
 import { fetchCodexUsage } from "./provider-usage.fetch.codex.js";
 
 describe("fetchCodexUsage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("returns token expired for auth failures", async () => {
     const mockFetch = createProviderUsageFetch(async () =>
       makeResponse(401, { error: "unauthorized" }),
@@ -78,5 +81,31 @@ describe("fetchCodexUsage", () => {
       { label: "3h", usedPercent: 7, resetAt: 1_700_000_000_000 },
       { label: "Week", usedPercent: 10, resetAt: 1_700_500_000_000 },
     ]);
+  });
+
+  it("labels secondary window as Week when reset horizon is multi-day", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00Z"));
+
+    const resetAtSec = Math.floor((Date.now() + (3 * 24 + 8) * 60 * 60 * 1000) / 1000);
+    const mockFetch = createProviderUsageFetch(async () =>
+      makeResponse(200, {
+        rate_limit: {
+          primary_window: {
+            limit_window_seconds: 10_800,
+            used_percent: 45,
+            reset_at: Math.floor((Date.now() + 2 * 60 * 60 * 1000) / 1000),
+          },
+          secondary_window: {
+            limit_window_seconds: 86_400,
+            used_percent: 85,
+            reset_at: resetAtSec,
+          },
+        },
+      }),
+    );
+
+    const result = await fetchCodexUsage("token", undefined, 5000, mockFetch);
+    expect(result.windows?.[1]?.label).toBe("Week");
   });
 });

--- a/src/infra/provider-usage.fetch.codex.ts
+++ b/src/infra/provider-usage.fetch.codex.ts
@@ -65,11 +65,15 @@ export async function fetchCodexUsage(
   if (data.rate_limit?.secondary_window) {
     const sw = data.rate_limit.secondary_window;
     const windowHours = Math.round((sw.limit_window_seconds || 86400) / 3600);
-    const label = windowHours >= 168 ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
+    const resetAt = sw.reset_at ? sw.reset_at * 1000 : undefined;
+    const resetHours = resetAt ? (resetAt - Date.now()) / (60 * 60 * 1000) : undefined;
+    const weekLikeWindow =
+      windowHours >= 168 || (windowHours >= 24 && resetHours !== undefined && resetHours > 48);
+    const label = weekLikeWindow ? "Week" : windowHours >= 24 ? "Day" : `${windowHours}h`;
     windows.push({
       label,
       usedPercent: clampPercent(sw.used_percent || 0),
-      resetAt: sw.reset_at ? sw.reset_at * 1000 : undefined,
+      resetAt,
     });
   }
 


### PR DESCRIPTION
Fixes misleading usage labeling for Codex secondary windows.

## Problem
Some accounts display a secondary window as `Day`, while reset countdown is clearly multi-day (week-like), e.g. `Day ... ⏱3d ...`.

## Change
- keep existing `limit_window_seconds` logic
- additionally treat the window as `Week` when reset horizon is clearly multi-day (>48h)
- add test coverage for this scenario

This keeps the output aligned with what users actually see in the timer.
