### PR TITLE
fix(edit): recover markdown-wrapped path arguments

### DIFF
--- a/src/agents/pi-tools.read.normalize-tool-params.test.ts
+++ b/src/agents/pi-tools.read.normalize-tool-params.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParams } from "./pi-tools.read.js";
+
+describe("normalizeToolParams", () => {
+  it("normalizes markdown-linked file paths for edit-style params", () => {
+    const normalized = normalizeToolParams({
+      file_path: "`~/.openclaw/workspace/SELF_LEARNING_LOOP_[CRON.md](http://cron.md/)`",
+      old_string: "before",
+      new_string: "after",
+    });
+
+    const normalizedPath = typeof normalized?.path === "string" ? normalized.path : "";
+    expect(normalizedPath).toContain("SELF_LEARNING_LOOP_CRON.md");
+    expect(normalizedPath).not.toContain("[CRON.md]");
+    expect(normalizedPath).not.toContain("(http://cron.md/)");
+    expect(normalized?.oldText).toBe("before");
+    expect(normalized?.newText).toBe("after");
+  });
+
+  it("converts file URLs into filesystem paths", () => {
+    const normalized = normalizeToolParams({
+      path: "file:///tmp/my%20doc.md",
+    });
+
+    expect(normalized?.path).toBe("/tmp/my doc.md");
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -410,6 +410,47 @@ function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
   }
 }
 
+const MARKDOWN_LINK_IN_PATH_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+const WRAPPED_PATH_RE = /^([`"'<>])(.*)\1$/;
+
+function normalizePathLikeParam(record: Record<string, unknown>, key: string) {
+  normalizeTextLikeParam(record, key);
+  const value = record[key];
+  if (typeof value !== "string") {
+    return;
+  }
+  let normalized = value.trim();
+  if (!normalized) {
+    record[key] = normalized;
+    return;
+  }
+
+  const wrapped = normalized.match(WRAPPED_PATH_RE);
+  if (wrapped) {
+    normalized = wrapped[2]?.trim() ?? normalized;
+  }
+
+  // Some providers emit markdown-linked file names for path args.
+  normalized = normalized.replace(MARKDOWN_LINK_IN_PATH_RE, "$1");
+
+  if (/^file:\/\//i.test(normalized)) {
+    try {
+      normalized = fileURLToPath(normalized);
+    } catch {
+      // Keep original when file URL parsing fails.
+    }
+  }
+
+  if (normalized.startsWith("~/")) {
+    const home = process.env.HOME?.trim();
+    if (home) {
+      normalized = path.join(home, normalized.slice(2));
+    }
+  }
+
+  record[key] = normalized;
+}
+
 // Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
 // Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
 // This prevents models trained on Claude Code from getting stuck in tool-call loops.
@@ -436,6 +477,7 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   }
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
+  normalizePathLikeParam(normalized, "path");
   normalizeTextLikeParam(normalized, "content");
   normalizeTextLikeParam(normalized, "oldText");
   normalizeTextLikeParam(normalized, "newText");


### PR DESCRIPTION
## Summary
- normalize path params that arrive wrapped as markdown links (for example `name[foo.md](http://foo)` fragments)
- support common path wrappers (`\`path\``, `<path>`, `file://...`, `~/...`) before dispatching read/edit/write tools
- add regression tests covering markdown-link path normalization and file URL conversion

## Test plan
- [x] `pnpm exec vitest run src/agents/pi-tools.read.normalize-tool-params.test.ts src/agents/pi-tools.read.host-edit-access.test.ts`

Closes #29435
