### PR TITLE
docs(browser): add high-reliability automation playbook [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
+- Docs/Browser best practices: add a reliability-focused browser automation guide covering snapshot/ref workflow, upload/download/dialog arming, iframe usage, and quick troubleshooting playbooks. (#30502)
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.
 - TUI/Session model status: clear stale runtime model identity when model overrides change so `/model` updates are reflected immediately in `sessions.patch` responses and `sessions.list` status surfaces. (#28619) Thanks @lejean2000.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -471,6 +471,55 @@ Notes:
 - `click`/`type`/etc require a `ref` from `snapshot` (either numeric `12` or role ref `e12`).
   CSS selectors are intentionally not supported for actions.
 
+## Best practices (reliable workflow)
+
+Use this sequence to avoid most browser automation failures:
+
+1. Start with a fresh snapshot before acting:
+   - `openclaw browser snapshot --interactive`
+2. Use refs from that snapshot for actions (`click`, `type`, `hover`, `drag`, `select`).
+3. Re-snapshot after navigation, major UI changes, or frame switches.
+4. Add explicit waits for dynamic pages:
+   - `openclaw browser wait --load networkidle`
+   - `openclaw browser wait --url "**/target"`
+   - `openclaw browser wait "#selector"`
+5. Prefer role refs over CSS selectors for stability.
+
+### Arming calls (critical)
+
+Some actions require an arming call **before** the trigger step:
+
+- File upload:
+  - arm: `openclaw browser upload /tmp/openclaw/uploads/file.pdf`
+  - trigger: `openclaw browser click <ref>`
+- File download:
+  - arm: `openclaw browser download <ref> report.pdf`
+  - trigger: click/export action
+- Dialogs:
+  - arm: `openclaw browser dialog --accept` (or `--dismiss`)
+  - trigger: click button that opens `alert/confirm/prompt`
+
+If you skip arming, upload/download/dialog behavior may fail or race.
+
+### iframe workflow (no manual frame switching)
+
+Use frame-scoped snapshots and refs instead of manual context switching:
+
+1. `openclaw browser snapshot --frame "iframe#app" --interactive`
+2. Use returned refs (`e12`, `e33`, etc.) with normal actions.
+3. Re-run frame snapshot after iframe navigation/reload.
+
+### Quick troubleshooting
+
+- `tab not found` / stale ref:
+  - take a new snapshot and retry with fresh refs.
+- Download file not found:
+  - ensure you armed with `browser download` before triggering.
+- Dialog closed unexpectedly:
+  - ensure `browser dialog --accept|--dismiss` ran before the trigger click.
+- Action hits wrong element:
+  - use `openclaw browser highlight <ref>` to verify target resolution.
+
 ## Snapshots and refs
 
 OpenClaw supports two “snapshot” styles:


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Browser docs already cover commands, but users still hit repeated reliability pitfalls (stale refs, missing arming calls, iframe confusion).
- Why it matters: these pitfalls cause fragile browser automation and repeated support/debug loops.
- What changed: added a dedicated “Best practices (reliable workflow)” section to browser docs with concrete workflows for refs/snapshots, arming calls, iframe usage, and troubleshooting.
- What did NOT change (scope boundary): no runtime code changes, no browser API/CLI behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30502
- Related #30570

## User-visible / Behavior Changes

- Browser docs now include a concise reliability playbook covering:
  - recommended snapshot/ref interaction sequence,
  - required arming order for upload/download/dialog,
  - iframe-safe workflow without manual frame switching,
  - quick troubleshooting for common failures.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: docs source + markdown formatter
- Model/provider: N/A
- Integration/channel (if any): Browser docs
- Relevant config (redacted): N/A

### Steps

1. Open `docs/tools/browser.md`.
2. Navigate to new “Best practices (reliable workflow)” section.
3. Verify guidance includes arming, iframe workflow, and troubleshooting examples.

### Expected

- Operators have one clear workflow section for reliable browser automation.

### Actual

- Added section with actionable command-level guidance and troubleshooting playbooks.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Local verification:
  - `pnpm oxfmt --check docs/tools/browser.md CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New section is discoverable and placed near existing action/snapshot guidance.
  - Examples use existing CLI command syntax.
- Edge cases checked:
  - Arming caveats explicitly documented for upload/download/dialog race conditions.
- What you did **not** verify:
  - Full docs-site build/lint baseline (repository has pre-existing markdownlint baseline warnings in `CHANGELOG.md`).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `docs/tools/browser.md`
- Known bad symptoms reviewers should watch for:
  - Any command examples that drift from actual CLI behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Docs guidance could become stale if browser CLI semantics change.
  - Mitigation: guidance references stable command families already documented in same page.

AI-assisted: yes (drafted and reviewed with human verification).
