### PR TITLE
fix(agents): avoid duplicate user turns on retry

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -41,6 +41,7 @@ export function makeAttemptResult(
     messagingToolSentMediaUrls: [],
     messagingToolSentTargets: [],
     cloudCodeAssistFormatError: false,
+    retryBranchBaseEntryId: null,
     ...overrides,
   };
 }

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts
@@ -86,6 +86,7 @@ vi.mock("../pi-embedded-helpers.js", () => ({
 
 vi.mock("./run/attempt.js", () => ({
   runEmbeddedAttempt: vi.fn(),
+  rollbackEmbeddedAttemptSession: vi.fn(async () => {}),
 }));
 
 vi.mock("./compact.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.shared-test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.shared-test.ts
@@ -1,12 +1,13 @@
 import { vi } from "vitest";
 import { compactEmbeddedPiSessionDirect } from "./compact.js";
-import { runEmbeddedAttempt } from "./run/attempt.js";
+import { rollbackEmbeddedAttemptSession, runEmbeddedAttempt } from "./run/attempt.js";
 import {
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInSession,
 } from "./tool-result-truncation.js";
 
 export const mockedRunEmbeddedAttempt = vi.mocked(runEmbeddedAttempt);
+export const mockedRollbackEmbeddedAttemptSession = vi.mocked(rollbackEmbeddedAttemptSession);
 export const mockedCompactDirect = vi.mocked(compactEmbeddedPiSessionDirect);
 export const mockedSessionLikelyHasOversizedToolResults = vi.mocked(
   sessionLikelyHasOversizedToolResults,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -12,6 +12,7 @@ import {
 import { mockedGlobalHookRunner } from "./run.overflow-compaction.mocks.shared.js";
 import {
   mockedCompactDirect,
+  mockedRollbackEmbeddedAttemptSession,
   mockedRunEmbeddedAttempt,
   mockedSessionLikelyHasOversizedToolResults,
   mockedTruncateOversizedToolResultsInSession,
@@ -114,6 +115,29 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
     expect(result.meta.error?.kind).toBe("context_overflow");
+  });
+
+  it("rewinds session branch before retrying with fallback thinking", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error("unsupported reasoning mode"),
+          retryBranchBaseEntryId: "entry-before-retry",
+          compactionCount: 0,
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedPickFallbackThinkingLevel.mockReturnValueOnce("low");
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedRollbackEmbeddedAttemptSession).toHaveBeenCalledTimes(1);
+    expect(mockedRollbackEmbeddedAttemptSession).toHaveBeenCalledWith({
+      sessionFile: overflowBaseRunParams.sessionFile,
+      baseEntryId: "entry-before-retry",
+    });
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.error).toBeUndefined();
   });
 
   it("returns retry_limit when repeated retries never converge", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -54,7 +54,7 @@ import { compactEmbeddedPiSessionDirect } from "./compact.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
-import { runEmbeddedAttempt } from "./run/attempt.js";
+import { rollbackEmbeddedAttemptSession, runEmbeddedAttempt } from "./run/attempt.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
@@ -641,6 +641,29 @@ export async function runEmbeddedPiAgent(
             sessionIdUsed,
             lastAssistant,
           } = attempt;
+          const rollbackRetryAttempt = async (reason: string): Promise<void> => {
+            if ((attempt.compactionCount ?? 0) > 0) {
+              return;
+            }
+            try {
+              await rollbackEmbeddedAttemptSession({
+                sessionFile: params.sessionFile,
+                baseEntryId: attempt.retryBranchBaseEntryId,
+              });
+              if (log.isEnabled("debug")) {
+                log.debug(
+                  `[retry-rewind] restored session branch before retry ` +
+                    `reason=${reason} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                    `baseEntryId=${attempt.retryBranchBaseEntryId ?? "root"}`,
+                );
+              }
+            } catch (err) {
+              log.warn(
+                `[retry-rewind] failed before retry reason=${reason} ` +
+                  `sessionKey=${params.sessionKey ?? params.sessionId} error=${String(err)}`,
+              );
+            }
+          };
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
@@ -913,6 +936,7 @@ export async function runEmbeddedPiAgent(
               promptFailoverReason !== "timeout" &&
               (await advanceAuthProfile())
             ) {
+              await rollbackRetryAttempt("prompt_failover_profile_rotate");
               continue;
             }
             const fallbackThinking = pickFallbackThinkingLevel({
@@ -920,6 +944,7 @@ export async function runEmbeddedPiAgent(
               attempted: attemptedThinking,
             });
             if (fallbackThinking) {
+              await rollbackRetryAttempt("prompt_fallback_thinking");
               log.warn(
                 `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
               );
@@ -929,6 +954,7 @@ export async function runEmbeddedPiAgent(
             // FIX: Throw FailoverError for prompt errors when fallbacks configured
             // This enables model fallback for quota/rate limit errors during prompt submission
             if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
+              await rollbackRetryAttempt("prompt_model_fallback");
               throw new FailoverError(errorText, {
                 reason: promptFailoverReason ?? "unknown",
                 provider,
@@ -945,6 +971,7 @@ export async function runEmbeddedPiAgent(
             attempted: attemptedThinking,
           });
           if (fallbackThinking && !aborted) {
+            await rollbackRetryAttempt("assistant_fallback_thinking");
             log.warn(
               `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
             );
@@ -1009,6 +1036,7 @@ export async function runEmbeddedPiAgent(
 
             const rotated = await advanceAuthProfile();
             if (rotated) {
+              await rollbackRetryAttempt("assistant_failover_profile_rotate");
               continue;
             }
 
@@ -1039,6 +1067,7 @@ export async function runEmbeddedPiAgent(
               const status =
                 resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
                 (isTimeoutErrorMessage(message) ? 408 : undefined);
+              await rollbackRetryAttempt("assistant_model_fallback");
               throw new FailoverError(message, {
                 reason: assistantFailoverReason ?? "unknown",
                 provider: activeErrorContext.provider,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -297,6 +297,26 @@ export function wrapStreamFnTrimToolCallNames(baseFn: StreamFn): StreamFn {
   };
 }
 
+export async function rollbackEmbeddedAttemptSession(params: {
+  sessionFile: string;
+  baseEntryId?: string | null;
+}): Promise<void> {
+  const sessionLock = await acquireSessionWriteLock({
+    sessionFile: params.sessionFile,
+  });
+  try {
+    const sessionManager = SessionManager.open(params.sessionFile);
+    const baseEntryId = params.baseEntryId?.trim();
+    if (baseEntryId) {
+      sessionManager.branch(baseEntryId);
+      return;
+    }
+    sessionManager.resetLeaf();
+  } finally {
+    await sessionLock.release();
+  }
+}
+
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
@@ -1180,6 +1200,7 @@ export async function runEmbeddedAttempt(
 
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
+      let retryBranchBaseEntryId: string | null = null;
       try {
         const promptStartedAt = Date.now();
 
@@ -1237,6 +1258,7 @@ export async function runEmbeddedAttempt(
               `runId=${params.runId} sessionId=${params.sessionId}`,
           );
         }
+        retryBranchBaseEntryId = sessionManager.getLeafEntry()?.id ?? null;
 
         try {
           // Idempotent cleanup for legacy sessions with persisted image payloads.
@@ -1530,6 +1552,7 @@ export async function runEmbeddedAttempt(
         ),
         attemptUsage: getUsageTotals(),
         compactionCount: getCompactionCount(),
+        retryBranchBaseEntryId,
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
       };

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -50,6 +50,11 @@ export type EmbeddedRunAttemptResult = {
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;
+  /**
+   * Session branch leaf id captured immediately before submitting this attempt's prompt.
+   * Retries can rewind to this checkpoint to avoid duplicating the same inbound user turn.
+   */
+  retryBranchBaseEntryId?: string | null;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
 };


### PR DESCRIPTION
## Summary
- capture a pre-prompt branch checkpoint for each embedded run attempt
- rewind the session branch before retrying prompt/assistant failover paths and before handing off to model fallback
- add a regression test to verify retry paths trigger rewind and do not replay the same inbound turn

## Test plan
- [x] `pnpm exec vitest run src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
- [x] `pnpm exec vitest run src/agents/pi-embedded-runner.test.ts`

Closes #30574
