### PR TITLE
fix: remove ack reaction on NO_REPLY when removeAckAfterReply is enabled

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -415,6 +415,30 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream.clear();
+    // Also remove ack reaction on NO_REPLY when removeAckAfterReply is enabled
+    if (ctx.removeAckAfterReply && prepared.ackReactionPromise) {
+      void prepared.ackReactionPromise.then((didAck) => {
+        if (!didAck) {
+          return;
+        }
+        removeSlackReaction(
+          message.channel,
+          prepared.ackReactionMessageTs ?? "",
+          prepared.ackReactionValue,
+          {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          },
+        ).catch((err) => {
+          logAckFailure({
+            log: shouldLogVerbose,
+            channel: "slack",
+            target: `${message.channel}/${message.ts}`,
+            error: err,
+          });
+        });
+      });
+    }
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -689,12 +689,38 @@ export const dispatchTelegramMessage = async ({
   const hasFinalResponse = queuedFinal || sentFallback;
 
   if (statusReactionController && !hasFinalResponse) {
-    void statusReactionController.setError().catch((err) => {
-      logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
-    });
+    // Remove ack reaction on NO_REPLY when removeAckAfterReply is enabled (like Discord does)
+    if (removeAckAfterReply) {
+      void statusReactionController.clear().catch((err) => {
+        logVerbose(`telegram: status reaction clear on NO_REPLY failed: ${String(err)}`);
+      });
+    } else {
+      void statusReactionController.setError().catch((err) => {
+        logVerbose(`telegram: status reaction error finalize failed: ${String(err)}`);
+      });
+    }
   }
 
   if (!hasFinalResponse) {
+    // Also remove ack reaction on NO_REPLY when removeAckAfterReply is enabled
+    if (!statusReactionController && removeAckAfterReply && ackReactionPromise) {
+      void ackReactionPromise.then((didAck) => {
+        if (!didAck) {
+          return;
+        }
+        reactionApi?.(chatId, msg.message_id ?? 0, []).catch((err) => {
+          if (!msg.message_id) {
+            return;
+          }
+          logAckFailure({
+            log: logVerbose,
+            channel: "telegram",
+            target: `${chatId}/${msg.message_id}`,
+            error: err,
+          });
+        });
+      });
+    }
     clearGroupHistory();
     return;
   }


### PR DESCRIPTION
Fixes #30585

## Problem
When messages.ackReaction is configured with removeAckAfterReply: true, the ack reaction is correctly added when the bot is mentioned. However, if the agent decides not to reply (NO_REPLY), the reaction is never removed and remains permanently stuck on the message.

## Solution
- Telegram: When statusReactionController exists and removeAckAfterReply is true, call clear() instead of setError() on NO_REPLY to remove the ack reaction
- Telegram: Also handle the non-statusReactionController case  
- Slack: Remove ack reaction on NO_REPLY when removeAckAfterReply is enabled

## Background
Similar to the typing indicator cleanup fix in PR #11093, this ensures that ack reactions are properly cleaned up when the agent decides not to reply.

When removeAckAfterReply is enabled:
- Discord already clears the reaction after a delay
- Now Telegram and Slack will also clear the reaction on NO_REPLY