### PR TITLE
fix(telegram): preserve original filename for document and audio uploads

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -320,7 +320,11 @@ export async function resolveMedia(
   stickerMetadata?: StickerMetadata;
 } | null> {
   const msg = ctx.message;
-  const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
+  const downloadAndSaveTelegramFile = async (
+    filePath: string,
+    fetchImpl: typeof fetch,
+    originalFileName?: string,
+  ) => {
     const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
@@ -329,7 +333,7 @@ export async function resolveMedia(
       maxBytes,
       ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
     });
-    const originalName = fetched.fileName ?? filePath;
+    const originalName = originalFileName ?? fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);
   };
 
@@ -451,7 +455,8 @@ export async function resolveMedia(
   if (!fetchImpl) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl);
+  const originalFileName = msg.document?.file_name ?? msg.audio?.file_name ?? undefined;
+  const saved = await downloadAndSaveTelegramFile(file.file_path, fetchImpl, originalFileName);
   const placeholder = resolveTelegramMediaPlaceholder(msg) ?? "<media:document>";
   return { path: saved.path, contentType: saved.contentType, placeholder };
 }


### PR DESCRIPTION


# Use original Telegram filename when saving downloaded media

Add `originalFileName` parameter to `downloadAndSaveTelegramFile` to use the actual filename from Telegram's document or audio metadata instead of falling back to the internal Telegram file path.

---

## Summary

* **Problem:**
  Telegram provides two different names:

  * `msg.document.file_name` → original filename (e.g., `bao-cao.txt`)
  * `getFile().file_path` → internal path (e.g., `documents/file_3`)
    Previous implementation derived filename from `file_path`, resulting in saved files like `file_3.txt`.

* **Why it matters:**
  Users expect uploaded files to retain their original names. Losing the original filename:

  * Reduces clarity
  * Breaks traceability
  * Hurts DX when debugging or reviewing artifacts

* **What changed:**

  * Added optional `originalFileName?: string` to `downloadAndSaveTelegramFile`.
  * Save logic now prioritizes:
    `originalFileName ?? fetched.fileName ?? filePath`
  * Call sites updated to pass:

    * `msg.document?.file_name`
    * `msg.audio?.file_name`

* **What did NOT change (scope boundary):**

  * No change to Telegram download logic.
  * No change to storage structure.
  * No change to UUID suffix logic.
  * No change to file validation or security behavior.

---

## Change Type (select all)

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Docs
* [ ] Security hardening
* [ ] Chore/infra

---

## Scope (select all touched areas)

* [ ] Gateway / orchestration
* [ ] Skills / tool execution
* [ ] Auth / tokens
* [x] Memory / storage
* [x] Integrations
* [ ] API / contracts
* [ ] UI / DX
* [ ] CI/CD / infra

---

## Linked Issue/PR

* Closes #
* Related #

---

## User-visible / Behavior Changes

Files uploaded via Telegram `document` or `audio` will now be saved using their original filename (e.g., `bao-cao---{uuid}.txt`) instead of Telegram's internal basename (e.g., `file_3.txt`).

---

## Security Impact (required)

* New permissions/capabilities? **No**
* Secrets/tokens handling changed? **No**
* New/changed network calls? **No**
* Command/tool execution surface changed? **No**
* Data access scope changed? **No**

No security surface changes. This PR only alters filename selection priority during save.

---

## Repro + Verification

### Environment

* OS: Ubuntu 22.04
* Runtime/container: Node.js (OpenClaw Gateway)
* Model/provider: N/A
* Integration/channel: Telegram
* Relevant config (redacted): TELEGRAM_BOT_TOKEN configured

---

### Steps

1. Upload a file named `bao-cao.txt` to Telegram bot.
2. Let gateway download and persist the file.
3. Inspect saved file name in storage.

---

### Expected

* File saved as:
  `bao-cao---{uuid}.txt`

---

### Actual (Before Fix)

* File saved as:
  `file_3---{uuid}.txt`

---

## Evidence

* [x] Trace/log snippets
* [ ] Failing test/log before + passing after
* [ ] Screenshot/recording
* [ ] Perf numbers (if relevant)

Example log after fix:

```
Saved Telegram file as: bao-cao---a12f9c3e.txt
```

---

## Human Verification (required)

* **Verified scenarios:**

  * Telegram document upload with filename
  * Telegram audio upload with filename
  * Fallback when `file_name` is undefined

* **Edge cases checked:**

  * Missing `file_name`
  * Non-ASCII filenames
  * Files without extension

* **What you did NOT verify:**

  * Extremely long filenames (>255 chars)
  * Uncommon Telegram media types (e.g., voice notes without filename)

---

## Compatibility / Migration

* Backward compatible? **Yes**
* Config/env changes? **No**
* Migration needed? **No**

---

## Failure Recovery (if this breaks)

* How to disable/revert this change quickly:
  Remove `originalFileName` argument and revert to previous filename resolution logic.

* Files/config to restore:
  `delivery.ts` (download + call site sections)

* Known bad symptoms reviewers should watch for:

  * Unexpected filename collisions
  * Improper extension handling
  * Encoding issues in filesystem

---

## Risks and Mitigations

* **Risk:** Original filename contains unsafe characters

  * **Mitigation:** Existing filename sanitization + UUID suffix logic unchanged

* **Risk:** Extremely long filenames

  * **Mitigation:** Underlying storage logic already enforces safe path constraints

---