### PR TITLE
fix(whatsapp): send unavailable presence on connect to preserve phone notifications

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -87,6 +87,9 @@ type WhatsAppConfigCore = {
   markdown?: MarkdownConfig;
   /** Allow channel-initiated config writes (default: true). */
   configWrites?: boolean;
+  /** Announce WhatsApp presence as online on connect (default: false).
+   * When false, sends unavailable presence to preserve phone push notifications. */
+  announcePresence?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
   /** Inbound message prefix override (WhatsApp only). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -36,6 +36,7 @@ const WhatsAppSharedSchema = z.object({
   capabilities: z.array(z.string()).optional(),
   markdown: MarkdownConfigSchema,
   configWrites: z.boolean().optional(),
+  announcePresence: z.boolean().optional(),
   sendReadReceipts: z.boolean().optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -13,6 +13,7 @@ export type ResolvedWhatsAppAccount = {
   accountId: string;
   name?: string;
   enabled: boolean;
+  announcePresence: boolean;
   sendReadReceipts: boolean;
   messagePrefix?: string;
   authDir: string;
@@ -127,6 +128,7 @@ export function resolveWhatsAppAccount(params: {
     accountId,
     name: accountCfg?.name?.trim() || undefined,
     enabled,
+    announcePresence: accountCfg?.announcePresence ?? rootCfg?.announcePresence ?? false,
     sendReadReceipts: accountCfg?.sendReadReceipts ?? rootCfg?.sendReadReceipts ?? true,
     messagePrefix:
       accountCfg?.messagePrefix ?? rootCfg?.messagePrefix ?? params.cfg.messages?.messagePrefix,

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -201,6 +201,7 @@ export async function monitorWebChannel(
       accountId: account.accountId,
       authDir: account.authDir,
       mediaMaxMb: account.mediaMaxMb,
+      announcePresence: account.announcePresence,
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -28,6 +28,8 @@ export async function monitorWebInbox(options: {
   authDir: string;
   onMessage: (msg: WebInboundMessage) => Promise<void>;
   mediaMaxMb?: number;
+  /** Announce presence as online on connect (default: false). When false, sends unavailable presence to preserve phone push notifications. */
+  announcePresence?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
@@ -57,12 +59,15 @@ export async function monitorWebInbox(options: {
   };
 
   try {
-    await sock.sendPresenceUpdate("available");
+    const presence = options.announcePresence ? "available" : "unavailable";
+    await sock.sendPresenceUpdate(presence);
     if (shouldLogVerbose()) {
-      logVerbose("Sent global 'available' presence on connect");
+      logVerbose(
+        `Sent global '${presence}' presence on connect${presence === "unavailable" ? " — preserves phone push notifications" : ""}`,
+      );
     }
   } catch (err) {
-    logVerbose(`Failed to send 'available' presence on connect: ${String(err)}`);
+    logVerbose(`Failed to send presence on connect: ${String(err)}`);
   }
 
   const selfJid = sock.user?.id;

--- a/src/web/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/src/web/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -74,7 +74,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     await listener.close();
   });
 

--- a/src/web/monitor-inbox.streams-inbound-messages.test.ts
+++ b/src/web/monitor-inbox.streams-inbound-messages.test.ts
@@ -105,7 +105,7 @@ describe("web monitor inbox", () => {
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     const upsert = buildMessageUpsert({
       id: "abc",
       remoteJid: "999@s.whatsapp.net",
@@ -128,7 +128,7 @@ describe("web monitor inbox", () => {
         fromMe: false,
       },
     ]);
-    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("unavailable");
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",


### PR DESCRIPTION
## Summary

Fixes #30286

Baileys explicitly called `sendPresenceUpdate('available')` in `src/web/inbound/monitor.ts` on connect, overriding `markOnlineOnConnect: false` in `session.ts`. This suppresses all push notifications on the phone for every chat while the gateway is running.

**Root cause:** The existing `markOnlineOnConnect: false` in `session.ts` is correct, but it was overridden by the explicit `sendPresenceUpdate("available")` call in `inbound/monitor.ts`.

## Changes

- `src/web/inbound/monitor.ts`: use `"unavailable"` presence by default; read from `options.announcePresence`
- `src/web/auto-reply/monitor.ts`: thread `announcePresence` through
- `src/web/accounts.ts`: resolve `announcePresence` (default `false`)
- `src/config/types.whatsapp.ts`: add `announcePresence` field
- `src/config/zod-schema.providers-whatsapp.ts`: add zod validation
- `src/web/monitor-inbox.streams-inbound-messages.test.ts`: update assertions
- `src/web/monitor-inbox.captures-media-path-image-messages.test.ts`: update assertions

## Config

```json
// To restore old behavior (announce online presence):
"channels": { "whatsapp": { "announcePresence": true } }
```

**Comparison:** Beeper (also Baileys-based) uses the same approach and does not suppress phone notifications.