### PR TITLE
fix(plugins): resolve bundled fallback from bare plugin specs

### DIFF
--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -88,10 +88,18 @@ describe("bundled plugin sources", () => {
     loadPluginManifestMock.mockReturnValue({ ok: true, manifest: { id: "feishu" } });
 
     const resolved = findBundledPluginByNpmSpec({ spec: "@openclaw/feishu" });
+    const resolvedByPluginId = findBundledPluginByNpmSpec({ spec: "feishu" });
+    const resolvedByVersionedScoped = findBundledPluginByNpmSpec({
+      spec: "@openclaw/feishu@2026.2.27",
+    });
+    const resolvedByVersionedBare = findBundledPluginByNpmSpec({ spec: "feishu@latest" });
     const missing = findBundledPluginByNpmSpec({ spec: "@openclaw/not-found" });
 
     expect(resolved?.pluginId).toBe("feishu");
     expect(resolved?.localPath).toBe("/app/extensions/feishu");
+    expect(resolvedByPluginId?.pluginId).toBe("feishu");
+    expect(resolvedByVersionedScoped?.pluginId).toBe("feishu");
+    expect(resolvedByVersionedBare?.pluginId).toBe("feishu");
     expect(missing).toBeUndefined();
   });
 });

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -7,6 +7,42 @@ export type BundledPluginSource = {
   npmSpec?: string;
 };
 
+function extractRegistryPackageName(spec: string): string {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const lastAt = trimmed.lastIndexOf("@");
+  if (lastAt > 0) {
+    return trimmed.slice(0, lastAt);
+  }
+  return trimmed;
+}
+
+function collectBundledLookupKeys(params: { pluginId: string; npmSpec?: string }): Set<string> {
+  const keys = new Set<string>();
+  const pluginId = params.pluginId.trim().toLowerCase();
+  if (pluginId) {
+    keys.add(pluginId);
+    keys.add(`@openclaw/${pluginId}`);
+  }
+  const npmSpec = params.npmSpec?.trim().toLowerCase() ?? "";
+  if (npmSpec) {
+    keys.add(npmSpec);
+    const pkg = extractRegistryPackageName(npmSpec);
+    if (pkg) {
+      keys.add(pkg);
+      if (pkg.startsWith("@openclaw/")) {
+        const short = pkg.slice("@openclaw/".length).trim();
+        if (short) {
+          keys.add(short);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
 export function resolveBundledPluginSources(params: {
   workspaceDir?: string;
 }): Map<string, BundledPluginSource> {
@@ -45,14 +81,35 @@ export function findBundledPluginByNpmSpec(params: {
   spec: string;
   workspaceDir?: string;
 }): BundledPluginSource | undefined {
-  const targetSpec = params.spec.trim();
+  const targetSpec = params.spec.trim().toLowerCase();
   if (!targetSpec) {
     return undefined;
   }
+  const targetKeys = new Set<string>();
+  targetKeys.add(targetSpec);
+  const targetPackage = extractRegistryPackageName(targetSpec);
+  if (targetPackage) {
+    targetKeys.add(targetPackage);
+    if (targetPackage.startsWith("@openclaw/")) {
+      const short = targetPackage.slice("@openclaw/".length).trim();
+      if (short) {
+        targetKeys.add(short);
+      }
+    } else if (!targetPackage.includes("/") && !targetPackage.startsWith("@")) {
+      targetKeys.add(`@openclaw/${targetPackage}`);
+    }
+  }
+
   const bundled = resolveBundledPluginSources({ workspaceDir: params.workspaceDir });
   for (const source of bundled.values()) {
-    if (source.npmSpec === targetSpec) {
-      return source;
+    const sourceKeys = collectBundledLookupKeys({
+      pluginId: source.pluginId,
+      npmSpec: source.npmSpec,
+    });
+    for (const key of targetKeys) {
+      if (sourceKeys.has(key)) {
+        return source;
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw plugins install telegram` can fail in environments where npm package resolution for bare names is unavailable, and bundled fallback matching only accepted exact scoped npm specs.
- **Why it matters:** Telegram channel setup appears broken even though a bundled plugin exists, causing false "plugin registry is broken" user experiences.
- **What changed:** Bundled fallback lookup now matches plugin id forms and versioned bare specs (e.g. `telegram`, `telegram@latest`, `@openclaw/telegram@...`) in addition to exact scoped specs.
- **What did NOT change:** No change to actual plugin installation logic, security gating, or manifest loading behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30165

## User-visible / Behavior Changes

- `openclaw plugins install telegram` (and similar bare/plugin-id specs) can now recover to bundled plugin installs when npm package fetch reports not-found.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime: Node.js + Vitest
- Integration/channel: plugins CLI fallback resolution

### Steps

1. Seed bundled plugin source with `pluginId=feishu` and `npmSpec=@openclaw/feishu`.
2. Resolve fallback via `feishu`, `feishu@latest`, and `@openclaw/feishu@<version>`.

### Expected

- All equivalent specs resolve to the bundled plugin source.

### Actual

- Before fix: only exact `@openclaw/<id>` matched.
- After fix: bare/versioned equivalents match too.

## Evidence

- `pnpm exec vitest run src/plugins/bundled-sources.test.ts`

## Human Verification (required)

- Verified scenarios: exact scoped spec, bare plugin id, versioned scoped spec, versioned bare spec, and missing spec path.
- Edge cases checked: case-normalized comparisons and openclaw scoped alias expansion.
- What I did **not** verify: full `plugins install telegram` end-to-end against a live failing npm registry mirror.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this PR commit.
- Files/config to restore: `src/plugins/bundled-sources.ts` (+ test file).
- Known bad symptoms: false positive fallback for non-openclaw names (mitigated by matching against discovered bundled plugin ids only).

## Risks and Mitigations

- Risk: broader matching could pick wrong plugin in ambiguous naming cases.
- Mitigation: matching is constrained to discovered bundled entries and exact normalized key intersection.
