### PR TITLE
fix(line): dedupe webhook message replays by message id [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/Custom providers: raise default custom-provider model context window to the runtime hard minimum (16k) and auto-heal existing custom model entries below that threshold during reconfiguration, preventing immediate `Model context window too small (4096 tokens)` failures. (#21653) Thanks @r4jiv007.
+- LINE/inbound dedupe: skip duplicate webhook message redeliveries by LINE message ID before dispatch, preventing the same inbound message from being replayed into sessions as repeated user turns after provider-side failures. (#30574)
 - Web UI/Assistant text: strip internal `<relevant-memories>...</relevant-memories>` scaffolding from rendered assistant messages (while preserving code-fence literals), preventing memory-context leakage in chat output for models that echo internal blocks. (#29851) Thanks @Valkster70.
 - Dashboard/Sessions: allow authenticated Control UI clients to delete and patch sessions while still blocking regular webchat clients from session mutation RPCs, fixing Dashboard session delete failures. (#21264) Thanks @jskoiz.
 - TUI/Session model status: clear stale runtime model identity when model overrides change so `/model` updates are reflected immediately in `sessions.patch` responses and `sessions.list` status surfaces. (#28619) Thanks @lejean2000.

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -64,6 +64,7 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
 }));
 
 let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
+let resetLineWebhookEventDedupeForTests: typeof import("./bot-handlers.js").resetLineWebhookEventDedupeForTests;
 
 const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
 
@@ -74,10 +75,12 @@ vi.mock("../pairing/pairing-store.js", () => ({
 
 describe("handleLineWebhookEvents", () => {
   beforeAll(async () => {
-    ({ handleLineWebhookEvents } = await import("./bot-handlers.js"));
+    ({ handleLineWebhookEvents, resetLineWebhookEventDedupeForTests } =
+      await import("./bot-handlers.js"));
   });
 
   beforeEach(() => {
+    resetLineWebhookEventDedupeForTests();
     buildLineMessageContextMock.mockClear();
     buildLinePostbackContextMock.mockClear();
     readAllowFromStoreMock.mockClear();
@@ -247,5 +250,65 @@ describe("handleLineWebhookEvents", () => {
 
     expect(processMessage).not.toHaveBeenCalled();
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+  });
+
+  it("skips duplicate inbound LINE message events by message id", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m-dup-1", type: "text", text: "hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-dup", userId: "user-dup" },
+      mode: "active",
+      webhookEventId: "evt-dup-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: { line: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    });
+
+    await handleLineWebhookEvents(
+      [
+        {
+          ...event,
+          webhookEventId: "evt-dup-redelivery",
+          deliveryContext: { isRedelivery: true },
+        } as MessageEvent,
+      ],
+      {
+        cfg: {
+          channels: { line: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] } },
+        },
+        account: {
+          accountId: "default",
+          enabled: true,
+          channelAccessToken: "token",
+          channelSecret: "secret",
+          tokenSource: "config",
+          config: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] },
+        },
+        runtime: createRuntime(),
+        mediaMaxBytes: 1,
+        processMessage,
+      },
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -14,6 +14,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
 import { danger, logVerbose } from "../globals.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { resolvePairingIdLabel } from "../pairing/pairing-labels.js";
 import { buildPairingReply } from "../pairing/pairing-messages.js";
 import {
@@ -48,6 +49,33 @@ export interface LineHandlerContext {
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
+}
+
+const lineWebhookEventDedupe = createDedupeCache({
+  ttlMs: 20 * 60_000,
+  maxSize: 5000,
+});
+
+function buildLineWebhookEventDedupeKey(event: WebhookEvent): string | null {
+  if (event.type === "message") {
+    const messageId = event.message?.id?.trim();
+    return messageId ? `message:${messageId}` : null;
+  }
+  if (event.type === "postback") {
+    const replyToken = event.replyToken?.trim();
+    if (replyToken) {
+      return `postback:${replyToken}`;
+    }
+  }
+  const webhookEventId = (event as { webhookEventId?: unknown }).webhookEventId;
+  if (typeof webhookEventId === "string" && webhookEventId.trim()) {
+    return `event:${webhookEventId.trim()}`;
+  }
+  return null;
+}
+
+export function resetLineWebhookEventDedupeForTests(): void {
+  lineWebhookEventDedupe.clear();
 }
 
 function resolveLineGroupConfig(params: {
@@ -319,6 +347,11 @@ export async function handleLineWebhookEvents(
   context: LineHandlerContext,
 ): Promise<void> {
   for (const event of events) {
+    const dedupeKey = buildLineWebhookEventDedupeKey(event);
+    if (dedupeKey && lineWebhookEventDedupe.check(dedupeKey)) {
+      logVerbose(`line: skipped duplicate webhook event (${dedupeKey})`);
+      continue;
+    }
     try {
       switch (event.type) {
         case "message":


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: LINE webhook redeliveries can re-enter inbound dispatch as fresh turns, causing the same LINE `message.id` to be replayed into sessions as duplicate `user` messages.
- Why it matters: duplicate inbound turns corrupt session history, inflate token/tool cost, and amplify side effects under provider failure conditions.
- What changed: added LINE webhook event dedupe keyed by message ID (and postback/replay fallbacks), plus regression tests proving duplicate redelivery is skipped.
- What did NOT change (scope boundary): no changes to provider retry semantics, routing policy logic, or outbound reply formatting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30574
- Related #30553

## User-visible / Behavior Changes

- Replayed LINE webhook deliveries for an already-seen `message.id` are now dropped before dispatch, so one inbound LINE message maps to one user turn.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): LINE webhook handler
- Relevant config (redacted): LINE `groupPolicy=allowlist` test fixture

### Steps

1. Deliver a LINE message event once and process normally.
2. Deliver the same event again as redelivery (`deliveryContext.isRedelivery=true`) with same `message.id`.
3. Observe dispatch invocations.

### Expected

- Duplicate event should be skipped; message context built once and processed once.

### Actual

- Before fix: duplicate event could be processed as a fresh inbound turn.
- After fix: duplicate event is skipped by webhook dedupe cache.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- Added test in `src/line/bot-handlers.test.ts`:
  - `skips duplicate inbound LINE message events by message id`
- Local verification:
  - `pnpm oxfmt --check src/line/bot-handlers.ts src/line/bot-handlers.test.ts CHANGELOG.md`
  - `pnpm oxlint --type-aware src/line/bot-handlers.ts src/line/bot-handlers.test.ts`
  - `pnpm vitest src/line/bot-handlers.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - First event is processed.
  - Redelivery of same `message.id` is skipped.
- Edge cases checked:
  - Added explicit reset helper to isolate dedupe cache between tests.
- What you did **not** verify:
  - Live LINE production webhook end-to-end under real 429/403 provider failures.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/line/bot-handlers.ts`
- Known bad symptoms reviewers should watch for:
  - Legitimate unique LINE events being skipped due key collisions.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-aggressive dedupe could suppress legitimate retries that should be reprocessed.
  - Mitigation: keying prioritizes stable LINE message IDs/postback reply tokens; duplicates must match exact identifiers.

AI-assisted: yes (implemented and validated locally with human review).
