### PR TITLE
fix(browser): retry relay navigation after frame detach

### DIFF
--- a/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -39,9 +39,40 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       cdpUrl: "http://127.0.0.1:18792",
       url: "https://example.com",
       timeoutMs: 10,
+      ssrfPolicy: { allowPrivateNetwork: true },
     });
 
     expect(goto).toHaveBeenCalledWith("https://example.com", { timeout: 1000 });
     expect(result.url).toBe("https://example.com");
+  });
+
+  it("reconnects and retries once when navigation detaches frame", async () => {
+    const goto = vi
+      .fn<(...args: unknown[]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("page.goto: Frame has been detached"))
+      .mockResolvedValueOnce(undefined);
+    setPwToolsCoreCurrentPage({
+      goto,
+      url: vi.fn(() => "https://example.com/recovered"),
+    });
+
+    const result = await mod.navigateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      url: "https://example.com/recovered",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(getPwToolsCoreSessionMocks().getPageForTargetId).toHaveBeenCalledTimes(2);
+    expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      reason: "retry navigate after detached frame",
+    });
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(result.url).toBe("https://example.com/recovered");
   });
 });

--- a/src/browser/pw-tools-core.test-harness.ts
+++ b/src/browser/pw-tools-core.test-harness.ts
@@ -22,7 +22,9 @@ const sessionMocks = vi.hoisted(() => ({
     return currentPage;
   }),
   ensurePageState: vi.fn(() => pageState),
+  forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
   restoreRoleRefsForTarget: vi.fn(() => {}),
+  storeRoleRefsForTarget: vi.fn(() => {}),
   refLocator: vi.fn(() => {
     if (!currentRefLocator) {
       throw new Error("missing locator");


### PR DESCRIPTION
## Summary

- **Problem:** Browser Relay sessions could lose control after `browser:navigate` when Playwright surfaced transient `Frame has been detached` / `Target page, context or browser has been closed` errors.
- **Why it matters:** After one failed navigate, follow-up browser actions often degraded into tab-not-found/timeouts, breaking remote browser automation flows.
- **What changed:** `navigateViaPlaywright` now treats those two transient navigation failures as retryable, forces a Playwright CDP reconnect, and retries once with a refreshed page handle; regression coverage added for reconnect+retry behavior.
- **What did NOT change:** No change to normal navigation policy/SSRF behavior, and no multi-retry loop was added (still single controlled retry).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29431

## User-visible / Behavior Changes

- Browser navigate now auto-recovers once from transient frame-detach / target-closed errors by reconnecting the Playwright CDP session before retrying.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + Vitest
- Integration/channel: Browser Relay / browser tool route

### Steps

1. Simulate `page.goto` failing once with `Frame has been detached`.
2. Verify navigate triggers reconnect then retries and succeeds.

### Expected

- Navigate succeeds after one reconnect+retry, without losing session control.

### Actual

- Before fix: first detach/target-closed error fails hard and often cascades to unusable tab/session.
- After fix: one controlled reconnect+retry succeeds for transient detach failures.

## Evidence

- `pnpm exec vitest run src/browser/pw-tools-core.snapshot.navigate-guard.test.ts`
- `pnpm exec vitest run src/browser/pw-tools-core.interactions.evaluate.abort.test.ts`

## Human Verification (required)

- Verified scenarios: retryable navigation error path, normal navigation path, unsupported URL guard path.
- Edge cases checked: reconnect function failures are tolerated (`catch`) while preserving original retry behavior.
- What I did **not** verify: full end-to-end remote Browser Relay run against a live SSH/tailscale setup.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/browser/pw-tools-core.snapshot.ts` and related tests.
- Known bad symptoms: repeated navigate retries on non-transient errors (not expected; logic matches only two known transient messages).

## Risks and Mitigations

- Risk: error-string matching could miss provider/runtime variants.
- Mitigation: retry is conservative (single retry only) and scoped to known transient detach/closed signatures.
